### PR TITLE
Idris: fix "addEnvHooks: command not found"  (#33820)

### DIFF
--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -2,26 +2,27 @@
 #
 # args: Additional arguments to pass to mkDerivation. Generally should include at least
 #       name and src.
-{ stdenv, idris, gmp }: args: stdenv.mkDerivation ({
-  preHook = ''
-    # Library import path
-    export IDRIS_LIBRARY_PATH=$PWD/idris-libs
-    mkdir -p $IDRIS_LIBRARY_PATH
+{ stdenv, writeScript, makeSetupHook, idris, gmp }: args:
+let setupfile = writeScript "setupfile" ''
+  export IDRIS_LIBRARY_PATH=$PWD/idris-libs
+  mkdir -p $IDRIS_LIBRARY_PATH
 
-    # Library install path
-    export IBCSUBDIR=$out/lib/${idris.name}
-    mkdir -p $IBCSUBDIR
+  # Library install path
+  export IBCSUBDIR=$out/lib/${idris.name}
+  mkdir -p $IBCSUBDIR
 
-    addIdrisLibs () {
-      if [ -d $1/lib/${idris.name} ]; then
-        ln -sv $1/lib/${idris.name}/* $IDRIS_LIBRARY_PATH
-      fi
-    }
+  addIdrisLibs () {
+  if [ -d $1/lib/${idris.name} ]; then
+  ln -svf $1/lib/${idris.name}/* $IDRIS_LIBRARY_PATH
+  fi
+  }
 
-    # All run-time deps
-    addEnvHooks 0 addIdrisLibs
-  '';
-
+  # All run-time deps
+  addEnvHooks "$targetOffset" addIdrisLibs
+'';
+in
+stdenv.mkDerivation ({
+  setupHook = setupfile;
   buildPhase = ''
     ${idris}/bin/idris --build *.ipkg
   '';
@@ -35,6 +36,7 @@
   '';
 
   installPhase = ''
+    export IBCSUBDIR=$out/lib/${idris.name}
     ${idris}/bin/idris --install *.ipkg --ibcsubdir $IBCSUBDIR
   '';
 


### PR DESCRIPTION
###### Motivation for this change

On the current head 'addEnvHooks' doesn't seem to be available in 'preHook'.
This patch tries to stay as close as the original by moving the code to
'setupHook' and changing the ln options.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
-  [ ? ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
   - Packages that depend on this are already broken, but that is something for a different issue.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

