### PR TITLE
pypy3: init at 6.0.0

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -484,10 +484,12 @@ and in this case the `python35` interpreter is automatically used.
 ### Interpreters
 
 Versions 2.7, 3.5, 3.6 and 3.7 of the CPython interpreter are available as
-respectively `python27`, `python35`, `python36`, and `python37`. The PyPy
-interpreter is available as `pypy`. The aliases `python2` and `python3`
-correspond to respectively `python27` and `python37`. The default interpreter,
-`python`, maps to `python2`. The Nix expressions for the interpreters can be
+respectively `python27`, `python35`, `python36` and `python37`. The aliases
+`python2` and `python3` correspond to respectively `python27` and
+`python37`. The default interpreter, `python`, maps to `python2`. The PyPy
+interpreters compatible with Python 2.7 and 3 are available as `pypy27` and
+`pypy3`, with aliases `pypy2` mapping to `pypy27` and `pypy` mapping to
+`pypy2`. The Nix expressions for the interpreters can be
 found in `pkgs/development/interpreters/python`.
 
 All packages depending on any Python interpreter get appended

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -256,6 +256,11 @@
     github = "AndrewMorsillo";
     name = "Andrew Morsillo";
   };
+  andersk = {
+    email = "andersk@mit.edu";
+    github = "andersk";
+    name = "Anders Kaseorg";
+  };
   AndersonTorres = {
     email = "torres.anderson.85@protonmail.com";
     github = "AndersonTorres";

--- a/pkgs/development/interpreters/python/pypy/3/default.nix
+++ b/pkgs/development/interpreters/python/pypy/3/default.nix
@@ -1,0 +1,138 @@
+{ stdenv, substituteAll, fetchurl
+, zlib ? null, zlibSupport ? true, bzip2, pkgconfig, libffi
+, sqlite, openssl, ncurses, python, expat, tcl, tk, tix, xlibsWrapper, libX11
+, makeWrapper, callPackage, self, gdbm, db, lzma
+, python-setup-hook
+# For the Python package set
+, packageOverrides ? (self: super: {})
+}:
+
+assert zlibSupport -> zlib != null;
+
+let
+  version = "6.0.0";
+  pythonVersion = "3.5";
+  libPrefix = "pypy${pythonVersion}";
+  sitePackages = "site-packages";
+
+  pythonForPypy = python.withPackages (ppkgs: [ ppkgs.pycparser ]);
+
+in stdenv.mkDerivation rec {
+  name = "pypy3-${version}";
+  inherit version pythonVersion;
+
+  src = fetchurl {
+    url = "https://bitbucket.org/pypy/pypy/get/release-pypy${pythonVersion}-v${version}.tar.bz2";
+    sha256 = "0lwq8nn0r5yj01bwmkk5p7xvvrp4s550l8184mkmn74d3gphrlwg";
+  };
+
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  buildInputs = [
+    bzip2 openssl pythonForPypy libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 gdbm db lzma
+  ] ++ stdenv.lib.optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc
+    ++ stdenv.lib.optional zlibSupport zlib;
+
+  hardeningDisable = stdenv.lib.optional stdenv.isi686 "pic";
+
+  C_INCLUDE_PATH = stdenv.lib.makeSearchPathOutput "dev" "include" buildInputs;
+  LIBRARY_PATH = stdenv.lib.makeLibraryPath buildInputs;
+  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath (stdenv.lib.filter (x : x.outPath != stdenv.cc.libc.outPath or "") buildInputs);
+
+  patches = [
+    (substituteAll {
+      src = ./tk_tcl_paths.patch;
+      inherit tk tcl;
+      tk_dev = tk.dev;
+      tcl_dev = tcl;
+      tk_libprefix = tk.libPrefix;
+      tcl_libprefix = tcl.libPrefix;
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace "lib-python/3/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
+
+    # hint pypy to find nix ncurses
+    substituteInPlace pypy/module/_minimal_curses/fficurses.py \
+      --replace "/usr/include/ncurses/curses.h" "${ncurses.dev}/include/curses.h" \
+      --replace "ncurses/curses.h" "${ncurses.dev}/include/curses.h" \
+      --replace "ncurses/term.h" "${ncurses.dev}/include/term.h" \
+      --replace "libraries=['curses']" "libraries=['ncurses']"
+
+    sed -i "s@libraries=\['sqlite3'\]\$@libraries=['sqlite3'], include_dirs=['${sqlite.dev}/include'], library_dirs=['${sqlite.out}/lib']@" lib_pypy/_sqlite3_build.py
+  '';
+
+  buildPhase = ''
+    ${pythonForPypy.interpreter} rpython/bin/rpython \
+      --make-jobs="$NIX_BUILD_CORES" \
+      -Ojit \
+      --batch pypy/goal/targetpypystandalone.py
+  '';
+
+  setupHook = python-setup-hook sitePackages;
+
+  doCheck = true;
+  checkPhase = ''
+    export TERMINFO="${ncurses.out}/share/terminfo/";
+    export TERM="xterm";
+    export HOME="$TMPDIR";
+    # disable asyncio due to https://github.com/NixOS/nix/issues/1238
+    # disable os due to https://github.com/NixOS/nixpkgs/issues/10496
+    # disable pathlib due to https://bitbucket.org/pypy/pypy/pull-requests/594
+    # disable shutils because it assumes gid 0 exists
+    # disable socket because it has two actual network tests that fail
+    # disable tarfile because it assumes gid 0 exists
+    ${pythonForPypy.interpreter} ./pypy/test_all.py --pypy=./pypy3-c -k 'not ( test_asyncio or test_os or test_pathlib or test_shutil or test_socket or test_tarfile )' lib-python
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,include,lib,pypy3-c}
+
+    cp -R {include,lib_pypy,lib-python,pypy3-c} $out/pypy3-c
+    cp libpypy3-c.so $out/lib/
+    ln -s $out/pypy3-c/pypy3-c $out/bin/pypy3
+
+    # other packages expect to find stuff according to libPrefix
+    ln -s $out/pypy3-c/include $out/include/${libPrefix}
+    ln -s $out/pypy3-c/lib-python/3 $out/lib/${libPrefix}
+
+    # We must wrap the original, not the symlink.
+    # PyPy uses argv[0] to find its standard library, and while it knows
+    # how to follow symlinks, it doesn't know about wrappers. So, it
+    # will think the wrapper is the original. As long as the wrapper has
+    # the same path as the original, this is OK.
+    wrapProgram "$out/pypy3-c/pypy3-c" \
+      --set LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:$out/lib" \
+      --set LIBRARY_PATH "${LIBRARY_PATH}:$out/lib"
+
+    # verify cffi modules
+    $out/bin/pypy3 -c "import tkinter;import sqlite3;import curses;import lzma"
+
+    # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
+    echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
+  '';
+
+  passthru = let
+    pythonPackages = callPackage ../../../../../top-level/python-packages.nix {python=self; overrides=packageOverrides;};
+  in rec {
+    inherit zlibSupport libPrefix sitePackages;
+    executable = "pypy3";
+    isPypy = true;
+    isPy3 = true;
+    isPy35 = true;
+    buildEnv = callPackage ../../wrapper.nix { python = self; inherit (pythonPackages) requiredPythonModules; };
+    interpreter = "${self}/bin/${executable}";
+    withPackages = import ../../with-packages.nix { inherit buildEnv pythonPackages;};
+    pkgs = pythonPackages;
+  };
+
+  enableParallelBuilding = true;  # almost no parallelization without STM
+
+  meta = with stdenv.lib; {
+    homepage = http://pypy.org/;
+    description = "Fast, compliant alternative implementation of the Python language (3.5.3)";
+    license = licenses.mit;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ andersk ];
+  };
+}

--- a/pkgs/development/interpreters/python/pypy/3/tk_tcl_paths.patch
+++ b/pkgs/development/interpreters/python/pypy/3/tk_tcl_paths.patch
@@ -1,0 +1,17 @@
+--- pypy-pypy-84a2f3e6a7f8.org/lib_pypy/_tkinter/tklib_build.py	2017-10-03 11:49:20.000000000 +0100
++++ pypy-pypy-84a2f3e6a7f8/lib_pypy/_tkinter/tklib_build.py	2017-11-21 13:20:51.398607530 +0000
+@@ -24,11 +24,11 @@
+ else:
+     # On some Linux distributions, the tcl and tk libraries are
+     # stored in /usr/include, so we must check this case also
+-    libdirs = []
++    libdirs = ["@tcl@/lib", "@tk@/lib"]
+     found = False
+     for _ver in ['', '8.6', '8.5']:
+-        incdirs = ['/usr/include/tcl' + _ver]
+-        linklibs = ['tcl' + _ver, 'tk' + _ver]
++        incdirs = ['@tcl_dev@/include', '@tk_dev@/include']
++        linklibs = ['@tcl_libprefix@', '@tk_libprefix@']
+         if os.path.isdir(incdirs[0]):
+             found = True
+             break

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7950,7 +7950,8 @@ in
   python = python2;
   python2 = python27;
   python3 = python37;
-  pypy = pypy27;
+  pypy = pypy2;
+  pypy2 = pypy27;
 
   # Python interpreter that is build with all modules, including tkinter.
   # These are for compatibility and should not be used inside Nixpkgs.
@@ -7989,6 +7990,11 @@ in
     python = python27.override{x11Support=true;};
     db = db.override { dbmSupport = true; };
   };
+  pypy3 = callPackage ../development/interpreters/python/pypy/3 {
+    self = pypy3;
+    python = python27;
+    db = db.override { dbmSupport = true; };
+  };
 
   # Python package sets.
   python27Packages = lib.hiPrioSet (recurseIntoAttrs python27.pkgs);
@@ -7996,6 +8002,9 @@ in
   python36Packages = python36.pkgs;
   python37Packages = recurseIntoAttrs python37.pkgs;
   pypyPackages = pypy.pkgs;
+  pypy2Packages = pypy2.pkgs;
+  pypy27Packages = pypy27.pkgs;
+  pypy3Packages = pypy3.pkgs;
 
   update-python-libraries = callPackage ../development/interpreters/python/update-python-libraries { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26,7 +26,7 @@ let
   isPy35 = python.pythonVersion == "3.5";
   isPy36 = python.pythonVersion == "3.6";
   isPy37 = python.pythonVersion == "3.7";
-  isPyPy = python.executable == "pypy";
+  isPyPy = strings.substring 0 4 python.executable == "pypy";
   isPy3k = strings.substring 0 1 python.pythonVersion == "3";
 
   callPackage = pkgs.newScope self;


### PR DESCRIPTION
###### Motivation for this change

Here’s a first draft of a `pypy3` package, mostly copied from the existing `pypy27`. Before merging, I want to address the following known issues/questions:

- Should I set the maintainer to myself, to @domenkozar who maintains the `pypy27` package I mostly copied, or both?
- Should we make an effort to share common packaging code between `pypy27` and `pypy3`?
- How should we resolve the inconsistency between `pypy27`’s `libPrefix = "pypy5.10"` vs. `pypy3`’s `libPrefix = "pypy3-5.10"`? Should we change the former to `"pypy-5.10"` or `"pypy27-5.10"` or `"pypy2.7-5.10"`?
- Which of the `isPy*` flags should be set by `pypy3`? Should we set none of the existing ones and make a new `isPypy3` flag? Or should we redefine `isPypy` for use by both `pypy27` and `pypy3`, and have `pypy27` set {`isPy2`, `isPy27`, `isPypy`} while `pypy3` sets {`isPy3`, `isPy35`, `isPypy`}?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
