### PR TITLE
Qt 5: Fix debug flags

### DIFF
--- a/pkgs/development/libraries/qt-5/5.10/default.nix
+++ b/pkgs/development/libraries/qt-5/5.10/default.nix
@@ -24,7 +24,7 @@ top-level attribute to `top-level/all-packages.nix`.
   # options
   developerBuild ? false,
   decryptSslTraffic ? false,
-  debug ? null,
+  debug ? false,
 }:
 
 with stdenv.lib;

--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -33,7 +33,7 @@ existing packages here and modify it as necessary.
   # options
   developerBuild ? false,
   decryptSslTraffic ? false,
-  debug ? null,
+  debug ? false,
 }:
 
 with stdenv.lib;

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -24,7 +24,7 @@ top-level attribute to `top-level/all-packages.nix`.
   # options
   developerBuild ? false,
   decryptSslTraffic ? false,
-  debug ? null,
+  debug ? false,
 }:
 
 with stdenv.lib;

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -11,20 +11,18 @@ let
 
     qmakeFlags =
       (args.qmakeFlags or [])
-      ++ optional (debug != null)
-          (if debug then "CONFIG+=debug" else "CONFIG+=release");
+      ++ [ ("CONFIG+=" + (if debug then "debug" else "release")) ];
 
     NIX_CFLAGS_COMPILE =
-      let arg = args.NIX_CFLAGS_COMPILE or []; in
-      optional (debug == true) "-DQT_NO_DEBUG"
-      ++ (if builtins.isList arg then arg else [arg]);
+      optional (!debug) "-DQT_NO_DEBUG"
+      ++ lib.toList (args.NIX_CFLAGS_COMPILE or []);
 
     cmakeFlags =
       (args.cmakeFlags or [])
-      ++ [ "-DBUILD_TESTING=OFF" ]
-      ++ optional (debug != null)
-          (if debug then "-DCMAKE_BUILD_TYPE=Debug"
-                    else "-DCMAKE_BUILD_TYPE=Release");
+      ++ [
+        "-DBUILD_TESTING=OFF"
+        ("-DCMAKE_BUILD_TYPE=" + (if debug then "Debug" else "Release"))
+      ];
 
     enableParallelBuilding = args.enableParallelBuilding or true;
 

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -14,7 +14,10 @@ let
       ++ optional (debug != null)
           (if debug then "CONFIG+=debug" else "CONFIG+=release");
 
-    NIX_CFLAGS_COMPILE = optional (debug != null) "-DQT_NO_DEBUG";
+    NIX_CFLAGS_COMPILE =
+      let arg = args.NIX_CFLAGS_COMPILE or []; in
+      optional (debug == true) "-DQT_NO_DEBUG"
+      ++ (if builtins.isList arg then arg else [arg]);
 
     cmakeFlags =
       (args.cmakeFlags or [])


### PR DESCRIPTION
### Motivation

Setting debug flags for Qt 5-based builds incorrectly overrides `NIX_CFLAGS_COMPILE`.

Incidentally I decided that `debug` should be `true` or `false`, but never `null`. (What would that even mean?)

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

