### PR TITLE
subtitleeditor: 0.53.0 -> 0.54.0

### DIFF
--- a/pkgs/applications/video/subtitleeditor/default.nix
+++ b/pkgs/applications/video/subtitleeditor/default.nix
@@ -1,29 +1,24 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, file, desktop_file_utils,
-  enchant, gnome3, gst_all_1, hicolor_icon_theme, libsigcxx, libxmlxx,
-  xdg_utils, isocodes, wrapGAppsHook
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, intltool, file,
+  desktop_file_utils, enchant, gnome3, gst_all_1, hicolor_icon_theme,
+  libsigcxx, libxmlxx, xdg_utils, isocodes, wrapGAppsHook
 }:
 
 let
-  ver_maj = "0.53";
-  ver_min = "0";
+  version = "0.54.0";
 in
 
 stdenv.mkDerivation rec {
-  name = "subtitle-editor-${ver_maj}.${ver_min}";
+  name = "subtitleeditor-${version}";
 
-  src = fetchurl {
-    url = "http://download.gna.org/subtitleeditor/${ver_maj}/subtitleeditor-${ver_maj}.${ver_min}.tar.gz";
-    sha256 = "087rxignjawby4z3lwnh9m6pcjphl3a0jf7gfp83h92mzcq79b4g";
+  src = fetchFromGitHub {
+    owner = "kitone";
+    repo = "subtitleeditor";
+    rev = version;
+    sha256 = "0vxcscc9m6gymgj173ahk2g9hlk9588z5fdaavmkpyriqdlhwm11";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/s/subtitleeditor/0.53.0-2/debian/patches/03-fix-build-gstreamermm-1.8.0.patch";
-      sha256 = "0di2i34id5dqnd3glibhifair1kdfnv8ay3k64lirad726ardw2c";
-    })
-  ];
-
   nativeBuildInputs =  [
+    autoreconfHook
     pkgconfig
     intltool
     file
@@ -48,11 +43,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # disable check because currently making check in po fails
-  doCheck = false;
-
-  hardeningDisable = [ "format" ];
-
   preConfigure = "substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file";
 
   configureFlags = [ "--disable-debug" ];
@@ -65,9 +55,9 @@ stdenv.mkDerivation rec {
       and refine existing subtitle. This program also shows sound waves, which
       makes it easier to synchronise subtitles to voices.
       '';
-    homepage = http://home.gna.org/subtitleeditor;
+    homepage = http://kitone.github.io/subtitleeditor/;
     license = stdenv.lib.licenses.gpl3Plus;
-    maintainers = [ stdenv.lib.maintainers.plcplc ];
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.plcplc ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to version [0.54.0](https://github.com/kitone/subtitleeditor/releases/tag/0.54.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).