### PR TITLE
whois: use idn, libiconv; update

### DIFF
--- a/pkgs/tools/networking/whois/default.nix
+++ b/pkgs/tools/networking/whois/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, gettext, pkgconfig, libidn2 }:
+{ stdenv, fetchFromGitHub, perl, gettext, pkgconfig, libidn2, libiconv }:
 
 stdenv.mkDerivation rec {
   version = "5.2.20";
@@ -12,17 +12,20 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ perl gettext pkgconfig ];
-  buildInputs = [ libidn2 ];
+  buildInputs = [ libidn2 libiconv ];
 
   preConfigure = ''
     for i in Makefile po/Makefile; do
       substituteInPlace $i --replace "prefix = /usr" "prefix = $out"
     done
+
+    substituteInPlace Makefile --replace "DEFS += HAVE_ICONV" "DEFS += HAVE_ICONV\nwhois_LDADD += -liconv"
   '';
 
-  buildPhase = "make whois";
+  makeFlags = [ "HAVE_ICONV=1" ];
+  buildFlags = [ "whois" ];
 
-  installPhase = "make install-whois";
+  installTargets = [ "install-whois" ];
 
   meta = with stdenv.lib; {
     description = "Intelligent WHOIS client from Debian";

--- a/pkgs/tools/networking/whois/default.nix
+++ b/pkgs/tools/networking/whois/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, gettext }:
+{ stdenv, fetchFromGitHub, perl, gettext, pkgconfig, libidn2 }:
 
 stdenv.mkDerivation rec {
   version = "5.2.20";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1aamasivfnghr9my1j6c1rf0dfal45axjcjf3mpv0g942bkxqp5b";
   };
 
-  buildInputs = [ perl gettext ];
+  nativeBuildInputs = [ perl gettext pkgconfig ];
+  buildInputs = [ libidn2 ];
 
   preConfigure = ''
     for i in Makefile po/Makefile; do

--- a/pkgs/tools/networking/whois/default.nix
+++ b/pkgs/tools/networking/whois/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, perl, gettext }:
 
 stdenv.mkDerivation rec {
-  version = "5.2.18";
+  version = "5.2.20";
   name = "whois-${version}";
 
   src = fetchFromGitHub {
     owner = "rfc1036";
     repo = "whois";
     rev = "v${version}";
-    sha256 = "0jzyq1rj6balc6a28swzgspv55xhkc75dw6wsn159in4ap61bzmi";
+    sha256 = "1aamasivfnghr9my1j6c1rf0dfal45axjcjf3mpv0g942bkxqp5b";
   };
 
   buildInputs = [ perl gettext ];


### PR DESCRIPTION
###### Motivation for this change

Support "international" domains, and update to latest while at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

