### PR TITLE
cassandra: version bump 2.1.15->2.1.19, 2.2.9->2.2.11, 3.0.9->3.0.15

### DIFF
--- a/pkgs/servers/nosql/cassandra/2.1.nix
+++ b/pkgs/servers/nosql/cassandra/2.1.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "2.1.15";
-  sha256 = "1yc6r4gmxz9c4zghzn6bz5wswz7dz61w7p4x9s5gqnixfp2mlapp";
+  version = "2.1.19";
+  sha256 = "1qlc62j3hf5831yrrbydn3z19zrn6bpirarinys6bmhshr7mhpyr";
 })

--- a/pkgs/servers/nosql/cassandra/2.2.nix
+++ b/pkgs/servers/nosql/cassandra/2.2.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "2.2.9";
-  sha256 = "1wc2l8l7i43r0yc6qqi3wj4pm0969kjkh2pgx80wglzxm7275hv5";
+  version = "2.2.11";
+  sha256 = "0r39mm5ibdn9dqv11n4x33vcb5247r6fl6r07l6frqp6i36ilvl6";
 })

--- a/pkgs/servers/nosql/cassandra/3.0.nix
+++ b/pkgs/servers/nosql/cassandra/3.0.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "3.0.9";
-  sha256 = "16jdh20cr4h47ldjqlnp2cdnb9zshqvnll6995s2a75d8m030c0g";
+  version = "3.0.15";
+  sha256 = "1n92wpp5gm41r4agjwjw9ymnnn114pmaqf04c1dx3fksk100wd5g";
 })


### PR DESCRIPTION
###### Motivation for this change

Bump older (but still supported) versions of Apache Cassandra.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I used the new tests of #31410. This tests `nodetool`, `cqlsh` and building a cassandra cluster.

---

