### PR TITLE
perf: apply patch to fix 4.9 build when inheriting kernel make flags

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf-tools-fix-build-with-arch-x86_64.patch
+++ b/pkgs/os-specific/linux/kernel/perf-tools-fix-build-with-arch-x86_64.patch
@@ -1,0 +1,255 @@
+From bfb560d4184c5371f0628c2473eacfb9b4ee8519 Mon Sep 17 00:00:00 2001
+From: Jiada Wang <jiada_wang@mentor.com>
+Date: Sun, 9 Apr 2017 20:02:37 -0700
+Subject: [PATCH] perf tools: Fix build with ARCH=x86_64
+
+With commit: 0a943cb10ce78 (tools build: Add HOSTARCH Makefile variable)
+when building for ARCH=x86_64, ARCH=x86_64 is passed to perf instead of
+ARCH=x86, so the perf build process searchs header files from
+tools/arch/x86_64/include, which doesn't exist.
+
+The following build failure is seen:
+
+  In file included from util/event.c:2:0:
+    tools/include/uapi/linux/mman.h:4:27: fatal error: uapi/asm/mman.h: No such file or directory
+    compilation terminated.
+
+Fix this issue by using SRCARCH instead of ARCH in perf, just like the
+main kernel Makefile and tools/objtool's.
+
+Signed-off-by: Jiada Wang <jiada_wang@mentor.com>
+Tested-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+Acked-by: Jiri Olsa <jolsa@kernel.org>
+Cc: Alexander Shishkin <alexander.shishkin@linux.intel.com>
+Cc: Andi Kleen <ak@linux.intel.com>
+Cc: Eugeniu Rosca <erosca@de.adit-jv.com>
+Cc: Jan Stancek <jstancek@redhat.com>
+Cc: Masami Hiramatsu <mhiramat@kernel.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Ravi Bangoria <ravi.bangoria@linux.vnet.ibm.com>
+Cc: Rui Teng <rui.teng@linux.vnet.ibm.com>
+Cc: Sukadev Bhattiprolu <sukadev@linux.vnet.ibm.com>
+Cc: Wang Nan <wangnan0@huawei.com>
+Fixes: 0a943cb10ce7 ("tools build: Add HOSTARCH Makefile variable")
+Link: http://lkml.kernel.org/r/1491793357-14977-2-git-send-email-jiada_wang@mentor.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/Makefile.config  | 38 +++++++++++++++++++-------------------
+ tools/perf/Makefile.perf    |  2 +-
+ tools/perf/arch/Build       |  2 +-
+ tools/perf/pmu-events/Build |  4 ++--
+ tools/perf/tests/Build      |  2 +-
+ tools/perf/util/header.c    |  2 +-
+ 6 files changed, 25 insertions(+), 25 deletions(-)
+
+diff --git a/tools/perf/Makefile.config b/tools/perf/Makefile.config
+index cffdd9cf3ebf..ff375310efe4 100644
+--- a/tools/perf/Makefile.config
++++ b/tools/perf/Makefile.config
+@@ -19,18 +19,18 @@ CFLAGS := $(EXTRA_CFLAGS) $(EXTRA_WARNINGS)
+ 
+ include $(srctree)/tools/scripts/Makefile.arch
+ 
+-$(call detected_var,ARCH)
++$(call detected_var,SRCARCH)
+ 
+ NO_PERF_REGS := 1
+ 
+ # Additional ARCH settings for ppc
+-ifeq ($(ARCH),powerpc)
++ifeq ($(SRCARCH),powerpc)
+   NO_PERF_REGS := 0
+   LIBUNWIND_LIBS := -lunwind -lunwind-ppc64
+ endif
+ 
+ # Additional ARCH settings for x86
+-ifeq ($(ARCH),x86)
++ifeq ($(SRCARCH),x86)
+   $(call detected,CONFIG_X86)
+   ifeq (${IS_64_BIT}, 1)
+     CFLAGS += -DHAVE_ARCH_X86_64_SUPPORT -DHAVE_SYSCALL_TABLE -I$(OUTPUT)arch/x86/include/generated
+@@ -43,12 +43,12 @@ ifeq ($(ARCH),x86)
+   NO_PERF_REGS := 0
+ endif
+ 
+-ifeq ($(ARCH),arm)
++ifeq ($(SRCARCH),arm)
+   NO_PERF_REGS := 0
+   LIBUNWIND_LIBS = -lunwind -lunwind-arm
+ endif
+ 
+-ifeq ($(ARCH),arm64)
++ifeq ($(SRCARCH),arm64)
+   NO_PERF_REGS := 0
+   LIBUNWIND_LIBS = -lunwind -lunwind-aarch64
+ endif
+@@ -61,7 +61,7 @@ endif
+ # Disable it on all other architectures in case libdw unwind
+ # support is detected in system. Add supported architectures
+ # to the check.
+-ifneq ($(ARCH),$(filter $(ARCH),x86 arm))
++ifneq ($(SRCARCH),$(filter $(SRCARCH),x86 arm))
+   NO_LIBDW_DWARF_UNWIND := 1
+ endif
+ 
+@@ -115,9 +115,9 @@ endif
+ FEATURE_CHECK_CFLAGS-libbabeltrace := $(LIBBABELTRACE_CFLAGS)
+ FEATURE_CHECK_LDFLAGS-libbabeltrace := $(LIBBABELTRACE_LDFLAGS) -lbabeltrace-ctf
+ 
+-FEATURE_CHECK_CFLAGS-bpf = -I. -I$(srctree)/tools/include -I$(srctree)/tools/arch/$(ARCH)/include/uapi -I$(srctree)/tools/include/uapi
++FEATURE_CHECK_CFLAGS-bpf = -I. -I$(srctree)/tools/include -I$(srctree)/tools/arch/$(SRCARCH)/include/uapi -I$(srctree)/tools/include/uapi
+ # include ARCH specific config
+--include $(src-perf)/arch/$(ARCH)/Makefile
++-include $(src-perf)/arch/$(SRCARCH)/Makefile
+ 
+ ifdef PERF_HAVE_ARCH_REGS_QUERY_REGISTER_OFFSET
+   CFLAGS += -DHAVE_ARCH_REGS_QUERY_REGISTER_OFFSET
+@@ -205,12 +205,12 @@ ifeq ($(DEBUG),0)
+ endif
+ 
+ CFLAGS += -I$(src-perf)/util/include
+-CFLAGS += -I$(src-perf)/arch/$(ARCH)/include
++CFLAGS += -I$(src-perf)/arch/$(SRCARCH)/include
+ CFLAGS += -I$(srctree)/tools/include/uapi
+ CFLAGS += -I$(srctree)/tools/include/
+-CFLAGS += -I$(srctree)/tools/arch/$(ARCH)/include/uapi
+-CFLAGS += -I$(srctree)/tools/arch/$(ARCH)/include/
+-CFLAGS += -I$(srctree)/tools/arch/$(ARCH)/
++CFLAGS += -I$(srctree)/tools/arch/$(SRCARCH)/include/uapi
++CFLAGS += -I$(srctree)/tools/arch/$(SRCARCH)/include/
++CFLAGS += -I$(srctree)/tools/arch/$(SRCARCH)/
+ 
+ # $(obj-perf)      for generated common-cmds.h
+ # $(obj-perf)/util for generated bison/flex headers
+@@ -321,7 +321,7 @@ ifndef NO_LIBELF
+ 
+   ifndef NO_DWARF
+     ifeq ($(origin PERF_HAVE_DWARF_REGS), undefined)
+-      msg := $(warning DWARF register mappings have not been defined for architecture $(ARCH), DWARF support disabled);
++      msg := $(warning DWARF register mappings have not been defined for architecture $(SRCARCH), DWARF support disabled);
+       NO_DWARF := 1
+     else
+       CFLAGS += -DHAVE_DWARF_SUPPORT $(LIBDW_CFLAGS)
+@@ -346,7 +346,7 @@ ifndef NO_LIBELF
+         CFLAGS += -DHAVE_BPF_PROLOGUE
+         $(call detected,CONFIG_BPF_PROLOGUE)
+       else
+-        msg := $(warning BPF prologue is not supported by architecture $(ARCH), missing regs_query_register_offset());
++        msg := $(warning BPF prologue is not supported by architecture $(SRCARCH), missing regs_query_register_offset());
+       endif
+     else
+       msg := $(warning DWARF support is off, BPF prologue is disabled);
+@@ -372,7 +372,7 @@ ifdef PERF_HAVE_JITDUMP
+   endif
+ endif
+ 
+-ifeq ($(ARCH),powerpc)
++ifeq ($(SRCARCH),powerpc)
+   ifndef NO_DWARF
+     CFLAGS += -DHAVE_SKIP_CALLCHAIN_IDX
+   endif
+@@ -453,7 +453,7 @@ else
+ endif
+ 
+ ifndef NO_LOCAL_LIBUNWIND
+-  ifeq ($(ARCH),$(filter $(ARCH),arm arm64))
++  ifeq ($(SRCARCH),$(filter $(SRCARCH),arm arm64))
+     $(call feature_check,libunwind-debug-frame)
+     ifneq ($(feature-libunwind-debug-frame), 1)
+       msg := $(warning No debug_frame support found in libunwind);
+@@ -717,7 +717,7 @@ ifeq (${IS_64_BIT}, 1)
+       NO_PERF_READ_VDSO32 := 1
+     endif
+   endif
+-  ifneq ($(ARCH), x86)
++  ifneq ($(SRCARCH), x86)
+     NO_PERF_READ_VDSOX32 := 1
+   endif
+   ifndef NO_PERF_READ_VDSOX32
+@@ -746,7 +746,7 @@ ifdef LIBBABELTRACE
+ endif
+ 
+ ifndef NO_AUXTRACE
+-  ifeq ($(ARCH),x86)
++  ifeq ($(SRCARCH),x86)
+     ifeq ($(feature-get_cpuid), 0)
+       msg := $(warning Your gcc lacks the __get_cpuid() builtin, disables support for auxtrace/Intel PT, please install a newer gcc);
+       NO_AUXTRACE := 1
+@@ -793,7 +793,7 @@ sysconfdir = $(prefix)/etc
+ ETC_PERFCONFIG = etc/perfconfig
+ endif
+ ifndef lib
+-ifeq ($(ARCH)$(IS_64_BIT), x861)
++ifeq ($(SRCARCH)$(IS_64_BIT), x861)
+ lib = lib64
+ else
+ lib = lib
+diff --git a/tools/perf/Makefile.perf b/tools/perf/Makefile.perf
+index ef52d1e3d431..2b92ffef554b 100644
+--- a/tools/perf/Makefile.perf
++++ b/tools/perf/Makefile.perf
+@@ -192,7 +192,7 @@ endif
+ 
+ ifeq ($(config),0)
+ include $(srctree)/tools/scripts/Makefile.arch
+--include arch/$(ARCH)/Makefile
++-include arch/$(SRCARCH)/Makefile
+ endif
+ 
+ # The FEATURE_DUMP_EXPORT holds location of the actual
+diff --git a/tools/perf/arch/Build b/tools/perf/arch/Build
+index 109eb75cf7de..d9b6af837c7d 100644
+--- a/tools/perf/arch/Build
++++ b/tools/perf/arch/Build
+@@ -1,2 +1,2 @@
+ libperf-y += common.o
+-libperf-y += $(ARCH)/
++libperf-y += $(SRCARCH)/
+diff --git a/tools/perf/pmu-events/Build b/tools/perf/pmu-events/Build
+index 9213a1273697..999a4e878162 100644
+--- a/tools/perf/pmu-events/Build
++++ b/tools/perf/pmu-events/Build
+@@ -2,7 +2,7 @@ hostprogs := jevents
+ 
+ jevents-y	+= json.o jsmn.o jevents.o
+ pmu-events-y	+= pmu-events.o
+-JDIR		=  pmu-events/arch/$(ARCH)
++JDIR		=  pmu-events/arch/$(SRCARCH)
+ JSON		=  $(shell [ -d $(JDIR) ] &&				\
+ 			find $(JDIR) -name '*.json' -o -name 'mapfile.csv')
+ #
+@@ -10,4 +10,4 @@ JSON		=  $(shell [ -d $(JDIR) ] &&				\
+ # directory and create tables in pmu-events.c.
+ #
+ $(OUTPUT)pmu-events/pmu-events.c: $(JSON) $(JEVENTS)
+-	$(Q)$(call echo-cmd,gen)$(JEVENTS) $(ARCH) pmu-events/arch $(OUTPUT)pmu-events/pmu-events.c $(V)
++	$(Q)$(call echo-cmd,gen)$(JEVENTS) $(SRCARCH) pmu-events/arch $(OUTPUT)pmu-events/pmu-events.c $(V)
+diff --git a/tools/perf/tests/Build b/tools/perf/tests/Build
+index 8a4ce492f7b2..546250a273e7 100644
+--- a/tools/perf/tests/Build
++++ b/tools/perf/tests/Build
+@@ -71,7 +71,7 @@ $(OUTPUT)tests/llvm-src-relocation.c: tests/bpf-script-test-relocation.c tests/B
+ 	$(Q)sed -e 's/"/\\"/g' -e 's/\(.*\)/"\1\\n"/g' $< >> $@
+ 	$(Q)echo ';' >> $@
+ 
+-ifeq ($(ARCH),$(filter $(ARCH),x86 arm arm64 powerpc))
++ifeq ($(SRCARCH),$(filter $(SRCARCH),x86 arm arm64 powerpc))
+ perf-$(CONFIG_DWARF_UNWIND) += dwarf-unwind.o
+ endif
+ 
+diff --git a/tools/perf/util/header.c b/tools/perf/util/header.c
+index 5337f49db361..28bdb48357f0 100644
+--- a/tools/perf/util/header.c
++++ b/tools/perf/util/header.c
+@@ -826,7 +826,7 @@ static int write_group_desc(int fd, struct perf_header *h __maybe_unused,
+ 
+ /*
+  * default get_cpuid(): nothing gets recorded
+- * actual implementation must be in arch/$(ARCH)/util/header.c
++ * actual implementation must be in arch/$(SRCARCH)/util/header.c
+  */
+ int __weak get_cpuid(char *buffer __maybe_unused, size_t sz __maybe_unused)
+ {
+-- 
+2.15.1
+

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -11,7 +11,7 @@ assert versionAtLeast kernel.version "3.12";
 stdenv.mkDerivation {
   name = "perf-linux-${kernel.version}";
 
-  inherit (kernel) src;
+  inherit (kernel) src makeFlags;
 
   preConfigure = ''
     cd tools/perf
@@ -38,10 +38,6 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optionals (hasPrefix "gcc-6" stdenv.cc.cc.name) [
       "-Wno-error=unused-const-variable" "-Wno-error=misleading-indentation"
     ];
-
-  makeFlags = if stdenv.hostPlatform == stdenv.buildPlatform
-    then null
-    else "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
 
   installFlags = "install install-man ASCIIDOC8=1";
 

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -50,6 +50,9 @@ stdenv.mkDerivation {
       --prefix PATH : "${binutils}/bin"
   '';
 
+
+  patches = optional (hasPrefix "4.9" kernel.version) [ ./perf-tools-fix-build-with-arch-x86_64.patch ];
+
   meta = {
     homepage = https://perf.wiki.kernel.org/;
     description = "Linux tools to profile with performance counters";


### PR DESCRIPTION
###### Motivation for this change

This PR adds a patch for the 4.9 kernel which [fixes the perf build when the `ARCH=x86_64` flag](https://lkml.org/lkml/2017/6/16/696) is passed to make. This bug was introduced in 4.8 and fixed in 4.12. I backported the fix to 4.9 and conditionally applied it to 4.9 only.

This issue was triggered by my patch which inherited `makeFlags` from the kernel derivation (which includes `ARCH`). The reason I wanted to do this was because it reduces unnecessary code duplication and should help with cross compilation (although this cannot be tested yet because some dependencies fail).

IMO, applying this patch is the best way of fixing this bug, because it actually fixes the problem rather than working around it. Alternatively, we could exclude the `ARCH` flag from `makeFlags` for 4.9, or we could just forget about this issue until cross compilation actually becomes possible.

This patch could possibly be accepted to the 4.9 upstream stable branch, if someone were willing to submit it to the mailing list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

