### PR TITLE
brotli: tests, install man pages

### DIFF
--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -25,6 +25,14 @@ stdenv.mkDerivation rec {
   # and the wonderful bazel BUILD file is already there (yay case-insensitivity?)
   prePatch = "rm BUILD";
 
+  # Don't bother with "man" output for now,
+  # it currently only makes the manpages hard to use.
+  postInstall = ''
+    mkdir -p $out/share/man/man{1,3}
+    cp ../docs/*.1 $out/share/man/man1/
+    cp ../docs/*.3 $out/share/man/man3/
+  '';
+
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
 

--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "lib" ];
 
+  doCheck = true;
+
+  checkTarget = "test";
+
   # This breaks on Darwin because our cmake hook tries to make a build folder
   # and the wonderful bazel BUILD file is already there (yay case-insensitivity?)
   prePatch = "rm BUILD";


### PR DESCRIPTION
Missing man page for brotli.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---