### PR TITLE
nixos/kresd: fix systemd dependency cycle

### DIFF
--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -113,7 +113,6 @@ in
 
       after = [ "kresd-cachedir.service" ];
       requires = [ "kresd.socket" "kresd-cachedir.service" ];
-      wantedBy = [ "sockets.target" ];
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`kresd.service` makes `sockets.target` depend on itself causing a dependency cycle:

```
$ systemd-analyze verify default.target
sockets.target: Found ordering cycle on sockets.target/start
sockets.target: Found dependency on kresd.service/start
sockets.target: Found dependency on kresd-cachedir.service/start
sockets.target: Found dependency on basic.target/start
sockets.target: Found dependency on sockets.target/start
sockets.target: Breaking ordering cycle by deleting job kresd.service/start
kresd.service: Job kresd.service/start deleted to break ordering cycle starting with sockets.target/start
```

As a result, `kresd.service` won't start on system boot. This PR fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

