### PR TITLE
awesome: Remove $LD_LIBRARY_PATH handling

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -41,7 +41,6 @@ with luaPackages; stdenv.mkDerivation rec {
   #cmakeFlags = "-DGENERATE_MANPAGES=ON";
   cmakeFlags = "-DOVERRIDE_VERSION=${version}";
 
-  LD_LIBRARY_PATH = "${stdenv.lib.makeLibraryPath [ cairo pango gobjectIntrospection ]}";
   GI_TYPELIB_PATH = "${pango.out}/lib/girepository-1.0";
   LUA_CPATH = "${lgi}/lib/lua/${lua.luaversion}/?.so";
   LUA_PATH  = "${lgi}/share/lua/${lua.luaversion}/?.lua;${lgi}/share/lua/${lua.luaversion}/lgi/?.lua";
@@ -52,7 +51,6 @@ with luaPackages; stdenv.mkDerivation rec {
       --add-flags '--search ${lgi}/lib/lua/${lua.luaversion}' \
       --add-flags '--search ${lgi}/share/lua/${lua.luaversion}' \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH" \
       --prefix PATH : "${stdenv.lib.makeBinPath [ compton unclutter procps iproute coreutils curl alsaUtils findutils xterm ]}"
 
     wrapProgram $out/bin/awesome-client \


### PR DESCRIPTION
I have no idea why gobjectIntrospection even was in here. The only
library in there, libgirepository-1.0.so, is not used by awesome. It is
only used by lgi.so and that means it should be found via its RPATH.

The Pango path is not needed in $LD_LIBRARY_PATH ever since
gobjectIntrospection started patching .typelib files with absolute
paths. Relevant commits are 36bef2b26731a9 from 2014
("gobject-introspection: refer to shlibs with absolute paths in
typelibs") and c420de6b05710 from 2016 ("gobject-introspection: Fix
patching shared objects").

The above patches did not work for cairo, because cairo's typelib is a
bit "special". However, this was fixed by e44038bccab0cae some days ago
("gobjectIntrospection: use absolute path for cairo GIR").

Thus, setting $GI_TYPELIB_PATH is enough so that all needed libraries
are found.

Fixes: https://github.com/NixOS/nixpkgs/issues/14164
Signed-off-by: Uli Schlachter <psychon@znc.in>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
