### PR TITLE
libzxcvbn: init at 2.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -732,6 +732,7 @@
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
   xaverdh = "Dominik Xaver Hörl <hoe.dom@gmx.de>";
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
+  xurei = "Olivier Bourdoux <olivier.bourdoux@gmail.com>";
   xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";
   xwvvvvwx = "David Terry <davidterry@posteo.de>";
   xzfc = "Albert Safin <xzfcpw@gmail.com>";

--- a/pkgs/development/libraries/libzxcvbn/default.nix
+++ b/pkgs/development/libraries/libzxcvbn/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit }:
+stdenv.mkDerivation rec {
+  name = "libzxcvbn0_${version}";
+  version = "2.3";
+
+  src = fetchgit {
+    url = "https://github.com/tsyrogit/zxcvbn-c";
+    rev = "50b74db43bc3467b3fbf28b10606e955b40566ed";
+    sha256 = "1m097b4qq1r3kk4b236pc3mpaj22il9fh43ifagad5wy54x8zf7b";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -R libzxcvbn.so* $out/lib/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/tsyrogit/zxcvbn-c;
+    description = "A C/C++ implementation of the zxcvbn password strength estimation";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ xurei ];
+  };
+}

--- a/pkgs/development/libraries/zxcvbn-c/default.nix
+++ b/pkgs/development/libraries/zxcvbn-c/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchFromGitHub }:
 stdenv.mkDerivation rec {
-  name = "libzxcvbn0_${version}";
+  name = "zxcvbn-c-${version}";
   version = "2.3";
 
-  src = fetchgit {
-    url = "https://github.com/tsyrogit/zxcvbn-c";
-    rev = "50b74db43bc3467b3fbf28b10606e955b40566ed";
+  src = fetchFromGitHub {
+    owner = "tsyrogit";
+    repo = "zxcvbn-c";
+    rev = "v${version}";
     sha256 = "1m097b4qq1r3kk4b236pc3mpaj22il9fh43ifagad5wy54x8zf7b";
   };
 
   installPhase = ''
-    mkdir -p $out/lib
-    cp -R libzxcvbn.so* $out/lib/
+    install -D -t $out/lib libzxcvbn.so*
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10047,8 +10047,6 @@ with pkgs;
 
   libzdb = callPackage ../development/libraries/libzdb { };
 
-  libzxcvbn = callPackage ../development/libraries/libzxcvbn { };
-
   libwacom = callPackage ../development/libraries/libwacom { };
 
   lightning = callPackage ../development/libraries/lightning { };
@@ -20127,6 +20125,8 @@ with pkgs;
   );
 
   zsnes = callPackage_i686 ../misc/emulators/zsnes { };
+
+  zxcvbn-c = callPackage ../development/libraries/zxcvbn-c { };
 
   snes9x-gtk = callPackage ../misc/emulators/snes9x-gtk { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10047,6 +10047,8 @@ with pkgs;
 
   libzdb = callPackage ../development/libraries/libzdb { };
 
+  libzxcvbn = callPackage ../development/libraries/libzxcvbn { };
+
   libwacom = callPackage ../development/libraries/libwacom { };
 
   lightning = callPackage ../development/libraries/lightning { };


### PR DESCRIPTION
###### Motivation for this change

Dependency for KeepassXC

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---