### PR TITLE
bpython: fetch from PyPi

### DIFF
--- a/pkgs/development/python-modules/bpython/default.nix
+++ b/pkgs/development/python-modules/bpython/default.nix
@@ -1,14 +1,13 @@
-{ stdenv, buildPythonPackage, fetchurl, pygments, greenlet, curtsies, urwid, requests, mock }:
+{ stdenv, buildPythonPackage, fetchPypi, pygments, greenlet, curtsies, urwid, requests, mock }:
 
 buildPythonPackage rec {
   pname = "bpython";
   version = "0.17";
   name  = "${pname}-${version}";
 
-  # 0.17 is still missing on PyPI, https://github.com/bpython/bpython/issues/706
-  src = fetchurl {
-    url = "https://bpython-interpreter.org/releases/${pname}-${version}.tar.gz";
-    sha256 = "13fyyx06645ikvmj9zmkixr12kzk1c3a3f9s9i2rvaczjycn82lz";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mbah208jhd7bsfaa17fwpi55f7fvif0ghjwgrjmpmx8w1vqab9l";
   };
 
   propagatedBuildInputs = [ curtsies greenlet pygments requests urwid ];


### PR DESCRIPTION
###### Motivation for this change
0.17 recently got released on PyPi, so we can stop fetching it from github

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

