### PR TITLE
boehm-gc, libatomic_ops: 7.6.0 -> 7.6.2

### DIFF
--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -3,11 +3,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "boehm-gc-7.6.0";
+  name = "boehm-gc-${version}";
+  version = "7.6.2";
 
   src = fetchurl {
-    url = http://www.hboehm.info/gc/gc_source/gc-7.6.0.tar.gz;
-    sha256 = "143x7g0d0k6250ai6m2x3l4y352mzizi4wbgrmahxscv2aqjhjm1";
+    urls = [
+      "http://www.hboehm.info/gc/gc_source/gc-${version}.tar.gz"
+      "https://github.com/ivmai/bdwgc/releases/download/v${version}/gc-${version}.tar.gz"
+    ];
+    sha256 = "07nli9hgdzc09qzw169sn7gchkrn5kqgyniv2rspcy1xaq2j04dx";
   };
 
   buildInputs = [ libatomic_ops ];
@@ -24,12 +28,6 @@ stdenv.mkDerivation rec {
 
   # Don't run the native `strip' when cross-compiling.
   dontStrip = hostPlatform != buildPlatform;
-
-  postInstall =
-    ''
-      mkdir -p $out/share/doc
-      mv $out/share/gc $out/share/doc/gc
-    '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libatomic_ops/default.nix
+++ b/pkgs/development/libraries/libatomic_ops/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "libatomic_ops-${version}";
-  version = "7.6.0";
+  version = "7.6.2";
 
   src = fetchurl {
     urls = [
       "http://www.ivmaisoft.com/_bin/atomic_ops/libatomic_ops-${version}.tar.gz"
       "https://github.com/ivmai/libatomic_ops/releases/download/v${version}/libatomic_ops-${version}.tar.gz"
     ];
-    sha256 ="03ylfr29g9zc0r6b6axz3i68alj5qmxgzknxwam3jlx0sz8hcb4f";
+    sha256 ="1rif2hjscq5mh639nsnjhb90c01gnmy1sbmj6x6hsn1xmpnj95r1";
   };
 
   nativeBuildInputs = stdenv.lib.optionals stdenv.isCygwin [ autoconf automake libtool ];


### PR DESCRIPTION
###### Motivation for this change

boehm-gc: https://github.com/ivmai/bdwgc/releases/tag/v7.6.2
libatomic_ops: https://github.com/ivmai/libatomic_ops/releases/tag/v7.6.2

Large number of fixes and (apparently) 7.6.0 was only a "pre-release".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

