### PR TITLE
flameshot: init at 0.5.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -607,6 +607,7 @@
   schmitthenner = "Fabian Schmitthenner <development@schmitthenner.eu>";
   schneefux = "schneefux <schneefux+nixos_pkg@schneefux.xyz>";
   schristo = "Scott Christopher <schristopher@konputa.com>";
+  scode = "Peter Schuller <peter.schuller@infidyne.com>";
   scolobb = "Sergiu Ivanov <sivanov@colimite.fr>";
   sdll = "Sasha Illarionov <sasha.delly@gmail.com>";
   SeanZicari = "Sean Zicari <sean.zicari@gmail.com>";

--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, qtbase, qmake, qttools }:
+
+stdenv.mkDerivation rec {
+  name = "flameshot-${version}";
+  version = "0.5.0";
+
+  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtbase ];
+
+  qmakeFlags = [
+    # flameshot.pro assumes qmake is being run in a git checkout and uses it
+    # to determine the version being built. Let's replace that.
+    "VERSION=${version}"
+    "PREFIX=/"
+  ];
+  patchPhase = ''
+    sed -i 's/VERSION =/#VERSION =/g' flameshot.pro
+    sed -i 's,USRPATH = /usr/local,USRPATH = /,g' flameshot.pro
+  '';
+
+  installFlags = [ "INSTALL_ROOT=$(out)" ];
+
+  src = fetchFromGitHub {
+    owner = "lupoDharkael";
+    repo = "flameshot";
+    rev = "v${version}";
+    sha256 = "1fy4il7rdj294l9cs642hx23bry25j9phn37274r2b87hwzy1rrv";
+  };
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Powerful yet simple to use screenshot software";
+    homepage = https://github.com/lupoDharkael/flameshot;
+    maintainers = [ maintainers.scode ];
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15197,6 +15197,8 @@ with pkgs;
 
   flac = callPackage ../applications/audio/flac { };
 
+  flameshot = libsForQt5.callPackage ../tools/misc/flameshot { };
+
   flashplayer = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer {
     debug = config.flashplayer.debug or false;
   };


### PR DESCRIPTION
###### Motivation for this change

flameshot is very useful, let's add it!

###### Things done

(tested on Ubuntu)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

