### PR TITLE
nixos/libvirtd: add qemu-img to $PATH of the daemon

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -128,6 +128,7 @@ in {
           dmidecode
           dnsmasq
           ebtables
+          cfg.qemuPackage # libvirtd requires qemu-img to manage disk images
         ]
         ++ optional vswitch.enable vswitch.package;
 


### PR DESCRIPTION
...because daemon's $PATH does not include "/run/current-system/sw/bin"

Fixes #34048 
Fixes #33246