### PR TITLE
ispc: 20170807 -> 1.9.2

### DIFF
--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -3,8 +3,8 @@ testedTargets ? ["sse2" "host"] # the default test target is sse4, but that is n
 }:
 
 stdenv.mkDerivation rec {
-  version = "20170807";
-  rev = "6e0fc2f148e95afad998a7c7f4d7908d29fd8e44";
+  version = "1.9.2";
+  rev = "v${version}";
 
   inherit testedTargets;
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "ispc";
     repo = "ispc";
     inherit rev;
-    sha256 = "17fwnfm8a329lgfhjwcvji4h1fm4iqmc28wz23hvgqbpj8lk6qgh";
+    sha256 = "0zaw7mwvly1csbdcbz9j8ry89n0r1fag1m1f579l4mgg1x6ksqry";
   };
 
   # there are missing dependencies in the Makefile, causing sporadic build failures


### PR DESCRIPTION
Version bump, fixes #29979

###### Motivation for this change

Upstream version was changed and includes a fix for #29979

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

