### PR TITLE
gobjectIntrospection: use absolute path for cairo GIR

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/absolute_gir_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_gir_path.patch
@@ -1,0 +1,11 @@
+--- a/gir/cairo-1.0.gir.in
++++ b/gir/cairo-1.0.gir.in
+@@ -5,7 +5,7 @@
+             xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+   <package name="%CAIRO_GIR_PACKAGE%"/>
+   <namespace name="cairo" version="1.0"
+-	     shared-library="%CAIRO_SHARED_LIBRARY%"
++	     shared-library="@cairoLib@/%CAIRO_SHARED_LIBRARY%"
+ 	     c:identifier-prefixes="cairo"
+ 	     c:symbol-prefixes="cairo">
+     <record name="Context" c:type="cairo_t" foreign="1"

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, flex, bison, pkgconfig, libffi, python
-, libintlOrEmpty, cctools
+, libintlOrEmpty, cctools, cairo
 , substituteAll, nixStoreDir ? builtins.storeDir
 }:
 # now that gobjectIntrospection creates large .gir files (eg gtk3 case)
@@ -38,10 +38,17 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
-  patches = stdenv.lib.singleton (substituteAll {
-    src = ./absolute_shlib_path.patch;
-    inherit nixStoreDir;
-  });
+  patches = [
+    (substituteAll {
+      src = ./absolute_shlib_path.patch;
+      inherit nixStoreDir;
+    })
+    # https://github.com/NixOS/nixpkgs/issues/34080
+    (substituteAll {
+      src = ./absolute_gir_path.patch;
+      cairoLib = "${getLib cairo}/lib";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "A middleware layer between C libraries and language bindings";


### PR DESCRIPTION
###### Motivation for this change
Cairo does not provide its own GObject bindinds so they are provided by gobject-introspection package. Unfortunately, this means that if we want to use the absolute path, we need gi to depend on cairo, which increases the closure size from 41M to 56M. We will probably want to split the typelib into a separate output.

Closes: #34080

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @psychon does this fix your thing?