### PR TITLE
python-modules: fix httpbin by adding all the deps

### DIFF
--- a/pkgs/development/python-modules/crayons/default.nix
+++ b/pkgs/development/python-modules/crayons/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchPypi, buildPythonPackage, colorama }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.1.2";
+  pname = "crayons";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17c0v0dkk8sn8kyyy2w7myxq9981glrbczh6h8sdcr750lb6j5sy";
+  };
+
+  propagatedBuildInputs = [ colorama ];
+
+  meta = with stdenv.lib; {
+    description = "TextUI colors for Python";
+    homepage = https://github.com/kennethreitz/crayons;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/crayons/default.nix
+++ b/pkgs/development/python-modules/crayons/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchPypi, buildPythonPackage, colorama }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "0.1.2";
   pname = "crayons";
+  version = "0.1.2";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/flask-common/default.nix
+++ b/pkgs/development/python-modules/flask-common/default.nix
@@ -2,9 +2,8 @@
 , crayons, flask, flask_cache, gunicorn, maya, meinheld, whitenoise }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "0.2.0";
   pname = "Flask-Common";
+  version = "0.2.0";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/flask-common/default.nix
+++ b/pkgs/development/python-modules/flask-common/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, crayons, flask, flask_cache, gunicorn, maya, meinheld, whitenoise }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.2.0";
+  pname = "Flask-Common";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1f6ibvkxpxgczxs4qcbh5bj8rf9ggggbagi2dkaphx5w29xbbys4";
+  };
+
+  propagatedBuildInputs = [ crayons flask flask_cache gunicorn maya meinheld whitenoise ];
+
+  meta = with stdenv.lib; {
+    description = "Flask extension with lots of common time-savers";
+    homepage = https://github.com/kennethreitz/flask-common;
+    license = licenses.asl20; # XXX: setup.py lists BSD but git repo has Apache 2.0 LICENSE
+  };
+}

--- a/pkgs/development/python-modules/flask-limiter/default.nix
+++ b/pkgs/development/python-modules/flask-limiter/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchPypi, buildPythonPackage, flask, limits }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "1.0.1";
   pname = "Flask-Limiter";
+  version = "1.0.1";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/flask-limiter/default.nix
+++ b/pkgs/development/python-modules/flask-limiter/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchPypi, buildPythonPackage, flask, limits }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "1.0.1";
+  pname = "Flask-Limiter";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1f0diannnc6rc0ngsh222lws3qf89wxm0aschaxxvwjvybf9iklc";
+  };
+
+  propagatedBuildInputs = [ flask limits ];
+
+  meta = with stdenv.lib; {
+    description = "Rate limiting for flask applications";
+    homepage = https://flask-limiter.readthedocs.org/;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/httpbin/default.nix
+++ b/pkgs/development/python-modules/httpbin/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , flask
 , flask_common
 , flask_limiter
@@ -21,6 +22,16 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0afa0486a76305cac441b5cc80d5d4ccd82b20875da7c5119ecfe616cefef45f";
   };
+
+  patches = [
+    # https://github.com/kennethreitz/httpbin/issues/403
+    # https://github.com/kennethreitz/flask-common/issues/7
+    # https://github.com/evansd/whitenoise/issues/166
+    (fetchpatch {
+      url = "https://github.com/javabrett/httpbin/commit/5735c888e1e51b369fcec41b91670a90535e661e.patch";
+      sha256 = "167h8mscdjagml33dyqk8nziiz3dqbggnkl6agsirk5270nl5f7q";
+    })
+  ];
 
   propagatedBuildInputs = [ brotlipy flask flask_common flask_limiter markupsafe decorator itsdangerous raven six ];
 

--- a/pkgs/development/python-modules/httpbin/default.nix
+++ b/pkgs/development/python-modules/httpbin/default.nix
@@ -2,10 +2,14 @@
 , buildPythonPackage
 , fetchPypi
 , flask
+, flask_common
+, flask_limiter
 , markupsafe
 , decorator
 , itsdangerous
+, raven
 , six
