### PR TITLE
taskwarrior: Fix bash completion

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p "$out/share/bash-completion/completions"
-    ln -s "../../doc/task/scripts/bash/task.sh" "$out/share/bash-completion/completions/"
+    ln -s "../../doc/task/scripts/bash/task.sh" "$out/share/bash-completion/completions/task.bash"
     mkdir -p "$out/share/fish/vendor_completions.d"
     ln -s "../../../share/doc/task/scripts/fish/task.fish" "$out/share/fish/vendor_completions.d/"
   '';


### PR DESCRIPTION
###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/33704

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

