### PR TITLE
mathematica: enable installation of localized editions

### DIFF
--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , coreutils
 , patchelf
-, requireFile
+, callPackage
 , alsaLib
 , dbus
 , fontconfig
@@ -18,6 +18,7 @@
 , zlib
 , libxml2
 , libuuid
+, lang ? "en"
 }:
 
 let
@@ -26,21 +27,15 @@ let
       "Linux"
     else
       throw "Mathematica requires i686-linux or x86_64 linux";
+
+  l10n =
+    with stdenv.lib;
+    with callPackage ./l10ns.nix {};
+    flip (findFirst (l: l.lang == lang)) l10ns
+      (throw "Language '${lang}' not supported");
 in
 stdenv.mkDerivation rec {
-  version = "11.2.0";
-
-  name = "mathematica-${version}";
-
-  src = requireFile rec {
-    name = "Mathematica_${version}_LINUX.sh";
-    message = '' 
-      This nix expression requires that ${name} is
-      already part of the store. Find the file on your Mathematica CD
-      and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
-    '';
-    sha256 = "4a1293cc1c404303aa1cab1bd273c7be151d37ac5ed928fbbb18e9c5ab2d8df9";
-  };
+  inherit (l10n) version name src;
 
   buildInputs = [
     coreutils

--- a/pkgs/applications/science/math/mathematica/l10ns.nix
+++ b/pkgs/applications/science/math/mathematica/l10ns.nix
@@ -1,0 +1,33 @@
+{ lib, requireFile }:
+
+with lib;
+{
+  l10ns = flip map
+  [
+    {
+      version = "11.2.0";
+      lang = "en";
+      language = "English";
+      sha256 = "4a1293cc1c404303aa1cab1bd273c7be151d37ac5ed928fbbb18e9c5ab2d8df9";
+    }
+    {
+      version = "11.2.0";
+      lang = "ja";
+      language = "Japanese";
+      sha256 = "916392edd32bed8622238df435dd8e86426bb043038a3336f30df10d819b49b1";
+    }
+  ]
+  ({ version, lang, language, sha256 }: {
+    inherit version lang;
+    name = "mathematica-${version}" + optionalString (lang != "en") "-${lang}";
+    src = requireFile rec {
+      name = "Mathematica_${version}" + optionalString (lang != "en") "_${language}" + "_LINUX.sh";
+      message = ''
+        This nix expression requires that ${name} is
+        already part of the store. Find the file on your Mathematica CD
+        and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
+      '';
+      inherit sha256;
+    };
+  });
+}


### PR DESCRIPTION
###### Motivation for this change

Mathematica has many localized editions, e.g. Japanese edition, which I want to install.
This PR aims to make it easier to add such localized editions.

For now English (default) and Japanese editions only.
Fill out information in `l10ns.nix` to add the other localized editions.
Example usage: `mathematica.override { lang = "ja"; }` derives Japanese edition.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

