### PR TITLE
mattermost: 4.4.1 -> 4.6.0

### DIFF
--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -2,18 +2,18 @@
 
 buildGoPackage rec {
   name = "mattermost-${version}";
-  version = "4.4.1";
+  version = "4.6.0";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mattermost-server";
     rev = "v${version}";
-    sha256 = "0imda96wgr2nkkxs2jfcqszx1fqgmbbrh7zqmgjh6ks3an1v4m3c";
+    sha256 = "158sfbg19sp165iavjwwfxx9s4y116yc5h3plsmvlxpdv674k7v3";
   };
 
   webApp = fetchurl {
     url = "https://releases.mattermost.com/${version}/mattermost-team-${version}-linux-amd64.tar.gz";
-    sha256 = "1gnzv9xkqawi36z7v9xsy1gk16x71qf0kn8r059qvyarjlyp7888";
+    sha256 = "1rbpl6zfmhfgzz2i1q2ym51ll6j54gk5p6ca99v9kjlm4ipcq9mv";
   };
 
   goPackagePath = "github.com/mattermost/mattermost-server";


### PR DESCRIPTION
On NixOS, I've built this; and tested the service works for the deployment I manage.