### PR TITLE
WIP: hydra: enable darwin build on 2017-11-21

### DIFF
--- a/pkgs/development/libraries/libpqxx/default.nix
+++ b/pkgs/development/libraries/libpqxx/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "A C++ library to access PostgreSQL databases";
     homepage = http://pqxx.org/development/libpqxx/;
     license = lib.licenses.postgresql;
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin;
     maintainers = [ lib.maintainers.eelco ];
   };
 }

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -64,15 +64,15 @@ let
   };
 in releaseTools.nixBuild rec {
   name = "hydra-${version}";
-  version = "2017-11-21";
+  version = "2018-03-16";
 
   inherit stdenv;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "hydra";
-    rev = "b7bc4384b7b471d1ddf892cb03f16189a66d5a0d";
-    sha256 = "05g37z3ilazzqa5rqj5zljndwxjbvpc18xibh6jlwjwpvg3kpbbh";
+    rev = "df27358e11ad09fe3516a4e41d9fe1fd49f911a7";
+    sha256 = "0wmd6b8m4ck96ngi768ap5d506xlry68di18rz8das1cns1gyrdi";
   };
 
   buildInputs =
@@ -92,6 +92,10 @@ in releaseTools.nixBuild rec {
     # Clean up when building from a working tree.
     (cd $sourceRoot && (git ls-files -o --directory | xargs -r rm -rfv)) || true
   '';
+
+  patches = lib.optional (stdenv.isDarwin) [
+    ./patches/darwin-missing-template-inst.patch
+  ];
 
   configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
 
@@ -130,7 +134,7 @@ in releaseTools.nixBuild rec {
   meta = with stdenv.lib; {
     description = "Nix-based continuous build system";
     license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ domenkozar ];
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ domenkozar periklis ];
   };
  }

--- a/pkgs/development/tools/misc/hydra/patches/darwin-missing-template-inst.patch
+++ b/pkgs/development/tools/misc/hydra/patches/darwin-missing-template-inst.patch
@@ -1,0 +1,12 @@
+diff --git a/src/hydra-queue-runner/hydra-queue-runner.cc b/src/hydra-queue-runner/hydra-queue-runner.cc
+index 85635823..2d1cda88 100644
+--- a/src/hydra-queue-runner/hydra-queue-runner.cc
++++ b/src/hydra-queue-runner/hydra-queue-runner.cc
+@@ -22,6 +22,7 @@ namespace nix {
+ 
+ template<> void toJSON<std::atomic<long>>(std::ostream & str, const std::atomic<long> & n) { str << n; }
+ template<> void toJSON<std::atomic<unsigned long>>(std::ostream & str, const std::atomic<unsigned long> & n) { str << n; }
++template<> void toJSON<std::atomic<unsigned long long>>(std::ostream & str, const std::atomic<unsigned long long> & n) { str << n; }
+ template<> void toJSON<double>(std::ostream & str, const double & n) { str << n; }
+ 
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9459,7 +9459,11 @@ with pkgs;
     x11Support = false;
   };
 
-  hydra = callPackage ../development/tools/misc/hydra { };
+  hydra = callPackage ../development/tools/misc/hydra {
+    stdenv = if stdenv.cc.isClang
+      then llvmPackages_5.stdenv
+      else overrideCC stdenv gcc6;
+  };
 
   hydraAntLogger = callPackage ../development/libraries/java/hydra-ant-logger { };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1195,7 +1195,7 @@ let self = _self // overrides; _self = with self; {
     meta = {
       description = "A storage class for Catalyst Authentication using DBIx::Class";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
     buildInputs = [ TestWarn ];
   };
