### PR TITLE
almonds: init at 2015-12-27

### DIFF
--- a/pkgs/applications/science/math/almonds/default.nix
+++ b/pkgs/applications/science/math/almonds/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, ncurses, pillow, pytest }:
+
+let
+  version = "1.25b";
+in
+
+buildPythonApplication {
+  name = "almonds-${version}";
+  src = fetchFromGitHub {
+    owner = "Tenchi2xh";
+    repo = "Almonds";
+    rev = version;
+    sha256 = "0j8d8jizivnfx8lpc4w6sbqj5hq35nfz0vdg7ld80sc5cs7jr3ws";
+  };
+
+  nativeBuildInputs = [ pytest ];
+  buildInputs = [ ncurses ];
+  propagatedBuildInputs = [ pillow ];
+
+  checkPhase = "py.test";
+
+  meta = with stdenv.lib; {
+    description = "Terminal Mandelbrot fractal viewer";
+    homepage = https://github.com/Tenchi2xh/Almonds;
+    # No license has been specified
+    license = licenses.unfree;
+    maintainers = with maintainers; [ infinisil ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18981,6 +18981,8 @@ with pkgs;
 
   ### SCIENCE/MATH
 
+  almonds = pythonPackages.callPackage ../applications/science/math/almonds { };
+
   arpack = callPackage ../development/libraries/science/math/arpack { };
 
   atlas = callPackage ../development/libraries/science/math/atlas {


### PR DESCRIPTION
###### Motivation for this change
Almonds is a pretty cool terminal mandelbrot set explorer!

![screenshot](https://cloud.githubusercontent.com/assets/4116708/10803277/adec2722-7dc1-11e5-9599-a5e90bead5d8.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

