### PR TITLE
spectre-meltdown-checker: 0.29 -> 0.31

### DIFF
--- a/pkgs/tools/security/spectre-meltdown-checker/default.nix
+++ b/pkgs/tools/security/spectre-meltdown-checker/default.nix
@@ -1,24 +1,19 @@
-{ stdenv, fetchFromGitHub, fetchpatch, makeWrapper, binutils-unwrapped }:
+{ stdenv, fetchFromGitHub, fetchpatch, makeWrapper, coreutils, binutils-unwrapped }:
 
 stdenv.mkDerivation rec {
   name = "spectre-meltdown-checker-${version}";
-  version = "0.29";
+  version = "0.31";
 
   src = fetchFromGitHub {
     owner = "speed47";
     repo = "spectre-meltdown-checker";
     rev = "v${version}";
-    sha256 = "14i9gx1ngs3ixjirlx4qd87pmac916rvv9y61a5f7nl0dig4awl4";
-  };
-
-  patches = fetchpatch {
-    url = "https://github.com/speed47/spectre-meltdown-checker/pull/79.patch";
-    sha256 = "185kac5r97s3dnihgpwx4aashnzffb1f09xv9jw409g7i6cv2sq9";
+    sha256 = "14g5q2prd5w2zhwi7sr9pnalakd87zkvxk0vrzw4cv3x71d44nk2";
   };
 
   prePatch = ''
     substituteInPlace spectre-meltdown-checker.sh \
-      --replace /bin/echo echo
+      --replace /bin/echo ${coreutils}/bin/echo
   '';
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
The patch to find NixOS kernel is now merged upstream.

Since the author explicitly specified `/bin/echo`, I did him a favour and use coreutils' `echo` as well :smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

