### PR TITLE
notbit: init at 2018-01-09

### DIFF
--- a/pkgs/applications/networking/mailreaders/notbit/default.nix
+++ b/pkgs/applications/networking/mailreaders/notbit/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig,
+  gettext, openssl
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "notbit-${version}";
+  version = "2018-01-09";
+
+  src = fetchFromGitHub {
+    owner  = "bpeel";
+    repo   = "notbit";
+    rev    = "8b5d3d2da8ce54abae2536b4d97641d2c798cff3";
+    sha256 = "1623n0lvx42mamvb2vwin5i38hh0nxpxzmkr5188ss2x7m20lmii";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ openssl gettext ];
+
+  meta = {
+    description = "A minimal Bitmessage client";
+    homepage = https://github.com/bpeel/notbit;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ mog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16287,6 +16287,8 @@ with pkgs;
 
   notepadqq = libsForQt56.callPackage ../applications/editors/notepadqq { };
 
+  notbit = callPackage ../applications/networking/mailreaders/notbit { };
+
   notmuch = callPackage ../applications/networking/mailreaders/notmuch {
     gmime = gmime3;
   };


### PR DESCRIPTION
###### Motivation for this change

I wanted to use the notbit client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

