### PR TITLE
julia-git: mark broken, hasn't built since 2017-04-08.

### DIFF
--- a/pkgs/development/compilers/julia/git.nix
+++ b/pkgs/development/compilers/julia/git.nix
@@ -175,6 +175,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
-    broken = stdenv.isi686;
+    broken = true;
   };
 }

--- a/pkgs/development/compilers/julia/git.nix
+++ b/pkgs/development/compilers/julia/git.nix
@@ -175,6 +175,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
-    broken = true;
+    broken = true; # since 2017-04-08.
   };
 }


### PR DESCRIPTION
Mark broken packages as broken.

Worth keeping around, hopefully won't be too hard to fix.
(I started but don't know Julia very well and it wanted new deps... :))


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

First broken: https://hydra.nixos.org/build/51447624
Last successful: https://hydra.nixos.org/build/51385779

cc #34135