### PR TITLE
stdenv: Kill off ensureDir

### DIFF
--- a/pkgs/development/interpreters/erlang/R16B02-basho.nix
+++ b/pkgs/development/interpreters/erlang/R16B02-basho.nix
@@ -36,7 +36,7 @@ mkDerivation rec {
     tar xf "${manpages}" -C "$out/lib/erlang"
     for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
       prefix="''${i%/*}"
-      ensureDir "$out/share/man/''${prefix##*/}"
+      mkdir -p "$out/share/man/''${prefix##*/}"
       ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
     done
   '';

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -546,7 +546,7 @@ in
           "--with-sha1=CommonCrypto"
         ];
         preConfigure = ''
-          ensureDir $out/Applications
+          mkdir -p $out/Applications
           export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-error"
           substituteInPlace hw/xquartz/pbproxy/Makefile.in --replace -F/System -F${args.apple_sdk.frameworks.ApplicationServices}
         '';

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -188,16 +188,6 @@ addToSearchPath() {
     addToSearchPathWithCustomDelimiter "${PATH_DELIMITER}" "$@"
 }
 
-
-ensureDir() {
-    echo "warning: ‘ensureDir’ is deprecated; use ‘mkdir’ instead" >&2
-    local dir
-    for dir in "$@"; do
-        if ! [ -x "$dir" ]; then mkdir -p "$dir"; fi
-    done
-}
-
-
 # Add $1/lib* into rpaths.
 # The function is used in multiple-outputs.sh hook,
 # so it is defined here but tried after the hook.

--- a/pkgs/tools/networking/bud/default.nix
+++ b/pkgs/tools/networking/bud/default.nix
@@ -14,14 +14,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     python gyp
   ] ++ lib.optional stdenv.isLinux utillinux;
- 
+
   buildPhase = ''
     python ./gyp_bud -f make
     make -C out
   '';
 
   installPhase = ''
-    ensureDir $out/bin
+    mkdir -p $out/bin
     cp out/Release/bud $out/bin
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Spotted this old relic and decided to kill it off

Ran a `nox-review wip` before removing the lines from `pkgs/stdenv/generic/setup.sh` and it succeded.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

