### PR TITLE
tifffile: init at v0.13.0

### DIFF
--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -1,25 +1,28 @@
-{lib, stdenv, fetchFromGitHub, python, buildPythonPackage, isPyPy, isPy27, numpy, nose,
- enum34, pythonOlder, futures}:
+{ lib, stdenv, fetchPypi, buildPythonPackage, isPy27, pythonOlder
+, numpy, nose, enum34, futures }:
 
 buildPythonPackage rec {
   pname = "tifffile";
-  rev = "v0.13.0";
-  name = "${pname}-${rev}";
+  version = "0.13.0";
 
-  src = fetchFromGitHub {
-    owner = "blink1073";
-    repo = "tifffile";
-    inherit rev;
-    sha256 = "0adm1zf3b4gf8yjriidjnl9abcycqiy5bzannwyb8rcbh3jwdbzv";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rqx2bar6dcsbmzq68mjh5bsyjzhbkqxi2dsv7j0vdbnjs5dfq9q";
   };
 
-  buildInputs = [ nose ];
-    
-  propagatedBuildInputs = [ numpy ] ++ lib.optional isPy27 futures ++ lib.optional (pythonOlder "3.0") enum34;
+  checkInputs = [ nose ];
+  checkPhase = ''
+    nosetests --exe -v --exclude="test_extension"
+  '';
 
-  meta = {
+  propagatedBuildInputs = [ numpy ]
+    ++ lib.optional isPy27 futures
+    ++ lib.optional (pythonOlder "3.0") enum34;
+
+  meta = with stdenv.lib; {
     description = "Read and write image data from and to TIFF files.";
     homepage = https://github.com/blink1073/tifffile;
-    maintainers = with lib.maintainers; [ lebastr ];
+    maintainers = [ maintainers.lebastr ];
+    license = licenses.bsd2;
   };
 }

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -1,0 +1,25 @@
+{lib, stdenv, fetchFromGitHub, python, buildPythonPackage, isPyPy, isPy27, numpy, nose,
+ enum34, pythonOlder, futures}:
+
+buildPythonPackage rec {
+  pname = "tifffile";
+  rev = "v0.13.0";
+  name = "${pname}-${rev}";
+
+  src = fetchFromGitHub {
+    owner = "blink1073";
+    repo = "tifffile";
+    inherit rev;
+    sha256 = "0adm1zf3b4gf8yjriidjnl9abcycqiy5bzannwyb8rcbh3jwdbzv";
+  };
+
+  buildInputs = [ nose ];
+    
+  propagatedBuildInputs = [ numpy ] ++ lib.optional isPy27 futures ++ lib.optional (pythonOlder "3.0") enum34;
+
+  meta = {
+    description = "Read and write image data from and to TIFF files.";
+    homepage = https://github.com/blink1073/tifffile;
+    maintainers = with lib.maintainers; [ lebastr ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17802,6 +17802,8 @@ in {
 
   tiros = callPackage ../development/python-modules/tiros { };
 
+  tifffile = callPackage ../development/python-modules/tifffile { };
+    
   # Tkinter/tkinter is part of the Python standard library.
   # The Python interpreters in Nixpkgs come without tkinter by default.
   # To make the module available, we make it available as any other


### PR DESCRIPTION
###### Motivation for this change
I needed to read a 16bit tiff files with python. Tifffile reads tiff into numpy array.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

