### PR TITLE
otter-browser: init at 0.9.94

### DIFF
--- a/pkgs/applications/networking/browsers/otter/default.nix
+++ b/pkgs/applications/networking/browsers/otter/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, qt5, cmake, openssl, gst_all_1, fetchFromGitHub
+{ stdenv, cmake, openssl, gst_all_1, fetchFromGitHub
+, qtbase, qtmultimedia, qtwebengine
 , version ? "0.9.94"
 , sourceSha ? "19mfm0f6qqkd78aa6q4nq1y9gnlasqiyk68zgqjp1i03g70h08k5"
 }:
@@ -14,10 +15,10 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = with qt5; [ qtbase qtmultimedia qtwebengine ];
+  buildInputs = [ qtbase qtmultimedia qtwebengine ];
 
   meta = with stdenv.lib; {
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     description = "Browser aiming to recreate the best aspects of the classic Opera (12.x) UI using Qt5";
     maintainers = with maintainers; [ lheckemann ];
   };

--- a/pkgs/applications/networking/browsers/otter/default.nix
+++ b/pkgs/applications/networking/browsers/otter/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, qt5, cmake, openssl, gst_all_1, fetchFromGitHub
+, version ? "0.9.94"
+, sourceSha ? "19mfm0f6qqkd78aa6q4nq1y9gnlasqiyk68zgqjp1i03g70h08k5"
+}:
+stdenv.mkDerivation {
+  name = "otter-browser-${version}";
+
+  src = fetchFromGitHub {
+    owner = "OtterBrowser";
+    repo = "otter-browser";
+    rev = "v${version}";
+    sha256 = sourceSha;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = with qt5; [ qtbase qtmultimedia qtwebengine ];
+
+  meta = with stdenv.lib; {
+    license = licenses.gpl3;
+    description = "Browser aiming to recreate the best aspects of the classic Opera (12.x) UI using Qt5";
+    maintainers = with maintainers; [ lheckemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4780,7 +4780,7 @@ with pkgs;
 
   staruml = callPackage ../tools/misc/staruml { inherit (gnome2) GConf; libgcrypt = libgcrypt_1_5; };
 
-  otter-browser = callPackage ../applications/networking/browsers/otter {};
+  otter-browser = qt5.callPackage ../applications/networking/browsers/otter {};
 
   privoxy = callPackage ../tools/networking/privoxy {
     w3m = w3m-batch;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4780,6 +4780,8 @@ with pkgs;
 
   staruml = callPackage ../tools/misc/staruml { inherit (gnome2) GConf; libgcrypt = libgcrypt_1_5; };
 
+  otter-browser = callPackage ../applications/networking/browsers/otter {};
+
   privoxy = callPackage ../tools/networking/privoxy {
     w3m = w3m-batch;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).