### PR TITLE
addPassthru: fix argument order

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -157,8 +157,9 @@ rec {
 
   /* Add attributes to each output of a derivation without changing
      the derivation itself. */
-  addPassthru = lib.warn "`addPassthru` is deprecated, replace with `extendDerivation true`"
-                         (extendDerivation true);
+  addPassthru =
+    lib.warn "`addPassthru drv passthru` is deprecated, replace with `extendDerivation true passthru drv`"
+      (drv: passthru: extendDerivation true passthru drv);
 
   /* Strip a derivation of all non-essential attributes, returning
      only those needed by hydra-eval-jobs. Also strictly evaluate the

--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -133,7 +133,7 @@ following incompatible changes:</para>
   </listitem>
   <listitem>
     <para>
-      <literal>lib.addPassthru</literal> is removed.  Use <literal>lib.extendDerivation true</literal> instead.  <emphasis role="strong">TODO: actually remove it before branching 18.03 off.</emphasis>
+      <literal>lib.addPassthru drv passthru</literal> is removed.  Use <literal>lib.extendDerivation true passthru drv</literal> instead.  <emphasis role="strong">TODO: actually remove it before branching 18.03 off.</emphasis>
     </para>
   </listitem>
   <listitem>


### PR DESCRIPTION
###### Motivation for this change

`addPassthru` became unused in #33057, but its signature was changed at the same time. @chris-martin has informed us at https://groups.google.com/forum/#!topic/nix-devel/YhIRYR7W5wM that this does not make sense.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).