### PR TITLE
gutenberg: init at 0.3.1

### DIFF
--- a/pkgs/applications/misc/gutenberg/default.nix
+++ b/pkgs/applications/misc/gutenberg/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, rustPlatform, cmake, CoreServices, cf-private }:
+
+rustPlatform.buildRustPackage rec {
+  name = "gutenberg-${version}";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Keats";
+    repo = "gutenberg";
+    rev = "v${version}";
+    sha256 = "03zhbwxp4dbqydiydx0hpp3vpg769zzn5i95h2sl868mpfia8gyd";
+  };
+
+  cargoSha256 = "0441lbmxx16aar6fn651ihk3psrx0lk3qdbbyih05xjlkkbk1qxs";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices cf-private ];
+
+  postInstall = ''
+    install -D -m 444 completions/gutenberg.bash \
+      -t $out/share/bash-completion/completions
+    install -D -m 444 completions/_gutenberg \
+      -t $out/share/zsh/site-functions
+    install -D -m 444 completions/gutenberg.fish \
+      -t $out/share/fish/vendor_completions.d
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An opinionated static site generator with everything built-in";
+    homepage = https://www.getgutenberg.io;
+    license = licenses.mit;
+    maintainers = [];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15828,6 +15828,11 @@ with pkgs;
 
   gv = callPackage ../applications/misc/gv { };
 
+  gutenberg = callPackage ../applications/misc/gutenberg {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+    inherit (darwin) cf-private;
+  };
+
   guvcview = callPackage ../os-specific/linux/guvcview {
     pulseaudioSupport = config.pulseaudio or true;
     ffmpeg = ffmpeg_2;


### PR DESCRIPTION
###### Motivation for this change

Reboot of #30737.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

