### PR TITLE
kallisto: init at 0.43.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -55,6 +55,7 @@
   antonxy = "Anton Schirg <anton.schirg@posteo.de>";
   apeschar = "Albert Peschar <albert@peschar.net>";
   apeyroux = "Alexandre Peyroux <alex@px.io>";
+  arcadio = "Arcadio Rubio García <arc@well.ox.ac.uk>";
   ardumont = "Antoine R. Dumont <eniotna.t@gmail.com>";
   aristid = "Aristid Breitkreuz <aristidb@gmail.com>";
   arobyn = "Alexei Robyn <shados@shados.net>";

--- a/pkgs/applications/science/biology/kallisto/default.nix
+++ b/pkgs/applications/science/biology/kallisto/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, hdf5, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "kallisto-${version}";
+  version = "0.43.1";
+
+  src = fetchFromGitHub {
+    repo = "kallisto";
+    owner = "pachterlab";
+    rev = "v${version}";
+    sha256 = "04697pf7jvy7vw126s1rn09q4iab9223jvb1nb0jn7ilwkq7pgwz";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  
+  buildInputs = [ hdf5 zlib ];
+
+  meta = with stdenv.lib; {
+    description = "kallisto is a program for quantifying abundances of transcripts from RNA-Seq data";
+    homepage = https://pachterlab.github.io/kallisto;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.arcadio ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18932,6 +18932,8 @@ with pkgs;
     neuron-version = neuron.version;
   };
 
+  kallisto = callPackage ../applications/science/biology/kallisto { };
+
   neuron = callPackage ../applications/science/biology/neuron {
     python = null;
   };


### PR DESCRIPTION
###### Motivation for this change

Add kallisto derivation.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

