### PR TITLE
 samba: 4.6.11 -> 4.7.4 

### DIFF
--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ldb-1.1.27";
+  name = "ldb-1.3.1";
 
   src = fetchurl {
     url = "mirror://samba/ldb/${name}.tar.gz";
-    sha256 = "1b1mkl5p8swb67s9aswavhzswlib34hpgsv66zgns009paf2df6d";
+    sha256 = "1b1mkggp8swb67s9aswavhzswlib34hpgsv66zgns009paf2df6d";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
 
   patches =
     [ ./4.x-no-persistent-install.patch
+      ./patch-source3__libads__kerberos_keytab.c.patch
     ];
 
   buildInputs =

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -19,11 +19,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "samba-${version}";
-  version = "4.6.11";
+  version = "4.7.4";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${name}.tar.gz";
-    sha256 = "07gd41y4ajdiansfqa8c5wvrincgddfzyfgh1pf7g388zaq7l6q5";
+    sha256 = "0iw290n0q4l5s92d0f9yz27yp3rdfr6bvsmvg1xvd19g8p2d04pv";
   };
 
   outputs = [ "out" "dev" "man" ];

--- a/pkgs/servers/samba/patch-source3__libads__kerberos_keytab.c.patch
+++ b/pkgs/servers/samba/patch-source3__libads__kerberos_keytab.c.patch
@@ -1,0 +1,20 @@
+--- old/source3/libads/kerberos_keytab.c	2017-12-23 14:23:53.247467000 +0100
++++ new/source3/libads/kerberos_keytab.c	2017-12-23 18:57:07.135340000 +0100
+@@ -32,8 +32,6 @@
+ 
+ #ifdef HAVE_KRB5
+ 
+-#ifdef HAVE_ADS
+-
+ /* This MAX_NAME_LEN is a constant defined in krb5.h */
+ #ifndef MAX_KEYTAB_NAME_LEN
+ #define MAX_KEYTAB_NAME_LEN 1100
+@@ -85,6 +83,8 @@
+ 	return ret;
+ }
+ 
++#ifdef HAVE_ADS
++
+ /**********************************************************************
+  Adds a single service principal, i.e. 'host' to the system keytab
+ ***********************************************************************/


### PR DESCRIPTION
###### Motivation for this change

###### Things done
updated samba and then made it compile again

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

