### PR TITLE
cataclysm-dda{,-git}: build on Darwin

### DIFF
--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     "OSX_MIN=10.6"  # SDL for macOS only supports deploying on 10.6 and above
   ];
 
-  postBuild = ''
+  postBuild = stdenv.lib.optionalString stdenv.isDarwin ''
     # iconutil on macOS is not available in nixpkgs
     png2icns data/osx/AppIcon.icns data/osx/AppIcon.iconset/*
   '';

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 
+  patches = [ ./patches/fix_locale_dir.patch ];
+
   postPatch = ''
     patchShebangs .
     sed -i Makefile \

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -1,5 +1,5 @@
 { fetchFromGitHub, stdenv, makeWrapper, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
-SDL2_mixer, freetype, gettext }:
+SDL2_mixer, freetype, gettext, Cocoa }:
 
 stdenv.mkDerivation rec {
   version = "0.C";
@@ -14,7 +14,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
 
-  buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ];
+  buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 
   postPatch = ''
     patchShebangs .
@@ -26,7 +27,12 @@ stdenv.mkDerivation rec {
       -i src/{crafting,skill,weather_data,melee,vehicle,overmap,iuse_actor}.cpp
   '';
 
-  makeFlags = "PREFIX=$(out) LUA=1 TILES=1 SOUND=1 RELEASE=1 USE_HOME_DIR=1";
+  makeFlags = [
+    "PREFIX=$(out) LUA=1 TILES=1 SOUND=1 RELEASE=1 USE_HOME_DIR=1"
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "NATIVE=osx CLANG=1"
+    "OSX_MIN=10.6"  # SDL for macOS only supports deploying on 10.6 and above
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/cataclysm-tiles \
@@ -64,6 +70,6 @@ stdenv.mkDerivation rec {
     homepage = http://en.cataclysmdda.com/;
     license = licenses.cc-by-sa-30;
     maintainers = [ maintainers.skeidel ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -1,5 +1,5 @@
 { fetchFromGitHub, stdenv, makeWrapper, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
-SDL2_mixer, freetype, gettext }:
+SDL2_mixer, freetype, gettext, CoreFoundation, Cocoa }:
 
 stdenv.mkDerivation rec {
   version = "2017-12-09";
@@ -14,7 +14,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
 
-  buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ];
+  buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Cocoa ];
 
   postPatch = ''
     patchShebangs .
@@ -26,7 +27,11 @@ stdenv.mkDerivation rec {
       -i src/{crafting,skill,weather_data,melee,vehicle,overmap,iuse_actor}.cpp
   '';
 
-  makeFlags = "PREFIX=$(out) LUA=1 TILES=1 SOUND=1 RELEASE=1 USE_HOME_DIR=1";
+  makeFlags = [
+    "PREFIX=$(out) LUA=1 TILES=1 SOUND=1 RELEASE=1 USE_HOME_DIR=1"
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "NATIVE=osx CLANG=1"
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/cataclysm-tiles \
@@ -65,6 +70,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://en.cataclysmdda.com/;
     license = licenses.cc-by-sa-30;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Cocoa ];
 
+  patches = [ ./patches/fix_locale_dir_git.patch ];
+
   postPatch = ''
     patchShebangs .
     sed -i Makefile \

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -36,6 +36,17 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/cataclysm-tiles \
       --add-flags "--datadir $out/share/cataclysm-dda/"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    app=$out/Applications/Cataclysm.app
+    install -D -m 444 data/osx/Info.plist -t $app/Contents
+    install -D -m 444 data/osx/AppIcon.icns -t $app/Contents/Resources
+    mkdir $app/Contents/MacOS
+    launcher=$app/Contents/MacOS/Cataclysm.sh
+    cat << SCRIPT > $launcher
+    #!/bin/sh
+    $out/bin/cataclysm-tiles
+    SCRIPT
+    chmod 555 $launcher
   '';
 
   # https://hydra.nixos.org/build/65193254

--- a/pkgs/games/cataclysm-dda/patches/fix_locale_dir.patch
+++ b/pkgs/games/cataclysm-dda/patches/fix_locale_dir.patch
@@ -1,0 +1,20 @@
+diff --git a/src/translations.cpp b/src/translations.cpp
+index 6520cfe..49f7b2c 100644
+--- a/src/translations.cpp
++++ b/src/translations.cpp
+@@ -72,15 +72,11 @@ void set_language(bool reload_options)
+ 
+     // Step 2. Bind to gettext domain.
+     const char *locale_dir;
+-#ifdef __linux__
+     if (!FILENAMES["base_path"].empty()) {
+         locale_dir = std::string(FILENAMES["base_path"] + "share/locale").c_str();
+     } else {
+         locale_dir = "lang/mo";
+     }
+-#else
+-    locale_dir = "lang/mo";
+-#endif // __linux__
+ 
+     bindtextdomain("cataclysm-dda", locale_dir);
+     bind_textdomain_codeset("cataclysm-dda", "UTF-8");

--- a/pkgs/games/cataclysm-dda/patches/fix_locale_dir_git.patch
+++ b/pkgs/games/cataclysm-dda/patches/fix_locale_dir_git.patch
@@ -1,0 +1,20 @@
+diff --git a/src/translations.cpp b/src/translations.cpp
+index 3a86291..e6c5f84 100644
+--- a/src/translations.cpp
++++ b/src/translations.cpp
+@@ -176,15 +176,11 @@ void set_language()
+ 
+     // Step 2. Bind to gettext domain.
+     std::string locale_dir;
+-#if (defined __linux__ || (defined MACOSX && !defined TILES))
+     if( !FILENAMES["base_path"].empty() ) {
+         locale_dir = FILENAMES["base_path"] + "share/locale";
+     } else {
+         locale_dir = "lang/mo";
+     }
+-#else
+-    locale_dir = "lang/mo";
+-#endif // __linux__
+ 
+     const char *locale_dir_char = locale_dir.c_str();
+     bindtextdomain( "cataclysm-dda", locale_dir_char );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18139,9 +18139,13 @@ with pkgs;
 
   bzflag = callPackage ../games/bzflag { };
 
-  cataclysm-dda = callPackage ../games/cataclysm-dda { };
+  cataclysm-dda = callPackage ../games/cataclysm-dda {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
-  cataclysm-dda-git = callPackage ../games/cataclysm-dda/git.nix { };
+  cataclysm-dda-git = callPackage ../games/cataclysm-dda/git.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Cocoa;
+  };
 
   chessdb = callPackage ../games/chessdb { };
 


### PR DESCRIPTION
###### Motivation for this change

Let's play Cataclysm DDA on Darwin!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

