### PR TITLE
Update Shibboleth Service Provider Packages

### DIFF
--- a/pkgs/development/libraries/opensaml-cpp/default.nix
+++ b/pkgs/development/libraries/opensaml-cpp/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "opensaml-cpp-${version}";
-  version = "2.6.0";
+  version = "2.6.1";
 
   src = fetchgit {
     url = "https://git.shibboleth.net/git/cpp-opensaml.git";
-    rev = "61193de29e4c9f1ccff7ed7e1f42c2748c62be77";
-    sha256 = "1jlxa1f2qn0kd15fzjqp80apxn42v47wg3mx1vk424m31rhi00xr";
+    rev = version;
+    sha256 = "0wjb6jyvh4hwpy1pvhh63i821746nqijysrd4vasbirkf4h6z7nx";
   };
 
   buildInputs = [ boost openssl log4shib xercesc xml-security-c xml-tooling-c zlib ];

--- a/pkgs/development/libraries/shibboleth-sp/default.nix
+++ b/pkgs/development/libraries/shibboleth-sp/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "shibboleth-sp-${version}";
-  version = "2.6.0";
+  version = "2.6.1";
 
   src = fetchgit {
     url = "https://git.shibboleth.net/git/cpp-sp.git";
-    rev = "9ebba5c3a16d03769f436e383e4c4cdaa33f5509";
-    sha256 = "1b5r4nd098lnjwr2g13f04ycqv5fvbrhpwg6fsdk8xy9cigvfzxj";
+    rev = version;
+    sha256 = "01q13p7gc0janjfml6zs46na8qnval8hc833fk2wrnmi4w9xw4fd";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/xml-tooling-c/default.nix
+++ b/pkgs/development/libraries/xml-tooling-c/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "xml-tooling-c-${version}";
-  version = "1.6.0";
+  version = "1.6.3";
 
   src = fetchgit {
     url = "https://git.shibboleth.net/git/cpp-xmltooling.git";
-    rev = "db08101c3854518a59096be95ed6564838381744";
-    sha256 = "0rhzvxm4z3pm28kpk34hayhm12bjjms2kygv1z68vnz8ijzgcinq";
+    rev = version;
+    sha256 = "09z2pp3yy3kqx22vwgxyi3s0vlpdv9camw8dpi3q8piff6zxak3q";
   };
 
   buildInputs = [ boost curl openssl log4shib xercesc xml-security-c ];


### PR DESCRIPTION
###### Motivation for this change

There are a few known vulnerabilities in the current version of shibboleth-sp, opensaml-cpp, and xml-tooling-c as noted in this issue: #33875

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

