### PR TITLE
j4-dmenu-desktop: 2.15 -> 2.16

### DIFF
--- a/pkgs/applications/misc/j4-dmenu-desktop/default.nix
+++ b/pkgs/applications/misc/j4-dmenu-desktop/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name    = "j4-dmenu-desktop-${version}";
-  version = "2.15";
+  version = "2.16";
 
   src = fetchFromGitHub {
     owner  = "enkore";
     repo   = "j4-dmenu-desktop";
     rev    = "r${version}";
-    sha256 = "1yn45i3hpim2hriaqkq7wmawwsmkynvy2xgz7dg6p5r0ikw5bn1r";
+    sha256 = "0714cri8bwpimmiirhzrkbri4xi24k0za6i1aw94d3fnblk2dg9f";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

