### PR TITLE
phantomjs2: set QT_QPA_PLATFORM to allow use in daemons

### DIFF
--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -105,6 +105,7 @@ in stdenv.mkDerivation rec {
     $out/bin/phantomjs
   '' + ''
     wrapProgram $out/bin/phantomjs \
+    --set QT_QPA_PLATFORM offscreen \
     --prefix PATH : ${stdenv.lib.makeBinPath [ qtbase ]}
   '';
 


### PR DESCRIPTION
resolves issues with Grafana alert image attachments

Suggested in https://github.com/ariya/phantomjs/issues/15217#issuecomment-354713760

Grafana logs showed this:
```
Jan 19 22:20:42 elastomer grafana-server[3418]: QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-grafana'
Jan 19 22:20:42 elastomer grafana-server[3418]: qt.qpa.screen: QXcbConnection: Could not connect to display
Jan 19 22:20:42 elastomer grafana-server[3418]: Could not connect to any X display.
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

