### PR TITLE
python3Packages.netdisco: init at 1.2.3

### DIFF
--- a/pkgs/development/python-modules/netdisco/default.nix
+++ b/pkgs/development/python-modules/netdisco/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub, requests, zeroconf, netifaces, pytest }:
+
+buildPythonPackage rec {
+  pname = "netdisco";
+  version = "1.2.3";
+
+  disabled = !isPy3k;
+
+  # PyPI is missing tests/ directory
+  src = fetchFromGitHub {
+    owner = "home-assistant";
+    repo = pname;
+    rev = version;
+    sha256 = "137p7qlv85mva96v6kav8xxca7i09k4giayag4cglrgjd7q3lk1r";
+  };
+
+  propagatedBuildInputs = [ requests zeroconf netifaces ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python library to scan local network for services and devices";
+    homepage = https://github.com/home-assistant/netdisco/;
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5954,6 +5954,8 @@ in {
 
   netcdf4 = callPackage ../development/python-modules/netcdf4 { };
 
+  netdisco = callPackage ../development/python-modules/netdisco { };
+
   Nikola = callPackage ../development/python-modules/Nikola { };
 
   nxt-python = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change
Necessary for #33675.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh 