### PR TITLE
python3Packages.pyhomematic: init at 0.1.38

### DIFF
--- a/pkgs/development/python-modules/pyhomematic/default.nix
+++ b/pkgs/development/python-modules/pyhomematic/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, isPy3k, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pyhomematic";
+  version = "0.1.38";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15b09ppn5sn3vpnwfb7gygrvn5v65k3zvahkfx2kqpk1xah0mqbf";
+  };
+
+  # Tests reuire network access
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python 3 Interface to interact with Homematic devices";
+    homepage = https://github.com/danielperna84/pyhomematic;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6156,6 +6156,8 @@ in {
 
   pydotplus = callPackage ../development/python-modules/pydotplus { };
 
+  pyhomematic = callPackage ../development/python-modules/pyhomematic { };
+
   pyphen = callPackage ../development/python-modules/pyphen {};
 
   pypoppler = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change
Useful for #33675.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

