### PR TITLE
 ckb: 0.2.8 -> 0.2.9 + project moved 

### DIFF
--- a/pkgs/tools/misc/ckb/default.nix
+++ b/pkgs/tools/misc/ckb/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, substituteAll, libudev, pkgconfig, qtbase, qmake, zlib, kmod }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.8";
+  version = "0.2.9";
   name = "ckb-next-${version}";
 
   src = fetchFromGitHub {
-    owner = "mattanger";
+    owner = "ckb-next";
     repo = "ckb-next";
     rev = "v${version}";
-    sha256 = "0b3h1d54mdyfcx46zvsd7dfqf2656h4jjkiw044170gnfdzxjb3w";
+    sha256 = "0hl41znyhp3k5l9rcgz0gig36gsg95ivrs1dyngv45q9jkr6fchm";
   };
 
   buildInputs = [
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Driver and configuration tool for Corsair keyboards and mice";
-    homepage = https://github.com/mattanger/ckb-next;
+    homepage = https://github.com/ckb-next/ckb-next;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ kierdavis ];


### PR DESCRIPTION
###### Motivation for this change
The ckb project owner was unreachable (see https://github.com/NixOS/nixpkgs/pull/33286) so the community has now organized itself around a github community instead and moved the project.
They has also made a new release.

This PR also includes a patch to fix a missing dependency (closes https://github.com/NixOS/nixpkgs/pull/33287).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

