### PR TITLE
nixos/tests/keymap: Workaround xterm not in focus

### DIFF
--- a/nixos/tests/keymap.nix
+++ b/nixos/tests/keymap.nix
@@ -101,6 +101,11 @@ let
           $machine->succeed("$cmd ${testReader} $shellTestdata &");
           while (my ($testname, $qwerty, $expect) = splice(@testdata, 0, 3)) {
             waitCatAndDelete "/tmp/reader.ready";
+
+            # Workaround for xterm not being in focus.
+            if ($desc eq "Xorg keymap") {
+              $machine->succeed("${pkgs.xdotool}/bin/xdotool search --class testterm windowactivate --sync");
+            }
             $machine->sendKeys($qwerty);
           };
           my $exitcode = waitCatAndDelete "/tmp/reader.exit";
@@ -111,7 +116,7 @@ let
       $machine->waitForX;
 
       mkTest "VT keymap", "openvt -sw --";
-      mkTest "Xorg keymap", "DISPLAY=:0 xterm -fullscreen -e";
+      mkTest "Xorg keymap", "DISPLAY=:0 xterm -class testterm -fullscreen -e";
     '';
   };
 


### PR DESCRIPTION
###### Motivation for this change
Attempt to alleviate the failing keymap tests discussed in #32020

###### Things done
xdotool now brings the xterm into focus before sending keys. Tested by starting xterm with -iconic, which works.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

