### PR TITLE
elasticsearch-curator-5.4.1 on release-17.09

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -8,7 +8,7 @@
 , ensureNewerSourcesHook
 }:
 
-{ name
+{ name ? "${attrs.pname}-${attrs.version}"
 
 # by default prefix `name` e.g. "python3.3-${name}"
 , namePrefix ? python.libPrefix + "-"

--- a/pkgs/development/python-modules/elasticsearch-curator/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-curator/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, click
+, certifi
+, voluptuous
+, pyyaml
+, elasticsearch
+, nosexcover
+, coverage
+, nose
+, mock
+, funcsigs
+} :
+
+buildPythonPackage rec {
+  pname   = "elasticsearch-curator";
+  version = "5.4.1";
+  name    = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bhiqa61h6bbrfp0aygwwchr785x281hnwk8qgnjhb8g4r8ppr3s";
+  };
+
+  # The integration tests require a running elasticsearch cluster.
+  postUnpackPhase = ''
+    rm -r test/integration
+  '';
+
+  propagatedBuildInputs = [
+    click
+    certifi
+    voluptuous
+    pyyaml
+    elasticsearch
+  ];
+
+  checkInputs = [
+    nosexcover
+    coverage
+    nose
+    mock
+    funcsigs
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/elastic/curator;
+    description = "Curate, or manage, your Elasticsearch indices and snapshots";
+    license = licenses.asl20;
+    longDescription = ''
+      Elasticsearch Curator helps you curate, or manage, your Elasticsearch
+      indices and snapshots by:
+
+      * Obtaining the full list of indices (or snapshots) from the cluster, as the
+        actionable list
+
+      * Iterate through a list of user-defined filters to progressively remove
+        indices (or snapshots) from this actionable list as needed.
+
+      * Perform various actions on the items which remain in the actionable list.
+    '';
+    maintainers = with maintainers; [ basvandijk ];
+  };
+}

--- a/pkgs/development/python-modules/elasticsearch-curator/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-curator/default.nix
@@ -16,7 +16,6 @@
 buildPythonPackage rec {
   pname   = "elasticsearch-curator";
   version = "5.4.1";
-  name    = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/elasticsearch/default.nix
+++ b/pkgs/development/python-modules/elasticsearch/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchPypi
+, urllib3, requests
+, nosexcover, mock
+, stdenv
+}:
+
+buildPythonPackage (rec {
+  pname = "elasticsearch";
+  version = "6.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "029q603g95fzkh87xkbxxmjfq5s9xkr9y27nfik6d4prsl0zxmlz";
+  };
+
+  # Check is disabled because running them destroy the content of the local cluster!
+  # https://github.com/elasticsearch/elasticsearch-py/tree/master/test_elasticsearch
+  doCheck = false;
+  propagatedBuildInputs = [ urllib3 requests ];
+  buildInputs = [ nosexcover mock ];
+
+  meta = with stdenv.lib; {
+    description = "Official low-level client for Elasticsearch";
+    homepage = https://github.com/elasticsearch/elasticsearch-py;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ desiderius ];
+  };
+})

--- a/pkgs/development/python-modules/voluptuous/default.nix
+++ b/pkgs/development/python-modules/voluptuous/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "voluptuous";
   version = "0.10.5";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/voluptuous/default.nix
+++ b/pkgs/development/python-modules/voluptuous/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "voluptuous";
+  version = "0.10.5";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15i3gaap8ilhpbah1ffc6q415wkvliqxilc6s69a4rinvkw6cx3s";
+  };
+
+  checkInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    description = "Voluptuous is a Python data validation library";
+    homepage = http://alecthomas.github.io/voluptuous/;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16633,26 +16633,6 @@ in {
     };
   };
 
-  pyelasticsearch = buildPythonPackage (rec {
-    name = "pyelasticsearch-1.4";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyelasticsearch/${name}.tar.gz";
-      sha256 = "18wp6llfjv6hvyhr3f6i8dm9wc5rf46wiqsfxwpvnf6mdrvk6xr7";
-    };
-
-    # Tests require a local instance of elasticsearch
-    doCheck = false;
-    propagatedBuildInputs = with self; [ elasticsearch six simplejson certifi ];
-    buildInputs = with self; [ nose mock ];
-
-    meta = {
-      description = "A clean, future-proof, high-scale API to elasticsearch";
-      homepage = https://pyelasticsearch.readthedocs.org;
-      license = licenses.bsd3;
-    };
-  });
-
   pyelftools = buildPythonPackage rec {
     pname = "pyelftools";
     version = "0.24";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5106,11 +5106,13 @@ in {
   edward = callPackage ../development/python-modules/edward { };
 
   elasticsearch = buildPythonPackage (rec {
-    name = "elasticsearch-1.9.0";
+    pname = "elasticsearch";
+    version = "6.0.0";
+    name = "${pname}-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/e/elasticsearch/${name}.tar.gz";
-      sha256 = "091s60ziwhyl9kjfm833i86rcpjx46v9h16jkgjgkk5441dln3gb";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "029q603g95fzkh87xkbxxmjfq5s9xkr9y27nfik6d4prsl0zxmlz";
     };
 
     # Check is disabled because running them destroy the content of the local cluster!
@@ -5126,7 +5128,6 @@ in {
       maintainers = with maintainers; [ desiderius ];
     };
   });
-
 
   elasticsearchdsl = buildPythonPackage (rec {
     name = "elasticsearch-dsl-0.0.9";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5105,29 +5105,7 @@ in {
 
   edward = callPackage ../development/python-modules/edward { };
 
-  elasticsearch = buildPythonPackage (rec {
-    pname = "elasticsearch";
-    version = "6.0.0";
-    name = "${pname}-${version}";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "029q603g95fzkh87xkbxxmjfq5s9xkr9y27nfik6d4prsl0zxmlz";
-    };
-
-    # Check is disabled because running them destroy the content of the local cluster!
-    # https://github.com/elasticsearch/elasticsearch-py/tree/master/test_elasticsearch
-    doCheck = false;
-    propagatedBuildInputs = with self; [ urllib3 requests ];
-    buildInputs = with self; [ nosexcover mock ];
-
-    meta = {
-      description = "Official low-level client for Elasticsearch";
-      homepage = https://github.com/elasticsearch/elasticsearch-py;
-      license = licenses.asl20;
-      maintainers = with maintainers; [ desiderius ];
-    };
-  });
+  elasticsearch = callPackage ../development/python-modules/elasticsearch { };
 
   elasticsearchdsl = buildPythonPackage (rec {
     name = "elasticsearch-dsl-0.0.9";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27001,6 +27001,7 @@ EOF
 
   parse-type = callPackage ../development/python-modules/parse-type { };
 
+  voluptuous = callPackage ../development/python-modules/voluptuous { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5151,6 +5151,8 @@ in {
     };
   });
 
+  elasticsearch-curator = callPackage ../development/python-modules/elasticsearch-curator { };
+
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 
   enzyme = callPackage ../development/python-modules/enzyme {};


### PR DESCRIPTION
###### Motivation for this change

@orivej I would like to use `elasticsearch-curator` on 17.09 so I cherry picked the commits from https://github.com/NixOS/nixpkgs/pull/32905 on `release-17.09`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

