### PR TITLE
bitscope: refactored to expose to nixpkgs-lint

### DIFF
--- a/pkgs/applications/science/electronics/bitscope/common.nix
+++ b/pkgs/applications/science/electronics/bitscope/common.nix
@@ -9,7 +9,7 @@
 , makeWrapper
 , pango
 , stdenv
-, writeScriptBin
+, writeTextFile
 , xorg
 }:
 
@@ -60,8 +60,11 @@ let
       ${(wrapBinary libs) attrs.toolName}
     '';
   });
+  fhs = target: buildFHSUserEnv {
+    inherit (pkg) name;
+    runScript = target;
+  };
 in buildFHSUserEnv {
   name = attrs.toolName;
-  meta = pkg.meta;
   runScript = "${pkg.outPath}/bin/${attrs.toolName}";
-}
+} // { inherit (pkg) meta name; }

--- a/pkgs/applications/science/electronics/bitscope/packages.nix
+++ b/pkgs/applications/science/electronics/bitscope/packages.nix
@@ -88,7 +88,7 @@ in {
 
     meta = {
       description = "Mixed signal logic timing and serial protocol analysis software for BitScope";
-      home = "http://bitscope.com/software/logic/";
+      homepage = "http://bitscope.com/software/logic/";
     };
 
     src = fetchurl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14241,7 +14241,8 @@ with pkgs;
 
   bitmeter = callPackage ../applications/audio/bitmeter { };
 
-  bitscope = callPackage ../applications/science/electronics/bitscope/packages.nix { };
+  bitscope = recurseIntoAttrs
+    (callPackage ../applications/science/electronics/bitscope/packages.nix { });
 
   bitwig-studio1 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio1.nix {
     inherit (gnome2) zenity;


### PR DESCRIPTION
###### Motivation for this change

The linter (nixpkgs-lint) was not able to find the bitscope packages
because I forgot to `recurseIntoAttrs` the bitscope suite set. Furthermore, I inherit the
`meta` and `name` attributes from the package builder helper. This fixes
a naming problem since the name of the derivation was formerly set to
the `attrs.toolName` which didn't postfix the version, whereas nix
packages are required to adhere to the `${PACKAGENAME}-${VERSION}`
pattern. 

In order to keep the produced FHSEnv binary's name short and sweet and produced it with a versionless name and subsequently merged the versioned-name into the resulting derivation.

Not sure if I'm doing some weird :hankey:... if so, please yell at me so I can fix that and developed a good mental association from preventing me from doing the same in the future :wink:.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

