### PR TITLE
apache-directory-studio: add missing desktop item

### DIFF
--- a/pkgs/applications/networking/apache-directory-studio/default.nix
+++ b/pkgs/applications/networking/apache-directory-studio/default.nix
@@ -1,9 +1,20 @@
-{ stdenv, fetchurl, xorg, jre, makeWrapper }:
+{ stdenv, fetchurl, xorg, jre, makeWrapper, makeDesktopItem }:
 
 let
   rpath = stdenv.lib.makeLibraryPath (with xorg; [
     libXtst
   ]);
+
+  desktopItem = makeDesktopItem {
+    name = "apache-directory-studio";
+    exec = "ApacheDirectoryStudio";
+    icon = "apache-directory-studio";
+    comment = "Eclipse-based LDAP browser and directory client";
+    desktopName = "Apache Directory Studio";
+    genericName = "Apache Directory Studio";
+    categories = "Java;Network";
+  };
+
 in
 stdenv.mkDerivation rec {
   name = "apache-directory-studio-${version}";
@@ -36,6 +47,10 @@ stdenv.mkDerivation rec {
         "$out/bin/ApacheDirectoryStudio" \
         --prefix PATH : "${jre}/bin" \
         --prefix LD_LIBRARY_PATH : "${rpath}"
+    mkdir -p "$out/share/pixmaps"
+    cp icon.xpm $out/share/pixmaps/apache-directory-studio.xpm
+    mkdir -p "$out/share/applications"
+    cp ${desktopItem}/share/applications/* $out/share/applications
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/apache-directory-studio/default.nix
+++ b/pkgs/applications/networking/apache-directory-studio/default.nix
@@ -47,10 +47,8 @@ stdenv.mkDerivation rec {
         "$out/bin/ApacheDirectoryStudio" \
         --prefix PATH : "${jre}/bin" \
         --prefix LD_LIBRARY_PATH : "${rpath}"
-    mkdir -p "$out/share/pixmaps"
-    cp icon.xpm $out/share/pixmaps/apache-directory-studio.xpm
-    mkdir -p "$out/share/applications"
-    cp ${desktopItem}/share/applications/* $out/share/applications
+    install -D icon.xpm "$out/share/pixmaps/apache-directory-studio.xpm"
+    install -D -t "$out/share/applications" ${desktopItem}/share/applications/*
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
I added Apache Directory Studio, but didn't find it in my application menu.
This adds the missing `.desktop` file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

