### PR TITLE
libvorbis: Fix CVE-2017-14160, CVE-2017-14632 & CVE-2017-14633

### DIFF
--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libogg, pkgconfig }:
+{ stdenv, fetchurl, libogg, pkgconfig, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "libvorbis-1.3.5";
@@ -10,6 +10,23 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "doc" ];
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/xiph/vorbis/commit/a79ec216cd119069c68b8f3542c6a425a74ab993.patch";
+      sha256 = "0xhsa96n3dlh2l85bxpz4b9m78mfxfgi2ibhjp77110a0nvkjr6h";
+      name = "CVE-2017-14633";
+    })
+    (fetchpatch {
+      url = "https://github.com/xiph/vorbis/commit/c1c2831fc7306d5fbd7bc800324efd12b28d327f.patch";
+      sha256 = "17lb86105im6fc0h0cx5sn94p004jsdbbs2vj1m9ll6z9yb4rxwc";
+      name = "CVE-2017-14632";
+    })
+    (fetchpatch {
+      url = "https://gitlab.xiph.org/xiph/vorbis/uploads/a68cf70fa10c8081a633f77b5c6576b7/0001-CVE-2017-14160-make-sure-we-don-t-overflow.patch";
+      sha256 = "0v21p59cb3z77ch1v6q5dcrd733h91f3m8ifnd7kkkr8gzn17d5x";
+      name = "CVE-2017-14160";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ libogg ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested a few applications using libvorbis and ogg works fine in all the tested ones.