### PR TITLE
hypothesis-python: 3.11.1 -> 3.27.0

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, python
 , pythonOlder, pythonAtLeast, enum34
-, doCheck ? true, pytest, pytest_xdist, flake8, flaky
+, doCheck ? true, pytest, pytest_xdist, flake8, flaky, mock
 }:
 buildPythonPackage rec {
   # http://hypothesis.readthedocs.org/en/latest/packaging.html
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   # pytz fake_factory django numpy pytest
   # If you need these, you can just add them to your environment.
 
-  version = "3.11.1";
+  version = "3.27.0";
   pname = "hypothesis";
   name = "${pname}-${version}";
 
@@ -18,19 +18,13 @@ buildPythonPackage rec {
     owner = "HypothesisWorks";
     repo = "hypothesis-python";
     rev = "${version}";
-    sha256 = "0damf6zbm0db2a3gfwrbbj92yal576wpmhhchc0w0np8vdnax70n";
+    sha256 = "1lvhd8jrwajyc5w1alb9vinsi97fjfqpkxkh8g8j527831lig0j0";
   };
 
-  checkInputs = stdenv.lib.optionals doCheck [ pytest pytest_xdist flake8 flaky ];
+  checkInputs = stdenv.lib.optionals doCheck [ pytest pytest_xdist flake8 flaky mock];
   propagatedBuildInputs = stdenv.lib.optionals (pythonOlder "3.4") [ enum34 ];
 
   inherit doCheck;
-
-  # https://github.com/DRMacIver/hypothesis/issues/300
-  checkPhase = ''
-    rm tox.ini # This file changes how py.test runs and breaks it
-    py.test tests/cover
-  '';
 
   # Unsupport by upstream on certain versions
   # https://github.com/HypothesisWorks/hypothesis-python/issues/477
@@ -38,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A Python library for property based testing";
-    homepage = https://github.com/DRMacIver/hypothesis;
+    homepage = https://github.com/HypothesisWorks/hypothesis;
     license = licenses.mpl20;
   };
 }

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -19,12 +19,18 @@ buildPythonPackage rec {
     repo = "hypothesis-python";
     rev = "${version}";
     sha256 = "1lvhd8jrwajyc5w1alb9vinsi97fjfqpkxkh8g8j527831lig0j0";
-  };
+ };
 
   checkInputs = stdenv.lib.optionals doCheck [ pytest pytest_xdist flake8 flaky mock];
   propagatedBuildInputs = stdenv.lib.optionals (pythonOlder "3.4") [ enum34 ];
 
   inherit doCheck;
+
+  # https://github.com/DRMacIver/hypothesis/issues/300
+  checkPhase = ''
+    rm tox.ini # This file changes how py.test runs and breaks it
+    py.test tests/cover
+  '';
 
   # Unsupport by upstream on certain versions
   # https://github.com/HypothesisWorks/hypothesis-python/issues/477


### PR DESCRIPTION
###### Motivation for this change
I wanted to update PyNaCl in Nixpkgs, but it's tests require this version of hypothesis. I chose 3.27.0 because that's the earliest one with the features needed by pynacl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). - no maintainer, fits otherwise

---

