### PR TITLE
libinput: 1.9.3 -> 1.9.4

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -16,11 +16,11 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libinput-${version}";
-  version = "1.9.3";
+  version = "1.9.4";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "09wkc5qqk1k2a68cwfy4x853z8z35wf2qkijh66kacsvc2fjq394";
+    sha256 = "142icwzpirwddl7ghfmynxpnsbjg53rjxpzv4arjsaiw9r6bvk8b";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
This replaces PR #34122, by moving it to the `staging` branch as requested due to the number of rebuilds it causes.

###### Motivation for this change
This rev-bump of libinput resolves issues with out of order key press
delivery as described here:

https://lists.freedesktop.org/archives/wayland-devel/2017-December/036147.html

###### Things done

In addition to the items below, I've been running this change in an overlay of unstable on two NixOS computers for several weeks without any problems.

- [*] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [*] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [*] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [*] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

