### PR TITLE
aview: init at 1.3.0rc1

### DIFF
--- a/pkgs/development/libraries/aalib/default.nix
+++ b/pkgs/development/libraries/aalib/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
     )
   '';
 
-  buildInputs = [ ncurses ];
+  propagatedBuildInputs = [ ncurses ];
 
   configureFlags = "--without-x --with-ncurses=${ncurses.dev}";
 

--- a/pkgs/tools/misc/aview/default.nix
+++ b/pkgs/tools/misc/aview/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, aalib }:
+
+stdenv.mkDerivation rec {
+  name = "aview-${version}";
+  version = "1.3.0rc1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/aa-project/${name}.tar.gz";
+    sha256 = "16gcfi2a7akk1qq8pq2rv9z7vciwr2cfdp8zi2dbdfg8ji0irmj2";
+  };
+
+  buildInputs = [ aalib ];
+
+  meta = with stdenv.lib; {
+    description = "High quality ascii-art image(pnm) browser and animation(fli/flc) player";
+    homepage = http://aa-project.sourceforge.net/aview;
+    license = licenses.gpl2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -585,6 +585,8 @@ with pkgs;
 
   bmap-tools = callPackage ../tools/misc/bmap-tools { };
 
+  aview = callPackage ../tools/misc/aview { };
+
   bonnie = callPackage ../tools/filesystems/bonnie { };
 
   bonfire = callPackage ../tools/misc/bonfire { };


### PR DESCRIPTION
Simple aalib-based utility.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---