### PR TITLE
nginx: Add option for enabling pagespeed, option for additional modules

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -40,6 +40,15 @@ let
     }
   ''));
 
+  enablePagespeed = any (vhost: vhost.enablePagespeed) (attrValues virtualHosts);
+
+  package = cfg.package.override {
+    modules = []
+      ++ cfg.package.modules
+      ++ cfg.extraModulePackages
+      ++ optional enablePagespeed pkgs.nginxModules.pagespeed;
+  };
+
   configFile = pkgs.writeText "nginx.conf" ''
     user ${cfg.user} ${cfg.group};
     error_log stderr;
@@ -55,9 +64,9 @@ let
 
     ${optionalString (cfg.httpConfig == "" && cfg.config == "") ''
     http {
-      include ${cfg.package}/conf/mime.types;
-      include ${cfg.package}/conf/fastcgi.conf;
-      include ${cfg.package}/conf/uwsgi_params;
+      include ${package}/conf/mime.types;
+      include ${package}/conf/fastcgi.conf;
+      include ${package}/conf/uwsgi_params;
 
       ${optionalString (cfg.resolver.addresses != []) ''
         resolver ${toString cfg.resolver.addresses} ${optionalString (cfg.resolver.valid != "") "valid=${cfg.resolver.valid}"};
@@ -139,9 +148,9 @@ let
 
     ${optionalString (cfg.httpConfig != "") ''
     http {
-      include ${cfg.package}/conf/mime.types;
-      include ${cfg.package}/conf/fastcgi.conf;
-      include ${cfg.package}/conf/uwsgi_params;
+      include ${package}/conf/mime.types;
+      include ${package}/conf/fastcgi.conf;
+      include ${package}/conf/uwsgi_params;
       ${cfg.httpConfig}
     }''}
 
@@ -191,6 +200,15 @@ let
           ''}
         '';
 
+        pagespeedLocations = ''
+          # Ensure requests for pagespeed optimized resources go to the pagespeed handler
+          # and no extraneous headers get set.
+          location ~ "\.pagespeed\.([a-z]\.)?[a-z]{2}\.[^.]{10}\.[^.]+" {
+            add_header "" "";
+          }
+          location ~ "^/pagespeed_static/" { }
+          location ~ "^/ngx_pagespeed_beacon$" { }
+        '';
       in ''
         ${optionalString vhost.forceSSL ''
           server {
@@ -218,6 +236,15 @@ let
           ''}
 
           ${optionalString (vhost.basicAuth != {}) (mkBasicAuth vhostName vhost.basicAuth)}
+
+          ${optionalString enablePagespeed ''
+            pagespeed ${if vhost.enablePagespeed then "on" else "off"};
+
+            # Needs to exist and be writable by nginx.  Use tmpfs for best performance.
+            pagespeed FileCachePath ${vhost.pagespeedFileCachePath};
+
+            ${optionalString vhost.enablePagespeed pagespeedLocations}
+          ''}
 
           ${mkLocations vhost.locations}
 
@@ -521,6 +548,16 @@ in
         '';
         description = "Declarative vhost config";
       };
+
+      extraModulePackages = mkOption {
+        type = types.listOf types.unspecified;
+        default = [];
+        example = literalExample "with pkgs; [ nginxModules.brotli ]";
+        description = ''
+          Additional module packages to use, extending base package.
+          Note: Requires nginx rebuild when changed.
+        '';
+      };
     };
   };
 
@@ -580,7 +617,7 @@ in
         chown -R ${cfg.user}:${cfg.group} ${cfg.stateDir}
         '';
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/nginx -c ${configFile} -p ${cfg.stateDir}";
+        ExecStart = "${package}/bin/nginx -c ${configFile} -p ${cfg.stateDir}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         Restart = "always";
         RestartSec = "10s";

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -207,5 +207,20 @@ with lib;
       '';
       description = "Declarative location config";
     };
+
+    enablePagespeed = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable ngx_pagespeed for this vhost";
+    };
+
+    pagespeedFileCachePath = mkOption {
+      type = types.str;
+      default = "/var/cache/ngx_pagespeed";
+      description = ''
+        Directory to use for pagespeed FileCachePath.
+        Documentation suggests using tmpfs for best performance.
+      '';
+    };
   };
 }

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -313,6 +313,7 @@ in rec {
   tests.nfs3 = callTest tests/nfs.nix { version = 3; };
   tests.nfs4 = callTest tests/nfs.nix { version = 4; };
   tests.nginx = callTest tests/nginx.nix { };
+  tests.nginx-pagespeed = callTest tests/nginx-pagespeed.nix { };
   tests.nghttpx = callTest tests/nghttpx.nix { };
   tests.leaps = callTest tests/leaps.nix { };
   tests.nsd = callTest tests/nsd.nix {};

--- a/nixos/tests/nginx-pagespeed.nix
+++ b/nixos/tests/nginx-pagespeed.nix
@@ -1,0 +1,71 @@
+# Test that ngx_pagespeed works
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "nginx-pagespeed";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ dtzWill ];
+  };
+
+  nodes = {
+    webserver = { config, pkgs, ... }: {
+      services.nginx = {
+        enable = true;
+
+        virtualHosts = let base = {
+            locations."/".root = pkgs.writeTextDir "test.html" ''
+              <!DOCTYPE html>
+              <html>
+              <body>
+
+              Hello world!
+
+              </body>
+              </html>
+            '';
+          }; in {
+          server = base // {
+            default = true;
+            enablePagespeed = true;
+          };
+          disabled = base;
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    startAll;
+
+    $webserver->waitForUnit("nginx");
+    $webserver->waitForOpenPort("80");
+
+    my $get = "curl -s --fail http://localhost/test.html";
+
+    # Ensure server runs and serves our document
+    $webserver->succeed("$get | grep -qF 'Hello world'");
+
+    # Check for Pagespeed header (and log to stderr)
+    $webserver->succeed("$get -I | grep -qF 'X-Page-Speed:' 1>&2");
+
+    # Check one of the CoreFilters worked: 'add_head'
+    $webserver->succeed("$get | grep -F '<head'");
+
+    # Check that the cache directory was created
+    # (it's likely empty but should exist)
+    $webserver->succeed("ls -ld /var/cache/ngx_pagespeed 1>&2");
+
+
+    # Check second vhost does not have pagespeed enabled
+    my $get2 = "$get -H 'Host: disabled'";
+
+    # First ensure we can access it
+    $webserver->succeed("$get2 | grep -qF 'Hello world'");
+
+    # Now check that pagespeed is off
+    $webserver->fail("$get2 -I | grep -qF 'X-Page-Speed:' 1>&2");
+    $webserver->fail("$get2 | grep -F '<head'");
+
+
+    $webserver->shutdown;
+  '';
+})

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -70,6 +70,8 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  passthru.modules = modules;
+
   meta = {
     description = "A reverse proxy and lightweight webserver";
     homepage    = http://nginx.org;

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -68,6 +68,8 @@ stdenv.mkDerivation {
     mv $out/sbin $out/bin
   '';
 
+  enableParallelBuilding = true;
+
   meta = {
     description = "A reverse proxy and lightweight webserver";
     homepage    = http://nginx.org;


### PR DESCRIPTION
###### Motivation for this change

Make it easier to configure nginx servers using modules beyond those bundled by default, especially to automate the boilerplate required to use pagespeed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @3noch @adisbladis 