### PR TITLE
twemoji-color-font: init at 1.3

### DIFF
--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, inkscape, imagemagick, potrace, svgo, scfbuild }:
+
+stdenv.mkDerivation rec {
+  name = "twemoji-color-font-${meta.version}";
+  src = fetchFromGitHub {
+    owner = "eosrei";
+    repo = "twemoji-color-font";
+    rev = "v${meta.version}";
+    sha256 = "0i7krmg99nrrj7mbjjd2cw6dx24aja63571mcyp6d7q1z09asz9k";
+  };
+
+  nativeBuildInputs = [ inkscape imagemagick potrace svgo scfbuild ];
+  # silence inkscape errors about non-writable home
+  preBuild = "export HOME=\"$NIX_BUILD_ROOT\"";
+  makeFlags = [ "SCFBUILD=${scfbuild}/bin/scfbuild" ];
+  enableParallelBuilding = true;
+  installPhase = "install -Dm755 build/TwitterColorEmoji-SVGinOT.ttf $out/share/fonts/truetype/TwitterColorEmoji-SVGinOT.ttf";
+
+  meta = with stdenv.lib; {
+    version = "1.3";
+    description = "Color emoji SVGinOT font using Twitter Unicode 10 emoji with diversity and country flags";
+    longDescription = ''
+      A color and B&W emoji SVGinOT font built from the Twitter Emoji for
+      Everyone artwork with support for ZWJ, skin tone diversity and country
+      flags.
+
+      The font works in all operating systems, but will currently only show
+      color emoji in Firefox, Thunderbird, Photoshop CC 2017, and Windows Edge
+      V38.14393+. This is not a limitation of the font, but of the operating
+      systems and applications. Regular B&W outline emoji are included for
+      backwards/fallback compatibility.
+    '';
+    homepage = "https://github.com/eosrei/twemoji-color-font";
+    downloadPage = "https://github.com/eosrei/twemoji-color-font/releases";
+    license = with licenses; [ cc-by-40 mit ];
+    maintainers = [ maintainers.fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14014,6 +14014,11 @@ with pkgs;
 
   ttf-envy-code-r = callPackage ../data/fonts/ttf-envy-code-r {};
 
+  twemoji-color-font = callPackage ../data/fonts/twemoji-color-font {
+    inherit (nodePackages) svgo;
+    inherit (pythonPackages) scfbuild;
+  };
+
   tzdata = callPackage ../data/misc/tzdata { };
 
   ubuntu_font_family = callPackage ../data/fonts/ubuntu-font-family { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

