### PR TITLE
Modern RabbitMQ

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -99,6 +99,11 @@
      </listitem>
     </itemizedlist>
    </listitem>
+   <listitem>
+     <para>
+       Package <varname>rabbitmq_server</varname> is renamed to <varname>rabbitmq-server</varname>.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -1,41 +1,30 @@
-{ stdenv, fetchurl
-, erlang, python, libxml2, libxslt, xmlto
-, docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync
+{ stdenv, fetchurl, erlang, elixir, python, libxml2, libxslt, xmlto
+, docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync, getconf, socat
 , AppKit, Carbon, Cocoa
-, getconf
 }:
 
 stdenv.mkDerivation rec {
   name = "rabbitmq-server-${version}";
-  version = "3.6.15";
+
+  version = "3.7.8";
 
   src = fetchurl {
-    url = "https://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
-    sha256 = "1zdmil657mhjmd20jv47s5dfpj2liqwvyg0zv2ky3akanfpgj98y";
+    url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${version}/${name}.tar.xz";
+    sha256 = "00jsix333g44y20psrp12c96b7d161yvrysnygjjz4wc5gbrzlxy";
   };
 
   buildInputs =
-    [ erlang python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip rsync ]
+    [ erlang elixir python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip rsync ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit Carbon Cocoa ];
 
   outputs = [ "out" "man" "doc" ];
 
-  postPatch = with stdenv.lib; ''
-    # patch the path to getconf
-    substituteInPlace deps/rabbit_common/src/vm_memory_monitor.erl \
-      --replace "getconf PAGESIZE" "${getconf}/bin/getconf PAGESIZE"
-  '';
-
-  preBuild = ''
-    # Fix the "/usr/bin/env" in "calculate-relative".
-    patchShebangs .
-  '';
-
   installFlags = "PREFIX=$(out) RMQ_ERLAPP_DIR=$(out)";
   installTargets = "install install-man";
 
+  runtimePath = stdenv.lib.makeBinPath [getconf erlang socat];
   postInstall = ''
-    echo 'PATH=${erlang}/bin:''${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
+    echo 'PATH=${runtimePath}:''${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
 
     # we know exactly where rabbitmq is gonna be,
     # so we patch that into the env-script
@@ -49,13 +38,7 @@ stdenv.mkDerivation rec {
 
     # and an unecessarily copied INSTALL file
     rm $out/INSTALL
-
-    # patched into a source file above;
-    # needs to be explicitely passed to not be stripped by fixup
-    mkdir -p $out/nix-support
-    echo "${getconf}" > $out/nix-support/dont-strip-getconf
-
-    '';
+  '';
 
   meta = {
     homepage = http://www.rabbitmq.com/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13472,8 +13472,10 @@ with pkgs;
 
   quagga = callPackage ../servers/quagga { };
 
-  rabbitmq_server = callPackage ../servers/amqp/rabbitmq-server {
+  rabbitmq-server = callPackage ../servers/amqp/rabbitmq-server {
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon Cocoa;
+    elixir = elixir_1_6;
+    erlang = erlang_nox;
   };
 
   radicale1 = callPackage ../servers/radicale/1.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

This series of commits upgrades RabbitMQ to latest stable version and modernizes corresponding NixOS module. Most important changes are:
- Proper integration with systemd: socket-activated epmd, startup notifications, sane defaults
- Using new configuration file format, which is more automation friendly

Parts of Erlang infrastructure were also touched to make socket-activation real.

Every commit message also contains more detailed description, together with relevant links to RabbitMQ and Erlang/OTP repositories.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
