### PR TITLE
libvncserver: reduce dependencies; only use systemd on linux

### DIFF
--- a/pkgs/development/libraries/libvncserver/default.nix
+++ b/pkgs/development/libraries/libvncserver/default.nix
@@ -1,11 +1,7 @@
 {stdenv, fetchurl,
-  libtool, libjpeg, openssl, libX11, libXdamage, xproto, damageproto, 
-  xextproto, libXext, fixesproto, libXfixes, xineramaproto, libXinerama, 
-  libXrandr, randrproto, libXtst, zlib, libgcrypt, autoreconfHook
-  , systemd, pkgconfig, libpng
+ libtool, libjpeg, openssl, zlib, libgcrypt, autoreconfHook, pkgconfig, libpng,
+ systemd
 }:
-
-assert stdenv.isLinux;
 
 let
   s = # Generated upstream information
@@ -16,27 +12,25 @@ let
     url="https://github.com/LibVNC/libvncserver/archive/LibVNCServer-${version}.tar.gz";
     sha256="15189n09r1pg2nqrpgxqrcvad89cdcrca9gx6qhm6akjf81n6g8r";
   };
-  buildInputs = [
-    libtool libjpeg openssl libX11 libXdamage xproto damageproto
-    xextproto libXext fixesproto libXfixes xineramaproto libXinerama
-    libXrandr randrproto libXtst zlib libgcrypt autoreconfHook systemd
-    pkgconfig libpng
-  ];
 in
 stdenv.mkDerivation {
   inherit (s) name version;
-  inherit buildInputs;
   src = fetchurl {
     inherit (s) url sha256;
   };
   preConfigure = ''
     sed -e 's@/usr/include/linux@${stdenv.cc.libc}/include/linux@g' -i configure
   '';
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [
+    libtool libjpeg openssl libgcrypt libpng
+  ] ++ stdenv.lib.optional stdenv.isLinux systemd;
+  propagatedBuildInputs = [ zlib ];
   meta = {
     inherit (s) version;
     description =  "VNC server library";
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I wanted to use this library on macOS. While I was removing the linux-specific assertions I noticed a lot of seemingly unused dependencies, and removed them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

