### PR TITLE
wp-cli: use as much memory as possible

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -26,7 +26,7 @@ let
 
   ini = writeText "wp-cli.ini" ''
     [PHP]
-    memory_limit = 512M ; composer can be a bit of a memory pig
+    memory_limit = -1 ; composer uses a lot of memory
 
     [Phar]
     phar.readonly = Off
@@ -40,6 +40,9 @@ in stdenv.mkDerivation rec {
 
     ln      -s     ${bin}        $out/bin/wp
     install -Dm644 ${completion} $out/share/bash-completion/completions/wp
+
+    # this is a very basic run test
+    $out/bin/wp --info
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Instead of imposing an arbitrary memory limit via php.ini, let wp-cli use as
much as possible. If you need to limit the memory use, there are mechanisms in
your OS far better suited for this.

Cc: @grahamc 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

