### PR TITLE
[WIP] ncbi-blast: init at 2.7.1

### DIFF
--- a/pkgs/applications/science/biology/ncbi-blast/default.nix
+++ b/pkgs/applications/science/biology/ncbi-blast/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchurl, substitute-paths
+, bash, coreutils, diffutils, findutils, gawk, glibc, gnugrep, gnutar
+, lmdb
+}:
+
+with stdenv.lib; let
+  path = makeBinPath [
+    bash coreutils diffutils findutils gawk glibc.bin gnugrep gnutar
+  ];
+in stdenv.mkDerivation rec {
+  name = "ncbi-blast-${version}";
+  version = "2.7.1";
+
+  src = fetchurl {
+    url = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${version}/${name}+-src.tar.gz";
+    sha256 = "1jlq0afxxgczpp35k6mxh8mn4jzq7vqcnaixk166sfj10wq8v9qh";
+  };
+
+  nativeBuildInputs = [ substitute-paths ];
+
+  buildInputs = [ lmdb ];
+
+  sourceRoot = "${name}+-src/c++";
+
+  postPatch = ''
+    find scripts -name '*.sh' \
+      -exec fgrep -q PATH=/bin:/usr/bin {} \; \
+      -exec sed -e 's,^ *PATH=/bin:/usr/bin,#&,' -i {} \;
+
+    find . -type f -exec substitute-paths -p ${path} {} +
+    sed -i src/build-system/configure scripts/common/impl/if_diff.sh \
+      -e 's#=/bin/#=${coreutils}/bin/#'
+
+    configureScript=$(pwd)/configure
+
+    unset AR
+  '';
+
+  configureFlags = [ "--with-dll" ];
+
+  preBuild = ''
+    cd ReleaseMT/build
+  '';
+
+  NCBICXX_RECONF_POLICY = "warn"; # Ignore the changes made in postPatch.
+
+  makeFlags = [ "all_r" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -a ../bin ../lib $out
+  '';
+
+  enableParallelBuilding = true;
+  hardeningDisable = [ "format" ];
+
+  meta = {
+    description = "Basic local alignment search tool";
+    homepage = https://blast.ncbi.nlm.nih.gov/Blast.cgi;
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.orivej ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/build-support/substitute-paths/default.nix
+++ b/pkgs/build-support/substitute-paths/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, go, removeReferencesTo }:
+
+stdenv.mkDerivation {
+  name = "substitute-paths";
+
+  src = ./.;
+
+  nativeBuildInputs = [ go removeReferencesTo ];
+
+  buildPhase = ''
+    go build -o $name
+    remove-references-to -t ${go} $name
+  '';
+
+  checkPhase = ''
+    go test
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin $name
+  '';
+
+  doCheck = true;
+}

--- a/pkgs/build-support/substitute-paths/main.go
+++ b/pkgs/build-support/substitute-paths/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+const BinPattern = "(/usr)?/bin/(env )?{}"
+
+var (
+	flList    = flag.Bool("l", false, "list files in PATH")
+	flPath    = flag.String("p", os.Getenv("PATH"), "PATH")
+	flPattern = flag.String("r", BinPattern, "regex to be replaced, with {} for basename placeholder")
+)
+
+func main() {
+	log.SetFlags(log.Lshortfile)
+	flag.Parse()
+	if _, err := regexp.Compile(*flPattern); err != nil {
+		log.Fatal(err)
+	}
+
+	files := flag.Args()
+	dirs := filepath.SplitList(*flPath)
+	table := makeLookupTable(dirs)
+	replacer := makeReplacer(*flPattern, table)
+
+	if *flList {
+		listTable(table)
+	}
+
+	for err := range pRunStrings(files, func(file string) error {
+		return replaceInFile(file, replacer)
+	}) {
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+// pRunStrings runs f on each x in xs in parallel and yields errors in any order.
+func pRunStrings(xs []string, f func(string) error) chan error {
+	errors := make(chan error)
+	queue := make(chan struct{}, runtime.NumCPU())
+	results := make(chan error)
+	for _, x := range xs {
+		go func(x string) {
+			queue <- struct{}{}
+			results <- f(x)
+			<-queue
+		}(x)
+	}
+	go func() {
+		for range xs {
+			errors <- <-results
+		}
+		close(errors)
+	}()
+	return errors
+}
+
+// makeLookupTable returns a map from basenames to absolute paths of files in
+// dirs, preferring earlier dirs on conflicts.
+func makeLookupTable(dirs []string) map[string]string {
+	table := map[string]string{}
+	for _, reldir := range dirs {
+		dir, err := filepath.Abs(reldir)
+		if err != nil {
+			continue
+		}
+		files, err := ioutil.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, file := range files {
+			name := file.Name()
+			if table[name] == "" {
+				table[name] = filepath.Join(dir, name)
+			}
+		}
+	}
+	return table
+}
+
+// listTable prints basenames and absolute paths in the table, sorted by basename.
+func listTable(table map[string]string) {
+	var list []string
+	for name := range table {
+		list = append(list, name)
+	}
+	sort.Strings(list)
+	for _, name := range list {
+		fmt.Println(name, table[name])
+	}
+}
+
+// makeReplacer returns a []byte mapper that applies table translations to the
+// matches of the pattern with {} replaced by a basename.
+func makeReplacer(pattern string, table map[string]string) func([]byte) []byte {
+	var names []string
+	for name := range table {
+		names = append(names, regexp.QuoteMeta(name))
+	}
+	alts := "(?P<basename>" + strings.Join(names, "|") + ")"
+	pattern = strings.Replace(pattern, "{}", alts, -1)
+	rx := regexp.MustCompile(pattern)
+	rx.Longest()
+
+	var basenameSubexps []int
+	for i, s := range rx.SubexpNames() {
+		if s == "basename" {
+			basenameSubexps = append(basenameSubexps, i)
+		}
+	}
+
+	replaceMatch := func(match []byte) []byte {
+		submatches := rx.FindSubmatch(match)
+		for _, i := range basenameSubexps {
+			replacement := table[string(submatches[i])]
+			if replacement != "" {
+				return []byte(replacement)
+			}
+		}
+		return match
+	}
+
+	return func(src []byte) []byte {
+		return rx.ReplaceAllFunc(src, replaceMatch)
+	}
+}
+
+// replaceInFile applies a []byte mapper to the contents of the file at path.
+func replaceInFile(path string, replace func([]byte) []byte) (err error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return
+	}
+	replacement := replace(data)
+	if bytes.Equal(replacement, data) {
+		return
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		return
+	}
+	defer func() {
+		cerr := f.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	_, err = f.Write(replacement)
+	return
+}

--- a/pkgs/build-support/substitute-paths/main_test.go
+++ b/pkgs/build-support/substitute-paths/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+)
+
+var testTable = map[string]string{
+	"a":   "/bin/a",
+	"xa":  "/bin/xa",
+	"ax":  "/bin/ax",
+	"a.b": "a.b",
+}
+
+func TestReplace(t *testing.T) {
+	source := `
+#! /usr/bin/env a
+/bin/a bin/a
+/usr/bin/xa /var/usr/bin/xa
+/bin/env ax
+/bin/a-b /bin/a.b
+`
+	expected := `
+#! /bin/a
+/bin/a bin/a
+/bin/xa /var/bin/xa
+/bin/ax
+/bin/a-b a.b
+`
+	replace := makeReplacer(BinPattern, testTable)
+	actual := string(replace([]byte(source)))
+	if expected != actual {
+		t.Errorf("\nEXPECTED%s\nACTUAL%s", expected, actual)
+		t.FailNow()
+	}
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -328,6 +328,8 @@ with pkgs;
 
   substituteAllFiles = callPackage ../build-support/substitute-files/substitute-all-files.nix { };
 
+  substitute-paths = callPackage ../build-support/substitute-paths { };
+
   replaceDependency = callPackage ../build-support/replace-dependency.nix { };
 
   nukeReferences = callPackage ../build-support/nuke-references/default.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18926,6 +18926,8 @@ with pkgs;
 
   minc-tools = callPackage ../applications/science/biology/minc-tools { };
 
+  ncbi-blast = callPackage ../applications/science/biology/ncbi-blast { };
+
   ncbi_tools = callPackage ../applications/science/biology/ncbi-tools { };
 
   paml = callPackage ../applications/science/biology/paml { };


### PR DESCRIPTION
###### Motivation for this change

BLAST tools are fundamental for bioinformatics. The official package and packages in various distributions are called `ncbi-blast` or `ncbi-blast+`, so I used this name.

This PR in its current state is a response to #33956. (I have made it for myself and did not want to publish until I was certain that it was done right, but that issue prompted me to publish it now.) It builds and works. It allows, but does not implement cross compilation. It is not clear that `substitute-paths` helper should be accepted into `all-packages`, be scoped to `ncbi-blast`, be implemented in a different language , or if another approach to packaging Blast+ should be used instead.

Blast+ build process is powered by a set of hand written Makefiles and shell scripts. They call various coreutils and other tools during the build time, but some of those tools are used during run time. It seemed nontrivial to figure out which occurrences of paths to programs are used during the build, which during the run, and which (if any) at both times, so I went with another approach which is both completely automatic and supports cross compilation. (Cross compilation part is not implemented yet.) The idea is to (1) rewrite absolute paths (e.g. `/bin/sh`, `/usr/bin/find`) to the paths of build platform tools before the configure phase, and (2) rewrite paths of build platform tools with paths of host platform tools after the install phase. (Nix approach imposes the unusual burden that build platform paths are different from host platform paths. My solution alleviates it by using one set of paths to programs at a time. It works on the same principle that Nix uses to detect run time dependencies of packages.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  (`legacy_blast.pl` and `update_blastdb.pl` are not wrapped with perl yet)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).