### PR TITLE
nixos/release.nix: More refactoring for multi-arch

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -80,7 +80,7 @@ in rec {
         (all nixos.tests.boot.uefiUsb)
         (all nixos.tests.boot-stage1)
         (all nixos.tests.hibernate)
-        nixos.tests.docker
+        nixos.tests.docker.x86_64-linux
         (all nixos.tests.ecryptfs)
         (all nixos.tests.env)
         (all nixos.tests.ipv6)

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -16,7 +16,8 @@ let
     inherit system;
   } // args);
 
-  callTest = fn: args: forAllSystems (system: hydraJob (importTest fn args system));
+  callTestOnTheseSystems = systems: fn: args: forTheseSystems systems (system: hydraJob (importTest fn args system));
+  callTest = callTestOnTheseSystems supportedSystems;
 
   callSubTests = fn: args: let
     discover = attrs: let
@@ -228,7 +229,7 @@ in rec {
   tests.blivet = callTest tests/blivet.nix {};
   tests.boot = callSubTests tests/boot.nix {};
   tests.boot-stage1 = callTest tests/boot-stage1.nix {};
-  tests.cadvisor = hydraJob (import tests/cadvisor.nix { system = "x86_64-linux"; });
+  tests.cadvisor = callTestOnTheseSystems ["x86_64-linux"] tests/cadvisor.nix {};
   tests.chromium = (callSubTests tests/chromium.nix { system = "x86_64-linux"; }).stable;
   tests.cjdns = callTest tests/cjdns.nix {};
   tests.cloud-init = callTest tests/cloud-init.nix {};
@@ -243,12 +244,12 @@ in rec {
   tests.containers-hosts = callTest tests/containers-hosts.nix {};
   tests.containers-macvlans = callTest tests/containers-macvlans.nix {};
   tests.couchdb = callTest tests/couchdb.nix {};
-  tests.docker = hydraJob (import tests/docker.nix { system = "x86_64-linux"; });
-  tests.docker-edge = hydraJob (import tests/docker-edge.nix { system = "x86_64-linux"; });
+  tests.docker = callTestOnTheseSystems ["x86_64-linux"] tests/docker.nix {};
+  tests.docker-edge = callTestOnTheseSystems ["x86_64-linux"] tests/docker-edge.nix {};
   tests.dovecot = callTest tests/dovecot.nix {};
-  tests.dnscrypt-proxy = callTest tests/dnscrypt-proxy.nix { system = "x86_64-linux"; };
+  tests.dnscrypt-proxy = callTestOnTheseSystems ["x86_64-linux"] tests/dnscrypt-proxy.nix {};
   tests.ecryptfs = callTest tests/ecryptfs.nix {};
-  tests.etcd = hydraJob (import tests/etcd.nix { system = "x86_64-linux"; });
+  tests.etcd = callTestOnTheseSystems ["x86_64-linux"] tests/etcd.nix {};
   tests.ec2-nixops = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-nixops;
   tests.ec2-config = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-config;
   tests.elk = callSubTests tests/elk.nix { system = "x86_64-linux"; };
@@ -256,7 +257,7 @@ in rec {
   tests.ferm = callTest tests/ferm.nix {};
   tests.firefox = callTest tests/firefox.nix {};
   tests.firewall = callTest tests/firewall.nix {};
-  tests.fleet = hydraJob (import tests/fleet.nix { system = "x86_64-linux"; });
+  tests.fleet = callTestOnTheseSystems ["x86_64-linux"] tests/fleet.nix {};
   #tests.gitlab = callTest tests/gitlab.nix {};
   tests.gitolite = callTest tests/gitolite.nix {};
   tests.gocd-agent = callTest tests/gocd-agent.nix {};
@@ -316,7 +317,7 @@ in rec {
   tests.openssh = callTest tests/openssh.nix {};
   tests.owncloud = callTest tests/owncloud.nix {};
   tests.pam-oath-login = callTest tests/pam-oath-login.nix {};
-  #tests.panamax = hydraJob (import tests/panamax.nix { system = "x86_64-linux"; });
+  #tests.panamax = callTestOnTheseSystems ["x86_64-linux"] tests/panamax.nix {};
   tests.peerflix = callTest tests/peerflix.nix {};
   tests.php-pcre = callTest tests/php-pcre.nix {};
   tests.postgresql = callSubTests tests/postgresql.nix {};

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -90,13 +90,13 @@ let
 
   makeNetboot = config:
     let
-      config_evaled = import lib/eval-config.nix config;
-      build = config_evaled.config.system.build;
-      kernelTarget = config_evaled.pkgs.stdenv.platform.kernelTarget;
+      configEvaled = import lib/eval-config.nix config;
+      build = configEvaled.config.system.build;
+      kernelTarget = configEvaled.pkgs.stdenv.platform.kernelTarget;
     in
       pkgs.symlinkJoin {
-        name="netboot";
-        paths=[
+        name = "netboot";
+        paths = [
           build.netbootRamdisk
           build.kernel
           build.netbootIpxeScript

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -107,6 +107,7 @@ let
           echo "file initrd $out/initrd" >> $out/nix-support/hydra-build-products
           echo "file ipxe $out/netboot.ipxe" >> $out/nix-support/hydra-build-products
         '';
+        preferLocalBuild = true;
       };
 
 


### PR DESCRIPTION
Currently, even if you pass `supportedSystems = [ "aarch64-linux" ]` you
end up with e.g. `nixos.tests.docker` which actually silently runs on
x86_64-linux. Using the new callTestOnTheseSystems fixes that.
    
As a side-effect, this also causes renames of e.g. `nixos.tests.docker` -> `nixos.tests.docker.x86_64-linux`, which is IMHO a good thing since it's makes them consistent with the rest of the tests.

Note: this doesn't fix all such instances, only two common patters. More fixes will come later.

Effect on aarch64-unstable: https://hydra.nixos.org/eval/1426827#tabs-removed