### PR TITLE
google-chrome: add new dep on at_spi2_atk

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -4,7 +4,7 @@
 , glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, gconf, nss, nspr
 , libXcursor, libXext, libXfixes, libXrender, libXScrnSaver, libXcomposite, libxcb
 , alsaLib, libXdamage, libXtst, libXrandr, expat, cups
-, dbus_libs, gtk2, gtk3, gdk_pixbuf, gcc-unwrapped
+, dbus_libs, gtk2, gtk3, gdk_pixbuf, gcc-unwrapped, at_spi2_atk
 
 # command line arguments which are always set e.g "--disable-gpu"
 , commandLineArgs ? ""
@@ -57,7 +57,7 @@ let
     libexif
     liberation_ttf curl utillinux xdg_utils wget
     flac harfbuzz icu libpng opusWithCustomModes snappy speechd
-    bzip2 libcap
+    bzip2 libcap at_spi2_atk
   ] ++ optional pulseSupport libpulseaudio
     ++ [ gtk ];
 


### PR DESCRIPTION
Fixes #32978

(cherry picked from commit fa6c8beaab4567b0c5b7e887d1c0a41f1f7e8c7a)

Motivation for this change
Current google-chrome beta and fail to run because of a failure to open libatk-bridge-2.0.so.0.

Things done
Build on NixOS
Tested execution of google-chrome{stable,beta,unstable}
Fits CONTRIBUTING.md