### PR TITLE
nixos/release.nix: Introduce callSubTestsOnTheseSystems

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -57,7 +57,7 @@ in rec {
         nixos.ova.x86_64-linux
 
         #(all nixos.tests.containers)
-        nixos.tests.chromium
+        nixos.tests.chromium.x86_64-linux
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
         (all nixos.tests.gnome3)

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -248,8 +248,8 @@ in rec {
   tests.dnscrypt-proxy = callTestOnTheseSystems ["x86_64-linux"] tests/dnscrypt-proxy.nix {};
   tests.ecryptfs = callTest tests/ecryptfs.nix {};
   tests.etcd = callTestOnTheseSystems ["x86_64-linux"] tests/etcd.nix {};
-  tests.ec2-nixops = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-nixops;
-  tests.ec2-config = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-config;
+  tests.ec2-nixops = (callSubTestsOnTheseSystems ["x86_64-linux"] tests/ec2.nix {}).boot-ec2-nixops;
+  tests.ec2-config = (callSubTestsOnTheseSystems ["x86_64-linux"] tests/ec2.nix {}).boot-ec2-config;
   tests.elk = callSubTestsOnTheseSystems ["x86_64-linux"] tests/elk.nix {};
   tests.env = callTest tests/env.nix {};
   tests.ferm = callTest tests/ferm.nix {};


### PR DESCRIPTION
The existing callSubTests seems to already have special-cased code to
allow enabling subtests on a single specific system by looking at the
`system` attribute in the test arguments. Replace it with a new version
similar to the callTestOnTheseSystems because:

- It's consistent with the existing functions for creating
  system-specific tests (though admittedly, the callSubTests special
  case for `system` predates them)
- This approach allows limiting to multiple system types, the previous
  one inherently allows only one system type.
- This also fixes the problem that if you pass in e.g.
  supportedSystems = [ "aarch64-linux" ], you end up with a
  tests.chromium job that silently runs on x86_64-linux.
- Finally, this causes renames of the jobs like:
  tests.chromium -> tests.chromium.x86_64-linux to be consistent with
  the rest of the tests.

Effect on an aarch64-only jobset: https://hydra.nixos.org/eval/1428589?compare=1428465#tabs-removed