### PR TITLE
bwa: 0.7.16a -> 0.7.17

### DIFF
--- a/pkgs/applications/science/biology/bwa/default.nix
+++ b/pkgs/applications/science/biology/bwa/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "bwa-${version}";
-  version = "0.7.16a";
+  version = "0.7.17";
 
   src = fetchurl {
     url = "mirror://sourceforge/bio-bwa/${name}.tar.bz2";
-    sha256 = "0w61zxh6b4isydw5qp6pdb1mc50jg1h8vhahw2xm24w7i1gxpv4g";
+    sha256 = "1zfhv2zg9v1icdlq4p9ssc8k01mca5d1bd87w71py2swfi74s6yy";
   };
 
   buildInputs = [ zlib ];


### PR DESCRIPTION
###### Motivation for this change

Upgrade bwa to the latest stable release.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@luispedro