### PR TITLE
prometheus-alertmanager: 0.9.1 -> 0.13.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/alertmanager.nix
+++ b/pkgs/servers/monitoring/prometheus/alertmanager.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "alertmanager-${version}";
-  version = "0.9.1";
+  version = "0.13.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/alertmanager";
@@ -11,31 +11,25 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "alertmanager";
-    sha256 = "1lkfj63pp4jf58xmn015r7s42p1wyj6fryihpmdn0k76b0ccwqzj";
+    sha256 = "170q5fynwa3g3wm77g61610n1lf5kqirhrgak6slqzn52ji870nc";
   };
 
   # Tests exist, but seem to clash with the firewall.
   doCheck = false;
 
-  buildFlagsArray = let t = "${goPackagePath}/version"; in ''
+  buildFlagsArray = let t = "${goPackagePath}/vendor/github.com/prometheus/common/version"; in ''
     -ldflags=
        -X ${t}.Version=${version}
-       -X ${t}.Revision=unknown
+       -X ${t}.Revision=${src.rev}
        -X ${t}.Branch=unknown
        -X ${t}.BuildUser=nix@nixpkgs
        -X ${t}.BuildDate=unknown
        -X ${t}.GoVersion=${stdenv.lib.getVersion go}
   '';
 
-  postBuild = ''
-    $NIX_BUILD_TOP/go/bin/artifacts
-  '';
-
   postInstall = ''
-    rm $bin/bin/artifacts
-    mkdir -p $bin/share/man/man1 $bin/etc/bash_completion.d
-    cp -v amtool*.1 $bin/share/man/man1
-    cp -v amtool_completion.sh $bin/etc/bash_completion.d
+    mkdir -p $bin/etc/bash_completion.d
+    $NIX_BUILD_TOP/go/bin/amtool --completion-script-bash > $bin/etc/bash_completion.d/amtool_completion.sh
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
new upstream version

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

