### PR TITLE
digitalbitbox: init at 2.2.2

### DIFF
--- a/nixos/modules/hardware/digitalbitbox.nix
+++ b/nixos/modules/hardware/digitalbitbox.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.digitalbitbox;
+in
+
+{
+  options.hardware.digitalbitbox = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables udev rules for Digital Bitbox devices.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.digitalbitbox;
+      defaultText = "pkgs.digitalbitbox";
+      description = "The Digital Bitbox package to use. This can be used to install a package with udev rules that differ from the defaults.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = [ cfg.package ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -31,6 +31,7 @@
   ./hardware/ckb.nix
   ./hardware/cpu/amd-microcode.nix
   ./hardware/cpu/intel-microcode.nix
+  ./hardware/digitalbitbox.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
   ./hardware/mcelog.nix
@@ -78,6 +79,7 @@
   ./programs/command-not-found/command-not-found.nix
   ./programs/criu.nix
   ./programs/dconf.nix
+  ./programs/digitalbitbox/default.nix
   ./programs/environment.nix
   ./programs/fish.nix
   ./programs/freetds.nix

--- a/nixos/modules/programs/digitalbitbox/default.nix
+++ b/nixos/modules/programs/digitalbitbox/default.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.digitalbitbox;
+in
+
+{
+  options.programs.digitalbitbox = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Installs the Digital Bitbox application and enables the complementary hardware module.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.digitalbitbox;
+      defaultText = "pkgs.digitalbitbox";
+      description = "The Digital Bitbox package to use. This can be used to install a package with udev rules that differ from the defaults.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    hardware.digitalbitbox = {
+      enable = true;
+      package = cfg.package;
+    };
+  };
+
+  meta = {
+    doc = ./doc.xml;
+    maintainers = with stdenv.lib.maintainers; [ vidbina ];
+  };
+}

--- a/nixos/modules/programs/digitalbitbox/doc.xml
+++ b/nixos/modules/programs/digitalbitbox/doc.xml
@@ -1,0 +1,85 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="module-programs-digitalbitbox">
+
+  <title>Digital Bitbox</title>
+
+  <para>
+    Digital Bitbox is a hardware wallet and second-factor authenticator.
+  </para>
+
+  <para>
+    The <literal>digitalbitbox</literal> programs module may be
+    installed by setting <literal>programs.digitalbitbox</literal>
+    to <literal>true</literal> in a manner similar to
+
+    <programlisting>
+      programs.digitalbitbox.enable = true;
+    </programlisting>
+
+    and bundles the <literal>digitalbitbox</literal> package (see <xref
+      linkend="sec-digitalbitbox-package" />), which contains the
+    <literal>dbb-app</literal> and <literal>dbb-cli</literal> binaries,
+    along with the hardware module (see <xref
+      linkend="sec-digitalbitbox-hardware-module" />) which sets up the
+    necessary udev rules to access the device.
+  </para>
+
+  <para>
+    Enabling the digitalbitbox module is pretty much the easiest way to
+    get a Digital Bitbox device working on your system.
+  </para>
+
+  <para>
+    For more information, see
+    <link xlink:href="https://digitalbitbox.com/start_linux" />.
+  </para>
+
+  <section xml:id="sec-digitalbitbox-package">
+    <title>Package</title>
+
+    <para>
+      The binaries, <literal>dbb-app</literal> (a GUI tool) and
+      <literal>dbb-cli</literal> (a CLI tool), are available through the
+      <literal>digitalbitbox</literal> package which could be installed
+      as follows:
+
+      <programlisting>
+        environment.systemPackages = [
+          pkgs.digitalbitbox
+        ];
+      </programlisting>
+    </para>
+  </section>
+
+
+  <section xml:id="sec-digitalbitbox-hardware-module">
+    <title>Hardware</title>
+
+    <para>
+      The digitalbitbox hardware package enables the udev rules for
+      Digital Bitbox devices and may be installed as follows:
+
+      <programlisting>
+        hardware.digitalbitbox.enable = true;
+      </programlisting>
+    </para>
+
+    <para>
+      In order to alter the udev rules, one may provide different values for
+      the <literal>udevRule51</literal> and <literal>udevRule52</literal>
+      attributes by means of overriding as follows:
+
+      <programlisting>
+        programs.digitalbitbox = {
+          enable = true;
+          package = pkgs.digitalbitbox.override {
+            udevRule51 = "something else";
+          };
+        };
+      </programlisting>
+    </para>
+  </section>
+</chapter>

