### PR TITLE
geis: fix python programs

### DIFF
--- a/pkgs/development/libraries/geis/default.nix
+++ b/pkgs/development/libraries/geis/default.nix
@@ -1,14 +1,20 @@
 { stdenv, fetchurl
 , pkgconfig
-, python3
+, python3Packages
+, wrapGAppsHook
+, atk
 , dbus_libs
 , evemu
 , frame
+, gdk_pixbuf
+, gobjectIntrospection
 , grail
+, gtk3
 , libX11
 , libXext
 , libXi
 , libXtst
+, pango
 , xorgserver
 }:
 
@@ -25,8 +31,23 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-format -Wno-misleading-indentation -Wno-error";
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ python3 dbus_libs evemu frame grail libX11 libXext libXi libXtst xorgserver ];
+  pythonPath = with python3Packages;
+    [ pygobject3  ];
+
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook python3Packages.wrapPython];
+  buildInputs = [ atk dbus_libs evemu frame gdk_pixbuf gobjectIntrospection grail
+    gtk3 libX11 libXext libXi libXtst pango python3Packages.python xorgserver
+  ];
+
+  patchPhase = ''
+    substituteInPlace python/geis/geis_v2.py --replace \
+      "ctypes.util.find_library(\"geis\")" "'$out/lib/libgeis.so'"
+  '';
+
+  preFixup = ''
+    buildPythonPath "$out $pythonPath"
+    gappsWrapperArgs+=(--set PYTHONPATH "$program_PYTHONPATH")
+  '';
 
   meta = {
     description = "A library for input gesture recognition";


### PR DESCRIPTION
###### Motivation for this change

Non working python programs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also ran the only dependent program `/szhw3miyaqfxsw2lwkrsz4qdp03hd7vz-touchegg-1.1.1/bin/touchegg` successfully.