### PR TITLE
 scid-vs-pc: init at version 4.18.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -506,6 +506,7 @@
   pakhfn = "Fedor Pakhomov <pakhfn@gmail.com>";
   panaeon = "Vitalii Voloshyn <vitalii.voloshyn@gmail.com";
   paperdigits = "Mica Semrick <mica@silentumbrella.com>";
+  paraseba = "Sebastian Galkin <paraseba@gmail.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   patternspandemic = "Brad Christensen <patternspandemic@live.com>";
   pawelpacana = "Paweł Pacana <pawel.pacana@gmail.com>";

--- a/pkgs/games/scid-vs-pc/0001-put-fonts-in-out.patch
+++ b/pkgs/games/scid-vs-pc/0001-put-fonts-in-out.patch
@@ -1,0 +1,77 @@
+From 7e99cf4ae3f38406133a4abf962527cd02416f8e Mon Sep 17 00:00:00 2001
+From: Sebastian Galkin <paraseba@gmail.com>
+Date: Wed, 20 Dec 2017 18:23:03 -0200
+Subject: [PATCH] put fonts in $out
+
+---
+ Makefile.conf | 22 ++++------------------
+ configure     | 12 ------------
+ 2 files changed, 4 insertions(+), 30 deletions(-)
+
+diff --git a/Makefile.conf b/Makefile.conf
+index e7f8de9..87f3fff 100644
+--- a/Makefile.conf
++++ b/Makefile.conf
+@@ -226,19 +226,11 @@ install_scid: all_scid
+ 	fi
+ 	install -m 755 -d $(SHAREDIR)/bitmaps
+ 	cp -r ./bitmaps/* $(SHAREDIR)/bitmaps/
+-	@if [ "`id -u`" -eq 0 ]; then \
+-		install -m 755 -d $(FONTDIR); \
+-		install -m 644 -p fonts/*.ttf $(FONTDIR); \
+-	else \
+-		install -m 755 -d ~/.fonts; \
+-		install -m 644 -p fonts/*.ttf ~/.fonts; \
+-	fi
++	install -m 755 -d $(FONTDIR); \
++	install -m 644 -p fonts/*.ttf $(FONTDIR); \
++
+ 	@if [ ! -z "`which fc-cache`" ]; then \
+-		if [ "`id -u`" -eq 0 ]; then \
+- 			fc-cache -fv $(FONTDIR); \
+-		else \
+-			fc-cache -fv ~/.fonts; \
+-		fi; \
++ 		fc-cache -fv $(FONTDIR); \
+ 	else \
+ 		echo "Don't know how to setup truetype fonts (fc-cache not available)."; \
+ 		echo "Please contact your system administrator."; \
+@@ -292,12 +284,6 @@ uninstall:
+ 		for f in `ls fonts/*.ttf`; do \
+ 			rm -f ~/.$$f; \
+ 		done; \
+-		if [ ! -z "`which fc-cache`" ]; then \
+-			fc-cache -fv ~/.fonts; \
+-		fi; \
+-		if [ "`find ~/.fonts -type d -empty`" = "`ls -d ~/.fonts`" ]; then \
+-			rmdir ~/.fonts; \
+-		fi; \
+ 	fi
+ 
+ clean:
+diff --git a/configure b/configure
+index 4599c77..8b09678 100755
+--- a/configure
++++ b/configure
+@@ -473,18 +473,6 @@ proc writeMakefile {{type ""}} {
+        exit 1
+     }
+ 
+-    if {[isDarwin]} {
+-        set var(FONTDIR) /Library/Fonts/
+-    } else {
+-        # Just install fonts in to /usr irrespective of system prefix. /usr/local may not be active
+-        set prefix /usr
+-        if {![file isdirectory $prefix/share/fonts]} {
+-            set var(FONTDIR) "~/.fonts"
+-        } else {
+-            set var(FONTDIR) $prefix/share/fonts/truetype/Scid
+-        }
+-    }
+-
+     set line [gets $from]
+     while {1} {
+         set line [gets $from]
+-- 
+2.15.1
+

--- a/pkgs/games/scid-vs-pc/default.nix
+++ b/pkgs/games/scid-vs-pc/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
     homepage = http://scidvspc.sourceforge.net/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ maintainers.paraseba ];
+    platforms = stdenv.lib.platforms.linux;
   };
 }
 

--- a/pkgs/games/scid-vs-pc/default.nix
+++ b/pkgs/games/scid-vs-pc/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchurl, tcl, tk, libX11, zlib, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "scid-vs-pc-${version}";
+  version = "4.18.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/scidvspc/scid_vs_pc-4.18.1.tgz";
+    sha256 = "01nd88g3wh3avz1yk9fka9zf20ij8dlnpwzz8gnx78i5b06cp459";
+  };
+
+  buildInputs = [ tcl tk libX11 zlib makeWrapper ];
+
+  prePatch = ''
+    sed -i -e '/^ *set headerPath *{/a ${tcl}/include ${tk}/include' \
+           -e '/^ *set libraryPath *{/a ${tcl}/lib ${tk}/lib' \
+           -e '/^ *set x11Path *{/a ${libX11}/lib/' \
+           configure
+
+    sed -i -e '/^ *set scidShareDir/s|\[file.*|"'"$out/share"'"|' \
+      tcl/config.tcl
+  '';
+
+  # configureFlags = [
+  #   "BINDIR=$(out)/bin"
+  #   "SHAREDIR=$(out)/share"
+  #   "FONTDIR=$(out)/fonts"
+  # ];
+
+  preConfigure = ''configureFlags="
+    BINDIR=$out/bin
+    SHAREDIR=$out/share
+    FONTDIR=$out/fonts"
+  '';
+
+  patches = [
+    ./0001-put-fonts-in-out.patch
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  dontPatchShebangs = true;
+
+  postFixup = ''
+    for cmd in sc_addmove sc_eco sc_epgn scidpgn \
+               sc_import sc_spell sc_tree spliteco
+    do
+      sed -i -e '1c#!'"$out"'/bin/tcscid' "$out/bin/$cmd"
+    done
+
+    sed -i -e '1c#!${tk}/bin/wish' "$out/bin/sc_remote"
+    sed -i -e '1c#!'"$out"'/bin/tkscid' "$out/bin/scid"
+
+    for cmd in $out/bin/*
+    do
+      wrapProgram "$cmd" \
+        --set TCLLIBPATH "${tcl}/${tcl.libdir}" \
+        --set TK_LIBRARY "${tk}/lib/${tk.libPrefix}"
+    done
+  '';
+
+
+  meta = with stdenv.lib; {
+    description = "Chess database with play and training functionality";
+    homepage = http://scidvspc.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ maintainers.paraseba ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18424,6 +18424,11 @@ with pkgs;
     tk = tk-8_5;
   };
 
+  scid-vs-pc = callPackage ../games/scid-vs-pc {
+    tcl = tcl-8_6;
+    tk = tk-8_6;
+  };
+
   scummvm = callPackage ../games/scummvm { };
 
   scorched3d = callPackage ../games/scorched3d { };


### PR DESCRIPTION
###### Motivation for this change
scid vs. PC is a chess program forked from scid and more maintained than the original. scid was packaged already

cc: @aszlig (packager of scid)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