--- a/pkgs/applications/misc/digitalbitbox/default.nix
+++ b/pkgs/applications/misc/digitalbitbox/default.nix
@@ -1,25 +1,26 @@
-{
-  stdenv,
-  autoreconfHook,
-  curl,
-  fetchFromGitHub,
-  gcc5,
-  git,
-  libevent,
-  libtool,
-  libqrencode,
-  libudev,
-  libusb,
-  makeWrapper,
-  pkgconfig,
-  qt59,
-  udevRule51 ? ''
-    SUBSYSTEM=="usb", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbb%n", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402"
-  '',
-  udevRule52 ? ''
-    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbbf%n"
-  '',
-  writeText,
+{ stdenv
+, autoreconfHook
+, curl
+, fetchFromGitHub
+, git
+, libevent
+, libtool
+, libqrencode
+, libudev
+, libusb
+, makeWrapper
+, pkgconfig
+, qtbase
+, qttools
+, qtwebsockets
+, qtmultimedia
+, udevRule51 ? ''
+,   SUBSYSTEM=="usb", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbb%n", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402"
+, ''
+, udevRule52 ? ''
+,   KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbbf%n"
+, ''
+, writeText
 }:
 
 # Enabling the digitalbitbox program
@@ -43,8 +44,6 @@
 
 # See https://digitalbitbox.com/start_linux for more information.
 let
-  gcc = gcc5;
-  qt = qt59;
   copyUdevRuleToOutput = name: rule:
     "cp ${writeText name rule} $out/etc/udev/rules.d/${name}";
 in stdenv.mkDerivation rec {
@@ -61,10 +60,10 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = with stdenv.lib; [
     autoreconfHook
     curl
-    gcc
     git
     makeWrapper
     pkgconfig
+    qttools
   ];
 
   buildInputs = with stdenv.lib; [
@@ -73,15 +72,18 @@ in stdenv.mkDerivation rec {
     libudev
     libusb
     libqrencode
-    qt.full
+
+    qtbase
+    qtwebsockets
+    qtmultimedia
   ];
 
-  LUPDATE="${qt.qttools.dev}/bin/lupdate";
-  LRELEASE="${qt.qttools.dev}/bin/lrelease";
-  MOC="${qt.qtbase.dev}/bin/moc";
-  QTDIR="${qt.qtbase.dev}";
-  RCC="${qt.qtbase.dev}/bin/rcc";
-  UIC="${qt.qtbase.dev}/bin/uic";
+  LUPDATE="${qttools.dev}/bin/lupdate";
+  LRELEASE="${qttools.dev}/bin/lrelease";
+  MOC="${qtbase.dev}/bin/moc";
+  QTDIR="${qtbase.dev}";
+  RCC="${qtbase.dev}/bin/rcc";
+  UIC="${qtbase.dev}/bin/uic";
 
   configureFlags = [
     "--enable-libusb"

--- a/pkgs/applications/misc/digitalbitbox/default.nix
+++ b/pkgs/applications/misc/digitalbitbox/default.nix
@@ -1,0 +1,138 @@
+{
+  stdenv,
+  autoreconfHook,
+  curl,
+  fetchFromGitHub,
+  gcc5,
+  git,
+  libevent,
+  libtool,
+  libqrencode,
+  libudev,
+  libusb,
+  makeWrapper,
+  pkgconfig,
+  qt59,
+  udevRule51 ? ''
+    SUBSYSTEM=="usb", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbb%n", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402"
+  '',
+  udevRule52 ? ''
+    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbbf%n"
+  '',
+  writeText,
+}:
+
+# Enabling the digitalbitbox program
+#
+#     programs.digitalbitbox.enable = true;
+#
+# will install the digitalbitbox package and enable the corresponding hardware
+# module and is by far the easiest way to get started with the Digital Bitbox on
+# NixOS.
+
+# In case you install the package only, please be aware that you may need to
+# apply some udev rules to allow the application to identify and access your
+# wallet. In a nixos-configuration, one may accomplish this by enabling the
+# digitalbitbox hardware module
+#
+#     hardware.digitalbitbox.enable = true;
+#
+# or by adding the digitalbitbox package to system.udev.packages
+#
+#     system.udev.packages = [ pkgs.digitalbitbox ];
+
+# See https://digitalbitbox.com/start_linux for more information.
+let
+  gcc = gcc5;
+  qt = qt59;
+  copyUdevRuleToOutput = name: rule:
+    "cp ${writeText name rule} $out/etc/udev/rules.d/${name}";
+in stdenv.mkDerivation rec {
+  name = "digitalbitbox-${version}";
+  version = "2.2.2";
+
+  src = fetchFromGitHub {
+    owner = "digitalbitbox";
+    repo = "dbb-app";
+    rev = "v${version}";
+    sha256 = "1r77fvqrlaryzij5dfbnigzhvg1d12g96qb2gp8dy3xph1j0k3s1";
+  };
+
+  nativeBuildInputs = with stdenv.lib; [
+    autoreconfHook
+    curl
+    gcc
+    git
+    makeWrapper
+    pkgconfig
+  ];
+
+  buildInputs = with stdenv.lib; [
+    libevent
+    libtool
+    libudev
+    libusb
+    libqrencode
+    qt.full
+  ];
+
+  LUPDATE="${qt.qttools.dev}/bin/lupdate";
+  LRELEASE="${qt.qttools.dev}/bin/lrelease";
+  MOC="${qt.qtbase.dev}/bin/moc";
+  QTDIR="${qt.qtbase.dev}";
+  RCC="${qt.qtbase.dev}/bin/rcc";
+  UIC="${qt.qtbase.dev}/bin/uic";
+
+  configureFlags = [
+    "--enable-libusb"
+  ];
+
+  hardeningDisable = [
+    "format"
+  ];
+
+  postInstall = ''
+    mkdir -p "$out/lib"
+    cp src/libbtc/.libs/*.so* $out/lib
+    cp src/libbtc/src/secp256k1/.libs/*.so* $out/lib
+    cp src/hidapi/libusb/.libs/*.so* $out/lib
+    cp src/univalue/.libs/*.so* $out/lib
+
+    # [RPATH][patchelf] Avoid forbidden reference error
+    rm -rf $PWD
+
+    wrapProgram "$out/bin/dbb-cli" --prefix LD_LIBRARY_PATH : "$out/lib"
+    wrapProgram "$out/bin/dbb-app" --prefix LD_LIBRARY_PATH : "$out/lib"
+
+    # Provide udev rules as documented in https://digitalbitbox.com/start_linux
+    mkdir -p "$out/etc/udev/rules.d"
+    ${copyUdevRuleToOutput "51-hid-digitalbox.rules" udevRule51}
+    ${copyUdevRuleToOutput "52-hid-digitalbox.rules" udevRule52}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A QT based application for the Digital Bitbox hardware wallet";
+    longDescription = ''
+      Digital Bitbox provides dbb-app, a GUI tool, and dbb-cli, a CLI tool, to manage Digital Bitbox devices.
+
+      This package will only install the dbb-app and dbb-cli, however; in order for these applications to identify and access Digital Bitbox devices, one may want to enable the digitalbitbox hardware module by adding
+
+          hardware.digitalbitbox.enable = true;
+
+      to the configuration which is equivalent to adding this package to the udev.packages list.
+
+
+      The easiest way to use the digitalbitbox package in NixOS is by adding
+
+          programs.digitalbitbox.enable = true;
+
+      to the configuration which installs the package and enables the hardware module.
+    '';
+    homepage = "https://digitalbitbox.com/";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      vidbina
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -121,7 +121,7 @@ with pkgs;
 
   dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;
 
-  digitalbitbox = callPackage ../applications/misc/digitalbitbox { };
+  digitalbitbox = libsForQt5.callPackage ../applications/misc/digitalbitbox { };
 
   # go 1.9 pin until https://github.com/moby/moby/pull/35739
   dockerTools = callPackage ../build-support/docker { go = go_1_9; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -121,6 +121,8 @@ with pkgs;
 
   dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;
 
+  digitalbitbox = callPackage ../applications/misc/digitalbitbox { };
+
   # go 1.9 pin until https://github.com/moby/moby/pull/35739
   dockerTools = callPackage ../build-support/docker { go = go_1_9; };
 


### PR DESCRIPTION
###### Motivation for this change

I just got a [digitalbitbox](https://digitalbitbox.com/) to play around with and couldn't find the apps (searched for `dbb` or `digitalbitbox`) in the nixpkgs index (or any PR or issue for that matter) so here goes...

For context's sake: Squashed it from [this branch on top of the latest master](https://github.com/vidbina/nixpkgs/tree/add/digitalbitbox-pre-rebase) which followed from [this branch based on my `nixos-version --revision`](https://github.com/vidbina/nixpkgs/tree/wip/digitalbitbox). Maybe that helps clarify some decisions made; however messy.

![2018-01-12-160210_3200x1800_scrot](https://user-images.githubusercontent.com/335406/34880853-0a5e3236-f7b2-11e7-9a35-cf85d79bdbec.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

