### PR TITLE
weka: 3.8.1 -> 3.8.2

### DIFF
--- a/pkgs/applications/science/math/weka/default.nix
+++ b/pkgs/applications/science/math/weka/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "weka-${version}";
-  version = "3.8.1";
+  version = "3.8.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/weka/${stdenv.lib.replaceChars ["."]["-"] name}.zip";
-    sha256 = "16n1a74d1cispp0a22zyiivi78izi354y67gmbyvv2lv9sc45wmk";
+    sha256 = "0p353lhhcv3swwn1bl64vkyjk480vv9ghhlyqjxiar4p3xifjayb";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

Update weka to the last version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

