### PR TITLE
clipster: 1.4.1 -> 1.5.0

### DIFF
--- a/pkgs/tools/misc/clipster/default.nix
+++ b/pkgs/tools/misc/clipster/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation  rec {
   name = "clipster-${version}";
-  version = "1.4.1";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "mrichar1";
     repo = "clipster";
     rev = "${version}";
-    sha256 = "16gdrm985qwbrsmsqjfyh33glcmx678abl2jpq49djk2qrbhm49k";
+    sha256 = "0bj7fk19z3c29vxm3mcp3s7vggkigmz3hrn4pcsqgfh96i5i5203";
   };
 
   pythonEnv = python3.withPackages(ps: with ps; [ pygobject3 ]);

--- a/pkgs/tools/misc/clipster/default.nix
+++ b/pkgs/tools/misc/clipster/default.nix
@@ -1,4 +1,5 @@
-{fetchFromGitHub , stdenv, makeWrapper, python3, gtk3, libwnck3 }:
+{fetchFromGitHub , stdenv, python3, gtk3, libwnck3,
+ gobjectIntrospection, wrapGAppsHook }:
 
 stdenv.mkDerivation  rec {
   name = "clipster-${version}";
@@ -13,15 +14,12 @@ stdenv.mkDerivation  rec {
 
   pythonEnv = python3.withPackages(ps: with ps; [ pygobject3 ]);
 
-  buildInputs =  [ pythonEnv gtk3 libwnck3 ];
-  nativeBuildInputs = [ makeWrapper ];
+  buildInputs =  [ pythonEnv gtk3 libwnck3 gobjectIntrospection wrapGAppsHook ];
 
   installPhase = ''
     sed -i 's/python/python3/g' clipster
     mkdir -p $out/bin/
     cp clipster $out/bin/
-    wrapProgram "$out/bin/clipster" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

the previous version is broken, when you run the daemon, it says:

```
Traceback (most recent call last):
  File "/nix/store/bzxnrc2lzcd8d8zbfx65vxypijjkhya6-clipster-1.4.1/bin/.clipster-wrapped", line 21, in <module>
    require_version("Gtk", "3.0")
  File "/nix/store/s5a6d9v9m939kw6ih9mq9v2bcnbi7cdv-python3-3.6.4-env/lib/python3.6/site-packages/gi/__init__.py", line 130, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Gtk not available
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

