### PR TITLE
pythonPackages.salmon: bec795cd -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/salmon-mail/default.nix
+++ b/pkgs/development/python-modules/salmon-mail/default.nix
@@ -1,16 +1,14 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder, nose, dnspython
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, nose, dnspython
 ,  chardet, lmtpd, pythondaemon, six, jinja2, mock }:
 
 buildPythonPackage rec {
-  pname = "salmon";
-  version = "3.0.0";
   name = "${pname}-${version}";
+  pname = "salmon-mail";
+  version = "3.0.0";
 
-  src = fetchFromGitHub {
-    owner = "moggers87";
-    repo = "salmon";
-    rev = version;
-    sha256 = "0ffnvvms9w5b2hkwq0ss018vadg5n7xwhc51dlrfynddhrf9p3m3";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1smggsnkwiqy8zjq604dkm5g0np27pdnj3szsbn8v4ja84nncq18";
   };
 
   checkInputs = [ nose jinja2 mock ];

--- a/pkgs/development/python-modules/salmon/default.nix
+++ b/pkgs/development/python-modules/salmon/default.nix
@@ -3,18 +3,14 @@
 
 buildPythonPackage rec {
   pname = "salmon";
-  # NOTE: The latest release version 2 is over 3 years old. So let's use some
-  # recent commit from master. There will be a new release at some point, then
-  # one can change this to use PyPI. See:
-  # https://github.com/moggers87/salmon/issues/52
-  version = "bec795cdab744be4f103d8e35584dfee622ddab2";
+  version = "3.0.0";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "moggers87";
     repo = "salmon";
     rev = version;
-    sha256 = "0nx8pyxy7n42nsqqvhd85ycm1i5wlacsi7lwb4rrs9d416bpd300";
+    sha256 = "0ffnvvms9w5b2hkwq0ss018vadg5n7xwhc51dlrfynddhrf9p3m3";
   };
 
   checkInputs = [ nose jinja2 mock ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -354,7 +354,7 @@ in {
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl {});
 
-  salmon = callPackage ../development/python-modules/salmon { };
+  salmon-mail = callPackage ../development/python-modules/salmon-mail { };
 
   simpleeval = callPackage ../development/python-modules/simpleeval { };
 


### PR DESCRIPTION
###### Motivation for this change

Upgrade Salmon Python module now that it released a new version after many years.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

