### PR TITLE
hplip: Fixes runtime errors

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -78,12 +78,12 @@ pythonPackages.buildPythonApplication {
   prePatch = ''
     # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.
     find . -type f -exec sed -i \
-      -e s,/etc/hp,$out/etc/hp, \
-      -e s,/etc/sane.d,$out/etc/sane.d, \
-      -e s,/usr/include/libusb-1.0,${libusb1.dev}/include/libusb-1.0, \
-      -e s,/usr/share/hal/fdi/preprobe/10osvendor,$out/share/hal/fdi/preprobe/10osvendor, \
-      -e s,/usr/lib/systemd/system,$out/lib/systemd/system, \
-      -e s,/var/lib/hp,$out/var/lib/hp, \
+      -e s,/etc/hp,$out/etc/hp,g \
+      -e s,/etc/sane.d,$out/etc/sane.d,g \
+      -e s,/usr/include/libusb-1.0,${libusb1.dev}/include/libusb-1.0,g \
+      -e s,/usr/share/hal/fdi/preprobe/10osvendor,$out/share/hal/fdi/preprobe/10osvendor,g \
+      -e s,/usr/lib/systemd/system,$out/lib/systemd/system,g \
+      -e s,/var/lib/hp,$out/var/lib/hp,g \
       {} +
   '';
 
@@ -96,6 +96,8 @@ pythonPackages.buildPythonApplication {
       --with-systraydir=$out/xdg/autostart
       --with-mimedir=$out/etc/cups
       --enable-policykit
+      --disable-qt4
+      ${stdenv.lib.optionals withQt5 "--enable-qt5"}
     "
 
     export makeFlags="
@@ -139,9 +141,6 @@ pythonPackages.buildPythonApplication {
 
     mkdir -p $out/var/lib/hp
     cp ${hplipState} $out/var/lib/hp/hplip.state
-
-    mkdir -p $out/etc/sane.d/dll.d
-    mv $out/etc/sane.d/dll.conf $out/etc/sane.d/dll.d/hpaio.conf
 
     rm $out/etc/udev/rules.d/56-hpmud.rules
   '';


### PR DESCRIPTION
The following errors are fixed:
- pyqt4 not found
- hpasio for sane not found

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