+, brotlipy
 }:
 
 buildPythonPackage rec {
@@ -18,7 +22,7 @@ buildPythonPackage rec {
     sha256 = "0afa0486a76305cac441b5cc80d5d4ccd82b20875da7c5119ecfe616cefef45f";
   };
 
-  propagatedBuildInputs = [ flask markupsafe decorator itsdangerous six ];
+  propagatedBuildInputs = [ brotlipy flask flask_common flask_limiter markupsafe decorator itsdangerous raven six ];
 
   # No tests
   doCheck = false;

--- a/pkgs/development/python-modules/httpbin/default.nix
+++ b/pkgs/development/python-modules/httpbin/default.nix
@@ -16,7 +16,6 @@
 buildPythonPackage rec {
   pname = "httpbin";
   version = "0.6.2";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchPypi, buildPythonPackage, six }:
+
+buildPythonPackage rec {
+  pname = "limits";
+  version = "1.2.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dfbrmqixsvhvzqgd4s8rfj933k1w5q4bm23pp9zyp70xlb0mfmd";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  doCheck = false; # ifilter
+
+  meta = with stdenv.lib; {
+    description = "Rate limiting utilities";
+    license = licenses.mit;
+    homepage = https://limits.readthedocs.org/;
+  };
+}

--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "limits";
   version = "1.2.1";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/maya/default.nix
+++ b/pkgs/development/python-modules/maya/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchPypi, fetchpatch, buildPythonPackage
+, dateparser, humanize, pendulum, ruamel_yaml, tzlocal }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.3.3";
+  pname = "maya";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1x88k4irpckvd7jf2yvqjw1s52hjqbxym1r1d928yb3fkj7rvlxs";
+  };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/kennethreitz/maya/issues/112
+      # Merged, so should be in next release.
+      url = "https://github.com/kennethreitz/maya/commit/f69a93b1103130139cdec30511777823957fb659.patch";
+      sha256 = "152ba7amv9dhhx1wcklfalsdzsxggik9f7rsrikms921lq9xqc8h";
+    })
+  ];
+
+  propagatedBuildInputs = [ dateparser humanize pendulum ruamel_yaml tzlocal ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Datetimes for Humans";
+    homepage = https://github.com/kennethreitz/maya;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/maya/default.nix
+++ b/pkgs/development/python-modules/maya/default.nix
@@ -2,9 +2,8 @@
 , dateparser, humanize, pendulum, ruamel_yaml, tzlocal }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "0.3.3";
   pname = "maya";
+  version = "0.3.3";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/meinheld/default.nix
+++ b/pkgs/development/python-modules/meinheld/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchPypi, buildPythonPackage, greenlet }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.6.1";
+  pname = "meinheld";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rg5878njn66cc0x2fwrakikz24946r0cxxl6j8vvz5phd4zygi9";
+  };
+
+  propagatedBuildInputs = [ greenlet ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "High performance asynchronous Python WSGI Web Server";
+    homepage = http://meinheld.org/;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/meinheld/default.nix
+++ b/pkgs/development/python-modules/meinheld/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchPypi, buildPythonPackage, greenlet }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "0.6.1";
   pname = "meinheld";
+  version = "0.6.1";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchPypi, buildPythonPackage, dateutil, pytzdata, tzlocal }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "1.3.2";
   pname = "pendulum";
