### PR TITLE
plano-theme: init at 3.24-3

### DIFF
--- a/pkgs/misc/themes/plano/default.nix
+++ b/pkgs/misc/themes/plano/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, gdk_pixbuf, gtk_engines, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "plano-theme-${version}";
+  version = "3.24-3";
+
+  src = fetchFromGitHub {
+    owner = "lassekongo83";
+    repo = "plano-theme";
+    rev = "v${version}";
+    sha256 = "079gj3kgsim01r7yb9dcxvrci3my1y0zkn86igdlspxcnjzmxkq0";
+  };
+
+  buildInputs = [ gdk_pixbuf gtk_engines ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -dm 755 $out/share/themes/Plano
+    cp -a * $out/share/themes/Plano/
+    rm $out/share/themes/Plano/{LICENSE,README.md}
+  '';
+
+  meta = {
+    description = "Flat theme for GNOME & Xfce4";
+    homepage = https://github.com/lassekongo83/plano-theme;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19736,6 +19736,8 @@ with pkgs;
 
   pjsip = callPackage ../applications/networking/pjsip { };
 
+  plano-theme = callPackage ../misc/themes/plano { };
+
   ppsspp = libsForQt5.callPackage ../misc/emulators/ppsspp { };
 
   pt = callPackage ../applications/misc/pt { };


### PR DESCRIPTION
###### Motivation for this change

Add [`plano-theme`](https://github.com/lassekongo83/plano-theme)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).