### PR TITLE
[WIP] anbox: init at 2018-01-06 

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -389,6 +389,7 @@
   lufia = "Kyohei Kadota <lufia@lufia.org>";
   luispedro = "Luis Pedro Coelho <luis@luispedro.org>";
   lukego = "Luke Gorrie <luke@snabb.co>";
+  lukeadams = "Luke Adams <luke.adams@belljar.io>";
   luz = "Luz <luz666@daum.net>";
   lw = "Sergey Sofeychuk <lw@fmap.me>";
   lyt = "Tim Liou <wheatdoge@gmail.com>";

--- a/pkgs/applications/virtualization/anbox/default.nix
+++ b/pkgs/applications/virtualization/anbox/default.nix
@@ -27,12 +27,12 @@
 
 }:
 let
-    images = {
-        "armv7l-linux" = "https://build.anbox.io/android-images/2017/06/12/android_1_armhf.img";
-        "aarch64-linux" = "https://build.anbox.io/android-images/2017/08/04/android_1_arm64.img";
-        "x86_64-linux" = "https://build.anbox.io/android-images/2017/07/13/android_3_amd64.img";
-    };
-    version = "2018-01-06";
+  images = {
+    "armv7l-linux" = "https://build.anbox.io/android-images/2017/06/12/android_1_armhf.img";
+    "aarch64-linux" = "https://build.anbox.io/android-images/2017/08/04/android_1_arm64.img";
+    "x86_64-linux" = "https://build.anbox.io/android-images/2017/07/13/android_3_amd64.img";
+  };
+  version = "2018-01-06";
 in
 stdenv.mkDerivation {
   name = "anbox-${version}";
@@ -53,6 +53,8 @@ stdenv.mkDerivation {
     SDL2 SDL2_image
   ];
 
+  # see https://github.com/volth/nixpkgs/blob/5591b05bd5986ad94df34973841558a64c78fe98/pkgs/applications/virtualization/anbox/default.nix#L21
+  # regarding gmock
   patchPhase = ''
     sed -i '/GMock/d' CMakeLists.txt
 

--- a/pkgs/applications/virtualization/anbox/default.nix
+++ b/pkgs/applications/virtualization/anbox/default.nix
@@ -46,11 +46,11 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
-    dbus dbus.lib dbus-cpp gmock gtest boost
-    libcap mesa glib SDL2 SDL2_image
-    protobuf protobufc lxc libdrm
-    libpthreadstubs libXdmcp libXdamage
-    python2 libproperties-cpp glm
+    boost dbus dbus.lib dbus-cpp glib glm gmock gtest
+    libcap libdrm libproperties-cpp libpthreadstubs libXdamage libXdmcp lxc
+    mesa protobuf protobufc
+    python2
+    SDL2 SDL2_image
   ];
 
   patchPhase = ''

--- a/pkgs/applications/virtualization/anbox/default.nix
+++ b/pkgs/applications/virtualization/anbox/default.nix
@@ -28,9 +28,9 @@
 }:
 let
     images = {
-        "armhf" = "https://build.anbox.io/android-images/2017/06/12/android_1_armhf.img";
-        "arm64" = "https://build.anbox.io/android-images/2017/08/04/android_1_arm64.img";
-        "amd64" = "https://build.anbox.io/android-images/2017/07/13/android_3_amd64.img";
+        "armv7l-linux" = "https://build.anbox.io/android-images/2017/06/12/android_1_armhf.img";
+        "aarch64-linux" = "https://build.anbox.io/android-images/2017/08/04/android_1_arm64.img";
+        "x86_64-linux" = "https://build.anbox.io/android-images/2017/07/13/android_3_amd64.img";
     };
     version = "2018-01-06";
 in

