### PR TITLE
google-chrome: remove "with" usage to simplify the expr

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -38,13 +38,12 @@
 
 with stdenv.lib;
 
-with chromium.upstream-info;
-
 let
   opusWithCustomModes = libopus.override {
     withCustomModes = true;
   };
 
+  version = chromium.upstream-info.version;
   gtk = if (versionAtLeast version "59.0.0.0") then gtk3 else gtk2;
   gnome = if (versionAtLeast version "59.0.0.0") then gnome3 else gnome2;
 
@@ -68,7 +67,7 @@ in stdenv.mkDerivation rec {
 
   name = "google-chrome${suffix}-${version}";
 
-  src = binary;
+  src = chromium.upstream-info.binary;
 
   buildInputs = [
     patchelf


### PR DESCRIPTION
This "with" usage makes it trickier to track where the actual source
package of this derivation comes from. Remove that use of with to make
it a little easier to understand.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

