### PR TITLE
parallel-rust: init at 0.11.3

### DIFF
--- a/pkgs/tools/misc/parallel-rust/default.nix
+++ b/pkgs/tools/misc/parallel-rust/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "parallel-rust-${version}";
+  version = "0.11.3";
+
+  src = fetchFromGitHub {
+    owner = "mmstick";
+    repo = "parallel";
+    rev = version;
+    sha256 = "1bb1m3ckkrxlnw9w24ig70bd1zwyrbaw914q3xz5yv43c0l6pn9c";
+  };
+
+  cargoSha256 = "0p3wpjz3jrqjasi39zq6q54dhpymc5jp0mfsnzbq6dvz18s8m588";
+
+  patches = [ ./fix_cargo_lock_version.patch ];
+
+  meta = with stdenv.lib; {
+    description = "A command-line CPU load balancer written in Rust";
+    homepage = https://github.com/mmstick/parallel;
+    license = licenses.mit;
+    maintainers = [];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/parallel-rust/fix_cargo_lock_version.patch
+++ b/pkgs/tools/misc/parallel-rust/fix_cargo_lock_version.patch
@@ -1,0 +1,12 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index c01308d..dba3927 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1,6 +1,6 @@
+ [root]
+ name = "parallel"
+-version = "0.11.2"
++version = "0.11.3"
+ dependencies = [
+  "arrayvec 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1253,6 +1253,8 @@ with pkgs;
 
   ps_mem = callPackage ../tools/system/ps_mem { };
 
+  parallel-rust = callPackage ../tools/misc/parallel-rust { };
+
   socklog = callPackage ../tools/system/socklog { };
 
   staccato = callPackage ../tools/text/staccato { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

