### PR TITLE
cava: 0.4.2 -> 0.6.0

### DIFF
--- a/pkgs/applications/audio/cava/default.nix
+++ b/pkgs/applications/audio/cava/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   name = "cava-${version}";
-  version = "0.4.2";
+  version = "0.6.0";
 
   buildInputs = [
     alsaLib
@@ -16,14 +16,16 @@ stdenv.mkDerivation rec {
     owner = "karlstav";
     repo = "cava";
     rev = version;
-    sha256 = "1c5gl8ghmd89f6097rjd2dzrgh1z4i4v9m4vn5wkpnnm68b96yyc";
+    sha256 = "01maaq5pfd4a7zilgarwr1nl7jbqyrvir6w7ikchggsckrlk23wr";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
   postConfigure = ''
-    substituteInPlace Makefile \
+    substituteInPlace Makefile.am \
       --replace "-L/usr/local/lib -Wl,-rpath /usr/local/lib" ""
+    substituteInPlace configure.ac \
+      --replace "/usr/share/consolefonts" "$out/share/consolefonts"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

closes #34090

###### Things done

- Built on NixOS
- Ran on NixOS. The basic command runs but I'm not sure what it does so I haven't tested it very well.
