### PR TITLE
oraclejdk: 8u151, 8u152, 9.0.1 -> 8u161, 8u162, 9.0.4 [Critical security fixes]

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,11 +1,11 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "151";
+  patchVersion = "161";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256.i686-linux = "0w1snn9hxwvdnk77frhdzbsm6v30v99dy5zmpy8ij7yxd57z6ql0";
-  sha256.x86_64-linux = "0zq2dxbxmshz080yskhc8y2wbqi0y0kl9girxjbb4rwk837010n7";
-  sha256.armv7l-linux = "0fdkvg1al7g9lqbq10rlw400aqr0xxi2a802319sw5n0zipkrjic";
-  sha256.aarch64-linux = "1xva22cjjpwa95h7x3xzyymn1bgxp1q67j5j304kn6cqah4k31j1";
+  sha256.i686-linux = "1p6p93msn3bsg9775rq171kd4160w4w8z57p0qpjdjycfix62sfg";
+  sha256.x86_64-linux = "07h2wah80qr78y0f821z12lbdmsv90xbckdn3glnj2riwfh5dg3d";
+  sha256.armv7l-linux = "0mngw2lnhx3hzgp444advybhjn5hjk3mi14y72km4kp03gh82a7x";
+  sha256.aarch64-linux = "18l5fny7yxhpj5c935rnlq4pvwadyr5zkid6yh9x87frl401shy7";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,11 +1,11 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "152";
+  patchVersion = "162";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256.i686-linux = "0gjc7kcfx40f43z1w1qsn1fqxdz8d46wml2g11qgm55ishhv2q7w";
-  sha256.x86_64-linux = "1gv1348hrgna9l3sssv3g9jzs37y1lkx05xq83chav9z1hs3p2r1";
-  sha256.armv7l-linux = "1w0hwslsd3z0kvb3z7gmbh20xsyiz73vglmdqz2108y7alim7arm";
-  sha256.aarch64-linux = "13qpxa8nxsnikmm7h6ysnsdqg5vl8j7hzfa8kgh20z8a17fhj9kk";
+  sha256.i686-linux = "097vlvvj1vr7815rgarf5x97lagi4q0kai0x4lvd4y3wrzdqikzf";
+  sha256.x86_64-linux = "0mq2d0lj53gzn4qqdjdgbwl0h857k2rnsnr2hkmvihnrgza85v38";
+  sha256.armv7l-linux = "0xzsgdmpgs1n1g70hgly0mpxflhjrmq3vxwx8gl0kmqdiv4hqwjp";
+  sha256.aarch64-linux = "19ykcsmvkf7sdq2lqwvyi60nhb8v7f88dqjycimrsar9y4r7skf8";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk9-linux.nix
@@ -30,7 +30,7 @@ assert stdenv.system == "x86_64-linux";
 assert swingSupport -> xorg != null;
 
 let
-  version = "9.0.1";
+  version = "9.0.4";
 
   downloadUrlBase = http://www.oracle.com/technetwork/java/javase/downloads;
 
@@ -63,7 +63,7 @@ let result = stdenv.mkDerivation rec {
       requireFile {
         name = "jdk-${version}_linux-x64_bin.tar.gz";
         url =  "${downloadUrlBase}/jdk9-downloads-3848520.html";
-        sha256 = "0560dc3icrwb0ifykshvzkr04b1jr153m26x1r8rp0nhjbzz1nic";
+        sha256 = "18nsjn64wkfmyb09wf2k7lvhazf83cs3dyichr038vl1gs3ymi4h";
       }
     else if packageType == "JRE" then
       requireFile {


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes.
- Other fixes and changes.

http://www.oracle.com/technetwork/java/javase/9-0-4-relnotes-4021191.html
http://www.oracle.com/technetwork/java/javase/8u161-relnotes-4021379.html
http://www.oracle.com/technetwork/java/javase/8u162-relnotes-4021436.html
http://www.oracle.com/technetwork/security-advisory/cpujan2018-3236628.html#AppendixJAVA

BTW, could you also merge #31552?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

