### PR TITLE
libnetfilter_queue: 1.0.2 -> 1.0.3

### DIFF
--- a/pkgs/development/libraries/libnetfilter_queue/default.nix
+++ b/pkgs/development/libraries/libnetfilter_queue/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, pkgconfig, libmnl, libnfnetlink }:
 
 stdenv.mkDerivation rec {
-  name = "libnetfilter_queue-1.0.2";
+  version = "1.0.3";
+  name = "libnetfilter_queue-${version}";
 
   src = fetchurl {
-    url = "ftp://ftp.netfilter.org/pub/libnetfilter_queue/${name}.tar.bz2";
-    sha256 = "0chsmj9ky80068vn458ijz9sh4sk5yc08dw2d6b8yddybpmr1143";
+    url = "https://www.netfilter.org/projects/libnetfilter_queue/files/${name}.tar.bz2";
+    sha256 = "0x77m1fvbqzz5z64jz59fb6j8dvv8b9pg4fmznqwax4x6imjcncq";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

