### PR TITLE
pythonPackages.nimfa: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/nimfa/default.nix
+++ b/pkgs/development/python-modules/nimfa/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "nimfa";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "05d0m5n96bg6wj94r7m1har48f93797gk5v9s62zdv7x83a6n6j5";
+    sha256 = "0iqcrr48jwy7nh8g13xf4rvpw9wq5qs3hyd6gqlh30mgyn9i85w7";
   };
 
   propagatedBuildInputs = [ numpy scipy ];

--- a/pkgs/development/python-modules/nimfa/default.nix
+++ b/pkgs/development/python-modules/nimfa/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, matplotlib
+, pytest
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "nimfa";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05d0m5n96bg6wj94r7m1har48f93797gk5v9s62zdv7x83a6n6j5";
+  };
+
+  propagatedBuildInputs = [ numpy scipy ];
+  buildInputs = [ matplotlib pytest ];
+  doCheck = false; # errors
+
+  meta = with stdenv.lib; {
+    description = "Nonnegative matrix factorization library";
+    homepage = "http://nimfa.biolab.si";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ashgillman ];
+  };
+}

--- a/pkgs/development/python-modules/nimfa/default.nix
+++ b/pkgs/development/python-modules/nimfa/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy3k
 , numpy
 , scipy
 , matplotlib
@@ -8,7 +9,6 @@
 }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "nimfa";
   version = "1.3.1";
 
@@ -18,8 +18,8 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ numpy scipy ];
-  buildInputs = [ matplotlib pytest ];
-  doCheck = false; # errors
+  checkInputs = [ matplotlib pytest ];
+  doCheck = !isPy3k;  # https://github.com/marinkaz/nimfa/issues/42
 
   meta = with stdenv.lib; {
     description = "Nonnegative matrix factorization library";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11343,6 +11343,28 @@ in {
 
   nilearn = callPackage ../development/python-modules/nilearn {};
 
+  nimfa = buildPythonPackage rec {
+    pname = "nimfa";
+    version = "1.3.1";
+    name = "${pname}-${version}";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/n/${pname}/${name}.tar.gz";
+      sha256 = "05d0m5n96bg6wj94r7m1har48f93797gk5v9s62zdv7x83a6n6j5";
+    };
+
+    propagatedBuildInputs = with self; [ numpy scipy ];
+    buildInputs = with self; [ matplotlib pytest ];
+    doCheck = false; # errors
+
+    meta = with pkgs.stdenv.lib; {
+      description = "Nonnegative matrix factorization library";
+      homepage = "http://nimfa.biolab.si";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ ashgillman ];
+    };
+  };
+
   nipy = buildPythonPackage rec {
     version = "0.4.0";
     name = "nipy-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11343,27 +11343,7 @@ in {
 
   nilearn = callPackage ../development/python-modules/nilearn {};
 
-  nimfa = buildPythonPackage rec {
-    pname = "nimfa";
-    version = "1.3.1";
-    name = "${pname}-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/n/${pname}/${name}.tar.gz";
-      sha256 = "05d0m5n96bg6wj94r7m1har48f93797gk5v9s62zdv7x83a6n6j5";
-    };
-
-    propagatedBuildInputs = with self; [ numpy scipy ];
-    buildInputs = with self; [ matplotlib pytest ];
-    doCheck = false; # errors
-
-    meta = with pkgs.stdenv.lib; {
-      description = "Nonnegative matrix factorization library";
-      homepage = "http://nimfa.biolab.si";
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ ashgillman ];
-    };
-  };
+  nimfa = callPackage ../development/python-modules/nimfa {};
 
   nipy = buildPythonPackage rec {
     version = "0.4.0";


### PR DESCRIPTION
###### Motivation for this change
New Python package for nonnegative matrix factorization (maths and science).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

