### PR TITLE
Elasticsearch curator 5.4.1 cleanup

### DIFF
--- a/pkgs/development/python-modules/elasticsearch-curator/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-curator/default.nix
@@ -16,7 +16,6 @@
 buildPythonPackage rec {
   pname   = "elasticsearch-curator";
   version = "5.4.1";
-  name    = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/elasticsearch/default.nix
+++ b/pkgs/development/python-modules/elasticsearch/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchPypi
+, urllib3, requests
+, nosexcover, mock
+, stdenv
+}:
+
+buildPythonPackage (rec {
+  pname = "elasticsearch";
+  version = "6.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "029q603g95fzkh87xkbxxmjfq5s9xkr9y27nfik6d4prsl0zxmlz";
+  };
+
+  # Check is disabled because running them destroy the content of the local cluster!
+  # https://github.com/elasticsearch/elasticsearch-py/tree/master/test_elasticsearch
+  doCheck = false;
+  propagatedBuildInputs = [ urllib3 requests ];
+  buildInputs = [ nosexcover mock ];
+
+  meta = with stdenv.lib; {
+    description = "Official low-level client for Elasticsearch";
+    homepage = https://github.com/elasticsearch/elasticsearch-py;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ desiderius ];
+  };
+})

--- a/pkgs/development/python-modules/voluptuous/default.nix
+++ b/pkgs/development/python-modules/voluptuous/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "voluptuous";
   version = "0.10.5";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4431,29 +4431,7 @@ in {
 
   edward = callPackage ../development/python-modules/edward { };
 
-  elasticsearch = buildPythonPackage (rec {
-    pname = "elasticsearch";
-    version = "6.0.0";
-    name = "${pname}-${version}";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "029q603g95fzkh87xkbxxmjfq5s9xkr9y27nfik6d4prsl0zxmlz";
-    };
-
-    # Check is disabled because running them destroy the content of the local cluster!
-    # https://github.com/elasticsearch/elasticsearch-py/tree/master/test_elasticsearch
-    doCheck = false;
-    propagatedBuildInputs = with self; [ urllib3 requests ];
-    buildInputs = with self; [ nosexcover mock ];
-
-    meta = {
-      description = "Official low-level client for Elasticsearch";
-      homepage = https://github.com/elasticsearch/elasticsearch-py;
-      license = licenses.asl20;
-      maintainers = with maintainers; [ desiderius ];
-    };
-  });
+  elasticsearch = callPackage ../development/python-modules/elasticsearch { };
 
   elasticsearchdsl = buildPythonPackage (rec {
     name = "elasticsearch-dsl-0.0.9";


### PR DESCRIPTION
###### Motivation for this change

@FRidh these are the changes you requested in: https://github.com/NixOS/nixpkgs/pull/33760#pullrequestreview-88400114. Please merge so that I can cherry-pick them in PR #33760.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

