### PR TITLE
rustc: adjust broken test src/test/run-pass/out-of-stack.rs

### DIFF
--- a/pkgs/development/compilers/rust/patches/adapt-out-of-stack-test.patch
+++ b/pkgs/development/compilers/rust/patches/adapt-out-of-stack-test.patch
@@ -1,0 +1,25 @@
+diff --git a/src/test/run-pass/out-of-stack.rs b/src/test/run-pass/out-of-stack.rs
+index a7748b6d6a..7679eabccc 100644
+--- a/src/test/run-pass/out-of-stack.rs
++++ b/src/test/run-pass/out-of-stack.rs
+@@ -47,7 +47,7 @@ fn check_status(status: std::process::ExitStatus)
+     use std::os::unix::process::ExitStatusExt;
+
+     assert!(!status.success());
+-    assert_eq!(status.signal(), Some(libc::SIGABRT));
++    assert_eq!(status.signal(), Some(libc::SIGSEGV));
+ }
+
+ #[cfg(not(unix))]
+@@ -86,10 +86,6 @@ fn main() {
+             let silent = Command::new(&args[0]).arg(mode).output().unwrap();
+
+             check_status(silent.status);
+-
+-            let error = String::from_utf8_lossy(&silent.stderr);
+-            assert!(error.contains("has overflowed its stack"),
+-                    "missing overflow message: {}", error);
+         }
+     }
+ }
+

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -55,7 +55,9 @@ stdenv.mkDerivation {
                 ++ optional (targets != []) "--target=${target}"
                 ++ optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
 
-  patches = patches ++ targetPatches;
+  patches = patches ++ targetPatches 
+    # See https://github.com/NixOS/nixpkgs/issues/34189 for that. This adjusts a test, which failed after a glibc update.
+    ++ [ ./patches/adapt-out-of-stack-test.patch ];
 
   passthru.target = target;
 


### PR DESCRIPTION
That test broke after the glibc update at 0186286433cccbf6faf288c22df03e63e46dd94d .
It was adjusted, so that it expects the results, which actually happen.

This solves #34189.

This is an alternative to #34205. Please don't merge both.

###### Motivation for this change

`rustc` is currently broken on `nixos-17.09` since 0186286433cccbf6faf288c22df03e63e46dd94d.

###### Things done

Made the failing test think, that it expects what it gets.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

