### PR TITLE
fix manual

### DIFF
--- a/nixos/modules/programs/zsh/oh-my-zsh.nix
+++ b/nixos/modules/programs/zsh/oh-my-zsh.nix
@@ -54,7 +54,7 @@ in
           type = types.str;
           description = ''
             Cache directory to be used by `oh-my-zsh`.
-            Default is /nix/store/<oh-my-zsh>/cache.
+            Default is /nix/store/&#60;oh-my-zsh&#62;/cache.
           '';
         };
       };


### PR DESCRIPTION
###### Motivation for this change
broken by: https://github.com/NixOS/nixpkgs/commit/b55d4c0564b0bde4cbc0c01b6ba7a1276382335a

Just replaced `<` and `>` by their xml-magic-numbers, to fix the build.

###### Things done
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

