### PR TITLE
gstreamermm: 1.8.0 -> 1.10.0

### DIFF
--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, file, glibmm, gst_all_1 }:
 
 let
-  ver_maj = "1.8";
+  ver_maj = "1.10";
   ver_min = "0";
 in
 stdenv.mkDerivation rec {
@@ -9,15 +9,8 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url    = "mirror://gnome/sources/gstreamermm/${ver_maj}/${name}.tar.xz";
-    sha256 = "0i4sk6ns4dyi4szk45bkm4kvl57l52lgm15p2wg2rhx2gr2w3qry";
+    sha256 = "0q4dx9sncqbwgpzma0zvj6zssc279yl80pn8irb95qypyyggwn5y";
   };
-
-  patches = [
-    (fetchurl {
-      url = https://bug783628.bugzilla-attachments.gnome.org/attachment.cgi?id=354765;
-      sha256 = "082510a934bl05mz4cyakp8mfmd97cdj7vdrbvyqc4g58dcskvz0";
-    })
-  ];
 
   outputs = [ "out" "dev" ];
 
@@ -31,8 +24,8 @@ stdenv.mkDerivation rec {
     description = "C++ interface for GStreamer";
     homepage = https://gstreamer.freedesktop.org/bindings/cplusplus.html;
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ romildo ];
     platforms = platforms.unix;
+    maintainers = with maintainers; [ romildo ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.10.0](http://ftp.gnome.org/pub/gnome/sources/gstreamermm/1.10/gstreamermm-1.10.0.news)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).