### PR TITLE
irqbalance: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/os-specific/linux/irqbalance/default.nix
+++ b/pkgs/os-specific/linux/irqbalance/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "irqbalance-${version}";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "irqbalance";
     repo = "irqbalance";
     rev = "v${version}";
-    sha256 = "1xznxjbjzg6sds3fymdq9rk3g4cgq7xj7rz3dwbqqjqvd3k2nxw6";
+    sha256 = "009777p5v72x4r58skqgaf03qv3app9b8lkxkpxq0226l0x3j4qh";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

