### PR TITLE
netcat-openbsd: 1.130 -> 1.187

### DIFF
--- a/pkgs/tools/networking/netcat-openbsd/default.nix
+++ b/pkgs/tools/networking/netcat-openbsd/default.nix
@@ -1,18 +1,18 @@
 {stdenv, fetchurl, pkgconfig, libbsd}:
 
 stdenv.mkDerivation rec {
-  version = "1.130";
-  deb-version = "${version}-3";
+  version = "1.187";
+  deb-version = "${version}-1";
   name = "netcat-openbsd-${version}";
 
   srcs = [
     (fetchurl {
       url = "mirror://debian/pool/main/n/netcat-openbsd/netcat-openbsd_${version}.orig.tar.gz";
-      sha256 = "0nqy14yvclgzs98gv0fwp6jlfpfy2kk367zka648jiqbbl30awpx";
+      sha256 = "0sxsxl7n7hnxz931jqsp86cdwiq2lm4h3w0i2a67935pki924gxw";
     })
     (fetchurl {
       url = "mirror://debian/pool/main/n/netcat-openbsd/netcat-openbsd_${deb-version}.debian.tar.xz";
-      sha256 = "0f9409vjm6v8a7m1zf5sr7wj6v5v8414i5vvxx1r45c11h69hh9a";
+      sha256 = "0jwbdis6avxdjzg8bcab1bdz296rkzzkdlv50fr3q0277fxjs49q";
     })
   ];
 
@@ -20,11 +20,18 @@ stdenv.mkDerivation rec {
   buildInputs = [ libbsd ];
 
   sourceRoot = name;
-  patches = [ "../debian/patches/*.patch" ];
+
+  prePatch = ''
+    for i in $(cat ../debian/patches/series); do
+      patch -p1 < "../debian/patches/$i"
+    done
+  '';
 
   installPhase = ''
+    runHook preInstall
     install -Dm0755 nc $out/bin/nc
     install -Dm0644 nc.1 $out/share/man/man1/nc.1
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
fixes #34002

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

