### PR TITLE
mktemp: 1.6 -> 1.7, fix for cross

### DIFF
--- a/pkgs/tools/security/mktemp/default.nix
+++ b/pkgs/tools/security/mktemp/default.nix
@@ -6,6 +6,11 @@ stdenv.mkDerivation {
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
   NROFF = "${groff}/bin/nroff";
 
+  # Don't use "install -s"
+  postPatch = ''
+    substituteInPlace Makefile.in --replace " 0555 -s " " 0555 "
+  '';
+
   src = fetchurl {
     url = ftp://ftp.mktemp.org/pub/mktemp/mktemp-1.7.tar.gz;
     sha256 = "0x969152znxxjbj7387xb38waslr4yv6bnj5jmhb4rpqxphvk54f";

--- a/pkgs/tools/security/mktemp/default.nix
+++ b/pkgs/tools/security/mktemp/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, groff }:
 
 stdenv.mkDerivation {
-  name = "mktemp-1.6";
+  name = "mktemp-1.7";
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
   NROFF = "${groff}/bin/nroff";
 
   src = fetchurl {
-    url = ftp://ftp.mktemp.org/pub/mktemp/mktemp-1.6.tar.gz;
-    sha256 = "1nfj89b0dv1c2fyqi1pg54fyzs3462cbp7jv7lskqsxvqy4mh9x1";
+    url = ftp://ftp.mktemp.org/pub/mktemp/mktemp-1.7.tar.gz;
+    sha256 = "0x969152znxxjbj7387xb38waslr4yv6bnj5jmhb4rpqxphvk54f";
   };
-  
+
   meta = {
     platforms = stdenv.lib.platforms.unix;
   };


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Have not tested all packages that depend on this, FWIW.