### PR TITLE
buildbot: 0.9.11 -> 0.9.15.post1

### DIFF
--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -14,11 +14,11 @@ let
   package = pythonPackages.buildPythonApplication rec {
     name = "${pname}-${version}";
     pname = "buildbot";
-    version = "0.9.11";
+    version = "0.9.15.post1";
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "1s3y218wry7502xp4zxccf3z996xm8cnp3dcxl7m5ldmmb055qwv";
+      sha256 = "01m5x4lpz90lqf8j0s2c26gqb5yzan6x9d1ffgmrklwf0bljkwni";
     };
 
     buildInputs = with pythonPackages; [

--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, openssh, buildbot-worker, pythonPackages, runCommand, makeWrapper }:
+{ stdenv, lib, openssh, buildbot-worker, buildbot-pkg, pythonPackages, runCommand, makeWrapper }:
 
 let
   withPlugins = plugins: runCommand "wrapped-${package.name}" {
@@ -36,6 +36,7 @@ let
       pyflakes
       openssh
       buildbot-worker
+      buildbot-pkg
       treq
     ];
 

--- a/pkgs/development/tools/build-managers/buildbot/pkg.nix
+++ b/pkgs/development/tools/build-managers/buildbot/pkg.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, setuptools }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "buildbot-pkg";
+  version = "0.9.15.post1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gsa5fi1gkwnz8dsrl2s5kzcfawnj3nl8g8h6z1winz627l9n8sh";
+  };
+
+  propagatedBuildInputs = [ setuptools ];
+
+  meta = with stdenv.lib; {
+    homepage = http://buildbot.net/;
+    description = "Buildbot Packaging Helper";
+    maintainers = with maintainers; [ nand0p ryansydnor ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/development/tools/build-managers/buildbot/plugins.nix
+++ b/pkgs/development/tools/build-managers/buildbot/plugins.nix
@@ -1,27 +1,6 @@
-{ stdenv, pythonPackages }:
+{ stdenv, pythonPackages, buildbot-pkg }:
 
-let
-  buildbot-pkg = pythonPackages.buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "buildbot-pkg";
-    version = "0.9.15.post1";
-
-    src = pythonPackages.fetchPypi {
-      inherit pname version;
-      sha256 = "0gsa5fi1gkwnz8dsrl2s5kzcfawnj3nl8g8h6z1winz627l9n8sh";
-    };
-
-    propagatedBuildInputs = with pythonPackages; [ setuptools ];
-
-    meta = with stdenv.lib; {
-      homepage = http://buildbot.net/;
-      description = "Buildbot Packaging Helper";
-      maintainers = with maintainers; [ nand0p ryansydnor ];
-      license = licenses.gpl2;
-    };
-  };
-
-in {
+{
   www = pythonPackages.buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "buildbot_www";

--- a/pkgs/development/tools/build-managers/buildbot/plugins.nix
+++ b/pkgs/development/tools/build-managers/buildbot/plugins.nix
@@ -4,11 +4,11 @@ let
   buildbot-pkg = pythonPackages.buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "buildbot-pkg";
-    version = "0.9.11";
+    version = "0.9.15.post1";
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "1gh7wj9z7n7yfs219jbv9pdd2w8dwj6qpa090ffjkfpgd3xana33";
+      sha256 = "0gsa5fi1gkwnz8dsrl2s5kzcfawnj3nl8g8h6z1winz627l9n8sh";
     };
 
     propagatedBuildInputs = with pythonPackages; [ setuptools ];
@@ -32,7 +32,7 @@ in {
 
     src = pythonPackages.fetchPypi {
       inherit pname version format;
-      sha256 = "0fk1swdncg4nha744mzkf6jqh1zv1cfhnqvd19669kjcyjx9i68d";
+      sha256 = "19cnzp5prima3jrk525xspw7vqc5pjln2nihj4kc3w90dhzllj8x";
     };
 
     meta = with stdenv.lib; {
@@ -50,7 +50,7 @@ in {
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "16wxgnh35916c2gw34971ynx319lnm9addhqvii885vid44pqim0";
+      sha256 = "1j6aw2j2sl7ix8rb67pbs6nfvv8v3smgkvqzsjsyh5sdfr2663cg";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -70,7 +70,7 @@ in {
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "1hcr8xsc0ajfg2vz2h8g5s8ypsp32kdplgqp21jh8z5y0a6nzqsl";
+      sha256 = "0k0wd4rq034bij2flfjv60h8czkfn836bnaa7hwsrl58gxds39m4";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -90,7 +90,7 @@ in {
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "0aw1073xq549q5jkjk31zhqpasp8jiy4gch0fjyw8qy0dax8hc7r";
+      sha256 = "08ng56jmy50s3zyn6wxizji1zhgzhi65z7w3wljg02qrbd5688gj";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -110,7 +110,7 @@ in {
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "0x99mdmn1ngcnmkxr40hwqafsq48jybdz45y5kpc0yw68n0bfwmv";
+      sha256 = "15fm72yymv873n3vsw9kprypcf6jzln18v4lb062n8lqw9pykwb1";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];

--- a/pkgs/development/tools/build-managers/buildbot/worker.nix
+++ b/pkgs/development/tools/build-managers/buildbot/worker.nix
@@ -3,11 +3,11 @@
 pythonPackages.buildPythonApplication (rec {
   name = "${pname}-${version}";
   pname = "buildbot-worker";
-  version = "0.9.11";
+  version = "0.9.15.post1";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "0lb8kwg3m9jgrww929d5nrjs4rj489mb4dnsdxcbdb358jbbym22";
+    sha256 = "12zscqb218w88y9fd1jwfn4cr2sw35j998d0jlgd22bch020sy65";
   };
 
   buildInputs = with pythonPackages; [ setuptoolsTrial mock ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7267,6 +7267,9 @@ with pkgs;
   buildbot-worker = callPackage ../development/tools/build-managers/buildbot/worker.nix {
     pythonPackages = python2Packages;
   };
+  buildbot-pkg = callPackage ../development/tools/build-managers/buildbot/pkg.nix {
+    inherit (python2Packages) buildPythonPackage fetchPypi setuptools;
+  };
   buildbot-plugins = callPackages ../development/tools/build-managers/buildbot/plugins.nix {
     pythonPackages = python2Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

Updates buildbot to 0.9.15.post1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

