### PR TITLE
maintainers: remove mornfall from packages

### DIFF
--- a/pkgs/applications/audio/flac/default.nix
+++ b/pkgs/applications/audio/flac/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = https://xiph.org/flac/;
     description = "Library and tools for encoding and decoding the FLAC lossless audio file format";
     platforms = platforms.all;
-    maintainers = [ maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/monkeys-audio/default.nix
+++ b/pkgs/applications/audio/monkeys-audio/default.nix
@@ -14,6 +14,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;
-    maintainers = [ maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/ncmpcpp/default.nix
+++ b/pkgs/applications/audio/ncmpcpp/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "A featureful ncurses based MPD client inspired by ncmpc";
     homepage    = https://ncmpcpp.rybczak.net/;
     license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ jfrankenau koral lovek323 mornfall ];
+    maintainers = with maintainers; [ jfrankenau koral lovek323 ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/applications/editors/emacs-modes/emacs-w3m/default.nix
+++ b/pkgs/applications/editors/emacs-modes/emacs-w3m/default.nix
@@ -56,6 +56,6 @@ stdenv.mkDerivation rec {
 
     homepage = http://emacs-w3m.namazu.org/;
 
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/graphics/photivo/default.nix
+++ b/pkgs/applications/graphics/photivo/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
       platforms = platforms.linux;
-      maintainers = [ maintainers.mornfall ];
+      maintainers = [ ];
   };
 }

--- a/pkgs/applications/misc/pstree/default.nix
+++ b/pkgs/applications/misc/pstree/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Show the set of running processes as a tree";
     license = "GPL";
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     homepage = http://jonls.dk/redshift;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ mornfall yegortimoshenko ];
+    maintainers = with maintainers; [ yegortimoshenko ];
   };
 }

--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (rec {
     inherit description;
     homepage = http://software.schmorp.de/pkg/rxvt-unicode.html;
     downloadPage = "http://dist.schmorp.de/rxvt-unicode/Attic/";
-    maintainers = [ maintainers.mornfall ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://w3m.sourceforge.net/;
     description = "A text-mode web browser";
-    maintainers = [ maintainers.mornfall maintainers.cstrahan ];
+    maintainers = [ maintainers.cstrahan ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/science/logic/stp/default.nix
+++ b/pkgs/applications/science/logic/stp/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Simple Theorem Prover";
-    maintainers = with maintainers; [ mornfall ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     license = licenses.mit;
   };

--- a/pkgs/applications/video/quvi/library.nix
+++ b/pkgs/applications/video/quvi/library.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     homepage = http://quvi.sf.net;
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/video/quvi/scripts.nix
+++ b/pkgs/applications/video/quvi/scripts.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     homepage = http://quvi.sf.net;
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/video/quvi/tool.nix
+++ b/pkgs/applications/video/quvi/tool.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = http://quvi.sf.net;
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/interpreters/lua-5/sockets.nix
+++ b/pkgs/development/interpreters/lua-5/sockets.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://w3.impa.br/~diego/software/luasocket/;
     hydraPlatforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage    = http://www.openldap.org/;
     description = "An open source implementation of the Lightweight Directory Access Protocol";
-    maintainers = with maintainers; [ lovek323 mornfall ];
+    maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
     homepage = http://www.open-mpi.org/;
     description = "Open source MPI-2 implementation";
     longDescription = "The Open MPI Project is an open source MPI-2 implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.";
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/fedpkg/default.nix
+++ b/pkgs/development/python-modules/fedpkg/default.nix
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "Subclass of the rpkg project for dealing with rpm packaging";
     homepage = https://pagure.io/fedpkg;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ mornfall ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/kitchen/default.nix
+++ b/pkgs/development/python-modules/kitchen/default.nix
@@ -12,6 +12,6 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Kitchen contains a cornucopia of useful code";
     license = licenses.lgpl2;
-    maintainers = with maintainers; [ mornfall ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/koji/default.nix
+++ b/pkgs/development/python-modules/koji/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/python_fedora/default.nix
+++ b/pkgs/development/python-modules/python_fedora/default.nix
@@ -18,6 +18,6 @@ buildPythonPackage rec {
     description = "Python Fedora Module";
     homepage = https://github.com/fedora-infra/python-fedora;
     license = licenses.lgpl2;
-    maintainers = with maintainers; [ mornfall ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/rpkg/default.nix
+++ b/pkgs/development/python-modules/rpkg/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     description = "Python library for dealing with rpm packaging";
     homepage = https://pagure.io/fedpkg;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ mornfall ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/development/tools/analysis/lcov/default.nix
+++ b/pkgs/development/tools/analysis/lcov/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage = http://ltp.sourceforge.net/coverage/lcov.php;
     license = stdenv.lib.licenses.gpl2Plus;
 
-    maintainers = with maintainers; [ dezgeg mornfall ];
+    maintainers = with maintainers; [ dezgeg ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/analysis/spin/default.nix
+++ b/pkgs/development/tools/analysis/spin/default.nix
@@ -35,6 +35,6 @@ in stdenv.mkDerivation rec {
     homepage = http://spinroot.com/;
     license = licenses.free;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ mornfall pSub ];
+    maintainers = with maintainers; [ pSub ];
   };
 }

--- a/pkgs/development/tools/build-managers/cmake/2.8.nix
+++ b/pkgs/development/tools/build-managers/cmake/2.8.nix
@@ -77,6 +77,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.cmake.org/;
     description = "Cross-Platform Makefile Generator";
     platforms = if useQt4 then qt4.meta.platforms else stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ mornfall ];
+    maintainers = with stdenv.lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -78,6 +78,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.cmake.org/;
     description = "Cross-Platform Makefile Generator";
     platforms = if useQt4 then qt4.meta.platforms else platforms.all;
-    maintainers = with maintainers; [ mornfall ttuegel lnl7 ];
+    maintainers = with maintainers; [ ttuegel lnl7 ];
   };
 }

--- a/pkgs/development/tools/misc/lsof/default.nix
+++ b/pkgs/development/tools/misc/lsof/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       socket (IPv6/IPv4/UNIX local), or partition (by opening a file
       from it).
     '';
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description = "A system call tracer for Linux";
     license = licenses.bsd3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ mornfall jgeerds globin ];
+    maintainers = with maintainers; [ jgeerds globin ];
   };
 }

