### PR TITLE
enpass: 5.6.0 -> 5.6.5

### DIFF
--- a/pkgs/tools/security/enpass/data.json
+++ b/pkgs/tools/security/enpass/data.json
@@ -1,12 +1,12 @@
 {
   "amd64": {
-    "path": "pool/main/e/enpass/enpass_5.6.0_amd64.deb", 
-    "sha256": "129ae4b4bfb8e0b4fa9acdfb3aebac3dd894364f2f31e9cd3bd5d3567e3a13b7", 
-    "version": "5.6.0"
+    "path": "pool/main/e/enpass/enpass_5.6.5_amd64.deb", 
+    "sha256": "c7529b745aa462b56eac17af6fe88d4c1610fd2f446d222aaad9510f19212a7d", 
+    "version": "5.6.5"
   }, 
   "i386": {
-    "path": "pool/main/e/enpass/enpass_5.6.0_i386.deb", 
-    "sha256": "c456002194c0be08a2c0da68ecf224425e35c46de5292098208e4e2b1f6d88ae", 
-    "version": "5.6.0"
+    "path": "pool/main/e/enpass/enpass_5.6.5_i386.deb", 
+    "sha256": "de46e27d5552dcd9d72abac8e5c3b6161ad551ce191a2ee689c67367b63ff8f9", 
+    "version": "5.6.5"
   }
 }


### PR DESCRIPTION
###### Motivation for this change

New release of Enpass https://www.enpass.io/release-notes/linux/

The changes in the file were done by using the "refresh" attribute on a nix-shell:
```
nix-shell  ./ -A enpass.refresh
```
which in turns uses `update_script.py` (part of the enpass tooling in nixpkgs)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

