### PR TITLE
virt-manager: add gobjectIntrospection to nativeBuildInputs

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -17,7 +17,10 @@ python2Packages.buildPythonApplication rec {
     sha256 = "093azs8p4p7y4nf5j25xpsvdxww7gky1g0hs8mkcvmpxl2wjd0jj";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook intltool file ];
+  nativeBuildInputs = [
+    wrapGAppsHook intltool file
+    gobjectIntrospection # for setup hook populating GI_TYPELIB_PATH
+  ];
 
   buildInputs =
     [ libvirt-glib vte virtinst dconf gtkvnc gnome3.defaultIconTheme avahi


### PR DESCRIPTION
Another package broken by removal of `gobjectIntrospection` from `propagatedBuildInputs` of `atk` (6bbec17d44d700c9d847a486b6168b2ea57e7350).

This is similar to ea595a0fbfeef0585f4f44ab5173e88018bf0d10, 5350b0f6694fe1aa3f0d8d2523d8301382f72ae5, 2a1425d8b7504572dbceb69e851aa27f05b4fc34, d99321cf68a2b200112f384f311de2c1f87d39d8, etc.

###### Motivation for this change

Without this, `virt-manager` fails to start with this error:
```
Traceback (most recent call last):
  File "/nix/store/5fvw5w6bykry9yqnz0wfrn39s7x3fhcx-virt-manager-1.4.3/share/virt-manager/virt-manager", line 32, in <module>
    gi.require_version('LibvirtGLib', '1.0')
  File "/nix/store/p6fnhmmvr28ziv19c37hr9n6vkcy25an-python2.7-pygobject-3.26.1/lib/python2.7/site-packages/gi/__init__.py", line 130, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace LibvirtGLib not available
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

