### PR TITLE
Fix remaining 4.14 libelf outbreak

### DIFF
--- a/pkgs/misc/emulators/cdemu/vhba.nix
+++ b/pkgs/misc/emulators/cdemu/vhba.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" "INSTALL_MOD_PATH=$(out)" ];
-  buildInputs = [ libelf ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/phc-intel/default.nix
+++ b/pkgs/os-specific/linux/phc-intel/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
     name = "phc-intel-pack-${revbump}.tar.bz2";
   };
 
-  buildInputs = [ which ];
+  nativeBuildInputs = [ which ] ++ kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     export PATH=${kmod}/sbin:$PATH
   '';
 
+  nativeBuildInputs = kernel.moduleBuildDependencies;
   buildInputs = [ kmod ];
 
   makeFlags = [

--- a/pkgs/servers/openafs-client/default.nix
+++ b/pkgs/servers/openafs-client/default.nix
@@ -3,38 +3,18 @@
 
 stdenv.mkDerivation rec {
   name = "openafs-${version}-${kernel.version}";
-  version = "1.6.21.1";
+  version = "1.6.22.1";
 
   src = fetchurl {
     url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "0nisxnfl8nllcfmi7mxj1gngkpxd4jp1wapbkhz07qwqynq9dn5f";
+    sha256 = "19nfbksw7b34jc3mxjk7cbz26zg9k5myhzpv2jf0fnmznr47jqaw";
   };
 
-  nativeBuildInputs = [ autoconf automake flex yacc perl which ];
+  nativeBuildInputs = [ autoconf automake flex yacc perl which ] ++ kernel.moduleBuildDependencies;
 
   buildInputs = [ ncurses ];
 
   hardeningDisable = [ "pic" ];
-
-  patches = [
-   (fetchpatch {
-      name = "fix-stdint-include.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=c193e5cba18273a062d4162118c7055b54f7eb5e";
-      sha256 = "1yc4gygcazwsslf6mzk1ai92as5jbsjv7212jcbb2dw83jydhc09";
-    })
-    # linux 4.14
-    (fetchpatch {
-      name = "test-for-__vfs_write-rather-than-__vfs_read.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=929e77a886fc9853ee292ba1aa52a920c454e94b";
-      sha256 = "0g4jxqzvyrjy2q7mhxc5ikhypj3ljw1wri4lipzm66crsvycp9x5";
-    })
-    # linux 4.14
-    (fetchpatch {
-      name = "use-kernel_read-kernel_write-when-__vfs-variants-are-unavailable.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=5ee516b3789d3545f3d78fb3aba2480308359945";
-      sha256 = "1vx55qb120y857mn1l00i58fj9cckschp86ch3g6hqrdc5q5bxv2";
-    })
-  ];
 
   preConfigure = ''
     ln -s "${kernel.dev}/lib/modules/"*/build $TMP/linux


### PR DESCRIPTION
###### Motivation for this change

Fixing up some remainign breakage after the 4.14 libelf dependency issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

