### PR TITLE
muchsync: 2 -> 5

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
@@ -2,14 +2,14 @@
 , notmuch, openssl, pkgconfig, sqlite, xapian, zlib
 }:
 stdenv.mkDerivation rec {
-  version = "2";
+  version = "5";
   name = "muchsync-${version}";
   passthru = {
     inherit version;
   };
   src = fetchurl {
     url = "http://www.muchsync.org/src/${name}.tar.gz";
-    sha256 = "1dqp23a043kkzl0g2f4j3m7r7lg303gz7a0fsj0dm5ag3kpvp5f1";
+    sha256 = "1k2m44pj5i6vfhp9icdqs42chsp208llanc666p3d9nww8ngq2lb";
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ notmuch openssl sqlite xapian zlib ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

