### PR TITLE
stdenv: Fix doCheck and doInstallCheck logic

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -191,10 +191,10 @@ rec {
           outputs = outputs';
         } // lib.optionalAttrs (attrs ? doCheck) {
           # TODO(@Ericson2314): Make unconditional / resolve #33599
-          doCheck = doCheck && (stdenv.hostPlatform == stdenv.targetPlatform);
+          doCheck = doCheck && (stdenv.hostPlatform == stdenv.buildPlatform);
         } // lib.optionalAttrs (attrs ? doInstallCheck) {
           # TODO(@Ericson2314): Make unconditional / resolve #33599
-          doInstallCheck = doInstallCheck && (stdenv.hostPlatform == stdenv.targetPlatform);
+          doInstallCheck = doInstallCheck && (stdenv.hostPlatform == stdenv.buildPlatform);
         });
 
       # The meta attribute is passed in the resulting attribute set,


### PR DESCRIPTION
###### Motivation for this change

It's host != build, not host != target. My mistake in #33603.

###### Things. done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  