### PR TITLE
lombok: 1.16.8 -> 1.16.20

### DIFF
--- a/pkgs/development/libraries/java/lombok/default.nix
+++ b/pkgs/development/libraries/java/lombok/default.nix
@@ -1,13 +1,18 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "lombok-1.16.8";
+  name = "lombok-1.16.20";
+
   src = fetchurl {
     url = "https://projectlombok.org/downloads/${name}.jar";
-    sha256 = "0s7ak6gx1h04da2rdhvc0fk896cwqm2m7g3chqcjpsrkgfdv4cpy";
+    sha256 = "0v8fq4qlpjh4b87xx35m32y2xpnj4d05xflrgghia6mar8c8n5y5";
   };
-  phases = [ "installPhase" ];
-  installPhase = "mkdir -p $out/share/java; cp $src $out/share/java/lombok.jar";
+
+  buildCommand = ''
+    mkdir -p $out/share/java
+    cp $src $out/share/java/lombok.jar
+  '';
+
   meta = {
     description = "A library that can write a lot of boilerplate for your Java project";
     platforms = stdenv.lib.platforms.all;


### PR DESCRIPTION
###### Motivation for this change

To bump the Lombok package to the latest version.

Maintainer CC: @CrystalGamma

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).