### PR TITLE
nixos/gnome3: use ibus from i18n.inputMethod

### DIFF
--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -23,7 +23,7 @@ let
   maintainers = with pkgs.lib.maintainers; [ lethalman jtojnar ];
 
   corePackages = with gnome3; [
-    pkgs.desktop-file-utils pkgs.ibus
+    pkgs.desktop-file-utils
     pkgs.shared-mime-info # for update-mime-database
     glib # for gsettings
     gtk3.out # for gtk-update-icon-cache


### PR DESCRIPTION
###### Motivation for this change

Since 3.6, GNOME 3 uses `ibus` by default: https://help.gnome.org/misc/release-notes/3.6/i18n-ibus.html.en

Before this change, vanilla `ibus` would end up in `environment.systemPackages` and clobber `ibus-with-plugins` as defined by `i18n.inputMethod.ibus.engines`.

Ref: https://github.com/NixOS/nixpkgs/pull/17532#issuecomment-237956139

I'm using these on top of unstable right now and it makes Anthy work at least.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

