### PR TITLE
syncthing-gtk: explicitly depend on gobjectIntrospection

### DIFF
--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, pythonPackages, libnotify, syncthing, librsvg
+, gobjectIntrospection, psmisc, gtk3
+}:
+
+pythonPackages.buildPythonApplication rec {
+  version = "0.9.2.3";
+  name = "syncthing-gtk-${version}";
+
+  src = fetchFromGitHub {
+    owner = "syncthing";
+    repo = "syncthing-gtk";
+    rev = "v${version}";
+    sha256 = "0chl0f0kp6z0z00d1f3xjlicjfr9rzabw39wmjr66fwb5w5hcc42";
+  };
+
+  propagatedBuildInputs = [
+    libnotify syncthing gobjectIntrospection psmisc gtk3
+    (librsvg.override { enableIntrospection = true; })
+  ] ++ (with pythonPackages; [ dateutil pyinotify pygobject3 ]);
+
+  preFixup = ''
+    wrapProgram $out/bin/syncthing-gtk \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
+  '';
+
+  patchPhase = ''
+    substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"
+    substituteInPlace scripts/syncthing-gtk --replace "/usr/share" "$out/share"
+    substituteInPlace syncthing_gtk/app.py --replace "/usr/share" "$out/share"
+    substituteInPlace syncthing_gtk/wizard.py --replace "/usr/share" "$out/share"
+    substituteInPlace syncthing-gtk.desktop --replace "/usr/bin/syncthing-gtk" "$out/bin/syncthing-gtk"
+  '';
+
+  meta = with stdenv.lib; {
+    description = " GTK3 & python based GUI for Syncthing ";
+    maintainers = with maintainers; [ ];
+    platforms = syncthing.meta.platforms;
+    homepage = "https://github.com/syncthing/syncthing-gtk";
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17191,6 +17191,8 @@ with pkgs;
 
   syncthing-inotify = callPackage ../applications/networking/syncthing/inotify.nix { };
 
+  syncthing-gtk = callPackage ../applications/networking/syncthing-gtk { pythonPackages = python2Packages; };
+
   syncthing-tray = callPackage ../applications/misc/syncthing-tray { };
 
   # linux only by now

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17329,48 +17329,6 @@ in {
 
   sybil = callPackage ../development/python-modules/sybil { };
 
-  syncthing-gtk = buildPythonPackage rec {
-    version = "0.9.2.3";
-    name = "syncthing-gtk-${version}";
-    src = pkgs.fetchFromGitHub {
-      owner = "syncthing";
-      repo = "syncthing-gtk";
-      rev = "v${version}";
-      sha256 = "0chl0f0kp6z0z00d1f3xjlicjfr9rzabw39wmjr66fwb5w5hcc42";
-    };
-
-    disabled = isPy3k;
-
-    propagatedBuildInputs = with self; [ pkgs.syncthing dateutil pyinotify
-      pkgs.libnotify
-      (pkgs.librsvg.override { enableIntrospection = true; })
-      pkgs.gobjectIntrospection
-      pkgs.psmisc pygobject3 pkgs.gtk3
-    ];
-
-    preFixup = ''
-      wrapProgram $out/bin/syncthing-gtk \
-        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
-    '';
-
-    patchPhase = ''
-        substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"
-        substituteInPlace scripts/syncthing-gtk --replace "/usr/share" "$out/share"
-        substituteInPlace syncthing_gtk/app.py --replace "/usr/share" "$out/share"
-        substituteInPlace syncthing_gtk/wizard.py --replace "/usr/share" "$out/share"
-        substituteInPlace syncthing-gtk.desktop --replace "/usr/bin/syncthing-gtk" "$out/bin/syncthing-gtk"
-    '';
-
-    meta = {
-      description = " GTK3 & python based GUI for Syncthing ";
-      maintainers = with maintainers; [ ];
-      platforms = pkgs.syncthing.meta.platforms;
-      homepage = "https://github.com/syncthing/syncthing-gtk";
-      license = licenses.gpl2;
-    };
-  };
-
   systemd = callPackage ../development/python-modules/systemd {
     inherit (pkgs) pkgconfig systemd;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17343,7 +17343,8 @@ in {
 
     propagatedBuildInputs = with self; [ pkgs.syncthing dateutil pyinotify
       pkgs.libnotify
-      (pkgs.librsvg.override { withGTK = true; })
+      (pkgs.librsvg.override { enableIntrospection = true; })
+      pkgs.gobjectIntrospection
       pkgs.psmisc pygobject3 pkgs.gtk3
     ];
 


### PR DESCRIPTION
###### Motivation for this change

After a recent update I found `syncthing-gtk` can no longer start up. The error message it displayed was:

```
Traceback (most recent call last):
  File "/nix/store/6lagyfbkijzwxfpbc8c2lsjr3gh25fql-python2.7-syncthing-gtk-0.9.2.3/bin/..syncthing-gtk-wrapped-wrapped", line 24, in <module>
    gi.require_version('Gtk', '3.0')
  File "/nix/store/fhw737zss63iyrf2vmwdwy7wjvlcqx5b-python2.7-pygobject-3.26.1/lib/python2.7/site-packages/gi/__init__.py", line 130, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Gtk not available
```

I diffed the store output of the most recent working version I had, and the main difference seemed to be that the new version didn't have a reference to gobjectIntrospection in its wrappers. Searching around led me to believe the cause may be a recent change to stop atk propagating gobjectIntrospection (see #32296).

Although I'm not familiar with all of the packages/issues involved, I did come up with a patch to fix it so that syncthing-gtk seems to work again.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

