### PR TITLE
 firefox-bin: 57.0.4 -> 58.0,  firefox-esr: 52.5.3esr -> 52.6.0esr 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,955 +1,965 @@
 {
-  version = "57.0.4";
+  version = "58.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ach/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ach/firefox-58.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "44b5cd0112f6d6a8577b831b55bff2df34ed86e7ba6e16f54d2ec8a738453b27fcd4cb0d2f1c6d64ebdf9492ab2d0dedf15e3a50c16eb1701e24ed7293708ae9";
+      sha512 = "746d50340fff7a198db8430a4fe927a81ebb5fa2527150c78612bd62225133aa06f7dfb657c439d7c2143eb3f3a3d5a0b7edbc019d3fc8337ab268f18c0ae65b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/af/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/af/firefox-58.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "734b6f164ec97e366f5e747c2bdd104f48c33d39f4467438da9eb9483d285688040cd508e864d9e451a9cae3907b4cbf0738489c3697ea38dfbf5d8186b85068";
+      sha512 = "fd09ccaf68d21cd299db1d86ee034db8f6ef81b763bce270126c3d51b9e5039411db8efc40666129d9cfad73804698cc64f0bf7f1eb810a9852d1a7b2c7cd5db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/an/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/an/firefox-58.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "1be1776853195dd56b83ed4e35ba96f263a72ba009311c48e59ed42b3206a3b9052805fa7573f7064307763396a3b10b44744dc38f11d767ea67c450aa33e129";
+      sha512 = "19eeea6f14e4c5457ada42443bb46cfc64019adb0e0d42310357c4fa834c9e0626a18d672276df3a3d8c9b2c3d217514e7cd843f6a71322c8a212bc51379b45a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ar/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ar/firefox-58.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "87ead011bce9035004af52e6f25b1606d3061cd425c0deb19de91f166ac793b0d8689440aab6e45f469426ee4deddcfc5a9f4872f92121e404c4e69cc50eb22e";
+      sha512 = "a3ac0579f614dbc10b81c5058a1182f68a3a16efeb1140cc13dbfcd171263e21f817922517ffe7715ee8af2cc24a41252e00c3c004ed4442fe641ab93159ca61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/as/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/as/firefox-58.0.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "0cef33747c17bf4646aec1d231269ca2198009038ac2b666edabe2b85333c375c18e249402ce201683d5145292057ee38082ef81d92304ce34d8fb31e5d240cd";
+      sha512 = "651a08ffeb020ce5d606c49e5d081ca9f97ee51300784d13ba2a12308b1c95074aa3d4e844d88e500db4ad611803c5fe52ac7561e5ad4f7e7bbd2ef4af0058f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ast/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ast/firefox-58.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "ee98e03759f85a3a52571b83c4fd9eb43bc655bb17735197a6cf30b894f1875ca1905e5807cdece521f24d7ded98118ac0c157b9c981720d80bba208d67f423b";
+      sha512 = "1d2766f2100e4a95bd8ae5a890f9619213f9ebff7801df5dbe8cbb13caf8c0de67e25d9c99b714fc43dc98816b920911a71837e5ce1025a98bdd7243195de226";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/az/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/az/firefox-58.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "78fdbdeb6ac24450f0c6a52e308edbb31f1cc2c6950fc25295315c4be953cf35e3ba220c8f8b9994be055d963f6a2f55775b743161c71e24552fd5882dcf0b57";
+      sha512 = "d7f250df0a62bd5114241e3db96dd961601d0da7c8dc4ceb8cb4d45a147a654a7b1fca9f1dc478cb2dfafffdaa246015ee814b6cbffbd81f57a9b81a7ac76185";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/be/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/be/firefox-58.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "07248a7ddf23657647d6e3f154be6325e04cc30b02a724a0b4c2c159060b7c11c2ebe4d7c4bd09313d1b37eea7e1bc45c666b9e19ae7d01e8e10f6392a70aa04";
+      sha512 = "1b835105b9ab4203e269696c1df29ac65aace7a62e9336a4405831f3483b14cec950d303743862119d96a1a9f57a95f19f5ba643c248c2e644720db8ee705a9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/bg/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/bg/firefox-58.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "6a05d69ec9e607bd1c7e48b882e90f2069522f99b8397c4daffe70d7e0ac2012287db2cf78d71df1a7e4f20ceaea1de86c61b857986cd3f785b4c55574346340";
+      sha512 = "7aea83a33f8e343ef52ebcd9e0e7b3b2a44ee2a93523834dc268ce9ffe5b90516d074403ed8c88c1f4b2ddac252b2078df98233c1f5279617bc38b83693119a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/bn-BD/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/bn-BD/firefox-58.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "441f56cc7eb513e20a89732745c1d3f56d82bccf09f2903d9f07547a018ec31fc95bf5b56b9875cba08f44bf5d9af0afb6314f72c5c4eb0f6546e06a6115fb4c";
+      sha512 = "93b7b7a83e51ac40e11763e947ac8f091eb4a6ad4c7cb3701a1a889a31b725a62daf520e1a1eac5ac1923ad1a11414f386db6b62095bf74bf36a51df2e49e0b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/bn-IN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/bn-IN/firefox-58.0.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "eded452d957d9bcc6c65e716e1271cc130ac76897a166f2507628e99b50d99dd970265e4e5ff276d509fcf2026d3c95f4ddbd7b0b09144495bd483af724c9636";
+      sha512 = "87852a6d1b84cbe83a490232ef571352c05f5f8eda5f7a26d87081e2814ffd5b41d761110aa75503a21989642a9fe1340ba04d7745d4267d129717d0a882e385";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/br/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/br/firefox-58.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "7ccf63c946299241612875d220c613887dbd4cfe5db019db4a2626df2ad6de8c00564bcf28aba66566eb26cdaa5cd7ae15eb5c6a37d7959663609581c617dd0e";
+      sha512 = "8914a9d5f5bdefc4a681b5766d8333434078e3717dab556f0781b68933fe3fd85b53fe8068cc4796107faed6a7279142e21b8e0a61c90b447d24965704e9f815";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/bs/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/bs/firefox-58.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "de319c64ef4a008d30dd1bd26e32c17a7fc5ed73a74af2029807004ee98393adeaba06ac9f02687e359ea0c41a5ec176630fc1cec1b87fbf789d2da68549dd35";
+      sha512 = "b6d40c6ae7033eb8b55f3013dd2eff05551ec78009593fa49033adcd8a30362c9aaf7335749ee91899a1203fe5a3ab0cc795a73f80e332c800270d64f34247f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ca/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ca/firefox-58.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "f90f57a74a082e1015d04e4992d3137d6cd92d15ad304a2eedd3c293babba3c4a2f352512c0d3971478cd3df353d29f9ae3b1fc09ffed19cc3c7ab4475129371";
+      sha512 = "53e774bb1d85ac8229fbc75884b7f781cc7fe0f7ce5235665da115a5a8b2ca4a05a82c1fe51d801daa6a5479e12f8e5531c84891ef922c89bc387699895439d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/cak/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/cak/firefox-58.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "0bf057c37cb1bfbad87dc79386dc13eca311399ddf1deaa625ba920c72f690f01e20ce3cf0d7d1afeb016e2f27c96dff405c1b168aa83bed0615e55f1eb259c8";
+      sha512 = "7079bc83b9a64c7ef932c7bbe57153d775dcdebaa938d031e1379678e4c127dd767c3296fde3c9a9b81d5f07e93f38bfa5a6ade9179b7e1dd5d790b560469fd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/cs/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/cs/firefox-58.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "609d94b2e7e920a70c2774c3ac9531c7b97492401a7860e43c3a8b0ff8870d9c51955dcc0eb9ab4f12eece415338e6a8a1f08f55f4c5ce5f15def081d03d783b";
+      sha512 = "9bc5b068b6f6a38e98cf26d43fb0c304603a69013eb0970a9a8b577f3edb59272ab81258544268213906168dd7bc58224032ca956593fe983b7a82ea82934ff0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/cy/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/cy/firefox-58.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "c77903916d9cbb55eaaf6220dd8a1a101c90a338fc3c9b289cbdb1c0e2080dd9a839b00575e38014ddce4478f53711cd31834d6dc94deb517b0a3e8e674df7e1";
+      sha512 = "95354ec119944578a047f3cb28de6565e3fc2c6fdd93c3cab6bb3b423dcbbd5b3dd7c002a185e800172e197900ddf07ac767e1bdfdad181d243c92ac6ad9ced2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/da/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/da/firefox-58.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "69486cfe520e313485eec89f64b446de50a87d5f94ff6bc76412c61c898177b0f7ff969bbcd7daca3bbde648394e2f82b2cd50be933f5ab6168157d18156d8da";
+      sha512 = "0e0fcf3a449c4c89d86e180391c4cea86a1ffad00857d7fe26f48d6a3958d0474faad236d3148c029e3671216c6941d3a57d4cab29f9ab3058bef7b24fb4fc60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/de/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/de/firefox-58.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "c85ac2270f30c9516df4a1331df5fe4a28c79787a12e306185b78c30a0b74d655c1cfa3e2b17ea17acb5ae28e47dc1235948deb6eba1a8d744f6a3864806c869";
+      sha512 = "53ec43f033a987dca6ae5477e58a6bb0a8f2c4299e373f8da674c522057022395c1d1d54e9874eb7e3d0872da12a7121c0edbab42eb404deef8212cac1339c32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/dsb/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/dsb/firefox-58.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "24b96b1db0e5f5f1a20e63d80dc69e309daaccddc0327b40fc8aae20a2e18f2698bfa50d3dbbd8268b54d3e92ab5a07ce1fa04de8c4dee31dc261109274728cb";
+      sha512 = "eb99b4a6aa2c1f4e75cadc7b22f0aa5967bf2e87a7a3071848cb8f9b8ce85be24aa696462acfed9888e3e8b3cb3e6a6c620c256f29b249c340e664c49b70c383";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/el/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/el/firefox-58.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "f22348ac3448a39472e427714136c51648f5bbf6979a402838b0c11dedb090b4c16397841cee5b2dc142fe942517386db0063ddc0e4b317e911110548a7805a5";
+      sha512 = "ba3281351b57e1727535f1b4979388e6bb9187be1f61a145fd7bbafc30ad5a8da79ce3971520255a597f8333bea7ce55ae472ae5e4698de062cd23c85d06430b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/en-GB/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-GB/firefox-58.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "6f53f1aa5f788f4b05135b610e117fb368c100053620f8283d39a9bad6e9710978b7ebc638514a04fbb3025407fe728b3be4a80d2708ba0aadfa11485e012e30";
+      sha512 = "53dd1af53def127e697a5cccb1d4b4292870868d480231981586257850c7ae7a4108eb6b9b00582eaf28c7d73273838ada0661d44a6346c5c1b08734e59a380b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/en-US/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-US/firefox-58.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "c6e9841fa901f78593d5bd60c3c4616e9a8dff696a5b812bcc4fed52287fe7db6c7bfef85a7433f08b3b940de6418aaf1c7c90dde6cff1cc6c7e0efe439e0ddd";
+      sha512 = "df0f86d1169256f73e68594177388afba5aba4d57260ac6b0b1cc1b61a15725ad7ea5a6210c3a60dbd290f8ad3333792353dcc4d3d23ada6bff8c366f75735f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/en-ZA/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-ZA/firefox-58.0.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "a980707b6b773c0e34f385ddce1be8c4ef3d5a378601ba3aa40890fb247a666cb8253aad8a64859527a7becc9925124c9eac1e13a19a932158aaa953bbe158ce";
+      sha512 = "2e158325f50140c085a9886884444f1aa62616e937e32b3ad9c621f62f1b98e642fe9b0d2821bbf8deed627595471a9d139257fc35c478213ca0f487fd7ea884";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/eo/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/eo/firefox-58.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "6b23c8ddcd84c96993b4cf7f256df3485871e170068db563e5d0c649abd8e3b5869cbe8732d3a97e1927f45c7c8c18d697fdebab4ec1bef7de78496d06c1c0f9";
+      sha512 = "af6129508481db96cb8cde0da39f421516115abc2b96b191bd3d5b60b8804e8eef1a1b406c28687c2d4423e721d0fffcd33a6f1c42dc031dd1c3f8624db60b4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/es-AR/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/es-AR/firefox-58.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "985149e873bdeccffd6be63b35a56b3f93d3dc35cf04b055af8dafff68ce82bfb752a0d48e3ab43a9b197d15cc11748243bd2e9537a42f59c27a7868c2b95546";
+      sha512 = "3fa95941bf365061cc72cc1d6f1c9ce6ee8044bf28e64821f23b56d63078772acf125746f2ced274a559dd7d0c1b8827fb03fefa9a7d4c325c3a0aa8e9e60c19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/es-CL/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/es-CL/firefox-58.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "4ec591554411410fb90215dfa229fe207bc3303a1bc68c4fc8894390386c07ebf958fcc894f2d17a9876c2da9b8424a00a62fd828921fa575ce0b0aeb037ea4d";
+      sha512 = "45b8e8a40522623dcce5df515be89fcaf030b29ec042674a9e21e0929867a51915eff3bb93503a802ca266aa0c6e1237c433c51cb7b38a5588598fa6f2e58ca5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/es-ES/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/es-ES/firefox-58.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "751741292c0794916be2636b42d03671d408b5e1675544c44238cb28131e64eae07b9524b57e5cebcd491ac80960d2d60619a641f94d333b5622ab8cda812e8e";
+      sha512 = "3dde1cceebde5b8eb599cff69b8c11009cef90d5d2cff5220088b1c25428e27afacaf6058b5e585e795002d3b3a8dad5438602b62b55c48951dce1758c1104fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/es-MX/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/es-MX/firefox-58.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "b54419f6cd1d7bbbcee875cdcfc06b9b6d053a1f320e47ef575c6d11ee3dcdef0937adcd6889e0b45c592e51547b66e09ceaa9ddbbd901aac6fdba0aa09df9e2";
+      sha512 = "80c4e7489be1c319f2d162c75e816d96213c04458f5fdcb4ea171800aef2b39ee5012d9b1b47fda287fe2d7f81526f858927df85cb24fc328ba0b12cc18c4aff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/et/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/et/firefox-58.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "fcbf4c77a053abbcf0e071edeec310db34a195c9b1d07fe75ada0dbee71854631756a148b9fb36aba96865c462b3efb6c5c6689cf094430c6b9704a2e3e57294";
+      sha512 = "d08d3b5cbeeb5d5556e961a289fc5af523fa456be29a749d21e258ef3430d5aa61d20071cfab1835dd9febb0d2686ba7f5c457f1e22804899f1bb7d3f23f0515";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/eu/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/eu/firefox-58.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "6930dd5dba3b9d75d1ed998ee079a06b4222e130b7456851b2be8353d29bfc883439617a0bdbfadbf027a1c14d987b5ef4e15419190cc67c54d88d942f2ada42";
+      sha512 = "c53d30e012ff1ae6432ed7c73de986210f955092fd702ae852163d359282ea79f4d3b5469fdfc4bc31cce4d300b84f17ee8246a437272b1fe7cd00232360c557";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/fa/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/fa/firefox-58.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "967abdce15e37d3cad52a5eb6a3e929b0ef0c6c8e43d803c88c20b649dfae3ecc980ba64f0ebdf140938627e857a86d1cd4884a4db682bdb4c9601e6cf1b3efa";
+      sha512 = "b82f7fcf18f896d4347b3c1830e28a2370f68f06865408bdb39738b78c9f72c99e4818dc4d0579699170d2a38ba3ff9c17230d71814addf5137733f852b016b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ff/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ff/firefox-58.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "28ee8f395cd3d214cc67068a1421b466dfba935cc63f9156c258556c89ec74ca70d21bcaa627f4ed7bbe372fd1577b77e03230b2f031ff26e72c87b8889cad93";
+      sha512 = "01bafe719ea62f3dca7a527057fac6e0b948de79b926f1c834a4d1f402c2f949f8010fc28e024cb5070b3510320b8d86e173ab74086270f36b4e9159c01799d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/fi/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/fi/firefox-58.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "bb3eff25215b09cd7789e80161b06c7a6e3929036895a9bd9d949b94233bfa98056ba2123602f06b2d7572857371390bb887c50c2c1a37c641b20e250b083a5d";
+      sha512 = "58f4ba6eb6580d41cf558b9157bd8853226885fe82caaf7b7a34c129e8a84e63581f59d6b908d7a27ec86662514c2c049e7bbab058805252eb767f447dc79dce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/fr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/fr/firefox-58.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "facac474073bcfceae7f1a1b8554e807136c277f31abc999b2abe33f2dd6f365cbe6549a5f9542982c3f5b80f42fc1c7e361a5402f74e359170c24570671802f";
+      sha512 = "3cf320b5f85e354f93f09db84a2a33c685cea1aa3a4558f6c404d208e715a1c9d03f2701f8f81bd6bfac9bbae8a82a84b7e1dc6a87aec41683463fd1d182ed11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/fy-NL/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/fy-NL/firefox-58.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "84deb0e23a3d6a56cb2e52958c7ec4a650ed32a0302d51ba0f9b02f9f6d7f974402c7445d51a7be4cb22be0bf582af377653e2944829cc075a01804727bf0387";
+      sha512 = "75e992be5eb1c3edb4cb4957e97c7feb239d30de56f26ac97ad694e7ec861e4bf044c5a91376c0f8c382149a8bc35faec5dba2435fa59dec075473c749d59909";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ga-IE/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ga-IE/firefox-58.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "41ca5151a5d76314255a9f772ae7483d8c67df84a5511ad78cb951c6d11c8b0b78d43f19d3047ddd8add13706303335058adc4be7779dbe3bfa5b3b60a1929ce";
+      sha512 = "8da831e7f92fcd6c8fd5fe36be833393fbcf4e7baf6db3b63a911c9a6292cc41095820bf59fdc734e3edfe6a0ea703e791a8f914b7e9105683eb8440f8938ecd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/gd/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/gd/firefox-58.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "020921ef0e372eb1a9cff8c71133668f6a708436027a5d163188b8d2928fc8a264ffe5f7a1cbc40e109a711ed4a8bec26c333c29c84d4cef6c1985fdfa54a0f0";
+      sha512 = "0cc1c318df7a9e7a4620f4e5c8de07a4feed524079b4e8e6a48662b285cbf04fe8b3ad26b92459c481d47268c2a80024f5f57d69c9ed99139887d9ed78e0057c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/gl/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/gl/firefox-58.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "40d1131d2f2a365bfa0432b8deefa8c705b508419ae3e1b764500fbe67cbe38ed9a9813031e37ccae2e835d1f9d6b6c18edab829bb24f0658a6885f197d108d2";
+      sha512 = "4c6ac835dcb079054d958f19eb68584a74af2cacd151a998c840beab39e22a710b205dad8cf3640718aff658b0a4175f51ef6c698208fdcf1a753e23651f8531";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/gn/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/gn/firefox-58.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "fc16f7ae512a49f5af381e3952b9af0772393c1e0b917d3d946a8565733dd8ae9187bb1101bd9604a4e860b8e4d001ad3bbd8c3ec023207cca28e91f6ead19bc";
+      sha512 = "bf3e3fb2b4641f7b82c75cd8f822cd95c86be5f533f889b4a15c9e46a73057f1e9be929a4d63f87188a0c2110290c67064346ba7d50a55b636e4ebe0853a92ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/gu-IN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/gu-IN/firefox-58.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "693dca0183d8dc7962a4505925abb40d286b86fae206ad2c88153ceff02138e756a61615d9043bd65fe9a60ab990d5a79f2bd0fcce784c361488c3047282be17";
+      sha512 = "a27e909769a20bb94ab1af19f1443a4257e71e1dc2eb4c4e90f38fb73afe4bd9c0c4b754b290abbaa42c9c6ed69644ae65e7a64dda5236dd5820a8939c0cb1eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/he/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/he/firefox-58.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "75c52bd15a6c3b7254981b82f9d5f0b9aaa43d2346bd1376913f6974b63d9f6929ef92fda0916103c643ecaa7f235b4268ecd956a4194ae41048d794029605d1";
+      sha512 = "a577f2d47a31945ec011b9419cc5b8a7c90cfbeccdda4f9ac8e5f204fde458a6cd9b6a5bc53f96414a4d6179368140680370da26d17a24d0da378d382a11aa71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/hi-IN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hi-IN/firefox-58.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "752852c1295153ceea9d55e49afcdd185ca34f31d38dc2a85252f5ef2b0dacd9a6b3a1828ed0d88314574241157dd90d1da33c6d19fe25d1180ee959bbd8ccf5";
+      sha512 = "667303f7e268f4e8f9b917bc406b22b4ffe4291ab4ff636413e2101c5bba24b6a8dbb7d6fdf66daa95cb948ebaf995ee2fb855a9056fae26284b1ce3513d227c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/hr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hr/firefox-58.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "01b29494db80f9483334bfe23d62859aa16dcd918b1acf308d765b9864304616182195d2c10e6ced4c7f1709ab2d5a3c5485614506ce727fefb2187b82a28895";
+      sha512 = "ca2b5d5d79bcdd86ea74cbfb5c43041b301bae4e20630a905657a642fb34671bc22c3e04e5942fc3ffb66203331c7048b6b9511cd45ff37fe246975b613e570b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/hsb/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hsb/firefox-58.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "efb189a9daa8335e8d2b2b31194d808edcfc0f8b607a227daf0b74ae456600b7ecfc9fdb1340a17cdb6913735ade2eaccd552603737c4c9bf3abdd99bf438d63";
+      sha512 = "94bda6aef07890518c11c2c05690a030487ae02d33f1f8cb64c4175d8131ba2aa7275b55dde306efaef64f7ceb53f9eaeb898d4105d6e8205e107a41e0834eea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/hu/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hu/firefox-58.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "4d6a08d3ea1cf72261aaffb7c1887fac28ee68f6e1bb5a540967164a4f7294f0a378b0cfe3dba867a5adfd21e4df3478a9bd5be057ce923c53fee39fdcbced4c";
+      sha512 = "c0151e3f36d227ee4d0d86338011bbb7c6c3fa8f5f4f3d8cf278738ec2936d91230223fa474a7825f07a9a3dc43b1bb20e75493a64fbe4d5d84c63d7df3eb1f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/hy-AM/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hy-AM/firefox-58.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "c68660b7e1482e46ad66c86623d9252466b15eaa3d2c848392985db2932624e3d953ee48d6eab39c42dcafda174713fa148aab41cf04ff63db38eba563303c96";
+      sha512 = "5567885d44b7c88e5f31298a93387c2faddadfbb6a67409320f8df37cead3f0f957e05eaaa8911301508eae3891bfa37201ee56359ae6df27919fa36907d0ce5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/id/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/id/firefox-58.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "c93a02327cb8679b65c9770d6105bfdb6ad3bca90191f3d0fb1a5a35d3bfb1d4616ea54f3af5aeb76449de973d4acad0873e37674524d90010cb830247189652";
+      sha512 = "eb1fa25f22dfff6074ce87b024c7b353fd628fa61ab6b8f4a2d1267122d362f12b2596240e96747417b728bcd2a37d91913206f3cada58c52a573af9d38168fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/is/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/is/firefox-58.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "b7961afc123a574e656e98eb7b6f819517d3658a36303af89d36f03c9a32137984e047e4021d30d137294f41930645a62f5dfc06456ade330942a880aa4381a1";
+      sha512 = "5dd3d4892b6dbd20ba0dab3cd542bb92f3330cedf6e1e94790b0ba065692ec89f58bfc7cea9d644963ad259a8d9c0bede5973b7c6987e2fa37de6f5ab1ed6ffa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/it/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/it/firefox-58.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "7ee154c376146c40828375072f0c5ecc652eff04f8df644a25f106963fb1ba6973aaa7e7d5b27918672fa42069d91d4207e8f779d684cb342c29d56a1a020ce0";
+      sha512 = "5192427f9350c2c10161af5772aa16cd7f9db3f156fdf1ae64ace20a250eb2552c14b11f0b96e809a1f70c267fea7ea8057087cdc8bdd3e953a2d14b81f93f27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ja/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ja/firefox-58.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "ff5ccae9fedb3366319a6ee2afeb849720ef9aab9a25700e15871b01addb1bd18d6a1ce655e0ef0adf4a1f826f81b85ee2a3e21161e554b5a2e9050f72c13786";
+      sha512 = "f9846b5b6f0687e997dcbfbb739cfc7664b41859a95c5b3c52f247c09a35cef738cf0f26f51f0a073363591a32171eeefadefd3eadc7ce9bab888e8c3c531f4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ka/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ka/firefox-58.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "fe165e0c5d4204209ee9a647272c73c28344bd16343338ae6b8261dca2b5ae4d05b7fc6cbd3a7b3871e693706b7e73a3b7ef3dcf40ee4dceabaeac12d5398a22";
+      sha512 = "8bdbf6ef487c0dd9902158bcb202008be69c6871b1702d78b10ed422b774729bed97d70d02d04daecb6cdbcd8ef25421ad186606abf44098ba893074c2fc4253";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/kab/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/kab/firefox-58.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "294d0980cc5f9d7feb628c797d260024d786e919d2872f3f5695ba7e4fbabdbfbe9bf5c7327645ad99771aae8902fb3fa6d6e5de1eb56746b32b36a24564501c";
+      sha512 = "f2b52322a311a68afecd91836995da457ba5afbcd66b87e8d297114280c92e73fd442e9c76340ba4298145e50ecdf69449b0a1acefe3c281e1fd6e22156b368d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/kk/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/kk/firefox-58.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "221497e9d38f2068f38ab37efd8818cfcb3f6281ada16436d7ed22be0c02806a0188ba5be52220ee632e575989e76fbf57263182281bf0bf736f203f6a048bd3";
+      sha512 = "d1232ce4c4f8c39d90163f4bca6ef73c2a46bcdd53496565678bb448ff538416bb116e1f93bf611d93c2a1d1fa9515975d291638dbf2b4be404d85fe5bc125d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/km/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/km/firefox-58.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "cce416868cfc51aaa334bc1fa5d7102177024bec64d98cc1034fd1741290876d4ab2244bb49befaaf7e198a4401e43b3010894226fbdf838aa3b8b8282577ff1";
+      sha512 = "ed3ca1cea325f223e01073f44ce96036a9e61f097f459a0b32d39dce505995d84e3db51e0511afe90c0285fed8f01b3e59ed7980aeb62758039cc8f4044e24f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/kn/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/kn/firefox-58.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "6f1039c079af325b6190e1a0396192270adc3aba374e7cfe2cb2deb39b86fe07d605c9a3d3b063c91abb8ec6348c324c419c212bcb79735ce8ccdb7ce4608fbd";
+      sha512 = "a9376c1bb8fde80ce16e1f4f6fe97ed326220a5a8a5c3323a7ec07f1c76b30be582cd4236021e320dfd8f1988b6908a32484e9c18fd965da41e5efafb62617aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ko/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ko/firefox-58.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "425b023e7eecb9f550fdf96c544faf21aadd04388a4b57fc28cf9e43f82d58dd957983046399592b21099039bb5976d691512a93f4c1a94bc384126b8667e19f";
+      sha512 = "0fce16b8e9f70ad33747523cc825079835a7de27338f4f26ec217662ebda1b85a7db165063c59db28288fee56ffefa35c5cc3cafc6a392af3801bb37cd185dfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/lij/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/lij/firefox-58.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "2410a21d6158314076474318c2be450cb3b3397ffc5a9e9e8391218b16116371e2816c6fb1684b3fc3589a7a9834874bec01a2af39331dd592fe9fe54a3f90f4";
+      sha512 = "d1200b85ef44047dac247406356ec7925cda8fcaa25f89a2c835a25e47841acc7ca0790ccf1b516dde4c0e0f66300557b7028db60f603d66d99fe85807e35809";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/lt/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/lt/firefox-58.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "78ec1d96aeee8f610c2637be20284fe85913cd885a46ecd3965ee0a8f62770307200e33505bbe67e192c38769d4614682536394186ad488b51593a7f6c7151f3";
+      sha512 = "34e7a9034ed9520ebdb2a6661404e9e4371866ede502305949faa0216cb029b90a3fc4da41a6d1e37afb50241c7e9675885038e43fc4801ddfa7064bba6ffe72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/lv/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/lv/firefox-58.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "9a257cc93498e256c9b0a12ad8b8922cf749fdda789197285f0d1910eb50b3d601da46806dd50a4510ea3b3fb8e8f4e494ef87d1e5db2208993a9e3ed59e57e5";
+      sha512 = "45ca64416bfe0f46b187deb05a23cede11e2b62d879a0389b95d30c10f5e6f8c5a480d900095121d69c37f451eb7d1b9cb5247ca90d99f31794f0e3098f5e1db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/mai/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/mai/firefox-58.0.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "bfd02ab5efb92205dc649afb65263b15ff46e7fd0d32c560ec3977ea18d420c89782fae63596571155ae7a77a59a5c2e9d25a41d18b845e502784bfa264638a7";
+      sha512 = "949549354bb7bee16ad78e0f090e72048db2df6735c5a1cf56f2b1ee2ef2f1c10d12f2b1310bff919289110d351ddb2e313c9697b3808d40449684d961a979d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/mk/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/mk/firefox-58.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "29d5b2edae82aeea218625ed9175455bd3a3928886035e55f60b6d5fb717d632769ed57023b4e6d944d22e03c5169eb2887c09ee4c682a6882a5bf298ee0af23";
+      sha512 = "c01b338cec43207691e01b9ab9735531c597afb04e660262514b3cb70b1967258d03b330d7274bd64a5ceca1e4a6a60e555e8267f07fb22a529152db1dceb20e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ml/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ml/firefox-58.0.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "f247d859982459d3438310fd9d3c86ad1cb7448238a71dd81f0c8712b31da1fe27adf1821e7e91d52e68212d70826d11bd3728ad3642a206574cd278df734b05";
+      sha512 = "07c4b35ed0385ebe5564992527a3eff6d9937ea8fe138997be31ec29cba2f24d067a464d119a46e169c2aa2e74649e44978f2e7a951f5196a44abbdff56a9b37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/mr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/mr/firefox-58.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "63654388432e076ae5d28cffb969213cf875894b94354f652d40891d63dd0a25e6175c3b51417ba5b760a85584bce85457d742829603dee9084c4c21469aa02e";
+      sha512 = "4ebe741edf2c02d4e1d9fb89d823e048c39b82a45f3af9cfdafb35c80e645c192017becc05e63e1d3f193b8257baf228147dd9814c3d9e432e4edf943659cc18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ms/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ms/firefox-58.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "bbaeecbb9d2f6d7a881f219120d9f3769abd5713a8d38a1cffac2dc3dcd7849b49098df20dcd84812bf4f3a55e70ca1199cc15e67ab248f4c5ab9d2ea91cfcc2";
+      sha512 = "9345f2c2daad990cdb61f3e066a5b9b1900af3bc3ab4c268a28b2315f81ec0371daa246b0ecc0caf78a66f61ac06bef57d97196c4186ae450708343031be7071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/my/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/my/firefox-58.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "882e00804181821783617db75170650d5d8f36db1d32fa183a7d1ffbf04dbd7a7b2c9405520bc09973af800f8d5aa9859ead7f298fb9a18c2c0ffb0f18ab3542";
+      sha512 = "138a60fe48fe5cef6879c928da51ba6c9ae70fcb4bba5be4b65e775cc2ab89b4fe550341f4c35359d98fffc1aa8f18a55438581fa6d422d07c4a7fc76247cf2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/nb-NO/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/nb-NO/firefox-58.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "5203d4a39f9a3ea14d262ca13d2e940d8381337cbb1e9d92773d3ae086d9853bb3b5e9d9bee550655b15ac2cd6f0fbb3d6ee52a836e94cf6b133f6924d6eee83";
+      sha512 = "610c955b6597d5df47a476df9340342ff5d8d33cb3086dc14e9ec7b6b5519309967b22183c953bab45180f0977f69ffd0e8b103cffbe04712dbc4c183936a2c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/nl/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ne-NP/firefox-58.0.tar.bz2";
+      locale = "ne-NP";
+      arch = "linux-x86_64";
+      sha512 = "bb6c63ffd60e6f239868b6ff74d381a6ff59c0f5534e4cf2e55eab54705e83260d527d4e88762f57c7228a04c9ac05fe0088f3a1f39a443018d6b11b7ece8171";
+    }
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/nl/firefox-58.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "4ec42e236d0fd252300d2785f865e9d1991ba5230a5621798c74bd2802220ddaeacdb43ae44fdd365dee79e7e4b97cb50597713acc603c72c630aa0f409cc5c4";
+      sha512 = "d4fa058c64b30a60f79c466b4cf889548acbaead22d5eb086f055cdc1c3039c2adba968d8d7330f4f43637db0a6a1d23308be2826278271d32a1d623914123fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/nn-NO/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/nn-NO/firefox-58.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "4a50223708c6a45869981bebdeb8b5192b3541eb54e57e29e60671d436e12ce688943936761a9033b03d069a3c09ee1cd5a2265c0173c30f581710a35f559e89";
+      sha512 = "5be23c6b02affde65852eb39e787eeb6a4c213f635a57b1e37f52d1588735180343185134522e35584c86c288734117881d2f0093aa77f9df3872f0fc122da29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/or/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/or/firefox-58.0.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "6439073c29b4d930a0b2365824bfdda5e1ae3ceadde8f1949c4eba55e9aee9f15a22ec7293e1c8dd7a5f0ec63914f8054d688dd3fafbbd70e6e9473821a482f1";
+      sha512 = "4075a64d79757f8bbe50bc1dccaff4229ec8386cded3b60f6dfee4dd4869737f5d8efe1f4c49a36f326dd8fb388f84c7f20006652e5da0306a6ab794cdea7fa3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/pa-IN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/pa-IN/firefox-58.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "ee2ba2085c389d70312390926f523e9e39d030d5b0b261088fe9b0dcd752fc1560b80817844d60835a38ddc49df315aa9575cd5091ce346a97e5634f810ff4e2";
+      sha512 = "84de66a473c3dbdc34e375e6eb48ef4ca00e1b884b6beddcb085b06daecbd1eb7bc921da4e1abd1a295e7e8f455e6d66f08f5a78121610327418ae64ddf145c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/pl/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/pl/firefox-58.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "b2c4b4ac6b2b70834787efab3bf6670ba4b9e378a3ea7a206877778a32a7acc51efc32376d8f358adf9f7756e0c784e436003b8f16366741c6c7f346344352c8";
+      sha512 = "a027461729a5284c31da1edaf9168369f5f921c9812b609a0657c9437c881e09454e9b67d9d593299f33d924fdcde2909c9a2249a5fcf1eeef9c91b3387d917e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/pt-BR/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/pt-BR/firefox-58.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "3acee98821d5f24f8ead9f27233fa22372e2b5d36bad52616b5a59705992f816ef6b4cec3e2add96a76f3e50fbffca762fc88445b5fba12f058ba06fb3c7ba6b";
+      sha512 = "fb7affeefdad0bb12ee5cb6a0e8c54c146079fd09c1670e81040e2887e3d4446d7cfb633c9eaa6d3dd77c4868cb7cacb1f56897889761237abfc1e9456311cb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/pt-PT/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/pt-PT/firefox-58.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "16ba9337bf8de3061d2d7fc9b609b02a61e7e33e5bacf5dc31f2b76bb281f8b298534f68b8bce4d5adfe87b0a18b660f71bf81bf556625b35a118630f2ef0d23";
+      sha512 = "a8fa801d18901f9a316c45f66b903f750bbba70ecb7d134a09ede0cf02f2bb2939d7c6b831c1ef77b27425139e3437dbc58e11fcaa80594efe62c767e4e1e186";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/rm/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/rm/firefox-58.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "433b965bb97d00e81071d1732941021166088b55bada961f8dfb1bb1c8831f0df7f2b89879e52f992c781b33ed68e2fb6058c9ae71fc6827459ea3a854ff7af6";
+      sha512 = "0a1fcb869512557000dd0ce03ff75941e268d59a5843b0873e1c299c9aa307f0a28e4838663c66ca3f85dc7c4ba564d6ddebab3cfc4fae978191fc54e3fec7dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ro/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ro/firefox-58.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "749c7351f99abe43f073eaf32fec454ff27e725e28eb6f2cb094570d1bde4fd772cca4f05ad3ca83803542c3d85dd2fe60c274c92a8339ab1b619e7fdfda7675";
+      sha512 = "891368634e22dba613191c19eb29634a87c49d32dc991bee9044e5f37d51489fd284e45888a8178bb25cf866da6e742e263e361cf0db23cdf100ce8ef3358671";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ru/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ru/firefox-58.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "430c7afe325707be3618d717bff3d9e5b39edf82b786d0060fe6f6df18d8c9145848f4a1e1daf61b4da83b548dc95d4e5766ec4c882a2cd016e934d7c179791e";
+      sha512 = "94b7b44ce9c724af069314b33512a5535429c56e9f69373c50308f093ba3a7cd28e9aad13d3ad43cce909a1f350976268f2e3c206045693b4c53a851f595db33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/si/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/si/firefox-58.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "452c3fcc5466e49c6e56192476d0957aeb60328ac2d5b9284204f50b07dee7a4835f287cc86a52476160da38f68212ad2508aa4599b8c2824190017fe3567764";
+      sha512 = "c6971203252b25d1c956e327aecc9c6e395b39be2691b53b421c96aa8dc49a1c2dbb16a03140a9d1020225068179e08fb784721137032b4f0d3020a83f89fb28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/sk/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sk/firefox-58.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "cb67db6707e32c44eba532323ea16c55146a53621ed1c37a50f963ac3b4e66040a028defc175a16a0d4c0986fe67c966c56b5ee19db042e1aa93c92517e42761";
+      sha512 = "73b9b3dec958550e015688261375dccf94e7c9e0886f40bb1fdc8bc6fcb75ed5da1416b5ef136811a7bff2f9c8b7b88836d9e92b29876a2748ae01fc300ccab0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/sl/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sl/firefox-58.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "f0269fbb62113370d23ef2ac9e26e602ec6457991e4b98335ddbb2df1e632604bccee27420ec4ff7910f936ac7518f7320ddc875c0bb3b95634ffed3cae5121a";
+      sha512 = "316915484eb9371a656d75ab05fc2616f514a97087126ccf2f2a75d9821641cc4157f019ebf9f946a07d0b1e7b92c464dfe3970dfae0ca375bda282819b7d53e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/son/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/son/firefox-58.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "1b5c3c0d2cb42eb985d6c05ea6454b5880c2cf33a6c46d7993ea8793027a9d1414373a14cd756f2e991d2f744ff87972cf7c050390dd4dd7a497e5ead3ef29c6";
+      sha512 = "38975465d0b416b3d86c677bcadfc49995d78a943f08704218df29d008ee4dee93ec4b99a6cc0f0c22b0faafffbc96b5dd3dd16891881a342951682f5e9f4018";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/sq/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sq/firefox-58.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "646bccefc4e52e823d099521b75d6796905d1ae1241ca2f0066996ca4e3a70fae901c8f890b821694699f101dfbcfcfea1cb7c7cb6de048bd896a62ea20e1348";
+      sha512 = "168372d4876ded273268cfc94860548777bc03b471e4da5f28735234e669f23cbb5ba9121a147971af26f78e84d22b2e7fa097b60c33ed7b784ef0dcd1a8e3dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/sr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sr/firefox-58.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "15ae853a20c97c380f3f6280d370a821461c462b2af5496416c81fcb1c47a0cbd0bcb80eaa0f017dabcf630f42a886dd72e6d5738305b599f24c5320180650e4";
+      sha512 = "7a8b38f4143b827287e6f629caa0bd5d85b4b28825b620330004be14e4506b7466a8daf80871914179a8001d8351bab30128fac5f5392cdf22b33fd8c2d8256e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/sv-SE/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sv-SE/firefox-58.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "2dc41cfc4cacebdaee4ebda94064bf9e2cf7e66a95b57e66936b69c7420302d0c3100c5101646b91438493016521b45fa378913b463fc55abc7681a34e24c4d6";
+      sha512 = "4f3d3b150bc3173a7eff5037fbc10af0d3db734405fde659ddea5981b3f7aeeb7474658e965e3ac4a6f06ea9fa03fabeea0572dd622bbea7dc18458b69939e85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ta/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ta/firefox-58.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "9f1fb4fef04e8a5944bed3293b190845e668431bf6fe214166ec3bd2dd7dbe328ab8ff904627788b80a0c1d663f37662c47a07c5f8a3818a8d2a509a4648b72c";
+      sha512 = "5dcd6d2b0a170f359fcdaad2ed9d0ae7696d821ea417c2584b2acb3db8d49f0a2c2951dbc5033507529687eeee54e40da5afadbc909758e04a76e5558c4563b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/te/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/te/firefox-58.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "a874ea926cf495a26fd1fd621686f0a123e3cbd67e51699c34e4e5874c30c98f6e36739f2b214d6abbc483bdc0fa202a1d5153078fe69fe9d20b4a3a517dcd91";
+      sha512 = "179f3f7b4249febb51f1649ade20da83c494eca5f84bc94fc31ba92cf421edcd28bfa10e4f2d0b183a2e64767e6005dff5284f7a68bfcd5ea4781e8ade80ba26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/th/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/th/firefox-58.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "dca7e779ca59b49f51198860541a6e0034ab132de0781ae76cbb0688ed0b9d4277ba6200d22020720abf0bab25326783eda0560f1c2fa0b912a50cb9afbf5ce5";
+      sha512 = "257cc1d4d6d25ba3ed8a4194e1bf83bd442b46560b41268828297a95b5009e809b7a0a1a436095a5b15a8d2e2537fa2ae0187a282fe5ec4c158bc6bd4e185953";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/tr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/tr/firefox-58.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "459051cee1bd3df7d9f2606006edcc134d701e9bae614b2baba6538b2fb738da5e671b7b79e65ee6996e5a35df45d285d9e354b635b12d860c926e0a167bf20e";
+      sha512 = "65b0feb6e1c0e9fa97b5f829060c83e9b1ec3a66e317400673891a2fea2cac3ba46924cd04e87ee0bd98fa6746482ec10d43f6acab541de4224d736ec3f5fbd3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/uk/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/uk/firefox-58.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "f3354ce8c703a3d204ebb1370aa561be7fd1fabcc7361a8f270156ca62863c04f74ef2acd25f56adb5c50a19f0256f1956a2cb38c25402ba046cc59b1096d35c";
+      sha512 = "a7c9966a5d90e83555315593d8ea76e8fb3077d1142ae42dd21a04664b071c3989b2ccb516b062acd9d54b9b9ded54224e3453052f0421cb1da2a05e853e70f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/ur/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ur/firefox-58.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "42f0d747bd8c5b3fe53a436472ccbd223ab9a23782065af2d4784e5ed075caf95cc0c4eb060fa1a2b11ade6dc12b99dc4ab497eba1339e2b8ddd99dbb5d286f0";
+      sha512 = "8792ca10de7e917f5f24f432832fae305b695673083b74d369e6a08da80345262612ed884d4506c06ddb16194ce98f12179af40ec6bed86ff582ce09ec306c8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/uz/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/uz/firefox-58.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "476a632365c53ce0c72503bfb7dfe9166c6a4cc389dc7b174823b9dff1717c9ffa91f95eb975ecbe13135d39b90c3f18d96a5a08501eaf32ceafba0c2203b990";
+      sha512 = "3bdeb9dbeb58e19222fdcc41360431ee5376b9d8a2e623a028ba3ae734bf8944117b705afdd56b922022587b3cd8976b3790e8db8b1b1fbf9025f9c1ac9162a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/vi/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/vi/firefox-58.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "8f8146925562109cc1e21a6146203b16306931f03fd1451f679f3d345e589626669f35d5028b4189d175cec3b7c652a3d863cebbb521b72d9a04dd77e65a2c35";
+      sha512 = "fedbac3c77ba7b2d264cf8f84d16c7e9ac8703e5181a05300168e7e1ab59a192c416e24f61f0de59076019f3fd9c5ebf70ba7fbc8986a922edfc9297c0df2ded";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/xh/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/xh/firefox-58.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "b382942e20e4188b4ade8417d5e1d036e81dba87ad0e5250c0fd3e43fcac5134b11f02e4220ecafd5b1fcf2a7fd12d44efb595251fe8e9a9b48a93400f264632";
+      sha512 = "9ef362061f74d4a989611f491fd030473f76696f3642fcf5d8f0d6110e7ae7d4b3dadc5ec630ce9016c1117bfc94d234131b709093d793910f036d2344f3fecf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/zh-CN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/zh-CN/firefox-58.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "9fabab7faff2a166a001c91d65953c6dc80150ab6548c72bc180dcb87aba485b2d06efebf5518f43b740909616b1ac04de57e17bd60fc3e7843e4c7e54b63259";
+      sha512 = "39c4dd67bda38bdcbc8dce7fc9c416ddbb004c03b2b57f8d5500b2686dde12e3e1661caaf12e800f9276bcb4ed01bf33d509543fb41ca4fd2963e22f4bf1e0c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-x86_64/zh-TW/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/zh-TW/firefox-58.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "a334f4904ff329ddea28cf1eb4416d0c665a8099b20673d40792f2bb653fa09f60b6efc09b6d22c25f8bbafc0aa1e1aed6615f1377da37f6f843adade51d881b";
+      sha512 = "8875690a4f6ba74108887f17fc64d87038a364ce2f603ae184aab36b6b2c11418ea2cbadb9244c8a8cc5e59d831657302f40dd7c94b855473a9bb4a6f7f49abe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ach/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ach/firefox-58.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "1bf24191ae24fb8bd553c97d2ce2bd9599f84b2b6d57162a5619821c3312e7671aa04fefece26aeb0786c48d5fb934b79adab513f3ab382ec1e71f44d7a3835e";
+      sha512 = "96da329d9ee86ba7ee01a99b57997d84b6084eee3c8b3ec9f852c07670798d17ff9b630d385b5b5c363cc45d95497cd36f742446f899c8edad2ccc00c12cb151";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/af/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/af/firefox-58.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "6fa02d454c375af8661826b23c0220d9dc402331c8739a8b09e2e4583dbc0d9d6e742f65509f69bdad2882265c51a956892a04b8d75f3885b722b0688eb87ab8";
+      sha512 = "280be62bbf765bc5123c3148d09597201a84ec40ae7a1643a4eb594f022242c1e9cb0af6f7f9f6b822925e871b800e1b83e7930a4848ef44d7822b944254a982";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/an/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/an/firefox-58.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "c75a7318937244cd8f227f05b8cd8b13c948312fd692040125fea3bf3b8100e7c0912e0f4edd67ac7c9425e4a333ad091a8ddcd29acb9f045d4a0459f9d35342";
+      sha512 = "c941e17fe3f8caadfc0de7d7254ca75ff7505a1a892bcad0a5a215ed2943cd0390637bb317717a2ed6d1958b22f6baf7ea8eced4649733a40514a75e82cf3524";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ar/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ar/firefox-58.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "baa36a5936edea572d6ffad24c968538baf5ec888be09c8ee8179993f0088f661fc9f275edf2b848fc17beb3799b50fd8ca5a5a76bb4d52360b9c1a2ad38b76d";
+      sha512 = "15b5362e71032df26df6a8903527a4b39dbc7e84e5c62964f0db08f4918cab97d451290ff92482c9bd99b488d17c06545f1463b98018015776710436358dfb27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/as/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/as/firefox-58.0.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "8094dff31f7ac1de02f5e8af06bf64d8fda669c68556faba2f30de63f3954b3aa18ee130c76c6acea8e59fcd532cffac0ed822d3bbdce737ea4e01e9f2abc7b8";
+      sha512 = "2811aee59e85ab535f0a57c3f286dc6dfbe38c2dc07a9cb103e9f9258bd8514db37db012c48e6afa0935aa573a676f40b0e802e70d81f13931e7a531d4b0134f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ast/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ast/firefox-58.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "0a5953952051dbf0aeb872593eb6efedc557d8e518393a4672d2fed5a327f2c56720c2c50f31ea64b0799722b30202c3df4c46bf4c8dd227333c42a9fcd2fbaf";
+      sha512 = "efe1404351c824142a49b58adc280b2490752e98a9e87bb3b7d7f1473d8bc2e93564b8b7ef3f8cd99ddb2d0afdf4a5370c97f908858a55f9e76b953fbbd5089d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/az/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/az/firefox-58.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "0eaa6a6d139868933b345b8ca62df9cd378c68053cca98d40f2cd83daf46bd9ac0dce4e91900eb447d1ab0ec8f76de293a65bd99913b560bd2f5b6794c565018";
+      sha512 = "a70621c70092c9d375cdb8f94f0176341d732989645c2492232f8e664e01484d4c5e18ee45ead3a1c732ad01fb2bd3468e4a723d2a8e3afdfabff82efe9447dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/be/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/be/firefox-58.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "b76736401d8f20d9638e9808b7acb41f46a51f29eeac9eb7d7850a8b3c32974982e946f679c98f8e71b548e87589edf5c7127a20f7108e4e42deb0e0ed71fc1f";
+      sha512 = "bf8089e6df9af11dff0b5cc19b15f0df5aec4b7451fa195fc3ef52f3447dac43c90119779596a4ff2aa61290af4c78f3af1dc10d89a501479b12c90e432fa93a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/bg/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/bg/firefox-58.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "7a47b07dd0791f1cbab7f02645e1b97173630ebc44fb81b2308ceb539d92f0197e8a9aa24f640ddba6fa888fb71a979837d6bd19d0315cc8c8eb2a8cbf99af15";
+      sha512 = "ae1580a6e882d7d4085f30ff35cbe94f97c4ec3aeff6c386fbc002bddab1894a3834ae2c8647c87de00f85e685e0cf06522fde87e20c13643269120246fb4506";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/bn-BD/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/bn-BD/firefox-58.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "15ece8585166d99b9d52b1de03a909d1c38cceccae5547dc13267da223026f4be4fcbc2cb42a7c225a4a74147b014ad19173635fe4c3249f4180169b4a503bfc";
+      sha512 = "b1f479d2bddd2f240ef150465854e9a49a3e8ef9b9e23dd8254e8fbe902f7b602a05f1f9fc156f1a94aef5edff4c65f59eedb49e268cfa755d7bcd9c88ec13eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/bn-IN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/bn-IN/firefox-58.0.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "72df101c9d0c602542e65da9235dc63d17c220ff56d2d1008c285fc6c10e090bf343ef968e60a36664d0dec72d7bccfe016af542b014ab116c0f243920aae93d";
+      sha512 = "614e224b18b2c9d698a210a21b21202c98e5bdd8725755edfb5533456fc9a5a74c9e6353db979b07fe5596ff97cdbc7110da88eec8b01701879b5992fe935ff2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/br/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/br/firefox-58.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "d0830fa2a0e4159d46c24e048767ac5c032910c6e73858eabff4a1ca0006189b3a4978c3e4822242883e6fb3abe639122ed76afeda5d9d2d5391806ea07f6796";
+      sha512 = "e99b5b609de56dc21af10f20eed110ddde1c7abd21a0ef79ece2d8e933a39d0dacf20f2ab8296acb885f1432ad5b58ae0cbe291056ac70576b098263c83f8558";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/bs/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/bs/firefox-58.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "cf93ea42460de4e9c13392eb1bbe4c6053c049a18cfd7038d99c658cf076d9989648abbcc006e345fdb2fc66f56ff8abd044b527ca0ae29accd2b0f52dfcc2a1";
+      sha512 = "f7967e7b9fdab113cd8546c7325276f4d35e760a1bf78ef3c56398bb06d8a98fca82d0fe5d9bf80045bed12edc6c6e8656f5b088e2de4cbd0f1e69cc142695f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ca/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ca/firefox-58.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "3fbbfc5973384a0a6d65e02d5b82a6b5591ea8d610fec2ece24aa423550eebac1b25fd7d0080bae4300f64ae1955fc6dc881816f10edf33b07e0cb308260a4cb";
+      sha512 = "2680323d28ec219662173d4f3556d9c9780b2c6a4efd7a4adbe92fd99cbe616c86ea154c2a3f3b38314a62663416a630f4efb93bc0845597ed69afd5afefae57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/cak/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/cak/firefox-58.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "0cf301895b2dab45cf487e41ba093e547bb4d42b997a9c7a90da2fbfcdb044e654cfc23e4bfb6de7065ecdb8e4923434f98e8b58313cd9ee7cf64dd5435951a5";
+      sha512 = "35900e03a398f5ffc48652589789164173366a4f07de1eff90b288b3793146173629baa9b66d587d69e0a26bc57687e61a08879ab66dcbe8436a5f393e968fb0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/cs/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/cs/firefox-58.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "20011fd4567fb3112a75a07ae181ab7d3a85702b9583efeb007dfe7a3009c34f8632db631710105dd68ca579b44a83f53d84bd4768f0030ed106bbe12eda8f16";
+      sha512 = "d9aef028c0430dbf5320e4bd12659652dba741f37ab94c48176c6dc380b005f177c6e5c38ade7a78931fe22e9f5840b6aef6f09bffa952966273937f3efd2bfd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/cy/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/cy/firefox-58.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "1f9b31e5e36a581ba51737e5e1f85a2d6ce804de854585ad2919f7070305567883724fad9368529ebd98d3f428eeb36c555d2f7ccefcfedb877227969688f896";
+      sha512 = "405e3b56b1a583066d04e3fd35f9c0ae9094c3e3bf241ed77728ceb41aa3e880c09a89f747ad22a5a0c33db052038053ae4b2b0904d5c40dfbbcc2eb43178093";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/da/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/da/firefox-58.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "a919e582953660fff4f438d58c8814cd5437f13fc42af9ddb383db163485754fac667b4e830e68cc827d7646436760bd6760ac4b2d7fca2a951c1d5f7d43be59";
+      sha512 = "b9402927aa684722cf772b6ce95158776414d5f1555a596f00a957d00123005fb804594001443393572eafcb2cc1c37aa278fe29eebb0931b7eca24751186d81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/de/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/de/firefox-58.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "c5f844f17a3201a7a62e1e9c9dab3ede7042ca33bc8d388d9677858ab289d1f0a823594701e7eedcf1f9ee015c2ff16cdb0d9bc0e6861701f065827c69204f90";
+      sha512 = "f5d480ac6e2dee9784b34391a289a53d85c5f132baba94a1573179c1183a4a216eab0e2d19067342b4eeeb6248f38f1fa0b8269b1aba2add7d5728d505f70019";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/dsb/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/dsb/firefox-58.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "fda1a2b51a3ae8d0d28629141575fe14263baef7d68f3bafed89a744a493382faba2bc7d263648d8ed809eca274dbaf0e1669b534a23281944135195593f0616";
+      sha512 = "07b8f40225b583186cc680e3269a12e123335f4fd2041f0db67daeb53e72642fc0f91a29074fc11182bbfb50e326d53ce8ceee543f4f93762c664c362e32cb9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/el/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/el/firefox-58.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "0c48e342f0ec141f4a7512c0f1cb4826b9dfe77cf315d22365e4f3eee090f067a35215798ace57eaa38a80a5b62dde257992eed2084737dcd85b1d4d3f46740c";
+      sha512 = "6dbaab9a026c060bbfa286ee2cd7b1ac34d7a50dd33af81f9696148ec11353ce1519005959aface7c6de723dca7bf03055ccaa8fc70177419179116b30a04140";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/en-GB/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/en-GB/firefox-58.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "d9d24a97b0257bcd1a1b468e6f986ff4fe8d26ced92e3878123d8667957ab187d87bb01e8d389da6fbffde66e1714fe81a9e926a9f3f5c52ea5d38a8eb961d00";
+      sha512 = "d3890fa00dc159a3a9494a9ae2dac84761ef6bca74c442504428809507196612cd1e362bfb837a93b9bc15ac4b58da10e05c4d8235dfba625e9349cd04c9f37b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/en-US/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/en-US/firefox-58.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "b641a671d7390c505577fa956bc1452f58f6cc8418b3ccaf25eb8b5bb08799a3a2e1e7113525ad720f710d7022b18901c5234be1a1c372881e4908d2ae419743";
+      sha512 = "c291f87696212c59624a87530a02b881243b5c7645b3a75aabea574161c488ffe71392d00d18827ab9e4533f272eb44e57d062cfa88a5d14e0eaaad4011b344f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/en-ZA/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/en-ZA/firefox-58.0.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "605b7027a57c75e90d8e7004c50415ebdd2e2e111ac679d6bb87f1c55f0ca022aa4b77394a04ed94aa634d9b05359d9384e428f8f9dd000ddb2da755bb5d797a";
+      sha512 = "2935c69302dc079266463058513b816d0631a5477aa535b876b15eb2406bf6c0c4adbd60a83823acec1a6fbeaafc951a9d2a4ad80d2b623d1f2194a79b0099a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/eo/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/eo/firefox-58.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "d5e81e82ffccb2538d94be4752d8bde9e5e84eaf06c5c29a34e0e16b13cc8df62ae17c88a50cdd846dc2ddf35c76355db39f39d74d1d9aac19c962d823d2a5d3";
+      sha512 = "92e893b038ee0611f85a55b262565982c9941570911c36b5e5fe41d7833596f23f703aad5b606ed266c33a5e1156dacc641f126d8e04ba22db7848c0cf1d0c03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/es-AR/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/es-AR/firefox-58.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "27ad3f34bdb4f94a08043c699f2c9ce2a5de2cd297e9dc2edf777b78656902dcde7aeebe17463e3f7125d58a2cb5ac7de671695d46852bf15225cf201541eaf3";
+      sha512 = "fa000f580bd0c1be1f3e89ce901723d7e11b5d7cc69ad16f7dd31f6b4c07a7c04505165983833c008f4be23b5720211ec8eb9921993e7e6b330347e9f0bc0d7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/es-CL/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/es-CL/firefox-58.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "e65607bb7e1f08a2f0aea512e384d44b7d219939c82cb98cdd8a3697b5d43e7fba7036d4529c102a2ddbdf660baac45e8f9358692293d0a5d0869f72c8ca677c";
+      sha512 = "5d9f4abfc8d66fc3ef0dc08f7dcf84fc430806ca629598edc0e0cdb8c173efb56d1b5c4ed5ba8fcf90878163032a645ce282d6934980b636e8a8c199efe8cf9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/es-ES/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/es-ES/firefox-58.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "f486c0f40cd610540743546a188c434bf16c2482d88145841ec90974a819e7f82952cc6f9e8c8787665f28f47f1e8b7def418f0b08f9fbce73f9d1aabe62e91e";
+      sha512 = "d03218163b91ea0f6c478bc33c05676c98de8bfe1a42646f07f2d6daa37439e756031a22e4ff980a34912adeb18ecaf20283a71edb51fe8926bcb4aec22f4ed1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/es-MX/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/es-MX/firefox-58.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "c4e45e86b5680cb9580948bf8db29c5f3a13d2b2c6a73753872ab2c77715ecb64f756522d4c1e50009d783cd4f589ae39e3bedf771ebb4b03ea6930506210a06";
+      sha512 = "a55b1c6b88518f0749a349cd527542fadf510e1948b4bd50f141a3abd68e60b8e595503380e7dca6dbd1d80466d206da8e9e418c7ff12bda1e5a41df913978ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/et/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/et/firefox-58.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "181772128d6eb85141169208c283caa0f4658e3ef627b92f723694fa5f38be7fa8e4c6591901971cfbfb760cffd693a285589089436bb25e72ff95fad36c632d";
+      sha512 = "43e3eb5c94bcd5c0678b2999d165d65d2996417e0edc3b88fc4c132747049309b6beb8d20d4b51302b7474167b6d03d74e4a76d9b9df505ca305f22468f0b7ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/eu/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/eu/firefox-58.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "e582332c908c98b6eddefa04b223366442e61e231e9039e237e5d15007113d7986a0759e8b927262370ae61b103e749f96160a2596a7b79d2e7321a5416fa0b0";
+      sha512 = "fd25b5548cd5de401332c63bd85aa493a60334fd95cf3069d832eb9ac0dcea33d4440594117e396066f827e8ec1737a9afb554904dc3fcd570d805287f2de87f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/fa/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/fa/firefox-58.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "118684887c685acf3fd2a9f0ab1b63bee19c29e285e1817d013202a9fb722b17a3e774db3afa4056618172d4ce741aa78952bf806752d52fda4b651a633139d8";
+      sha512 = "3b0fc55a09e4e3bdbcb957116fc301311bebe56a1ef627578bee9972a5e24d7406ebb62899a7e896aaa67cc2d35a6269392846deb306790a25661038c0e12d26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ff/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ff/firefox-58.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "d4917fd09f789ae2ec456b4cef807ba17fd1e2a80f1cf9dd635c18dcebf87c9c5ccaa5937df7846ec24de943c8c58ba4a0c9282ed586958bb3275234fc9bd27c";
+      sha512 = "3ae6196faf8adcc409abb61eda980652b98a9b4b1eb750626dcc879520019b17486210dc50732eb4beae6910df9876edadd16a7ed001f2442fa0c5fa67d0b3c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/fi/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/fi/firefox-58.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "891c8a01940d9896dba75de258ba7da71b5e1b03697fcc04c5919b6570fa8b7164d9f8fba6f5a52614e637c5fe859f59da7fba34d4387c9763b82e7dd4e4ffd0";
+      sha512 = "6ca46b0e0234984cad7401ee4770b7d121783d5ec6a5aab6cfcdc0c560da23ece1c3c581afe5d2c33d0baea3966d4bca41085b142196dacc96f24bf07bc7c71b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/fr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/fr/firefox-58.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "cb6bf51bd4362b21416dc82a2c52cbecf0afb2aa88d6ab96affac7668d3ff0d7f81f345ce3440b04e0b4df0740505c204efa0d7eaf43af0b5c99294e0170a357";
+      sha512 = "46de1b2996a40bc5401b9e1717465fe8420d4eed26a4c2aab4a20933a3b7ff9bfaa81b1913b587dd0e48c827626eea9ab5ad459d08c1b0f3b6f0c90abf710537";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/fy-NL/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/fy-NL/firefox-58.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "17e3030507c7cd0dccb2b94bb36414ad9e4c8248b671f438dce27ec849c06a2a98343520bd457b9157813e11f9360a1e38cd9dc3dda49ee039ed2757168e5d26";
+      sha512 = "f5ed577816da80549fa9c8bc4755c4bab8aa2c9da7174f37606cff62512b0307c54572b87501b440eed66c5727b23d679e749254049c91860e10389794ca2ed7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ga-IE/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ga-IE/firefox-58.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "18bf7782acd20cb9972e419ddd62be4c9b0d18d2f545bf728f1729f2a63e9f69353cf47b8e2fdf8525829fafa3c87cecc6bc272e899a2df6dd1ae4cf11b5bed4";
+      sha512 = "282d7bc4c2ab46aa7fb2157d21e24295a82e9f28f833b756e96adb640667f611ad460f6102fb58e9e38087ab3c8dff439c942e1fd9536cd2782470622ae8301b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/gd/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/gd/firefox-58.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "27d56b6d98b4478821e1697398aa0b39ed51123eb72a18f06f03bcca53c7017b4c55fbd32af626a52a74b5c53c9efbd7a20bb265af1d43140189f6f5d03168d7";
+      sha512 = "f11a73f1b2ee2371eef7dd85ce66b7d0fb25b020103003ea326480ebc16c55922967245fd76791cb25a7ab99b96f842394f0fd290c3214174d0bc218a4327bca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/gl/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/gl/firefox-58.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "5a7c2e1faee64d224c8dcd822d0e3f0b064f4aa5617944aa048d32335fb2a45caefe7f6971058368493c483a5ac107808794289c68530d97f85d0e2438285a4c";
+      sha512 = "4f562d3b74ec69ee495d901cc91b2af12b68bad92f7ad66d45a94777fb34559e35aa103effabcd311ecf952acc9939ba16c3a17905684532d7e0f7b2b7c784e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/gn/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/gn/firefox-58.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "5c05eb1d50d0de7f7e25bc0821767ec916ff17a3499ed4cbbe53cb7d833fd43edaf3ec1c1c2db02b76523bad8a78043d7ac25be4d1a4076da942b09097949dd9";
+      sha512 = "fe08fc07cd11c00f932c042aefea193c7d6ffdc000b210117bf39e8f1c01689ed5abb5f26dbc55ee971d53abea2fe209f7359be990263229d43b49ed73cef5be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/gu-IN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/gu-IN/firefox-58.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "43eaf8f5ff8f921ead14cc2a2a5d9a98ca674af49087407dff37afe4acd9c22a4d83e96750bb50e8e6fd4219beab08c8bf52831fe15b8320b5858d6c93c611f5";
+      sha512 = "06eb8635eb7ee46f3e9e4bd2444d8beef4da5db534530d4d1572122a617558f27d7e8bee1efbe43e916c58406ad0728f294c2208048331cbe3c54da42a43ffe6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/he/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/he/firefox-58.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "9573f5d24af9f89abad0d46d99750b9380ce77c4c017143236178f3fbbfb2e43d1c1f1ae2223ae0d4c81b22688fc7da8c1fc2a19cb5619bdd42ca03ea7ef810e";
+      sha512 = "b45d06a32d3d6fea1c2093ad21168329137ea4cc1e2aa8133822b4355a67be081b7c5d9afaf01122e474ff43ecf2f802c881cb6da5bafcf1e3765204ae33d011";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/hi-IN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hi-IN/firefox-58.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "ac0d13b6d935f8b51379287f5ad5e434bec58eee0e29fdc786e43e7d7e270afea094b8af27c779e0f0c11e3f3582f84e2cac4e01fc69339aa569830d180fca6f";
+      sha512 = "30cfa4d45da6cb519396ca143e929695b7a2cacae1df4c88ca4ab85acd4ff74afc880f13d23f11f6bdbd99843cdfe88b3becbac15c0add4635ce8c2009996304";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/hr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hr/firefox-58.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "3f17557b50fff4334a27885358cd1c91fcfbaab4394b5cb9a571c47a24bd45a2b807534c6645b58220b65285aef5014582ec6e1a04e57e54f7cdc5cbc4d0e1ff";
+      sha512 = "64c6ae787603cd3b1855bdc01a458b3034b7ab959e15312e261c170f5e6435bd47cec560667dd0a1aecb48824df73534540f9e6a91f690f5e50c7b5a3b2fddf2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/hsb/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hsb/firefox-58.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "ea3cc8998fa736c27469efaa6aeef4263c1c23d62804721ef577d020295100bd99e6690336c29a0af7f274f8c0fd554d16ce39638b8c9de2132dc0fabe21b91e";
+      sha512 = "30da250712f6cf80749350e4c2a0ca069b4b0079d0bce9cbe16657232c1ce76212f962f5891f9cde86f9c88811996e922c2acf7b99a651bf6733fcc3b83613cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/hu/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hu/firefox-58.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "988721816865e6db32a4e874d7bcc67c0e7bfcf621bc9e8d6a8aa8732ac448930646891a53a6f66bdf64d625b1607ffcca4141ba8b011ec2b69803fb0eca32c1";
+      sha512 = "b60242512dcff653d758a9984b66ef77a718836da5b726233f2ba44f09cc6fbcd3f4502446c4c4c1d4c6112cf213ddba40d0078f9f7c7ed4e9cd6305b64d8c71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/hy-AM/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hy-AM/firefox-58.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "214105d839762ba56f8f30f9fd4e2b706ba2ab0ff4f76826661745505d2bf7b85481b17782182ee5250d82f0f233b9f3c7123669c2475d33bec40aa270cb83bb";
+      sha512 = "36afb61bcab97ee12a30c2ac50f366c8b35337ef91d9fca7a935bdc0dbdc4c150c6cba62ddb532ec194df93b4f9df96800d048857790b5c634a9f0bf7faa2570";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/id/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/id/firefox-58.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "60af8126c39ee9b7bd9f9c06048677ce5e9ac1b4da28176c965064e6d937df3218d01c923fe6bda822ac9fcfd95904e4f01438b88e0659b7df6c5a4b7b475330";
+      sha512 = "d7e36fad6b94e3a3887b346b863c13c5c3f0bf8c0ad85354cae62724e6f320af2b8afb988b390c7c620f763fe90e9719bbc8033b1b65f516157e569de076662f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/is/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/is/firefox-58.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "07230ab55805e4bc26c6aa427d43daef7d799115780d712db5b358a8d731296abb06baa8e21a200310922ac81e23a1e33584c1a25a76031c03a849e33aaabf0f";
+      sha512 = "d9e7caad2e362ec7e764d29b4c1052d9dcdf0d329762b8c74fcf54d3542fbd9d9920ec693be45a26eff9d09a713bb2867ad39a9e30196e92716bb21aa09281bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/it/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/it/firefox-58.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "4e80d7f042dec9c9752a81f434520b4ea2605319fdbe26a4ffee8e01ff60163a9df9100f154d45690ea4a492953f09a9b602609b88a350250dd71b2f66029713";
+      sha512 = "309bc35eebcfbef93b26eefe1a0fcd0aeb16648636857ea2d65dbf89ecfa03dc071ce1e26b2ebcbf64b58f7b5a8aca110fd6f20ab3af306acc7a32195920c0ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ja/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ja/firefox-58.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "a14fdbc6e2fb341d78878bbed3df456d3906a6f9721ed80764f8747faa82407ceb48a4a6e8b6c90c4164fcf231208b3f4f147d6465bc434496e991613c7cf250";
+      sha512 = "61b26b1c808798dcee28d59179f53117981d655b4b50215d53889f029e75eb32dea5e5b291ec6301c77b1578febfafacf0de0e1924153b5c56d2b67287d05924";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ka/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ka/firefox-58.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "e411fd39ee928f4e66937f55589f7a7d77eb9ee64abb30d49622e18b20d2ed2eecc34a54bb32a40d28a83b43e822b526494227b7b1a8b3cef831dbe8d5573dcf";
+      sha512 = "1394a91c94ea06abaae35b82a041667699b4a55977dd7aff2f5dbf39e21d18488db00dd52fe39fdb01af02a753e2f2e5810d456eab3e2c7524cff12f744eaa1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/kab/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/kab/firefox-58.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "b430ee1803556d791fdd19ffa21aa32d8245421c2e8a7dda7cda10d751cf9be125bc089de9149fe8b858db663397827b2e511a54a56053827c405b0fa2e17ad3";
+      sha512 = "663043b3f1cf1c47be7fa40f8bcb807611df665545041fcd5cce9b93a605abbc52cea6663dfd696ee48a3b462f412d2825d0ffe03e5a35166772090475e167cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/kk/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/kk/firefox-58.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "24f142f4c9b85cefb404905317d1afcfb37868fa4061b5e4c659a3e172d86f2fd9d7c07672fc4a78283da27c534e2f0639d1c567350740d698aae6fa50846772";
+      sha512 = "7fd70d200ab915f01f7239d8d84351dcf2f5aff159112f6f60e9ca4eb204b087461d8af00cebf282b4ee05dfd5571ceaa4dc1076c31353635c7eed7dfc8fa464";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/km/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/km/firefox-58.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "226fa56eec9704baacf04e54a5f74ed4a6fb01eab2020badd61542f2059f47ddac605f69117d23635fe0562c02d86a088d695ee1a15071315ebe5e19100b965c";
+      sha512 = "c8057c8108e588a26737dda5c6244f738f3d9f86334e18f2373072830b99a02cbcef7a5e4961e6adf5bd48e6605064ce0569ab10923b8c7fb649be2ef1fbab28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/kn/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/kn/firefox-58.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "c0c5eb6887ab1e3fe7f8669ff1c09cb5cea4fdad9c8fa488412bb3aef33b7252526ce5069e1dc8a2186c0ab4aa48a6d223487ef62554f90a022287aaed31d09e";
+      sha512 = "958c4cd905f2b7fcedf75b819e6136a98577cf8a87b0d20d643d74068332b33003a6a92ca7348f9336cdc5e88333cce2efdfe522817a8450672c8e103212df6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ko/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ko/firefox-58.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "397063d49b248302df350e01bc87fbb691e63681371fd9b2180edd8cffa9d00ddaa68de320165e0414bdf89dba037ebf8decdc6801ae0f5134dfe81cbb3c7052";
+      sha512 = "1a50dc600063481468769e8f9ea4f150068e9636b1ee84ef86c7f55e515ffb6124db686b3d2b52a29c12538342f13d9838d7499d89afaf49481d89eb2995fd8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/lij/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/lij/firefox-58.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "0c47e5568f5776829163ee5823c512d91e795478049ca0aa6239afc66c2ec0af940aaa32fb70473f41ddac3755c0dd32cd5b68207e94f095a033bf5accbe9675";
+      sha512 = "429681a147f3575ac693dd6002579751ca24ddbaa51a9926e303369e2c1273a2f3199889c9ae9db82533f7cce73e177dcbadaffb1be0f189db98327a71260b69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/lt/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/lt/firefox-58.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "3a18a2209fcc5adcfe4426b8acfafc7e6e781c01b7562d35cd02001f8469d93e1db4db400ba34844ad5296ac40a3540ebad5341457fcf00b7d33b9b672514a27";
+      sha512 = "a5c7c999210b05c88c354e0c88cc25e5128da8fb6f399dc05ce512ed0bfafdcc109ea17259772304d99027fb73ad667f091ad312d32cda5b4de0f387c39c3b9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/lv/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/lv/firefox-58.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "ec9938c819e98f3d1b7979b6e207cdf798af6e0f937f9ad7f23ceae9968272fb44c6d2d28c066b20d6aafcb7edddedb299fa32d0bba29f17e3c50db7bbbf6cc8";
+      sha512 = "d1f95c065173cfe5256e5733d3c4d551623355745cb7de570b5dc4ff2d7dd7da0a31ce2637d96c22556e41b92a637bba07278efa710d4be096ecab1e4476aa80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/mai/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/mai/firefox-58.0.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "ea5cce55b13cb8eaa652aef1cdc2883720397f872d63728c781805000835c41bbac1c2bef035700c72d1dff79ccb6a8d4980d6485f0774b3aa8c0424e94a3ce1";
+      sha512 = "1a7fab6cd71d67c46022dc8ea0484aae0915b1458e83dd3c5f1bde5daa77ad730da046ab1d1ad7f2cc3d34d418cd7ddfb95747bbf219841ea304bbb615697fcf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/mk/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/mk/firefox-58.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "653d8d32d776fbc08126a25fa8a70b3826302e9cce01b8bb6f8abe958a79456df7cdfb8ae09a74b560594c29c515e50afc77bbc1ee260980028d1b1f10cfc1a8";
+      sha512 = "ffd6a31976e3dc795e52c6431a2447ca64e4bf39b6bdbaf88e7f9c975678473f36952a33db9f17d80d3086fe0e8a8272bd9a8b1926b3291cb4abbb2d0adc1b2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ml/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ml/firefox-58.0.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "e99a9acba626060fe8eea88a478879f3be751ba224ff1e1cfe28ae6c9eedc2d672329f67773f71edbb58d6c3e71be26f57b53504474c67dd65e7ffac79767fc9";
+      sha512 = "21a2c8450e7057a882d2ff901eedd08b21d3ba7c421f8591a0bf2cce8424757298ad608560eada9f3300d387f071fb7b3e199e0878d413d66ba1be5fdc0d01fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/mr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/mr/firefox-58.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "6f64740c424e77ce62270b80594915d3e2eb4cc2d3606791e6c9e3c8d3d8bd362ea4d46ed742b13aa427389150fe1a97af782ddd05190b0a5a84e8dfae04563f";
+      sha512 = "3836a86acfe8e7c2e812ac447be62158e6bc2e00e73345d40f288214b703a9399d12f43f909c48aa7ffc32bd8b1b1e592af3595a2fb4369a68ccd801f3085a29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ms/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ms/firefox-58.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "f3d2450ef0770ccac86b11e84a27c2e58d8a1c4133e874f9ae1cb7524ddb5f104d4bd42ca1fc37c20a8a3b297b386a1df0d2fb348616cbe9ef5d01c59b43ae3f";
+      sha512 = "ecfc28fa91aee525e54bde80b0d2d76da9a88b595f6b48dfe93632776228ca79b95f2116eccd585460cd8af6dd90d81352db6f21d86b51582b806721207df31f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/my/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/my/firefox-58.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "8398627bba83a1d0bb4929d1fd15c135bd35c8e8d0560ca804a49a0e36a083fe377652cdded198eef2b8ec1492cd1d7a33d6c660cf72081d090d40ea8b4cf7f3";
+      sha512 = "2d57e9bdcee5a3b1ca91567dd97f98c554d62ae54544ec4b789b5bb75648cc7aaed617aa508897f8e4143c9bec6f79926396b7cabd6a4a9fe86f38f714af5211";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/nb-NO/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/nb-NO/firefox-58.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "123552055f7838ea2215a379f97c82b5d2e4085dc8e2a9cfc12f0ef5f3550f7247c4f3e70c806baf7eb12e031ff8b857eee721366d480e959dc1acae1d9453cc";
+      sha512 = "9f2b0f925054107eabc00a28f08604aa482694abf70d60d3e7d5f5808485f4e7fbd36289fb87dc8aed090a7cddf1172db6cbe768052aafe3d8d775277808aed2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/nl/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ne-NP/firefox-58.0.tar.bz2";
+      locale = "ne-NP";
+      arch = "linux-i686";
+      sha512 = "7e85227c6e3fe28382ae17fca3e2e91a06fe1d6971c9abb8e06c8b4c1b4b9e0d26a1fff88d747c07a9da942f91f95354402f6c12cb992a555af210f01d5e13d1";
+    }
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/nl/firefox-58.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "179c634792a96d8b3f5537273bff06d962cf5faf2ae7e299fa3e11aa4e5b08aba10759e17eaf656fb373c9a9a807590656f905b477c79a5f7da385b66f17a55a";
+      sha512 = "9febb386608d0d7b34c2d00637f85971c00c5395b229b44dd29d2d18bd0007e5f105bacb24f6a9f39c0e2eeb882478bc279b3a18a45cdacee6f697607b411511";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/nn-NO/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/nn-NO/firefox-58.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "b71efed9fe95408710ef4a4e8d7040ddd2c3f9979567211c5ccb48dabc2eecc609f29c2bdae59ef96913d54f0c52ae432a2bec265cc5d7a9ed1b683cc83379a9";
+      sha512 = "8e5bbbbbbc1cc8d195e0503d982d50b92d3ed832e6a8b9662e7a7fc0cce21a0a5b0ad8769026f8d78d8b59a1f5605164fb07059600e7c92bfaf2eb2f2e4d2eaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/or/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/or/firefox-58.0.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "998b2d7a6c215a4634209d1f2e04f5e80858a4172276afe5f3440416212351093c1083e19c116dcf2480a09287749e55adb3d522f62ea4170bfa2610e3884e4b";
+      sha512 = "9e7089f9e53d2136805f58d449c697e811b4c81af00e0bb321d2ec96ddf58838dd04b7c357530fde6fd69864c797ce3d4f0db105eb0534a1ea95588b779dea2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/pa-IN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/pa-IN/firefox-58.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "f15b76ba3fed7604b96315343e04b11823bcd9b1407c10678fb5a57193b37ca365bab3a41106f1113f2487ee5b81a14068a083243cb4a298aa53105c814b8b22";
+      sha512 = "5e1ce5092040a3c0ab7e5431dcd6731e16757b49c1dcd48e4520dd3caf728bcfd1dfe7ec75013e2359d9759526a9dfc2e8c87df88dd85708ee023b3a51a51603";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/pl/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/pl/firefox-58.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "cf10e29d8daee0ccca0a3260b97abc4c61f13716b209babed7dbac72809645a05f12ee0baa5ceb02a2b8cf283f27796697eb72bdaaeab5adb07cd89525da924c";
+      sha512 = "dd42a424f88c169dc26c0fa4876285440f019e2de936c6737ecc4255953bb44728ee63577d15a3bdb55b9540be5b8560984df936c2dbaa9b6b393efd1af0651f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/pt-BR/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/pt-BR/firefox-58.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "0bcc63288bb18b5dcaf382857a65e408d802da8e703cbc376be828e512fe66ed6f12b5e3a46db8c5f883000dd0ce152ab387d25642878abc2660d4d3782c5a0e";
+      sha512 = "83256d6c42257eb57b6926c04a1e7adc0a7ae120207477a7e79fe71b342802391ff5844cd1f6b15464a6cba12ea0d3e62dbf2e43ef0e4e275d16bf60c8e3bc5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/pt-PT/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/pt-PT/firefox-58.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "79969af79356540c274935741e00a0507ec2d7d7047bd03ab5420246daa0329b51320f0f2e92250e8e1c11491cd500a3112bcc7d4c61acebe079ffac8284e0ff";
+      sha512 = "80133f87098b9d2d5855fa87f16b441fa3845d19464dc3a156bab55adb8fb32e2b2055c22883963f37aef9e2051a9e859f02f4ccdf829e02cdd3ac326ea246bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/rm/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/rm/firefox-58.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "5ba523ff6ce9cf291b6d16c56eaa9688f8bab2fc43eb00d1c496cac9909187e781e0436a0afe47d8cd3808533a1f762e0e7dd417428ac7e5958487271b3e6d5f";
+      sha512 = "c01b84a6e5c087ecc28eec795275a065d7f370ed965ee0c876371dd7e442110bfe4c8c9356d9ae6ca0cd09448e4688901281973536ac0c72092a3ce5550605f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ro/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ro/firefox-58.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "9575744e3f62b7803a93524e24baf9838488067df5dcdcbce2031fd735fa25223869f22de807d33217f8b541d2185a4a6dd62ada6bd37bf6386f1d6f6b776ff7";
+      sha512 = "a00d1c473e0ead438c04c44a7169884d93e488bee068898abc2082570340c747bda7f77a597eef4353488fd94b811e955f1b44ea51e96a49b02b2a51299230d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ru/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ru/firefox-58.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "7529dc04a413c7ad5db86b199318bdf8bba0e8837b3f5e50840326301ebd84562d2a3cae2ae352e2625db85d652675bec20dad2de5db46ec520853789fc930f9";
+      sha512 = "3e2df508529125004f9e21fa100ab941c5cef0a849dd413fef3a22db67e8c7d3445f26cbbab26e76e716379af2156ab06c9be2b8b6996cbcca55f7966aad8b04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/si/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/si/firefox-58.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "7ec9f3b071ca4b7436b81c81c847acc915d8cc6e4d147587cde63527ba5b3f7d177857af308c0d4dc4566e53b3e4cc2398b3dfd367cc4ceae6eb90582027dda4";
+      sha512 = "9e3c4e1f46e528343d9a12555427706b387fa666fad133c1ecd051dd0ae0766f81ac21e90b80ed492dba0f37638211319cbbe6119955dd9daec01b1dd65730e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/sk/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sk/firefox-58.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "9fa5dc5cd172388bc61719e03fe7df5a2a6e56cd49ad3c7afd9622aca64ba25fbbe83f834431dc4c2a26b2873d80026769e7712c78dce550077cad4d84559dab";
+      sha512 = "bf82820a071ff046d51f3b8e0867f3776976ee9084b0753bb15bab5407d3fde1d8c7ce3ebb57832f3395aa4c228471cd1c6da1d9e5c03610ec1845c4a07db6aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/sl/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sl/firefox-58.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "3e142ce6878e9b01ee34e9a18152e4c869fdb9902a8f78810293d854e4196c8e0a43a8bfb7f7354dd27f2547792a48ac957bec96751aca050a3d65dc5e227f5b";
+      sha512 = "51a54b0ab14636b8a002280589c8dfea6dd3dbc25236432dd774156cba0de2ca814dd4845118934a719e2b0240da0c6a7a38588e2fa2f54301f8625a14cd8a37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/son/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/son/firefox-58.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "b0bda73680d788b55526763306477504430b49b4ce465f091b5d3aa62f5e56618f8d6125cc1a68dc4b5403dbe28ae2c1dfa9e7d85e0bde9f06dc8735083d159d";
+      sha512 = "0709b04b9c2d9b316132a5643c951f05cad0adaca9ec8aea9374e3e80019a990fa12419bee06185712e7c100b038d4eee648a12b8fde186f1a7caab472c40cde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/sq/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sq/firefox-58.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "285d6f4b2f27c14642bd44c572776c49c80d4360a635da1e92161f665a6714b011bd0be2b37f3ec1b2c1726ea6627eb7a21879e2af72bb4c04560a1f701770a3";
+      sha512 = "f5de9ad3600867e039a801642256ce8c0fd2feae4c2072561a7bb3cf2e4af7774fc68d388b884fefdb4a4e9e44bab288da489f9edce2f663926ac4755332fe42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/sr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sr/firefox-58.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "14c451f7a3237e43bbd6f5fd9370224452a401f97732901c9796e40d313f4542d635984b5feaaba9d44be77e6e3e65a6c191d4081bc5d2d1b57bae12d432c414";
+      sha512 = "816c6d2e5de45d069506ac6a54c6292c18442ff310397f4f8f8a5bc38e87d9cb9fc02293dc71f94010b01f965de625bd437f245342ee12615966fed3b1e9e3f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/sv-SE/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sv-SE/firefox-58.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "70eb6083426d6e382934e7734718d6eaa4884a9ac24e36b1fd87a9c9405dce16353e8f6058912adc4fac0cb4ddecf7e2fdc8428e088b44d56508bc47f6c55abc";
+      sha512 = "0b31a68d604c6d8c46c875054bdf60e05afbce7b074c63e2c2dd715a03e77540aab12de27305a9a6215ec138b76b5375e5103ace750bbf78269d838905efa43b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ta/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ta/firefox-58.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "615d3727a9efc2e14fefe093678cb83f83e1efaab9053a98391b7613754e40fa7929e4fa3de34da7aaef8053ea752e6ca00f83d114c90c1769f708742f492db5";
+      sha512 = "69b591bf072db73e8c083f6052b239d4331dc2688ea35b99055ee1938009b198f19de56b12059132c3b4b66cf5fa0e7a171a8c01eb998e0aeb8f1db921246593";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/te/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/te/firefox-58.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "246c2699bbd27a318778f5517d62bc7c96dd6fdba0a8291f291b0e803d2a68710d96c4a11118fd105d00e4489924a62195c7752edc403b5b42a8a06a36962571";
+      sha512 = "985e78c31ef1c3604d5fd3ffc5cc8871c897522dfff37675a6da6d72bb15c9538caa9cf346ade4304207ccf1dc790f7b353f4a7f76dc8b1ee7df91d0ef912644";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/th/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/th/firefox-58.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "3b34c97e9e3b0ec436e299c45e4913fcb90c9a565687d587774adef2fb10bacf9fd8c576a15a5c8100e2f82cec2d3c4353e645acc9c20245e6fb6e2b73213011";
+      sha512 = "9474d8ea5bb99dc0d6cc84f13c70df13f3958b23057a8a4c20180b57e5803ae108add8e8e385c5c6b5a76442adefb20cfa328987d9651e200e9cab5cfe96f8b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/tr/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/tr/firefox-58.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "184b6e4f5a88fd7606868bba6860718d2dec0a6db123222195ea9bafd5ff3a391ee34a911591eff58c5ae7bc90b171aa1866d3d872349d4057ce72a709eea0b8";
+      sha512 = "6be02174476b94a899227d93c3ade402f48ac7126e13f896ada068f34ba32f718f6ee28de7eb2475a0190cde1a10f1e08fcd8a95e0216c827457b0d6b5be13d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/uk/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/uk/firefox-58.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "bb343353890e94526ae5dab5c2dca510ddda25d0d808decdd5ed628af174e60e584f1a883e19f33be2b316e423ed1be7e8c30916eb10ed11c618a015beaa538c";
+      sha512 = "c6e21ada75939a968eebcc57598844b60a24e155bb540f295d727315b3b91f5533207372ee5826e85d740c77ef134e8dfa779828f8308627b96b57ed58589a21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/ur/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ur/firefox-58.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "f54e1cb54992436bc78b1491214978aa7986153564bc93f9da2c64e038f4bbb77dbf3f44ab4cece5a02e1ff8e1c0d4bf5ed64815817fc908482f9ef203689cc3";
+      sha512 = "c3e10cb76ec9851a1cd2853e44a57437450d67ff130c6be2c0367c0bef2d2c22bd67966667b71feea2d308ac05a652f72dace7f0436678d2be46ad1361524515";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/uz/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/uz/firefox-58.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "832c7b687c1db9545ac9fd81ecf95d29eb329518dad9386541073f6834ba88e80ad9bc70d6ab7e12d820e8430064f638d1558c0559d6b410a8ebd81a7a82b245";
+      sha512 = "01852bd4d2404270180070b81446679e7467904cb476fbd245ecd086c3f914f01fd61706d7a2d75d903540ac5ca254aeb12470d708fc86e3f475147591eaf479";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/vi/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/vi/firefox-58.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "e60023cc021263b402ffe829b24ec00f0c0e2e782fb0acba23b3527f612aed710a1c8c65cc28bcb03bbfa54a4450085adeff36be69bb21bbb175bddf4c5894c1";
+      sha512 = "3980ad79b0a6b9dd72d882dca046be9c43406e3ac84663af3dd46bf03fded2be303adbbc4669077df7c803546aaabd0ec0d2aac34b6f8a6f03f86955e34f4c83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/xh/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/xh/firefox-58.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "94ba86099376c14900fadef25a77b9b4422d8f50d26bcc3bf024dc5d6a35f4c08f897cb5dc1c94232798d9fff11e7b018c90ff7808bc7ee9c861e57f425e96e5";
+      sha512 = "3e1664e57115d4d9f817363cbc1c5a68039a7baa3e5b430dcf6b1be4252857daef1806f606f6eddd2bf7cc48542f382aa937915fa6f3dddcd2faf27bb8217943";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/zh-CN/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/zh-CN/firefox-58.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "a6cdd0d0553e84a727da33e8f06afe004f4a95d726982b32dc7f74f36182e8bd2b186dfd7f3a90760ab7b01f932fdfc8de4d1b154c5133151f29b7a4d78a409f";
+      sha512 = "e159a96858204f27d76cfecfcff32f400b2cdd8bfd847fb98dddd085f77565d5cd0e280b0f8a5552b397a08578144bda8307563454282de3fc70cb555ccd1554";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/57.0.4/linux-i686/zh-TW/firefox-57.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/zh-TW/firefox-58.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "a6ecdee1aefeb29b51861b011334346acf9816971c8b40196a06969c3e21e1a8ed96f1393f25e558f6fc6e5cf35b5a497de91df4764ad30c52d7ce06bd7d6732";
+      sha512 = "66f5978aac39e4be86745570cdc2fe6cbaae233b19b6d2ea710584862580027ac1a6033a2238601e6ca6968b39cf1313b088348c788dce9dbb3bdef9d97d8784";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -32,10 +32,10 @@ rec {
 
   firefox-esr = common rec {
     pname = "firefox-esr";
-    version = "52.5.3esr";
+    version = "52.6.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "7b9c87905c53bc681dc6475e05596449fed88850f9dc07c8223d0d3edd2dd9d8a0dd88ebae1cd59eced2165696df9370de5e85cc03cded58ec4d0f622634417f";
+      sha512 = "cf583df34272b7ff8841c3b093ca0819118f9c36d23c6f9b3135db298e84ca022934bcd189add6473922b199b47330c0ecf14c303ab4177c03dbf26e64476fa4";
     };
 
     patches =


### PR DESCRIPTION
###### Motivation for this change

Release notes are not updated yet:
https://www.mozilla.org/en-US/firefox/58.0/releasenotes/
https://www.mozilla.org/en-US/firefox/52.6.0/releasenotes/

Notes on the source package:

I could not build the source package. It results in `error: failed to acquire jobserver token`.

This may related to the following issues:

- https://github.com/NixOS/nixpkgs/issues/33050
- https://github.com/NixOS/nixpkgs/pull/33975
- https://github.com/alexcrichton/backtrace-rs/issues/78

Using rustc 1.23.0 doesn't help.

Full message:

```
[nix-shell:~/tmp/firefox-58.0]$ ./mach build
 0:00.48 /nix/store/pi3cnkd4v5d4ncgg1c4m3avmvdin953s-gnumake-4.2.1/bin/make -f client.mk -s
 0:01.50 Adding client.mk options from /home/t/tmp/firefox-58.0/mozconfig:
 0:01.50     MOZ_OBJDIR=/home/t/tmp/firefox-58.0/obj-x86_64-pc-linux-gnu
 0:01.50     OBJDIR=/home/t/tmp/firefox-58.0/obj-x86_64-pc-linux-gnu
 0:01.50     FOUND_MOZCONFIG=/home/t/tmp/firefox-58.0/mozconfig
 0:01.76 Elapsed: 0.00s; From dist/branding: Kept 4 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:01.77 Elapsed: 0.00s; From dist/public: Kept 0 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:01.77 Elapsed: 0.00s; From dist/xpi-stage: Kept 3 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:01.78 Elapsed: 0.00s; From dist/private: Kept 0 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:01.81 Elapsed: 0.03s; From _tests: Kept 453 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:01.83 Elapsed: 0.06s; From dist/idl: Kept 1006 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:01.94 Elapsed: 0.16s; From dist/bin: Kept 2101 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:02.03 Elapsed: 0.26s; From dist/include: Kept 4908 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:02.05 buildid.h
 0:02.13 source-repo.h
 0:02.24 backend.mk:2263: warning: overriding recipe for target '../dist/system_wrappers/pixman.h'
 0:02.24 backend.mk:1353: warning: ignoring old recipe for target '../dist/system_wrappers/pixman.h'
 0:02.26 backend.mk:2263: warning: overriding recipe for target '../dist/system_wrappers/pixman.h'
 0:02.26 backend.mk:1353: warning: ignoring old recipe for target '../dist/system_wrappers/pixman.h'
 0:02.27 application.ini
 0:02.37 application.ini.h
 0:02.47 Elapsed: 0.06s; From ../../dist/idl: Kept 1006 existing; Added/updated 0; Removed 0 files and 0 directories.
 0:02.67 force-cargo-library-build
 0:03.35    Compiling slab v0.3.0
 0:03.76 error: failed to acquire jobserver token
 0:03.76 
 0:03.76 Caused by:
 0:03.76   Resource temporarily unavailable (os error 11)
 0:03.76 make[4]: *** [/home/t/tmp/firefox-58.0/config/rules.mk:953: force-cargo-library-build] Error 101
 0:03.76 make[3]: *** [/home/t/tmp/firefox-58.0/config/recurse.mk:73: toolkit/library/rust/target] Error 2
 0:03.76 make[3]: *** Waiting for unfinished jobs....
 0:03.93 libnetwerk_dns_mdns_libmdns.a.desc
 0:04.32 libnetwerk_streamconv.a.desc
 0:04.42 libnetwerk_mime.a.desc
 0:04.70 libnetwerk_socket.a.desc
 0:07.56 libnetwerk_streamconv_converters.a.desc
 0:09.15 libnetwerk_cache.a.desc
 0:13.51 libnetwerk_cache2.a.desc
 0:13.58 make[2]: *** [/home/t/tmp/firefox-58.0/config/recurse.mk:33: compile] Error 2
 0:13.58 make[1]: *** [/home/t/tmp/firefox-58.0/config/rules.mk:432: default] Error 2
 0:13.58 make: *** [client.mk:274: build] Error 2
 0:13.60 0 compiler warnings present.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

