### PR TITLE
why3: 0.88.1 -> 0.88.3

### DIFF
--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "why3-${version}";
-  version = "0.88.1";
+  version = "0.88.3";
 
   src = fetchurl {
-    url    = https://gforge.inria.fr/frs/download.php/file/37185/why3-0.88.1.tar.gz;
-    sha256 = "1qj00963si0vdrqjp79ai27g9rr8sqvly6n6nwpga6bnss98xqkw";
+    url    = https://gforge.inria.fr/frs/download.php/file/37313/why3-0.88.3.tar.gz;
+    sha256 = "0limdqy9l5bjzwhdalcfdyh0b6laxgiphhvr4bby9p0030agssiy";
   };
 
   buildInputs = (with ocamlPackages; [


### PR DESCRIPTION
###### Motivation for this change

Announce of 0.88.2: https://lists.gforge.inria.fr/pipermail/why3-club/2017-December/001617.html
Announce of 0.88.3: https://lists.gforge.inria.fr/pipermail/why3-club/2018-January/001622.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

