### PR TITLE
qt510-qtbase: fix darwin build

### DIFF
--- a/pkgs/development/libraries/qt-5/5.10/default.nix
+++ b/pkgs/development/libraries/qt-5/5.10/default.nix
@@ -37,7 +37,7 @@ let
   srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
 
   patches = {
-    qtbase = [ ./qtbase.patch ];
+    qtbase = [ ./qtbase.patch ] ++ optional stdenv.isDarwin ./qtbase-darwin.patch;
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];

--- a/pkgs/development/libraries/qt-5/5.10/qtbase-darwin.patch
+++ b/pkgs/development/libraries/qt-5/5.10/qtbase-darwin.patch
@@ -1,0 +1,57 @@
+diff --git a/src/plugins/bearer/corewlan/qcorewlanengine.mm b/src/plugins/bearer/corewlan/qcorewlanengine.mm
+index 341d3bccf2..3368234c26 100644
+--- a/src/plugins/bearer/corewlan/qcorewlanengine.mm
++++ b/src/plugins/bearer/corewlan/qcorewlanengine.mm
+@@ -287,7 +287,7 @@ void QScanThread::getUserConfigurations()
+     QMacAutoReleasePool pool;
+     userProfiles.clear();
+ 
+-    NSArray<NSString *> *wifiInterfaces = [CWWiFiClient interfaceNames];
++    NSArray *wifiInterfaces = [CWWiFiClient interfaceNames];
+     for (NSString *ifName in wifiInterfaces) {
+ 
+         CWInterface *wifiInterface = [[CWWiFiClient sharedWiFiClient] interfaceWithName:ifName];
+@@ -602,7 +602,7 @@ void QCoreWlanEngine::doRequestUpdate()
+ 
+     QMacAutoReleasePool pool;
+ 
+-    NSArray<NSString *> *wifiInterfaces = [CWWiFiClient interfaceNames];
++    NSArray *wifiInterfaces = [CWWiFiClient interfaceNames];
+     for (NSString *ifName in wifiInterfaces) {
+             scanThread->interfaceName = QString::fromNSString(ifName);
+             scanThread->start();
+diff --git a/src/plugins/platforms/cocoa/qcocoawindow.mm b/src/plugins/platforms/cocoa/qcocoawindow.mm
+index d1f19f2..1ac2cf1 100644
+--- a/src/plugins/platforms/cocoa/qcocoawindow.mm
++++ b/src/plugins/platforms/cocoa/qcocoawindow.mm
+@@ -1699,7 +1699,7 @@ void QCocoaWindow::applyContentBorderThickness(NSWindow *window)
+
+     if (!m_drawContentBorderGradient) {
+         window.styleMask = window.styleMask & ~NSTexturedBackgroundWindowMask;
+-        [window.contentView.superview setNeedsDisplay:YES];
++        [[window.contentView superview] setNeedsDisplay:YES];
+         window.titlebarAppearsTransparent = NO;
+         return;
+     }
+diff --git a/src/plugins/platforms/cocoa/qnswindow.mm b/src/plugins/platforms/cocoa/qnswindow.mm
+index e846fa0..4171cd4 100644
+--- a/src/plugins/platforms/cocoa/qnswindow.mm
++++ b/src/plugins/platforms/cocoa/qnswindow.mm
+@@ -224,7 +224,7 @@ static bool isMouseEvent(NSEvent *ev)
+     if (pw->frameStrutEventsEnabled() && isMouseEvent(theEvent)) {
+         NSPoint loc = [theEvent locationInWindow];
+         NSRect windowFrame = [self convertRectFromScreen:self.frame];
+-        NSRect contentFrame = self.contentView.frame;
++        NSRect contentFrame = [self.contentView frame];
+         if (NSMouseInRect(loc, windowFrame, NO) && !NSMouseInRect(loc, contentFrame, NO))
+             [qnsview_cast(pw->view()) handleFrameStrutMouseEvent:theEvent];
+     }
+@@ -253,7 +253,7 @@ static bool isMouseEvent(NSEvent *ev)
+ + (void)applicationActivationChanged:(NSNotification*)notification
+ {
+     const id sender = self;
+-    NSEnumerator<NSWindow*> *windowEnumerator = nullptr;
++    NSEnumerator *windowEnumerator = nullptr;
+     NSApplication *application = [NSApplication sharedApplication];
+
+ #if QT_MACOS_PLATFORM_SDK_EQUAL_OR_ABOVE(__MAC_10_12)


### PR DESCRIPTION
###### Motivation for this change

Includes most of the changes from 37933209588792db24104dbfaef0106c3bef870d,
moved it to a separate patch to avoid accidental removal.

Only tested qtbase, but everything else worked fine with the qt510 update.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

