### PR TITLE
i3lock-color: 2.9.1-c -> 2.10.1-1-c & i3lock-fancy: 2016-10-13 -> 2017-12-14

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -1,19 +1,22 @@
-{ stdenv, fetchFromGitHub, which, pkgconfig, libxcb, xcbutilkeysyms
-, xcbutilimage, pam, libX11, libev, cairo, libxkbcommon, libxkbfile }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libxcb,
+  xcbutilkeysyms , xcbutilimage, pam, libX11, libev, cairo, libxkbcommon,
+  libxkbfile, libjpeg_turbo
+}:
 
 stdenv.mkDerivation rec {
-  version = "2.9.1-c";
+  version = "2.10.1-1-c";
   name = "i3lock-color-${version}";
 
   src = fetchFromGitHub {
-    owner = "chrjguill";
+    owner = "PandorasFox";
     repo = "i3lock-color";
-    rev = version;
-    sha256 = "0qnw71qbppgp3ywj1k07av7wkl9syfb8j6izrkhj143q2ks4rkvl";
+    rev = "01476c56333cccae80cdd3f125b0b9f3a0fe2cb3";
+    sha256 = "06ca8496fkdkvh4ycg0b7kd3r1bjdqdwfimb51v4nj1lm87pdkdf";
   };
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ which libxcb xcbutilkeysyms xcbutilimage pam libX11
-    libev cairo libxkbcommon libxkbfile ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libxcb xcbutilkeysyms xcbutilimage pam libX11
+    libev cairo libxkbcommon libxkbfile libjpeg_turbo ];
 
   makeFlags = "all";
   preInstall = ''

--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -3,13 +3,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  rev = "546ce2e71bd2339f2134904c7d22062e86105b46";
-  name = "i3lock-fancy-unstable-2016-10-13_rev${builtins.substring 0 7 rev}";
+  rev = "3734fba160166006521e513f5734eb76ac6aa48f";
+  name = "i3lock-fancy-unstable-2017-12-14_rev${builtins.substring 0 7 rev}";
   src = fetchFromGitHub {
     owner = "meskarune";
     repo = "i3lock-fancy";
     inherit rev;
-    sha256 = "1pbxydwdfd7jlw3b8cnlwlrkqlyh5jyanfhjybndqmacd3y8vplb";
+    sha256 = "1bg4xds2hmbq8rp6azbdqvgp1aaq5y1bp05cfwqqm6y3sjw7ywzl";
   };
   patchPhase = ''
     sed -i -e "s|(mktemp)|(${coreutils}/bin/mktemp)|" lock
@@ -18,12 +18,12 @@ stdenv.mkDerivation rec {
     sed -i -e "s|convert |${imagemagick.out}/bin/convert |" lock
     sed -i -e "s|awk -F|${gawk}/bin/awk -F|" lock
     sed -i -e "s| awk | ${gawk}/bin/awk |" lock
-    sed -i -e "s|i3lock -n |${i3lock-color}/bin/i3lock-color -n |" lock
-    sed -i -e 's|ICON="$SCRIPTPATH/icons/lockdark.png"|ICON="'$out'/share/i3lock-fancy/icons/lockdark.png"|' lock
-    sed -i -e 's|ICON="$SCRIPTPATH/icons/lock.png"|ICON="'$out'/share/i3lock-fancy/icons/lock.png"|' lock
+    sed -i -e "s|i3lock -i |${i3lock-color}/bin/i3lock-color -i |" lock
+    sed -i -e 's|icon="$scriptpath/icons/lockdark.png"|icon="'$out'/share/i3lock-fancy/icons/lockdark.png"|' lock
+    sed -i -e 's|icon="$scriptpath/icons/lock.png"|icon="'$out'/share/i3lock-fancy/icons/lock.png"|' lock
     sed -i -e "s|getopt |${getopt}/bin/getopt |" lock
     sed -i -e "s|fc-match |${fontconfig.bin}/bin/fc-match |" lock
-    sed -i -e "s|SHOT=(import -window root)|SHOT=(${scrot}/bin/scrot -z)|" lock
+    sed -i -e "s|shot=(import -window root)|shot=(${scrot}/bin/scrot -z)|" lock
   '';
   installPhase = ''
     mkdir -p $out/bin $out/share/i3lock-fancy/icons


### PR DESCRIPTION
###### Motivation for this change

Updated versions. i3lock-color requires now autotools and libjpeg_turbo.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

