### PR TITLE
pythonPackages.fritzconnection: init at 0.6.5

### DIFF
--- a/pkgs/development/python-modules/fritzconnection/default.nix
+++ b/pkgs/development/python-modules/fritzconnection/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, lxml, requests, tkinter }:
+
+buildPythonPackage rec {
+  pname = "fritzconnection";
+  version = "0.6.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14g3sxprq65lxbgkf3rjgb1bjqnj2jc5p1swlq9sk9gwnl6ca3ds";
+  };
+
+  prePatch = ''
+    substituteInPlace fritzconnection/test.py \
+      --replace "from fritzconnection import" "from .fritzconnection import"
+  '';
+
+  propagatedBuildInputs = [ lxml requests tkinter ];
+
+  meta = with stdenv.lib; {
+    description = "Python-Tool to communicate with the AVM FritzBox using the TR-064 protocol";
+    homepage = https://bitbucket.org/kbr/fritzconnection;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4736,6 +4736,8 @@ in {
     };
   };
 
+  fritzconnection = callPackage ../development/python-modules/fritzconnection { };
+
   frozendict = buildPythonPackage rec {
     name = "frozendict-0.5";
 


### PR DESCRIPTION
###### Motivation for this change
Does anyone have an idea why the `substituteInPlace` is only necessary for Python 3?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

