### PR TITLE
Backport: teamviewer: 12.0.76279 -> 12.0.85001

### DIFF
--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -16,13 +16,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "teamviewer-${version}";
-  version = "12.0.76279";
+  version = "12.0.85001";
 
   src = fetchurl {
     # There is a 64-bit package, but it has no differences apart from Debian dependencies.
     # Generic versioned packages (teamviewer_${version}_i386.tar.xz) are not available for some reason.
-    url = "http://download.teamviewer.com/download/teamviewer_${version}_i386.deb";
-    sha256 = "15yhx66zxbjk0x3dpfg39gb1f2ajcp9kbp4zi58bfnvby277jl00";
+    url = "https://dl.tvcdn.de/download/version_12x/teamviewer_${version}_i386.deb";
+    sha256 = "01vzky22gisjxa4ihaygkb7jwhl4z9ldd9lli8fc863nxxbrawks";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
Backport #32232
(cherry picked from commit 1ba448252d2a8091a20c2a9adf1e46d4c3a4e243)

###### Motivation for this change
Teamviewer download broken on 17.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

