### PR TITLE
avrgcc: bake path to avr-ar into avr-gcc-ar

### DIFF
--- a/pkgs/development/misc/avr/gcc/avrbinutils-path.patch
+++ b/pkgs/development/misc/avr/gcc/avrbinutils-path.patch
@@ -1,0 +1,15 @@
+diff --git a/gcc/gcc-ar.c b/gcc/gcc-ar.c
+index 838ebc2..3ac4ee7 100644
+--- a/gcc/gcc-ar.c
++++ b/gcc/gcc-ar.c
+@@ -118,8 +118,8 @@ setup_prefixes (const char *exec_path)
+ 				dir_separator, NULL);
+   prefix_from_string (self_libexec_prefix, &target_path);
+ 
+-  /* Add path as a last resort.  */
+-  prefix_from_env ("PATH", &path);
++  /* Add path to avrbinutils.  */
++  prefix_from_string ("@avrbinutils@/bin", &path);
+ }
+ 
+ int 

--- a/pkgs/development/misc/avr/gcc/default.nix
+++ b/pkgs/development/misc/avr/gcc/default.nix
@@ -11,6 +11,16 @@ stdenv.mkDerivation {
     sha256 = "0fihlcy5hnksdxk0sn6bvgnyq8gfrgs8m794b1jxwd1dxinzg3b0";
   };
 
+  patches = [
+    ./avrbinutils-path.patch
+  ];
+
+  # avrbinutils-path.patch introduces a reference to @avrbinutils@, substitute
+  # it now.
+  postPatch = ''
+    substituteInPlace gcc/gcc-ar.c --subst-var-by avrbinutils ${avrbinutils}
+  '';
+
   buildInputs = [ gmp mpfr libmpc zlib avrbinutils ];
 
   nativeBuildInputs = [ texinfo ];


### PR DESCRIPTION
(tl;dr: this fixes a bug in `avrgcc` that's present in master and in the current release)

`gcc` provides wrappers for `binutils`' `ar`, `nm` and `ranlib`
executables, which must be used instead when using link-time
optimisation. See also:
http://manpages.ubuntu.com/manpages/zesty/man1/aarch64-linux-gnu-gcc-ar-5.1.html

The upstream version of `avr-gcc-ar` searches in paths passed to
the `configure` script for the `avr-ar` binary that it wraps, falling
back to searching `PATH` instead. Thus currently `avr-gcc-ar` works on
Nix, but only if `avrbinutils` is already in the environment.

This change bakes the path to `avr-ar` into `avr-gcc-ar`, since its path
is known at compile time. It also no longer searches `PATH`, meaning the
user's local environment won't override this path.

Note that `avr-gcc-nm` and `avr-gcc-ranlib` are compiled from the same
source file as `avr-gcc-ar`, just with different compiler flags.

Testing on master (without `avrbinutils` in the environment):

    $ nix-build -A avrgcc
    $ result/bin/avr-gcc-ar --version
    result/bin/avr-gcc-ar: Cannot find binary 'avr-ar'

Testing on branch with this fix:

    $ nix-build -A avrgcc
    $ result/bin/avr-gcc-ar --version
    GNU ar (GNU Binutils) 2.26.20160125
    ...

###### Motivation for this change

`avr-gcc-ar` shouldn't require any particular package to be present in the user's environment when it is run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc package maintainer @mguentner