### PR TITLE
nixos/release.nix: Refactoring for better multi-system support

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -123,22 +123,13 @@ in rec {
   # Build the initial ramdisk so Hydra can keep track of its size over time.
   initialRamdisk = buildFromConfig ({ pkgs, ... }: { }) (config: config.system.build.initialRamdisk);
 
-  netboot = {
-    x86_64-linux = makeNetboot {
-      system = "x86_64-linux";
-      modules = [
-        ./modules/installer/netboot/netboot-minimal.nix
-        versionModule
-      ];
-    };
-  } // (optionalAttrs (elem "aarch64-linux" supportedSystems) {
-    aarch64-linux = makeNetboot {
-      system = "aarch64-linux";
-      modules = [
-        ./modules/installer/netboot/netboot-minimal.nix
-        versionModule
-      ];
-    };});
+  netboot = forTheseSystems [ "x86_64-linux" "aarch64-linux" ] (system: makeNetboot {
+    inherit system;
+    modules = [
+      ./modules/installer/netboot/netboot-minimal.nix
+      versionModule
+    ];
+  });
 
   iso_minimal = forAllSystems (system: makeIso {
     module = ./modules/installer/cd-dvd/installation-cd-minimal.nix;
@@ -146,7 +137,7 @@ in rec {
     inherit system;
   });
 
-  iso_graphical = genAttrs [ "x86_64-linux" ] (system: makeIso {
+  iso_graphical = forTheseSystems [ "x86_64-linux" ] (system: makeIso {
     module = ./modules/installer/cd-dvd/installation-cd-graphical-kde.nix;
     type = "graphical";
     inherit system;
@@ -154,7 +145,7 @@ in rec {
 
   # A variant with a more recent (but possibly less stable) kernel
   # that might support more hardware.
-  iso_minimal_new_kernel = genAttrs [ "x86_64-linux" ] (system: makeIso {
+  iso_minimal_new_kernel = forTheseSystems [ "x86_64-linux" ] (system: makeIso {
     module = ./modules/installer/cd-dvd/installation-cd-minimal-new-kernel.nix;
     type = "minimal-new-kernel";
     inherit system;
@@ -162,7 +153,7 @@ in rec {
 
 
   # A bootable VirtualBox virtual appliance as an OVA file (i.e. packaged OVF).
-  ova = genAttrs [ "x86_64-linux" ] (system:
+  ova = forTheseSystems [ "x86_64-linux" ] (system:
 
     with import nixpkgs { inherit system; };
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -3,6 +3,7 @@
 , supportedSystems ? [ "x86_64-linux" "aarch64-linux" ]
 }:
 
+with import ../pkgs/top-level/release-lib.nix { inherit supportedSystems; };
 with import ../lib;
 
 let
@@ -10,8 +11,6 @@ let
   version = fileContents ../.version;
   versionSuffix =
     (if stableBranch then "." else "pre") + "${toString nixpkgs.revCount}.${nixpkgs.shortRev}";
-
-  forAllSystems = genAttrs supportedSystems;
 
   importTest = fn: args: system: import fn ({
     inherit system;

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -75,7 +75,7 @@ in
         f (["buildPackages"] ++ path) { inherit system crossSystem; }
       );
 
-    testEqual = path: systems: forAllSupportedSystems systems (testEqualOne path);
+    testEqual = path: systems: forTheseSystems systems (testEqualOne path);
 
     mapTestEqual = lib.mapAttrsRecursive testEqual;
 

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -58,6 +58,7 @@ rec {
      interested in the result of cross building a package. */
   crossMaintainers = [ maintainers.viric ];
 
+  forAllSystems = genAttrs supportedSystems;
   forTheseSystems = systems: f:
     genAttrs (filter (x: elem x supportedSystems) systems) f;
 

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -58,7 +58,7 @@ rec {
      interested in the result of cross building a package. */
   crossMaintainers = [ maintainers.viric ];
 
-  forAllSupportedSystems = systems: f:
+  forTheseSystems = systems: f:
     genAttrs (filter (x: elem x supportedSystems) systems) f;
 
   /* Build a package on the given set of platforms.  The function `f'
@@ -66,14 +66,14 @@ rec {
      platform as an argument .  We return an attribute set containing
      a derivation for each supported platform, i.e. ‘{ x86_64-linux =
      f pkgs_x86_64_linux; i686-linux = f pkgs_i686_linux; ... }’. */
-  testOn = systems: f: forAllSupportedSystems systems
+  testOn = systems: f: forTheseSystems systems
     (system: hydraJob' (f (pkgsFor system)));
 
 
   /* Similar to the testOn function, but with an additional
      'crossSystem' parameter for allPackages, defining the target
      platform for cross builds. */
-  testOnCross = crossSystem: systems: f: forAllSupportedSystems systems
+  testOnCross = crossSystem: systems: f: forTheseSystems systems
     (system: hydraJob' (f (allPackages { inherit system crossSystem; })));
 
 


### PR DESCRIPTION
Currently, even if you pass `supportedSystems = [ "aarch64-linux" ]` you
end up with e.g. `nixos.iso_graphical.x86_64-linux` job. Using the new
forSubsetOfSystems avoids that.

This shouldn't affect the usual x86 trunk-combined jobset.

https://hydra.nixos.org/eval/1425558#tabs-removed for the effect on an aarch64-only jobset.