### PR TITLE
[17.09] Apache Spark address CVE-2017-12612

### DIFF
--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation rec {
     license          = stdenv.lib.licenses.asl20;
     platforms        = stdenv.lib.platforms.all;
     maintainers      = with maintainers; [ thoughtpolice offline ];
+    knownVulnerabilities = optional (!((versionAtLeast version "2.2.0") || (versionOlder version "2.2.0" && versionAtLeast version "2.1.2"))) "CVE-2017-12612";
     repositories.git = git://git.apache.org/spark.git;
   };
 }

--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -10,9 +10,9 @@ let
                 hadoopVersion = "cdh4";
                 sparkSha256 = "00il083cjb9xqzsma2ifphq9ggichwndrj6skh2z5z9jk3z0lgyn";
               };
-    "2.1.0" = {
+    "2.1.2" = {
                 hadoopVersion = "hadoop2.4";
-                sparkSha256 = "0pbsmbjwijsfgbnm56kgwnmnlqkz3w010ma0d7vzlkdklj40vqn2";
+                sparkSha256 = "0ri272bbpdbhj68ynp1d769zp5rhpjc7hh1zi8gfp0lj31h6vpza";
               };
   };
 in

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -153,6 +153,7 @@ let
     broken = bool;
 
     # Weirder stuff that doesn't appear in the documentation?
+    knownVulnerabilities = listOf str;
     version = str;
     tag = str;
     updateWalker = bool;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6689,7 +6689,7 @@ with pkgs;
 
   spark = spark_21;
   spark_16 = callPackage ../applications/networking/cluster/spark { version = "1.6.3"; };
-  spark_21 = callPackage ../applications/networking/cluster/spark { version = "2.1.0"; };
+  spark_21 = callPackage ../applications/networking/cluster/spark { version = "2.1.2"; };
 
   spidermonkey_1_8_5 = callPackage ../development/interpreters/spidermonkey/1.8.5.nix { };
   spidermonkey_17 = callPackage ../development/interpreters/spidermonkey/17.nix { };


### PR DESCRIPTION
###### Motivation for this change

During a routine check I found that our current Apache Spark version is affected by CVE-2017-12612.

This PR marks the ancient Apache Spark version form the 1.6 branch as insecure. It doesn't receive any updates anymore.

The minor version bump for the 2.1 branch should fix the mentioned CVE among some upstream fixes [1].

CC maintainers and contributors:  @thoughtpolice @offlinehacker @cko @mboes @samuelrivas 


[1] https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315420&version=12340295

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

