### PR TITLE
2048-in-terminal: 2015-01-15 -> 2017-11-29

### DIFF
--- a/pkgs/games/2048-in-terminal/default.nix
+++ b/pkgs/games/2048-in-terminal/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "2048-in-terminal-${version}";
-  version = "2015-01-15";
+  version = "2017-11-29";
 
   src = fetchFromGitHub {
-    sha256 = "1fdfmyhh60sz0xbilxkh2y09lvbcs9lamk2jkjkhxhlhxknmnfgs";
-    rev = "3e4e44fd360dfe114e81e6332a5a058a4b287cb1";
+    sha256 = "1cqv5z1i5zcrvj0w6pdfnnff8m6kjndqxwkwsw5ma9jz503bmyc6";
+    rev = "4e525066b0ef3442e92d2ba8dd373bdc205ece28";
     repo = "2048-in-terminal";
     owner = "alewmoose";
   };
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   preInstall = ''
     mkdir -p $out/bin
   '';
-  installFlags = [ "DESTDIR=$(out)" ];
+  installFlags = [ "DESTDIR=$(out)/bin" ];
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
Only functionality change AFAICT is
https://github.com/alewmoose/2048-in-terminal/commit/e7595caa2d07bf9122f15258259d69cf3fb32edd
which resets the board on exit at game over.

###### Motivation for this change

Mention on nix-devel and ended up checking for newer version than 2015.  Answer is "kinda".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

