### PR TITLE
nixos/ckb: Add option to restrict access to the devices to a particu...

### DIFF
--- a/nixos/modules/hardware/ckb.nix
+++ b/nixos/modules/hardware/ckb.nix
@@ -10,6 +10,15 @@ in
     options.hardware.ckb = {
       enable = mkEnableOption "the Corsair keyboard/mouse driver";
 
+      gid = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 100;
+        description = ''
+          Limit access to the ckb daemon to a particular group.
+        '';
+      };
+
       package = mkOption {
         type = types.package;
         default = pkgs.ckb;
@@ -26,7 +35,7 @@ in
       systemd.services.ckb = {
         description = "Corsair Keyboard Daemon";
         wantedBy = ["multi-user.target"];
-        script = "${cfg.package}/bin/ckb-daemon";
+        script = "${cfg.package}/bin/ckb-daemon${optionalString (cfg.gid != null) " --gid=${builtins.toString cfg.gid}"}";
         serviceConfig = {
           Restart = "always";
           StandardOutput = "syslog";


### PR DESCRIPTION
…ar group

###### Motivation for this change

By default, the ckb daemon allows acces to its controlling socket to any process (chmod 666), which is kinda crazy. This PR allows to restrict access to a unix group.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

