### PR TITLE
maxscale: init at 2.1.17

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -99,6 +99,16 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = ''BSD 4-clause "Original" or "Old" License'';
   };
 
+  bsl10 = {
+    fullName = "Business Source License 1.0";
+    url = https://mariadb.com/bsl10;
+  };
+
+  bsl11 = {
+    fullName = "Business Source License 1.1";
+    url = https://mariadb.com/bsl11;
+  };
+
   clArtistic = spdx {
     spdxId = "ClArtistic";
     fullName = "Clarified Artistic License";

--- a/pkgs/tools/networking/maxscale/default.nix
+++ b/pkgs/tools/networking/maxscale/default.nix
@@ -1,0 +1,87 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, gcc, glibc
+, bison2, curl, flex, gperftools, jansson, jemalloc, kerberos, lua, mariadb
+, ncurses, openssl, pcre, pcre2, perl, rabbitmq-c, sqlite, tcl
+, libaio, libedit, libtool, libui, libuuid, zlib
+}:
+
+stdenv.mkDerivation rec {
+  name = "maxscale-${version}";
+  version = "2.1.17";
+
+  src = fetchFromGitHub {
+    owner = "mariadb-corporation";
+    repo = "MaxScale";
+    rev = "${name}";
+    sha256 = "161kc6aqqj3z509q4qwvsd86h06hlyzdask4gawn2ij0h3ca58q6";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [
+    bison2 curl flex gperftools jansson jemalloc kerberos lua mariadb.connector-c
+    ncurses openssl pcre pcre2 perl rabbitmq-c sqlite tcl
+    libaio libedit libtool libui libuuid zlib
+  ];
+
+  patches = [ ./getopt.patch ];
+
+  preConfigure = ''
+    for i in `grep -l -R '#include <getopt.h>' .`; do
+      substituteInPlace $i --replace "#include <getopt.h>" "#include <${glibc.dev}/include/getopt.h>"
+    done
+ '';
+
+  cmakeFlags = [
+    "-DUSE_C99=YES"
+    "-DDEFAULT_ADMIN_USER=root"
+    "-DWITH_MAXSCALE_CNF=YES"
+    "-DSTATIC_EMBEDDED=YES"
+    "-DBUILD_RABBITMQ=YES"
+    "-DBUILD_BINLOG=YES"
+    "-DBUILD_CDC=NO"
+    "-DBUILD_MMMON=YES"
+    "-DBUILD_LUAFILTER=YES"
+    "-DLUA_LIBRARIES=${lua}/lib"
+    "-DLUA_INCLUDE_DIR=${lua}/include"
+    "-DGCOV=NO"
+    "-DWITH_SCRIPTS=OFF"
+    "-DBUILD_TESTS=NO"
+    "-DBUILD_TOOLS=NO"
+    "-DPROFILE=NO"
+    "-DWITH_TCMALLOC=YES"
+    "-DWITH_JEMALLOC=YES"
+    "-DINSTALL_EXPERIMENTAL=YES"
+    "-DTARGET_COMPONENT=all"
+  ];
+
+  CFLAGS = "-std=gnu99";
+
+  enableParallelBuilding = false;
+
+  dontStrip = true;
+
+  postInstall = ''
+    find $out/bin -type f -perm -0100 | while read f1; do
+      patchelf \
+        --set-rpath "$(patchelf --print-rpath $f1):${mariadb.connector-c}/lib/mariadb:$out/lib/maxscale" \
+        --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" $f1 \
+        && patchelf --shrink-rpath $f1
+    done
+
+    find $out/lib/maxscale -type f -perm -0100 | while read f2; do
+      patchelf \
+        --set-rpath "$(patchelf --print-rpath $f2)":$out/lib/maxscale $f2
+    done
+
+    mv $out/share/maxscale/create_grants $out/bin
+    rm -rf $out/{etc,var}
+  '';
+
+  meta = with stdenv.lib; {
+     description = ''MaxScale database proxy extends MariaDB Server's high availability'';
+     homepage = https://mariadb.com/products/technology/maxscale;
+     license = licenses.bsl11;
+     platforms = platforms.linux;
+     maintainers = with maintainers; [ izorkin ];
+ };
+}

--- a/pkgs/tools/networking/maxscale/getopt.patch
+++ b/pkgs/tools/networking/maxscale/getopt.patch
@@ -1,0 +1,11 @@
+--- a/server/core/maxpasswd.c   2018-01-12 05:06:49.000000000 -0500
++++ b/server/core/maxpasswd.c   2018-01-12 06:50:18.518000000 -0500
+@@ -25,6 +25,7 @@
+
+ #include <maxscale/cdefs.h>
+
++#include <getopt.h>
+ #include <stdio.h>
+ #include <errno.h>
+ #include <sys/stat.h>
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17224,6 +17224,10 @@ with pkgs;
 
   maxlib = callPackage ../applications/audio/pd-plugins/maxlib { };
 
+  maxscale = callPackage ../tools/networking/maxscale {
+    stdenv = overrideCC stdenv gcc6;
+  };
+
   pdfdiff = callPackage ../applications/misc/pdfdiff { };
 
   mupdf = callPackage ../applications/misc/mupdf { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

