### PR TITLE
python: thespian: 3.9.0 -> 3.9.1

### DIFF
--- a/pkgs/development/python-modules/thespian/default.nix
+++ b/pkgs/development/python-modules/thespian/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchPypi, buildPythonPackage, lib }:
 
 buildPythonPackage rec {
-  version = "3.9.0";
+  version = "3.9.1";
   pname = "thespian";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "e698e3c5369d7b06de5c4ce7b877ea65991c99f7b0fabd09f29e91bc981c7d22";
+    sha256 = "0b303bv85176xd5mf3q5j549s28wi70ck2xxgj1cvpydh23dzipb";
   };
 
-  # Do not run the test suite: it takes a long type and uses
+  # Do not run the test suite: it takes a long time and uses
   # significant system resources, including requiring localhost
-  # network operations.  Thespian tests are performed via it's Travis
+  # network operations.  Thespian tests are performed via its Travis
   # CI configuration and do not need to be duplicated here.
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change

New version of the python thespian package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

