### PR TITLE
pythonPackages.pytestrunner: 2.6.2 -> 3.0

### DIFF
--- a/pkgs/development/python-modules/progressbar2/default.nix
+++ b/pkgs/development/python-modules/progressbar2/default.nix
@@ -14,6 +14,7 @@
 , pytestcov
 , pytestcache
 , pep8
+, pytestrunner
 }:
 
 buildPythonPackage rec {
@@ -30,6 +31,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ python-utils ];
+  nativeBuildInputs = [ pytestrunner ];
   checkInputs = [
     pytest sphinx coverage execnet flake8 pytestpep8 pytestflakes pytestcov
     pytestcache pep8

--- a/pkgs/development/python-modules/pytestrunner/default.nix
+++ b/pkgs/development/python-modules/pytestrunner/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, setuptools_scm, pytest }:
+
+buildPythonPackage rec {
+  pname = "pytest-runner";
+  version = "3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00v7pi09q60yx0l1kzyklnmr5bp597mir85a9gsi7bdfyly3lz0g";
+  };
+
+  buildInputs = [ setuptools_scm pytest ];
+
+  meta = with stdenv.lib; {
+    description = "Invoke py.test as distutils command with dependency resolution";
+    homepage = https://bitbucket.org/pytest-dev/pytest-runner;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3488,26 +3488,7 @@ in {
     };
   };
 
-  pytestrunner = buildPythonPackage rec {
-    version = "2.6.2";
-    name = "pytest-runner-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-runner/${name}.tar.gz";
-      sha256 = "e775a40ee4a3a1d45018b199c44cc20bbe7f3df2dc8882f61465bb4141c78cdb";
-    };
-
-    buildInputs = with self; [setuptools_scm pytest];
-
-    meta = {
-      description = "Invoke py.test as distutils command with dependency resolution";
-      homepage = https://bitbucket.org/pytest-dev/pytest-runner;
-      license = licenses.mit;
-    };
-
-    # Trying to run tests fails with # RuntimeError: dictionary changed size during iteration
-    doCheck = false;
-  };
+  pytestrunner = callPackage ../development/python-modules/pytestrunner { };
 
   pytestquickcheck = callPackage ../development/python-modules/pytest-quickcheck { };
 


### PR DESCRIPTION
Also add missing dependency to progressbar2

~Not yet tested whether this solves the issue, build still running~
`progressbar2` build fine now.

Those 501+ rebuilds are a little scary.
Is a test via `nox-review` sufficient? But I fear such a test would take days on my machine.

###### Motivation for this change
See #33920.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ashgillman @FRidh 