### PR TITLE
gpp: init at 2.25 and add @nmattia as maintainer

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -485,6 +485,7 @@
   nico202 = "Nicolò Balzarotti <anothersms@gmail.com>";
   NikolaMandic = "Ratko Mladic <nikola@mandic.email>";
   nixy = "Andrew R. M. <nixy@nixy.moe>";
+  nmattia = "Nicolas Mattia <nicolas@nmattia.com>";
   nocoolnametom = "Tom Doggett <nocoolnametom@gmail.com>";
   notthemessiah = "Brian Cohen <brian.cohen.88@gmail.com>";
   np = "Nicolas Pouillard <np.nix@nicolaspouillard.fr>";

--- a/pkgs/development/tools/gpp/default.nix
+++ b/pkgs/development/tools/gpp/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "gpp-${version}";
+  version = "2.25";
+
+  src = fetchFromGitHub {
+    owner = "logological";
+    repo = "gpp";
+    rev = "96c5dd8905384ea188f380f51d24cbd7fd58f642";
+    sha256 = "0bvhnx3yfhbfiqqhhz6k2a596ls5rval7ykbp3jl5b6062xj861b";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  installCheckPhase = "$out/bin/gpp --help";
+  doInstallCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "General-purpose preprocessor with customizable syntax";
+    homepage = "https://logological.org/gpp";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ nmattia ];
+    platforms = with platforms; linux ++ darwin;
+    downloadPage = "https://github.com/logological/gpp";
+    inherit version;
+  };
+}

--- a/pkgs/development/tools/gpp/default.nix
+++ b/pkgs/development/tools/gpp/default.nix
@@ -22,7 +22,5 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3;
     maintainers = with maintainers; [ nmattia ];
     platforms = with platforms; linux ++ darwin;
-    downloadPage = "https://github.com/logological/gpp";
-    inherit version;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2468,6 +2468,8 @@ with pkgs;
 
   gpodder = callPackage ../applications/audio/gpodder { };
 
+  gpp = callPackage ../development/tools/gpp { };
+
   gpredict = callPackage ../applications/science/astronomy/gpredict { };
 
   gptfdisk = callPackage ../tools/system/gptfdisk { };


### PR DESCRIPTION
###### Motivation for this change

The handy [gpp](https://github.com/logological/gpp) tool was not yet available in Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

