### PR TITLE
Adds support xen domU lightweight containers

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -35,7 +35,7 @@ let
 
       # Containers don't have their own kernel or initrd.  They boot
       # directly into stage 2.
-      ${optionalString (!config.boot.isContainer) ''
+      ${optionalString (!config.boot.isContainer && !config.boot.usePvKernel) ''
         if [ ! -f ${kernelPath} ]; then
           echo "The bootloader cannot find the proper kernel image."
           echo "(Expecting ${kernelPath})"

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -21,6 +21,17 @@ in
 
   options = {
 
+    boot.usePvKernel = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether this NixOS machine is a lightweight domU running
+        the paravirtualized kernel provided by dom0.  This is the
+        case if your host provides you with a kernel and initrd,
+        and you can not bring your own.
+      '';
+    };
+
     boot.kernelPackages = mkOption {
       default = pkgs.linuxPackages;
       apply = kernelPackages: kernelPackages.extend (self: super: {
@@ -158,7 +169,7 @@ in
 
   ###### implementation
 
-  config = mkIf (!config.boot.isContainer) {
+  config = mkIf (!config.boot.isContainer && !config.boot.usePvKernel) {
 
     system.build = { inherit kernel; };
 

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -90,7 +90,7 @@ in
     boot.loader.grub = {
 
       enable = mkOption {
-        default = !config.boot.isContainer;
+        default = !config.boot.isContainer && !config.boot.usePvKernel;
         type = types.bool;
         description = ''
           Whether to enable the GNU GRUB boot loader.

--- a/nixos/modules/system/boot/loader/init-script/init-script.nix
+++ b/nixos/modules/system/boot/loader/init-script/init-script.nix
@@ -22,7 +22,10 @@ in
     boot.loader.initScript = {
 
       enable = mkOption {
-        default = false;
+        # When being booted in as a xen domU
+        # with a provided kernel and initrd,
+        # we need the /sbin/init script.
+        default = config.boot.usePvKernel;
         type = types.bool;
         description = ''
           Some systems require a /sbin/init script which is started.

--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -39,7 +39,7 @@ with lib;
 
   ###### implementation
 
-  config = mkIf (!config.boot.isContainer) {
+  config = mkIf (!config.boot.isContainer && !config.boot.usePvKernel) {
 
     environment.etc."modprobe.d/ubuntu.conf".source = "${pkgs.kmod-blacklist-ubuntu}/modprobe.conf";
 

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -480,7 +480,7 @@ in
 
   };
 
-  config = mkIf (!config.boot.isContainer) {
+  config = mkIf (!config.boot.isContainer && !config.boot.usePvKernel) {
     assertions = [
       { assertion = any (fs: fs.mountPoint == "/") fileSystems;
         message = "The ‘fileSystems’ option does not specify your root file system.";


### PR DESCRIPTION
When runnign nixOS in a xen setup without it's own
kernel (the kernel and initrd are provided by the host)
we need to use init-scripts (/sbin/init) instead of grub
and have no kernel.

###### Motivation for this change

This adds support to run nixOS on DomainFactorys
(df.eu) JiffyBoxs with the "PV-Kernel". It should also
allow to run nixOS on similar setups xen guest setups
where the host provides the kernel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

