### PR TITLE
git-hub: add darwin support

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-hub/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-hub/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
       directly through the Git command line.
     '';
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This works on darwin, but had overly-restrictive `platforms`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

