### PR TITLE
pythonPackages.oauthenticator & dependencies

### DIFF
--- a/pkgs/development/python-modules/globus-sdk/default.nix
+++ b/pkgs/development/python-modules/globus-sdk/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, flake8
+, nose2
+, mock
+, requests
+, pyjwt
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "globus-sdk";
+  version = "1.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nwdhhn9ib5ln56q8h3g42dl93jl67xlxkgl1wqkh7pacg00r4vs";
+  };
+
+  checkPhase = ''
+    py.test tests
+  '';
+
+  # No tests in archive
+  doCheck = false;
+  
+  checkInputs = [ flake8 nose2 mock ];
+  
+  propagatedBuildInputs = [ requests pyjwt  ];
+ 
+  meta = with lib; {
+    description = "A convenient Pythonic interface to Globus REST APIs, including the Transfer API and the Globus Auth API.";
+    homepage =  https://github.com/globus/globus-sdk-python;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ixxie ];
+  };
+}

--- a/pkgs/development/python-modules/mwoauth/default.nix
+++ b/pkgs/development/python-modules/mwoauth/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, six
+, pyjwt
+, requests
+, oauthlib
+, requests_oauthlib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "mwoauth";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1krqz755415z37z1znrc77vi4xyp5ys6fnq4zwcwixjjbzddpavj";
+  };
+
+  # package has no tests
+  doCheck = false;
+  
+  propagatedBuildInputs = [ six pyjwt requests oauthlib requests_oauthlib ];
+
+  meta = with lib; {
+    description = "A library designed to provide a simple means to performing an OAuth handshake with a MediaWiki installation with the OAuth Extension installed.";
+    homepage =  https://github.com/mediawiki-utilities/python-mwoauth;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ixxie ];
+  };
+}

--- a/pkgs/development/python-modules/oauthenticator/default.nix
+++ b/pkgs/development/python-modules/oauthenticator/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, jupyterhub
+, globus-sdk
+, mwoauth
+, codecov
+, flake8
+, pyjwt
+, pytest
+, pytestcov
+, pytest-tornado
+, requests-mock
+, pythonOlder
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "oauthenticator";
+  version = "0.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rlg63ii7sxj1xad2nx6wk1xgv3a8dm0az0q9g2v6hdv9cnc4b55";
+  };
+
+  checkPhase = ''
+    py.test oauthenticator/tests
+  '';
+
+  # No tests in archive
+  doCheck = false;
+   
+  checkInputs = [  globus-sdk mwoauth codecov flake8 pytest
+    pytestcov pytest-tornado requests-mock pyjwt ];
+  
+  propagatedBuildInputs = [ jupyterhub ];
+
+  disabled = pythonOlder "3.4";
+
+  meta = with lib; {
+    description = "Authenticate JupyterHub users with common OAuth providers, including GitHub, Bitbucket, and more.";
+    homepage =  https://github.com/jupyterhub/oauthenticator;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ixxie ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-tornado/default.nix
+++ b/pkgs/development/python-modules/pytest-tornado/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, pytest
+, tornado
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-tornado";
+  version = "0.4.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0b1r5im7qmbpmxhfvq13a6rp78sjjrrpysfnjkd9hggavgc75dr8";
+  };
+
+  # package has no tests
+  doCheck = false;
+
+  propagatedBuildInputs = [ pytest tornado ];
+
+  meta = with lib; {
+    description = "A py.test plugin providing fixtures and markers to simplify testing of asynchronous tornado applications.";
+    homepage =  https://github.com/eugeniy/pytest-tornado;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ixxie ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -263,6 +263,8 @@ in {
 
   ntlm-auth = callPackage ../development/python-modules/ntlm-auth { };
 
+  oauthenticator = callPackage ../development/python-modules/oauthenticator { };
+
   plantuml = callPackage ../tools/misc/plantuml { };
 
   Pmw = callPackage ../development/python-modules/Pmw { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -346,6 +346,8 @@ in {
     slurm = pkgs.slurm;
   };
 
+  pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
+  
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -243,6 +243,8 @@ in {
     mpi = pkgs.openmpi;
   };
 
+  mwoauth = callPackage ../development/python-modules/mwoauth { };
+  
   neuron = pkgs.neuron.override {
     inherit python;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -223,6 +223,8 @@ in {
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
 
+  globus-sdk = callPackage ../development/python-modules/globus-sdk { };
+  
   gssapi = callPackage ../development/python-modules/gssapi { };
 
   h5py = callPackage ../development/python-modules/h5py {


### PR DESCRIPTION
Packaged pythonPackages.oauthenticator and its dependencies, pythonPackages.mwoauth and pythonPackages.globus-sdk.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

