### PR TITLE
nixpkgs-lint: fix

### DIFF
--- a/maintainers/scripts/nixpkgs-lint.pl
+++ b/maintainers/scripts/nixpkgs-lint.pl
@@ -34,7 +34,7 @@ GetOptions("package|p=s" => \$filter,
     ) or exit 1;
 
 # Evaluate Nixpkgs into an XML representation.
-my $xml = `nix-env -f '$path' -qa '$filter' --xml --meta --drv-path`;
+my $xml = `nix-env -f '$path' -qA '$filter' --xml --meta --drv-path`;
 die "$0: evaluation of ‘$path’ failed\n" if $? != 0;
 
 my $info = XMLin($xml, KeyAttr => { 'item' => '+attrPath', 'meta' => 'name' }, ForceArray => 1, SuppressEmpty => '' ) or die "cannot parse XML output";


### PR DESCRIPTION
###### Motivation for this change
Gave runtime error before

Note that while it runs with this change, it throws a warning at runtime because the variable `drvPath` isn't defined in this line: https://github.com/NixOS/nixpkgs/blob/master/maintainers/scripts/nixpkgs-lint.pl#L151. My perl is insufficient to decipher the meaning of this line and how to get rid of the warning.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

