### PR TITLE
meson: add ninja to propagatedNativeBuildInputs

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages }:
+{ lib, python3Packages, ninja }:
 python3Packages.buildPythonApplication rec {
   version = "0.44.0";
   pname = "meson";
@@ -32,6 +32,8 @@ python3Packages.buildPythonApplication rec {
   '';
 
   setupHook = ./setup-hook.sh;
+
+  propagatedNativeBuildInputs = [ ninja ];
 
   meta = with lib; {
     homepage = http://mesonbuild.com;


### PR DESCRIPTION
###### Motivation for this change
This increases the degree to which meson builds in nixpkgs Just Work. By propagating `ninja` through by default, we avoid every downstream package needing to explicitly include it. The addition of `mesonCheckPhase` further allows `doCheck = true;` alone to run any test suites meson is aware of.

This is the first time I've touched a setup hook, so careful review is very welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

