### PR TITLE
pythonPackages.colorlog: 2.6.1 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/colorlog/default.nix
+++ b/pkgs/development/python-modules/colorlog/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "colorlog";
+  version = "3.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0i21sd6pggr2gqza41vyq2rqyb552wf5iwl4bc16i7kqislbd53z";
+  };
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test -p no:logging
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Log formatting with colors";
+    homepage = https://github.com/borntyping/python-colorlog;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1397,24 +1397,7 @@ in {
     };
   };
 
-  colorlog = buildPythonPackage rec {
-    name = "colorlog-${version}";
-    version = "2.6.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/colorlog/${name}.tar.gz";
-      sha256 = "0djv6ky1yk28s1l093w8plg19kp88q4nyrm1vfxyq0s9j4pix29l";
-    };
-
-    # No tests included
-    doCheck = false;
-
-    meta = {
-      description = "Log formatting with colors";
-      homepage = https://github.com/borntyping/python-colorlog;
-      license = licenses.free; # BSD-like
-    };
-  };
+  colorlog = callPackage ../development/python-modules/colorlog { };
 
   colour = buildPythonPackage rec {
     name = "${pname}-${version}";


### PR DESCRIPTION
The disabled tests fail:

```
=================================== FAILURES ===================================
_____________________________ test_logging_module ______________________________

test_logger = <function test_logger.<locals>.function at 0x7ffff180ed08>

    def test_logging_module(test_logger):
>       test_logger(logging)

colorlog/tests/test_logging.py:9: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
colorlog/tests/conftest.py:36: in function
    assert_log_message(logger.debug, 'a debug message', capsys),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

log_function = <function debug at 0x7ffff2d92840>, message = 'a debug message'
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff2a67550>

    def assert_log_message(log_function, message, capsys):
        """Call a log function and check the message has been output."""
        log_function(message)
        out, err = capsys.readouterr()
        # Print the output so that py.test shows it when a test fails
        print(err, end='', file=sys.stderr)
        # Assert the message send to the logger was output
>       assert message in err, 'Log message not output to STDERR'
E       AssertionError: Log message not output to STDERR
E       assert 'a debug message' in ''

colorlog/tests/conftest.py:22: AssertionError
------------------------------ Captured log call -------------------------------
conftest.py                 17 DEBUG    a debug message
_____________________________ test_colorlog_module _____________________________

test_logger = <function test_logger.<locals>.function at 0x7ffff180ed90>

    def test_colorlog_module(test_logger):
>       test_logger(colorlog)

colorlog/tests/test_logging.py:13: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
colorlog/tests/conftest.py:36: in function
    assert_log_message(logger.debug, 'a debug message', capsys),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

log_function = <function debug at 0x7ffff2abc400>, message = 'a debug message'
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff2a67be0>

    def assert_log_message(log_function, message, capsys):
        """Call a log function and check the message has been output."""
        log_function(message)
        out, err = capsys.readouterr()
        # Print the output so that py.test shows it when a test fails
        print(err, end='', file=sys.stderr)
        # Assert the message send to the logger was output
>       assert message in err, 'Log message not output to STDERR'
E       AssertionError: Log message not output to STDERR
E       assert 'a debug message' in ''

colorlog/tests/conftest.py:22: AssertionError
------------------------------ Captured log call -------------------------------
logging.py                  33 DEBUG    a debug message
__________________________ test_colorlog_basicConfig ___________________________

test_logger = <function test_logger.<locals>.function at 0x7ffff180ef28>

    def test_colorlog_basicConfig(test_logger):
        colorlog.basicConfig()
>       test_logger(colorlog.getLogger())

colorlog/tests/test_logging.py:18: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
colorlog/tests/conftest.py:36: in function
    assert_log_message(logger.debug, 'a debug message', capsys),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

log_function = <bound method Logger.debug of <RootLogger root (WARNING)>>
message = 'a debug message'
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff17d2550>

    def assert_log_message(log_function, message, capsys):
        """Call a log function and check the message has been output."""
        log_function(message)
        out, err = capsys.readouterr()
        # Print the output so that py.test shows it when a test fails
        print(err, end='', file=sys.stderr)
        # Assert the message send to the logger was output
>       assert message in err, 'Log message not output to STDERR'
E       AssertionError: Log message not output to STDERR
E       assert 'a debug message' in ''

colorlog/tests/conftest.py:22: AssertionError
------------------------------ Captured log call -------------------------------
DEBUG:root:a debug message
===================== 3 failed, 24 passed in 0.19 seconds ======================
```
I don't understand what the problem is.
Maybe @FRidh can help.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

