### PR TITLE
salt: Prefer to load Nix libcrypto

### DIFF
--- a/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
+++ b/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
@@ -1,14 +1,15 @@
-diff --git a/salt/utils/rsax931.py b/salt/utils/rsax931.py
-index f827cc6db8..b728595186 100644
---- a/salt/utils/rsax931.py
-+++ b/salt/utils/rsax931.py
-@@ -47,6 +47,9 @@ def _load_libcrypto():
-             lib = lib[0] if len(lib) > 0 else None
-         if lib:
-             return cdll.LoadLibrary(lib)
-+        else:
+diff --git i/salt/utils/rsax931.py w/salt/utils/rsax931.py
+index b7ecfcd0b8..e2727e0b27 100644
+--- i/salt/utils/rsax931.py
++++ w/salt/utils/rsax931.py
+@@ -34,6 +34,10 @@ def _load_libcrypto():
+             os.path.dirname(sys.executable),
+             'libcrypto.so*'))[0])
+     else:
++        try:
 +            return cdll.LoadLibrary('@libcrypto@')
-+
-         raise OSError('Cannot locate OpenSSL libcrypto')
- 
- 
++        except OSError:
++            pass
+         lib = find_library('crypto')
+         if not lib and salt.utils.is_sunos():
+             # Solaris-like distribution that use pkgsrc have


### PR DESCRIPTION
Prefer to load the static Nix version,
but still fallback to the normal loading pathway if needed.

Being more aggressive about using the Nix dependency
improves stability and means Salt works more often,
namely in cases where find_library/LoadLibrary don't work
even though we have the Nix libcrypto available.

We still need to keep the fallback for usage with salt-ssh.

###### Motivation for this change

Better fix than what was in #29020.
See also #29723 cc @danbst.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

