### PR TITLE
newsboat: clean up and fix on Darwin

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, stfl, sqlite, curl, gettext, pkgconfig, libxml2, json_c, ncurses
-, asciidoc, docbook_xml_dtd_45, libxslt, docbook_xml_xslt, makeWrapper }:
+, asciidoc, docbook_xml_dtd_45, libxslt, docbook_xml_xslt, libiconv, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "newsboat-${version}";
@@ -12,16 +12,24 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     substituteInPlace Makefile --replace "|| true" ""
+    # Allow other ncurses versions on Darwin
+    substituteInPlace config.sh \
+      --replace "ncurses5.4" "ncurses"
   '';
 
   nativeBuildInputs = [ pkgconfig asciidoc docbook_xml_dtd_45 libxslt docbook_xml_xslt ]
-                      ++ stdenv.lib.optional stdenv.isDarwin makeWrapper;
+                      ++ stdenv.lib.optional stdenv.isDarwin [ makeWrapper libiconv ];
 
   buildInputs = [ stfl sqlite curl gettext libxml2 json_c ncurses ];
 
-  installFlags = [ "DESTDIR=$(out)" "prefix=" ];
+  makeFlags = [ "prefix=$(out)" ];
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  doCheck = true;
+  checkTarget = "test";
+
+  postInstall = ''
+    cp -r contrib $out
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
     for prog in $out/bin/*; do
       wrapProgram "$prog" --prefix DYLD_LIBRARY_PATH : "${stfl}/lib"
     done
@@ -30,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage    = https://newsboat.org/;
     description = "A fork of Newsbeuter, an RSS/Atom feed reader for the text console.";
-    maintainers = with maintainers; [ dotlambda ];
+    maintainers = with maintainers; [ dotlambda nicknovitski ];
     license     = licenses.mit;
     platforms   = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change
Build is currently broken on Darwin: https://hydra.nixos.org/build/67522006/nixlog/1
I am not able to test whether this actually fixes it.

Also, I noticed a `-DLOCALEDIR=\"/usr/share/locale\"` in the output of `make`.

Finally I followed some suggestions from @nicknovitski's [comment](https://github.com/NixOS/nixpkgs/pull/31719#issuecomment-346526046):
- copying `contrib/` to `$out` and
- adding him as a maintainer.

On a side note, can someone please close #31719?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @joachifm 