### PR TITLE
serviio: init at 1.9

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -348,6 +348,7 @@
   ./services/misc/rippled.nix
   ./services/misc/ripple-data-api.nix
   ./services/misc/rogue.nix
+  ./services/misc/serviio.nix
   ./services/misc/siproxd.nix
   ./services/misc/snapper.nix
   ./services/misc/sonarr.nix

--- a/nixos/modules/services/misc/serviio.nix
+++ b/nixos/modules/services/misc/serviio.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.serviio;
+
+  serviioStart = pkgs.writeScript "serviio.sh" ''
+    #!${pkgs.bash}/bin/sh
+
+    SERVIIO_HOME=${pkgs.serviio}
+    
+    # Setup the classpath
+    SERVIIO_CLASS_PATH="$SERVIIO_HOME/lib/*:$SERVIIO_HOME/config"
+
+    # Setup Serviio specific properties
+    JAVA_OPTS="-Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dorg.restlet.engine.loggerFacadeClass=org.restlet.ext.slf4j.Slf4jLoggerFacade
+               -Dderby.system.home=${cfg.dataDir}/library -Dserviio.home=${cfg.dataDir} -Dffmpeg.location=${pkgs.ffmpeg}/bin/ffmpeg -Ddcraw.location=${pkgs.dcraw}/bin/dcraw"
+
+    # Execute the JVM in the foreground
+    exec ${pkgs.jre}/bin/java -Xmx512M -Xms20M -XX:+UseG1GC -XX:GCTimeRatio=1 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 $JAVA_OPTS -classpath "$SERVIIO_CLASS_PATH" org.serviio.MediaServer "$@"
+  '';
+  
+in {
+
+  ###### interface
+  options = {
+    services.serviio = {
+      
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable the Serviio Media Server.
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/serviio";
+        description = ''
+          The directory where serviio stores its state, data, etc.
+        '';
+      };
+
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    systemd.services.serviio = {
+      description = "Serviio Media Server";
+      after = [ "local-fs.target" "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.serviio ];
+      serviceConfig = {
+        User = "serviio";
+        Group = "serviio";
+        ExecStart = "${serviioStart}";
+        ExecStop = "${serviioStart} -stop";
+      };
+    };
+
+    users.extraUsers = [
+      { 
+        name = "serviio";
+        group = "serviio";
+        home = cfg.dataDir;
+        description = "Serviio Media Server User";
+        createHome = true;
+        isSystemUser = true;
+      }
+    ];
+
+    users.extraGroups = [
+      { name = "serviio";} 
+    ];
+
+    networking.firewall = {
+      allowedTCPPorts = [ 
+        8895  # serve UPnP responses
+        23423 # console
+        23424 # mediabrowser
+      ];
+      allowedUDPPorts = [ 
+        1900 # UPnP service discovey
+      ];
+    };
+  };
+}

--- a/pkgs/servers/serviio/default.nix
+++ b/pkgs/servers/serviio/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "serviio-${version}";
+  version = "1.9";
+
+  src = fetchurl {
+    url = "http://download.serviio.org/releases/${name}-linux.tar.gz";
+    sha256 = "0vi9dwpdrk087gpi0xib0hwpvdmaf9g99nfdfx2r3wmmdzw7wysl";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R config legal lib library plugins LICENCE.txt NOTICE.txt README.txt RELEASE_NOTES.txt $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://serviio.org;
+    description = "UPnP Media Streaming Server";
+    longDescription = ''
+      Serviio is a free media server. It allows you to stream your media files (music, video or images)
+      to any DLNA-certified renderer device (e.g. a TV set, Bluray player, games console) on your home network.
+    '';
+    license = licenses.free;
+    maintainers = [ maintainers.thpham ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/serviio/default.nix
+++ b/pkgs/servers/serviio/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       Serviio is a free media server. It allows you to stream your media files (music, video or images)
       to any DLNA-certified renderer device (e.g. a TV set, Bluray player, games console) on your home network.
     '';
-    license = licenses.free;
+    license = licenses.unfree;
     maintainers = [ maintainers.thpham ];
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20066,6 +20066,8 @@ with pkgs;
 
   seafile-shared = callPackage ../misc/seafile-shared { };
 
+  serviio = callPackage ../servers/serviio {};
+
   slock = callPackage ../misc/screensavers/slock {
     conf = config.slock.conf or null;
   };


### PR DESCRIPTION
###### Motivation for this change

Serviio is a free media server. It allows you to stream your media files (music, video or images) to any DLNA-certified renderer device (e.g. a TV set, Bluray player, games console) on your home network.

###### Things done

- package + nixos option
- tested with NixOps on a virtualbox machine.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

