### PR TITLE
kernel: fix cross compilation

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -51,7 +51,7 @@ with stdenv.lib;
 
   # Bump the maximum number of CPUs to support systems like EC2 x1.*
   # instances and Xeon Phi.
-  ${optionalString (stdenv.system == "x86_64-linux" || stdenv.system == "aarch64-linux") ''
+  ${optionalString (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "aarch64-linux") ''
     NR_CPUS 384
   ''}
 
@@ -347,11 +347,12 @@ with stdenv.lib;
   SECURITY_SELINUX_BOOTPARAM_VALUE 0 # Disable SELinux by default
   SECURITY_YAMA? y # Prevent processes from ptracing non-children processes
   DEVKMEM n # Disable /dev/kmem
-  ${if versionOlder version "3.14" then ''
-    CC_STACKPROTECTOR? y # Detect buffer overflows on the stack
-  '' else ''
-    CC_STACKPROTECTOR_REGULAR? y
-  ''}
+  ${optionalString (! stdenv.hostPlatform.isArm)
+    (if versionOlder version "3.14" then ''
+        CC_STACKPROTECTOR? y # Detect buffer overflows on the stack
+      '' else ''
+        CC_STACKPROTECTOR_REGULAR? y
+      '')}
   ${optionalString (versionAtLeast version "3.12") ''
     USER_NS y # Support for user namespaces
   ''}

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -44,13 +44,11 @@ let
     netfilterRPFilter = true;
   } // features) kernelPatches;
 
-  configWithPlatform = kernelPlatform: import ./common-config.nix {
-    inherit stdenv version kernelPlatform extraConfig;
+  config = import ./common-config.nix {
+    inherit stdenv version extraConfig;
+    kernelPlatform = hostPlatform;
     features = kernelFeatures; # Ensure we know of all extra patches, etc.
   };
-
-  config = configWithPlatform stdenv.platform;
-  configCross = configWithPlatform hostPlatform.platform;
 
   kernelConfigFun = baseConfig:
     let
@@ -74,12 +72,6 @@ let
     autoModules = hostPlatform.platform.kernelAutoModules;
     preferBuiltin = hostPlatform.platform.kernelPreferBuiltin or false;
     arch = hostPlatform.platform.kernelArch;
-
-    crossAttrs = let
-        cp = hostPlatform.platform;
-      in {
-        ignoreConfigErrors = true;
-      };
 
     prePatch = kernel.prePatch + ''
       # Patch kconfig to print "###" after every question so that
@@ -108,9 +100,7 @@ let
   };
 
   kernel = buildLinux {
-    inherit version modDirVersion src kernelPatches stdenv extraMeta;
-
-    configfile = configfile.nativeDrv or configfile;
+    inherit version modDirVersion src kernelPatches stdenv extraMeta configfile;
 
     config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
   };

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -64,7 +64,8 @@ let
 
     kernelConfig = kernelConfigFun config;
 
-    nativeBuildInputs = [ buildPackages.stdenv.cc perl ];
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+    nativeBuildInputs = [ perl ];
 
     platformName = hostPlatform.platform.name;
     kernelBaseConfig = hostPlatform.platform.kernelBaseConfig;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -23,7 +23,8 @@
   # symbolic name and `patch' is the actual patch.  The patch may
   # optionally be compressed with gzip or bzip2.
   kernelPatches ? []
-, ignoreConfigErrors ? hostPlatform.platform.name != "pc"
+, ignoreConfigErrors ? hostPlatform.platform.name != "pc" ||
+                       hostPlatform != stdenv.buildPlatform
 , extraMeta ? {}
 , hostPlatform
 , ...
