### PR TITLE
bettercap: init at 1.6.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -738,6 +738,7 @@
   xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";
   xwvvvvwx = "David Terry <davidterry@posteo.de>";
   xzfc = "Albert Safin <xzfcpw@gmail.com>";
+  y0no = "Yoann Ono <y0no@y0no.fr>";
   yarr = "Dmitry V. <savraz@gmail.com>";
   yegortimoshenko = "Yegor Timoshenko <yegortimoshenko@gmail.com>";
   ylwghst = "Burim Augustin Berisa <ylwghst@onionmail.info>";

--- a/pkgs/tools/security/bettercap/Gemfile
+++ b/pkgs/tools/security/bettercap/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'bettercap'

--- a/pkgs/tools/security/bettercap/Gemfile.lock
+++ b/pkgs/tools/security/bettercap/Gemfile.lock
@@ -1,0 +1,42 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bettercap (1.6.2)
+      colorize (~> 0.8.0)
+      em-proxy (~> 0.1, >= 0.1.8)
+      net-dns (~> 0.8, >= 0.8.0)
+      network_interface (~> 0.0, >= 0.0.1)
+      packetfu (~> 1.1, >= 1.1.10)
+      pcaprub (~> 0.12, >= 0.12.0, <= 1.1.11)
+      rubydns (~> 1.0, >= 1.0.3)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    celluloid-io (0.16.2)
+      celluloid (>= 0.16.0)
+      nio4r (>= 1.1.0)
+    colorize (0.8.1)
+    em-proxy (0.1.9)
+      eventmachine
+    eventmachine (1.2.5)
+    hitimes (1.2.6)
+    net-dns (0.8.0)
+    network_interface (0.0.2)
+    nio4r (2.2.0)
+    packetfu (1.1.13)
+      pcaprub
+    pcaprub (0.12.4)
+    rubydns (1.0.3)
+      celluloid (= 0.16.0)
+      celluloid-io (= 0.16.2)
+      timers (~> 4.0.1)
+    timers (4.0.4)
+      hitimes
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bettercap
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/tools/security/bettercap/default.nix
+++ b/pkgs/tools/security/bettercap/default.nix
@@ -1,0 +1,23 @@
+{ lib, bundlerEnv, ruby, libpcap}:
+
+bundlerEnv rec {
+  name = "bettercap-${version}";
+
+  version = (import gemset).bettercap.version;
+  inherit ruby;
+  gemdir = ./.;
+  gemset = ./gemset.nix;
+
+  buildInputs = [ libpcap ruby ];
+
+  meta = with lib; {
+    description = "A man in the middle tool";
+    longDescription = ''
+      BetterCAP is a powerful, flexible and portable tool created to perform various types of MITM attacks against a network, manipulate HTTP, HTTPS and TCP traffic in realtime, sniff for credentials and much more.
+    '' ;
+    homepage = https://www.bettercap.org/;
+    license = with licenses; mit;
+    maintainers = with maintainers; [ y0no ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/security/bettercap/default.nix
+++ b/pkgs/tools/security/bettercap/default.nix
@@ -16,7 +16,7 @@ bundlerEnv rec {
       BetterCAP is a powerful, flexible and portable tool created to perform various types of MITM attacks against a network, manipulate HTTP, HTTPS and TCP traffic in realtime, sniff for credentials and much more.
     '' ;
     homepage = https://www.bettercap.org/;
-    license = with licenses; mit;
+    license = with licenses; gpl3;
     maintainers = with maintainers; [ y0no ];
     platforms = platforms.all;
   };

--- a/pkgs/tools/security/bettercap/gemset.nix
+++ b/pkgs/tools/security/bettercap/gemset.nix
@@ -1,0 +1,121 @@
+{
+  bettercap = {
+    dependencies = ["colorize" "em-proxy" "net-dns" "network_interface" "packetfu" "pcaprub" "rubydns"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mns96yfyfnksk720p8k83qkwwsid4sicwgrzxaa9gbc53aalll0";
+      type = "gem";
+    };
+    version = "1.6.2";
+  };
+  celluloid = {
+    dependencies = ["timers"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "044xk0y7i1xjafzv7blzj5r56s7zr8nzb619arkrl390mf19jxv3";
+      type = "gem";
+    };
+    version = "0.16.0";
+  };
+  celluloid-io = {
+    dependencies = ["celluloid" "nio4r"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l1x0p6daa5vskywrvaxdlanwib3k5pps16axwyy4p8d49pn9rnx";
+      type = "gem";
+    };
+    version = "0.16.2";
+  };
+  colorize = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "133rqj85n400qk6g3dhf2bmfws34mak1wqihvh3bgy9jhajw580b";
+      type = "gem";
+    };
+    version = "0.8.1";
+  };
+  em-proxy = {
+    dependencies = ["eventmachine"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yzkg6jkmcg859b5mf13igpf8q2bjhsmqjsva05948fi733w5n2j";
+      type = "gem";
+    };
+    version = "0.1.9";
+  };
+  eventmachine = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "075hdw0fgzldgss3xaqm2dk545736khcvv1fmzbf1sgdlkyh1v8z";
+      type = "gem";
+    };
+    version = "1.2.5";
+  };
+  hitimes = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06222h9236jw9jgmdlpi0q7psac1shvxqxqx905qkvabmxdxlfar";
+      type = "gem";
+    };
+    version = "1.2.6";
+  };
+  net-dns = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12nal6vhdyg0pbcqpsxqr59h7mbgdhcqp3v0xnzvy167n40gabf9";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  network_interface = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xh4knfq77ii4pjzsd2z1p3nd6nrcdjhb2vi5gw36jqj43ffw0zp";
+      type = "gem";
+    };
+    version = "0.0.2";
+  };
+  nio4r = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jjrj7vs29w6dfgsxq08226jfbi2j0x62lf4p9zmvyp19dj4z00a";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  packetfu = {
+    dependencies = ["pcaprub"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16ppq9wfxq4x2hss61l5brs3s6fmi8gb50mnp1nnnzb1asq4g8ll";
+      type = "gem";
+    };
+    version = "1.1.13";
+  };
+  pcaprub = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pl4lqy7308185pfv0197n8b4v20fhd0zb3wlpz284rk8ssclkvz";
+      type = "gem";
+    };
+    version = "0.12.4";
+  };
+  rubydns = {
+    dependencies = ["celluloid" "celluloid-io" "timers"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cvj8li8shz7zn1rc5hdrkqmvr9j187g4y28mvkfvmv1j9hdln62";
+      type = "gem";
+    };
+    version = "1.0.3";
+  };
+  timers = {
+    dependencies = ["hitimes"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jx4wb0x182gmbcs90vz0wzfyp8afi1mpl9w5ippfncyk4kffvrz";
+      type = "gem";
+    };
+    version = "4.0.4";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1372,6 +1372,8 @@ with pkgs;
 
   bepasty = callPackage ../tools/misc/bepasty { };
 
+  bettercap = callPackage ../tools/security/bettercap { };
+
   bfg-repo-cleaner = gitAndTools.bfg-repo-cleaner;
 
   bgs = callPackage ../tools/X11/bgs { };


### PR DESCRIPTION
###### Motivation for this change
This package was missing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

