### PR TITLE
octopus: init at 7.2

### DIFF
--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, symlinkJoin, gfortran, perl, procps
+, libyaml, libxc, fftw, openblas, gsl
+}:
+
+let
+  version = "7.2";
+  fftwAll = symlinkJoin { name ="ftw-dev-out"; paths = [ fftw.dev fftw.out ]; };
+
+in stdenv.mkDerivation {
+  name = "octopus-${version}";
+
+  src = fetchurl {
+    url = "http://www.tddft.org/programs/octopus/down.php?file=${version}/octopus-${version}.tar.gz";
+    sha256 = "03zzmq72zdnjkhifbmlxs7ig7x6sf6mv8zv9mxhakm9hzwa9yn7m";
+  };
+
+  nativeBuildInputs = [ perl procps fftw.dev ];
+  buildInputs = [ libyaml gfortran libxc openblas gsl fftw.out ];
+
+  configureFlags = ''
+    --with-yaml-prefix=${libyaml}
+    --with-blas=-lopenblas
+    --with-lapack=-lopenblas
+    --with-fftw-prefix=${fftwAll}
+    --with-gsl-prefix=${gsl}
+    --with-libxc-prefix=${libxc}
+  '';
+
+  doCheck = false;
+  checkTarget = "check-short";
+
+  postPatch = ''
+    patchShebangs ./
+  '';
+
+  postConfigure = ''
+    patchShebangs testsuite/oct-run_testsuite.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Real-space time dependent density-functional theory code";
+    homepage = http://octopus-code.org;
+    maintainers = with maintainers; [ markuskowa ];
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6827,6 +6827,8 @@ with pkgs;
 
   ocropus = callPackage ../applications/misc/ocropus { };
 
+  octopus = callPackage ../applications/science/chemistry/octopus { openblas=openblasCompat; };
+
   inherit (callPackages ../development/interpreters/perl {}) perl perl522 perl524 perl526;
 
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done
Test suite runs all relevant tests (one minor failure).
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

