### PR TITLE
ghc841:  update to 8.4.1-alpha2

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -24,7 +24,7 @@
   # platform). Static libs are always built.
   enableShared ? true
 
-, version ? "8.4.20180115"
+, version ? "8.4.20180122"
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -73,8 +73,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "git://git.haskell.org/ghc.git";
-    rev = "3e3a096885c0fcd0703edbeffb4e47f5cbd8f4cc";
-    sha256 = "06slymbsd7vsfp4hh40v7cxf7nmp0kvlni2wfq7ag5wlqh04slgs";
+    rev = "61db0b8941cfb7ed8941ed29bdb04bd8ef3b71a5";
+    sha256 = "15sbpgkal4854jc1xn3sprvpnxwdj0fyy43y5am0h9vja3pjhjyi";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Update `ghc841` to -alpha2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

