### PR TITLE
Deluge: use mkEnableOption, add test

### DIFF
--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -11,10 +11,7 @@ in {
   options = {
     services = {
       deluge = {
-        enable = mkOption {
-          default = false;
-          description = "Start the Deluge daemon";
-        };
+        enable = mkEnableOption "Deluge daemon";
 
         openFilesLimit = mkOption {
           default = openFilesLimit;
@@ -25,14 +22,7 @@ in {
         };
       };
 
-      deluge.web = {
-        enable = mkOption {
-          default = false;
-          description = ''
-            Start Deluge Web daemon.
-          '';
-        };
-      };
+      deluge.web.enable = mkEnableOption "Deluge Web daemon";
     };
   };
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -264,6 +264,7 @@ in rec {
   tests.containers-hosts = callTest tests/containers-hosts.nix {};
   tests.containers-macvlans = callTest tests/containers-macvlans.nix {};
   tests.couchdb = callTest tests/couchdb.nix {};
+  tests.deluge = callTest tests/deluge.nix {};
   tests.docker = callTestOnMatchingSystems ["x86_64-linux"] tests/docker.nix {};
   tests.docker-tools = callTestOnMatchingSystems ["x86_64-linux"] tests/docker-tools.nix {};
   tests.docker-edge = callTestOnMatchingSystems ["x86_64-linux"] tests/docker-edge.nix {};

--- a/nixos/tests/deluge.nix
+++ b/nixos/tests/deluge.nix
@@ -1,0 +1,29 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "deluge";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ flokli ];
+  };
+
+  nodes = {
+    server =
+      { pkgs, config, ... }:
+
+      { services.deluge = {
+          enable = true;
+          web.enable = true;
+        };
+        networking.firewall.allowedTCPPorts = [ 8112 ];
+      };
+
+    client = { };
+  };
+
+  testScript = ''
+    startAll;
+
+    $server->waitForUnit("deluged");
+    $server->waitForUnit("delugeweb");
+    $client->waitForUnit("network.target");
+    $client->waitUntilSucceeds("curl --fail http://server:8112");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
This updates the deluge module to use `mkEnableOption` and adds a nixos test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

