### PR TITLE
platformio: add git, cleanup derivation

### DIFF
--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -1,5 +1,4 @@
 { stdenv, lib, buildFHSUserEnv
-, platformio
 }:
 let
   pio-pkgs = pkgs: (with pkgs;

--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -1,26 +1,20 @@
 { lib, buildFHSUserEnv, platformio, stdenv }:
-
+let
+  pio-pkgs = pkgs: (with pkgs;
+    [
+      python27Packages.python
+      python27Packages.setuptools
+      python27Packages.pip
+      python27Packages.bottle
+      python27Packages.platformio
+      zlib
+    ]);
+in
 buildFHSUserEnv {
   name = "platformio";
 
-  targetPkgs = pkgs: (with pkgs;
-    [
-      python27Packages.python
-      python27Packages.setuptools
-      python27Packages.pip
-      python27Packages.bottle
-      python27Packages.platformio
-      zlib
-    ]);
-  multiPkgs = pkgs: (with pkgs;
-    [
-      python27Packages.python
-      python27Packages.setuptools
-      python27Packages.pip
-      python27Packages.bottle
-      python27Packages.platformio
-      zlib
-    ]);
+  targetPkgs = pio-pkgs;
+  multiPkgs = pio-pkgs;
 
   meta = with stdenv.lib; {
     description = "An open source ecosystem for IoT development";

--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -1,4 +1,6 @@
-{ lib, buildFHSUserEnv, platformio, stdenv }:
+{ stdenv, lib, buildFHSUserEnv
+, platformio
+}:
 let
   pio-pkgs = pkgs: (with pkgs;
     [

--- a/pkgs/development/python-modules/platformio/default.nix
+++ b/pkgs/development/python-modules/platformio/default.nix
@@ -3,6 +3,7 @@
 , lockfile, pyserial, requests
 , semantic-version
 , isPy3k, isPyPy
+, git
 }:
 buildPythonPackage rec {
   disabled = isPy3k || isPyPy;
@@ -17,7 +18,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs =  [
-    bottle click_5 colorama lockfile
+    bottle click_5 colorama git lockfile
     pyserial requests semantic-version
   ];
 


### PR DESCRIPTION
###### Motivation for this change
* Clean up platformio FHSUserEnv builder
* add Git input to platformio python module to allow pulling arduino libraries from git


###### Other notes
- may add a note to remind users to add themselves to `dialout` group to allow serial port access
- may be better to build a python.withPackages env

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  
  