### PR TITLE
inboxer: init at 1.0.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/inboxer/default.nix
+++ b/pkgs/applications/networking/mailreaders/inboxer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, nodejs }:
+{ stdenv, fetchurl, binutils, patchelf, expat, xorg, gdk_pixbuf, glib, gnome2, cairo, atk, freetype, fontconfig, dbus, nss, nspr, gtk2-x11, alsaLib, cups }:
 
 stdenv.mkDerivation rec {
   name = "inboxer-${version}";
@@ -12,17 +12,62 @@ stdenv.mkDerivation rec {
     platforms   = [ "x86_64-linux" ];
   };
 
-  src = fetchFromGitHub {
-    owner = "denysdovhan";
-    repo = "inboxer";
-    rev = "v${version}";
-    sha256 = "0mvkvsqc36y3r2lxa5f4rjrj2z5jxwadpcx585sdsx37ndi1z9m5";
+  src = fetchurl {
+    url = "https://github.com/denysdovhan/inboxer/releases/download/v${version}/inboxer_${version}_amd64.deb";
+    sha256 = "01384fi5vrfqpznk9389nf3bwpi2zjbnkg84g6z1css8f3gp5i1c";
   };
 
-  buildInputs = [ nodejs ];
+  unpackPhase = ''
+    ar p $src data.tar.xz | tar xJ
+  '';
+  buildInputs = [ binutils patchelf ];
 
-  buildPhase = ''
-    npm install
-    npm test
+  preFixup = with stdenv.lib; let
+    lpath = makeLibraryPath [
+      alsaLib
+      atk
+      cairo
+      cups
+      dbus
+      nss
+      nspr
+      freetype
+      fontconfig
+      gtk2-x11
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXi
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXcomposite
+      xorg.libXtst
+      xorg.libXScrnSaver
+      xorg.libxcb
+      gdk_pixbuf
+      glib
+      gnome2.pango
+      gnome2.GConf
+      expat
+      stdenv.cc.cc.lib
+    ];
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "$out/opt/Inboxer:${lpath}" \
+      $out/opt/Inboxer/inboxer
+  '';
+  
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R usr/share opt $out/
+    # fix the path in the desktop file
+    substituteInPlace \
+      $out/share/applications/inboxer.desktop \
+      --replace /opt/ $out/opt/
+    # symlink the binary to bin/
+    ln -s $out/opt/Inboxer/inboxer $out/bin/inboxer
   '';
 }

--- a/pkgs/applications/networking/mailreaders/inboxer/default.nix
+++ b/pkgs/applications/networking/mailreaders/inboxer/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, nodejs }:
+
+stdenv.mkDerivation rec {
+  name = "inboxer-${version}";
+  version = "1.0.0";
+
+  meta = with stdenv.lib; {
+    description = "Unofficial, free and open-source Google Inbox Desktop App";
+    homepage    = "https://denysdovhan.com/inboxer";
+    maintainers = [ maintainers.mgttlinger ];
+    license     = licenses.mit;
+    platforms   = [ "x86_64-linux" ];
+  };
+
+  src = fetchFromGitHub {
+    owner = "denysdovhan";
+    repo = "inboxer";
+    rev = "v${version}";
+    sha256 = "0mvkvsqc36y3r2lxa5f4rjrj2z5jxwadpcx585sdsx37ndi1z9m5";
+  };
+
+  buildInputs = [ nodejs ];
+
+  buildPhase = ''
+    npm install
+    npm test
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2792,6 +2792,8 @@ with pkgs;
 
   inadyn = callPackage ../tools/networking/inadyn { };
 
+  inboxer = callPackage ../applications/networking/mailreaders/inboxer { };
+  
   inetutils = callPackage ../tools/networking/inetutils { };
 
   inform7 = callPackage ../development/compilers/inform7 { };


### PR DESCRIPTION
###### Motivation for this change
There was no derivation for inboxer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

