### PR TITLE
minio: 2017-09-29T19-16-56Z -> 2018-01-02T23-07-00Z

### DIFF
--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "minio-${version}";
 
-  version = "2017-09-29T19-16-56Z";
+  version = "2018-01-02T23-07-00Z";
 
   src = fetchurl {
     url = "https://github.com/minio/minio/archive/RELEASE.${version}.tar.gz";
-    sha256 = "1h028gyfvyh5x6k4fsj4s64sgzqy7jgln6kvs27bnxzigj6dp2wx";
+    sha256 = "1a4x14pn5dp6cclpkfd72wbn3xzp3dmxxbjgkcgn3s5w83qmsvv9";
   };
 
   buildInputs = [ go ];

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -1,38 +1,28 @@
-{ lib, stdenv, fetchurl, go }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+buildGoPackage rec {
   name = "minio-${version}";
 
   version = "2018-01-02T23-07-00Z";
 
-  src = fetchurl {
-    url = "https://github.com/minio/minio/archive/RELEASE.${version}.tar.gz";
-    sha256 = "1a4x14pn5dp6cclpkfd72wbn3xzp3dmxxbjgkcgn3s5w83qmsvv9";
+  src = fetchFromGitHub {
+    owner = "minio";
+    repo = "minio";
+    rev = "RELEASE.${version}";
+    sha256 = "1bpiy6q9782mxs5f5lzw6c7zx83s2i68rf5f65xa9z7cyl19si74";
   };
 
-  buildInputs = [ go ];
+  goPackagePath = "github.com/minio/minio";
 
-  unpackPhase = ''
-    d=$TMPDIR/src/github.com/minio/minio
-    mkdir -p $d
-    tar xf $src -C $d --strip-component 1
-    export GOPATH=$TMPDIR
-    cd $d
-  '';
+  buildFlagsArray = [''-ldflags=
+    -X github.com/minio/minio/cmd.Version=${version}
+  ''];
 
-  buildPhase = ''
-    mkdir -p $out/bin
-    go build -o $out/bin/minio \
-      --ldflags "-X github.com/minio/minio/cmd.Version=${version}"
-  '';
-
-  installPhase = "true";
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://www.minio.io/;
     description = "An S3-compatible object storage server";
-    maintainers = with lib.maintainers; [ eelco bachp ];
-    platforms = lib.platforms.x86_64;
-    license = lib.licenses.asl20;
+    maintainers = with maintainers; [ eelco bachp ];
+    platforms = platforms.x86_64 ++ ["aarch64-linux"];
+    license = licenses.asl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/minio/minio/releases/tag/RELEASE.2018-01-02T23-07-00Z

@grahamc Contains security fixes (see: https://blog.minio.io/minio-release-jan-2nd-2018-security-advisory-ef0342a4ddba) so it might be worth to backport to 17.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

