### PR TITLE
cytoscape: 3.5.1 -> 3.6.0

### DIFF
--- a/pkgs/applications/science/misc/cytoscape/default.nix
+++ b/pkgs/applications/science/misc/cytoscape/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cytoscape-${version}";
-  version = "3.5.1";
+  version = "3.6.0";
 
   src = fetchurl {
     url = "http://chianti.ucsd.edu/${name}/${name}.tar.gz";
-    sha256 = "1dvv0f7sc7q7lwmpd7xkcx86dd8lxh2il3wiwkij44gh7ni1qkfm";
+    sha256 = "13q8caksbzi6j7xy8v5f0pi6766yfawys6jcm50ng78mnhrv2v97";
   };
 
   buildInputs = [jre makeWrapper];


### PR DESCRIPTION
###### Motivation for this change

Update cytoscape to the last version
http://www.cytoscape.org/release_notes_3_6_0.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

