### PR TITLE
pgmanage: 10.0.2 -> 10.1.0

### DIFF
--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pgmanage-${version}";
-  version = "10.0.2";
+  version = "10.1.0";
 
   src = fetchFromGitHub {
     owner  = "pgManage";
     repo   = "pgManage";
     rev    = "v${version}";
-    sha256 = "0g9kvhs9b6kc1s7j90fqv71amiy9v0w5p906yfvl0j7pf3ayq35a";
+    sha256 = "0kzdq3xl6wyclngq307544yk57vpm10wyklkbgzx649z3pls3kyw";
   };
 
   buildInputs = [ postgresql openssl ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/pgManage/pgManage/releases/tag/v10.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

