### PR TITLE
platformio: 3.5.0 -> 3.5.1

### DIFF
--- a/pkgs/development/python-modules/platformio/default.nix
+++ b/pkgs/development/python-modules/platformio/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, arrow, bottle, click_5, colorama
+, bottle, click_5, colorama
 , lockfile, pyserial, requests
 , semantic-version
 , isPy3k, isPyPy
@@ -8,17 +8,17 @@ buildPythonPackage rec {
   disabled = isPy3k || isPyPy;
 
   pname = "platformio";
-  version="3.5.0";
+  version="3.5.1";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0gy13cwp0i97lgjd8hh8kh9cswxh53x4cx2sq5b7d7vv8kd7bh6c";
+    sha256 = "0cc15mzh7p1iykip0jpxldz81yz946vrgvhwmfl8w3z5kgjjgx3n";
   };
 
   propagatedBuildInputs =  [
-    arrow bottle click_5 colorama
-    lockfile pyserial requests semantic-version
+    bottle click_5 colorama lockfile
+    pyserial requests semantic-version
   ];
 
   patches = [ ./fix-searchpath.patch ];


### PR DESCRIPTION
###### Motivation for this change
New version released today, I noticed they refactored out the python code, so excellent chance to reduce the package size.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

