### PR TITLE
linux_testing: 4.15-rc4 -> 4.15-rc7

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,13 +1,13 @@
 { stdenv, hostPlatform, fetchurl, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.15-rc4";
-  modDirVersion = "4.15.0-rc4";
+  version = "4.15-rc7";
+  modDirVersion = "4.15.0-rc7";
   extraMeta.branch = "4.15";
 
   src = fetchurl {
     url = "https://git.kernel.org/torvalds/t/linux-${version}.tar.gz";
-    sha256 = "13mz21pdqk17hrwga9246cj9bkcz3xmmg0cb4mrbsrb1nv4niv0k";
+    sha256 = "1ph3asz5cc82mj7vb5cd5n80wnf66cm9jrlpa66da8kz8za0cdkh";
   };
 
   # Should the testing kernels ever be built on Hydra?


### PR DESCRIPTION
###### Motivation for this change

This should have the recent cpu side-channel mitigations, so I thought it was a good time to upgrade.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

