### PR TITLE
acme-client: init at 0.1.6

### DIFF
--- a/pkgs/tools/networking/acme-client/default.nix
+++ b/pkgs/tools/networking/acme-client/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, apple_sdk ? null
+, cacert
+, defaultCaFile ? "${cacert}/etc/ssl/certs/ca-bundle.crt"
+, fetchurl
+, libbsd
+, libressl
+, pkgconfig
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "acme-client-${version}";
+  version = "0.1.16";
+
+  src = fetchurl {
+    url = "https://kristaps.bsd.lv/acme-client/snapshots/acme-client-portable-${version}.tgz";
+    sha256 = "00q05b3b1dfnfp7sr1nbd212n0mqrycl3cr9lbs51m7ncaihbrz9";
+  };
+
+  buildInputs = [ libbsd libressl pkgconfig ]
+    ++ optional stdenv.isDarwin apple_sdk.sdk;
+
+  CFLAGS = "-DDEFAULT_CA_FILE='\"${defaultCaFile}\"'";
+
+  preConfigure = ''
+    export PREFIX="$out"
+  '';
+
+  meta = {
+    homepage = https://kristaps.bsd.lv/acme-client/;
+    description = "Secure ACME/Let's Encrypt client";
+    platforms = platforms.unix;
+    license = licenses.isc;
+    maintainers = with maintainers; [ pmahoney ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -414,6 +414,8 @@ with pkgs;
 
   aescrypt = callPackage ../tools/misc/aescrypt { };
 
+  acme-client = callPackage ../tools/networking/acme-client { inherit (darwin) apple_sdk; };
+
   afew = callPackage ../applications/networking/mailreaders/afew { pythonPackages = python3Packages; };
 
   afio = callPackage ../tools/archivers/afio { };


### PR DESCRIPTION
###### Motivation for this change

Add [acme-client](https://kristaps.bsd.lv/acme-client/) package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

