### PR TITLE
moe: fix build w/libc++ using touchup from mailing list

### DIFF
--- a/pkgs/applications/editors/moe/default.nix
+++ b/pkgs/applications/editors/moe/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
     sha256 = "1wsfzy0iia0c89wnx1ilzw54wqcmlp2nz8mkpvc393z0zagrx48q";
   };
 
+  prePatch = ''
+    substituteInPlace window_vector.cc --replace \
+      "insert( 0U, 1," \
+      "insert( 0U, 1U,"
+  '';
+
   nativeBuildInputs = [ lzip ];
   buildInputs = [ ncurses ];
 


### PR DESCRIPTION
http://lists.gnu.org/archive/html/bug-moe/2017-10/msg00000.html

###### Motivation for this change

Fix build w/libc++.

Example (fails currently, succeeds after this fix):
```
$ nix build "(with import ./. {}; moe.override { stdenv = llvmPackages_4.libcxxStdenv; })" 
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

