### PR TITLE
nix-info: build locally

### DIFF
--- a/pkgs/tools/nix/info/default.nix
+++ b/pkgs/tools/nix/info/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation {
     cp ./nix-info $out/bin/nix-info
   '';
 
+  preferLocalBuild = true;
+
   meta = {
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change

/cc @grahamc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

