### PR TITLE
Update Vapoursynth machinery

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -172,7 +172,7 @@ in stdenv.mkDerivation rec {
   '' + optionalString youtubeSupport ''
       --prefix PATH : "${youtube-dl}/bin" \
   '' + optionalString vapoursynthSupport ''
-      --prefix PYTHONPATH : "$(toPythonPath ${vapoursynth}):$PYTHONPATH"
+      --prefix PYTHONPATH : "${vapoursynth}/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
   '' + ''
 
     cp TOOLS/umpv $out/bin

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -12,13 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "vapoursynth-${version}";
-  version = "R39";
+  version = "R40";
 
   src = fetchFromGitHub {
     owner  = "vapoursynth";
     repo   = "vapoursynth";
     rev    = version;
-    sha256 = "0cw7w8xiwhxhwykydy13m44wm9vn9hrsi30z6017ngga9d84fhqy";
+    sha256 = "1ycc3fdhhryp7hap80z3qmh89br31kcswzp8ai3wlc07zfvcrfck";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook nasm ];

--- a/pkgs/development/libraries/zimg/default.nix
+++ b/pkgs/development/libraries/zimg/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec{
   name = "zimg-${version}";
-  version = "2.6.1";
+  version = "2.7";
 
   src = fetchFromGitHub {
     owner  = "sekrit-twc";
     repo   = "zimg";
     rev    = "release-${version}";
-    sha256 = "08hynzcxz95a4i67k5cn6isafdb6xjgd0x0miyhlnp2xc220zfqj";
+    sha256 = "1jvx3a523mzkc54rrjab9kz66kc6q1snry9ymwmsx7rrd3kv3j6m";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change
Besides the version bump this fixes an issue that appeared recently (I couldn't find exactly what caused it): for some reason now `toPythonPath` returns the path for the wrong python version (2.7 instead of 3.6).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh 