### PR TITLE
nextcloud-client: fix icon name in desktop file

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -36,7 +36,10 @@ stdenv.mkDerivation rec {
     "-DINOTIFY_INCLUDE_DIR=${inotify-tools}/include"
   ];
 
-  postInstall = stdenv.lib.optionalString (withGnomeKeyring) ''
+  postInstall = ''
+    sed -i 's/\(Icon.*\)=nextcloud/\1=Nextcloud/g' \
+      $out/share/applications/nextcloud.desktop
+  '' + stdenv.lib.optionalString (withGnomeKeyring) ''
     wrapProgram "$out/bin/nextcloud" \
       --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ libgnome_keyring ]}
   '';


### PR DESCRIPTION
###### Motivation for this change

The desktop file bundled with nextcloud calls the icon `nextcloud`, but the
icons are named `Nextcloud` and so desktop environments won't find it.

Note that upstream uses the opposite workaround in their appimage creation script (renaming an icon file to match what the desktop file expects): https://github.com/nextcloud/client_theming/blob/d0a46ea2f04eb9fe1b99d4cedfb595bc7664d27f/linux/AppImage/build-appimage.sh#L61

I'm using the capture group to find matching lines because the translations generate lines like `Icon[ja_JP]=nextcloud` and those need to be changed too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

