### PR TITLE
grammalecte: 0.5.18 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -7,23 +7,19 @@
 
 buildPythonPackage rec {
   pname = "grammalecte";
-  version = "0.5.18";
+  version = "0.6.1";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "http://www.dicollecte.org/grammalecte/zip/Grammalecte-fr-v${version}.zip";
-    sha256 = "0izfsqsj8w4awhmwmn4x8wwpqsmqbnfvfafzk93i6yj0l3fn3i97";
+    sha256 = "0y2ck6pkd2p3cbjlxxvz3x5rnbg3ghfx97n13302rnab66cy4zkh";
   };
 
   propagatedBuildInputs = [ bottle ];
 
   preBuild = "cd ..";
   postInstall = ''
-    mkdir $out/bin
-    cp $out/cli.py $out/bin/gramalecte
-    cp $out/server.py $out/bin/gramalected
-    chmod a+rx $out/bin/gramalecte
-    chmod a+rx $out/bin/gramalected
+    rm $out/bin/bottle.py
   '';
 
   disabled = !isPy3k;


### PR DESCRIPTION
###### Motivation for this change

update grammalecte: 0.5.18 -> 0.6.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