--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     description = "Free dance and rhythm game for Windows, Mac, and Linux";
     platforms = platforms.linux;
     license = licenses.mit; # expat version
-    maintainers = [ maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/os-specific/linux/acpi/default.nix
+++ b/pkgs/os-specific/linux/acpi/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/acpiclient/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -9,7 +9,7 @@ in {
   fuse_2 = mkFuse {
     version = "2.9.7";
     sha256Hash = "1wyjjfb7p4jrkk15zryzv33096a5fmsdyr2p4b00dd819wnly2n2";
-    maintainers = [ maintainers.mornfall ];
+    maintainers = [ ];
   };
 
   fuse_3 = mkFuse {

--- a/pkgs/os-specific/linux/pam_krb5/default.nix
+++ b/pkgs/os-specific/linux/pam_krb5/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.linux;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wkennington mornfall ];
+    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/servers/dict/default.nix
+++ b/pkgs/servers/dict/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "Dict protocol server and client";
     homepage    = http://www.dict.org;
     license     = licenses.gpl2;
-    maintainers = with maintainers; [ mornfall ];
+    maintainers = with maintainers; [ ];
     platforms   = platforms.linux;
   };
 }

--- a/pkgs/servers/dict/dictd-wiktionary.nix
+++ b/pkgs/servers/dict/dictd-wiktionary.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "DICT version of English Wiktionary";
     homepage = http://en.wiktionary.org/;
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
     platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/servers/dict/dictd-wordnet.nix
+++ b/pkgs/servers/dict/dictd-wordnet.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
     homepage = http://wordnet.princeton.edu/;
 
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
+    maintainers = [ ];
     platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/servers/dict/libmaa.nix
