### PR TITLE
wakatime: don't run check phase

### DIFF
--- a/pkgs/tools/misc/wakatime/default.nix
+++ b/pkgs/tools/misc/wakatime/default.nix
@@ -11,6 +11,8 @@ buildPythonApplication rec {
     sha256 = "1bg8fzd3rdc6na0a7z1d55m2gbnfq6d72mf2jlyzc817r6dr4bfx";
   };
 
+  doCheck = false;
+
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "WakaTime command line interface";

--- a/pkgs/tools/misc/wakatime/default.nix
+++ b/pkgs/tools/misc/wakatime/default.nix
@@ -1,17 +1,26 @@
-{ stdenv, buildPythonApplication, fetchFromGitHub }:
+{ stdenv, python3Packages, fetchFromGitHub, glibcLocales }:
 
+with python3Packages;
 buildPythonApplication rec {
   name = "wakatime-${version}";
-  version = "10.0.1";
+  version = "10.1.0";
 
   src = fetchFromGitHub {
     owner = "wakatime";
     repo = "wakatime";
     rev = version;
-    sha256 = "1bg8fzd3rdc6na0a7z1d55m2gbnfq6d72mf2jlyzc817r6dr4bfx";
+    sha256 = "0mq1b5hwm03jz1mhlfiwi8k5r6556r1nfv9h7qs3y32zrj9mvifv";
   };
 
+  # needs more dependencies from https://github.com/wakatime/wakatime/blob/191b302bfb5f272ae928c6d3867d06f3dfcba4a8/dev-requirements.txt
+  # especially nose-capturestderr, which we do not package yet.
   doCheck = false;
+  checkInputs = [ mock testfixtures pytest glibcLocales ];
+
+  checkPhase = ''
+    export HOME=$(mktemp -d) LC_ALL=en_US.utf-8
+    pytest tests
+  '';
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
###### Motivation for this change
Wakatime would not previously build for me (`nix-build -A wakatime`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

