### PR TITLE
refind: 0.10.3 -> 0.11.2

### DIFF
--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -13,31 +13,17 @@ in
 
 stdenv.mkDerivation rec {
   name = "refind-${version}";
-  version = "0.10.3";
+  version = "0.11.2";
   srcName = "refind-src-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/refind/${version}/${srcName}.tar.gz";
-    sha256 = "1r2qp29mz08lx36i7x52i2598773bxvfhwryd954ssq2baifjav5";
+    sha256 = "1k0xpm4y0gk1rxqdyprqyqpg5j16xw3l2gm3d9zpi5n9id43jkzn";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=831258;filename=002-efiprot.patch;msg=10";
-      sha256 = "17h03h5mgkpamcj9jcq8h6x2admpknysrbdwccg7yxirlc52fc2s";
-      name = "002-efiprot.patch";
-    })
-  ];
 
   buildInputs = [ gnu-efi ];
 
   hardeningDisable = [ "stackprotector" ];
-
-  postPatch = ''
-    sed -e 's|-DEFI_FUNCTION_WRAPPER|-DEFI_FUNCTION_WRAPPER -maccumulate-outgoing-args|g' -i Make.common
-    sed -e 's|-DEFIX64|-DEFIX64 -maccumulate-outgoing-args|g' -i Make.common
-    sed -e 's|-m64|-maccumulate-outgoing-args -m64|g' -i filesystems/Make.gnuefi
-  '';
 
   makeFlags =
     [ "prefix="
@@ -139,7 +125,6 @@ EOF
     homepage = http://refind.sourceforge.net/;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = [ "i686-linux" "x86_64-linux" ];
-    broken = true;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

 * Unbreak refind
 * Update refind

See #33686 for a use-case where this built refind is in use.

The patches have been removed, there are no patches on debian's build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - NixOS
- NOT ~~Tested execution of all binary files (usually in `./result/bin/`)~~ It is assumed they are in the state they were before.
  * I have not tested `refind-install`, it should work if it worked.
  * The `refind-mkrlconf` and `refind-mvrefind` have been executed but not tested.
  * The `refind-mkfont` program has been used up to printing usage.
- Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


  