### PR TITLE
Ruby: 2.2.8 -> 2.2.9, 2.3.5 -> 2.3.6, 2.4.2 -> 2.4.3

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -196,27 +196,27 @@ in {
     };
   };
 
-  ruby_2_2_8 = generic {
-    version = rubyVersion "2" "2" "8" "";
+  ruby_2_2_9 = generic {
+    version = rubyVersion "2" "2" "9" "";
     sha256 = {
-      src = "12i6v5i0djl4xx3x7fq12snqb5d4drqjmnwqs05fby4bagcbjdwg";
-      git = "16nw0795nhrj13crp5x4jis8hmi3gsyjl96pwk698wlrb89lf9bw";
+      src = "19m1ximl7vcrsvq595dgrjh4yb6kar944095wbywqh7waiqcfirg";
+      git = "03qrjh55098wcqh2khxryzkzfqkznjrcdgwf27r2bgcycbg5ca5q";
     };
   };
 
-  ruby_2_3_5 = generic {
-    version = rubyVersion "2" "3" "5" "";
+  ruby_2_3_6 = generic {
+    version = rubyVersion "2" "3" "6" "";
     sha256 = {
-      src = "1k6x4g68lq30i0myip5bn56rcbwjxmqq95j1fkdgbvwbnaxzfqjl";
-      git = "0spwqz4b5xxqzs13azsd4xz4jkc3is7d9q4s6s2qilb8ib4863jl";
+      src = "07jpa7fw1gyf069m7alf2b0zm53qm08w2ns45mhzmvgrg4r528l3";
+      git = "1bk59i0ygdc5z3zz3k6indfrxd2ix55np6rwvkcdpdw8svm749ds";
     };
   };
 
-  ruby_2_4_2 = generic {
-    version = rubyVersion "2" "4" "2" "";
+  ruby_2_4_3 = generic {
+    version = rubyVersion "2" "4" "3" "";
     sha256 = {
-      src = "174cdiz3am1f76vsnm3iqi9c5vqphypbf9kbxx6vqqmj01gfgfck";
-      git = "1w83kzak3m6vv3k09ynfw9vpgc7vpmij3x3zmgrhwm4ds1sp5irl";
+      src = "161smb52q19r9lrzy22b3bhnkd0z8wjffm0qsfkml14j5ic7a0zx";
+      git = "0x2lqbqm2rq9j5zh1p72dma56nqvdkfbgzb9wybm4y4hwhiw8c1m";
     };
   };
 }

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -24,17 +24,17 @@ rec {
     "${patchSet}/patches/ruby/2.1.8/railsexpress/08-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.8/railsexpress/09-heap-dump-support.patch"
   ];
-  "2.2.8" = ops useRailsExpress [
+  "2.2.9" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.2/head/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.2/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.2/head/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
-  "2.3.5" = ops useRailsExpress [
+  "2.3.6" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.3/head/railsexpress/01-skip-broken-tests.patch"
     "${patchSet}/patches/ruby/2.3/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.3/head/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
-  "2.4.2" = ops useRailsExpress [
+  "2.4.3" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.4/head/railsexpress/01-skip-broken-tests.patch"
     "${patchSet}/patches/ruby/2.4/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.4/head/railsexpress/03-display-more-detailed-stack-trace.patch"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6669,17 +6669,17 @@ with pkgs;
   inherit (callPackage ../development/interpreters/ruby {})
     ruby_2_0_0
     ruby_2_1_10
-    ruby_2_2_8
-    ruby_2_3_5
-    ruby_2_4_2;
+    ruby_2_2_9
+    ruby_2_3_6
+    ruby_2_4_3;
 
   # Ruby aliases
   ruby = ruby_2_3;
   ruby_2_0 = ruby_2_0_0;
   ruby_2_1 = ruby_2_1_10;
-  ruby_2_2 = ruby_2_2_8;
-  ruby_2_3 = ruby_2_3_5;
-  ruby_2_4 = ruby_2_4_2;
+  ruby_2_2 = ruby_2_2_9;
+  ruby_2_3 = ruby_2_3_6;
+  ruby_2_4 = ruby_2_4_3;
 
   scsh = callPackage ../development/interpreters/scsh { };
 


### PR DESCRIPTION
(cherry picked from commit e90412debb744dfc481cebf4243e48aef512c726)

###### Motivation for this change

Fixes two security issues:

* http://blog.rubygems.org/2017/10/09/unsafe-object-deserialization-vulnerability.html
* https://www.ruby-lang.org/en/news/2017/12/14/net-ftp-command-injection-cve-2017-17405/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

