### PR TITLE
pixie: refactor to allow macOS build

### DIFF
--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -63,15 +63,15 @@ let
       mkdir -p $out/share $out/bin
       cp pixie-src/pixie-vm $out/share/pixie-vm
       cp -R pixie-src/pixie $out/share/pixie
-      makeWrapper $out/share/pixie-vm $out/bin/pixie-vm \
+      makeWrapper $out/share/pixie-vm $out/bin/pixie \
         --prefix LD_LIBRARY_PATH : ${library-path} \
         --prefix C_INCLUDE_PATH : ${include-path} \
         --prefix LIBRARY_PATH : ${library-path} \
         --prefix PATH : ${bin-path}
       cat > $out/bin/pxi <<EOF
       #!$shell
-      >&2 echo "[\$\$] WARNING: 'pxi' is a deprecated alias for 'pixie-vm', please update your scripts."
-      exec $out/bin/pixie-vm "\$@"
+      >&2 echo "[\$\$] WARNING: 'pxi' and 'pixie-vm' are deprecated aliases for 'pixie', please update your scripts."
+      exec $out/bin/pixie "\$@"
       EOF
       chmod +x $out/bin/pxi
     '';
@@ -79,7 +79,7 @@ let
       description = "A clojure-like lisp, built with the pypy vm toolkit";
       homepage = https://github.com/pixie-lang/pixie;
       license = stdenv.lib.licenses.lgpl3;
-      platforms = ["x86_64-linux" "i686-linux"];
+      platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
     };
   };
 in build (builtins.getAttr variant variants)

--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -79,7 +79,7 @@ let
       description = "A clojure-like lisp, built with the pypy vm toolkit";
       homepage = https://github.com/pixie-lang/pixie;
       license = stdenv.lib.licenses.lgpl3;
-      platforms = ["x86_64-linux" "x86_64-darwin"];
+      platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
     };
   };
 in build (builtins.getAttr variant variants)

--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -79,7 +79,7 @@ let
       description = "A clojure-like lisp, built with the pypy vm toolkit";
       homepage = https://github.com/pixie-lang/pixie;
       license = stdenv.lib.licenses.lgpl3;
-      platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
+      platforms = ["x86_64-linux" "x86_64-darwin"];
     };
   };
 in build (builtins.getAttr variant variants)

--- a/pkgs/development/interpreters/pixie/dust.nix
+++ b/pkgs/development/interpreters/pixie/dust.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     description = "Provides tooling around pixie, e.g. a nicer repl, running tests and fetching dependencies";
     homepage = src.meta.homepage;
     license = stdenv.lib.licenses.lgpl3;
-    platforms = ["x86_64-linux" "x86_64-darwin"];
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }

--- a/pkgs/development/interpreters/pixie/dust.nix
+++ b/pkgs/development/interpreters/pixie/dust.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     description = "Provides tooling around pixie, e.g. a nicer repl, running tests and fetching dependencies";
     homepage = src.meta.homepage;
     license = stdenv.lib.licenses.lgpl3;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = ["x86_64-linux" "x86_64-darwin"];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
- Adding macOS support for pixie (pixie has been support on macOS for quite a while already)
- Updating the name as discussed on issue 445 (https://github.com/pixie-lang/pixie/issues/455)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---