### PR TITLE
ldc: Disable cdvecfill test to fix build on older processors

### DIFF
--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -110,6 +110,13 @@ let
         substituteInPlace dmd2/root/port.c --replace __inline_isnanl __inline_isnan
     ''
 
+    + stdenv.lib.optionalString (!bootstrapVersion) ''
+        # TODO Can be removed with the next ldc version > 1.7.0
+        # https://github.com/ldc-developers/ldc/issues/2493
+        substituteInPlace tests/d2/dmd-testsuite/Makefile \
+            --replace "# disable tests based on arch" "DISABLED_TESTS += test_cdvecfill"
+    ''
+
     + stdenv.lib.optionalString (bootstrapVersion) ''
         substituteInPlace runtime/${datetimePath} \
             --replace "import std.traits;" "import std.traits;import std.path;"


### PR DESCRIPTION
###### Motivation for this change

Continuation of https://github.com/NixOS/nixpkgs/pull/33723 to fix build of ldc on hydra/Linux and other machines with older processors.

cc @joachifm 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

