### PR TITLE
abcmidi: 2018.01.02 -> 2018.01.25

### DIFF
--- a/pkgs/tools/audio/abcmidi/default.nix
+++ b/pkgs/tools/audio/abcmidi/default.nix
@@ -2,12 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "abcMIDI-${version}";
-  version = "2018.01.02";
+  version = "2018.01.25";
 
-  # You can find new releases on http://ifdo.ca/~seymour/runabc/top.html
   src = fetchzip {
     url = "http://ifdo.ca/~seymour/runabc/${name}.zip";
-    sha256 = "0s8wm637dgzgpgdxba3a6fh06i0c4iwvv9cdghh8msnx428k68iw";
+    sha256 = "18h6gqhh75qdi8krpp0m2pxbxi0n08wrh8xay477jm3vaggyr8s9";
   };
 
   # There is also a file called "makefile" which seems to be preferred by the standard build phase
@@ -15,8 +14,10 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = http://abc.sourceforge.net/abcMIDI/;
+    downloadPage = https://ifdo.ca/~seymour/runabc/top.html;
     license = licenses.gpl2Plus;
     description = "Utilities for converting between abc and MIDI";
+    platforms = platforms.unix;
     maintainers = [ maintainers.dotlambda ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Tested with clang stdenv, so it probably works on Darwin too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

