### PR TITLE
dcm2niix: init at 1.0.20170130

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -60,6 +60,7 @@
   arobyn = "Alexei Robyn <shados@shados.net>";
   artuuge = "Artur E. Ruuge <artuuge@gmail.com>";
   ashalkhakov = "Artyom Shalkhakov <artyom.shalkhakov@gmail.com>";
+  ashgillman = "Ashley Gillman <gillmanash@gmail.com>";
   aske = "Kirill Boltaev <aske@fmap.me>";
   asppsa = "Alastair Pharo <asppsa@gmail.com>";
   astsmtl = "Alexander Tsamutali <astsmtl@yandex.ru>";

--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, libyamlcpp
+}:
+
+let
+  version = "v1.0.20170130";
+  sha256 = "1f2nzd8flp1rfn725bi64z7aw3ccxyyygzarxijw6pvgl476i532";
+
+in stdenv.mkDerivation rec {
+  name = "dcm2niix-${version}";
+
+  src = fetchFromGitHub {
+    inherit sha256;
+    owner = "rordenlab";
+    repo = "dcm2niix";
+    rev = version;
+  };
+
+  enableParallelBuilding = true;
+  buildInputs = [ cmake libyamlcpp];
+
+  meta = {
+    description = "dcm2niix DICOM to NIfTI converter";
+    longDescription = ''
+      dcm2niix is a designed to convert neuroimaging data from the
+      DICOM format to the NIfTI format.
+    '';
+    homepage = https://www.nitrc.org/projects/dcm2nii;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.ashgillman ];
+    platforms = stdenv.lib.platforms.linux;
+};
+}

--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -4,32 +4,30 @@
 , libyamlcpp
 }:
 
-let
-  version = "v1.0.20170130";
-  sha256 = "1f2nzd8flp1rfn725bi64z7aw3ccxyyygzarxijw6pvgl476i532";
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
+  version = "1.0.20170130";
   name = "dcm2niix-${version}";
 
   src = fetchFromGitHub {
-    inherit sha256;
     owner = "rordenlab";
     repo = "dcm2niix";
-    rev = version;
+    rev = "v${version}";
+    sha256 = "1f2nzd8flp1rfn725bi64z7aw3ccxyyygzarxijw6pvgl476i532";
   };
 
   enableParallelBuilding = true;
-  buildInputs = [ cmake libyamlcpp];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libyamlcpp ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "dcm2niix DICOM to NIfTI converter";
     longDescription = ''
       dcm2niix is a designed to convert neuroimaging data from the
       DICOM format to the NIfTI format.
     '';
     homepage = https://www.nitrc.org/projects/dcm2nii;
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = [ stdenv.lib.maintainers.ashgillman ];
-    platforms = stdenv.lib.platforms.linux;
-};
+    license = licenses.bsd3;
+    maintainers = [ maintainers.ashgillman ];
+    platforms = platforms.all;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18844,6 +18844,8 @@ with pkgs;
 
   bcftools = callPackage ../applications/science/biology/bcftools { };
 
+  dcm2niix = callPackage ../applications/science/biology/dcm2niix { };
+
   diamond = callPackage ../applications/science/biology/diamond { };
 
   ecopcr = callPackage ../applications/science/biology/ecopcr { };


### PR DESCRIPTION
###### Motivation for this change
Add a package used in biomedical imaging

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

