### PR TITLE
julia: 0.6.0 -> 0.6.2

### DIFF
--- a/pkgs/development/compilers/julia/0.6.nix
+++ b/pkgs/development/compilers/julia/0.6.nix
@@ -54,12 +54,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "julia";
-  version = "0.6.0";
+  version = "0.6.2";
   name = "${pname}-${version}";
 
   src = fetchzip {
     url = "https://github.com/JuliaLang/${pname}/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "19xk2cs43lnsy9y0d8wmxj7ich908ipb40vkf7xg9031x272brxw";
+    sha256 = "0ym4n9vn6w8vj175mmsc2nzvdk2ij0cdrs44lkr3p0signji73b5";
   };
   prePatch = ''
     mkdir deps/srccache

--- a/pkgs/development/compilers/julia/0.6.nix
+++ b/pkgs/development/compilers/julia/0.6.nix
@@ -33,10 +33,10 @@ let
     sha256 = "03kaqbjbi6viz0n33dk5jlf6ayxqlsq4804n7kwkndiga9s4hd42";
   };
 
-  libuvVersion = "52d72a52cc7ccd570929990f010ed16e2ec604c8";
+  libuvVersion = "d8ab1c6a33e77bf155facb54215dd8798e13825d";
   libuv = fetchurl {
     url = "https://api.github.com/repos/JuliaLang/libuv/tarball/${libuvVersion}";
-    sha256 = "1vldy94sfmlfqmi14126g590wi61fv78rzh7afk82zkipaixvak8";
+    sha256 = "0q5ahc9dzca2yc6cjbhpfi9nwc4yhhjbgxgsychksn13d24gv7ba";
   };
 
   rmathVersion = "0.1";


### PR DESCRIPTION
###### Motivation for this change

Julia 0.6.2 is a minor release containing corrections.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

