### PR TITLE
icu: fix include path returned by icu-config

### DIFF
--- a/pkgs/development/libraries/icu/base.nix
+++ b/pkgs/development/libraries/icu/base.nix
@@ -34,6 +34,9 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     sed -i -e "s|/bin/sh|${stdenv.shell}|" configure
+
+    # $(includedir) is different from $(prefix)/include due to multiple outputs
+    sed -i -e 's|^\(CPPFLAGS = .*\) -I\$(prefix)/include|\1 -I$(includedir)|' config/Makefile.inc.in
   '' + stdenv.lib.optionalString stdenv.isArm ''
     # From https://archlinuxarm.org/packages/armv7h/icu/files/icudata-stdlibs.patch
     sed -e 's/LDFLAGSICUDT=-nodefaultlibs -nostdlib/LDFLAGSICUDT=/' -i config/mh-linux


### PR DESCRIPTION
###### Motivation for this change

`icu-config --cppflags` returns an incorrect include path pointing to the `out` output while the includes are in the `dev` output.

```
$ nix-shell -p icu.dev --run "icu-config --cppflags"
-I/nix/store/5bp445w0c6l8ng28yrb3k4cw58wq8kcx-icu4c-59.1/include
$ ls /nix/store/5bp445w0c6l8ng28yrb3k4cw58wq8kcx-icu4c-59.1/include
ls: cannot access '/nix/store/5bp445w0c6l8ng28yrb3k4cw58wq8kcx-icu4c-59.1/include': No such file or directory
```

Fortunately, most nix builds are not affected by this bug because they get the correct include path via the `NIX_CFLAGS_COMPILE` variable. But this is still broken and can potentially lead to further breakage and suffering, so let's fix it. :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

