### PR TITLE
[RDY] neovim: init wrapper

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,16 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, gettext, libmsgpack, libtermkey
 , libtool, libuv, luaPackages, ncurses, perl, pkgconfig
-, unibilium, makeWrapper, vimUtils, xsel, gperf, callPackage
-
-, withPython ? true, pythonPackages, extraPythonPackages ? []
-, withPython3 ? true, python3Packages, extraPython3Packages ? []
+, unibilium, vimUtils, xsel, gperf, callPackage
 , withJemalloc ? true, jemalloc
-, withRuby ? true, bundlerEnv, ruby
-
-, withPyGUI ? false
-, vimAlias ? false
-, viAlias ? false
-, configure ? null
 }:
 
 with stdenv.lib;
@@ -46,47 +37,8 @@ let
     };
   };
 
-  rubyEnv = bundlerEnv {
-    name = "neovim-ruby-env";
-    gemdir = ./ruby_provider;
-    postBuild = ''
-      ln -s ${ruby}/bin/* $out/bin
-    '';
-  };
-  rubyWrapper = ''--cmd \"let g:ruby_host_prog='$out/bin/nvim-ruby'\" '';
-
-  pluginPythonPackages = if configure == null then [] else builtins.concatLists
-    (map ({ pythonDependencies ? [], ...}: pythonDependencies)
-         (vimUtils.requiredPlugins configure));
-  pythonEnv = pythonPackages.python.buildEnv.override {
-    extraLibs = (
-        if withPyGUI
-          then [ pythonPackages.neovim_gui ]
-          else [ pythonPackages.neovim ]
-      ) ++ extraPythonPackages ++ pluginPythonPackages;
-    ignoreCollisions = true;
-  };
-  pythonWrapper = ''--cmd \"let g:python_host_prog='$out/bin/nvim-python'\" '';
-
-  pluginPython3Packages = if configure == null then [] else builtins.concatLists
-    (map ({ python3Dependencies ? [], ...}: python3Dependencies)
-         (vimUtils.requiredPlugins configure));
-  python3Env = python3Packages.python.buildEnv.override {
-    extraLibs = [ python3Packages.neovim ] ++ extraPython3Packages ++ pluginPython3Packages;
-    ignoreCollisions = true;
-  };
-  python3Wrapper = ''--cmd \"let g:python3_host_prog='$out/bin/nvim-python3'\" '';
-
-  additionalFlags =
-    optionalString (withPython || withPython3 || withRuby)
-      ''--add-flags "${(optionalString withPython pythonWrapper) +
-                       (optionalString withPython3 python3Wrapper) +
-                       (optionalString withRuby rubyWrapper)}" --unset PYTHONPATH '' +
-    optionalString (withRuby)
-      ''--suffix PATH : ${rubyEnv}/bin --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath} '';
-
   neovim = stdenv.mkDerivation rec {
-    name = "neovim-${version}";
+    name = "neovim-unwrapped-${version}";
     version = "0.2.1";
 
     src = fetchFromGitHub {
@@ -113,7 +65,6 @@ let
     nativeBuildInputs = [
       cmake
       gettext
-      makeWrapper
       pkgconfig
     ];
 
@@ -140,17 +91,6 @@ let
       install_name_tool -change libjemalloc.1.dylib \
                 ${jemalloc}/lib/libjemalloc.1.dylib \
                 $out/bin/nvim
-    '' + optionalString withPython ''
-      ln -s ${pythonEnv}/bin/python $out/bin/nvim-python
-    '' + optionalString withPython3 ''
-      ln -s ${python3Env}/bin/python3 $out/bin/nvim-python3
-    '' + optionalString withPython3 ''
-      ln -s ${rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
-    '' + optionalString withPyGUI ''
-      makeWrapper "${pythonEnv}/bin/pynvim" "$out/bin/pynvim" \
-        --prefix PATH : "$out/bin"
-    '' + optionalString (withPython || withPython3 || withRuby) ''
-      wrapProgram $out/bin/nvim ${additionalFlags}
     '';
 
     meta = {
@@ -175,24 +115,5 @@ let
     };
   };
 
-in if (vimAlias == false && viAlias == false && configure == null)
-      then neovim
-      else stdenv.mkDerivation {
-  name = "neovim-${neovim.version}-configured";
-  inherit (neovim) version meta;
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  buildCommand = ''
-    mkdir -p $out/bin
-    for item in ${neovim}/bin/*; do
-      ln -s $item $out/bin/
-    done
-  '' + optionalString vimAlias ''
-    ln -s $out/bin/nvim $out/bin/vim
-  '' + optionalString viAlias ''
-    ln -s $out/bin/nvim $out/bin/vi
-  '' + optionalString (configure != null) ''
-    wrapProgram $out/bin/nvim --add-flags "-u ${vimUtils.vimrcFile configure}"
-  '';
-}
+in
+  neovim

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -1,0 +1,109 @@
+{ stdenv, lib, makeDesktopItem, makeWrapper, lndir
+, vimUtils
+, neovim
+, bundlerEnv, ruby
+, pythonPackages
+, python3Packages
+}:
+with stdenv.lib;
+
+neovim:
+
+let
+  wrapper = {
+    name ? "neovim"
+    , withPython ? true,  extraPythonPackages ? []
+    , withPython3 ? true,  extraPython3Packages ? []
+    , withRuby ? true
+    , withPyGUI ? false
+    , vimAlias ? false
+    , viAlias ? false
+    , configure ? null
+  }:
+  let
+
+  rubyEnv = bundlerEnv {
+    name = "neovim-ruby-env";
+    gemdir = ./ruby_provider;
+    postBuild = ''
+      ln -s ${ruby}/bin/* $out/bin
+    '';
+  };
+
+  pluginPythonPackages = if configure == null then [] else builtins.concatLists
+    (map ({ pythonDependencies ? [], ...}: pythonDependencies)
+         (vimUtils.requiredPlugins configure));
+  pythonEnv = pythonPackages.python.buildEnv.override {
+    extraLibs = (
+        if withPyGUI
+          then [ pythonPackages.neovim_gui ]
+          else [ pythonPackages.neovim ]
+      ) ++ extraPythonPackages ++ pluginPythonPackages;
+    ignoreCollisions = true;
+  };
+
+  pluginPython3Packages = if configure == null then [] else builtins.concatLists
+    (map ({ python3Dependencies ? [], ...}: python3Dependencies)
+         (vimUtils.requiredPlugins configure));
+  python3Env = python3Packages.python.buildEnv.override {
+    extraLibs = [ python3Packages.neovim ] ++ extraPython3Packages ++ pluginPython3Packages;
+    ignoreCollisions = true;
+  };
+
+  in
+  stdenv.mkDerivation {
+      inherit name;
+      buildCommand = let bin="${neovim}/bin/nvim"; in ''
+        if [ ! -x "${bin}" ]
+        then
+            echo "cannot find executable file \`${bin}'"
+            exit 1
+        fi
+
+        makeWrapper "$(readlink -v --canonicalize-existing "${bin}")" \
+          "$out/bin/nvim" --add-flags " \
+        --cmd \"${if withPython then "let g:python_host_prog='$out/bin/nvim-python'" else "let g:loaded_python_provider = 1"}\" \
+        --cmd \"${if withPython3 then "let g:python3_host_prog='$out/bin/nvim-python3'" else "let g:loaded_python3_provider = 1"}\" \
+        --cmd \"${if withRuby then "let g:ruby_host_prog='$out/bin/nvim-ruby'" else "let g:loaded_ruby_provider=1"}\" " \
+        --unset PYTHONPATH \
+         ${optionalString withRuby '' --suffix PATH : ${rubyEnv}/bin --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
+
+        # copy and patch the original neovim.destkop file
+        mkdir -p $out/share/applications
+        substitute ${neovim}/share/applications/nvim.desktop $out/share/applications/nvim.desktop \
+          --replace 'TryExec=nvim' "TryExec=$out/bin/nvim" \
+          --replace 'Name=Neovim' 'Name=WrappedNeovim'
+      ''
+      + optionalString withPython ''
+      ln -s ${pythonEnv}/bin/python $out/bin/nvim-python
+    '' + optionalString withPython3 ''
+      ln -s ${python3Env}/bin/python3 $out/bin/nvim-python3
+    '' + optionalString withRuby ''
+      ln -s ${rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
+    ''
+      + optionalString withPyGUI ''
+      makeWrapper "${pythonEnv}/bin/pynvim" "$out/bin/pynvim" \
+        --prefix PATH : "$out/bin"
+    '' + optionalString vimAlias ''
+      ln -s $out/bin/nvim $out/bin/vim
+    '' + optionalString viAlias ''
+      ln -s $out/bin/nvim $out/bin/vi
+    '' + optionalString (configure != null) ''
+    wrapProgram $out/bin/nvim --add-flags "-u ${vimUtils.vimrcFile configure}"
+    ''
+    ;
+
+    preferLocalBuild = true;
+
+    buildInputs = [makeWrapper];
+    passthru = { unwrapped = neovim; };
+
+    meta = neovim.meta // {
+      description = neovim.meta.description;
+      hydraPlatforms = [];
+      # prefer wrapper over the package
+      priority = (neovim.meta.priority or 0) - 1;
+    };
+  };
+in
+  lib.makeOverridable wrapper

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17357,9 +17357,13 @@ with pkgs;
 
   vimpc = callPackage ../applications/audio/vimpc { };
 
-  neovim = callPackage ../applications/editors/neovim {
+  wrapNeovim = callPackage ../applications/editors/neovim/wrapper.nix { };
+
+  neovim-unwrapped = callPackage ../applications/editors/neovim {
     luaPackages = luajitPackages;
   };
+
+  neovim = wrapNeovim neovim-unwrapped { };
 
   neovim-qt = libsForQt5.callPackage ../applications/editors/neovim/qt.nix { };
 


### PR DESCRIPTION
I accidentally deleted the branch on https://github.com/NixOS/nixpkgs/pull/32657 so I reopen the PR.

###### Motivation for this change
Adding a python/ruby package to the neovim environment should not trigger a neovim recompilation.
This adds a wrapper to prevent that.

###### Things done
This moves the neovim configuration (python packages/ ruby etc) to a wrapper.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---