@@ -1319,7 +1319,7 @@ let self = _self // overrides; _self = with self; {
     meta = {
       description = "DBIx::Class::Schema Model Class";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1388,7 +1388,7 @@ let self = _self // overrides; _self = with self; {
     meta = {
       description = "Role based authorization for Catalyst based on Catalyst::Plugin::Authentication";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1433,7 +1433,7 @@ let self = _self // overrides; _self = with self; {
     propagatedBuildInputs = [ CatalystPluginSession GDSecurityImage ];
     meta = {
       description = "Create and validate Captcha for Catalyst";
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1552,7 +1552,7 @@ let self = _self // overrides; _self = with self; {
     };
     propagatedBuildInputs = [ CatalystPluginSession ];
     meta = {
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1564,7 +1564,7 @@ let self = _self // overrides; _self = with self; {
     };
     propagatedBuildInputs = [ CacheFastMmap CatalystPluginSession ];
     meta = {
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1592,7 +1592,7 @@ let self = _self // overrides; _self = with self; {
     meta = {
       description = "Display a stack trace on the debug screen";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1648,7 +1648,7 @@ let self = _self // overrides; _self = with self; {
     buildInputs = [ CatalystRuntime TestLongString TestSimple13 TestWWWMechanize TestWWWMechanizeCatalyst TextCSV XMLSimple ];
     meta = {
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1663,7 +1663,7 @@ let self = _self // overrides; _self = with self; {
     meta = {
       description = "JSON view for your data";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1677,7 +1677,7 @@ let self = _self // overrides; _self = with self; {
     meta = {
       description = "Template View Class";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1710,7 +1710,7 @@ let self = _self // overrides; _self = with self; {
     meta = {
       description = "Replace request base with value passed by HTTP proxy";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -1729,7 +1729,7 @@ let self = _self // overrides; _self = with self; {
     meta = {
       description = "Replace the development server with Starman";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -7714,7 +7714,7 @@ let self = _self // overrides; _self = with self; {
       homepage = http://search.cpan.org/perldoc?CPAN::Meta::Spec;
       description = "IO Interface to compressed data files/buffers";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
     # Same as CompressRawZlib
     doCheck = false && !stdenv.isDarwin;
@@ -13754,7 +13754,7 @@ let self = _self // overrides; _self = with self; {
     buildInputs = [ TestException ];
     propagatedBuildInputs = [ ClassAccessor ListMoreUtils RegexpCommon SQLTokenizer ];
     meta = {
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -14400,7 +14400,7 @@ let self = _self // overrides; _self = with self; {
     };
     doCheck = false; # no `hostname' in stdenv
     meta = {
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 
@@ -16519,7 +16519,7 @@ let self = _self // overrides; _self = with self; {
       homepage = http://www.shlomifish.org/open-source/projects/docmake/;
       description = "Organize Data in Tables";
       license = stdenv.lib.licenses.isc;
-      platforms = stdenv.lib.platforms.linux;
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
Enable hydra builds on macOS to support darwin-based ecosystem. Currently WIP, because of:
```
/nix/store/hgsbnqhg7zr5vbjazb250ac4wnj3cfhy-bash-4.4-p12/bin/bash ../../libtool  --tag=CXX   --mode=link clang++ -I/nix/store/x2r5fphb4gh7jp7brkfd92va40yp9hy0-boehm-gc-7.6.0-dev/include -I/nix/store/j72w
hnasj6hx49ipnjpc844ndr1b13mz-nix-unstable-1.12pre5849_74f75c85-dev/include/nix -Wall -I ../libhydra -g -O2 -std=c++17 -include nix/config.h   -o hydra-queue-runner hydra_queue_runner-hydra-queue-runner.o
 hydra_queue_runner-queue-monitor.o hydra_queue_runner-dispatcher.o hydra_queue_runner-builder.o hydra_queue_runner-build-result.o hydra_queue_runner-build-remote.o -L/nix/store/5a8601rl5434yaffvs6vlrvzf
z7qi730-boehm-gc-7.6.0/lib -L/nix/store/d7x3mh58yr5x913d172jl45zqw6ah19z-nix-unstable-1.12pre5849_74f75c85/lib -lnixmain -lnixexpr -lgc -lnixstore -lnixutil -lnixformat -lpqxx                           
libtool: link: clang++ -I/nix/store/x2r5fphb4gh7jp7brkfd92va40yp9hy0-boehm-gc-7.6.0-dev/include -I/nix/store/j72whnasj6hx49ipnjpc844ndr1b13mz-nix-unstable-1.12pre5849_74f75c85-dev/include/nix -Wall -I ..
/libhydra -g -O2 -std=c++17 -include nix/config.h -o hydra-queue-runner hydra_queue_runner-hydra-queue-runner.o hydra_queue_runner-queue-monitor.o hydra_queue_runner-dispatcher.o hydra_queue_runner-build
er.o hydra_queue_runner-build-result.o hydra_queue_runner-build-remote.o  -L/nix/store/5a8601rl5434yaffvs6vlrvzfz7qi730-boehm-gc-7.6.0/lib -L/nix/store/d7x3mh58yr5x913d172jl45zqw6ah19z-nix-unstable-1.12p
re5849_74f75c85/lib -lnixmain -lnixexpr /nix/store/5a8601rl5434yaffvs6vlrvzfz7qi730-boehm-gc-7.6.0/lib/libgc.dylib -L/nix/store/3v14j0vgq7iiwvwx8zllzzw9fx2ykasx-libatomic_ops-7.6.0/lib -lpthread -lnixsto
re -lnixutil -lnixformat -lpqxx                                                                                                                                                                           
Undefined symbols for architecture x86_64:
  "void nix::toJSON<std::__1::atomic<unsigned long long> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, std::__1::atomic<unsigned long long> const&)", referenced from:
      State::dumpStatus(Connection&, bool) in hydra_queue_runner-hydra-queue-runner.o
ld: symbol(s) not found for architecture x86_64
clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
``` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

