### PR TITLE
you-get: 0.4.390 -> 0.4.1011

### DIFF
--- a/pkgs/tools/misc/you-get/default.nix
+++ b/pkgs/tools/misc/you-get/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonApplication, fetchPypi }:
+
+buildPythonApplication rec {
+  pname = "you-get";
+  version = "0.4.1011";
+
+  # Tests aren't packaged, but they all hit the real network so
+  # probably aren't suitable for a build environment anyway.
+  doCheck = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0h6aspnfic30s89xsv6qss1jfka9px4ll60bqrjbds4y0k3h818g";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A tiny command line utility to download media contents from the web";
+    homepage = https://you-get.org;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ryneeverett ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5460,6 +5460,8 @@ with pkgs;
 
   yle-dl = callPackage ../tools/misc/yle-dl {};
 
+  you-get = python3Packages.callPackage ../tools/misc/you-get { };
+
   zbackup = callPackage ../tools/backup/zbackup {};
 
   zbar = callPackage ../tools/graphics/zbar { };
@@ -18029,8 +18031,6 @@ with pkgs;
   inherit (gnome3) yelp;
 
   yoshimi = callPackage ../applications/audio/yoshimi { };
-
-  inherit (python3Packages) you-get;
 
   inherit (pythonPackages) youtube-dl;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18730,29 +18730,6 @@ EOF
     };
   };
 
-  you-get = buildPythonApplication rec {
-    version = "0.4.390";
-    name = "you-get-${version}";
-    disabled = !isPy3k;
-
-    # Tests aren't packaged, but they all hit the real network so
-    # probably aren't suitable for a build environment anyway.
-    doCheck = false;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/y/you-get/${name}.tar.gz";
-      sha256 = "17hs0g9yvgvkmr7p1cz39mbbvb40q65qkc31j3ixc2f873gahagw";
-    };
-
-    meta = {
-      description = "A tiny command line utility to download media contents from the web";
-      homepage = https://you-get.org;
-      license = licenses.mit;
-      maintainers = with maintainers; [ ryneeverett ];
-      platforms = platforms.all;
-    };
-  };
-
   zetup = callPackage ../development/python-modules/zetup { };
 
   zope_broken = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change
you-get isn't a library, so it doesn't belong into `python-packages.nix`.
However, I'm not sure if this breaking change is allowed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @ryneeverett