### PR TITLE
dbeaver: 4.3.2 -> 4.3.3

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   name = "dbeaver-ce-${version}";
-  version = "4.3.2";
+  version = "4.3.3";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.jkiss.org/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "0spiwx5dxchpl2qq10rinj9db723w2hf7inqmg4m7fjaj75bpl3s";
+    sha256 = "063h2za2m33b4k9s756lwicxwszzsqr2sqr2gi4ai05dqkgkw951";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

New release:

 * https://dbeaver.jkiss.org/2018/01/21/dbeaver-4-3-3/

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🚫 macOS
   - ✖️ other Linux distributions
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- ✔️ Built using `env -i NIX_REMOTE=daemon 'NIX_OTHER_STORES=/run/nix/remote-stores/*/nix' NIX_CONF_DIR=/etc/nix nix-build -A dbeaver`