+  version = "1.3.2";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchPypi, buildPythonPackage, dateutil, pytzdata, tzlocal }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "1.3.2";
+  pname = "pendulum";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1j6hdsdhhw4d6fy9byr0vyxqnb53ap8bh2a0cibl7p0ks0zvb14j";
+  };
+
+  propagatedBuildInputs = [ dateutil pytzdata tzlocal ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python datetimes made easy";
+    homepage = https://github.com/sdispater/pendulum;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pytest-httpbin/default.nix
+++ b/pkgs/development/python-modules/pytest-httpbin/default.nix
@@ -12,20 +12,18 @@
 buildPythonPackage rec {
   pname = "pytest-httpbin";
   name = "${pname}-${version}";
-  version = "0.2.3";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "kevin1024";
     repo = "pytest-httpbin";
     rev = "v${version}";
-    sha256 = "0j3n12jjy8cm0va8859wqra6abfyajrgh2qj8bhcngf3a72zl9ks";
+    sha256 = "0p86ljx775gxxicscs1dydmmx92r1g9bs00vdvxrsl3qdll1ksfm";
   };
 
-  checkPhase = ''
-    py.test -k "not test_chunked_encoding"
-  '';
+  checkInputs = [ pytest ];
+  checkPhase = "py.test";
 
-  buildInputs = [ pytest ];
   propagatedBuildInputs = [ flask decorator httpbin six requests ];
 
   meta = {

--- a/pkgs/development/python-modules/pytest-httpbin/default.nix
+++ b/pkgs/development/python-modules/pytest-httpbin/default.nix
@@ -11,7 +11,6 @@
 
 buildPythonPackage rec {
   pname = "pytest-httpbin";
-  name = "${pname}-${version}";
   version = "0.3.0";
 
   src = fetchFromGitHub {
@@ -22,7 +21,6 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest ];
-  checkPhase = "py.test";
 
   propagatedBuildInputs = [ flask decorator httpbin six requests ];
 

--- a/pkgs/development/python-modules/pytzdata/default.nix
+++ b/pkgs/development/python-modules/pytzdata/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "2017.3.1";
+  pname = "pytzdata";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wi3jh39zsa9iiyyhynhj7w5b2p9wdyd0ppavpsrmf3wxvr7cwz8";
+  };
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Official timezone database for Python";
+    homepage = https://github.com/sdispater/pytzdata;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pytzdata/default.nix
+++ b/pkgs/development/python-modules/pytzdata/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchPypi, buildPythonPackage }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "2017.3.1";
   pname = "pytzdata";
+  version = "2017.3.1";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/raven/default.nix
+++ b/pkgs/development/python-modules/raven/default.nix
@@ -1,12 +1,11 @@
-{ lib, buildPythonPackage, fetchurl, isPy3k, contextlib2, blinker }:
+{ lib, buildPythonPackage, fetchPypi, isPy3k, contextlib2, blinker }:
 
 buildPythonPackage rec {
   pname = "raven";
   version = "6.4.0";
-  name = pname + "-" + version;
 
-  src = fetchurl {
-    url = "mirror://pypi/r/raven/${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "00m985w9fja2jf8dpvdhygcr26rwabxkgvcc2v5j6v7d6lrvpvdq";
   };
 

--- a/pkgs/development/python-modules/raven/default.nix
+++ b/pkgs/development/python-modules/raven/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchurl, isPy3k, contextlib2 }:
+{ lib, buildPythonPackage, fetchurl, isPy3k, contextlib2, blinker }:
 
 buildPythonPackage rec {
   pname = "raven";
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   # see https://github.com/getsentry/raven-python/blob/master/setup.py
   doCheck = false;
 
-  propagatedBuildInputs = lib.optionals (!isPy3k) [ contextlib2 ];
+  propagatedBuildInputs = [ blinker ] ++ lib.optionals (!isPy3k) [ contextlib2 ];
 
   meta = {
     description = "A Python client for Sentry (getsentry.com)";

--- a/pkgs/development/python-modules/whitenoise/default.nix
+++ b/pkgs/development/python-modules/whitenoise/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchPypi, buildPythonPackage }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "4.0b4";
   pname = "whitenoise";
+  version = "4.0b4";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/whitenoise/default.nix
+++ b/pkgs/development/python-modules/whitenoise/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "4.0b4";
+  pname = "whitenoise";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ra2bbsihwfhnf1ibahzzabgfjfghxqcrbfx6r5r50mlil5n8bf4";
+  };
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Radically simplified static file serving for WSGI applications";
+    homepage = http://whitenoise.evans.io/;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7145,6 +7145,8 @@ in {
 
   chardet = callPackage ../development/python-modules/chardet { };
 
+  crayons = callPackage ../development/python-modules/crayons{ };
+
   django = self.django_1_11;
 
   django_1_11 = callPackage ../development/python-modules/django/1_11.nix {
@@ -8035,11 +8037,15 @@ in {
     };
   };
 
+  flask_common = callPackage ../development/python-modules/flask-common { };
+
   flask-compress = callPackage ../development/python-modules/flask-compress { };
 
   flask-cors = callPackage ../development/python-modules/flask-cors { };
 
   flask_elastic = callPackage ../development/python-modules/flask-elastic { };
+
+  flask_limiter = callPackage ../development/python-modules/flask-limiter { };
 
   flask_login = callPackage ../development/python-modules/flask-login { };
 
@@ -9825,6 +9831,8 @@ in {
   libxslt = disabledIf isPy3k
     (toPythonModule (pkgs.libxslt.override{pythonSupport=true; python2=python; inherit (self) libxml2;})).py;
 
+  limits = callPackage ../development/python-modules/limits { };
+
   limnoria = buildPythonPackage rec {
     name = "limnoria-${version}";
     version = "2016.05.06";
@@ -10156,6 +10164,8 @@ in {
 
   matrix-client = callPackage ../development/python-modules/matrix-client/default.nix { };
 
+  maya = callPackage ../development/python-modules/maya { };
+
   mccabe = callPackage ../development/python-modules/mccabe { };
 
   mechanize = buildPythonPackage (rec {
@@ -10200,6 +10210,8 @@ in {
   };
 
   meliae = callPackage ../development/python-modules/meliae {};
+
+  meinheld = callPackage ../development/python-modules/meinheld { };
 
   memcached = buildPythonPackage rec {
     name = "memcached-1.51";
@@ -10399,6 +10411,8 @@ in {
       maintainers = with maintainers; [ thoughtpolice ];
     };
   };
+
+  pendulum = callPackage ../development/python-modules/pendulum { };
 
   pocket = buildPythonPackage rec {
     name = "pocket-${version}";
@@ -15107,6 +15121,8 @@ in {
       license = licenses.mit;
     };
   };
+
+  pytzdata = callPackage ../development/python-modules/pytzdata { };
 
   pyutil = buildPythonPackage (rec {
     name = "pyutil-2.0.0";
@@ -22480,6 +22496,8 @@ EOF
   versioneer = callPackage ../development/python-modules/versioneer { };
 
   vine = callPackage ../development/python-modules/vine { };
+
+  whitenoise = callPackage ../development/python-modules/whitenoise { };
 
   wp_export_parser = buildPythonPackage rec {
     name = "${pname}-${version}";


### PR DESCRIPTION

###### Motivation for this change

Fixes #33604 .

Fixes httpbin build failure.
Introduces number of new packages that are required by httpbin as of 0.6.2.

httpbin should not have [been updated](https://github.com/NixOS/nixpkgs/commit/0a447a6a3da3087b9ca6ebf3ce1eb277d41cdebd) without testing that it builds....

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

