### PR TITLE
bedtools: 2.26.0 -> 2.27.1

### DIFF
--- a/pkgs/applications/science/biology/bedtools/default.nix
+++ b/pkgs/applications/science/biology/bedtools/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "bedtools-${version}";
-  version = "2.26.0";
+  version = "2.27.1";
 
   src = fetchFromGitHub {
     owner = "arq5x";
     repo = "bedtools2";
     rev = "v${version}";
-    sha256 = "1j2ia68rmcw3qksjm5gvv1cb84bh76vmln59mvncr2an23f5a3ss";
+    sha256 = "1pk68y052rm2m24yfmy82ms8p6kd6xcqxxgi7n0a1sbh89wllm6s";
   };
 
   buildInputs = [ zlib python ];


### PR DESCRIPTION
###### Motivation for this change

Upgrade bedtools to latest stable release.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@jbedo