### PR TITLE
nixos/jupyter: init service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -232,6 +232,7 @@
   ./services/desktops/profile-sync-daemon.nix
   ./services/desktops/telepathy.nix
   ./services/development/hoogle.nix
+  ./services/development/jupyter/default.nix
   ./services/editors/emacs.nix
   ./services/editors/infinoted.nix
   ./services/games/factorio.nix

--- a/nixos/modules/services/development/jupyter/default.nix
+++ b/nixos/modules/services/development/jupyter/default.nix
@@ -1,0 +1,179 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.jupyter;
+
+
+  kernels = (pkgs.jupyterKernels.create  {
+    kernelDefinitions = if cfg.kernels != null
+      then cfg.kernels
+      else  pkgs.jupyterKernels.defaultKernelDefinition;
+  });
+
+  notebookConfig = pkgs.writeText "jupyter_config.py" ''
+    ${cfg.notebookConfig}
+
+    c.NotebookApp.password = ${cfg.password}
+  '';
+
+in {
+  meta.maintainers = with maintainers; [ aborsu ];
+
+  options.services.jupyter = {
+    enable = mkEnableOption "Jupyter development server";
+
+    ip = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = ''
+        IP address Jupyter will be listening on.
+      '';
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 8888;
+      description = ''
+        Port number Jupyter will be listening on.
+      '';
+    };
+
+    notebookDir = mkOption {
+      type = types.str;
+      default = "~/";
+      description = ''
+        Root directory for notebooks.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "jupyter";
+      description = ''
+        Name of the user used to run the jupyter service.
+        For security reason, jupyter should really not be run as root.
+        If not set (jupyter), the service will create a jupyter user with appropriate settings.
+      '';
+      example = "aborsu";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "jupyter";
+      description = ''
+        Name of the group used to run the jupyter service.
+        Use this if you want to create a group of users that are able to view the notebook directory's content.
+      '';
+      example = "users";
+    };
+
+    password = mkOption {
+      type = types.str;
+      description = ''
+        Password to use with notebook.
+        Can be generated using:
+          In [1]: from notebook.auth import passwd
+          In [2]: passwd('test')
+          Out[2]: 'sha1:1b961dc713fb:88483270a63e57d18d43cf337e629539de1436ba'
+          NOTE: you need to keep the single quote inside the nix string.
+        Or you can use a python oneliner:
+          "open('/path/secret_file', 'r', encoding='utf8').read().strip()"
+        It will be interpreted at the end of the notebookConfig.
+      '';
+      example = [
+        "'sha1:1b961dc713fb:88483270a63e57d18d43cf337e629539de1436ba'"
+        "open('/path/secret_file', 'r', encoding='utf8').read().strip()"
+      ];
+    };
+
+    notebookConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Raw jupyter config.
+      '';
+    };
+
+    kernels = mkOption {
+      type = types.nullOr (types.attrsOf(types.submodule (import ./kernel-options.nix {
+        inherit lib;
+      })));
+
+      default = null;
+      example = literalExample ''
+        {
+          python3 = let
+            env = (pkgs.python3.withPackages (pythonPackages: with pythonPackages; [
+                    ipykernel
+                    pandas
+                    scikitlearn
+                  ]));
+          in {
+            displayName = "Python 3 for machine learning";
+            argv = [
+              "$ {env.interpreter}"
+              "-m"
+              "ipykernel_launcher"
+              "-f"
+              "{connection_file}"
+            ];
+            language = "python";
+            logo32 = "$ {env.sitePackages}/ipykernel/resources/logo-32x32.png";
+            logo64 = "$ {env.sitePackages}/ipykernel/resources/logo-64x64.png";
+          };
+        }
+      '';
+      description = "Declarative kernel config
+
+      Kernels can be declared in any language that supports and has the required
+      dependencies to communicate with a jupyter server.
+      In python's case, it means that ipykernel package must always be included in
+      the list of packages of the targeted environment.
+      ";
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable  {
+      systemd.services.jupyter = {
+        description = "Jupyter development server";
+
+        wantedBy = [ "multi-user.target" ];
+
+        path = [ pkgs.bash ]; # needed for sh in cell magic to work
+
+        environment = {
+          JUPYTER_PATH = toString kernels;
+        };
+
+        serviceConfig = {
+          Restart = "always";
+          ExecStart = ''${pkgs.python3.pkgs.notebook}/bin/jupyter-notebook \
+            --no-browser \
+            --ip=${cfg.ip} \
+            --port=${toString cfg.port} --port-retries 0 \
+            --notebook-dir=${cfg.notebookDir} \
+            --NotebookApp.config_file=${notebookConfig}
+          '';
+          User = cfg.user;
+          Group = cfg.group;
+          WorkingDirectory = "~";
+        };
+      };
+    })
+    (mkIf (cfg.enable && (cfg.group == "jupyter")) {
+      users.groups.jupyter = {};
+    })
+    (mkIf (cfg.enable && (cfg.user == "jupyter")) {
+      users.extraUsers.jupyter = {
+        extraGroups = [ cfg.group ];
+        home = "/var/lib/jupyter";
+        createHome = true;
+        useDefaultShell = true; # needed so that the user can start a terminal.
+      };
+    })
+  ];
+}

