### PR TITLE
star: init at 2.5.3a

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -55,6 +55,7 @@
   antonxy = "Anton Schirg <anton.schirg@posteo.de>";
   apeschar = "Albert Peschar <albert@peschar.net>";
   apeyroux = "Alexandre Peyroux <alex@px.io>";
+  arcadio = "Arcadio Rubio García <arc@well.ox.ac.uk>";
   ardumont = "Antoine R. Dumont <eniotna.t@gmail.com>";
   aristid = "Aristid Breitkreuz <aristidb@gmail.com>";
   arobyn = "Alexei Robyn <shados@shados.net>";

--- a/pkgs/applications/science/biology/star/default.nix
+++ b/pkgs/applications/science/biology/star/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "star-${version}";
+  version = "2.5.3a";
+
+  src = fetchFromGitHub {
+    repo = "STAR";
+    owner = "alexdobin";
+    rev = version;
+    sha256 = "1fd9xl7i1zxgsxn2qf6gz8s42g2djm29qmp6qb35d8nnxh8ns54x";
+  };
+
+  sourceRoot = "source/source";
+  
+  postPatch = "sed 's:/bin/rm:rm:g' -i Makefile";
+  
+  buildInputs = [ zlib ];
+  
+  buildPhase = "make STAR STARlong";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp STAR STARlong $out/bin
+  '';
+  
+  meta = with stdenv.lib; {
+    description = "Spliced Transcripts Alignment to a Reference";
+    homepage = https://github.com/alexdobin/STAR;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.arcadio ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18962,6 +18962,8 @@ with pkgs;
 
   snpeff = callPackage ../applications/science/biology/snpeff/default.nix { };
 
+  star = callPackage ../applications/science/biology/star { };
+
   varscan = callPackage ../applications/science/biology/varscan/default.nix { };
 
   bwa = callPackage ../applications/science/biology/bwa/default.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add star derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

