### PR TITLE
networkmanager: 1.10.0 -> 1.10.2, update users

### DIFF
--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
   name    = "${pname}-${major}.${minor}";
   pname   = "network-manager-applet";
   major   = "1.8";
-  minor   = "2";
+  minor   = "6";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${major}/${name}.tar.xz";
-    sha256 = "09f9hjpn9nkhw57mk6pi7q1bq3lhf5hvmwas0fknscssak7yjmry";
+    sha256 = "0c4wxwxpa7wlskvnqaqfa7mmc0c6a2pj7jcvymcchjnq4wn9wx01";
   };
 
   configureFlags = [

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -9,11 +9,11 @@ stdenv.mkDerivation rec {
   name    = "network-manager-${version}";
   pname   = "NetworkManager";
   major   = "1.10";
-  version = "${major}.0";
+  version = "${major}.2";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
-    sha256 = "1ph45rqpl8p9k4rirhss0hpf104clm8fp322p6kh6q75y06ddfwa";
+    sha256 = "0nv2jm2lsidlrzn4dkbc5rpj8ma4cpzjqz8z8dmwkqvh0zsk970n";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/networking/network-manager/iodine.nix
+++ b/pkgs/tools/networking/network-manager/iodine.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
        --replace "/usr/bin/iodine" "${iodine}/bin/iodine"
   '';
 
+  CFLAGS = [ "-Wno-error=deprecated-declarations" ];
+
   meta = {
     description = "NetworkManager's iodine plugin";
     inherit (networkmanager.meta) maintainers platforms;

--- a/pkgs/tools/networking/network-manager/strongswan.nix
+++ b/pkgs/tools/networking/network-manager/strongswan.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-charon=${strongswanNM}/libexec/ipsec/charon-nm" ];
 
+  CFLAGS = [ "-Wno-error=deprecated-declarations" ];
+
   meta = {
     description = "NetworkManager's strongswan plugin";
     inherit (networkmanager.meta) platforms;


### PR DESCRIPTION
###### Motivation for this change

http://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/NEWS?h=1.10.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

