### PR TITLE
apparmor: updating utilities to fresh python

### DIFF
--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, which
 , flex, bison
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
-, python3
+, python
 , gawk
 , perl
 , swig
@@ -53,7 +53,7 @@ let
 
     buildInputs = [
       perl
-      python3
+      python
     ];
 
     # required to build apparmor-parser
@@ -84,7 +84,7 @@ let
 
     buildInputs = [
       perl
-      python3
+      python
       libapparmor
       libapparmor.python
     ];
@@ -96,7 +96,7 @@ let
 
     postInstall = ''
       for prog in aa-audit aa-autodep aa-cleanprof aa-complain aa-disable aa-enforce aa-genprof aa-logprof aa-mergeprof aa-status aa-unconfined ; do
-        wrapProgram $out/bin/$prog --prefix PYTHONPATH : "$out/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
+        wrapProgram $out/bin/$prog --prefix PYTHONPATH : "$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
       done
 
       for prog in aa-notify ; do

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, which
 , flex, bison
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
-, python3Packages
+, python3
 , gawk
 , perl
 , swig
@@ -11,8 +11,6 @@
 }:
 
 let
-  python = python3Packages.python;
-
   apparmor-series = "2.12";
   apparmor-patchver = "0";
   apparmor-version = apparmor-series + "." + apparmor-patchver;
@@ -55,7 +53,7 @@ let
 
     buildInputs = [
       perl
-      python
+      python3
     ];
 
     # required to build apparmor-parser
@@ -86,7 +84,7 @@ let
 
     buildInputs = [
       perl
-      python
+      python3
       libapparmor
       libapparmor.python
     ];
@@ -98,7 +96,7 @@ let
 
     postInstall = ''
       for prog in aa-audit aa-autodep aa-cleanprof aa-complain aa-disable aa-enforce aa-genprof aa-logprof aa-mergeprof aa-status aa-unconfined ; do
-        wrapProgram $out/bin/$prog --prefix PYTHONPATH : "$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+        wrapProgram $out/bin/$prog --prefix PYTHONPATH : "$out/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
       done
 
       for prog in aa-notify ; do

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12499,7 +12499,7 @@ with pkgs;
 
   microcodeIntel = callPackage ../os-specific/linux/microcode/intel.nix { };
 
-  inherit (callPackages ../os-specific/linux/apparmor { })
+  inherit (callPackages ../os-specific/linux/apparmor { python = python3; })
     libapparmor apparmor-utils apparmor-bin-utils apparmor-parser apparmor-pam
     apparmor-profiles apparmor-kernel-patches;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12499,8 +12499,9 @@ with pkgs;
 
   microcodeIntel = callPackage ../os-specific/linux/microcode/intel.nix { };
 
-  inherit (callPackages ../os-specific/linux/apparmor { pythonPackages = python27Packages; swig = swig2; })
-    libapparmor apparmor-pam apparmor-parser apparmor-profiles apparmor-utils;
+  inherit (callPackages ../os-specific/linux/apparmor { })
+    libapparmor apparmor-utils apparmor-bin-utils apparmor-parser apparmor-pam
+    apparmor-profiles apparmor-kernel-patches;
 
   atop = callPackage ../os-specific/linux/atop { };
 


### PR DESCRIPTION
###### Motivation for this change
Apparmor utils are broken(I use 9ab77680b6a at the moment). For example, this is `aa-audit --help` output:

``` console
Traceback (most recent call last):
  File "/nix/store/jwc12pm1shfkp4bnp8yrf0w74xnryfn5-apparmor-utils-2.10/bin/.aa-audit-wrapped", line 17, in <module>
    import apparmor.tools
  File "/nix/store/jwc12pm1shfkp4bnp8yrf0w74xnryfn5-apparmor-utils-2.10/lib/python2.7/site-packages/apparmor/tools.py", line 17, in <module>
    import apparmor.aa as apparmor
  File "/nix/store/jwc12pm1shfkp4bnp8yrf0w74xnryfn5-apparmor-utils-2.10/lib/python2.7/site-packages/apparmor/aa.py", line 4345, in <module>
    if cfg['settings'].get('default_owner_prompt', False):
  File "/nix/store/jwc12pm1shfkp4bnp8yrf0w74xnryfn5-apparmor-utils-2.10/lib/python2.7/site-packages/apparmor/config.py", line 27, in __getitem__
    section_val = self.items(section)
  File "/nix/store/6yb5rvr6rvgvx8ylpchwz808djfw07rb-python-2.7.14/lib/python2.7/ConfigParser.py", line 642, in items
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'settings'
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/nix/store/6yb5rvr6rvgvx8ylpchwz808djfw07rb-python-2.7.14/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/nix/store/jwc12pm1shfkp4bnp8yrf0w74xnryfn5-apparmor-utils-2.10/lib/python2.7/site-packages/apparmor/aa.py", line 128, in on_exit
    debug_logger.debug('Exiting..')
AttributeError: 'NoneType' object has no attribute 'debug'
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/nix/store/6yb5rvr6rvgvx8ylpchwz808djfw07rb-python-2.7.14/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/nix/store/jwc12pm1shfkp4bnp8yrf0w74xnryfn5-apparmor-utils-2.10/lib/python2.7/site-packages/apparmor/aa.py", line 128, in on_exit
    debug_logger.debug('Exiting..')
AttributeError: 'NoneType' object has no attribute 'debug'
```

I was trying to fix them, and decided to update apparmor. Found this PR #33222, but it does not fix the tools, just made an update. Apparmor utils have moved to python 3, so I have updated the python version(python 2 is deprecated in apparmor since 2.11) and added separate derivation for `aa-exec`(it was moved to `binutils` directory inside apparmor source tree).

Mostly all tools are running successfully now, except two:
- `aa-notify` probably perl(?) complains about `ERROR: bad programe name '.aa-notify-wrapped'`, I tried to give `.aa-notify-wrapped` different name, after that it failed with `Cannot read '/var/log/kern.log'`. Probably we should have a patch so this tool could work with journald?
- `aa-remove-unknown` fails with `line 25: /lib/apparmor/rc.apparmor.functions: No such file or directory`. I have no idea what could be done to fix this.

Based my changes on staging because #33222 is based on staging, feel free to contact me for a rebase :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

