### PR TITLE
python2.7: Return full path from find_library

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/2.7.14-return-full-path-from-find_library.patch
+++ b/pkgs/development/interpreters/python/cpython/2.7/2.7.14-return-full-path-from-find_library.patch
@@ -1,0 +1,16 @@
+diff --git i/Lib/ctypes/util.py w/Lib/ctypes/util.py
+index ab10ec52ee..c27f7d3ef7 100644
+--- i/Lib/ctypes/util.py
++++ w/Lib/ctypes/util.py
+@@ -271,7 +271,10 @@ elif os.name == "posix":
+             return res.group(1)
+ 
+         def find_library(name):
+-            return _findSoname_ldconfig(name) or _get_soname(_findLib_gcc(name))
++            lib_path = _findLib_gcc(name)
++            if lib_path is None:
++                return lib_path
++            return os.path.realpath(lib_path)
+ 
+ ################################################################
+ # test code

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -69,6 +69,9 @@ let
       # libuuid, slowing down program startup a lot).
       ./no-ldconfig.patch
 
+      # If find_library is used (e.g. by Salt), return a full path.
+      ./2.7.14-return-full-path-from-find_library.patch
+
     ] ++ optionals hostPlatform.isCygwin [
       ./2.5.2-ctypes-util-find_library.patch
       ./2.5.2-tkinter-x11.patch


### PR DESCRIPTION
###### Motivation for this change

Fixes #7307. (Also fixes #33971 in a different way; would love to get both patches in.)

The [upstream cpython patch](https://bugs.python.org/issue21042) to implement this behavior got reverted as it caused issues on some niche platforms, but I think Nixpkgs can punt on those issues for now.

cc @edolstra and @FRidh who have put in patches around Python's find_library previously.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

