### PR TITLE
innoextract: support extraction of multi-file archives

### DIFF
--- a/pkgs/tools/archivers/innoextract/default.nix
+++ b/pkgs/tools/archivers/innoextract/default.nix
@@ -1,4 +1,6 @@
-{stdenv, fetchurl, cmake, python, doxygen, lzma, boost}:
+{ stdenv, fetchurl, cmake, doxygen, makeWrapper, python
+, boost, lzma
+, withGog ? false, unar ? null }:
 
 stdenv.mkDerivation rec {
   name = "innoextract-1.6";
@@ -8,14 +10,23 @@ stdenv.mkDerivation rec {
     sha256 = "0gh3q643l8qlwla030cmf3qdcdr85ixjygkb7j4dbm7zbwa3yik6";
   };
 
-  buildInputs = [ python doxygen lzma boost ];
-  nativeBuildInputs = [ cmake ];
+  buildInputs = [ python lzma boost ];
+
+  nativeBuildInputs = [ cmake makeWrapper ];
+
+  enableParallelBuilding = true;
+
+  # we need unar to for multi-archive extraction
+  postFixup = stdenv.lib.optionalString withGog ''
+    wrapProgram $out/bin/innoextract \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ unar ]}
+  '';
 
   meta = with stdenv.lib; {
     description = "A tool to unpack installers created by Inno Setup";
     homepage = http://constexpr.org/innoextract/;
-    platforms = platforms.linux;
     license = licenses.zlib;
     maintainers = with maintainers; [ abbradar ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

innoextract supports a ```--gog``` argument which will process extra multi-file archives distributed by gog.com

A slight downside is the increase of the closure size from 76MB to 1.4GB so we can of course make the ```withGog``` argument ```false``` instead by default.

Cc: @abbradar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

