### PR TITLE
yajl: small clean up

### DIFF
--- a/pkgs/development/libraries/yajl/default.nix
+++ b/pkgs/development/libraries/yajl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, ruby }:
+{ stdenv, fetchurl, cmake }:
 
 stdenv.mkDerivation rec {
   name = "yajl-2.1.0";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0f6yrjc05aa26wfi7lqn2gslm19m6rm81b30ksllpkappvh162ji";
   };
 
-  buildInputs = [ cmake ruby ];
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Yet Another JSON Library";


### PR DESCRIPTION
- ruby dependency is no longer needed
- cmake belongs in nativeBuildInputs

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

