### PR TITLE
terraform-landscape: init at 0.1.17

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-landscape/Gemfile
+++ b/pkgs/applications/networking/cluster/terraform-landscape/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'terraform_landscape'

--- a/pkgs/applications/networking/cluster/terraform-landscape/Gemfile.lock
+++ b/pkgs/applications/networking/cluster/terraform-landscape/Gemfile.lock
@@ -1,0 +1,25 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorize (0.8.1)
+    commander (4.4.4)
+      highline (~> 1.7.2)
+    diffy (3.2.0)
+    highline (1.7.10)
+    polyglot (0.3.5)
+    terraform_landscape (0.1.17)
+      colorize (~> 0.7)
+      commander (~> 4.4)
+      diffy (~> 3.0)
+      treetop (~> 1.6)
+    treetop (1.6.9)
+      polyglot (~> 0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  terraform_landscape
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/applications/networking/cluster/terraform-landscape/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-landscape/default.nix
@@ -1,0 +1,19 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv rec {
+  name = "terraform-landscape-${version}";
+
+  version = (import gemset).terraform_landscape.version;
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  meta = with lib; {
+    description = "Improve Terraform's plan output to be easier to read and understand";
+    homepage    = https://github.com/coinbase/terraform-landscape;
+    license     = with licenses; apsl20;
+    maintainers = with maintainers; [ mbode ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/cluster/terraform-landscape/gemset.nix
+++ b/pkgs/applications/networking/cluster/terraform-landscape/gemset.nix
@@ -1,0 +1,61 @@
+{
+  colorize = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "133rqj85n400qk6g3dhf2bmfws34mak1wqihvh3bgy9jhajw580b";
+      type = "gem";
+    };
+    version = "0.8.1";
+  };
+  commander = {
+    dependencies = ["highline"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "165yr8qzan3gnk241mnwxsvdfwp6p1afg13z0mqdily6lh95acl9";
+      type = "gem";
+    };
+    version = "4.4.4";
+  };
+  diffy = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "015nn9zaciqj43mfpjlw619r5dvnfkrjcka8nsa6j260v6qya941";
+      type = "gem";
+    };
+    version = "3.2.0";
+  };
+  highline = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01ib7jp85xjc4gh4jg0wyzllm46hwv8p0w1m4c75pbgi41fps50y";
+      type = "gem";
+    };
+    version = "1.7.10";
+  };
+  polyglot = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  terraform_landscape = {
+    dependencies = ["colorize" "commander" "diffy" "treetop"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bx8nfqbpxb2hnxnnl1m4sq6jlzf451c85m047jfq04b6w9691fl";
+      type = "gem";
+    };
+    version = "0.1.17";
+  };
+  treetop = {
+    dependencies = ["polyglot"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sdkd1v2h8dhj9ncsnpywmqv7w1mdwsyc5jwyxlxwriacv8qz8bd";
+      type = "gem";
+    };
+    version = "1.6.9";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19999,6 +19999,8 @@ with pkgs;
 
   terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};
 
+  terraform-landscape = callPackage ../applications/networking/cluster/terraform-landscape {};
+
   terragrunt = callPackage ../applications/networking/cluster/terragrunt {};
 
   terragrunt_0_11_1 = callPackage ../applications/networking/cluster/terragrunt/0.11.1.nix {


### PR DESCRIPTION
###### Motivation for this change
Add package terraform-landscape (ruby gem)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

