### PR TITLE
ipvsadm: init at 1.29

### DIFF
--- a/pkgs/os-specific/linux/ipvsadm/default.nix
+++ b/pkgs/os-specific/linux/ipvsadm/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, pkgconfig, libnl, popt, gnugrep }:
+
+stdenv.mkDerivation rec {
+  name = "ipvsadm-${version}";
+  version = "1.29";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/utils/kernel/ipvsadm/${name}.tar.xz";
+    sha256 = "c3de4a21d90a02c621f0c72ee36a7aa27374b6f29fd4178f33fbf71b4c66c149";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "-lnl" "$(pkg-config --libs libnl-genl-3.0)"
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libnl popt ];
+
+  preBuild = ''
+    makeFlagsArray+=(
+      INCLUDE=$(pkg-config --cflags libnl-genl-3.0)
+      BUILD_ROOT=$out
+      MANDIR=share/man
+    )
+  '';
+
+  postInstall = ''
+    sed -i -e "s|^PATH=.*|PATH=$out/bin:${gnugrep}/bin|" $out/sbin/ipvsadm-{restore,save}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Linux Virtual Server support programs";
+    homepage = http://www.linuxvirtualserver.org/software/ipvs.html;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1225,6 +1225,8 @@ with pkgs;
 
   iio-sensor-proxy = callPackage ../os-specific/linux/iio-sensor-proxy { };
 
+  ipvsadm = callPackage ../os-specific/linux/ipvsadm { };
+
   lynis = callPackage ../tools/security/lynis { };
 
   mathics = pythonPackages.mathics;


### PR DESCRIPTION
Request.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #34226.

The binaries "run", man pages work...
I think a custom kernel with proper support enabled
is required to actually confirm functionality.