### PR TITLE
skim: init at 0.3.1

### DIFF
--- a/pkgs/tools/misc/skim/default.nix
+++ b/pkgs/tools/misc/skim/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, rustPlatform, fetchFromGitHub, ncurses }:
+
+rustPlatform.buildRustPackage rec {
+  name = "skim-v${version}";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "lotabout";
+    repo = "skim";
+    rev = "v${version}";
+    sha256 = "1dvvrjvryzffqxqpg10ahg7rx9wkkav1q413bza3x3afb0jlsx15";
+  };
+
+  cargoSha256 = "0zf3y74382m4347yn1sygzd3g9b6vn5dmckj5nyll20azc6shyvc";
+
+  buildInputs = [ ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "Fuzzy Finder in rust";
+    homepage = https://github.com/lotabout/skim;
+    license = licenses.mit;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1253,6 +1253,8 @@ with pkgs;
 
   ps_mem = callPackage ../tools/system/ps_mem { };
 
+  skim = callPackage ../tools/misc/skim { };
+
   socklog = callPackage ../tools/system/socklog { };
 
   staccato = callPackage ../tools/text/staccato { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

