### PR TITLE
diff_cover: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/diff_cover/default.nix
+++ b/pkgs/development/python-modules/diff_cover/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, buildPythonPackage, fetchPypi, jinja2, jinja2_pluralize, pygments,
+  six, inflect, mock, nose, coverage, pycodestyle, flake8, pyflakes, git,
+  pylint, pydocstyle, fetchpatch }:
+
+buildPythonPackage rec {
+  pname = "diff_cover";
+  version = "1.0.2";
+
+  preCheck = ''
+    export LC_ALL=en_US.UTF-8;
+  '';
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wbp0kfv2mjxwnq2jlqmwvb71fywwc4x4azxi7ll5dll6nhjyd61";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "tests-fix.patch";
+      url = "https://github.com/Bachmann1234/diff-cover/commit/85c30959c8ed2aa3848f400095a2418f15bb7777.patch";
+      sha256 = "0xni4syrxww9kdv8495f416vqgfdys4w2hgf5rdi35hy3ybfslh0";
+    })
+  ];
+
+  propagatedBuildInputs = [ jinja2 jinja2_pluralize pygments six inflect ];
+
+  checkInputs = [ mock nose coverage pycodestyle flake8 pyflakes pylint pydocstyle git ];
+
+  meta = with stdenv.lib; {
+    description = "Automatically find diff lines that need test coverage";
+    homepage = https://github.com/Bachmann1234/diff-cover;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dzabraev ];
+  };
+}

--- a/pkgs/development/python-modules/jinja2_pluralize/default.nix
+++ b/pkgs/development/python-modules/jinja2_pluralize/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, jinja2, inflect }:
+
+buildPythonPackage rec {
+  pname = "jinja2_pluralize";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "071wnzzz20wjb0iw7grxgj1lb2f0kz50qyfbcq54rddr2x82sp6z";
+  };
+
+  propagatedBuildInputs = [
+    jinja2
+    inflect
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Jinja2 pluralize filters";
+    homepage = https://github.com/audreyr/jinja2_pluralize;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ dzabraev ];
+  };
+}

--- a/pkgs/development/python-modules/pydocstyle/default.nix
+++ b/pkgs/development/python-modules/pydocstyle/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, snowballstemmer, configparser,
+  pytest, pytestpep8, mock, pathlib }:
+
+buildPythonPackage rec {
+  pname = "pydocstyle";
+  version = "2.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15ssv8l6cvrmzgwcdzw76rnl4np3qf0dbwr1wsx76y0hc7lwsnsd";
+  };
+
+  propagatedBuildInputs = [ snowballstemmer configparser ];
+
+  checkInputs = [ pytest pytestpep8 mock pathlib ];
+
+  meta = with stdenv.lib; {
+    description = "Python docstring style checker";
+    homepage = https://github.com/PyCQA/pydocstyle/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dzabraev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9471,6 +9471,8 @@ in {
     };
   };
 
+  jinja2_pluralize = callPackage ../development/python-modules/jinja2_pluralize { };
+
   jmespath = buildPythonPackage rec {
     name = "jmespath-0.9.0";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -281,6 +281,8 @@ in {
 
   pydbus = callPackage ../development/python-modules/pydbus { };
 
+  pydocstyle = callPackage ../development/python-modules/pydocstyle { };
+
   pyexiv2 = disabledIf isPy3k (callPackage ../development/python-modules/pyexiv2 {});
 
   py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -205,6 +205,8 @@ in {
 
   dkimpy = callPackage ../development/python-modules/dkimpy { };
 
+  diff_cover = callPackage ../development/python-modules/diff_cover { };
+
   emcee = callPackage ../development/python-modules/emcee { };
 
   email_validator = callPackage ../development/python-modules/email-validator { };


### PR DESCRIPTION
###### Motivation for this change
new packages for `diff_cover`, `pydocstyle`, `jinja2_pluralize`

diff_cover depends on `pydocstyle`, `jinja2_pluralize`
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

