### PR TITLE
linux_beagleboard: 4.9.61-ti-r76 -> 4.14.12-ti-r23

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
+++ b/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
@@ -1,10 +1,10 @@
-{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ubootTools, dtc, ... } @ args:
 
 let
-  modDirVersion = "4.9.61";
-  tag = "r76";
+  modDirVersion = "4.14.12";
+  tag = "r23";
 in
-import ./generic.nix (args // rec {
+stdenv.lib.overrideDerivation (import ./generic.nix (args // rec {
   version = "${modDirVersion}-ti-${tag}";
   inherit modDirVersion;
 
@@ -12,7 +12,7 @@ import ./generic.nix (args // rec {
     owner = "beagleboard";
     repo = "linux";
     rev = "${version}";
-    sha256 = "0hcz4fwjyic42mrn8qsvzm4jq1g5k51awjj3d2das7k8frjalaby";
+    sha256 = "07hdv2h12gsgafxsqqr7b0fir10rv9k66riklpjba2cg6x0p2nr4";
   };
 
   kernelPatches = args.kernelPatches;
@@ -21,5 +21,14 @@ import ./generic.nix (args // rec {
     efiBootStub = false;
   } // (args.features or {});
 
-  extraMeta.hydraPlatforms = [];
-} // (args.argsOverride or {}))
+  extraMeta.hydraPlatforms = [ "armv7l-linux" ];
+} // (args.argsOverride or {}))) (oldAttrs: {
+
+  # This kernel will run mkuboot.sh.
+  postPatch = ''
+    patchShebangs scripts/
+  '';
+
+  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ dtc ubootTools ];
+
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12795,8 +12795,7 @@ with pkgs;
   linux_beagleboard = callPackage ../os-specific/linux/kernel/linux-beagleboard.nix {
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
-        kernelPatches.p9_fixes
-        kernelPatches.cpu-cgroup-v2."4.9"
+        kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
       ];
   };


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest upstream.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