--- a/nixos/modules/services/development/jupyter/kernel-options.nix
+++ b/nixos/modules/services/development/jupyter/kernel-options.nix
@@ -1,0 +1,60 @@
+# Options that can be used for creating a jupyter kernel.
+{lib }:
+
+with lib;
+
+{
+  options = {
+
+    displayName = mkOption {
+      type = types.str;
+      default = "";
+      example = [
+        "Python 3"
+        "Python 3 for Data Science"
+      ];
+      description = ''
+        Name that will be shown to the user.
+      '';
+    };
+
+    argv = mkOption {
+      type = types.listOf types.str;
+      example = [
+        "{customEnv}/bin/python"
+        "-m"
+        "ipykernel_launcher"
+        "-f"
+        "{connection_file}"
+      ];
+      description = ''
+        Command and arguments to start the kernel.
+      '';
+    };
+
+    language = mkOption {
+      type = types.str;
+      example = "python";
+      description = ''
+        Language of the environment. Typically the name of the binary.
+      '';
+    };
+
+    logo32 = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "{env}/lib/python3.6/site-packages/ipykernel/resources/logo-32x32.png";
+      description = ''
+        Path to 32x32 logo png.
+      '';
+    };
+    logo64 = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "{env}/lib/python3.6/site-packages/ipykernel/resources/logo-64x64.png";
+      description = ''
+        Path to 64x64 logo png.
+      '';
+    };
+  };
+}

--- a/pkgs/applications/editors/jupyter/default.nix
+++ b/pkgs/applications/editors/jupyter/default.nix
@@ -1,0 +1,16 @@
+{ python3
+, jupyterKernels
+, kernelDefinitions ? jupyterKernels.defaultKernelDefinition
+}:
+
+let
+
+  jupyterPath = (jupyterKernels.create  { kernelDefinitions =  kernelDefinitions; });
+
+in
+
+with python3.pkgs; toPythonModule (
+  notebook.overrideAttrs(oldAttrs: {
+    makeWrapperArgs = ["--set JUPYTER_PATH ${jupyterPath}"];
+  })
+)

--- a/pkgs/development/misc/jupyterKernels/default.nix
+++ b/pkgs/development/misc/jupyterKernels/default.nix
@@ -1,0 +1,76 @@
+{ lib, pkgs, stdenv}:
+
+let
+
+  defaultKernelDefinition = {
+    python3 = let
+      env = (pkgs.python3.withPackages (pythonPackages: with pythonPackages; [
+              ipykernel
+              pandas
+              scikitlearn
+            ]));
+    in {
+      displayName = "Python 3";
+      argv = [
+        "${env.interpreter}"
+        "-m"
+        "ipykernel_launcher"
+        "-f"
+        "{connection_file}"
+      ];
+      language = "python";
+      logo32 = "${env.sitePackages}/ipykernel/resources/logo-32x32.png";
+      logo64 = "${env.sitePackages}/ipykernel/resources/logo-64x64.png";
+    };
+  };
+
+in
+{
+  defaultKernelDefinition = defaultKernelDefinition;
+  create = { kernelDefinitions ?  defaultKernelDefinition }:
+  with lib; stdenv.mkDerivation rec {
+    name = "jupyter-kernels";
+
+    src = "/dev/null";
+
+    unpackCmd ="mkdir jupyter_kernels";
+
+    installPhase =  ''
+        mkdir kernels
+
+        ${concatStringsSep "\n" (mapAttrsToList (kernelName: kernel:
+          let
+            config = builtins.toJSON {
+              display_name = if (kernel.displayName != "")
+                then kernel.displayName
+                else kernelName;
+              argv = kernel.argv;
+              language = kernel.language;
+            };
+            logo32 =
+              if (kernel.logo32 != null)
+              then "ln -s ${kernel.logo32} 'kernels/${kernelName}/logo-32x32.png';"
+              else "";
+            logo64 =
+              if (kernel.logo64 != null)
+              then "ln -s ${kernel.logo64} 'kernels/${kernelName}/logo-64x64.png';"
+              else "";
+          in ''
+            mkdir 'kernels/${kernelName}';
+            echo '${config}' > 'kernels/${kernelName}/kernel.json';
+            ${logo32}
+            ${logo64}
+          '') kernelDefinitions)}
+
+        mkdir $out
+        cp -r kernels $out
+      '';
+
+    meta = {
+      description = "Wrapper to create jupyter notebook kernel definitions";
+      homepage = http://jupyter.org/;
+      # NIXOS license as this is a nixos meta package.
+      maintainers = with maintainers; [ aborsu ];
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3109,6 +3109,8 @@ with pkgs;
 
   jupp = callPackage ../applications/editors/jupp { };
 
+  jupyterKernels = callPackage ../development/misc/jupyterKernels { };
+
   jwhois = callPackage ../tools/networking/jwhois { };
 
   k2pdfopt = callPackage ../applications/misc/k2pdfopt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3109,6 +3109,8 @@ with pkgs;
 
   jupp = callPackage ../applications/editors/jupp { };
 
+  jupyter = callPackage ../applications/editors/jupyter { };
+
   jupyterKernels = callPackage ../development/misc/jupyterKernels { };
 
   jwhois = callPackage ../tools/networking/jwhois { };


### PR DESCRIPTION
###### Motivation for this change
I believe that having a configurable service for jupyter with a template to write new kernels is a wanted feature.
cfr
https://www.reddit.com/r/NixOS/comments/7oujo4/getting_all_the_jupyter_kernels/
https://github.com/NixOS/nixpkgs/issues/10713

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This pull requests brings a jupyter service to nixos.
It contains a default bare python3 kernel and a literal example on how to define multiple kernels.


  