### PR TITLE
pixie: 1356 -> 1367

### DIFF
--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -3,7 +3,7 @@
   variant ? "jit", buildWithPypy ? false }:
 
 let
-  commit-count = "1356";
+  commit-count = "1367";
   common-flags = "--thread --gcrootfinder=shadowstack --continuation";
   variants = {
     jit = { flags = "--opt=jit"; target = "target.py"; };
@@ -13,8 +13,8 @@ let
   };
   pixie-src = fetchgit {
     url = "https://github.com/pixie-lang/pixie.git";
-    rev = "d2a4267ea088f711af36a74928e8dfd8360584ad";
-    sha256 = "1asf6yx7zy9cx4bsg8iai57dy3r3m45xcmkmw2vix70xvfy23ryf";
+    rev = "d76adb041a4968906bf22575fee7a572596e5796";
+    sha256 = "1lq2cd9gg6f0myswjdvd75jhmbk035zzmz40mc4ny8sdkpbd5v9l";
   };
   pypy-tag = "91db1a9";
   pypy-src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

Update pixie to latest git version: https://github.com/pixie-lang/pixie/commit/d76adb041a4968906bf22575fee7a572596e5796

Pixie compiles successfully, but running it fails with:

```
± ./result/bin/pixie
in internal function run_load_stdlib

in internal function load-ns

in internal function load-file

in internal function load-reader

RuntimeException: <inst pixie.stdlib.Keyword> Var assoc is undefined
```

@alekcz do you have an idea, what's going on?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

