### PR TITLE
speedometer: init at 2.8

### DIFF
--- a/pkgs/os-specific/linux/speedometer/default.nix
+++ b/pkgs/os-specific/linux/speedometer/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, lib, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "speedometer-${version}";
+  version = "2.8";
+  src = fetchurl {
+    url = "https://excess.org/speedometer/speedometer-${version}.tar.gz";
+    sha256 = "060bikv3gwr203jbdmvawsfhc0yq0bg1m42dk8czx1nqvwvgv6fm";
+  };
+  propagatedBuildInputs = [ pythonPackages.urwid ];
+  meta = with lib; {
+    description = "Measure and display the rate of data across a network connection or data being stored in a file";
+    homepage = https://excess.org/speedometer/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Baughn ];
+  };
+}

--- a/pkgs/os-specific/linux/speedometer/default.nix
+++ b/pkgs/os-specific/linux/speedometer/default.nix
@@ -3,15 +3,23 @@
 pythonPackages.buildPythonApplication rec {
   name = "speedometer-${version}";
   version = "2.8";
+
   src = fetchurl {
-    url = "https://excess.org/speedometer/speedometer-${version}.tar.gz";
+    url = "http://excess.org/speedometer/speedometer-${version}.tar.gz";
     sha256 = "060bikv3gwr203jbdmvawsfhc0yq0bg1m42dk8czx1nqvwvgv6fm";
   };
+
   propagatedBuildInputs = [ pythonPackages.urwid ];
+
+  postPatch = ''
+    sed -i "/'entry_points': {/d" setup.py
+    sed -i "/'console_scripts': \['speedometer = speedometer:console'\],},/d" setup.py
+  '';
+
   meta = with lib; {
     description = "Measure and display the rate of data across a network connection or data being stored in a file";
-    homepage = https://excess.org/speedometer/;
-    license = licenses.gpl2;
+    homepage = http://excess.org/speedometer/;
+    license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ Baughn ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13083,6 +13083,8 @@ with pkgs;
 
   smem = callPackage ../os-specific/linux/smem { };
 
+  speedometer = callPackage ../os-specific/linux/speedometer { };
+
   statifier = callPackage ../os-specific/linux/statifier { };
 
   inherit (callPackage ../os-specific/linux/spl {


### PR DESCRIPTION
###### Motivation for this change

Adds a useful bandwidth monitoring CLI tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

