### PR TITLE
librepcb-unstable: init at 2017-12-29

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -389,6 +389,7 @@
   lufia = "Kyohei Kadota <lufia@lufia.org>";
   luispedro = "Luis Pedro Coelho <luis@luispedro.org>";
   lukego = "Luke Gorrie <luke@snabb.co>";
+  luz = "Luz <luz666@daum.net>";
   lw = "Sergey Sofeychuk <lw@fmap.me>";
   lyt = "Tim Liou <wheatdoge@gmail.com>";
   m3tti = "Mathaeus Sander <mathaeus.peter.sander@gmail.com>";

--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qtbase ];
 
+	# LibrePCB still supports QT below 5.9. But some code lines break the build, so they are removed by this patch so that the software builds.
   patches = [ ./fix-2017-12.patch ];
 
   qmakeFlags = ["-r"];

--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -1,29 +1,32 @@
-{ stdenv, fetchgit, qtbase, qttools, qmake, mesa, openssl, zlib }:
+{ stdenv, fetchFromGitHub, qtbase, qttools, qmake, mesa, openssl, zlib }:
 
 stdenv.mkDerivation rec {
-	name = "librepcb-unstable";
-	version = "2017-12-29";
-	src = fetchgit {
-		url = "git://github.com/LibrePCB/LibrePCB";
-		rev = "4efb06fa42755abc5e606da4669cc17e8de2f8c6";
-		sha256 = "0r33fm1djqpy0dzvnf5gv2dfh5nj2acaxb7w4cn8yxdgrazjf7ak";
-	};
+  name = "librepcb-${version}";
+  version = "2017-12-29";
 
-	enableParallelBuilding=true;
+  src = fetchFromGitHub {
+    owner = "LibrePCB";
+    repo = "LibrePCB";
+    fetchSubmodules = true;
+    rev = "4efb06fa42755abc5e606da4669cc17e8de2f8c6";
+    sha256 = "0r33fm1djqpy0dzvnf5gv2dfh5nj2acaxb7w4cn8yxdgrazjf7ak";
+  };
 
-	nativeBuildInputs = [ qmake qttools qtbase ];
+  enableParallelBuilding = true;
 
-	patches = [ ./fix-2017-12.patch ];
+  nativeBuildInputs = [ qmake qttools ];
 
-	#recursive qmake building is required -> therefore this line is required (qmake -r)
-	preBuild = "mkdir build && cd build && qmake -r ../librepcb.pro PREFIX=$out QMAKE_LRELEASE=${stdenv.lib.getDev qttools.dev}/bin/lrelease";
+  buildInputs = [ qtbase ];
 
-	meta = with stdenv.lib; {
-		description = "A free EDA software to develop printed circuit boards";
-		homepage = http://librepcb.org/;
-		maintainers = with maintainers; [ luz ];
-		license = licenses.gpl3;
-		platforms = platforms.linux;
-	};
+  patches = [ ./fix-2017-12.patch ];
+
+  qmakeFlags = ["-r"];
+
+  meta = with stdenv.lib; {
+    description = "A free EDA software to develop printed circuit boards";
+    homepage = http://librepcb.org/;
+    maintainers = with maintainers; [ luz ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
 }
-

--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "librepcb-${version}";
-  version = "2017-12-29";
+  version = "20171229";
 
   src = fetchFromGitHub {
     owner = "LibrePCB";

--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, qtbase, qttools, qmake, mesa, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+	name = "librepcb-unstable";
+	version = "2017-12-29";
+	src = fetchgit {
+		url = "git://github.com/LibrePCB/LibrePCB";
+		rev = "4efb06fa42755abc5e606da4669cc17e8de2f8c6";
+		sha256 = "0r33fm1djqpy0dzvnf5gv2dfh5nj2acaxb7w4cn8yxdgrazjf7ak";
+	};
+
+	enableParallelBuilding=true;
+
+	nativeBuildInputs = [ qmake qttools qtbase ];
+
+	patches = [ ./fix-2017-12.patch ];
+
+	#recursive qmake building is required -> therefore this line is required (qmake -r)
+	preBuild = "mkdir build && cd build && qmake -r ../librepcb.pro PREFIX=$out QMAKE_LRELEASE=${stdenv.lib.getDev qttools.dev}/bin/lrelease";
+
+	meta = with stdenv.lib; {
+		description = "A free EDA software to develop printed circuit boards";
+		homepage = http://librepcb.org/;
+		maintainers = with maintainers; [ luz ];
+		license = licenses.gpl3;
+		platforms = platforms.linux;
+	};
+}
+

--- a/pkgs/applications/science/electronics/librepcb/fix-2017-12.patch
+++ b/pkgs/applications/science/electronics/librepcb/fix-2017-12.patch
@@ -1,0 +1,29 @@
+--- a/libs/librepcb/common/fileio/serializableobjectlist.h
++++ b/libs/librepcb/common/fileio/serializableobjectlist.h
+@@ -374,26 +374,6 @@
+ } // namespace librepcb
+
+ /*****************************************************************************************
+- * Prevent from using SerializableObjectList in a foreach loop because it always would
+- * create a deep copy of the list! You should use C++11 range based for loops instead.
+- ****************************************************************************************/
+-
+-#if (QT_VERSION > QT_VERSION_CHECK(5, 9, 0))
+-#define QFOREACHCONTAINER_TEMPLATE QtPrivate::QForeachContainer
+-#else
+-#define QFOREACHCONTAINER_TEMPLATE QForeachContainer
+-#endif
+-
+-template <typename T, typename P>
+-class QFOREACHCONTAINER_TEMPLATE<librepcb::SerializableObjectList<T, P>> { public:
+-    ~QForeachContainer() = delete;
+-};
+-template <typename T, typename P>
+-class QFOREACHCONTAINER_TEMPLATE<const librepcb::SerializableObjectList<T, P>> { public:
+-    ~QForeachContainer() = delete;
+-};
+-
+-/*****************************************************************************************
+  *  End of File
+  ****************************************************************************************/
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19155,6 +19155,8 @@ with pkgs;
     boost = boost160;
   };
 
+  librepcb = libsForQt5.callPackage ../applications/science/electronics/librepcb { };
+
   ngspice = callPackage ../applications/science/electronics/ngspice { };
 
   pcb = callPackage ../applications/science/electronics/pcb { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

