### PR TITLE
discord: fix "corrupt install" warnings, misc cleanup

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     nativeBuildInputs = [ makeWrapper ];
 
     libPath = stdenv.lib.makeLibraryPath [
+        libcxx systemd libpulseaudio
         stdenv.cc.cc alsaLib atk cairo cups dbus expat fontconfig freetype
         gdk_pixbuf glib gnome2.GConf gtk2 libnotify libX11 libXcomposite
         libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
@@ -28,15 +29,12 @@ stdenv.mkDerivation rec {
         mkdir -p $out/{bin,opt/discord,share/pixmaps}
         mv * $out/opt/discord
 
-        # Copying how adobe-reader does it,
-        # see pkgs/applications/misc/adobe-reader/builder.sh
-        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-                 --set-rpath "$out/opt/discord:$libPath"                                   \
+        patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
                  $out/opt/discord/Discord
 
         paxmark m $out/opt/discord/Discord
 
-        wrapProgram $out/opt/discord/Discord --prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH:${libcxx}/lib:${systemd.lib}/lib:${libpulseaudio}/lib"
+        wrapProgram $out/opt/discord/Discord --prefix LD_LIBRARY_PATH : ${libPath}
 
         ln -s $out/opt/discord/Discord $out/bin/
         ln -s $out/opt/discord/discord.png $out/share/pixmaps


### PR DESCRIPTION
Few things:
* Discord binary has RUNPATH not RPATH set
* patchelf uses RUNPATH if it already exits, so deps end up in RUNPATH
* RUNPATH isn't searched for plugins or transitive deps
* ..badness results

Despite this, it currently seems to work-- with the caveat
that it has a little bar on top complaining about how
"it looks like your installation is corrupt".

This fixes that warning and does some minor cleanup.

###### Motivation for this change

(see above)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

