### PR TITLE
gnuclad: init at 0.2.4

### DIFF
--- a/pkgs/applications/graphics/gnuclad/default.nix
+++ b/pkgs/applications/graphics/gnuclad/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  name = "gnuclad";
+  version = "0.2.4";
+
+  src = fetchurl {
+    url = "https://launchpad.net/gnuclad/trunk/0.2/+download/${name}-${version}.tar.gz";
+    sha256 = "0ka2kscpjff7gflsargv3r9fdaxhkf3nym9mfaln3pnq6q7fwdki";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  meta = with stdenv.lib; {
+    homepage = https://launchpad.net/gnuclad;
+    description = "gnuclad tries to help the environment by creating trees.  It's primary use will be generating cladogram trees for the GNU/Linux distro timeline project.";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ mog ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2371,6 +2371,8 @@ with pkgs;
 
   gnu-cobol = callPackage ../development/compilers/gnu-cobol { };
 
+  gnuclad = callPackage ../applications/graphics/gnuclad { };
+
   gnufdisk = callPackage ../tools/system/fdisk {
     guile = guile_1_8;
   };


### PR DESCRIPTION
###### Motivation for this change
Nifty tool to make graphs of trees like https://github.com/jeffmaury/gldt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

