### PR TITLE
kimageformats: Fixes build

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kimageformats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kimageformats.nix
@@ -12,5 +12,5 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ karchive openexr qtbase ];
   outputs = [ "out" ]; # plugins only
-  NIX_CFLAGS_COMPILE = "-I${getDev ilmbase}/include/OpenEXR";
+  CXXFLAGS = "-I${getDev ilmbase}/include/OpenEXR";
 }


### PR DESCRIPTION
###### Motivation for this change
Was broken after recent changes.

@adisbladis 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

