### PR TITLE
palemoon: install icons

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -76,7 +76,6 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     chmod u+w .
-    sed -i /status4evar/d browser/installer/package-manifest.in
   '';
 
   buildPhase = ''

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   desktopItem = makeDesktopItem {
     name = "palemoon";
     exec = "palemoon %U";
+    icon = "palemoon";
     desktopName = "Pale Moon";
     genericName = "Web Browser";
     categories = "Application;Network;WebBrowser;";
@@ -86,6 +87,14 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/share/applications
     cp ${desktopItem}/share/applications/* $out/share/applications
+
+    for n in 16 22 24 32 48 256; do
+      size=$n"x"$n
+      mkdir -p $out/share/icons/hicolor/$size/apps
+      cp $src/browser/branding/official/default$n.png \
+         $out/share/icons/hicolor/$size/apps/palemoon.png
+    done
+
     cd $builddir
     $src/mach install
   '';


### PR DESCRIPTION
###### Motivation for this change
Fix #33770 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using (none)
- [x] Tested execution of all binary files
- [x] Tested the icons are picked up by the DE (xfce at least)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

