### PR TITLE
duktape: init at 2.2.0

### DIFF
--- a/pkgs/development/interpreters/duktape/default.nix
+++ b/pkgs/development/interpreters/duktape/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "duktape-${version}";
+  version = "2.2.0";
+  src = fetchurl {
+    url = "http://duktape.org/duktape-${version}.tar.xz";
+    sha256 = "050csp065ll67dck94s0vdad5r5ck4jwsz1fn1y0fcvn88325xv2";
+  };
+
+  buildPhase = ''
+    make -f Makefile.sharedlibrary
+    make -f Makefile.cmdline
+  '';
+  installPhase = ''
+    install -d $out/bin
+    install -m755 duk $out/bin/
+    install -d $out/lib
+    install -m755 libduktape* $out/lib/
+  '';
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "An embeddable Javascript engine, with a focus on portability and compact footprint";
+    homepage = "http://duktape.org/";
+    downloadPage = "http://duktape.org/download.html";
+    license = licenses.mit;
+    maintainers = [ maintainers.fgaz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6685,6 +6685,8 @@ with pkgs;
 
   dhall-text = haskell.lib.justStaticExecutables haskellPackages.dhall-text;
 
+  duktape = callPackage ../development/interpreters/duktape { };
+
   beam = callPackage ./beam-packages.nix { };
 
   inherit (beam.interpreters)


### PR DESCRIPTION
###### Motivation for this change

The duktape js interpreter

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

