### PR TITLE
linux-steam-integration: Append "Settings" to launcher menu item

### DIFF
--- a/pkgs/games/linux-steam-integration/default.nix
+++ b/pkgs/games/linux-steam-integration/default.nix
@@ -27,6 +27,8 @@ in stdenv.mkDerivation rec {
     sed -i -e "s|/usr/|$out/|g" src/shim/shim.c
     sed -i -e "s|/usr/|$out/|g" data/lsi-steam.desktop
     sed -i -e "s|zenity|${zenityBinPath}|g" src/lsi/lsi.c
+    sed -i -e "s|Name=Linux Steam Integration|Name=Linux Steam Integration Settings|" data/lsi-settings.desktop.in
+
   '';
 
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change

It just shows up as "Linux Steam Integration" otherwise, which is confusing.  The actual LSI launcher's name in the menu is "LSI Steam", right next to this one.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

