### PR TITLE
muchsync: add homepage

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ notmuch openssl sqlite xapian zlib ];
   meta = {
     description = "Synchronize maildirs and notmuch databases";
+    homepage = "http://www.muchsync.org/";
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ ocharles ];
     license = stdenv.lib.licenses.gpl2Plus;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

