### PR TITLE
aenum: make tests pass

### DIFF
--- a/pkgs/development/python-modules/aenum/default.nix
+++ b/pkgs/development/python-modules/aenum/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   # For Python 3, locale has to be set to en_US.UTF-8 for
   # tests to pass
-  buildInputs = if isPy3k then [ glibcLocales ] else [];
+  checkInputs = if isPy3k then [ glibcLocales ] else [];
 
   checkPhase = ''
   runHook preCheck

--- a/pkgs/development/python-modules/aenum/default.nix
+++ b/pkgs/development/python-modules/aenum/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, buildPythonPackage, isPy3k }:
+{ stdenv, fetchPypi, buildPythonPackage, python, isPy3k, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "aenum";
@@ -10,12 +10,17 @@ buildPythonPackage rec {
     sha256 = "d98bc55136d696fcf323760c3db0de489da9e41fd51283fa6f90205deb85bf6a";
   };
 
-  doCheck = !isPy3k;
-  # The following tests fail (only in python3
-  # test_convert (aenum.test.TestIntEnumConvert)
-  # test_convert_value_lookup_priority (aenum.test.TestIntEnumConvert)
-  # test_convert (aenum.test.TestIntEnumConvert)
-  # test_convert_value_lookup_priority (aenum.test.TestIntEnumConvert)
+  # For Python 3, locale has to be set to en_US.UTF-8 for
+  # tests to pass
+  buildInputs = if isPy3k then [ glibcLocales ] else [];
+
+  checkPhase = ''
+  runHook preCheck
+  ${if isPy3k then "export LC_ALL=en_US.UTF-8" else ""}
+  PYTHONPATH=`pwd` ${python.interpreter} aenum/test.py
+  runHook postCheck
+  '';
+
 
   meta = {
     description = "Advanced Enumerations (compatible with Python's stdlib Enum), NamedTuples, and NamedConstants";


### PR DESCRIPTION
For Python 2, tests were failing because they depended on a particular
way of executing the tests module as it defined a global variable
and created a temporary file. Running it through setup.py didn't work.
Invoking it directly solved the issue.

For Python 3, aenum tests were disabled, however, they did't have to
fail. Configuring UTF8 locale resolved the failure that was happening
after the above fix for Python 2 was applied.

###### Motivation for this change

Couldn't build another derivation that had to depend on aenum, even on Python 2, as the tests were failing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tried to use `nox-review wip`, however, I got a failure on the `dbf` derivation, however, at least for me, building `dbf` fails for Python 2.7 on master nixpkgs anyway (because `aenum`'s tests fail). Any advice on this will be highly appreciated.

cc @vrthra 
