### PR TITLE
gnome-shell-extension-pixel-saver: init at 1.10

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/pixel-saver/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/pixel-saver/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-pixel-saver-${version}";
+  version = "1.10";
+
+  src = fetchFromGitHub {
+    owner = "deadalnix";
+    repo = "pixel-saver";
+    rev = version;
+    sha256 = "040ayzhpv9jq49vp32w85wvjs57047faa7872qm4brii450iy7v4";
+  };
+
+  uuid = "pixel-saver@deadalnix.me";
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ${uuid} $out/share/gnome-shell/extensions
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pixel Saver is designed to save pixel by fusing activity bar and title bar in a natural way";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonafato ];
+    platforms = platforms.linux;
+    homepage = https://github.com/deadalnix/pixel-saver;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18815,6 +18815,7 @@ with pkgs;
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     mediaplayer = callPackage ../desktops/gnome-3/extensions/mediaplayer { };
     nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
+    pixel-saver = callPackage ../desktops/gnome-3/extensions/pixel-saver { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Add the pixel saver GNOME Shell extension

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

