### PR TITLE
pythonPackages.user-agents: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/ua-parser/default.nix
+++ b/pkgs/development/python-modules/ua-parser/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "ua-parser";
+  version = "0.7.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p8siba0rnb5nsl354fd5fc4751d5ybw7hgnd56yn8dncxdb1bqa";
+  };
+
+  buildInputs = [ pyyaml ];
+
+  doCheck = false; # requires files from uap-core
+
+  meta = with stdenv.lib; {
+    description = "A python implementation of the UA Parser";
+    homepage = https://github.com/ua-parser/uap-python;
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/user-agents/default.nix
+++ b/pkgs/development/python-modules/user-agents/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, ua-parser }:
+
+buildPythonPackage rec {
+  pname = "user-agents";
+  version = "1.1.0";
+
+  # PyPI is missing devices.json
+  src = fetchFromGitHub {
+    owner = "selwin";
+    repo = "python-user-agents";
+    rev = "v${version}";
+    sha256 = "14kxd780zhp8718xr1z63xffaj3bvxgr4pldh9sv943m4hvi0gw5";
+  };
+
+  propagatedBuildInputs = [ ua-parser ];
+
+  meta = with stdenv.lib; {
+    description = "A Python library to identify devices by parsing user agent strings";
+    homepage = https://github.com/selwin/python-user-agents;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18134,6 +18134,8 @@ in {
 
   u-msgpack-python = callPackage ../development/python-modules/u-msgpack-python { };
 
+  ua-parser = callPackage ../development/python-modules/ua-parser { };
+
   ukpostcodeparser = callPackage ../development/python-modules/ukpostcodeparser { };
 
   umalqurra = buildPythonPackage rec {
@@ -18353,6 +18355,8 @@ in {
       maintainers = with maintainers; [ profpatsch ];
     };
   };
+
+  user-agents = callPackage ../development/python-modules/user-agents { };
 
   pyuv = buildPythonPackage rec {
     name = "pyuv-1.2.0";


### PR DESCRIPTION
###### Motivation for this change
Necessary for #33675.

It would be nice if someone could trigger a build on Darwin since I have no way to test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh 