### PR TITLE
gephi: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/applications/science/misc/gephi/default.nix
+++ b/pkgs/applications/science/misc/gephi/default.nix
@@ -2,13 +2,13 @@
 
 with stdenv.lib;
 
-let version = "0.9.1"; in
+let version = "0.9.2"; in
 stdenv.mkDerivation {
   name = "gephi-${version}";
 
   src = fetchurl {
     url = "https://github.com/gephi/gephi/releases/download/v${version}/gephi-${version}-linux.tar.gz";
-    sha256 = "f1d54157302df05a53b94e1518880c949c43ba4ab21e52d57f3edcbdaa06c7ee";
+    sha256 = "1wr3rka8j2y10nnwbg27iaxkbrp4d7d07ccs9n94yqv6wqawj5z8";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Update gephi to the last version
https://github.com/gephi/gephi/wiki/Releases#gephi-092-sep-24-2017

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

