### PR TITLE
arpack: 3.3.0 -> 3.5.0

### DIFF
--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -4,22 +4,26 @@
 with stdenv.lib;
 
 let
-  version = "3.3.0";
+  version = "3.5.0";
 in
 stdenv.mkDerivation {
   name = "arpack-${version}";
 
   src = fetchurl {
     url = "https://github.com/opencollab/arpack-ng/archive/${version}.tar.gz";
-    sha256 = "1cz53wqzcf6czmcpfb3vb61xi0rn5bwhinczl65hpmbrglg82ndd";
+    sha256 = "0f8jx3fifmj9qdp289zr7r651y1q48k1jya859rqxq62mvis7xsh";
   };
 
   nativeBuildInputs = [ autoconf automake gettext libtool ];
   buildInputs = [ gfortran openblas ];
 
+  doCheck = true;
+
   BLAS_LIBS = "-L${openblas}/lib -lopenblas";
 
   FFLAGS = optional openblas.blas64 "-fdefault-integer-8";
+
+  INTERFACE64 = optional openblas.blas64 "1";
 
   preConfigure = ''
     ./bootstrap

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation {
 
   BLAS_LIBS = "-L${openblas}/lib -lopenblas";
 
-  FFLAGS = optional openblas.blas64 "-fdefault-integer-8";
-
   INTERFACE64 = optional openblas.blas64 "1";
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
Update version. This PR also contains a solution for https://github.com/NixOS/nixpkgs/issues/33921. 

CC @ttuegel 
###### Things done
Enabled `doCheck`, since the test suite provides checks for incompatibilities with the underlying BLAS libraries

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

