### PR TITLE
pngpp: darwin support

### DIFF
--- a/pkgs/development/libraries/png++/default.nix
+++ b/pkgs/development/libraries/png++/default.nix
@@ -21,13 +21,17 @@ stdenv.mkDerivation rec {
 
   postCheck = "cat test/test.log";
 
-  buildInputs = [ ]
-    ++ stdenv.lib.optional docSupport doxygen;
+  buildInputs = stdenv.lib.optional docSupport doxygen;
 
   propagatedBuildInputs = [ libpng ];
 
-  makeFlags = [ "PREFIX=\${out}" ]
-    ++ stdenv.lib.optional docSupport "docs";
+  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace error.hpp --replace "#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE" "#if (__clang__ || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE"
+  '' + ''
+    sed "s|\(PNGPP := .\)|PREFIX := ''${out}\n\\1|" -i Makefile
+  '';
+
+  makeFlags = stdenv.lib.optional docSupport "docs";
 
   enableParallelBuilding = true;
 
@@ -35,7 +39,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.nongnu.org/pngpp/;
     description = "C++ wrapper for libpng library";
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.ramkromberg ];
   };
 }


### PR DESCRIPTION
1) Building with clang is addressed by navigating a minor #if in some
of the code.

2) I noticed that even when things were building correctly, passing
`${out}` as a variable assignment to `make` was actually not working:
there were compiler warnings about missing include directories whose
bogus paths involved the literal string `out`. I ended up fixing this
by performing the assignment to the make variable `PREFIX` in the
`Makefile` itself.

###### Motivation for this change
Make pngpp build on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

