### PR TITLE
notmuch: 0.25.3 -> 0.26

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
     description = "Mail indexer";
     homepage    = https://notmuchmail.org/;
     license     = licenses.gpl3;
-    maintainers = with maintainers; [ chaoflow garbas the-kenny ];
+    maintainers = with maintainers; [ chaoflow flokli garbas the-kenny ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -12,7 +12,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "0.25.3";
+  version = "0.26";
   name = "notmuch-${version}";
 
   passthru = {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://notmuchmail.org/releases/${name}.tar.gz";
-    sha256 = "1fyx20rjpwbf2j1v5fpa5s0rjnwhcgvijzh2qyinp8rlbh1qxmab";
+    sha256 = "1pvn1n7giv8n3xlazi3wpscdqhd2yak0fgv68aj23myr5bnr9s6k";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
         "{}" ";"
 
     for src in \
-      crypto.c \
+      util/crypto.c \
       notmuch-config.c \
       emacs/notmuch-crypto.el
     do

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -47,8 +47,7 @@ stdenv.mkDerivation rec {
 
     for src in \
       util/crypto.c \
-      notmuch-config.c \
-      emacs/notmuch-crypto.el
+      notmuch-config.c
     do
       substituteInPlace "$src" \
         --replace \"gpg\" \"${gnupg}/bin/gpg\"


### PR DESCRIPTION
###### Motivation for this change
This bumps notmuch from version 0.25.3 to 0.26, which brings a ton of new features,
including support for cleartext indexing of encrypted emails and fixes for encoding-related crashes in Python 3.

> Notmuch 0.26 (2018-01-09)
> =========================
> 
> Command Line Interface
> ----------------------
> 
> Support for re-indexing existing messages
> 
>   There is a new subcommand, `notmuch reindex`, which re-indexes all
>   messages matching supplied search terms.  This permits users to
>   change the way specific messages are indexed.
> 
>   Note that for messages with multiple variants in the message
>   archive, the recorded Subject: of may change upon reindexing,
>   depending on the order in which the variants are indexed.
> 
> Improved error reporting in notmuch new
> 
>   Give more details when reporting certain Xapian exceptions.
> 
> Support maildir synced tags in `new.tags`
> 
>   Tags `draft`, `flagged`, `passed`, and `replied` are now supported
>   in `new.tags`. The tag `unread` is still special in the presence of
>   maildir syncing, and will be added for files in `new/` regardless of
>   the setting of `new.tags`.
> 
> Support /regex/ in new.ignore
> 
>   Files and directories may be ignored based on regular expressions.
> 
> Allow `notmuch insert --folder=""`
> 
>   This inserts into the top level folder.
> 
> Strip trailing '/' from folder path for notmuch insert
> 
>   This prevents a potential problem with duplicated database records.
> 
> New option --output=address for notmuch address
> 
> Make `notmuch show` more robust against deleting duplicate files
> 
> The option --decrypt now takes an explicit argument
> 
>   The --decrypt option to `notmuch show` and `notmuch reply` now takes
>   an explicit argument.  If you were used to invoking `notmuch show
>   --decrypt`, you should switch to `notmuch show --decrypt=true`.
> 
> Boolean and keyword arguments now take a `--no-` prefix
> 
> Encrypted Mail
> --------------
> 
> Indexing cleartext of encrypted e-mails
> 
>   It's now possible to include the cleartext of encrypted e-mails in
>   the notmuch index.  This makes it possible to search your encrypted
>   e-mails with the same ease as searching cleartext.  This can be done
>   on a per-message basis by passing --decrypt=true to indexing
>   commands (new, insert, reindex), or by default by running "notmuch
>   config set index.decrypt true".
> 
>   Encrypted messages whose cleartext is indexed will typically also
>   have their session keys stashed as properties associated with the
>   message.  Stashed session keys permit rapid rendering of long
>   encrypted threads, and disposal of expired encryption-capable keys.
>   If for some reason you want cleartext indexing without stashed
>   session keys, use --decrypt=nostash for your indexing commands (or
>   run "notmuch config set index.decrypt nostash"). See `index.decrypt`
>   in notmuch-config(1) for more details.
> 
>   Note that stashed session keys permit reconstruction of the
>   cleartext of the encrypted message itself, and the contents of the
>   index are roughly equivalent to the cleartext as well.  DO NOT USE
>   this feature without considering the security of your index.
> 
> Emacs
> -----
> 
> Guard against concurrent searches in notmuch-tree
> 
> Use make-process when available
> 
>   This allows newer Emacs to separate stdout and stderr from the
>   notmuch command without using temporary files.
> 
> Library Changes
> ---------------
> 
> Indexing files with duplicate message-id
> 
>   Files with duplicate message-id's are now indexed, and searchable
>   via terms and phrases. There are known issues related to
>   presentation of results and regular-expression search, but in
>   principle no mail file should be completely unsearchable now.
> 
> New functions to count files
> 
>   Two new functions in the libnotmuch API:
>   `notmuch_message_count_files`, and `notmuch_thread_get_total_files`.
> 
> New function to remove properties
> 
>   A new function was added to the libnotmuch API to make it easier to
>   drop all properties with a common pattern:
>   `notmuch_message_remove_all_properties_with_prefix`
> 
> Change of return value of `notmuch_thread_get_authors`
> 
>   In certain corner cases, `notmuch_thread_get_authors` previously
>   returned NULL.  This has been replaced by an empty string, since the
>   possibility of NULL was not documented.
> 
> Transition `notmuch_database_add_message` to `notmuch_database_index_file`
> 
>    When indexing an e-mail message, the new
>    `notmuch_database_index_file` function is the preferred form, and
>    the old `notmuch_database_add_message` is deprecated.  The new form
>    allows passing a set of options to the indexing engine, which the
>    operator may decide to change from message to message.
> 
> Test Suite
> ----------
> 
> Out-of-tree builds
> 
>   The test suite now works properly with out-of-tree builds, i.e. with
>   separate source and build directories. The --root option to tests
>   has been dropped. The same can now be achieved more reliably using
>   out-of-tree builds.
> 
> Python Bindings
> ---------------
> 
> Python bindings specific Debian packaging is removed
> 
>   The bindings have been build by the top level Debian packaging for a
>   long time, and `bindings/python/debian` has bit-rotted.
> 
> Open mail files in binary mode when using Python 3
> 
>   This avoids certain encoding related crashes under Python 3.
> 
> Add python bindings for `notmuch_database_{get,set}_config*`
> 
> Optional `decrypt_policy` flag is available for notmuch.database().index_file()
> 
> nmbug
> -----
> 
> nmbug's internal version increases to 0.3 in this notmuch release.
> User-facing changes with this notmuch release:
> 
> * Accept failures to unset `core.worktree` in `clone`, which allows
>   nmbug to be used with Git 2.11.0 and later.
> * Auto-checkout in `clone` if it wouldn't clobber existing content,
>   which makes the initial clone more convenient.
> * Only error for invalid diff lines in `tags/`, which allows for
>   `README`s and similar in nmbug repositories.
> 
> Documentation
> -------------
> 
> New man page: notmuch-properties(7)
> 
>   This new page to the manual describes common conventions for how
>   properties are used by libnotmuch, the CLI, and associated programs.
>   External projects that use properties are encouraged to claim their
>   properties and conventions here to avoid collisions.
> 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

