### PR TITLE
rhash: cleanup, 1.3.3 -> 1.3.5

### DIFF
--- a/pkgs/tools/security/rhash/darwin.patch
+++ b/pkgs/tools/security/rhash/darwin.patch
@@ -11,28 +11,3 @@ index e40dbc3..e198b93 100644
  SHRDLFLAGS = $(LDFLAGS) $(ADDLDFLAGS)
  HEADERS = calc_sums.h hash_print.h common_func.h hash_update.h file_mask.h file_set.h find_file.h hash_check.h output.h parse_cmdline.h rhash_main.h win_utils.h version.h
  SOURCES = calc_sums.c hash_print.c common_func.c hash_update.c file_mask.c file_set.c find_file.c hash_check.c output.c parse_cmdline.c rhash_main.c win_utils.c
-diff --git a/librhash/Makefile b/librhash/Makefile
-index 2f9bcc9..0c5aaad 100644
---- a/librhash/Makefile
-+++ b/librhash/Makefile
-@@ -28,8 +28,8 @@ PREFIX  = /usr/local
- INCDIR  = $(PREFIX)/include
- LIBDIR  = $(PREFIX)/lib
- LIBRARY = librhash.a
--SONAME  = librhash.so.0
--SOLINK  = librhash.so
-+SONAME  = librhash.0.dylib
-+SOLINK  = librhash.dylib
- TEST_TARGET = test_hashes
- TEST_SHARED = test_shared
- # Set variables according to GNU coding standard
-@@ -182,8 +182,7 @@ test-dll: $(DLLNAME) test_hashes.o
- 
- # shared and static libraries
- $(SONAME): $(SOURCES)
--	sed -n '1s/.*/{ global:/p; s/^RHASH_API.* \([a-z0-9_]\+\)(.*/  \1;/p; $$s/.*/local: *; };/p' $(SO_HEADERS) > exports.sym
--	$(CC) -fpic $(ALLCFLAGS) -shared $(SOURCES) -Wl,--version-script,exports.sym,-soname,$(SONAME) $(LIBLDFLAGS) -o $@
-+	$(CC) -fpic $(ALLCFLAGS) -dynamiclib $(SOURCES) $(LIBLDFLAGS) -Wl,-install_name,$(PREFIX)/lib/$@ -o $@
- 	ln -s $(SONAME) $(SOLINK)
- # use 'nm -Cg --defined-only $@' to view exported symbols
- 

--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -1,31 +1,23 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "1.3.3";
+  version = "1.3.5";
   name = "rhash-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/rhash/${name}-src.tar.gz";
-    sha1 = "0981bdc98ba7ef923b1a6cd7fd8bb0374cff632e";
-    sha256 = "0nii6p4m2x8rkaf8r6smgfwb1q4hpf117kkg64yr6gyqgdchnljv";
+    sha256 = "0bhz3xdl6r06k1bqigdjz42l31iqz2qdpg7zk316i7p2ra56iq4q";
   };
 
   patches = stdenv.lib.optional stdenv.isDarwin ./darwin.patch;
 
-  installFlags = [ "DESTDIR=$(out)" "PREFIX=/" ];
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=/" "AR:=$(AR)" "CC:=$(CC)" ];
 
-  # we build the static library because of two makefile bugs
-  # * .h files installed for static library target only
-  # * .so.0 -> .so link only created in the static library install target
-  buildPhase = ''
-    make lib-shared lib-static build-shared CC=$CC AR=$AR PREFIX=$out
-  '';
+  buildFlags = [ "build-shared" "lib-shared" ];
 
-  # we don't actually want the static library, so we remove it after it
-  # gets installed
   installPhase = ''
-    make DESTDIR="$out" PREFIX="/" install-shared install-lib-shared install-lib-static
-    rm $out/lib/librhash.a
+    make $makeFlags -C librhash install-lib-shared install-headers install-so-link
+    make $makeFlags install-shared
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

1.3.5: https://github.com/rhash/RHash/releases/tag/v1.3.5
1.3.4: https://github.com/rhash/RHash/releases/tag/v1.3.4

* cleanup quite a bit
* port darwin patch--
  don't believe still needed but shouldn't hurt.

Among other things (see release notes), improves support on numerous platforms including aarch64 and musl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
