### PR TITLE
libmpc: 1.0.3 -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/libmpc/default.nix
+++ b/pkgs/development/libraries/libmpc/default.nix
@@ -4,14 +4,14 @@
 }:
 
 let
-  version = "1.0.3";
+  version = "1.1.0";
 in
 stdenv.mkDerivation rec {
   name = "libmpc-${version}"; # to avoid clash with the MPD client
 
   src = fetchurl {
-    url = "http://www.multiprecision.org/mpc/download/mpc-${version}.tar.gz";
-    sha256 = "1hzci2zrrd7v3g1jk35qindq05hbl0bhjcyyisq9z209xb3fqzb1";
+    url = "https://ftp.gnu.org/gnu/mpc/mpc-${version}.tar.gz";
+    sha256 = "0biwnhjm3rx3hc0rfpvyniky4lpzsvdcwhmcn7f0h4iw2hwcb1b9";
   };
 
   buildInputs = [ gmp mpfr ];


### PR DESCRIPTION
###### Motivation for this change
The nix expression was using an outdated fetchurl and a new version was available

###### Things done

 - libmpc: 1.0.3 -> 1.1.0
 - updated fetchurl


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

