### PR TITLE
{llvm,clang}-{4,5}: don't rebuild entire projects just to get manpages

### DIFF
--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -5,7 +5,7 @@
 
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
-  self = stdenv.mkDerivation {
+  self = stdenv.mkDerivation ({
     name = "clang-${version}";
 
     unpackPhase = ''
@@ -37,10 +37,6 @@ let
 
     patches = [ ./purity.patch ];
 
-    postBuild = stdenv.lib.optionalString enableManpages ''
-      cmake --build . --target docs-clang-man
-    '';
-
     postPatch = ''
       sed -i -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/Tools.cpp
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp
@@ -49,8 +45,7 @@ let
       sed -i '1s,^,find_package(Sphinx REQUIRED)\n,' docs/CMakeLists.txt
     '';
 
-    outputs = [ "out" "python" ]
-      ++ stdenv.lib.optional enableManpages "man";
+    outputs = [ "out" "python" ];
 
     # Clang expects to find LLVMgold in its own prefix
     # Clang expects to find sanitizer libraries in its own prefix
@@ -67,13 +62,6 @@ let
       mv $out/share/clang/*.py $python/share/clang
 
       rm $out/bin/c-index-test
-    ''
-    + stdenv.lib.optionalString enableManpages ''
-      # Manually install clang manpage
-      cp docs/man/*.1 $out/share/man/man1/
-
-      # Move it and other man pages to 'man' output
-      moveToOutput "share/man" "$man"
     '';
 
     enableParallelBuilding = true;
@@ -92,5 +80,23 @@ let
       license     = stdenv.lib.licenses.ncsa;
       platforms   = stdenv.lib.platforms.all;
     };
-  };
+  } // stdenv.lib.optionalAttrs enableManpages {
+    name = "clang-manpages-${version}";
+
+    buildPhase = ''
+      make docs-clang-man
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share/man/man1
+      # Manually install clang manpage
+      cp docs/man/*.1 $out/share/man/man1/
+    '';
+
+    outputs = [ "out" ];
+
+    doCheck = false;
+
+    meta.description = "man page for Clang ${version}";
+  });
 in self

--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -37,6 +37,9 @@ let
 
     patches = [ ./purity.patch ];
 
+    # XXX: TODO: This should be removed on next rebuild
+    postBuild = "";
+
     postPatch = ''
       sed -i -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/Tools.cpp
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -20,7 +20,7 @@ let
   # Add man output without introducing extra dependencies.
   overrideManOutput = drv:
     let drv-manpages = drv.override { enableManpages = true; }; in
-    drv // { man = drv-manpages.man; /*outputs = drv.outputs ++ ["man"];*/ };
+    drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
 
   llvm = callPackage ./llvm.nix {
     inherit compiler-rt_src stdenv;

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -37,6 +37,9 @@ let
 
     patches = [ ./purity.patch ];
 
+    # XXX: TODO: This should be removed on next rebuild
+    postBuild = "";
+
     postPatch = ''
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \
              -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' \

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -5,7 +5,7 @@
 
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
-  self = stdenv.mkDerivation {
+  self = stdenv.mkDerivation ({
     name = "clang-${version}";
 
     unpackPhase = ''
@@ -37,10 +37,6 @@ let
 
     patches = [ ./purity.patch ];
 
-    postBuild = stdenv.lib.optionalString enableManpages ''
-      cmake --build . --target docs-clang-man
-    '';
-
     postPatch = ''
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \
              -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' \
@@ -50,8 +46,7 @@ let
       sed -i '1s,^,find_package(Sphinx REQUIRED)\n,' docs/CMakeLists.txt
     '';
 
-    outputs = [ "out" "python" ]
-      ++ stdenv.lib.optional enableManpages "man";
+    outputs = [ "out" "python" ];
 
     # Clang expects to find LLVMgold in its own prefix
     # Clang expects to find sanitizer libraries in its own prefix
@@ -68,13 +63,6 @@ let
       mv $out/share/clang/*.py $python/share/clang
 
       rm $out/bin/c-index-test
-    ''
-    + stdenv.lib.optionalString enableManpages ''
-      # Manually install clang manpage
-      cp docs/man/*.1 $out/share/man/man1/
-
-      # Move it and other man pages to 'man' output
-      moveToOutput "share/man" "$man"
     '';
 
     enableParallelBuilding = true;
@@ -93,5 +81,23 @@ let
       license     = stdenv.lib.licenses.ncsa;
       platforms   = stdenv.lib.platforms.all;
     };
-  };
+  } // stdenv.lib.optionalAttrs enableManpages {
+    name = "clang-manpages-${version}";
+
+    buildPhase = ''
+      make docs-clang-man
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share/man/man1
+      # Manually install clang manpage
+      cp docs/man/*.1 $out/share/man/man1/
+    '';
+
+    outputs = [ "out" ];
+
+    doCheck = false;
+
+    meta.description = "man page for Clang ${version}";
+  });
 in self

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -20,7 +20,7 @@ let
   # Add man output without introducing extra dependencies.
   overrideManOutput = drv:
     let drv-manpages = drv.override { enableManpages = true; }; in
-    drv // { man = drv-manpages.man; /*outputs = drv.outputs ++ ["man"];*/ };
+    drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
 
   llvm = callPackage ./llvm.nix {
     inherit compiler-rt_src stdenv;

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -27,7 +27,7 @@ let
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;
     concatStringsSep "." (take 2 (splitString "." release_version));
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (rec {
   name = "llvm-${version}";
 
   unpackPhase = ''
@@ -39,8 +39,7 @@ in stdenv.mkDerivation rec {
   '';
 
   outputs = [ "out" ]
-    ++ stdenv.lib.optional enableSharedLibraries "lib"
-    ++ stdenv.lib.optional enableManpages "man";
+    ++ stdenv.lib.optional enableSharedLibraries "lib";
 
   nativeBuildInputs = [ perl groff cmake python ]
     ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
@@ -123,10 +122,7 @@ in stdenv.mkDerivation rec {
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
   '';
 
-  postInstall = stdenv.lib.optionalString enableManpages ''
-    moveToOutput "share/man" "$man"
-  ''
-  + stdenv.lib.optionalString enableSharedLibraries ''
+  postInstall = stdenv.lib.optionalString enableSharedLibraries ''
     moveToOutput "lib/libLLVM-*" "$lib"
     moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
@@ -154,4 +150,22 @@ in stdenv.mkDerivation rec {
     maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric dtzWill ];
     platforms   = stdenv.lib.platforms.all;
   };
-}
+} // stdenv.lib.optionalAttrs enableManpages {
+  name = "llvm-manpages-${version}";
+
+  buildPhase = ''
+    make docs-llvm-man
+  '';
+
+  propagatedBuildInputs = [];
+
+  installPhase = ''
+    make -C docs install
+  '';
+
+  outputs = [ "out" ];
+
+  doCheck = false;
+
+  meta.description = "man pages for LLVM ${version}";
+})


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/33369#issuecomment-355086339

Also give manpage derivations different names so that they
don't clutter up `nix-env -qaP` and such.

Doesn't change hash for current llvm/clang-unwrapped,
hopefully avoids mass-rebuild on Darwin.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---