### PR TITLE
cargo-vendor-bin: init at 0.1.13

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -1,11 +1,7 @@
-{ fetchurl, stdenv, path, cacert, git, rust }:
+{ fetchurl, stdenv, path, cacert, git, rust, cargo-vendor-bin }:
 let
-  cargoVendor = import ./cargo-vendor.nix {
-    inherit fetchurl stdenv;
-  };
-
   fetchcargo = import ./fetchcargo.nix {
-    inherit stdenv cacert git rust cargoVendor;
+    inherit stdenv cacert git rust cargo-vendor-bin;
   };
 in
 { name, cargoSha256

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -1,8 +1,8 @@
-{ stdenv, cacert, git, rust, cargoVendor }:
+{ stdenv, cacert, git, rust, cargo-vendor-bin }:
 { name ? "cargo-deps", src, srcs, sourceRoot, sha256, cargoUpdateHook ? "" }:
 stdenv.mkDerivation {
   name = "${name}-vendor";
-  nativeBuildInputs = [ cacert cargoVendor git rust.cargo ];
+  nativeBuildInputs = [ cacert cargo-vendor-bin git rust.cargo ];
   inherit src srcs sourceRoot;
 
   phases = "unpackPhase installPhase";

--- a/pkgs/tools/package-management/cargo-vendor-bin/default.nix
+++ b/pkgs/tools/package-management/cargo-vendor-bin/default.nix
@@ -1,12 +1,12 @@
-{ fetchurl, stdenv }:
+{ stdenv, lib, fetchurl }:
 let
   inherit (stdenv) system;
 
-  version = "0.1.12";
+  version = "0.1.13";
 
   hashes = {
-    x86_64-linux = "1hxlavcxy374yypfamlkygjg662lhll8j434qcvdawkvlidg5ii5";
-    x86_64-darwin = "1jkvhh710gwjnnjx59kaplx2ncfvkx9agfa76rr94sbjqq4igddm";
+    x86_64-linux = "1znv8hm4z4bfb6kncf95jv6h20qkmz3yhhr8f4vz2wamynklm9pr";
+    x86_64-darwin = "0hcib4yli216qknjv7r2w8afakhl9yj19yyppp12c1p4pxhr1qr6";
   };
   hash = hashes. ${system} or badSystem;
 
@@ -19,7 +19,7 @@ let
   platform = platforms . ${system} or badSystem;
 
 in stdenv.mkDerivation {
-  name = "cargo-vendor-${version}";
+  name = "cargo-vendor-bin-${version}";
 
   src = fetchurl {
      url = "https://github.com/alexcrichton/cargo-vendor/releases/download/${version}/cargo-vendor-${version}-${platform}.tar.gz";
@@ -31,4 +31,12 @@ in stdenv.mkDerivation {
   installPhase = ''
     install -Dm755 cargo-vendor $out/bin/cargo-vendor
   '';
+
+  meta = with lib; {
+    description = "Cargo subcommand to vendor crates.io dependencies";
+    homepage = "https://github.com/alexcrichton/cargo-vendor";
+    licenses = licenses.asl20;
+    maintainers = with maintainers; [ zimbatm ];
+    platforms = builtins.attrNames hashes;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6490,6 +6490,7 @@ with pkgs;
     });
 
   cargo-edit = callPackage ../tools/package-management/cargo-edit { };
+  cargo-vendor-bin = callPackage ../tools/package-management/cargo-vendor-bin { };
 
   rainicorn = callPackage ../development/tools/rust/rainicorn { };
   rustfmt = callPackage ../development/tools/rust/rustfmt { };


### PR DESCRIPTION
###### Motivation for this change

Unroll the rust bootstrap phase. By moving cargo-vendor to the top-level it makes it easier to update it or override in overlays.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

