### PR TITLE
screenkey: init at 0.9

### DIFF
--- a/pkgs/applications/video/screenkey/default.nix
+++ b/pkgs/applications/video/screenkey/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, substituteAll
+, buildPythonApplication
+, fetchFromGitHub
+, distutils_extra
+, setuptools-git
+, intltool
+, pygtk
+, libX11
+, libXtst
+, wrapGAppsHook
+, defaultIconTheme
+, hicolor_icon_theme
+}:
+buildPythonApplication rec {
+  pname = "screenkey";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "wavexx";
+    repo = "screenkey";
+    rev = "screenkey-${version}";
+    sha256 = "14g7fiv9n7m03djwz1pp5034pffi87ssvss9bc1q8vq0ksn23vrw";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./paths.patch;
+      inherit libX11 libXtst;
+    })
+  ];
+
+  nativeBuildInputs = [
+    distutils_extra
+    setuptools-git
+    intltool
+
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    defaultIconTheme
+    hicolor_icon_theme
+  ];
+
+  propagatedBuildInputs = [
+    pygtk
+  ];
+
+  # screenkey does not have any tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://www.thregr.org/~wavexx/software/screenkey/;
+    description = "A screencast tool to display your keys inspired by Screenflick";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.rasendubi ];
+  };
+}

--- a/pkgs/applications/video/screenkey/paths.patch
+++ b/pkgs/applications/video/screenkey/paths.patch
@@ -1,0 +1,20 @@
+--- a/Screenkey/xlib.py
++++ b/Screenkey/xlib.py
+@@ -6,7 +6,7 @@
+ from ctypes import *
+ 
+ ## base X11
+-libX11 = CDLL('libX11.so.6')
++libX11 = CDLL('@libX11@/lib/libX11.so.6')
+ 
+ # types
+ Atom = c_ulong
+@@ -278,7 +278,7 @@
+ 
+ 
+ ## record extensions
+-libXtst = CDLL('libXtst.so.6')
++libXtst = CDLL('@libXtst@/lib/libXtst.so.6')
+ 
+ # types
+ XPointer = String

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4514,6 +4514,10 @@ with pkgs;
     quazip = quazip_qt4;
   };
 
+  screenkey = python2Packages.callPackage ../applications/video/screenkey {
+    inherit (gnome3) defaultIconTheme;
+  };
+
   quazip_qt4 = libsForQt5.quazip.override {
     qtbase = qt4; qmake = qmake4Hook;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19144,38 +19144,6 @@ EOF
     };
   };
 
-  screenkey = buildPythonPackage rec {
-    version = "0.2-b3634a2c6eb6d6936c3b2c1ef5078bf3a84c40c6";
-    name = "screenkey-${version}";
-
-    propagatedBuildInputs = with self; [ pygtk distutils_extra xlib pkgs.xorg.xmodmap ];
-
-    preConfigure = ''
-      substituteInPlace setup.py --replace "/usr/share" "./share"
-
-      # disable the feature that binds a shortcut to turning on/off
-      # screenkey. This is because keybinder is not packages in Nix as
-      # of today.
-      substituteInPlace Screenkey/screenkey.py \
-        --replace "import keybinder" "" \
-        --replace "        keybinder.bind(self.options['hotkey'], self.hotkey_cb, show_item)" ""
-    '';
-
-    src = pkgs.fetchgit {
-        url = https://github.com/scs3jb/screenkey.git;
-        rev = "b3634a2c6eb6d6936c3b2c1ef5078bf3a84c40c6";
-        sha256 = "1535mpm5x6v85d4ghxhdiianhjrsz280dwvs61ss0yyjx4kivx3s";
-    };
-
-    meta = {
-      homepage = https://github.com/scs3jb/screenkey;
-      description = "A screencast tool to show your keys";
-      license = licenses.gpl3Plus;
-      maintainers = with maintainers; [ ];
-      platforms = platforms.linux;
-    };
-  };
-
   tarman = buildPythonPackage rec {
     version = "0.1.3";
     name = "tarman-${version}";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

