### PR TITLE
librsvg: 2.40.18 -> 2.42.0

### DIFF
--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -6,7 +6,7 @@
 # no introspection by default, it's too big
 
 let
-  version = "2.42.0";
+  version = "2.42.2";
   releaseVersion = (lib.concatStringsSep "." (lib.lists.take 2
     (lib.splitString "." version)));
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url    = "mirror://gnome/sources/librsvg/${releaseVersion}/${name}.tar.xz";
-    sha256 = "06j60hb1m96hnrp8phbqn8lfw2j8ai8dcddzc72yvrnrn8lagc4s";
+    sha256 = "0c550a0bffef768a436286116c03d9f6cd3f97f5021c13e7f093b550fac12562";
   };
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -1,16 +1,22 @@
 { lib, stdenv, fetchurl, pkgconfig, glib, gdk_pixbuf, pango, cairo, libxml2, libgsf
-, bzip2, libcroco, libintlOrEmpty, darwin
+, bzip2, libcroco, libintlOrEmpty, darwin, rust
 , withGTK ? false, gtk3 ? null
 , gobjectIntrospection ? null, enableIntrospection ? false }:
 
 # no introspection by default, it's too big
 
+let
+  version = "2.42.0";
+  releaseVersion = (lib.concatStringsSep "." (lib.lists.take 2
+    (lib.splitString "." version)));
+
+in
 stdenv.mkDerivation rec {
-  name = "librsvg-2.40.19";
+  name = "librsvg-${version}";
 
   src = fetchurl {
-    url    = "mirror://gnome/sources/librsvg/2.40/librsvg-2.40.18.tar.xz";
-    sha256 = "0k2nbd4g31qinkdfd8r5c5ih2ixl85fbkgkqqh9747lwr24c9j5z";
+    url    = "mirror://gnome/sources/librsvg/${releaseVersion}/${name}.tar.xz";
+    sha256 = "06j60hb1m96hnrp8phbqn8lfw2j8ai8dcddzc72yvrnrn8lagc4s";
   };
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
@@ -22,7 +28,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib gdk_pixbuf cairo ] ++ lib.optional withGTK gtk3;
 
-  nativeBuildInputs = [ pkgconfig ]
+  nativeBuildInputs = [ pkgconfig rust.rustc rust.cargo ]
     ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
       ApplicationServices
     ]);


### PR DESCRIPTION
###### Motivation for this change
Package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jtojnar 
The old version attribute did not correspond to the source tarball.

Tested rebuilding a few applications that required `librsvg` and they seem to work as expected.