### PR TITLE
fetchpatch: Add support for an arbitrary extra prefix

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -5,7 +5,7 @@
 # stripLen acts as the -p parameter when applying a patch.
 
 { lib, fetchurl, patchutils }:
-{ stripLen ? 0, addPrefixes ? false, excludes ? [], ... }@args:
+{ stripLen ? 0, extraPrefix ? null, excludes ? [], ... }@args:
 
 fetchurl ({
   postFetch = ''
@@ -16,9 +16,9 @@ fetchurl ({
         "${patchutils}/bin/filterdiff" \
         --include={} \
         --strip=${toString stripLen} \
-        ${lib.optionalString addPrefixes ''
-           --addoldprefix=a/ \
-           --addnewprefix=b/ \
+        ${lib.optionalString (extraPrefix != null) ''
+           --addoldprefix=a/${extraPrefix} \
+           --addnewprefix=b/${extraPrefix} \
         ''} \
         --clean "$out" > "$tmpfile"
     ${patchutils}/bin/filterdiff \
@@ -27,4 +27,4 @@ fetchurl ({
       "$tmpfile" > "$out"
     ${args.postFetch or ""}
   '';
-} // builtins.removeAttrs args ["stripLen" "addPrefixes" "excludes" "postFetch"])
+} // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "postFetch"])

--- a/pkgs/development/libraries/libstdc++5/default.nix
+++ b/pkgs/development/libraries/libstdc++5/default.nix
@@ -21,13 +21,13 @@ stdenv.mkDerivation rec {
       name = "siginfo.patch";
       url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/siginfo.patch?h=packages/libstdc%2B%2B5&id=e36ee8ed9bb5942db14cf6249a2ead14974a2bfa";
       sha256 = "15zldbm33yba293dgrgsbv3j332hkc3iqpyc8fa7zl42mh9qk22j";
-      addPrefixes = true;
+      extraPrefix = "";
     })
     (fetchpatch {
       name = "gcc-3.4.3-no_multilib_amd64.patch";
       url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/gcc-3.4.3-no_multilib_amd64.patch?h=packages/libstdc%2B%2B5&id=e36ee8ed9bb5942db14cf6249a2ead14974a2bfa";
       sha256 = "11m5lc51b0addhc4yq4rz0dwpv6k73rrj73wya3lqdk8rly6cjpm";
-      addPrefixes = true;
+      extraPrefix = "";
     })
     # Required because of glibc 2.26
     ./struct-ucontext.patch

--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -20,21 +20,21 @@ stdenv.mkDerivation rec {
       url = "https://vcs.pcre.org/pcre2/code/trunk/src/pcre2_ucd.c?view=patch&r1=316&r2=670&sortby=date";
       sha256 = "10yzglvbn7h06hg7zffr5zh378i5jihvx7d5gggkynws79vgwvfr";
       stripLen = 2;
-      addPrefixes = true;
+      extraPrefix = "";
     })
     (fetchpatch {
       name = "CVE-2017-7186-part2.patch";
       url = "https://vcs.pcre.org/pcre2/code/trunk/src/pcre2_internal.h?view=patch&r1=600&r2=670&sortby=date";
       sha256 = "1bggk7vd5hg0bjg96lj4h1lacmr6grq68dm6iz1n7vg3zf7virjn";
       stripLen = 2;
-      addPrefixes = true;
+      extraPrefix = "";
     })
     (fetchpatch {
       name = "CVE-2017-8786.patch";
       url = "https://vcs.pcre.org/pcre2/code/trunk/src/pcre2test.c?r1=692&r2=697&view=patch";
       sha256 = "1c629nzrk4il2rfclwyc1a373q58m4q9ys9wr91zhl4skfk7x19b";
       stripLen = 2;
-      addPrefixes = true;
+      extraPrefix = "";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

I need this to patch a cloned submodule from upstream for https://github.com/NixOS/nixpkgs/pull/26799

We still ensure the old and new ones start, respectfully, with `a/` and `b/`. Use with `stripLen` to ensure tha the old `a/` and `/b` are gone if a new prefix is added.

###### Things done

I checked (disabling cached builds) that existing uses with or without `addPrefixes = true` still have the same hash.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

