### PR TITLE
Fixed GHCJS

### DIFF
--- a/pkgs/development/compilers/ghcjs/base.nix
+++ b/pkgs/development/compilers/ghcjs/base.nix
@@ -174,6 +174,7 @@ in mkDerivation (rec {
     isGhcjs = true;
     inherit nodejs ghcjsBoot;
     socket-io = pkgs.nodePackages."socket.io";
+    haskellCompilerName = "ghcjs";
 
     # let us assume ghcjs is never actually cross compiled
     targetPrefix = "";

--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -1,5 +1,5 @@
-{ bootPkgs }:
+{ bootPkgs, cabal-install }:
 
 bootPkgs.callPackage ./base.nix {
-  inherit bootPkgs;
+  inherit bootPkgs cabal-install;
 }

--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -1,9 +1,9 @@
-{ fetchgit, fetchFromGitHub, bootPkgs }:
+{ fetchgit, fetchFromGitHub, bootPkgs, cabal-install }:
 
 bootPkgs.callPackage ./base.nix {
   version = "0.2.020170323";
 
-  inherit bootPkgs;
+  inherit bootPkgs cabal-install;
 
   ghcjsSrc = fetchFromGitHub {
     owner = "ghcjs";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -946,4 +946,7 @@ self: super: {
   # Add support for https://github.com/haskell-hvr/multi-ghc-travis.
   multi-ghc-travis = self.callPackage ../tools/haskell/multi-ghc-travis { ShellCheck = self.ShellCheck_0_4_6; };
 
+  # https://github.com/yesodweb/Shelly.hs/issues/162
+  shelly = dontCheck super.shelly;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -68,4 +68,8 @@ self: super: {
   # inline-c > 0.5.6.0 requires template-haskell >= 2.12
   inline-c = super.inline-c_0_5_6_1;
   inline-c-cpp = super.inline-c-cpp_0_1_0_0;
+
+  # Newer versions require GHC 8.2.
+  haddock-api = self.haddock-api_2_17_4;
+  haddock = self.haddock_2_17_5;
 }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, newScope, stdenv, buildPlatform, targetPlatform }:
+{ pkgs, lib, newScope, stdenv, buildPlatform, targetPlatform, cabal-install }:
 
 let
   # These are attributes in compiler and packages that don't support integer-simple.
@@ -91,10 +91,12 @@ in rec {
       selfPkgs = packages.ghcHEAD;
     };
     ghcjs = packages.ghc7103.callPackage ../development/compilers/ghcjs {
-      bootPkgs = packages.ghc821Binary;
+      bootPkgs = packages.ghc7103;
+      inherit cabal-install;
     };
     ghcjsHEAD = packages.ghc802.callPackage ../development/compilers/ghcjs/head.nix {
-      bootPkgs = packages.ghc821Binary;
+      bootPkgs = packages.ghc802;
+      inherit cabal-install;
     };
     ghcHaLVM240 = callPackage ../development/compilers/halvm/2.4.0.nix rec {
       bootPkgs = packages.ghc7103Binary;


### PR DESCRIPTION
###### Motivation for this change

- The bindists are [not currently suitable](https://github.com/NixOS/nixpkgs/issues/33815) for bootstrapping GHCJS
- GHCJS needs to be built with the GHC version it represents
- The `haddock` library in the package set depends on GHC 8.2's `Cabal` version, so needs to be downgraded.
- `ghcjsHEAD` has a library dependency on `Cabal` (< 2.0), but needs `cabal-install` (>= 2.0) as a build tool. I think the best way to satisfy this is to just pass `pkgs.cabal-install` as the tool.

We *should* fix the bindists issue, but that's orthogonal to this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

