### PR TITLE
nixos/acpid: pass event parameters to handler

### DIFF
--- a/nixos/modules/services/hardware/acpid.nix
+++ b/nixos/modules/services/hardware/acpid.nix
@@ -31,7 +31,7 @@ let
           ''
             fn=$out/${name}
             echo "event=${handler.event}" > $fn
-            echo "action=${pkgs.writeScript "${name}.sh" (concatStringsSep "\n" [ "#! ${pkgs.bash}/bin/sh" handler.action ])}" >> $fn
+            echo "action=${pkgs.writeShellScript "${name}.sh" handler.action } '%e'" >> $fn
           '';
         in concatStringsSep "\n" (mapAttrsToList f (canonicalHandlers // config.services.acpid.handlers))
       }
@@ -69,11 +69,33 @@ in
           };
         });
 
-        description = "Event handlers.";
+        description = ''
+          Event handlers.
+
+          <note><para>
+            Handler can be a single command.
+          </para></note>
+        '';
         default = {};
-        example = { mute = { event = "button/mute.*"; action = "amixer set Master toggle"; }; };
-
-
+        example = {
+          ac-power = {
+            event = "ac_adapter/*";
+            action = ''
+              vals=($1)  # space separated string to array of multiple values
+              case ''${vals[3]} in
+                  00000000)
+                      echo unplugged >> /tmp/acpi.log
+                      ;;
+                  00000001)
+                      echo plugged in >> /tmp/acpi.log
+                      ;;
+                  *)
+                      echo unknown >> /tmp/acpi.log
+                      ;;
+              esac
+            '';
+          };
+        };
       };
 
       powerEventCommands = mkOption {

--- a/nixos/modules/services/hardware/acpid.nix
+++ b/nixos/modules/services/hardware/acpid.nix
@@ -31,7 +31,7 @@ let
           ''
             fn=$out/${name}
             echo "event=${handler.event}" > $fn
-            echo "action=${pkgs.writeShellScript "${name}.sh" handler.action } '%e'" >> $fn
+            echo "action=${pkgs.writeShellScriptBin "${name}.sh" handler.action }/bin/${name}.sh '%e'" >> $fn
           '';
         in concatStringsSep "\n" (mapAttrsToList f (canonicalHandlers // config.services.acpid.handlers))
       }

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -58,6 +58,18 @@ rec {
   writeScriptBin = name: text: writeTextFile {inherit name text; executable = true; destination = "/bin/${name}";};
 
   # Create a Shell script, check its syntax
+  writeShellScript = name : text :
+    writeTextFile {
+      inherit name;
+      executable = true;
+      text = ''
+        #!${stdenv.shell}
+        ${text}
+        '';
+      checkPhase = ''
+        ${stdenv.shell} -n $out
+      '';
+    };
   writeShellScriptBin = name : text :
     writeTextFile {
       inherit name;

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -58,18 +58,6 @@ rec {
   writeScriptBin = name: text: writeTextFile {inherit name text; executable = true; destination = "/bin/${name}";};
 
   # Create a Shell script, check its syntax
-  writeShellScript = name : text :
-    writeTextFile {
-      inherit name;
-      executable = true;
-      text = ''
-        #!${stdenv.shell}
-        ${text}
-        '';
-      checkPhase = ''
-        ${stdenv.shell} -n $out
-      '';
-    };
   writeShellScriptBin = name : text :
     writeTextFile {
       inherit name;


### PR DESCRIPTION
Previously the parameters were just dropped. Now they can be read
from within the handler script. An example to show this is added.

Makes use of the new writeShellScript function as suggested in:
issue #21557

resolves:  #21557

###### Motivation for this change
Previously the script for a certain event was run with no further information. This is fine for a button event where an action is executed on every press. But for something like ac_adapter we want to know what state the connection changed to.

To find out what the parameters are, you can listen to the socket with: `nc -U /var/run/acpid.socket`

###### Things done
- Pass parameter with '%e' argument
- Add example which takes advantage of parameters
- Add and use new writeShellScript function

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)). _There are no tests_
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)  __no binaries because is a module__
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

