### PR TITLE
Mark syncthing012 and syncthing013 as insecure

### DIFF
--- a/pkgs/applications/networking/syncthing012/default.nix
+++ b/pkgs/applications/networking/syncthing012/default.nix
@@ -24,4 +24,12 @@ buildGoPackage rec {
   preBuild = ''
     export buildFlagsArray+=("-tags" "noupgrade release")
   '';
+
+  meta = {
+    knownVulnerabilities = [ "CVE-2017-1000420" ];
+    homepage = https://www.syncthing.net/;
+    description = "Open Source Continuous File Synchronization";
+    license = stdenv.lib.licenses.mpl20;
+    platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
+  };
 }

--- a/pkgs/applications/networking/syncthing013/default.nix
+++ b/pkgs/applications/networking/syncthing013/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    knownVulnerabilities = [ "CVE-2017-1000420" ];
     homepage = https://www.syncthing.net/;
     description = "Open Source Continuous File Synchronization";
     license = stdenv.lib.licenses.mpl20;


### PR DESCRIPTION
###### Motivation for this change

Marked 012 and 013 as insecure as discussed in #33568.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

