### PR TITLE
stdenv: Force `doCheck` to be false when we are cross compiling

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -995,13 +995,14 @@ but only if the <varname>doCheck</varname> variable is enabled.</para>
 
   <varlistentry>
     <term><varname>doCheck</varname></term>
-    <listitem><para>If set to a non-empty string, the check phase is
-    executed, otherwise it is skipped (default).  Thus you should set
-
-    <programlisting>
-doCheck = true;</programlisting>
-
-    in the derivation to enable checks.</para></listitem>
+    <listitem><para>
+      Controls whether the check phase is executed.
+      By default it is skipped, but if <varname>doCheck</varname> is set to true, the check phase is usually executed.
+      Thus you should set <programlisting>doCheck = true;</programlisting> in the derivation to enable checks.
+      The exception is cross compilation.
+      Cross compiled builds never run tests, no matter how <varname>doCheck</varname> is set,
+      as the newly-built program won't run on the platform used to build it.
+    </para></listitem>
   </varlistentry>
 
   <varlistentry>
@@ -1280,12 +1281,14 @@ installcheck</command>.</para>
 
   <varlistentry>
     <term><varname>doInstallCheck</varname></term>
-    <listitem><para>If set to a non-empty string, the installCheck phase is
-    executed, otherwise it is skipped (default).  Thus you should set
-
-    <programlisting>doInstallCheck = true;</programlisting>
-
-    in the derivation to enable install checks.</para></listitem>
+    <listitem><para>
+      Controls whether the installCheck phase is executed.
+      By default it is skipped, but if <varname>doInstallCheck</varname> is set to true, the installCheck phase is usually executed.
+      Thus you should set <programlisting>doInstallCheck = true;</programlisting> in the derivation to enable install checks.
+      The exception is cross compilation.
+      Cross compiled builds never run tests, no matter how <varname>doInstallCheck</varname> is set,
+      as the newly-built program won't run on the platform used to build it.
+    </para></listitem>
   </varlistentry>
 
   <varlistentry>

--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ lzip ];
 
-  doCheck = hostPlatform == buildPlatform;
+  doCheck = true; # not cross;
 
   meta = {
     description = "An implementation of the standard Unix editor";

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     [ "--enable-cplusplus" ]
     ++ lib.optional enableLargeConfig "--enable-large-config";
 
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = true; # not cross;
 
   # Don't run the native `strip' when cross-compiling.
   dontStrip = hostPlatform != buildPlatform;

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   outputMan = "dev"; # tiny page for a dev tool
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = true; # not cross;
 
   preCheck = ''
     patchShebangs ./run.sh

--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0lx201q20dvc70f8a3c9s7s18z15inlxvbffph97ngvrgnyjq9cx";
   };
 
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = true; # not cross;
 
   # Linking static stubs on cygwin requires correct ordering.
   # Consider upstreaming this.

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -1,6 +1,5 @@
 { stdenv, fetchurl, m4, cxx ? true
 , buildPackages
-, buildPlatform, hostPlatform
 , withStatic ? false }:
 
 let inherit (stdenv.lib) optional optionalString; in
