### PR TITLE
tinyxml-2: 4.0.1 -> 6.0.0

### DIFF
--- a/pkgs/development/libraries/tinyxml-2/default.nix
+++ b/pkgs/development/libraries/tinyxml-2/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "tinyxml-2-${version}";
-  version = "4.0.1";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     repo = "tinyxml2";
     owner = "leethomason";
     rev = version;
-    sha256 = "1a0skfi8rzk53qcxbv88qlvhlqzvsvg4hm20dnx4zw7vrn6anr9y";
+    sha256 = "031fmhpah449h3rkyamzzdpzccrrfrvjb4qn6vx2vjm47jwc54qv";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

