### PR TITLE
scanmem: 0.16 -> 0.17

### DIFF
--- a/pkgs/tools/misc/scanmem/default.nix
+++ b/pkgs/tools/misc/scanmem/default.nix
@@ -1,26 +1,26 @@
 { stdenv, autoconf, automake, intltool, libtool, fetchFromGitHub, readline }:
 
 stdenv.mkDerivation rec {
-  version = "0.16";
+  version = "0.17";
   name = "scanmem-${version}";
- 
+
   src = fetchFromGitHub {
     owner  = "scanmem";
     repo   = "scanmem";
     rev    = "v${version}";
-    sha256 = "131rx6cpnlz2x36r0ry80gqapmxpz2qc3h0040xhvp7ydmd4fyjd";
+    sha256 = "17p8sh0rj8yqz36ria5bp48c8523zzw3y9g8sbm2jwq7sc27i7s9";
   };
 
   nativeBuildInputs = [ autoconf automake intltool libtool ];
   buildInputs = [ readline ];
-  
+
   preConfigure = ''
     ./autogen.sh
   '';
   meta = with stdenv.lib; {
     homepage = https://github.com/scanmem/scanmem;
     description = "Memory scanner for finding and poking addresses in executing processes";
-    maintainers = [ maintainers.chattered  ];
+    maintainers = [ maintainers.chattered ];
     platforms = platforms.linux;
     license = licenses.gpl3;
   };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

