### PR TITLE
molden: init at 5.7

### DIFF
--- a/pkgs/applications/science/chemistry/molden/default.nix
+++ b/pkgs/applications/science/chemistry/molden/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, which, gfortran, mesa_glu, xorg } :
+
+stdenv.mkDerivation rec {
+  version = "5.7";
+  name = "molden-${version}";
+
+  src = fetchurl {
+    url = "ftp://ftp.cmbi.ru.nl/pub/molgraph/molden/molden${version}.tar.gz";
+    sha256 = "0gaq11gm09ax25lvgfrvxv9dxvi76hps116fp6k7sqgvdd68vf0s";
+  };
+
+  nativeBuildInputs = [ which ];
+  buildInputs = [ gfortran mesa_glu xorg.libX11 xorg.libXmu ];
+
+  postPatch = ''
+     substituteInPlace ./makefile --replace '-L/usr/X11R6/lib'  "" \
+                                  --replace '-I/usr/X11R6/include' "" \
+                                  --replace '/usr/local/' $out/ \
+                                  --replace 'sudo' "" \
+				                          --replace '-C surf depend' '-C surf'
+     sed -in '/^# DO NOT DELETE THIS LINE/q;' surf/Makefile
+  '';
+
+  preInstall = ''
+     mkdir -p $out/bin
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+     description = "Display and manipulate molecular structures";
+     homepage = http://www.cmbi.ru.nl/molden/;
+     license = {
+       fullName = "Free for academic/non-profit use";
+       url = http://www.cmbi.ru.nl/molden/CopyRight.html;
+       free = false;
+     };
+     platforms = platforms.linux;
+     maintainers = with maintainers; [ markuskowa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3511,6 +3511,8 @@ with pkgs;
 
   modsecurity_standalone = callPackage ../tools/security/modsecurity { };
 
+  molden = callPackage ../applications/science/chemistry/molden { };
+
   molly-guard = callPackage ../os-specific/linux/molly-guard { };
 
   moneyplex = callPackage ../applications/office/moneyplex { };


### PR DESCRIPTION
###### Motivation for this change
App to display output from quantum chemistry calculations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

