### PR TITLE
pypy: 5.9.0 -> 5.10.0

### DIFF
--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -79,17 +79,6 @@ in stdenv.mkDerivation rec {
 
   setupHook = python-setup-hook sitePackages;
 
-  postBuild = ''
-    pushd ./lib_pypy
-    ../pypy-c ./_audioop_build.py
-    ../pypy-c ./_curses_build.py
-    ../pypy-c ./_pwdgrp_build.py
-    ../pypy-c ./_sqlite3_build.py
-    ../pypy-c ./_syslog_build.py
-    ../pypy-c ./_tkinter/tklib_build.py
-    popd
-  '';
-
   doCheck = true;
   checkPhase = ''
     export TERMINFO="${ncurses.out}/share/terminfo/";

--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -10,7 +10,7 @@
 assert zlibSupport -> zlib != null;
 
 let
-  majorVersion = "5.9";
+  majorVersion = "5.10";
   minorVersion = "0";
   minorVersionSuffix = "";
   pythonVersion = "2.7";
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://bitbucket.org/pypy/pypy/get/release-pypy${pythonVersion}-v${version}.tar.bz2";
-    sha256 = "1q3kcnniyvnca1l7x10mbhp4xwjr03ajh2h8j6cbdllci38zdjy1";
+    sha256 = "10j1s6r6iv80nvpi6gv8w05v505h2ndj9xx31yz7d50ab04dfg23";
   };
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

PyPy 5.10.0 was released on 2017-12-25.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: gprof2dot, which depends on pypy, compiles but fails to run outside of nix-shell; this is a pre-existing issue that I’ve reported as #33997.