### PR TITLE
texlive: don't remove luatex from packages that require it.

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -55,15 +55,9 @@ let
 
       # remove dependency-heavy packages from the basic collections
       collection-basic = orig.collection-basic // {
-        deps = removeAttrs orig.collection-basic.deps [ "luatex" "metafont" "xdvi" ];
-      };
-      latex = orig.latex // {
-        deps = removeAttrs orig.latex.deps [ "luatex" ];
+        deps = removeAttrs orig.collection-basic.deps [ "metafont" "xdvi" ];
       };
       # add them elsewhere so that collections cover all packages
-      collection-luatex = orig.collection-luatex // {
-        deps = orig.collection-luatex.deps // { inherit (tl) luatex; };
-      };
       collection-metapost = orig.collection-metapost // {
         deps = orig.collection-metapost.deps // { inherit (tl) metafont; };
       };


### PR DESCRIPTION
Fixes #31482.

###### Motivation for this change

Leaving other dependencies that we patch out into other collections, but keeping luatex since it is needed by at least `texlive-scripts` which is part of `collection-basic` (which is foundation of many other collections).

I'm not sure why it was not included in the first place--if it was closure size it appears that is not a significant concern, see https://github.com/NixOS/nixpkgs/issues/32661#issuecomment-351804524 for some numbers.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

PS I wish we had a place to dump things like Nix expressions that test "ensure this MWE still builds" or something.  Soon, hopefully! :)