### PR TITLE
android-studio: set `ANDROID_EMULATOR_USE_SYSTEM_LIBS`

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -34,7 +34,7 @@
 
 let
   androidStudio = stdenv.mkDerivation {
-    name = "${pname}";
+    name = "${pname}-${version}";
 
     src = fetchurl {
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
@@ -48,6 +48,7 @@ let
     installPhase = ''
       cp -r . $out
       wrapProgram $out/bin/studio.sh \
+        --set ANDROID_EMULATOR_USE_SYSTEM_LIBS 1 \
         --set PATH "${stdenv.lib.makeBinPath [
 
           # Checked in studio.sh
@@ -68,7 +69,6 @@ let
 
           # Runtime stuff
           git
-
         ]}" \
         --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
 


### PR DESCRIPTION
###### Motivation for this change

This change sets an environment variable to ensure that Android Studio
uses the correct drivers to avoid any breackage when trying to run a
native application on a virtual device.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

