### PR TITLE
giac: fix build

### DIFF
--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -29,7 +29,10 @@ stdenv.mkDerivation rec {
   # perl is only needed for patchShebangs fixup.
   buildInputs = [
     gmp mpfr pari ntl gsl blas mpfi liblapackWithAtlas
-    readline gettext libpng libao gfortran perl
+    readline gettext libpng libao perl
+    # gfortran.cc default output contains static libraries compiled without -fPIC
+    # we want libgfortran.so.3 instead
+    (stdenv.lib.getLib gfortran.cc)
   ] ++ stdenv.lib.optionals enableGUI [
     mesa fltk xorg.libX11
   ];


### PR DESCRIPTION
giac was broken somewhere between 310ad4 and b33b4a, see
https://hydra.nixos.org/build/67137469
libgfortran.so.3 was not found

###### Motivation for this change
fix build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

