### PR TITLE
kindlegen: Use unzip where necessary

### DIFF
--- a/pkgs/tools/typesetting/kindlegen/default.nix
+++ b/pkgs/tools/typesetting/kindlegen/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv }:
+{ fetchurl, stdenv, unzip }:
 
 let
   version = "2.9";
@@ -31,6 +31,8 @@ in stdenv.mkDerivation rec {
   };
 
   sourceRoot = ".";
+
+  nativeBuildInputs = stdenv.lib.optional (stdenv.lib.hasSuffix ".zip" url) unzip;
 
   installPhase = ''
     mkdir -p $out/bin $out/share/kindlegen/doc


### PR DESCRIPTION
###### Motivation for this change

kindlegen: Cannot unpack on macOS #33145

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
