### PR TITLE
flashplayer: 28.0.0.126 -> 28.0.0.137

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -94,12 +94,12 @@ let
 
   flash = stdenv.mkDerivation rec {
     name = "flashplayer-ppapi-${version}";
-    version = "28.0.0.126";
+    version = "28.0.0.137";
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/"
           + "${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 = "10q005jp5vcfqx35jzwp138djv9g7jp83jqbyism40k67ah33i1z";
+      sha256 = "1776jjv2abzrwhgff8c75wm9dh3gfsihv9c5vzllhdys21zvravy";
       stripRoot = false;
     };
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -73,7 +73,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "28.0.0.126";
+  version = "28.0.0.137";
 
   src = fetchurl {
     url =
@@ -84,14 +84,14 @@ stdenv.mkDerivation rec {
     sha256 =
       if debug then
         if arch == "x86_64" then
-          "16ivf0j7kr7hak2pxs4mbhw5g0i8ky72mvdkaxpfq42g4mr7qf62"
+          "1hj3sfrspdkhq967fmnpgamgiq90k263cqfas94gp3dzslmkingw"
         else
-          "09dn1zr5bcfvkb46z86p7gr2g9p0a3nj9vvw1qw2fblvbajmznk0"
+          "1v4k6hzngm23xwxnh6ngplp2m0ga480sbcm668bpcj61krmi6xy4"
       else
         if arch == "x86_64" then
-          "0z5p3zimvx8zas649gn2nzp4gfvwc69hklza3d2hpmzb35ckfqbc"
+          "0ijmrk6262a1xcf98g94vdlqxnik9f7igjy08j3a2i4b5bikq479"
         else
-          "0kyyjqim7qq0am2hr9ldcbm4sx8dsbgf3916km9gbgg8vjddgxwy";
+          "10a17dba4zy29padvi3fnv2s8v71q698ffqjp8ggsla42pjyhvkh";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -55,7 +55,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-standalone-${version}";
-  version = "28.0.0.126";
+  version = "28.0.0.137";
 
   src = fetchurl {
     url =
@@ -65,9 +65,9 @@ stdenv.mkDerivation rec {
         "https://fpdownload.macromedia.com/pub/flashplayer/updaters/28/flash_player_sa_linux.x86_64.tar.gz";
     sha256 =
       if debug then
-        "07692qivf09zh36vlaczwwq93f8p7v1afnsgkry7m9yybxh1753d"
+        "0xr3hf828sm0xdnmk2kavxmvzc6m0mw369khrxyfwrbxvdsibwn8"
       else
-        "14xj55wjp9jvm01n8bwrbwmkhpcrxc44yfqi3jq8f8pzrqi7smck";
+        "1wr0avjpshrj51svb1sfnshz39xxla1brqs8pbcgfgyqjh350rgn";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

The release notes are not updated yet.

https://helpx.adobe.com/flash-player/release-note/fp_28_air_28_release_notes.html
https://helpx.adobe.com/security.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- Built packages
  - `nix-env -i -f . -A pkgs.flashplayer`
  - `nix-build -I nixpkgs=. -A pkgsi686Linux.flashplayer`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).pkgsi686Linux.flashplayer.override { debug = true; }"`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone`
  - `nix-build -I nixpkgs=. -A pkgs.flashplayer-standalone-debugger`
  - `nix-build -I nixpkgs=. -E "(import <nixpkgs> {}).chromium.override { enablePepperFlash = true; }"`
- Played a video with Firefox and Chromium.
- Checked the version with Firefox, Chromium,  flashplayer-standalone, and flashplayer-standalone-debugger (x86_64) http://www.adobe.com/software/flash/about/

---

