### PR TITLE
libxc: 2.2.3 -> 3.0.1

### DIFF
--- a/pkgs/development/libraries/libxc/default.nix
+++ b/pkgs/development/libraries/libxc/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchurl, gfortran, perl }:
 
 let
-  version = "2.2.3";
+  version = "3.0.1";
+
 in stdenv.mkDerivation {
   name = "libxc-${version}";
   src = fetchurl {
-    url = "http://www.tddft.org/programs/octopus/down.php?file=libxc/libxc-${version}.tar.gz";
-    sha256 = "1rv8vsf7zzw0g7j93rqcipzhk2pj1iq71bpkwf7zxivmgavh0arg";
+    url = "http://www.tddft.org/programs/octopus/down.php?file=libxc/${version}/libxc-${version}.tar.gz";
+    sha256 = "1xyac89yx03vm86rvk07ps1d39xss3amw46a1k53mv30mgr94rl3";
   };
 
   buildInputs = [ gfortran ];


### PR DESCRIPTION
###### Motivation for this change
Update version. Recomended for octopus 7.2 (https://github.com/NixOS/nixpkgs/pull/34094)

###### Things done
builds  succesfully and tests succeed
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

