### PR TITLE
mono{48,50,54}: Fix libgdiplus path in dll config map

### DIFF
--- a/pkgs/development/compilers/mono/generic-cmake.nix
+++ b/pkgs/development/compilers/mono/generic-cmake.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   postBuild = ''
     find . -name 'config' -type f | xargs \
     sed -i -e "s@libX11.so.6@${libX11.out}/lib/libX11.so.6@g" \
-           -e "s@/.*libgdiplus.so@${libgdiplus}/lib/libgdiplus.so@g" \
+           -e 's#[^"]*libgdiplus[^"]*"#${libgdiplus}/lib/libgdiplus.so"#' \
   '';
 
   # Without this, any Mono application attempting to open an SSL connection will throw with


### PR DESCRIPTION
###### Motivation for this change

mono/xbuild can't find libgdiplus library in versions 4.8 and greater. Below is difference between versions 4.6 and above:

${mono46}/etc/mono/config:

```
<dllmap dll="gdiplus" target="/nix/store/plmc9bs7k4r6szf1sd1ivf30h2mfb44g-libgdiplus-2.10.9/lib/libgdiplus.so" os="!windows"/>
<dllmap dll="gdiplus.dll" target="/nix/store/plmc9bs7k4r6szf1sd1ivf30h2mfb44g-libgdiplus-2.10.9/lib/libgdiplus.so"  os="!windows"/>
<dllmap dll="gdi32" target="/nix/store/plmc9bs7k4r6szf1sd1ivf30h2mfb44g-libgdiplus-2.10.9/lib/libgdiplus.so" os="!windows"/>
<dllmap dll="gdi32.dll" target="/nix/store/plmc9bs7k4r6szf1sd1ivf30h2mfb44g-libgdiplus-2.10.9/lib/libgdiplus.so" os="!windows"/>
```

${mono{48,50,54}}/etc/mono/config:

```
<dllmap dll="gdiplus" target="libgdiplus.so.0" os="!windows"/>
<dllmap dll="gdiplus.dll" target="libgdiplus.so.0"  os="!windows"/>
<dllmap dll="gdi32" target="libgdiplus.so.0" os="!windows"/>
<dllmap dll="gdi32.dll" target="libgdiplus.so.0" os="!windows"/>
```

This causes the following error to be thrown:

```
Unhandled Exception:
System.TypeInitializationException: The type initializer for 'System.Drawing.GDIPlus' threw an exception. ---> System.DllNotFoundException: libgdiplus.dylib
  at (wrapper managed-to-native) System.Drawing.GDIPlus:GdiplusStartup (ulong&,System.Drawing.GdiplusStartupInput&,System.Drawing.GdiplusStartupOutput&)
  at System.Drawing.GDIPlus..cctor () [0x000b0] in <5279de5321b24f0b8e1f255c47ecc93c>:0 
   --- End of inner exception stack trace ---
  at System.Drawing.Icon.Dispose () [0x00011] in <5279de5321b24f0b8e1f255c47ecc93c>:0 
  at (wrapper remoting-invoke-with-check) System.Drawing.Icon:Dispose ()
  at System.Drawing.Icon.Finalize () [0x00000] in <5279de5321b24f0b8e1f255c47ecc93c>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.TypeInitializationException: The type initializer for 'System.Drawing.GDIPlus' threw an exception. ---> System.DllNotFoundException: libgdiplus.dylib
  at (wrapper managed-to-native) System.Drawing.GDIPlus:GdiplusStartup (ulong&,System.Drawing.GdiplusStartupInput&,System.Drawing.GdiplusStartupOutput&)
  at System.Drawing.GDIPlus..cctor () [0x000b0] in <5279de5321b24f0b8e1f255c47ecc93c>:0 
   --- End of inner exception stack trace ---
  at System.Drawing.Icon.Dispose () [0x00011] in <5279de5321b24f0b8e1f255c47ecc93c>:0 
  at (wrapper remoting-invoke-with-check) System.Drawing.Icon:Dispose ()
  at System.Drawing.Icon.Finalize () [0x00000] in <5279de5321b24f0b8e1f255c47ecc93c>:0
```


As you can see the sed doesn't work, as it is targeting the wrong string. So simply fix that. Also note **I tested that xbuild can now find the libgdiplus library**.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
