### PR TITLE
yabar-unstable: 2018-01-02 -> 2018-01-18

### DIFF
--- a/pkgs/applications/window-managers/yabar/unstable.nix
+++ b/pkgs/applications/window-managers/yabar/unstable.nix
@@ -2,10 +2,10 @@
 
 let
   pkg = callPackage ./build.nix ({
-    version = "unstable-2018-01-02";
+    version = "unstable-2018-01-18";
 
-    rev    = "d9f75933f1fdd7bec24bf7db104c7e1df2728b98";
-    sha256 = "0ry2pgqsnl6cmvkhakm73cjqdnirkimldnmbngl6hbvggx32z8c9";
+    rev    = "c516e8e78d39dd2b339acadc4c175347171150bb";
+    sha256 = "1p9lx78cayyn7qc2q66id2xfs76jyddnqv2x1ypsvixaxwcvqgdb";
   } // attrs);
 in pkg.overrideAttrs (o: {
   buildInputs = o.buildInputs ++ [


### PR DESCRIPTION
###### Motivation for this change

The following changes landed in master:

- Reset colors unconditionally (2f1ee69d4c75e210265dca732ff6c2ddd7f440f2)
- Document NixOS support (993f1b5a7bc2a41a353a104cff0763860c053c92)
- ya_int_song: improve configuration of playerctl properties (1f776cd5f1f4e89e6ebca3ca09feb7e09f79e79e)
- 1f776cd5f1f4e89e6ebca3ca09feb7e09f79e79e (3a3a361ae0d5f04ad93ca4e9829b3298c83db129)

(__NOTE:__ I recompiled `yabar` locally and tested the result with my own config and everything continued to work)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

