### PR TITLE
gnome-shell-extension-nohotcorner: init at 16.0

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/nohotcorner/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/nohotcorner/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-nohotcorner-${version}";
+  version = "16.0";
+
+  src = fetchFromGitHub {
+    owner = "HROMANO";
+    repo = "nohotcorner";
+    rev = "v${version}";
+    sha256 = "042lv4pvzsxv6spa8k1hji1bfqj893arx55p56mmm20wa5dr5qm3";
+  };
+
+  # Taken from the extension download link at
+  # https://extensions.gnome.org/extension/118/no-topleft-hot-corner/
+  uuid = "nohotcorner@azuri.free.fr";
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp extension.js $out/share/gnome-shell/extensions/${uuid}
+    cp metadata.json $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Disables the top left hot corner";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ jonafato ];
+    homepage = https://github.com/HROMANO/nohotcorner;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18814,6 +18814,7 @@ with pkgs;
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     mediaplayer = callPackage ../desktops/gnome-3/extensions/mediaplayer { };
+    nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Add the no top left hotcorner GNOME Shell extension

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

