### PR TITLE
pythonPackages update: asn1ate and asn2quickder

### DIFF
--- a/pkgs/development/libraries/quickder/default.nix
+++ b/pkgs/development/libraries/quickder/default.nix
@@ -29,19 +29,21 @@ stdenv.mkDerivation rec {
     pkgconfig
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./CMakeLists.txt \
       --replace "get_version_from_git" "set (Quick-DER_VERSION 1.2) #"
     substituteInPlace ./CMakeLists.txt \
       --replace \$\{ARPA2CM_TOOLCHAIN_DIR} "$out/share/ARPA2CM/toolchain/"
-    '';
+    patchShebangs python/scripts/
+  '';
 
-   cmakeFlags = [ "-DNO_TESTING=ON"
-   		  "-DARPA2CM_TOOLCHAIN_DIR=$out/share/ARPA2CM/toolchain/"
-  		  "-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON"
-  		  "-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON"
-  		  "-DPACKAGE_NO_PACKAGE_REGISTRY=ON"
-	        ];
+  cmakeFlags = [
+    "-DNO_TESTING=ON"
+    "-DARPA2CM_TOOLCHAIN_DIR=$out/share/ARPA2CM/toolchain/"
+    "-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON"
+    "-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON"
+    "-DPACKAGE_NO_PACKAGE_REGISTRY=ON"
+  ];
 
   preConfigure = ''
     export PREFIX=$out

--- a/pkgs/development/libraries/quickder/default.nix
+++ b/pkgs/development/libraries/quickder/default.nix
@@ -1,32 +1,51 @@
-{ stdenv, fetchFromGitHub, fetchurl, hexio, python, which, asn2quickder, bash }:
+{ stdenv, fetchFromGitHub, fetchurl, python2Packages, hexio
+, which, cmake, bash, arpa2cm, git, asn2quickder, pkgconfig }:
 
 stdenv.mkDerivation rec {
   pname = "quickder";
   name = "${pname}-${version}";
-  version = "1.0-RC2";
+  version = "1.2-6";
 
   src = fetchFromGitHub {
-    sha256 = "1nzk8x6qzpvli8bf74dc2qya63nlppqjrnkaxvjxr2dbqb8qcrqd";
+    sha256 = "00wifjydgmqw2i5vmr049visc3shjqccgzqynkmmhkjhs86ghzr6";
     rev = "version-${version}";
     owner = "vanrein";
     repo = "quick-der";
   };
 
-  buildInputs = [ which asn2quickder bash ];
+  buildInputs = with python2Packages; [
+    arpa2cm
+    asn1ate
+    bash
+    cmake
+    git
+    hexio
+    pyparsing
+    python
+    six
+    which
+    asn1ate
+    asn2quickder
+    pkgconfig
+  ];
 
   patchPhase = ''
-    substituteInPlace Makefile \
-      --replace 'lib tool test rfc' 'lib test rfc'
-    substituteInPlace ./rfc/Makefile \
-      --replace 'ASN2QUICKDER_CMD = ' 'ASN2QUICKDER_CMD = ${asn2quickder}/bin/asn2quickder #'
+    substituteInPlace ./CMakeLists.txt \
+      --replace "get_version_from_git" "set (Quick-DER_VERSION 1.2) #"
+    substituteInPlace ./CMakeLists.txt \
+      --replace \$\{ARPA2CM_TOOLCHAIN_DIR} "$out/share/ARPA2CM/toolchain/"
     '';
 
-  installFlags = "ASN2QUICKDER_DIR=${asn2quickder}/bin ASN2QUICKDER_CMD=${asn2quickder}/bin/asn2quickder";
-  installPhase = ''
-    mkdir -p $out/lib $out/man
-    make DESTDIR=$out PREFIX=/ all
-    make DESTDIR=$out PREFIX=/ install
-    '';
+   cmakeFlags = [ "-DNO_TESTING=ON"
+   		  "-DARPA2CM_TOOLCHAIN_DIR=$out/share/ARPA2CM/toolchain/"
+  		  "-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON"
+  		  "-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON"
+  		  "-DPACKAGE_NO_PACKAGE_REGISTRY=ON"
+	        ];
+
+  preConfigure = ''
+    export PREFIX=$out
+  '';
 
   meta = with stdenv.lib; {
     description = "Quick (and Easy) DER, a Library for parsing ASN.1";

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -1,15 +1,12 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
-, pyparsing }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, pyparsing }:
 
 buildPythonPackage rec {
   pname = "asn1ate";
-  date = "20160810";
-  version = "unstable-${date}";
-  name = "${pname}-${version}";
+  version= "0.6";
 
   src = fetchFromGitHub {
-    sha256 = "04pddr1mh2v9qq8fg60czwvjny5qwh4nyxszr3qc4bipiiv2xk9w";
-    rev = "c56104e8912400135509b584d84423ee05a5af6b";
+    sha256 = "1p8hv4gsyqsdr0gafcq497n52pybiqmc22di8ai4nsj60fv0km45";
+    rev = "v${version}";
     owner = "kimgr";
     repo = pname;
   };

--- a/pkgs/development/tools/asn2quickder/default.nix
+++ b/pkgs/development/tools/asn2quickder/default.nix
@@ -1,30 +1,25 @@
-{ stdenv, fetchFromGitHub, python2Packages, makeWrapper }:
+{ stdenv, buildPythonApplication, fetchFromGitHub, makeWrapper, cmake
+, pytestrunner, pytest, six, pyparsing, asn1ate }:
 
-stdenv.mkDerivation rec {
+buildPythonApplication rec {
   pname = "asn2quickder";
-  name = "${pname}-${version}";
-  version = "0.7-RC1";
+  version = "1.2-6";
 
   src = fetchFromGitHub {
-    sha256 = "0ynajhbml28m4ipbj5mscjcv6g1a7frvxfimxh813rhgl0w3sgq8";
+    sha256 = "00wifjydgmqw2i5vmr049visc3shjqccgzqynkmmhkjhs86ghzr6";
     rev = "version-${version}";
     owner = "vanrein";
-    repo = "${pname}";
+    repo = "quick-der";
   };
 
-  propagatedBuildInputs = with python2Packages; [ pyparsing makeWrapper ];
+  patchPhase = ''
+    patchShebangs ./python/scripts/*
+  '';
 
-  patchPhase = with python2Packages; ''
-    substituteInPlace Makefile \
-      --replace '..' '..:$(DESTDIR)/${python.sitePackages}:${python2Packages.pyparsing}/${python.sitePackages}' \
-    '';
+  buildInputs = [ makeWrapper cmake ];
+  checkInputs = [ pytestrunner pytest ];
 
-  installPhase = ''
-    mkdir -p $out/${python2Packages.python.sitePackages}/
-    mkdir -p $out/bin $out/lib $out/sbin $out/man
-    make DESTDIR=$out PREFIX=/ all
-    make DESTDIR=$out PREFIX=/ install
-    '';
+  propagatedBuildInputs = [ pyparsing asn1ate six ];
 
   meta = with stdenv.lib; {
     description = "An ASN.1 compiler with a backend for Quick DER";

--- a/pkgs/development/tools/build-managers/arpa2cm/default.nix
+++ b/pkgs/development/tools/build-managers/arpa2cm/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "arpa2cm";
+  version = "0.5";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    sha256 = "093h7njj8d8iiwnw5byfxkkzlbny60fwv1w57j8f1lsd4yn6rih4";
+    rev = "version-${version}";
+    repo = "${pname}";
+    owner = "arpa2";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "CMake Module library for the ARPA2 project";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7231,6 +7231,8 @@ with pkgs;
 
   kt = callPackage ../tools/misc/kt {};
 
+  arpa2cm = callPackage ../development/tools/build-managers/arpa2cm { };
+
   asn2quickder = callPackage ../development/tools/asn2quickder {};
 
   astyle = callPackage ../development/tools/misc/astyle { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7233,7 +7233,7 @@ with pkgs;
 
   arpa2cm = callPackage ../development/tools/build-managers/arpa2cm { };
 
-  asn2quickder = callPackage ../development/tools/asn2quickder {};
+  asn2quickder = python2Packages.callPackage ../development/tools/asn2quickder {};
 
   astyle = callPackage ../development/tools/misc/astyle { };
 


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest released version of these asn1 tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

