### PR TITLE
hll2390dw-cups: init at 4.0.0-1

### DIFF
--- a/pkgs/misc/cups/drivers/hll2390dw-cups/default.nix
+++ b/pkgs/misc/cups/drivers/hll2390dw-cups/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchurl, makeWrapper
+, cups
+, dpkg
+, a2ps, ghostscript, gnugrep, gnused, coreutils, file, perl, which
+}:
+
+stdenv.mkDerivation rec {
+  name = "hll2390dw-cups-${version}";
+  version = "4.0.0-1";
+
+  src = fetchurl {
+    # The i386 part is a lie. There are x86, x86_64 and armv7l drivers.
+    # Though this builds only supports x86_64 for now.
+    url = "http://download.brother.com/welcome/dlf103579/hll2390dwpdrv-${version}.i386.deb";
+    sha256 = "0w8rxh1sa5amxr87qmzs4m2p06b1b36wn2q127mg427sbkh1rwni";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups ghostscript dpkg a2ps ];
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    substituteInPlace $out/opt/brother/Printers/HLL2390DW/lpd/lpdfilter \
+      --replace /opt "$out/opt" \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"HLL2390DW\"; #"
+
+    # FIXME : Allow i686 and armv7l variations to be setup instead.
+    _PLAT=x86_64
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/opt/brother/Printers/HLL2390DW/lpd/$_PLAT/brprintconflsr3
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/opt/brother/Printers/HLL2390DW/lpd/$_PLAT/rawtobr3
+    ln -s $out/opt/brother/Printers/HLL2390DW/lpd/$_PLAT/brprintconflsr3 $out/opt/brother/Printers/HLL2390DW/lpd/brprintconflsr3
+    ln -s $out/opt/brother/Printers/HLL2390DW/lpd/$_PLAT/rawtobr3 $out/opt/brother/Printers/HLL2390DW/lpd/rawtobr3
+
+    for f in \
+      $out/opt/brother/Printers/HLL2390DW/cupswrapper/lpdwrapper \
+      $out/opt/brother/Printers/HLL2390DW/cupswrapper/paperconfigml2 \
+    ; do
+      #substituteInPlace $f \
+      wrapProgram $f \
+        --prefix PATH : ${stdenv.lib.makeBinPath [
+          coreutils ghostscript gnugrep gnused
+        ]}
+    done
+
+    mkdir -p $out/lib/cups/filter/
+    ln -s $out/opt/brother/Printers/HLL2390DW/lpd/lpdfilter $out/lib/cups/filter/brother_lpdwrapper_HLL2390DW
+
+    mkdir -p $out/share/cups/model
+    ln -s $out/opt/brother/Printers/HLL2390DW/cupswrapper/brother-HLL2390DW-cups-en.ppd $out/share/cups/model/
+
+    wrapProgram $out/opt/brother/Printers/HLL2390DW/lpd/lpdfilter \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ ghostscript a2ps file gnused gnugrep coreutils which ] }
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.brother.com/;
+    description = "Brother HL-L2390DW combined print driver";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    downloadPage = http://support.brother.com/g/b/downloadlist.aspx?c=us_ot&lang=en&prod=hll2390dw_us&os=128;
+    maintainers = [ maintainers.samueldr ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19765,6 +19765,8 @@ with pkgs;
 
   canon-cups-ufr2 = callPackage ../misc/cups/drivers/canon { };
 
+  hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };
+
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
   mfcj470dwlpr = callPackage_i686 ../misc/cups/drivers/mfcj470dwlpr { };
 


### PR DESCRIPTION
###### Motivation for this change

Adding the driver for my printer.

This driver is *unified*, it has both the lpr and cupswrapper parts in one, when compared to other older brother drivers. This is why I used the `-cups` suffix. I definitely didn't know what to use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - NixOS
- Tested execution of all binary files THROUGH CUPS (it prints!)
- Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

