### PR TITLE
ngx_pagespeed, psol: 1.11.33.4 -> 1.13.35.1

### DIFF
--- a/pkgs/development/libraries/psol/default.nix
+++ b/pkgs/development/libraries/psol/default.nix
@@ -1,5 +1,5 @@
 { callPackage }:
 callPackage ./generic.nix {} {
-  version = "1.11.33.4";
-  sha256  = "1jq2llp0i4666rwqnx1hs4pjlpblxivvs1jkkjzlmdbsv28jzjq8";
+  version = "1.13.35.1"; # Latest beta, 2017-11-08
+  sha256  = "126823gpr3rdqakwixmr887rbvwhksr3xg14jnyzlp84q4hg1p0n";
 }

--- a/pkgs/development/libraries/psol/generic.nix
+++ b/pkgs/development/libraries/psol/generic.nix
@@ -3,7 +3,7 @@
 { inherit version; } // fetchzip {
   inherit sha256;
   name   = "psol-${version}";
-  url    = "https://dl.google.com/dl/page-speed/psol/${version}.tar.gz";
+  url    = "https://dl.google.com/dl/page-speed/psol/${version}-x64.tar.gz";
 
   meta = {
     description = "PageSpeed Optimization Libraries";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -153,7 +153,7 @@
         owner  = "pagespeed";
         repo   = "ngx_pagespeed";
         rev    = "v${version}-beta";
-        sha256 = "03dvzf1lgsjxcs1jjxq95n2rhgq0wy0f9ahvgascy0fak7qx4xj9";
+        sha256 = "176skx7zmi7islc1hmdxcynix4lkvgmr78lknn13s9gskc7qi25w";
       };
 
       ngx_pagespeed = pkgs.runCommand
@@ -172,6 +172,7 @@
         '';
     in {
       src = ngx_pagespeed;
+      inputs = [ pkgs.zlib pkgs.libuuid ]; # psol deps
     };
 
     shibboleth = {


### PR DESCRIPTION
Fixes build when used with nginxMainline.

(FWIW, 1.11.33.4 is from 2016-09-15)

###### Motivation for this change

Fix ngx_pagespeed when used with nginxMainline.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @3noch 

I haven't tested this on an actual server yet, just ran into the build failure and thought I'd fix it.
Looks like enabling requires non-trivial (and possibly Nix-unfriendly) configuration, don't think I'll be using it in the near future.