### PR TITLE
transmission: fix RCE via dns rebinding attach

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, file, wrapGAppsHook
+{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, file, wrapGAppsHook
 , openssl, curl, libevent, inotify-tools, systemd, zlib
 , enableGTK3 ? false, gtk3
 , enableSystemd ? stdenv.isLinux
@@ -26,6 +26,16 @@ stdenv.mkDerivation rec {
     ++ optionals enableGTK3 [ gtk3 ]
     ++ optionals enableSystemd [ systemd ]
     ++ optionals stdenv.isLinux [ inotify-tools ];
+
+  patches = [
+    (fetchpatch {
+      # See https://github.com/transmission/transmission/pull/468
+      # Patch from: https://github.com/transmission/transmission/pull/468#issuecomment-357098126
+      name = "transmission-fix-dns-rebinding-vuln.patch";
+      url = https://github.com/transmission/transmission/files/1624507/transmission-fix-dns-rebinding-vuln.patch.txt;
+      sha256 = "1p9m20kp4kdyp5jjr3yp5px627n8cfa29mg5n3wzsdfv0qzk9gy4";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace ./configure \


### PR DESCRIPTION
###### Motivation for this change
For further details see [1] & [2].

[1] https://github.com/transmission/transmission/pull/468
[2] http://www.openwall.com/lists/oss-security/2018/01/12/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

