### PR TITLE
pythonPackages.rx: init at 1.6.0

### DIFF
--- a/pkgs/development/python-modules/rx/default.nix
+++ b/pkgs/development/python-modules/rx/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, buildPythonPackage, nose }:
+
+buildPythonPackage rec {
+  pname = "rx";
+  version = "1.6.0";
+
+  # There are no tests on the pypi source
+  src = fetchFromGitHub {
+    owner = "ReactiveX";
+    repo = "rxpy";
+    rev = version;
+    sha256 = "174xi2j36igxmaqcgl5p64p31a7z19v62xb5czybjw72gpyyfyri";
+  };
+
+  checkInputs = [ nose ];
+
+  meta = {
+    homepage = https://github.com/ReactiveX/RxPY;
+    description = "Reactive Extensions for Python";
+    maintainers = with lib.maintainers; [ thanegill ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -358,6 +358,8 @@ in {
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl {});
 
+  rx = callPackage ../development/python-modules/rx { };
+
   salmon-mail = callPackage ../development/python-modules/salmon-mail { };
 
   simpleeval = callPackage ../development/python-modules/simpleeval { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

