### PR TITLE
pythonPackages.structlog: patch to fix tests, build

### DIFF
--- a/pkgs/development/python-modules/structlog/default.nix
+++ b/pkgs/development/python-modules/structlog/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , pytest
 , pretend
 , freezegun
@@ -15,6 +16,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "6980001045abd235fa12582222627c19b89109e58b85eb77d5a5abc778df6e20";
   };
+
+  patches = [
+    # Fix tests for pytest 3.3
+    (fetchpatch {
+      url = "https://github.com/hynek/structlog/commit/22f0ae50607a0cb024361599f84610ce290deb99.patch";
+      sha256 = "03622i13ammkpyrdk48kimbz94gbkpcmdpy0kj2z09m1kp6q2ljv";
+    })
+  ];
 
   checkInputs = [ pytest pretend freezegun ];
   propagatedBuildInputs = [ simplejson ];


### PR DESCRIPTION
###### Motivation for this change

Fix structlog build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