@@ -58,7 +59,7 @@ let
     in lib.concatStringsSep "\n" ([baseConfig] ++ configFromPatches);
 
   configfile = stdenv.mkDerivation {
-    #inherit ignoreConfigErrors;
+    inherit ignoreConfigErrors;
     name = "linux-config-${version}";
 
     generateConfig = ./generate-config.pl;
@@ -73,9 +74,6 @@ let
     autoModules = hostPlatform.platform.kernelAutoModules;
     preferBuiltin = hostPlatform.platform.kernelPreferBuiltin or false;
     arch = hostPlatform.platform.kernelArch;
-
-    # TODO(@Ericson2314): No null next hash break
-    ignoreConfigErrors = if stdenv.hostPlatform == stdenv.buildPlatform then null else true;
 
     crossAttrs = let
         cp = hostPlatform.platform;

--- a/pkgs/os-specific/linux/kernel/linux-4.13.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.13.16";

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 with stdenv.lib;
 

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.4.111";

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.9.76";

--- a/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
+++ b/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
   modDirVersion = "4.9.61";

--- a/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 with stdenv.lib;
 

--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (rec {
   mptcpVersion = "0.93";

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
   modDirVersion = "4.9.59";

--- a/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchFromGitHub, perl, buildLinux, ncurses, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ncurses, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.12.2";

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.11.2017.08.23";

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchurl, perl, buildLinux, libelf, utillinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.15-rc8";

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -225,8 +225,8 @@ let
           maintainers.thoughtpolice
         ];
         platforms = platforms.linux;
-      };
-    } // extraMeta;
+      } // extraMeta;
+    };
 in
 
 assert stdenv.lib.versionAtLeast version "4.14" -> libelf != null;

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,4 +1,4 @@
-{ buildPackages, runCommand, nettools, bc, perl, gmp, libmpc, mpfr, kmod, openssl
+{ buildPackages, runCommand, nettools, bc, perl, gmp, libmpc, mpfr, openssl
 , libelf
 , utillinux
 , writeTextFile, ubootTools
@@ -97,7 +97,7 @@ let
             echo "stripping FHS paths in \`$mf'..."
             sed -i "$mf" -e 's|/usr/bin/||g ; s|/bin/||g ; s|/sbin/||g'
         done
-        sed -i Makefile -e 's|= depmod|= ${kmod}/bin/depmod|'
+        sed -i Makefile -e 's|= depmod|= ${buildPackages.kmod}/bin/depmod|'
       '';
 
       configurePhase = ''
@@ -203,7 +203,7 @@ let
         find -empty -type d -delete
 
         # Remove reference to kmod
-        sed -i Makefile -e 's|= ${kmod}/bin/depmod|= depmod|'
+        sed -i Makefile -e 's|= ${buildPackages.kmod}/bin/depmod|= depmod|'
       '' else optionalString installsFirmware ''
         make firmware_install $makeFlags "''${makeFlagsArray[@]}" \
           $installFlags "''${installFlagsArray[@]}"

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -236,8 +236,8 @@ stdenv.mkDerivation ((drvAttrs config hostPlatform.platform kernelPatches config
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ perl bc nettools openssl gmp libmpc mpfr ]
-      ++ optional (stdenv.platform.kernelTarget == "uImage") ubootTools
+  nativeBuildInputs = [ perl bc nettools openssl gmp libmpc mpfr buildPackages.stdenv.cc ]
+      ++ optional (stdenv.hostPlatform.platform.kernelTarget == "uImage") buildPackages.ubootTools
       ++ optional (stdenv.lib.versionAtLeast version "4.14") libelf
       ++ optional (stdenv.lib.versionAtLeast version "4.15") utillinux
       ;

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -236,7 +236,8 @@ stdenv.mkDerivation ((drvAttrs config hostPlatform.platform kernelPatches config
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ perl bc nettools openssl gmp libmpc mpfr buildPackages.stdenv.cc ]
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ perl bc nettools openssl gmp libmpc mpfr ]
       ++ optional (stdenv.hostPlatform.platform.kernelTarget == "uImage") buildPackages.ubootTools
       ++ optional (stdenv.lib.versionAtLeast version "4.14") libelf
       ++ optional (stdenv.lib.versionAtLeast version "4.15") utillinux

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -11,7 +11,7 @@ assert versionAtLeast kernel.version "3.12";
 stdenv.mkDerivation {
   name = "perf-linux-${kernel.version}";
 
-  inherit (kernel) src;
+  inherit (kernel) src makeFlags;
 
   preConfigure = ''
     cd tools/perf
@@ -39,10 +39,6 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optionals (hasPrefix "gcc-6" stdenv.cc.cc.name) [
       "-Wno-error=unused-const-variable" "-Wno-error=misleading-indentation"
     ];
-
-  makeFlags = if stdenv.hostPlatform == stdenv.buildPlatform
-    then null
-    else "CROSS_COMPILE=${stdenv.cc.prefix}";
 
   installFlags = "install install-man ASCIIDOC8=1";
 

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation {
   # perf refers both to newt and slang
   # binutils is required for libbfd.
   nativeBuildInputs = [ asciidoc xmlto docbook_xsl docbook_xml_dtd_45 libxslt
-      flex bison libiberty libaudit makeWrapper pkgconfig ];
-  buildInputs = [ elfutils python perl newt slang libunwind binutils zlib ] ++
+      flex bison libiberty libaudit makeWrapper pkgconfig python perl ];
+  buildInputs = [ elfutils newt slang libunwind binutils zlib ] ++
     stdenv.lib.optional withGtk gtk2;
 
   # Note: we don't add elfutils to buildInputs, since it provides a
@@ -40,21 +40,16 @@ stdenv.mkDerivation {
       "-Wno-error=unused-const-variable" "-Wno-error=misleading-indentation"
     ];
 
+  makeFlags = if stdenv.hostPlatform == stdenv.buildPlatform
+    then null
+    else "CROSS_COMPILE=${stdenv.cc.prefix}";
+
   installFlags = "install install-man ASCIIDOC8=1";
 
   preFixup = ''
     wrapProgram $out/bin/perf \
       --prefix PATH : "${binutils}/bin"
   '';
-
-  crossAttrs = {
-    /* I don't want cross-python or cross-perl -
-       I don't know if cross-python even works */
-    propagatedBuildInputs = [ elfutils.crossDrv newt.crossDrv ];
-    makeFlags = "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
-    elfutils = elfutils.crossDrv;
-    inherit (kernel.crossDrv) src patches;
-  };
 
   meta = {
     homepage = https://perf.wiki.kernel.org/;

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, kernel, elfutils, python, perl, newt, slang, asciidoc, xmlto, makeWrapper
 , docbook_xsl, docbook_xml_dtd_45, libxslt, flex, bison, pkgconfig, libunwind, binutils
-, libiberty, libaudit
+, libiberty, libaudit, libbfd
 , zlib, withGtk ? false, gtk2 ? null }:
 
 with lib;
@@ -21,10 +21,9 @@ stdenv.mkDerivation {
   '';
 
   # perf refers both to newt and slang
-  # binutils is required for libbfd.
   nativeBuildInputs = [ asciidoc xmlto docbook_xsl docbook_xml_dtd_45 libxslt
       flex bison libiberty libaudit makeWrapper pkgconfig python perl ];
-  buildInputs = [ elfutils newt slang libunwind binutils zlib ] ++
+  buildInputs = [ elfutils newt slang libunwind libbfd zlib ] ++
     stdenv.lib.optional withGtk gtk2;
 
   # Note: we don't add elfutils to buildInputs, since it provides a


### PR DESCRIPTION
This PR contains rebased versions of patches from #30882 to fix Linux kernel cross compilation.

Specifically, this includes:
5c6473c5ff4879711d28243f4be299380ead10fb - kernel: Enable cross compiling
d1ccc5d0b48321498a57bfb372fb782701446ad7 - kernel: Use build kmod
5e917600fc61f996c297aeeeb8a231b75460dfd4 - kernel fixes
e915e4a7d0cd798070b969517310acaaf378bd39 - kernel: Fix cross-compilation

5e917600fc61f996c297aeeeb8a231b75460dfd4 has been squashed into 5c6473c5ff4879711d28243f4be299380ead10fb because the changes are closely related.

There are a few things that I'm not sure about, or didn't seem right to me.

In 5c6473c5ff4879711d28243f4be299380ead10fb, `pkgs/os-specific/linux/kernel/perf.nix` refers to a [patch that no longer exists in master](https://github.com/NixOS/nixpkgs/pull/30882/commits/5c6473c5ff4879711d28243f4be299380ead10fb#diff-ec4e01e2f58d1c9120aad93a3dde92e4R16) and did not exist in the tree that #30882 is based on. It also seems to revert the [fix that was used to replace the patch](https://github.com/NixOS/nixpkgs/pull/30882/commits/5c6473c5ff4879711d28243f4be299380ead10fb#diff-ec4e01e2f58d1c9120aad93a3dde92e4L45). This seems like it could be due to a bad rebase at some point, but I wanted to make sure there wasn't another reason.

I put a few other concerns as comments on the diff.

I have tested cross building 4.14 kernels for `armv7l` and `aarch64`, as well as a native `x86_64` kernel.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

