### PR TITLE
Update our default version of OpenSSL from 1.0.x to 1.1.x

### DIFF
--- a/pkgs/desktops/gnome-2/default.nix
+++ b/pkgs/desktops/gnome-2/default.nix
@@ -1,5 +1,6 @@
-{ callPackage, self, stdenv, gettext, gvfs, libunique, bison2
-, libstartup_notification, overrides ? {} }:
+{ callPackage, self, stdenv, gettext, gvfs, libunique, bison2, openssl_1_0_2
+, libstartup_notification, overrides ? {}
+}:
 
 let overridden = set // overrides; set = with overridden; {
   # Backward compatibility.
@@ -50,7 +51,7 @@ let overridden = set // overrides; set = with overridden; {
   gnome_python_desktop = callPackage ./bindings/gnome-python-desktop { };
   python_rsvg = overridden.gnome_python_desktop;
 
-  gnome_vfs = callPackage ./platform/gnome-vfs { };
+  gnome_vfs = callPackage ./platform/gnome-vfs { openssl = openssl_1_0_2; };
 
   gnome_vfs_monikers = callPackage ./platform/gnome-vfs-monikers { };
 

--- a/pkgs/development/libraries/openssl/CVE-2017-3738.patch
+++ b/pkgs/development/libraries/openssl/CVE-2017-3738.patch
@@ -1,0 +1,77 @@
+From 5630661aecbea5fe3c4740f5fea744a1f07a6253 Mon Sep 17 00:00:00 2001
+From: Andy Polyakov <appro@openssl.org>
+Date: Fri, 24 Nov 2017 11:35:50 +0100
+Subject: [PATCH] bn/asm/rsaz-avx2.pl: fix digit correction bug in
+ rsaz_1024_mul_avx2.
+
+Credit to OSS-Fuzz for finding this.
+
+CVE-2017-3738
+
+Reviewed-by: Rich Salz <rsalz@openssl.org>
+---
+ crypto/bn/asm/rsaz-avx2.pl | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/crypto/bn/asm/rsaz-avx2.pl b/crypto/bn/asm/rsaz-avx2.pl
+index f26390155c7..8c56a91484e 100755
+--- a/crypto/bn/asm/rsaz-avx2.pl
++++ b/crypto/bn/asm/rsaz-avx2.pl
+@@ -217,7 +217,7 @@
+ 	vmovdqu		32*8-128($ap), $ACC8
+ 
+ 	lea	192(%rsp), $tp0			# 64+128=192
+-	vpbroadcastq	.Land_mask(%rip), $AND_MASK
++	vmovdqu	.Land_mask(%rip), $AND_MASK
+ 	jmp	.LOOP_GRANDE_SQR_1024
+ 
+ .align	32
+@@ -1067,10 +1067,10 @@
+ 	vpmuludq	32*6-128($np),$Yi,$TEMP1
+ 	vpaddq		$TEMP1,$ACC6,$ACC6
+ 	vpmuludq	32*7-128($np),$Yi,$TEMP2
+-	 vpblendd	\$3, $ZERO, $ACC9, $ACC9	# correct $ACC3
++	 vpblendd	\$3, $ZERO, $ACC9, $TEMP1	# correct $ACC3
+ 	vpaddq		$TEMP2,$ACC7,$ACC7
+ 	vpmuludq	32*8-128($np),$Yi,$TEMP0
+-	 vpaddq		$ACC9, $ACC3, $ACC3		# correct $ACC3
++	 vpaddq		$TEMP1, $ACC3, $ACC3		# correct $ACC3
+ 	vpaddq		$TEMP0,$ACC8,$ACC8
+ 
+ 	mov	%rbx, %rax
+@@ -1083,7 +1083,9 @@
+ 	 vmovdqu	-8+32*2-128($ap),$TEMP2
+ 
+ 	mov	$r1, %rax
++	 vpblendd	\$0xfc, $ZERO, $ACC9, $ACC9	# correct $ACC3
+ 	imull	$n0, %eax
++	 vpaddq		$ACC9,$ACC4,$ACC4		# correct $ACC3
+ 	and	\$0x1fffffff, %eax
+ 
+ 	 imulq	16-128($ap),%rbx
+@@ -1319,15 +1321,12 @@
+ #	But as we underutilize resources, it's possible to correct in
+ #	each iteration with marginal performance loss. But then, as
+ #	we do it in each iteration, we can correct less digits, and
+-#	avoid performance penalties completely. Also note that we
+-#	correct only three digits out of four. This works because
+-#	most significant digit is subjected to less additions.
++#	avoid performance penalties completely.
+ 
+ $TEMP0 = $ACC9;
+ $TEMP3 = $Bi;
+ $TEMP4 = $Yi;
+ $code.=<<___;
+-	vpermq		\$0, $AND_MASK, $AND_MASK
+ 	vpaddq		(%rsp), $TEMP1, $ACC0
+ 
+ 	vpsrlq		\$29, $ACC0, $TEMP1
+@@ -1774,7 +1773,7 @@
+ 
+ .align	64
+ .Land_mask:
+-	.quad	0x1fffffff,0x1fffffff,0x1fffffff,-1
++	.quad	0x1fffffff,0x1fffffff,0x1fffffff,0x1fffffff
+ .Lscatter_permd:
+ 	.long	0,2,4,6,7,7,7,7
+ .Lgather_permd:

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -110,13 +110,7 @@ in {
   openssl_1_1_0 = common {
     version = "1.1.0g";
     sha256 = "1bvka2wf33w2vxv7yw578nnjqyhz2b3chvfb0l4k2ffscw950kfy";
-    patches = [
-      (fetchpatch {
-        name = "CVE-2017-3738.patch";
-        url = "https://github.com/openssl/openssl/commit/563066.patch";
-        sha256 = "0ni9fwpxf8raw8b58pfa15akbqmxx4q64v0ldsm4b9dqhbxf8mkz";
-      })
-    ];
+    patches = [ ./CVE-2017-3738.patch ];
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8314,6 +8314,7 @@ with pkgs;
   cxxtest = callPackage ../development/libraries/cxxtest { };
 
   cyrus_sasl = callPackage ../development/libraries/cyrus-sasl {
+    openssl = openssl_1_0_2;
     kerberos = if stdenv.isFreeBSD then libheimdal else kerberos;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3887,13 +3887,13 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
-  openssh =
-    callPackage ../tools/networking/openssh {
-      hpnSupport = false;
-      withKerberos = stdenv.isDarwin;
-      etcDir = "/etc/ssh";
-      pam = if stdenv.isLinux then pam else null;
-    };
+  openssh = callPackage ../tools/networking/openssh {
+    hpnSupport = false;
+    withKerberos = stdenv.isDarwin;
+    etcDir = "/etc/ssh";
+    pam = if stdenv.isLinux then pam else null;
+    openssl = openssl_1_0_2;
+  };
 
   openssh_hpn = pkgs.appendToName "with-hpn" (openssh.override { hpnSupport = true; });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12209,6 +12209,7 @@ with pkgs;
     # https://sourceforge.net/p/net-snmp/bugs/2712/
     # remove after net-snmp > 5.7.3
     perl = perl522;
+    openssl = openssl_1_0_2;
   };
 
   newrelic-sysmond = callPackage ../servers/monitoring/newrelic-sysmond { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5231,7 +5231,7 @@ with pkgs;
 
   unrar = callPackage ../tools/archivers/unrar { };
 
-  xar = callPackage ../tools/compression/xar { };
+  xar = callPackage ../tools/compression/xar { openssl = openssl_1_0_2; };
 
   xarchive = callPackage ../tools/archivers/xarchive { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10649,6 +10649,8 @@ with pkgs;
     # XXX: mariadb doesn't built on fbsd as of nov 2015
     mysql = if (!stdenv.isFreeBSD) then mysql else null;
 
+    openssl = openssl_1_0_2;
+
     inherit (pkgs.darwin) cf-private libobjc;
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices OpenGL Cocoa AGL;
   };
@@ -15010,7 +15012,7 @@ with pkgs;
   inherit (gnome3) evince;
   evolution_data_server = gnome3.evolution_data_server;
 
-  keepass = callPackage ../applications/misc/keepass { 
+  keepass = callPackage ../applications/misc/keepass {
     buildDotnetPackage = buildDotnetPackage.override { mono = mono54; };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10452,7 +10452,7 @@ with pkgs;
 
   wolfssl = callPackage ../development/libraries/wolfssl { };
 
-  openssl = openssl_1_0_2;
+  openssl = openssl_1_1_0;
 
   inherit (callPackages ../development/libraries/openssl {
       fetchurl = fetchurlBoot;


### PR DESCRIPTION
Test builds are running at https://hydra.nixos.org/jobset/nixpkgs/openssl-1.1.x-update.