### PR TITLE
rdma-core: init at 16.1

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gfortran, perl, libibverbs
+{stdenv, fetchurl, gfortran, perl, rdma-core
 
 # Enable the Sun Grid Engine bindings
 , enableSGE ? false
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [ gfortran ]
-    ++ optional (stdenv.isLinux || stdenv.isFreeBSD) libibverbs;
+    ++ optional (stdenv.isLinux || stdenv.isFreeBSD) rdma-core;
 
   nativeBuildInputs = [ perl ];
 

--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, ethtool, libnl, libudev, python, perl
+} :
+
+let
+  version = "16.1";
+
+in stdenv.mkDerivation {
+  name = "rdma-core-${version}";
+
+  src = fetchFromGitHub {
+    owner = "linux-rdma";
+    repo = "rdma-core";
+    rev = "v${version}";
+    sha256 = "1fixw6hpf732vzlpczx0b2y84jrhgfjr3cljqxky7makzgh2s7ng";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ libnl ethtool libudev python perl ];
+
+  postFixup = ''
+    substituteInPlace $out/bin/rxe_cfg --replace ethtool "${ethtool}/bin/ethtool"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "RDMA Core Userspace Libraries and Daemons";
+    homepage = https://github.com/linux-rdma/rdma-core;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ markuskowa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4321,6 +4321,8 @@ with pkgs;
 
   rc = callPackage ../shells/rc { };
 
+  rdma-core = callPackage ../os-specific/linux/rdma-core { };
+
   read-edid = callPackage ../os-specific/linux/read-edid { };
 
   redir = callPackage ../tools/networking/redir { };


### PR DESCRIPTION
###### Motivation for this change
This package replaces `libibverbs` and `librdmacm`. The `libibverbs`  package source is deprecated (see https://github.com/NixOS/nixpkgs/issues/33090). This package also combines both libraries, provides the modules for more recent infiniband adapters, and support for RDMA over Converged Ethernet. 

###### Things done
I don't have access to an Infiniband setup at the moment. Any help testing it is welcome.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

