### PR TITLE
netsniff-ng: 0.6.2 -> 0.6.3

### DIFF
--- a/pkgs/tools/networking/netsniff-ng/default.nix
+++ b/pkgs/tools/networking/netsniff-ng/default.nix
@@ -1,24 +1,27 @@
-{ stdenv, fetchFromGitHub, bison, flex, geoip, geolite-legacy, libcli, libnet
-, libnetfilter_conntrack, libnl, libpcap, libsodium, liburcu, ncurses, perl
-, pkgconfig, zlib }:
+{ stdenv, fetchFromGitHub, makeWrapper, bison, flex, geoip, geolite-legacy
+, libcli, libnet, libnetfilter_conntrack, libnl, libpcap, libsodium
+, liburcu, ncurses, perl, pkgconfig, zlib }:
 
 stdenv.mkDerivation rec {
   name = "netsniff-ng-${version}";
-  version = "0.6.2";
+  version = "0.6.3";
 
   # Upstream recommends and supports git
   src = fetchFromGitHub rec {
     repo = "netsniff-ng";
     owner = repo;
     rev = "v${version}";
-    sha256 = "1lz4hwgwdq3znlqjmvl7cw3g3ilbayn608h0hwqdf7v2jq6n67kg";
+    sha256 = "0g3105c5ha897bpwsnrp72gx4n61gspxmld594i37g8k7vwzny4l";
   };
 
   patches = [ ./glibc-2.26.patch ];
 
   buildInputs = [ bison flex geoip geolite-legacy libcli libnet libnl
     libnetfilter_conntrack libpcap libsodium liburcu ncurses perl
-    pkgconfig zlib ];
+    pkgconfig zlib makeWrapper ];
+
+  # trafgen and bpfc can call out to cpp to process config files.
+  propagatedBuildInputs = [ stdenv.cc ];
 
   # ./configure is not autoGNU but some home-brewn magic
   configurePhase = ''
@@ -33,6 +36,9 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" "ETCDIR=$(out)/etc" ];
 
   postInstall = ''
+    wrapProgram "$out/sbin/trafgen" --prefix PATH ":" "${stdenv.cc}/bin"
+    wrapProgram "$out/sbin/bpfc" --prefix PATH ":" "${stdenv.cc}/bin"
+
     ln -sv ${geolite-legacy}/share/GeoIP/GeoIP.dat		$out/etc/netsniff-ng/country4.dat
     ln -sv ${geolite-legacy}/share/GeoIP/GeoIPv6.dat		$out/etc/netsniff-ng/country6.dat
     ln -sv ${geolite-legacy}/share/GeoIP/GeoIPCity.dat		$out/etc/netsniff-ng/city4.dat


### PR DESCRIPTION

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

