### PR TITLE
[WIP] Rust platform improvements

### DIFF
--- a/pkgs/build-support/rust/cargo-vendor.nix
+++ b/pkgs/build-support/rust/cargo-vendor.nix
@@ -2,11 +2,11 @@
 let
   inherit (stdenv) system;
 
-  version = "0.1.12";
+  version = "0.1.13";
 
   hashes = {
-    x86_64-linux = "1hxlavcxy374yypfamlkygjg662lhll8j434qcvdawkvlidg5ii5";
-    x86_64-darwin = "1jkvhh710gwjnnjx59kaplx2ncfvkx9agfa76rr94sbjqq4igddm";
+    x86_64-linux = "1znv8hm4z4bfb6kncf95jv6h20qkmz3yhhr8f4vz2wamynklm9pr";
+    x86_64-darwin = "0hcib4yli216qknjv7r2w8afakhl9yj19yyppp12c1p4pxhr1qr6";
   };
   hash = hashes. ${system} or badSystem;
 

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -48,14 +48,7 @@ in stdenv.mkDerivation (args // {
     chmod -R +w "$cargoDepsCopy"
 
     mkdir .cargo
-    cat >.cargo/config <<-EOF
-      [source.crates-io]
-      registry = 'https://github.com/rust-lang/crates.io-index'
-      replace-with = 'vendored-sources'
-
-      [source.vendored-sources]
-      directory = '$(pwd)/$cargoDepsCopy'
-    EOF
+    substitute "$cargoDeps/config" .cargo/config --subst-var-by out "$cargoDeps"
 
     unset cargoDepsCopy
 

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -21,9 +21,8 @@ stdenv.mkDerivation {
 
     export CARGO_HOME=$(mktemp -d cargo-home.XXX)
 
-    cargo vendor
-
-    cp -ar vendor $out
+    mkdir -p "$out"
+    cargo vendor "$out/sources" | sed "s|$out|@out@|g" > "$out/config"
   '';
 
   outputHashAlgo = "sha256";

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -32,7 +32,7 @@ rec {
   cargo = callPackage ./cargo.nix rec {
     version = "0.23.0";
     srcSha = "14b2n1msxma19ydchj54hd7f2zdsr524fg133dkmdn7j65f1x6aj";
-    cargoSha256 = "1sj59z0w172qvjwg1ma5fr5am9dgw27086xwdnrvlrk4hffcr7y7";
+    cargoSha256 = "0m0dvm2zpr0ca8nqxy4aqfz4gq8bljqzl5wic897ggp5gjjn1iab";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo


### PR DESCRIPTION
This enables `rustPlatform` to build crates that have dependencies specified as git repositories. Previously, the cargo config file output of `cargo vendor` was being discarded in favor of a hardcoded config, which was missing the extra sections necessary for non-crates.io dependencies to work.

Unfortunately, this breaks every single `cargoSha256` in nixpkgs, which will be a huge pain to fix. Better ideas very welcome.