### PR TITLE
darktable: lua support requires lua 5.3

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14453,6 +14453,7 @@ with pkgs;
 
   darktable = callPackage ../applications/graphics/darktable {
     inherit (gnome2) GConf libglade;
+    lua = lua5_3;
     pugixml = pugixml.override { shared = true; };
   };
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/33710#issuecomment-356680711

Fixes #33710.

###### Things done

```
$ ./result/bin/darktable --version                                                                                                                                              
this is darktable 2.4.0                                                                                                                                                                                             
copyright (c) 2009-2017 johannes hanika                                                                                                                                                                             
darktable-dev@lists.darktable.org                                                                                                                                                                                   

compile options:                                                                                                                                                                                                    
  bit depth is 64 bit                                                                                                                                                                                               
  normal build                                                                                                                                                                                                      
  SSE2 optimized codepath enabled                                                                                                                                                                                   
  OpenMP support enabled                                                                                                                                                                                            
  OpenCL support enabled                                                                                                                                                                                            
  Lua support enabled, API version 5.0.0                                                                                                                                                                            
  Colord support enabled                                                                                                                                                                                            
  gPhoto2 support enabled                                                                                                                                                                                           
  GraphicsMagick support enabled                                                                                                                                                                                    
  OpenEXR support enabled                                                                                                                                                                                           
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Executed a "hello world" lua script
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

