### PR TITLE
rtl-sdr: 0.5.3 -> 0.5.3-git

### DIFF
--- a/pkgs/applications/misc/rtl-sdr/default.nix
+++ b/pkgs/applications/misc/rtl-sdr/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "rtl-sdr-${version}";
-  version = "0.5.3";
+  version = "0.5.3-git";
 
   src = fetchgit {
     url = "git://git.osmocom.org/rtl-sdr.git";
-    rev = "refs/tags/v${version}";
-    sha256 = "1dh52xcvxkjb3mj80wlm20grz8cqf5wipx2ksi91ascz12b5pym6";
+    rev = "b04c2f9f035c5aede43d731e5d58e4725d2f8bb4";
+    sha256 = "1w71z74czp0a3655iv38zrhsh0l897rdsmisx6iii1rix2dswk57";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Version 0.5.3 is already 4 years old. The latest git version contains bug fixes and feature enhancements like, e.g. bias-T control.  

###### Things done
Tested with a RTL-SDR receiver dongle.
 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

