### PR TITLE
home-assistant: init at 0.62.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -231,6 +231,7 @@
   fadenb = "Tristan Helmich <tristan.helmich+nixos@gmail.com>";
   falsifian = "James Cook <james.cook@utoronto.ca>";
   fare = "Francois-Rene Rideau <fahree@gmail.com>";
+  f-breidenstein = "Felix Breidenstein <mail@felixbreidenstein.de>";
   fgaz = "Francesco Gazzetta <francygazz@gmail.com>";
   FireyFly = "Jonas Höglund <nix@firefly.nu>";
   flokli = "Florian Klink <flokli@flokli.de>";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -302,6 +302,7 @@
       kodi = 283;
       restya-board = 284;
       mighttpd2 = 285;
+      hass = 286;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -572,6 +573,7 @@
       kodi = 283;
       restya-board = 284;
       mighttpd2 = 285;
+      hass = 286;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -314,6 +314,7 @@
   ./services/misc/gogs.nix
   ./services/misc/gollum.nix
   ./services/misc/gpsd.nix
+  ./services/misc/home-assistant.nix
   ./services/misc/ihaskell.nix
   ./services/misc/irkerd.nix
   ./services/misc/jackett.nix

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -1,0 +1,90 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.home-assistant;
+
+  configFile = pkgs.writeText "configuration.yaml" (builtins.toJSON cfg.config);
+in {
+  meta.maintainers = with maintainers; [ dotlambda ];
+
+  options.services.home-assistant = {
+    enable = mkEnableOption "Home Assistant";
+
+    configDir = mkOption {
+      default = "/var/lib/hass";
+      type = types.path;
+      description = "The config directory, where your <filename>configuration.yaml</filename> is located.";
+    };
+
+    config = mkOption {
+      default = null;
+      type = with types; nullOr attrs;
+      example = literalExample ''
+        {
+          homeassistant = {
+            name = "Home";
+            time_zone = "UTC";
+          };
+          frontend = { };
+          http = { };
+        }
+      '';
+      description = ''
+        Your <filename>configuration.yaml</filename> as a Nix attribute set.
+        Beware that setting this option will delete your previous <filename>configuration.yaml</filename>.
+      '';
+    };
+
+    package = mkOption {
+      default = pkgs.home-assistant;
+      defaultText = "pkgs.home-assistant";
+      type = types.package;
+      example = literalExample ''
+        pkgs.home-assistant.override {
+          extraPackages = ps: with ps; [ colorlog ];
+        }
+      '';
+      description = ''
+        Home Assistant package to use.
+        Most Home Assistant components require additional dependencies,
+        which are best specified by overriding <literal>pkgs.home-assistant</literal>.
+        You can find the dependencies by searching for failed imports in your log or by looking at this list:
+        <link xlink:href="https://github.com/home-assistant/home-assistant/blob/master/requirements_all.txt"/>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.home-assistant = {
+      description = "Home Assistant";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      preStart = lib.optionalString (cfg.config != null) ''
+        rm -f ${cfg.configDir}/configuration.yaml
+        ln -s ${configFile} ${cfg.configDir}/configuration.yaml
+      '';
+      serviceConfig = {
+        ExecStart = ''
+          ${cfg.package}/bin/hass --config "${cfg.configDir}"
+        '';
+        User = "hass";
+        Group = "hass";
+        Restart = "on-failure";
+        ProtectSystem = "strict";
+        ReadWritePaths = "${cfg.configDir}";
+        PrivateTmp = true;
+      };
+    };
+
+    users.extraUsers.hass = {
+      home = cfg.configDir;
+      createHome = true;
+      group = "hass";
+      uid = config.ids.uids.hass;
+    };
+
+    users.extraGroups.hass.gid = config.ids.gids.hass;
+  };
+}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -267,6 +267,7 @@ in rec {
   tests.graphite = callTest tests/graphite.nix {};
   tests.hardened = callTest tests/hardened.nix { };
   tests.hibernate = callTest tests/hibernate.nix {};
+  tests.home-assistant = callTest tests/home-assistant.nix { };
   tests.hound = callTest tests/hound.nix {};
   tests.i3wm = callTest tests/i3wm.nix {};
   tests.initrd-network-ssh = callTest tests/initrd-network-ssh {};

--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -1,0 +1,41 @@
+import ./make-test.nix ({ pkgs, ... }:
+
+let
+  configDir = "/var/lib/foobar";
+
+in {
+  name = "home-assistant";
+
+  nodes = {
+    hass =
+      { config, pkgs, ... }:
+      {
+        services.home-assistant = {
+          inherit configDir;
+          enable = true;
+          config = {
+            homeassistant = {
+              name = "Home";
+              time_zone = "UTC";
+            };
+            frontend = { };
+            http = { };
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    startAll;
+    $hass->waitForUnit("home-assistant.service");
+    
+    # Since config is specified using a Nix attribute set,
+    # configuration.yaml is a link to the Nix store
+    $hass->succeed("test -L ${configDir}/configuration.yaml");
+
+    # Check that Home Assistant's web interface and API can be reached
+    $hass->waitForOpenPort(8123);
+    $hass->succeed("curl --fail http://localhost:8123/states");
+    $hass->succeed("curl --fail http://localhost:8123/api/ | grep 'API running'");
+  '';
+})

--- a/pkgs/development/python-modules/aiohttp/cors.nix
+++ b/pkgs/development/python-modules/aiohttp/cors.nix
@@ -3,7 +3,7 @@
 buildPythonPackage rec {
   pname = "aiohttp-cors";
   version = "0.6.0";
-  name = "${pname}-${version}";
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "1r0mb4dw0dc1lpi54dk5vxqs06nyhvagp76lyrvk7rd94z5mjkd4";

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -14,7 +14,6 @@
 buildPythonPackage rec {
   pname = "aiohttp";
   version = "2.3.9";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/astral/default.nix
+++ b/pkgs/development/python-modules/astral/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytz, pytest }:
+
+buildPythonPackage rec {
+  pname = "astral";
+  version = "1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "1zm1ypc6w279gh7lbgsfbzfxk2x4gihlq3rfh59hj70hmhjwiwp7";
+  };
+
+  propagatedBuildInputs = [ pytz ];
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    py.test -k "not test_GoogleLocator"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Calculations for the position of the sun and the moon";
+    homepage = https://github.com/sffjunkie/astral/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/pytest-aiohttp/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, aiohttp }:
+
+buildPythonPackage rec {
+  pname = "pytest-aiohttp";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kx4mbs9bflycd8x9af0idcjhdgnzri3nw1qb0vpfyb3751qaaf9";
+  };
+
+  propagatedBuildInputs = [ pytest aiohttp ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/aio-libs/pytest-aiohttp/;
+    description = "Pytest plugin for aiohttp support";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -1,0 +1,72 @@
+{ stdenv, fetchFromGitHub, python3
+, extraPackages ? ps: []
+, skipPip ? true }:
+
+let
+
+  py = python3.override {
+    packageOverrides = self: super: {
+      yarl = super.yarl.overridePythonAttrs (oldAttrs: rec {
+        version = "0.18.0";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "11j8symkxh0ngvpddqpj85qmk6p70p20jca3alxc181gk3vx785s";
+        };
+      });
+      aiohttp = super.aiohttp.overridePythonAttrs (oldAttrs: rec {
+        version = "2.3.7";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0fzfpx5ny7559xrxaawnylq20dvrkjiag0ypcd13frwwivrlsagy";
+        };
+      });
+      hass-frontend = super.callPackage ./frontend.nix { };
+    };
+  };
+
+  # Ensure that we are using a consistent package set
+  extraBuildInputs = extraPackages py.pkgs;
+
+in with py.pkgs; buildPythonApplication rec {
+  pname = "homeassistant";
+  version = "0.62.1";
+
+  diabled = !isPy3k;
+
+  # PyPI tarball is missing tests/ directory
+  src = fetchFromGitHub {
+    owner = "home-assistant";
+    repo = "home-assistant";
+    rev = version;
+    sha256 = "0151prwk2ci6bih0mdmc3r328nrvazn9jwk0w26wmd4cpvnb5h26";
+  };
+
+  propagatedBuildInputs = [
+    # From setup.py
+    requests pyyaml pytz pip jinja2 voluptuous typing aiohttp yarl async-timeout chardet astral certifi
+    # From the components that are part of the default configuration.yaml
+    sqlalchemy aiohttp-cors hass-frontend user-agents distro mutagen xmltodict netdisco 
+  ] ++ extraBuildInputs;
+
+  checkInputs = [
+    pytest requests-mock pydispatcher pytest-aiohttp
+  ];
+
+  checkPhase = ''
+    # The components' dependencies are not included, so they cannot be tested
+    py.test --ignore tests/components
+    # Some basic components should be tested however
+    py.test \
+      tests/components/{group,http} \
+      tests/components/test_{api,configurator,demo,discovery,frontend,init,introduction,logger,script,shell_command,system_log,websocket_api}.py
+  '';
+
+  makeWrapperArgs = [] ++ stdenv.lib.optional skipPip [ "--add-flags --skip-pip" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://home-assistant.io/;
+    description = "Open-source home automation platform running on Python 3";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ f-breidenstein dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -1,0 +1,11 @@
+{ stdenv, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "home-assistant-frontend";
+  version = "20180130.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0b9klisl7hh30rml8qlrp9gpz33z9b825pd1vxbck48k0s98z1zi";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11974,6 +11974,8 @@ with pkgs;
 
   hiawatha = callPackage ../servers/http/hiawatha {};
 
+  home-assistant = callPackage ../servers/home-assistant { };
+
   ircdHybrid = callPackage ../servers/irc/ircd-hybrid { };
 
   jboss = callPackage ../servers/http/jboss { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3217,6 +3217,8 @@ in {
 
   pytest-asyncio = callPackage ../development/python-modules/pytest-asyncio { };
 
+  pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
+
   pytestcache = buildPythonPackage rec {
     name = "pytest-cache-1.0";
     src = pkgs.fetchurl {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -165,6 +165,8 @@ in {
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };
 
+  astral = callPackage ../development/python-modules/astral { };
+
   astropy = callPackage ../development/python-modules/astropy {  };
 
   augeas = callPackage ../development/python-modules/augeas {


### PR DESCRIPTION
closes #33675 

Regarding `--skip-pip`:
When I disable that option, not even the frontend component can be loaded because home-assistant isn't able to import pip. I have no idea why.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @FRidh @f-breidenstein @flokli