--- a/pkgs/applications/virtualization/anbox/default.nix
+++ b/pkgs/applications/virtualization/anbox/default.nix
@@ -1,0 +1,75 @@
+{ stdenv, lib, fetchFromGitHub, fetchurl
+, cmake
+, pkgconfig
+
+### Discovered
+, libdrm
+, libpthreadstubs
+, libXdmcp
+, libXdamage
+, SDL2_image
+, python2
+, libproperties-cpp
+, glm
+### From README
+, dbus
+, gmock
+, gtest
+, boost
+, libcap
+, dbus-cpp
+, mesa
+, glib
+, SDL2
+, protobuf
+, protobufc
+, lxc
+
+}:
+let
+    images = {
+        "armhf" = "https://build.anbox.io/android-images/2017/06/12/android_1_armhf.img";
+        "arm64" = "https://build.anbox.io/android-images/2017/08/04/android_1_arm64.img";
+        "amd64" = "https://build.anbox.io/android-images/2017/07/13/android_3_amd64.img";
+    };
+    version = "2018-01-06";
+in
+stdenv.mkDerivation {
+  name = "anbox-${version}";
+
+  src = fetchFromGitHub {
+    owner = "anbox";
+    repo = "anbox";
+    rev = "da3319106e6f568680017592aecdee34f0e407ac";
+    sha256 = "0mgc6gp1km12qnshvsr26zn8bdd9gdix2s9xab594vq06ckznysd";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [
+    dbus dbus.lib dbus-cpp gmock gtest boost
+    libcap mesa glib SDL2 SDL2_image
+    protobuf protobufc lxc libdrm
+    libpthreadstubs libXdmcp libXdamage
+    python2 libproperties-cpp glm
+  ];
+
+  patchPhase = ''
+    sed -i '/GMock/d' CMakeLists.txt
+
+    sed -i '1c#!python' scripts/gen-emugl-entries.py
+    sed -i 's/native()/native_handle()/g' src/anbox/network/base_socket_messenger.cpp
+
+    sed -i '/tests/d' CMakeLists.txt
+    patchShebangs scripts
+    # source/src/anbox/runtime.cpp:56:16:
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-narrowing"
+  '';
+
+  meta = {
+    description = "Android containerization layer";
+    homepage = "https://anbox.io/";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ lukeadams ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/anbox/default.nix
+++ b/pkgs/applications/virtualization/anbox/default.nix
@@ -27,10 +27,26 @@
 
 }:
 let
-  images = {
-    "armv7l-linux" = "https://build.anbox.io/android-images/2017/06/12/android_1_armhf.img";
-    "aarch64-linux" = "https://build.anbox.io/android-images/2017/08/04/android_1_arm64.img";
-    "x86_64-linux" = "https://build.anbox.io/android-images/2017/07/13/android_3_amd64.img";
+  imgroot = "https://build.anbox.io/android-images";
+  android_image = {
+    "armv7l-linux" = {
+      url = "${imgroot}/2017/06/12/android_1_armhf.img";
+      sha256 = "1za4q6vnj8wgphcqpvyq1r8jg6khz7v6b7h6ws1qkd5ljangf1w5";
+    };
+    "aarch64-linux" = {
+      url = "${imgroot}/2017/08/04/android_1_arm64.img";
+      sha256 = "02yvgpx7n0w0ya64y5c7bdxilaiqj9z3s682l5s54vzfnm5a2bg5";
+    };
+    "x86_64-linux" = {
+      url = "${imgroot}/2017/07/13/android_3_amd64.img";
+      sha256 = "1l22pisan3kfq4hwpizxc24f8lr3m5hd6k69nax10rki9ljypji0";
+    };
+  }.${stdenv.system};
+  imgDrv = stdenv.mkDerivation {
+    name = "anbox-image-${stdenv.system}-${version}";
+    src = fetchurl {
+      inherit (android_image) url sha256;
+    };
   };
   version = "2018-01-06";
 in
@@ -46,6 +62,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
+    imgDrv
     boost dbus dbus.lib dbus-cpp glib glm gmock gtest
     libcap libdrm libproperties-cpp libpthreadstubs libXdamage libXdmcp lxc
     mesa protobuf protobufc

--- a/pkgs/applications/virtualization/anbox/kmod-ashmem.nix
+++ b/pkgs/applications/virtualization/anbox/kmod-ashmem.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub
+, linuxPackages
+}:
+let
+  version = "2018-01-06";
+in
+stdenv.mkDerivation {
+  name = "anbox-kmod-ashmem-${version}";
+  src = fetchFromGitHub {
+    owner = "anbox";
+    repo = "anbox";
+    rev = "da3319106e6f568680017592aecdee34f0e407ac";
+    sha256 = "0mgc6gp1km12qnshvsr26zn8bdd9gdix2s9xab594vq06ckznysd";
+  };
+
+  nativeBuildInputs = [ ];
+  buildInputs = [
+    linuxPackages.kernel.dev
+  ];
+  patchPhase = ''
+    mkdir -p $out/kmod
+  '';
+  makeFlags = [
+    "KERNEL_SRC=${linuxPackages.kernel.dev}/lib/modules/${linuxPackages.kernel.dev.version}/build"
+    "DESTDIR=\${out}/kmod"
+  ];
+  sourceRoot = "source/kernel/ashmem";
+  hardeningDisable = [ "pic" ];
+  meta = {
+    description = "Android containerization layer";
+    homepage = "https://anbox.io/";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ lukeadams ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/anbox/kmod-binder.nix
+++ b/pkgs/applications/virtualization/anbox/kmod-binder.nix
@@ -1,18 +1,14 @@
 { stdenv, lib, fetchFromGitHub, fetchurl
 
 , linuxPackages
+, anbox
 }:
 let
   version = "2018-01-06";
 in
 stdenv.mkDerivation {
   name = "anbox-kmod-binder-${version}";
-  src = fetchFromGitHub {
-    owner = "anbox";
-    repo = "anbox";
-    rev = "da3319106e6f568680017592aecdee34f0e407ac";
-    sha256 = "0mgc6gp1km12qnshvsr26zn8bdd9gdix2s9xab594vq06ckznysd";
-  };
+  src = anbox.src;
 
   nativeBuildInputs = [ ];
   buildInputs = [

--- a/pkgs/applications/virtualization/anbox/kmod-binder.nix
+++ b/pkgs/applications/virtualization/anbox/kmod-binder.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitHub, fetchurl
+
+, linuxPackages
+}:
+let
+  version = "2018-01-06";
+in
+stdenv.mkDerivation {
+  name = "anbox-kmod-binder-${version}";
+  src = fetchFromGitHub {
+    owner = "anbox";
+    repo = "anbox";
+    rev = "da3319106e6f568680017592aecdee34f0e407ac";
+    sha256 = "0mgc6gp1km12qnshvsr26zn8bdd9gdix2s9xab594vq06ckznysd";
+  };
+
+  nativeBuildInputs = [ ];
+  buildInputs = [
+    linuxPackages.kernel.dev
+  ];
+  patchPhase = ''
+    mkdir -p $out/kmod
+  '';
+  makeFlags = [
+    "KERNEL_SRC=${linuxPackages.kernel.dev}/lib/modules/${linuxPackages.kernel.dev.version}/build"
+    "DESTDIR=\${out}/kmod"
+  ];
+  sourceRoot = "source/kernel/binder";
+  hardeningDisable = [ "pic" ];
+  meta = {
+    description = "Android containerization layer";
+    homepage = "https://anbox.io/";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ lukeadams ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/dbus-cpp/default.nix
+++ b/pkgs/development/libraries/dbus-cpp/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl
+, dbus
+, boost
+, cmake
+, pkgconfig
+, libxml2
+, lcov
+, gmock
+, libprocess-cpp
+, libproperties-cpp
+}:
+
+stdenv.mkDerivation rec {
+  name = "dbus-cpp-${version}";
+  version = "5.0.0";
+
+  src = fetchurl {
+    url = "https://launchpad.net/ubuntu/+archive/primary/+files/dbus-cpp_5.0.0+16.10.20160809.orig.tar.gz";
+    sha256 = "1d0k65yfaxwvmskrcl3li5g0ylaj0k9sz2n19l7q5qlrl33v5lrf";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ dbus dbus.dev boost libxml2 lcov gmock libprocess-cpp libproperties-cpp];
+  sourceRoot = ".";
+  cmakeFlags = [
+    "-DDBUS_CPP_VERSION_MAJOR=5"
+    "-DDBUS_CPP_VERSION_MINOR=0"
+    "-DDBUS_CPP_VERSION_PATCH=0"
+  ];
+
+  patchPhase = ''
+    truncate -s 0 tests/CMakeLists.txt
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://dbus-cplusplus.sourceforge.net;
+    description = "C++ API for D-BUS";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/development/libraries/libprocess-cpp/default.nix
+++ b/pkgs/development/libraries/libprocess-cpp/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     truncate -s 0 tests/CMakeLists.txt
   '';
+
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     homepage = http://dbus-cplusplus.sourceforge.net;
     description = "C++ API for D-BUS";

--- a/pkgs/development/libraries/libprocess-cpp/default.nix
+++ b/pkgs/development/libraries/libprocess-cpp/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [  boost libproperties-cpp ];
   #sourceRoot = ".";
+
+  # Tests fail when built, so disable them:
   patchPhase = ''
     truncate -s 0 tests/CMakeLists.txt
   '';

--- a/pkgs/development/libraries/libprocess-cpp/default.nix
+++ b/pkgs/development/libraries/libprocess-cpp/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl
+, boost
+, cmake
+, pkgconfig
+, libproperties-cpp
+}:
+
+stdenv.mkDerivation rec {
+  name = "libprocess-cpp-${version}";
+  version = "3.0.1";
+
+  src = fetchurl {
+    url = "https://launchpad.net/ubuntu/+archive/primary/+files/process-cpp_3.0.1.orig.tar.gz";
+    sha256 = "0ssap5i0y8qqkzcwh6bg0mybdr4gqg075if9j5vgblwr9qw3vl9k";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [  boost libproperties-cpp ];
+  #sourceRoot = ".";
+  patchPhase = ''
+    truncate -s 0 tests/CMakeLists.txt
+  '';
+  meta = with stdenv.lib; {
+    homepage = http://dbus-cplusplus.sourceforge.net;
+    description = "C++ API for D-BUS";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/development/libraries/libproperties-cpp/default.nix
+++ b/pkgs/development/libraries/libproperties-cpp/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl
+, cmake
+, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  name = "libproperties-cpp-${version}";
+  version = "0.0.1";
+
+  src = fetchurl {
+    url = "https://launchpad.net/ubuntu/+archive/primary/+files/properties-cpp_0.0.1+14.10.20140730.orig.tar.gz";
+    sha256 = "08vjyv7ibn6jh2ikj5v48kjpr3n6hlkp9qlvdn8r0vpiwzah0m2w";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [    ];
+
+  patchPhase = ''
+    truncate -s 0 tests/CMakeLists.txt
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://dbus-cplusplus.sourceforge.net;
+    description = "C++ API for D-BUS";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -456,6 +456,10 @@ with pkgs;
 
   analog = callPackage ../tools/admin/analog {};
 
+  anbox = callPackage ../applications/virtualization/anbox {
+    boost = boost15x;
+  };
+
   ansifilter = callPackage ../tools/text/ansifilter {};
 
   apktool = callPackage ../development/tools/apktool {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -459,7 +459,7 @@ with pkgs;
   anbox = callPackage ../applications/virtualization/anbox {
     boost = boost15x;
   };
-
+  # need to move to kmods section
   anbox-binder = callPackage ../applications/virtualization/anbox/kmod-binder.nix { };
   anbox-ashmem = callPackage ../applications/virtualization/anbox/kmod-ashmem.nix { };
 
@@ -12893,7 +12893,7 @@ with pkgs;
     acpi_call = callPackage ../os-specific/linux/acpi-call {};
 
     amdgpu-pro = callPackage ../os-specific/linux/amdgpu-pro { };
-
+    
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
     bcc = callPackage ../os-specific/linux/bcc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -461,6 +461,8 @@ with pkgs;
   };
 
   anbox-binder = callPackage ../applications/virtualization/anbox/kmod-binder.nix { };
+  anbox-ashmem = callPackage ../applications/virtualization/anbox/kmod-ashmem.nix { };
+
   ansifilter = callPackage ../tools/text/ansifilter {};
 
   apktool = callPackage ../development/tools/apktool {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8264,6 +8264,7 @@ with pkgs;
 
   dbus = callPackage ../development/libraries/dbus { };
   dbus-cpp  = callPackage ../development/libraries/dbus-cpp {boost = boost15x; };
+  libprocess-cpp  = callPackage ../development/libraries/libprocess-cpp  {boost = boost15x; };
   dbus_cplusplus  = callPackage ../development/libraries/dbus-cplusplus { };
   dbus_glib       = callPackage ../development/libraries/dbus-glib { };
   dbus_java       = callPackage ../development/libraries/java/dbus-java { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8263,6 +8263,7 @@ with pkgs;
   db62 = callPackage ../development/libraries/db/db-6.2.nix { };
 
   dbus = callPackage ../development/libraries/dbus { };
+  dbus-cpp  = callPackage ../development/libraries/dbus-cpp {boost = boost15x; };
   dbus_cplusplus  = callPackage ../development/libraries/dbus-cplusplus { };
   dbus_glib       = callPackage ../development/libraries/dbus-glib { };
   dbus_java       = callPackage ../development/libraries/java/dbus-java { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -460,6 +460,7 @@ with pkgs;
     boost = boost15x;
   };
 
+  anbox-binder = callPackage ../applications/virtualization/anbox/kmod-binder.nix { };
   ansifilter = callPackage ../tools/text/ansifilter {};
 
   apktool = callPackage ../development/tools/apktool {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8264,6 +8264,7 @@ with pkgs;
 
   dbus = callPackage ../development/libraries/dbus { };
   dbus-cpp  = callPackage ../development/libraries/dbus-cpp {boost = boost15x; };
+  libproperties-cpp  = callPackage ../development/libraries/libproperties-cpp  { };
   libprocess-cpp  = callPackage ../development/libraries/libprocess-cpp  {boost = boost15x; };
   dbus_cplusplus  = callPackage ../development/libraries/dbus-cplusplus { };
   dbus_glib       = callPackage ../development/libraries/dbus-glib { };


### PR DESCRIPTION
###### Motivation for this change
pr for tracking

Anbox allows execution of Android apps within a lxc namespace on the host kernel.
Requires `binder` and `ashmem` kmods (included in src), in addition to application of kernel patches.

Probably need to add a NixOS module for this eventually.

Needed to add dbus-cpp (not the same as dbus-cplusplus) and a few other libraries.

~currently library commits are after Anbox, need to rebase~
_Rebased as much as possible (now anbox init is after deps). Still need to reorder to be in the following order for bisectability:_
1. libproperties
2. libprocess
3. dbus-cpp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

