### PR TITLE
unbound: Fix CVE-2017-15105

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unbound-${version}";
-  version = "1.6.7";
+  version = "1.6.8";
 
   src = fetchurl {
-    url = "http://unbound.net/downloads/${name}.tar.gz";
-    sha256 = "17qwfmlls0w9kpkya3dlpn44b3kr87wsswzg3gawc13hh8yx8ysf";
+    url = "https://unbound.net/downloads/${name}.tar.gz";
+    sha256 = "0jfxhh4gc5amhndikskz1s7da27ycn442j3l20bm992n7zijid73";
   };
 
   outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB


### PR DESCRIPTION
###### Motivation for this change
I was looking at unbound and discovered it has a [CVE](https://unbound.net/downloads/CVE-2017-15105.txt) for which nixpkgs does not have a patch.

Upstream [ships a patch](https://unbound.net/downloads/patch_cve_2017_15105.diff) for 1.6.7 but it failed to apply, so I have `wget unbound-1.6.7.tgz && tar x && git init && patch && git diff` to generate a patch. There is also a new version(1.6.8) of unbound, [looks like](https://gist.github.com/corpix/29e568bf5eda455d263a9b6978cf1841) it was shiped just to fix this CVE so I have two commits:

1) patch 1.6.7
2) update to 1.6.8

Probably they should be squashed, what should I do?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

