### PR TITLE
miniupnp{d,c} updates, fix for CVE-2017-1000494

### DIFF
--- a/pkgs/tools/networking/miniupnpc/default.nix
+++ b/pkgs/tools/networking/miniupnpc/default.nix
@@ -27,8 +27,8 @@ let
     };
 in {
   miniupnpc_2 = generic {
-    version = "2.0.20170509";
-    sha256 = "0spi75q6nafxp3ndnrhrlqagzmjlp8wwlr5x7rnvdpswgxi6ihyk";
+    version = "2.0.20171212";
+    sha256 = "0za7pr6hrr3ajkifirhhxfn3hlhl06f622g8hnj5h8y18sp3bwff";
   };
   miniupnpc_1 = generic {
     version = "1.9.20160209";

--- a/pkgs/tools/networking/miniupnpd/default.nix
+++ b/pkgs/tools/networking/miniupnpd/default.nix
@@ -3,11 +3,11 @@
 assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "miniupnpd-2.0";
+  name = "miniupnpd-2.0.20171212";
 
   src = fetchurl {
     url = "http://miniupnp.free.fr/files/download.php?file=${name}.tar.gz";
-    sha256 = "1dxzhvkylrnbkd5srb9rb2g4f9ydd1zbjg5sdf190m0g1sha6snr";
+    sha256 = "0jdcll1nd8jf356fpl0n2yw8sww58nfz6hkx052d77l34afq6sn7";
     name = "${name}.tar.gz";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Randomly browsing through issue trackers and checking with nixpkgs made me discover an issue with miniupnpd. Miniupnpc also received an update but I am uncertain if that is also affected by the same issue. Bumping it shouldn't hurt tho..

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests]
(https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - [x] `nixos/tests/bittorent.nix` contains code that uses `miniupnpd` so I used that as a test case.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

