### PR TITLE
python-telegram-bot: init at 9.0.0

### DIFF
--- a/pkgs/development/python-modules/python-telegram-bot/default.nix
+++ b/pkgs/development/python-modules/python-telegram-bot/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchPypi, buildPythonPackage, isPy3k, certifi, future }:
+
+buildPythonPackage rec {
+  pname = "python-telegram-bot";
+  version = "9.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0a5b4wfc6ms7kblynw2h3ygpww98kyz5n8iibqbdyykwx8xj7hzm";
+  };
+
+  propagatedBuildInputs = [ certifi future ];
+  doCheck = !isPy3k;
+
+  meta = with stdenv.lib; {
+    description = "This library provides a pure Python interface for the Telegram Bot API.";
+    homepage = https://python-telegram-bot.org;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/python-telegram-bot/default.nix
+++ b/pkgs/development/python-modules/python-telegram-bot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, buildPythonPackage, isPy3k, certifi, future }:
+{ stdenv, fetchPypi, buildPythonPackage, certifi, future, urllib3 }:
 
 buildPythonPackage rec {
   pname = "python-telegram-bot";
@@ -9,8 +9,18 @@ buildPythonPackage rec {
     sha256 = "0a5b4wfc6ms7kblynw2h3ygpww98kyz5n8iibqbdyykwx8xj7hzm";
   };
 
-  propagatedBuildInputs = [ certifi future ];
-  doCheck = !isPy3k;
+  prePatch = ''
+    rm -rf telegram/vendor
+    substituteInPlace telegram/utils/request.py \
+      --replace "import telegram.vendor.ptb_urllib3.urllib3 as urllib3" "import urllib3 as urllib3" \
+      --replace "import telegram.vendor.ptb_urllib3.urllib3.contrib.appengine as appengine" "import urllib3.contrib.appengine as appengine" \
+      --replace "from telegram.vendor.ptb_urllib3.urllib3.connection import HTTPConnection" "from urllib3.connection import HTTPConnection" \
+      --replace "from telegram.vendor.ptb_urllib3.urllib3.util.timeout import Timeout" "from urllib3.util.timeout import Timeout"
+  '';
+
+  propagatedBuildInputs = [ certifi future urllib3 ];
+
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "This library provides a pure Python interface for the Telegram Bot API.";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22203,6 +22203,8 @@ EOF
     };
   };
 
+  python-telegram-bot = callPackage ../development/python-modules/python-telegram-bot { };
+
   irc = buildPythonPackage rec {
     name = "irc-${version}";
     version = "14.2.2";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

