### PR TITLE
citra: 2017-07-26 -> 2018-01-24

### DIFF
--- a/pkgs/misc/emulators/citra/default.nix
+++ b/pkgs/misc/emulators/citra/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchgit, cmake, SDL2, qtbase, boost, curl, gtest }:
 
 stdenv.mkDerivation rec { 
-  name = "citra-2017-07-26";
+  name = "citra-2018-01-24";
 
   # Submodules
   src = fetchgit {
     url = "https://github.com/citra-emu/citra";
-    rev = "a724fb365787718f9e44adedc14e59d0854905a6";
-    sha256 = "0lkrwhxvq85c0smix27xvj8m463bxa67qhy8m8r43g39n0h8d5sf";
+    rev = "33b0b5163fdb08bc8aa1d7eb83e0931a14ed3046";
+    sha256 = "07z32d8lj84yy3l5iqpk37mnmvzjmppqhyqr64kbx14dh5hb6cbj";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
citra is broken currently, see #34212 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (tried a rom and it seems ok)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

