### PR TITLE
linode-api: 4.1.2b0 -> 4.1.6b0

### DIFF
--- a/pkgs/development/python-modules/linode-api/default.nix
+++ b/pkgs/development/python-modules/linode-api/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "linode-api";
-  version = "4.1.2b0"; # NOTE: this is a beta, and the API may change in future versions.
+  version = "4.1.6b0"; # NOTE: this is a beta, and the API may change in future versions.
   name = "${pname}-${version}";
 
   disabled = (pythonOlder "2.7");
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "19yzyb4sbxib8yxmrqm6d8i0fm8cims56q7kiq2ana26nbcm0gr4";
+    sha256 = "0k80shsp10zvl5h4w83b8irv90mwmwygl59h97zi2q784xr4dxs5";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Needed because the underlying HTTP endpoint has also changed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

I've run `nix-shell -I "nixpkgs=." -p nox --run "nox-review wip"` . 

It makes result and result-2 folders for python3.6-linode-api and python2.7-linode-api. I haven't managed to import them into Python though. Presumably I need to do something with the PYTHONPATH environment variable?

- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

