### PR TITLE
check-wmiplus: init at 1.64

### DIFF
--- a/pkgs/servers/monitoring/plugins/wmiplus/default.nix
+++ b/pkgs/servers/monitoring/plugins/wmiplus/default.nix
@@ -1,0 +1,77 @@
+{ stdenv, fetchFromGitHub, makeWrapper, perlPackages, txt2man
+, monitoring-plugins
+, wmic-bin ? null }:
+
+stdenv.mkDerivation rec {
+  pname = "check-wmiplus";
+  version = "1.64";
+
+  # We fetch from github.com instead of the proper upstream as nix-build errors
+  # out with 406 when trying to fetch the sources
+  src = fetchFromGitHub {
+    owner = "speartail";
+    repo = "checkwmiplus";
+    rev = "v${version}";
+    sha256 = "1m36rd2wnc5dk4mm9q4ch67w19144dl112p9s6lhc1sh6h25ln6r";
+  };
+
+  patches = [
+    ./wmiplus_fix_manpage.patch
+  ];
+
+  propagatedBuildInputs = with perlPackages; [
+    BHooksEndOfScope ClassDataInheritable ClassInspector ClassSingleton
+    ConfigIniFiles DateTime DateTimeLocale DateTimeTimeZone DevelStackTrace
+    EvalClosure ExceptionClass FileShareDir ModuleImplementation ModuleRuntime
+    MROCompat namespaceautoclean namespaceclean NumberFormat PackageStash
+    ParamsValidate ParamsValidationCompiler RoleTiny Specio
+    SubExporterProgressive SubIdentify TryTiny
+  ];
+
+  nativeBuildInputs = [ makeWrapper txt2man ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = false; # no checks
+
+  postPatch = ''
+    substituteInPlace check_wmi_plus.pl \
+      --replace /usr/bin/wmic                      ${wmic-bin}/bin/wmic \
+      --replace /etc/check_wmi_plus                $out/etc/check_wmi_plus \
+      --replace /opt/nagios/bin/plugins            $out/etc/check_wmi_plus \
+      --replace /usr/lib/nagios/plugins            ${monitoring-plugins}/libexec \
+      --replace '$base_dir/check_wmi_plus_help.pl' "$out/bin/check_wmi_plus_help.pl"
+
+    for f in *.pl ; do
+      substituteInPlace $f --replace /usr/bin/perl ${perlPackages.perl}/bin/perl
+    done
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin *.pl
+    install -Dm644 -t $out/share/doc/${pname} *.txt
+    cp -r etc $out/
+
+    runHook postInstall
+  '';
+
+  # 1. we need to wait until the main binary has been fixed up with proper perl paths before we can run it to generate the man page
+  # 2. txt2man returns exit code 3 even if it works, so we add the || true bit
+  postFixup = ''
+    wrapProgram $out/bin/check_wmi_plus.pl \
+      --set PERL5LIB "${perlPackages.makePerlPath propagatedBuildInputs}"
+
+    mkdir -p $out/share/man/man1
+    $out/bin/check_wmi_plus.pl --help | txt2man -d 1970-01-01 -s 1 -t check_wmi_plus -r "Check WMI Plus ${version}" > $out/share/man/man1/check_wmi_plus.1 || true
+    gzip $out/share/man/man1/check_wmi_plus.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A sensu/nagios plugin using WMI to query Windows hosts";
+    homepage = "http://edcint.co.nz/checkwmiplus";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/servers/monitoring/plugins/wmiplus/wmiplus_fix_manpage.patch
+++ b/pkgs/servers/monitoring/plugins/wmiplus/wmiplus_fix_manpage.patch
@@ -1,0 +1,40 @@
+diff --git a/check_wmi_plus.makeman.sh b/check_wmi_plus.makeman.sh
+index 38dc7a4..3fe4369 100755
+--- a/check_wmi_plus.makeman.sh
++++ b/check_wmi_plus.makeman.sh
+@@ -19,15 +19,6 @@ mkdir -p "$manpage_dir/man1"
+ # the full path to the manpage file
+ manfile="$manpage_dir/man1/check_wmi_plus.1"
+ 
+-# if we are not running in a terminal then only show the text-based help
+-if [ ! -t 0 ]; then
+-   # we are not running in a terminal
+-   echo "Not running in a terminal - showing text-based help"
+-   echo
+-   exec $check_wmi_plus_text_help
+-fi
+-
+-
+ usage()
+ {
+ cat << EOT
+diff --git a/check_wmi_plus_help.pl b/check_wmi_plus_help.pl
+index 3440db2..2982da2 100755
+--- a/check_wmi_plus_help.pl
++++ b/check_wmi_plus_help.pl
+@@ -24,7 +24,7 @@ if ($opt_help) {
+       # we have the script to make the manpage and have not been asked to show text only help
+       exec ("$make_manpage_script \"$0 --itexthelp\" \"$manpage_dir\"") or print STDERR "couldn't exec $make_manpage_script: $!";
+    } else {
+-      print "Warning: Can not access/execute Manpage script ($make_manpage_script).\nShowing help in text-only format.\n\n";
++     # print "Warning: Can not access/execute Manpage script ($make_manpage_script).\nShowing help in text-only format.\n\n";
+    }
+ }
+ 
+@@ -692,4 +692,4 @@ show_ini_help_overview(1);
+ finish_program($ERRORS{'UNKNOWN'});
+ }
+ 
+-1;
+\ No newline at end of file
++1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15178,6 +15178,8 @@ in
     sensu-go-backend
     sensu-go-cli;
 
+  check-wmiplus = callPackage ../servers/monitoring/plugins/wmiplus { };
+
   uchiwa = callPackage ../servers/monitoring/uchiwa { };
 
   shishi = callPackage ../servers/shishi {


### PR DESCRIPTION
###### Motivation for this change

~~This PR includes 2 dependencies in addition to pulling ```callPackage``` into the ```perl-modules.nix``` file so we can have perl packages in separate files like we do for other languages.~~

Been using this for ages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

