### PR TITLE
cataclysm-dda{,-git}: fix share directory 

### DIFF
--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -23,8 +23,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs .
     sed -i Makefile \
-      -e 's,-Werror,,g' \
-      -e 's,\(DATA_PREFIX=$(PREFIX)/share/\)cataclysm-dda/,\1,g'
+      -e 's,-Werror,,g'
 
     sed '1i#include <cmath>' \
       -i src/{crafting,skill,weather_data,melee,vehicle,overmap,iuse_actor}.cpp
@@ -44,7 +43,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/cataclysm-tiles \
-      --add-flags "--datadir $out/share/"
+      --add-flags "--datadir $out/share/cataclysm-dda/"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     app=$out/Applications/Cataclysm.app
     install -D -m 444 data/osx/Info.plist -t $app/Contents

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out) LUA=1 TILES=1 SOUND=1 RELEASE=1 USE_HOME_DIR=1"
+    # "LANGUAGES=all"  # vanilla C:DDA installs all translations even without this flag!
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     "NATIVE=osx CLANG=1"
     "OSX_MIN=10.6"  # SDL for macOS only supports deploying on 10.6 and above

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, makeWrapper, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
+{ fetchFromGitHub, stdenv, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
 SDL2_mixer, freetype, gettext, Cocoa, libicns }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "03sdzsk4qdq99qckq0axbsvg1apn6xizscd8pwp5w6kq2fyj5xkv";
   };
 
-  nativeBuildInputs = [ makeWrapper pkgconfig ]
+  nativeBuildInputs = [ pkgconfig ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ libicns ];
 
   buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ]
@@ -41,10 +41,7 @@ stdenv.mkDerivation rec {
     png2icns data/osx/AppIcon.icns data/osx/AppIcon.iconset/*
   '';
 
-  postInstall = ''
-    wrapProgram $out/bin/cataclysm-tiles \
-      --add-flags "--datadir $out/share/cataclysm-dda/"
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     app=$out/Applications/Cataclysm.app
     install -D -m 444 data/osx/Info.plist -t $app/Contents
     install -D -m 444 data/osx/AppIcon.icns -t $app/Contents/Resources

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, makeWrapper, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
+{ fetchFromGitHub, stdenv, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
 SDL2_mixer, freetype, gettext, CoreFoundation, Cocoa }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1a7kdmx76na4g65zra01qaq98lxp9j2dl9ddv09r0p5yxaizw68z";
   };
 
-  nativeBuildInputs = [ makeWrapper pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Cocoa ];
@@ -34,10 +34,7 @@ stdenv.mkDerivation rec {
     "NATIVE=osx CLANG=1"
   ];
 
-  postInstall = ''
-    wrapProgram $out/bin/cataclysm-tiles \
-      --add-flags "--datadir $out/share/cataclysm-dda/"
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     app=$out/Applications/Cataclysm.app
     install -D -m 444 data/osx/Info.plist -t $app/Contents
     install -D -m 444 data/osx/AppIcon.icns -t $app/Contents/Resources

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -22,8 +22,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs .
     sed -i Makefile \
-      -e 's,-Werror,,g' \
-      -e 's,\(DATA_PREFIX=$(PREFIX)/share/\)cataclysm-dda/,\1,g'
+      -e 's,-Werror,,g'
 
     sed '1i#include <cmath>' \
       -i src/{crafting,skill,weather_data,melee,vehicle,overmap,iuse_actor}.cpp

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out) LUA=1 TILES=1 SOUND=1 RELEASE=1 USE_HOME_DIR=1"
+    "LANGUAGES=all"
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     "NATIVE=osx CLANG=1"
   ];


### PR DESCRIPTION
###### Motivation for this change

So far, the data (mods, tile sets, etc.) have been put into `$out/share`. This is weird. They should be in `$out/share/cataclysm-dda`.
Then, no need to wrap the binary because `$out/share/cataclysm-dda` is the default data path.

Moreover, fixed to install missing translations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS: merge #34107 and then test it
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

