### PR TITLE
abcm2ps: 8.13.18 -> 8.13.19

### DIFF
--- a/pkgs/tools/audio/abcm2ps/default.nix
+++ b/pkgs/tools/audio/abcm2ps/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "abcm2ps-${version}";
-  version = "8.13.18";
+  version = "8.13.19";
 
   src = fetchFromGitHub {
     owner = "leesavide";
     repo = "abcm2ps";
     rev = "v${version}";
-    sha256 = "0fzhk43fidyflqj8wd7m3m4pibzrbr1c120xi9wskzb3627pgyh1";
+    sha256 = "0iv8fzl601rkww9dplajwzlfdb8r7142qdsj8xmvrbwqkaval51f";
   };
 
   prePatch = ''
@@ -19,12 +19,17 @@ stdenv.mkDerivation rec {
     "--INSTALL=install"
   ];
 
+  buildFlags = [
+    "CC=${stdenv.cc}/bin/cc"
+  ];
+
   buildInputs = [ which pkgconfig freetype pango ];
 
   meta = with stdenv.lib; {
     homepage = http://moinejf.free.fr/;
     license = licenses.gpl3;
     description = "abcm2ps is a command line program which converts ABC to music sheet in PostScript or SVG format";
+    platforms = platforms.unix;
     maintainers = [ maintainers.dotlambda ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

