### PR TITLE
release-small: Don't attempt to access "dbus.libs", etc., don't exist

### DIFF
--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -35,6 +35,7 @@ with import ./release-lib.nix { inherit supportedSystems; };
   cpio = all;
   cron = linux;
   cups = linux;
+  dbus = linux;
   dhcp = linux;
   diffutils = all;
   e2fsprogs = linux;
@@ -173,11 +174,5 @@ with import ./release-lib.nix { inherit supportedSystems; };
   xkeyboard_config = linux;
   zile = linux;
   zip = all;
-
-  dbus = {
-    libs = linux;
-    daemon = linux;
-    tools = linux;
-  };
 
 } ))


### PR DESCRIPTION
dbus_libs and others do, but they're deprecated.

Just build 'dbus', these are now its various outputs.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

