### PR TITLE
xcbuild: platform version

### DIFF
--- a/pkgs/development/tools/xcbuild/sdk.nix
+++ b/pkgs/development/tools/xcbuild/sdk.nix
@@ -1,26 +1,30 @@
 { stdenv, writeText, toolchainName, sdkName, xcbuild }:
 
 let
+  # TODO: expose MACOSX_DEPLOYMENT_TARGET in nix so we can use it here.
+  version = "10.10";
 
   SDKSettings = {
     CanonicalName = sdkName;
     DisplayName = sdkName;
     Toolchains = [ toolchainName ];
-    Version = "10.10";
-    MaximumDeploymentTarget = "10.10";
+    Version = version;
+    MaximumDeploymentTarget = version;
     isBaseSDK = "YES";
   };
 
   SystemVersion = {
     ProductName = "Mac OS X";
-    ProductVersion = "10.10";
+    ProductVersion = version;
   };
-
 in
 
 stdenv.mkDerivation {
-  name = "MacOSX.sdk";
+  name = "MacOSX${version}.sdk";
+  inherit version;
+
   buildInputs = [ xcbuild ];
+
   buildCommand = ''
     mkdir -p $out/
     plutil -convert xml1 -o $out/SDKSettings.plist ${writeText "SDKSettings.json" (builtins.toJSON SDKSettings)}

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -30,7 +30,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "xcbuild-wrapper";
+  name = "xcbuild-wrapper-${xcbuild.version}";
 
   buildInputs = [ xcbuild makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change

Without this xcbuild can detect an incorrect version for store paths
that have a sequence of digits in their hash. See https://hydra.nixos.org/build/67632952.

```
ld: malformed 32-bit x.y.z version number: 85294
/nix/store/yz966rdvw1blblvzs15pxpcd85294isw-MacOSX.platform/Developer/SDKs/MacOSX.sdk
```

/cc @copumpkin @matthewbauer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
