### PR TITLE
pythonPackages.progressbar2: init at 3.12.0

### DIFF
--- a/pkgs/development/python-modules/progressbar2/default.nix
+++ b/pkgs/development/python-modules/progressbar2/default.nix
@@ -1,23 +1,45 @@
 { stdenv
+, python
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, isPy3k
 , pytest
 , python-utils
+, sphinx
+, coverage
+, execnet
+, flake8
+, pytestpep8
+, pytestflakes
+, pytestcov
+, pytestcache
+, pep8
 }:
 
-buildPythonPackage (rec {
-  name = "${pname}-${version}";
+buildPythonPackage rec {
   pname = "progressbar2";
   version = "3.12.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "16r21cpjvv0spf4mymgpy7hx6977iy11k44n2w9kipwg4lhwh02k";
+  # Use source from GitHub, PyPI is missing tests
+  # https://github.com/WoLpH/python-progressbar/issues/151
+  src = fetchFromGitHub {
+    owner = "WoLpH";
+    repo = "python-progressbar";
+    rev = "v${version}";
+    sha256 = "1gk45sh8cd0kkyvzcvx95z6nlblmyx0x189mjfv3vfa43cr1mb0f";
   };
 
-  buildInputs = [ pytest ];
   propagatedBuildInputs = [ python-utils ];
-  doCheck = false;
+  checkInputs = [
+    pytest sphinx coverage execnet flake8 pytestpep8 pytestflakes pytestcov
+    pytestcache pep8
+  ];
+  # ignore tests on the nix wrapped setup.py and don't flake .eggs directory
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} setup.py test --addopts "--ignore=nix_run_setup.py --ignore=.eggs"
+    runHook postCheck
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://progressbar-2.readthedocs.io/en/latest/;
@@ -25,4 +47,4 @@ buildPythonPackage (rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ ashgillman ];
   };
-})
+}

--- a/pkgs/development/python-modules/progressbar2/default.nix
+++ b/pkgs/development/python-modules/progressbar2/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, python-utils
+}:
+
+buildPythonPackage (rec {
+  name = "${pname}-${version}";
+  pname = "progressbar2";
+  version = "3.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16r21cpjvv0spf4mymgpy7hx6977iy11k44n2w9kipwg4lhwh02k";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ python-utils ];
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://progressbar-2.readthedocs.io/en/latest/;
+    description = "Text progressbar library for python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ashgillman ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14580,6 +14580,29 @@ in {
     };
   });
 
+  progressbar2 = buildPythonPackage (rec {
+    name = "progressbar2-${version}";
+    version = "3.12.0";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "WoLpH";
+      repo = "python-progressbar";
+      rev = "v${version}";
+      sha256 = "1gk45sh8cd0kkyvzcvx95z6nlblmyx0x189mjfv3vfa43cr1mb0f";
+    };
+
+    buildInputs = with self; [ pytest ];
+    propagatedBuildInputs = with self; [ python-utils ];
+    doCheck = false;
+
+    meta = {
+      homepage = https://progressbar-2.readthedocs.io/en/latest/;
+      description = "Text progressbar library for python";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ ashgillman ];
+    };
+  });
+
   ldap = callPackage ../development/python-modules/ldap {
     inherit (pkgs) openldap cyrus_sasl openssl;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14580,28 +14580,7 @@ in {
     };
   });
 
-  progressbar2 = buildPythonPackage (rec {
-    name = "progressbar2-${version}";
-    version = "3.12.0";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "WoLpH";
-      repo = "python-progressbar";
-      rev = "v${version}";
-      sha256 = "1gk45sh8cd0kkyvzcvx95z6nlblmyx0x189mjfv3vfa43cr1mb0f";
-    };
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ python-utils ];
-    doCheck = false;
-
-    meta = {
-      homepage = https://progressbar-2.readthedocs.io/en/latest/;
-      description = "Text progressbar library for python";
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ ashgillman ];
-    };
-  });
+  progressbar2 = callPackage ../development/python-modules/progressbar2 { };
 
   ldap = callPackage ../development/python-modules/ldap {
     inherit (pkgs) openldap cyrus_sasl openssl;


### PR DESCRIPTION
###### Motivation for this change
New python package, simple to use progress bar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