+++ b/pkgs/servers/dict/libmaa.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Dict protocol server and client";
-    maintainers = [ maintainers.mornfall ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/mpd/clientlib.nix
+++ b/pkgs/servers/mpd/clientlib.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.musicpd.org/libs/libmpdclient/;
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ mornfall ehmry ];
+    maintainers = with maintainers; [ ehmry ];
   };
 }

--- a/pkgs/tools/networking/iftop/default.nix
+++ b/pkgs/tools/networking/iftop/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     homepage = http://ex-parrot.com/pdw/iftop/;
     platforms = platforms.unix;
-    maintainers = [ maintainers.mornfall ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "Network sniffer";
     homepage = http://www.tcpdump.org/;
     license = "BSD-style";
-    maintainers = with stdenv.lib.maintainers; [ mornfall jgeerds ];
+    maintainers = with stdenv.lib.maintainers; [ jgeerds ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -69,6 +69,6 @@ stdenv.mkDerivation rec {
     homepage = https://wiki.debian.org/Teams/Dpkg;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ mornfall ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.rpm.org/;
     license = licenses.gpl2;
     description = "The RPM Package Manager";
-    maintainers = with maintainers; [ mornfall copumpkin ];
+    maintainers = with maintainers; [ copumpkin ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -58,6 +58,6 @@ in stdenv.mkDerivation rec {
     homepage    = http://www.nmap.org;
     license     = licenses.gpl2;
     platforms   = platforms.all;
-    maintainers = with maintainers; [ mornfall thoughtpolice fpletz ];
+    maintainers = with maintainers; [ thoughtpolice fpletz ];
   };
 }

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -402,7 +402,7 @@ let
       description = "Network support for Lua";
       homepage = "http://w3.impa.br/~diego/software/luasocket/";
       license = licenses.mit;
-      maintainers = with maintainers; [ mornfall ];
+      maintainers = with maintainers; [ ];
       platforms = with platforms; darwin ++ linux ++ freebsd ++ illumos;
     };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -592,7 +592,7 @@ in {
   async = buildPythonPackage rec {
     name = "async-0.6.1";
     disabled = isPy3k;
-    meta.maintainers = with maintainers; [ mornfall ];
+    meta.maintainers = with maintainers; [ ];
 
     buildInputs = with self; [ pkgs.zlib ];
     doCheck = false;
@@ -2047,7 +2047,7 @@ in {
 
   bunch = buildPythonPackage (rec {
     name = "bunch-1.0.1";
-    meta.maintainers = with maintainers; [ mornfall ];
+    meta.maintainers = with maintainers; [ ];
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/b/bunch/${name}.tar.gz";
@@ -5002,7 +5002,7 @@ in {
 
     meta = {
       description = "Git Object Database";
-      maintainers = with maintainers; [ mornfall ];
+      maintainers = with maintainers; [ ];
       homepage = https://github.com/gitpython-developers/gitdb;
       license = licenses.bsd3;
     };
@@ -5028,7 +5028,7 @@ in {
 
     meta = {
       description = "Python Git Library";
-      maintainers = with maintainers; [ mornfall ];
+      maintainers = with maintainers; [ ];
       homepage = https://github.com/gitpython-developers/GitPython;
       license = licenses.bsd3;
     };
@@ -11909,7 +11909,7 @@ in {
 
   offtrac = buildPythonPackage rec {
     name = "offtrac-0.1.0";
-    meta.maintainers = with maintainers; [ mornfall ];
+    meta.maintainers = with maintainers; [ ];
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/o/offtrac/${name}.tar.gz";
@@ -17806,7 +17806,7 @@ in {
   smmap = buildPythonPackage rec {
     name = "smmap-0.9.0";
     disabled = isPyPy;  # This fails the tests if built with pypy
-    meta.maintainers = with maintainers; [ mornfall ];
+    meta.maintainers = with maintainers; [ ];
 
     buildInputs = with self; [ nosexcover ];
 


### PR DESCRIPTION
This commit removes @mornfall from `meta.maintainers` in all packages. They have not been active for the last three years. I've found their new email address and asked to approve this change.

The rationale behind this change is to make it clear which packages are maintained, and by whom, and which are not.