### PR TITLE
wildmidi: 0.3.9 -> 0.4.2

### DIFF
--- a/pkgs/development/libraries/wildmidi/default.nix
+++ b/pkgs/development/libraries/wildmidi/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, alsaLib, freepats }:
 
 stdenv.mkDerivation rec {
-  name = "wildmidi-0.3.9";
+  name = "wildmidi-0.4.2";
 
   src = fetchurl {
     url = "https://github.com/Mindwerks/wildmidi/archive/${name}.tar.gz";
-    sha256 = "1fbcsvzn8akvvy7vg6vmnikcc8gh405b4gp1r016bq7yginljwwp";
+    sha256 = "178hm2wh5h7apkcb1a0dyla2ia8569php8ikz62rh0g6dp5l67am";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
0.4.2 fixes the following CVEs:
CVE-2017-11661
CVE-2017-11662
CVE-2017-11663
CVE-2017-11664

Fixes #33877.

---

Untested! Also, I'm not sure if this can be backported to release-17.09 due to 0.4.0 seemingly having breaking changes. https://github.com/Mindwerks/wildmidi/releases 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

