### PR TITLE
gnuradio-osmosdr: 0.1.4->0.1.5-git

### DIFF
--- a/pkgs/applications/misc/gnuradio-osmosdr/default.nix
+++ b/pkgs/applications/misc/gnuradio-osmosdr/default.nix
@@ -7,12 +7,12 @@ assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
   name = "gnuradio-osmosdr-${version}";
-  version = "0.1.4";
+  version = "0.1.5-git";
 
   src = fetchgit {
     url = "git://git.osmocom.org/gr-osmosdr";
-    rev = "refs/tags/v${version}";
-    sha256 = "0vyzr4fhkblf2v3d7m0ch5hws4c493jw3ydl4y6b2dfbfzchhsz8";
+    rev = "c653754dde5e2cf682965e939cc016fbddbd45e4";
+    sha256 = "05na9bbcv3sd533p5q57x40jq5ypknrzr89y8kxrjq7w3xlyk6qd";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
The latest release is from 0.1.4 is from Nov. 2014. This version supports soapysdr as a backend (PR in preparation). Note that this PR needs an updated rtl-sdr version (see PR https://github.com/NixOS/nixpkgs/pull/33849)

###### Things done
 Tested with RTL-SDR and airspy devices.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

