### PR TITLE
dbeaver: inits at 4.3.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -588,6 +588,7 @@
   rzetterberg = "Richard Zetterberg <richard.zetterberg@gmail.com>";
   s1lvester = "Markus Silvester <s1lvester@bockhacker.me>";
   samdroid-apps = "Sam Parkinson <sam@sam.today>";
+  samueldr = "Samuel Dionne-Riel <samuel@dionne-riel.com>";
   samuelrivas = "Samuel Rivas <samuelrivas@gmail.com>";
   sander = "Sander van der Burg <s.vanderburg@tudelft.nl>";
   sargon = "Daniel Ehlers <danielehlers@mindeye.net>";

--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchurl, makeDesktopItem, makeWrapper
+, fontconfig, freetype, glib, gtk2
+, jdk, libX11, libXrender, libXtst, zlib }:
+
+# The build process is almost like eclipse's.
+# See `pkgs/applications/editors/eclipse/*.nix`
+
+stdenv.mkDerivation rec {
+  name = "dbeaver-ce-${version}";
+  version = "4.3.2";
+
+  desktopItem = makeDesktopItem {
+    name = "dbeaver";
+    exec = "dbeaver";
+    icon = "dbeaver";
+    desktopName = "dbeaver";
+    comment = "SQL Integrated Development Environment";
+    genericName = "SQL Integrated Development Environment";
+    categories = "Application;Development;";
+  };
+
+  buildInputs = [
+    fontconfig freetype glib gtk2
+    jdk libX11 libXrender libXtst zlib
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  src = fetchurl {
+    url = "https://dbeaver.jkiss.org/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
+    sha256 = "0spiwx5dxchpl2qq10rinj9db723w2hf7inqmg4m7fjaj75bpl3s";
+  };
+
+  installPhase = ''
+    mkdir -p $out/
+    cp -r . $out/dbeaver
+
+    # Patch binaries.
+    interpreter=$(cat $NIX_CC/nix-support/dynamic-linker)
+    patchelf --set-interpreter $interpreter $out/dbeaver/dbeaver
+
+    makeWrapper $out/dbeaver/dbeaver $out/bin/dbeaver \
+      --prefix PATH : ${jdk}/bin \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk2 libXtst ])} \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+
+    # Create desktop item.
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+
+    mkdir -p $out/share/pixmaps
+    ln -s $out/dbeaver/icon.xpm $out/share/pixmaps/dbeaver.xpm
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://dbeaver.jkiss.org;
+    description = "Universal SQL Client for developers, DBA and analysts. Supports MySQL, PostgreSQL, MariaDB, SQLite, and more";
+    longDescription = ''
+      Free multi-platform database tool for developers, SQL programmers, database
+      administrators and analysts. Supports all popular databases: MySQL,
+      PostgreSQL, MariaDB, SQLite, Oracle, DB2, SQL Server, Sybase, MS Access,
+      Teradata, Firebird, Derby, etc.
+    '';
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.samueldr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1721,6 +1721,8 @@ with pkgs;
 
   davfs2 = callPackage ../tools/filesystems/davfs2 { };
 
+  dbeaver = callPackage ../applications/misc/dbeaver { };
+
   dbench = callPackage ../development/tools/misc/dbench { };
 
   dclxvi = callPackage ../development/libraries/dclxvi { };


### PR DESCRIPTION
###### Motivation for this change

Adds `dbeaver-ce` to nixpkgs.

###### Details to be checked

The attribute name chosen is `dbeaver`, even though dbeaver comes in two variations, CE and EE. I didn't know whether I should have picked dbeaverCE even though EE isn't packaged (yet?). I personally am not going to package EE, as I am not using it.

The build process uses a "built" release, just like eclipse does. In fact, this is pretty much copied from eclipse's build process, since dbeaver is built on the tooling eclipse is made from.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

