### PR TITLE
SDL2_{gfx,mixer,net,ttf}: fix Darwin build

### DIFF
--- a/pkgs/development/libraries/SDL2_gfx/default.nix
+++ b/pkgs/development/libraries/SDL2_gfx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL2 }:
+{ stdenv, darwin, fetchurl, SDL2 }:
 
 stdenv.mkDerivation rec {
   name = "SDL2_gfx-${version}";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/sdl2gfx/${name}.tar.gz";
     sha256 = "16jrijzdp095qf416zvj9gs2fqqn6zkyvlxs5xqybd0ip37cp6yn";
   };
+
+  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
 
   buildInputs = [ SDL2 ];
 
@@ -38,6 +40,6 @@ stdenv.mkDerivation rec {
     license = licenses.zlib;
 
     maintainers = with maintainers; [ bjg ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/SDL2_gfx/default.nix
+++ b/pkgs/development/libraries/SDL2_gfx/default.nix
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "16jrijzdp095qf416zvj9gs2fqqn6zkyvlxs5xqybd0ip37cp6yn";
   };
 
-  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
-
-  buildInputs = [ SDL2 ];
+  buildInputs = [ SDL2 ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
 
   configureFlags = if stdenv.isi686 || stdenv.isx86_64 then "--enable-mmx" else "--disable-mmx";
 

--- a/pkgs/development/libraries/SDL2_mixer/default.nix
+++ b/pkgs/development/libraries/SDL2_mixer/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, autoreconfHook, pkgconfig, which
 , SDL2, libogg, libvorbis, smpeg2, flac, libmodplug
+, CoreServices, AudioUnit, AudioToolbox
 , enableNativeMidi ? false, fluidsynth ? null }:
 
 stdenv.mkDerivation rec {
@@ -17,6 +18,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig which ];
 
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices AudioUnit AudioToolbox ];
+
   propagatedBuildInputs = [ SDL2 libogg libvorbis fluidsynth smpeg2 flac libmodplug ];
 
   configureFlags = [ "--disable-music-ogg-shared" ]
@@ -24,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "SDL multi-channel audio mixer library";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     homepage = https://www.libsdl.org/projects/SDL_mixer/;
     maintainers = with maintainers; [ MP2E ];
     license = licenses.zlib;

--- a/pkgs/development/libraries/SDL2_net/default.nix
+++ b/pkgs/development/libraries/SDL2_net/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "08cxc1bicmyk89kiks7izw1rlx5ng5n6xpy8fy0zxni3b9z8mkhm";
   };
 
-  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
+  buildInputs = stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
 
   propagatedBuildInputs = [ SDL2 ];
 

--- a/pkgs/development/libraries/SDL2_net/default.nix
+++ b/pkgs/development/libraries/SDL2_net/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL2 }:
+{ stdenv, darwin, fetchurl, SDL2 }:
 
 stdenv.mkDerivation rec {
   name = "SDL2_net-${version}";
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "08cxc1bicmyk89kiks7izw1rlx5ng5n6xpy8fy0zxni3b9z8mkhm";
   };
 
+  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
+
   propagatedBuildInputs = [ SDL2 ];
 
   meta = with stdenv.lib; {
@@ -16,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.libsdl.org/projects/SDL_net;
     license = licenses.zlib;
     maintainers = with maintainers; [ MP2E ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/SDL2_ttf/default.nix
+++ b/pkgs/development/libraries/SDL2_ttf/default.nix
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0xljwcpvd2knrjdfag5b257xqayplz55mqlszrqp0kpnphh5xnrl";
   };
 
-  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
-
-  buildInputs = [ SDL2 freetype mesa_noglu ];
+  buildInputs = [ SDL2 freetype mesa_noglu ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
 
   meta = with stdenv.lib; {
     description = "SDL TrueType library";

--- a/pkgs/development/libraries/SDL2_ttf/default.nix
+++ b/pkgs/development/libraries/SDL2_ttf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL2, freetype, mesa_noglu }:
+{ stdenv, darwin, fetchurl, SDL2, freetype, mesa_noglu }:
 
 stdenv.mkDerivation rec {
   name = "SDL2_ttf-${version}";
@@ -9,11 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "0xljwcpvd2knrjdfag5b257xqayplz55mqlszrqp0kpnphh5xnrl";
   };
 
+  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
+
   buildInputs = [ SDL2 freetype mesa_noglu ];
 
   meta = with stdenv.lib; {
     description = "SDL TrueType library";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.zlib;
     homepage = https://www.libsdl.org/projects/SDL_ttf/;
   };

--- a/pkgs/development/libraries/smpeg2/default.nix
+++ b/pkgs/development/libraries/smpeg2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, autoconf, automake, libtool, m4, pkgconfig, makeWrapper, SDL2 }:
+{ stdenv, darwin, fetchsvn, autoconf, automake, libtool, m4, pkgconfig, makeWrapper, SDL2 }:
 
 stdenv.mkDerivation rec {
   name = "smpeg2-svn${version}";
@@ -15,7 +15,8 @@ stdenv.mkDerivation rec {
     ./sdl2.patch
   ];
 
-  nativeBuildInputs = [ autoconf automake pkgconfig makeWrapper ];
+  nativeBuildInputs = [ autoconf automake pkgconfig makeWrapper ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
 
   buildInputs = [ SDL2 ];
 
@@ -37,7 +38,7 @@ stdenv.mkDerivation rec {
     homepage = http://icculus.org/smpeg/;
     description = "SDL2 MPEG Player Library";
     license = licenses.lgpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ orivej ];
   };
 }

--- a/pkgs/development/libraries/smpeg2/default.nix
+++ b/pkgs/development/libraries/smpeg2/default.nix
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
     ./sdl2.patch
   ];
 
-  nativeBuildInputs = [ autoconf automake pkgconfig makeWrapper ]
-    ++ stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
+  nativeBuildInputs = [ autoconf automake pkgconfig makeWrapper ];
 
-  buildInputs = [ SDL2 ];
+  buildInputs = [ SDL2 ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.libobjc;
 
   preConfigure = ''
     sh autogen.sh

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10961,7 +10961,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
-  SDL2_mixer = callPackage ../development/libraries/SDL2_mixer { };
+  SDL2_mixer = callPackage ../development/libraries/SDL2_mixer {
+    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit AudioToolbox;
+  };
 
   SDL2_net = callPackage ../development/libraries/SDL2_net { };
 


### PR DESCRIPTION
###### Motivation for this change

Hopefully this fixes 89c867196cd0db983eaef80e6ad497edaea362e0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

