### PR TITLE
mencal: init at 3.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -442,6 +442,7 @@
   mjanczyk = "Marcin Janczyk <m@dragonvr.pl>";
   mjp = "Mike Playle <mike@mythik.co.uk>"; # github = "MikePlayle";
   mlieberman85 = "Michael Lieberman <mlieberman85@gmail.com>";
+  mmahut = "Marek Mahut <marek.mahut@gmail.com>";
   moaxcp = "John Mercier <moaxcp@gmail.com>";
   modulistic = "Pablo Costa <modulistic@gmail.com>";
   mog = "Matthew O'Gorman <mog-lists@rldn.net>";

--- a/pkgs/applications/misc/mencal/default.nix
+++ b/pkgs/applications/misc/mencal/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, perl }:
+
+stdenv.mkDerivation rec {
+  name = "mencal-3.0";
+
+  src = fetchurl {
+    url = "http://kyberdigi.cz/projects/mencal/files/${name}.tar.gz";
+    sha256 = "9328d0b2f3f57847e8753c5184531f4832be7123d1b6623afdff892074c03080";
+  };
+
+  installPhase = ''
+      mkdir -p $out/bin
+      cp mencal $out/bin/
+    '';
+
+  buildInputs = [ perl ];
+
+  meta = with stdenv.lib; {
+    description = "Menstruation calendar";
+    longDescription = ''
+      Mencal is a simple variation of the well-known unix command cal.
+      The main difference is that you can have some periodically repeating
+      days highlighted in color. This can be used to track
+      menstruation (or other) cycles conveniently.
+    '';
+    homepage = "http://www.kyberdigi.cz/projects/mencal/english.html";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3459,6 +3459,8 @@ with pkgs;
 
   memo = callPackage ../applications/misc/memo/default.nix { };
 
+  mencal = callPackage ../applications/misc/mencal/default.nix { } ;
+
   metamorphose2 = callPackage ../applications/misc/metamorphose2 { };
 
   metar = callPackage ../applications/misc/metar { };


### PR DESCRIPTION
###### Motivation for this change

Adding mencal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

