### PR TITLE
lib: Allow parsing platform configs with arch of `{riscv,wasm}{32,64}`

### DIFF
--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -5,8 +5,6 @@ with lib.lists;
 
 rec {
   patterns = rec {
-    "32bit"      = { cpu = { bits = 32; }; };
-    "64bit"      = { cpu = { bits = 64; }; };
     i686         = { cpu = cpuTypes.i686; };
     x86_64       = { cpu = cpuTypes.x86_64; };
     PowerPC      = { cpu = cpuTypes.powerpc; };
@@ -14,6 +12,11 @@ rec {
     Arm          = { cpu = { family = "arm"; }; };
     Aarch64      = { cpu = { family = "aarch64"; }; };
     Mips         = { cpu = { family = "mips"; }; };
+    RiscV        = { cpu = { family = "riscv"; }; };
+    Wasm         = { cpu = { family = "wasm"; }; };
+
+    "32bit"      = { cpu = { bits = 32; }; };
+    "64bit"      = { cpu = { bits = 64; }; };
     BigEndian    = { cpu = { significantByte = significantBytes.bigEndian; }; };
     LittleEndian = { cpu = { significantByte = significantBytes.littleEndian; }; };
 

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -44,6 +44,10 @@ rec {
     x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; };
     mips64el = { bits = 32; significantByte = littleEndian; family = "mips"; };
     powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; };
+    riscv32  = { bits = 32; significantByte = littleEndian; family = "riscv"; };
+    riscv64  = { bits = 64; significantByte = littleEndian; family = "riscv"; };
+    wasm32   = { bits = 32; significantByte = littleEndian; family = "wasm"; };
+    wasm64   = { bits = 64; significantByte = littleEndian; family = "wasm"; };
   };
 
   isVendor = isType "vendor";


### PR DESCRIPTION
Also add `isRiscv` and `isWasm` predicates.

###### Motivation for this change

We want to compile to more platforms! This is the first step.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @ElvishJerricco @boomshroom 
