### PR TITLE
batman-adv 2017.4

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/alfred.nix
+++ b/pkgs/os-specific/linux/batman-adv/alfred.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, pkgconfig, gpsd, libcap, libnl }:
 
 let
-  ver = "2017.3";
+  ver = "2017.4";
 in
 stdenv.mkDerivation rec {
   name = "alfred-${ver}";
 
   src = fetchurl {
     url = "http://downloads.open-mesh.org/batman/releases/batman-adv-${ver}/${name}.tar.gz";
-    sha256 = "0202mxp7hwflkqnkkajx5lv1nxjng45q5gcvvdv68x46p8ikb5n2";
+    sha256 = "126wfmng4x19k8n4930v03qbjhwrikq9bvhl7mlng1k2fpx1msn4";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/os-specific/linux/batman-adv/batctl.nix
+++ b/pkgs/os-specific/linux/batman-adv/batctl.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, pkgconfig, libnl }:
 
 let
-  ver = "2017.3";
+  ver = "2017.4";
 in
 stdenv.mkDerivation rec {
   name = "batctl-${ver}";
 
   src = fetchurl {
     url = "http://downloads.open-mesh.org/batman/releases/batman-adv-${ver}/${name}.tar.gz";
-    sha256 = "1a48kc2v8cb1757pxlli96qf3d7x7k3qw04rjadfs0iy09sz1ir9";
+    sha256 = "0r742krc9mn677wmfwbhwhqq9739n74vpw0xfasvy7d59nn6lz84";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1m541czjwgi4rfhjr6rg9r9c3cp2ncnif4ln7ri926zigwlxs3l3";
   };
 
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
   hardeningDisable = [ "pic" ];
 
   preBuild = ''

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, kernel }:
 
-let base = "batman-adv-2017.3"; in
+let base = "batman-adv-2017.4"; in
 
 stdenv.mkDerivation rec {
   name = "${base}-${kernel.version}";
 
   src = fetchurl {
     url = "http://downloads.open-mesh.org/batman/releases/${base}/${base}.tar.gz";
-    sha256 = "1m541czjwgi4rfhjr6rg9r9c3cp2ncnif4ln7ri926zigwlxs3l3";
+    sha256 = "0k4sf52sbk39m25w6plk8spwcf4kzc3axckyk2r6anxxsangyl4a";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
###### Motivation for this change

Update to latest stable release of `batman-adv` and the surrounding tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

