### PR TITLE
spectre-meltdown-checker: init at 0.29

### DIFF
--- a/pkgs/tools/security/spectre-meltdown-checker/default.nix
+++ b/pkgs/tools/security/spectre-meltdown-checker/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, fetchpatch, makeWrapper, binutils-unwrapped }:
+
+stdenv.mkDerivation rec {
+  name = "spectre-meltdown-checker-${version}";
+  version = "0.29";
+
+  src = fetchFromGitHub {
+    owner = "speed47";
+    repo = "spectre-meltdown-checker";
+    rev = "v${version}";
+    sha256 = "14i9gx1ngs3ixjirlx4qd87pmac916rvv9y61a5f7nl0dig4awl4";
+  };
+
+  patches = fetchpatch {
+    url = "https://github.com/speed47/spectre-meltdown-checker/pull/79.patch";
+    sha256 = "185kac5r97s3dnihgpwx4aashnzffb1f09xv9jw409g7i6cv2sq9";
+  };
+
+  prePatch = ''
+    substituteInPlace spectre-meltdown-checker.sh \
+      --replace /bin/echo echo
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = with stdenv.lib; ''
+    install -Dt $out/lib spectre-meltdown-checker.sh
+    makeWrapper $out/lib/spectre-meltdown-checker.sh $out/bin/spectre-meltdown-checker \
+      --prefix PATH : ${makeBinPath [ binutils-unwrapped ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Spectre & Meltdown vulnerability/mitigation checker for Linux";
+    homepage = https://github.com/speed47/spectre-meltdown-checker;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4627,6 +4627,8 @@ with pkgs;
 
   sparsehash = callPackage ../development/libraries/sparsehash { };
 
+  spectre-meltdown-checker = callPackage ../tools/security/spectre-meltdown-checker { };
+
   spiped = callPackage ../tools/networking/spiped { };
 
   sqliteman = callPackage ../applications/misc/sqliteman { };


### PR DESCRIPTION
###### Motivation for this change
~Can someone please help me adding `readelf` to the path?~
I didn't have any success using
```
makeWrapper $out/lib/spectre-meltdown-checker.sh $out/bin/spectre-meltdown-checker \
  --prefix PATH : ${makeBinPath [ binutils ]}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

