### PR TITLE
Added JDK dependency to libguestfs

### DIFF
--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -2,7 +2,10 @@
 , ncurses, cpio, gperf, perl, cdrkit, flex, bison, qemu, pcre, augeas, libxml2
 , acl, libcap, libcap_ng, libconfig, systemd, fuse, yajl, libvirt, hivex
 , gmp, readline, file, libintlperl, GetoptLong, SysVirt, numactl, xen, libapparmor
-, getopt, perlPackages, ocamlPackages, jdk }:
+, getopt, perlPackages, ocamlPackages
+, javaSupport ? false, jdk ? null }:
+
+assert javaSupport -> jdk != null;
 
 stdenv.mkDerivation rec {
   name = "libguestfs-${version}";
@@ -24,8 +27,8 @@ stdenv.mkDerivation rec {
     cdrkit flex bison qemu pcre augeas libxml2 acl libcap libcap_ng libconfig
     systemd fuse yajl libvirt gmp readline file hivex libintlperl GetoptLong
     SysVirt numactl xen libapparmor getopt perlPackages.ModuleBuild
-    jdk
-  ] ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml_libvirt ocaml_gettext ounit ]);
+  ] ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml_libvirt ocaml_gettext ounit ])
+    ++ stdenv.lib.optional javaSupport jdk;
 
   prePatch = ''
     # build-time scripts
@@ -41,7 +44,8 @@ stdenv.mkDerivation rec {
     # some scripts hardcore /usr/bin/env which is not available in the build env
     patchShebangs .
   '';
-  configureFlags = "--disable-appliance --disable-daemon";
+  configureFlags = [ "--disable-appliance" "--disable-daemon" ]
+    ++ stdenv.lib.optionals (!javaSupport) [ "--disable-java" "--without-java" ];
   patches = [ ./libguestfs-syms.patch ];
   NIX_CFLAGS_COMPILE="-I${libxml2.dev}/include/libxml2/";
   installFlags = "REALLY_INSTALL=yes";

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -2,7 +2,7 @@
 , ncurses, cpio, gperf, perl, cdrkit, flex, bison, qemu, pcre, augeas, libxml2
 , acl, libcap, libcap_ng, libconfig, systemd, fuse, yajl, libvirt, hivex
 , gmp, readline, file, libintlperl, GetoptLong, SysVirt, numactl, xen, libapparmor
-, getopt, perlPackages, ocamlPackages }:
+, getopt, perlPackages, ocamlPackages, jdk }:
 
 stdenv.mkDerivation rec {
   name = "libguestfs-${version}";
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     cdrkit flex bison qemu pcre augeas libxml2 acl libcap libcap_ng libconfig
     systemd fuse yajl libvirt gmp readline file hivex libintlperl GetoptLong
     SysVirt numactl xen libapparmor getopt perlPackages.ModuleBuild
+    jdk
   ] ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml_libvirt ocaml_gettext ounit ]);
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

The current libguestfs package doesn't build, unless you patch it to either include the JDK dependency, or to disable the Java bindings.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Ideally the language bindings should probably be managed by flags, so that they can be enabled/disabled per language, but at least this gets the package buildable.
  