### PR TITLE
ldc: Remove dynamiccompile tests for Darwin too

### DIFF
--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -58,9 +58,9 @@ let
         rm tests/d2/dmd-testsuite/runnable/variadic.d
     ''
 
-    + stdenv.lib.optionalString (stdenv.hostPlatform.isLinux && !bootstrapVersion) ''
-	# http://forum.dlang.org/thread/xtbbqthxutdoyhnxjhxl@forum.dlang.org
-	rm -r tests/dynamiccompile
+    + stdenv.lib.optionalString (!bootstrapVersion) ''
+	    # http://forum.dlang.org/thread/xtbbqthxutdoyhnxjhxl@forum.dlang.org
+	    rm -r tests/dynamiccompile
     '';
 
     ROOT_HOME_DIR = "$(echo ~root)";


### PR DESCRIPTION
@joachifm This fixes the ldc build on Darwin introduced through https://github.com/NixOS/nixpkgs/pull/33532.