### PR TITLE
[17.09] tablib: 0.10.0 -> 0.12.1, re-enable on Python 3

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3399,16 +3399,15 @@ in {
 
   tablib = buildPythonPackage rec {
     name = "tablib-${version}";
-    version = "0.10.0";
+    version = "0.12.1";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/t/tablib/tablib-${version}.tar.gz";
-      sha256 = "14wc8bmz60g35r6gsyhdzfvgfqpd3gw9lfkq49z5bxciykbxmhj1";
+      sha256 = "11wxchj0qz77dn79yiq30k4b4gsm429f4bizk4lm4rb63nk51kxq";
     };
 
-    buildInputs = with self; [ pytest ];
-
-    disabled = isPy3k;
+    buildInputs = with self; [ pytest unicodecsv pandas ];
+    propagatedBuildInputs = with self; [ xlwt openpyxl pyyaml xlrd odfpy ];
 
     meta = with stdenv.lib; {
       description = "Tablib: format-agnostic tabular dataset library";


### PR DESCRIPTION
### PR &rarr; `release-17.09` (_not_ `master`)
This PR targets branch `release-17.09`, not branch `master`. The changes proposed here are also based on `release-17.09` and (other than advised in [the README](https://github.com/NixOS/nixpkgs/blob/master/README.md)) have **not** been rebased onto `master`.

Rebasing these changes onto `master` would lose a part of them, as the `disabled = isPy3k;` line being removed here isn't even present on `master`. (It was introduced with 4b5cc4e808b1 that as of today isn't an ancestor of `master`.)

### Motivation for this change

Progress on: #28643

https://github.com/NixOS/nixpkgs/commit/4b5cc4e808b1#diff-2afbba83e1b14f9e0c304c769831a0e2R3411 disabled `tablib` for Python&nbsp;3, probably because [the build was failing](https://hydra.nixos.org/build/61458071) with
> ValueError: cannot use LOCALE flag with a str pattern

at https://github.com/kennethreitz/tablib/blob/v0.10.0/tablib/packages/xlwt3/ExcelFormulaLexer.py#L52

`tablib` `v0.10.0` seems to be back [from 2014](https://github.com/kennethreitz/tablib/commits/v0.10.0) and the failing code itself [from 2011](https://github.com/kennethreitz/tablib/commit/0e56db632ad18d169a2e935b5e9aaa97f9c3b71b). The issue at hand has been fixed in kennethreitz/tablib#263 in 2016 for `tablib` `v0.11.4` and later, incl. the current `v0.12.1`. Time for us to update, too, I guess.

#### New dependencies

`tablib` `v0.12.1` needs some additional build- and runtime dependencies that are also being added to the derivation with this change:
* `xlwt`, `openpyxl`, `pyyaml`, `xlrd`, `odfpy`, `unicodecsv` and `pandas` are needed for the build to succeed.
* `xlwt`, `openpyxl`, `pyyaml`, `xlrd` and `odfpy` are needed for `import tablib` to succeed in a Python&nbsp;3.6 environment with the resulting `tablib` installed.

The latter have therefore be added as `propagatedBuildInputs`, while `unicodecsv` and `pandas` have been added to `buildInputs`.

### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

