### PR TITLE
libsigcxx: removed patch that forced -std=c++11 in pkg-config file

### DIFF
--- a/pkgs/development/libraries/libsigcxx/default.nix
+++ b/pkgs/development/libraries/libsigcxx/default.nix
@@ -10,11 +10,6 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/libsigc++/${ver_maj}/${name}.tar.xz";
     sha256 = "f843d6346260bfcb4426259e314512b99e296e8ca241d771d21ac64f28298d81";
   };
-  patches = [(fetchpatch {
-    url = "https://anonscm.debian.org/cgit/collab-maint/libsigc++-2.0.git/plain"
-      + "/debian/patches/0002-Enforce-c-11-via-pkg-config.patch?id=d451a4d195b1";
-    sha256 = "19g19473syp2z3kg8vdrli89lm9kcvaqajkqfmdig1vfpkbq0nci";
-  })];
 
   nativeBuildInputs = [ pkgconfig gnum4 ];
 


### PR DESCRIPTION
This pull request aims to resolve issue #33534 where a left over patch from 2015 caused projects that use libsigc++ via pkg-config to be built according to C++11.

###### Motivation for this change
This pull requests removed a patch from the derivation for libsigc++-2.0 that is no longer needed and may have unexpected effects when using libsigc++ in a project via pkg-config. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  