### PR TITLE
schedulingPriority should be an int, fix check-meta type and in-tree use

### DIFF
--- a/pkgs/build-support/release/source-tarball.nix
+++ b/pkgs/build-support/release/source-tarball.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation (
 
       # Tarball builds are generally important, so give them a high
       # default priority.
-      schedulingPriority = "200";
+      schedulingPriority = 200;
     };
   }
 

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -162,7 +162,7 @@ let
     position = str;
     repositories = attrsOf str;
     isBuildPythonPackage = platforms;
-    schedulingPriority = str;
+    schedulingPriority = int;
     downloadURLRegexp = str;
     isFcitxEngine = bool;
     isIbusEngine = bool;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nix/pull/1786

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

