### PR TITLE
vim: fix for cross, add missing configure test override

### DIFF
--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     "vim_cv_toupper_broken=no"
     "--with-tlib=ncurses"
     "vim_cv_terminfo=yes"
+    "vim_cv_tgetent=zero" # it does on native anyway
     "vim_cv_tty_group=tty"
     "vim_cv_tty_mode=0660"
     "vim_cv_getcwd_broken=no"


### PR DESCRIPTION
vim currently doesn't build on cross (for armv6l or aarch64 anyway),
complaining about unable to test what tgetent does in special circumstances.

Since this is a mentioned issue in the vim installation documentation,
this commit adds it to the set of variables we set/override when
cross-compiling.

This fixes cross-compilation of vim on the platforms mentioned above!


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is one of the variables mentioned to set
when cross-compiling:

https://github.com/vim/vim/blob/master/src/INSTALLx.txt