### PR TITLE
Fix build of linuxPackages.perf

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
 
   makeFlags = if stdenv.hostPlatform == stdenv.buildPlatform
     then null
-    else "CROSS_COMPILE=${stdenv.cc.prefix}";
+    else "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
 
   installFlags = "install install-man ASCIIDOC8=1";
 

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -11,7 +11,7 @@ assert versionAtLeast kernel.version "3.12";
 stdenv.mkDerivation {
   name = "perf-linux-${kernel.version}";
 
-  inherit (kernel) src makeFlags;
+  inherit (kernel) src;
 
   preConfigure = ''
     cd tools/perf
@@ -38,6 +38,10 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optionals (hasPrefix "gcc-6" stdenv.cc.cc.name) [
       "-Wno-error=unused-const-variable" "-Wno-error=misleading-indentation"
     ];
+
+  makeFlags = if stdenv.hostPlatform == stdenv.buildPlatform
+    then null
+    else "CROSS_COMPILE=${stdenv.cc.prefix}";
 
   installFlags = "install install-man ASCIIDOC8=1";
 


### PR DESCRIPTION
It should build, but it doesn't.

https://github.com/NixOS/nixpkgs/issues/34013


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---