### PR TITLE
[17.09] fix kernel modules that fail with linux-4.14

### DIFF
--- a/pkgs/misc/emulators/cdemu/vhba.nix
+++ b/pkgs/misc/emulators/cdemu/vhba.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" "INSTALL_MOD_PATH=$(out)" ];
 
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
   hardeningDisable = [ "pic" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1w3nx5cqf8z600bdlbwz7brmdb5yn233qrqvv24kbmmxhbwp7qld";
   };
 
-  buildInputs = [ pkgconfig libvirt ];
+  nativeBuildInputs = [ pkgconfig ] ++ kernel.moduleBuildDependencies;
+  buildInputs = [ libvirt ];
 
   RTE_KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";

--- a/pkgs/os-specific/linux/phc-intel/default.nix
+++ b/pkgs/os-specific/linux/phc-intel/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
     name = "phc-intel-pack-${revbump}.tar.bz2";
   };
 
-  buildInputs = [ which ];
+  nativeBuildInputs = [ which ] ++ kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     export PATH=${kmod}/sbin:$PATH
   '';
 
+  nativeBuildInputs = kernel.moduleBuildDependencies;
   buildInputs = [ kmod ];
 
   makeFlags = [

--- a/pkgs/servers/openafs-client/default.nix
+++ b/pkgs/servers/openafs-client/default.nix
@@ -3,14 +3,14 @@
 
 stdenv.mkDerivation rec {
   name = "openafs-${version}-${kernel.version}";
-  version = "1.6.21.1";
+  version = "1.6.22.1";
 
   src = fetchurl {
     url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "0nisxnfl8nllcfmi7mxj1gngkpxd4jp1wapbkhz07qwqynq9dn5f";
+    sha256 = "19nfbksw7b34jc3mxjk7cbz26zg9k5myhzpv2jf0fnmznr47jqaw";
   };
 
-  nativeBuildInputs = [ autoconf automake flex yacc perl which ];
+  nativeBuildInputs = [ autoconf automake flex yacc perl which ] ++ kernel.moduleBuildDependencies;
 
   buildInputs = [ ncurses ];
 


### PR DESCRIPTION
###### Motivation for this change

Providing a stable kernel to a stable distribution with stable kernel modules ;-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

