### PR TITLE
electron-cash: 3.1.1 -> 3.1.2

### DIFF
--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -7,14 +7,14 @@ let
 in
 
 python3Packages.buildPythonApplication rec {
-  version = "3.1.1";
+  version = "3.1.2";
   name = "electron-cash-${version}";
 
   src = fetchurl {
     url = "https://electroncash.org/downloads/${version}/win-linux/ElectronCash-${version}.tar.gz";
     # Verified using official SHA-1 and signature from
     # https://github.com/fyookball/keys-n-hashes
-    sha256 = "cd42a0a0075787125f195508834d8c34d651896c0986d0b2066763add59bad2b";
+    sha256 = "18h44jfbc2ksj34hdzgszvvq82xi28schl3wp3lkq9fjp7ny0mf3";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
###### Motivation for this change
Apparently 3.1.1 didn't fix the RPC vulnerability. Hopefully this version does.
This should also be backported to older NixOS versions.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (none)
- [x] Tested compilation of all pkgs that depend on this change using (none)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @Lassulus @adisbladis 