@@ -43,7 +42,7 @@ let self = stdenv.mkDerivation rec {
       configureFlagsArray+=("--build=$(./configfsf.guess)")
     '';
 
-  doCheck = buildPlatform == hostPlatform;
+  doCheck = true; # not cross;
 
   dontDisableStatic = withStatic;
 

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = true; # not cross;
   checkTarget = "test";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libmpc/default.nix
+++ b/pkgs/development/libraries/libmpc/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   CFLAGS = "-I${gmp.dev}/include";
 
-  doCheck = hostPlatform == buildPlatform;
+  doCheck = true; # not cross;
 
   meta = {
     description = "Library for multiprecision complex arithmetic with exact rounding";

--- a/pkgs/development/libraries/libpng/default.nix
+++ b/pkgs/development/libraries/libpng/default.nix
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
 
   # it's hard to cross-run tests and some check programs didn't compile anyway
   makeFlags = stdenv.lib.optional (!doCheck) "check_PROGRAMS=";
-  doCheck = hostPlatform == buildPlatform;
+  doCheck = true; # not cross;
 
   passthru = { inherit zlib; };
 

--- a/pkgs/development/libraries/libsigsegv/default.nix
+++ b/pkgs/development/libraries/libsigsegv/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   patches = if enableSigbusFix then [ ./sigbus_fix.patch ] else null;
 
-  doCheck = hostPlatform == buildPlatform;
+  doCheck = true; # not cross;
 
   meta = {
     homepage = http://www.gnu.org/software/libsigsegv/;

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = true; # not cross;
 
   meta = with stdenv.lib; {
     description = "Library and utilities for working with the TIFF image file format";

--- a/pkgs/development/libraries/lzo/default.nix
+++ b/pkgs/development/libraries/lzo/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = true; # not cross;
 
   meta = with stdenv.lib; {
     description = "Real-time data (de)compression library";

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional hostPlatform.isSunOS "--disable-thread-safe" ++
     stdenv.lib.optional hostPlatform.is64bit "--with-pic";
 
-  doCheck = hostPlatform == buildPlatform;
+  doCheck = true; # not cross;
 
   enableParallelBuilding = true;
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -36,6 +36,7 @@ rec {
     , depsTargetTarget            ? [] #  1 ->  1
     , depsTargetTargetPropagated  ? [] #  1 ->  1
 
+    # Configure Phase
     , configureFlags ? []
     , # Target is not included by default because most programs don't care.
       # Including it then would cause needless mass rebuilds.
@@ -44,6 +45,13 @@ rec {
       configurePlatforms ? lib.optionals
         (stdenv.hostPlatform != stdenv.buildPlatform)
         [ "build" "host" ]
+
+    # Check phase
+    , doCheck ? false
+
+    # InstallCheck phase
+    , doInstallCheck ? false
+
     , crossConfig ? null
     , meta ? {}
     , passthru ? {}
@@ -60,6 +68,7 @@ rec {
 
     , hardeningEnable ? []
     , hardeningDisable ? []
+
     , ... } @ attrs:
 
     # TODO(@Ericson2314): Make this more modular, and not O(n^2).
@@ -178,9 +187,15 @@ rec {
             "/bin/sh"
           ];
           __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
-        } // (if outputs' != [ "out" ] then {
+        } // lib.optionalAttrs (outputs' != [ "out" ]) {
           outputs = outputs';
-        } else { }));
+        } // lib.optionalAttrs (attrs ? doCheck) {
+          # TODO(@Ericson2314): Make unconditional / resolve #33599
+          doCheck = doCheck && (stdenv.hostPlatform == stdenv.targetPlatform);
+        } // lib.optionalAttrs (attrs ? doInstallCheck) {
+          # TODO(@Ericson2314): Make unconditional / resolve #33599
+          doInstallCheck = doInstallCheck && (stdenv.hostPlatform == stdenv.targetPlatform);
+        });
 
       # The meta attribute is passed in the resulting attribute set,
       # but it's not part of the actual derivation, i.e., it's not

--- a/pkgs/tools/system/ddrescue/default.nix
+++ b/pkgs/tools/system/ddrescue/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ lzip ];
 
-  doCheck = hostPlatform == buildPlatform;
+  doCheck = true; # not cross;
   configureFlags = [ "CXX=${stdenv.cc.targetPrefix}c++" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/text/gnupatch/default.nix
+++ b/pkgs/tools/text/gnupatch/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     "ac_cv_func_strnlen_working=yes"
   ];
 
-  doCheck = hostPlatform == buildPlatform;
+  doCheck = true; # not cross;
 
   meta = {
     description = "GNU Patch, a program to apply differences to files";


### PR DESCRIPTION
###### Motivation for this change

This restores in effect what the old `gcc-cross-wrapper` did.

I hope this will be a temporary measure. If there is consensus around issue #33599, then we can follow an explicit `dontCheck`, but default to not checking during cross builds when none is given.

In anticipation of what I outline in #33599, I only simplify exactly those  `doCheck`s which are equal to `hostPlatform != buildPlatform`. I also stick a comment next to them so I can grep for them later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @dezgeg @bgamari @dtzWill
  
  