### PR TITLE
Pyrseas: init at 0.8.0

### DIFF
--- a/pkgs/development/tools/database/pyrseas/default.nix
+++ b/pkgs/development/tools/database/pyrseas/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, python27Packages, fetchFromGitHub }:
+
+let
+  pgdbconn = python27Packages.buildPythonPackage rec {
+    name = "pgdbconn-${version}";
+    version = "0.8.0";
+    src = fetchFromGitHub {
+      owner = "perseas";
+      repo = "pgdbconn";
+      rev = "26c1490e4f32e4b5b925e5b82014ad106ba5b057";
+      sha256 = "09r4idk5kmqi3yig7ip61r6js8blnmac5n4q32cdcbp1rcwzdn6z";
+    };
+    doCheck = false;
+    propagatedBuildInputs = [
+      python27Packages.psycopg2
+      python27Packages.pytest
+    ];
+  };
+in
+
+python27Packages.buildPythonPackage rec {
+  name = "pyrseas-${version}";
+  version = "0.8.0";
+  src = fetchFromGitHub {
+    owner = "perseas";
+    repo = "Pyrseas";
+    rev = "2e9be763e61168cf20d28bd69010dc5875bd7b97";
+    sha256 = "1h9vahplqh0rzqjsdq64qqar6hj1bpbc6nl1pqwwgca56385br8r";
+  };
+  doCheck = false;
+  propagatedBuildInputs = [
+    python27Packages.psycopg2
+    python27Packages.pytest
+    python27Packages.pyyaml
+    pgdbconn
+  ];
+  meta = {
+    description = "A declarative language to describe PostgreSQL databases";
+    homepage = http://perseas.github.io/;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ pmeunier ];
+  };
+}

--- a/pkgs/development/tools/database/pyrseas/default.nix
+++ b/pkgs/development/tools/database/pyrseas/default.nix
@@ -10,6 +10,7 @@ let
       rev = "26c1490e4f32e4b5b925e5b82014ad106ba5b057";
       sha256 = "09r4idk5kmqi3yig7ip61r6js8blnmac5n4q32cdcbp1rcwzdn6z";
     };
+    # The tests are impure (they try to access a PostgreSQL server)
     doCheck = false;
     propagatedBuildInputs = [
       python2Packages.psycopg2
@@ -27,6 +28,7 @@ python2Packages.buildPythonPackage rec {
     rev = "2e9be763e61168cf20d28bd69010dc5875bd7b97";
     sha256 = "1h9vahplqh0rzqjsdq64qqar6hj1bpbc6nl1pqwwgca56385br8r";
   };
+  # The tests are impure (they try to access a PostgreSQL server)
   doCheck = false;
   propagatedBuildInputs = [
     python2Packages.psycopg2

--- a/pkgs/development/tools/database/pyrseas/default.nix
+++ b/pkgs/development/tools/database/pyrseas/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, python2Packages, fetchFromGitHub }:
+{ stdenv, pythonPackages, fetchFromGitHub }:
 
 let
-  pgdbconn = python2Packages.buildPythonPackage rec {
-    name = "pgdbconn-${version}";
+  pgdbconn = pythonPackages.buildPythonPackage rec {
+    pname = "pgdbconn";
     version = "0.8.0";
     src = fetchFromGitHub {
       owner = "perseas";
@@ -13,14 +13,14 @@ let
     # The tests are impure (they try to access a PostgreSQL server)
     doCheck = false;
     propagatedBuildInputs = [
-      python2Packages.psycopg2
-      python2Packages.pytest
+      pythonPackages.psycopg2
+      pythonPackages.pytest
     ];
   };
 in
 
-python2Packages.buildPythonPackage rec {
-  name = "pyrseas-${version}";
+pythonPackages.buildPythonApplication rec {
+  pname = "pyrseas";
   version = "0.8.0";
   src = fetchFromGitHub {
     owner = "perseas";
@@ -31,9 +31,9 @@ python2Packages.buildPythonPackage rec {
   # The tests are impure (they try to access a PostgreSQL server)
   doCheck = false;
   propagatedBuildInputs = [
-    python2Packages.psycopg2
-    python2Packages.pytest
-    python2Packages.pyyaml
+    pythonPackages.psycopg2
+    pythonPackages.pytest
+    pythonPackages.pyyaml
     pgdbconn
   ];
   meta = {

--- a/pkgs/development/tools/database/pyrseas/default.nix
+++ b/pkgs/development/tools/database/pyrseas/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, python27Packages, fetchFromGitHub }:
+{ stdenv, python2Packages, fetchFromGitHub }:
 
 let
-  pgdbconn = python27Packages.buildPythonPackage rec {
+  pgdbconn = python2Packages.buildPythonPackage rec {
     name = "pgdbconn-${version}";
     version = "0.8.0";
     src = fetchFromGitHub {
@@ -12,13 +12,13 @@ let
     };
     doCheck = false;
     propagatedBuildInputs = [
-      python27Packages.psycopg2
-      python27Packages.pytest
+      python2Packages.psycopg2
+      python2Packages.pytest
     ];
   };
 in
 
-python27Packages.buildPythonPackage rec {
+python2Packages.buildPythonPackage rec {
   name = "pyrseas-${version}";
   version = "0.8.0";
   src = fetchFromGitHub {
@@ -29,9 +29,9 @@ python27Packages.buildPythonPackage rec {
   };
   doCheck = false;
   propagatedBuildInputs = [
-    python27Packages.psycopg2
-    python27Packages.pytest
-    python27Packages.pyyaml
+    python2Packages.psycopg2
+    python2Packages.pytest
+    python2Packages.pyyaml
     pgdbconn
   ];
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7796,6 +7796,8 @@ with pkgs;
 
   pup = callPackage ../development/tools/pup { };
 
+  pyrseas = callPackage ../development/tools/database/pyrseas { };
+
   qtcreator = libsForQt5.callPackage ../development/qtcreator { };
 
   r10k = callPackage ../tools/system/r10k { };


### PR DESCRIPTION
Pyrseas is a declarative tool for managing PostgreSQL schemas.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

