### PR TITLE
pythonPackages.versioneer: init at 0.18

### DIFF
--- a/pkgs/development/python-modules/versioneer/default.nix
+++ b/pkgs/development/python-modules/versioneer/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+
+buildPythonPackage rec {
+
+  pname = "versioneer";
+  version = "0.18";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dgkzg1r7mjg91xp81sv9z4mabyxl39pkd11jlc1200md20zglga";
+  };
+
+  # Couldn't get tests to work because, for instance, they used virtualenv and
+  # pip.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Version-string management for VCS-controlled trees";
+    homepage = https://github.com/warner/python-versioneer;
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ jluttine ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23152,6 +23152,8 @@ EOF
     pyqt5 = self.pyqt56;
   };
 
+  versioneer = callPackage ../development/python-modules/versioneer { };
+
   vine = callPackage ../development/python-modules/vine { };
 
   wp_export_parser = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Add versioneer Python package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

