### PR TITLE
 thunderbird: 52.5.2 -> 52.6.0 [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,595 +1,595 @@
 {
-  version = "52.5.2";
+  version = "52.6.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ar/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ar/thunderbird-52.6.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "637ca11b07a86b806ea274cf3cd9a47dc2d23a2700203c1ddfb25bac15bb4ed1eb4749f630021dd0f33f00c43539954d9fecc192d3582e752940ade0930422ef";
+      sha512 = "fa4cc97701d7a44e2256149497a72a7057f3b677163b85029a9721fa03b4b518fa8c3564ad727824faf3c81242bc7dfe673f7fbbe1bb2b92aea16b779df8d6f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ast/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ast/thunderbird-52.6.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "78c6da93f60134c9b033f270d04b983713dd84ba6af8cd1c0529471dbd3c860085491bc54f0fd37a8373dd5164b064653d9ae6ab12f7748a9722aa61472ed7cb";
+      sha512 = "f40ae6c5f72ad797b42c6ada1302eebf63b649bfa2d5838cea7371ad92de8e1eaaa79cd115993d96dd873bca996b12fb20c8f4f40ee4db144cc2bbd5a27ef182";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/be/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/be/thunderbird-52.6.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "7081fddbc88cdd0280bb35c7f16c33f8935d639d91e2ed4258e344565ea6f27d1ed8f2b5daa5d2e861e92357ba65c4c4b05260fab83f0bfaf6e2fa44ab081fbb";
+      sha512 = "768453738bda8b0040d3b4cb21b1695dacaa54cacac5ec3130d5e4ebeea4e0ad8303ff2860fe5cfe5915df951aabe2f8a069b979abdc8ab8eb161811d93a8558";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/bg/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/bg/thunderbird-52.6.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "d5d21dfea54ac7c75c515cd95f0140a21451a3b2c533cc95f0a519a13b950e01c6f1d17e2fdae3610b46fef7450e1d816158a71ae37e8813d8b9dbbde2fbb4e1";
+      sha512 = "dbe67671831f90f739a7af794578270f1177ce7e54727c78e6b74d6bc400ca3cff2ed4174b5b38b73ad1ebab0d9d0df34fd6e3ee769cf96e99f4fd84ff69d018";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/bn-BD/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/bn-BD/thunderbird-52.6.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "c59b5b7381ce8fc65018bd70dce55488b12915d2c9fab7421433d7836cde95a409c2f5206323581bcf7af08b90e7ce8eb3c55b0a4f660734d3e159077ba60374";
+      sha512 = "4d7aa1a03c1ec122150611270502fc209406703f0081e4e6ed212d07b327adc67c49db2891b1b62799c48218935200c5f671615a159a900f4d838250ab578798";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/br/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/br/thunderbird-52.6.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "f3d5bea008f0849dc8834d51b6ba0529c2f803e5b059582076baf016fd9a02288d57851e1073c1df3f79f4fdb0f72ca8c707d25f75109d6b33ed60353180e80c";
+      sha512 = "9e229670bb1a4263a1922b5c4d6329209d95aed8f92264977c8c9d1de81c89440666602fad19b686fe214e8847e305d531046fc00a77347393d3d38be31f7f1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ca/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ca/thunderbird-52.6.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "64d024e4c696cffd4d97566411f7412ae16e98f169101bd36e87efb027555bc163f38ea1898b29a772fe31e1667dd69cc5eb19a96e04982b01b0de3975654292";
+      sha512 = "0a905562d18452535a6cc05b945467e40c4ab8dd80d13ea07de293e02477cf5ac1c49546213e236f8266aaccc923ed261f1702b38289f2e165d818bb7e55b218";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/cs/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/cs/thunderbird-52.6.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "ecd78ba038a9133d8ecd0184ae44af661efd38d08e53184cb26b221d50101df38bc7833a0cd7c76d55a185288f055f5ac630b1da525a9008d878b4c5a3d9166c";
+      sha512 = "3a2417f8b8396e0bd9c1b900f1547ea631683d35cf1e089698641dfd62672824a5594c8bae1ceed6d9fa4adb646da1b027a3c0378687b86ecd2351e4db227d22";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/cy/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/cy/thunderbird-52.6.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "1aaef9550bb3e3e5a49ad220344a9b8e20db885e06eea182f87dc8ddeaac62b0cd2b94f58524b0c6d3afea054cea0d75cc96f80732e390cc47848da16cad3fba";
+      sha512 = "6f705e71057c5f4016ffc60ffd0dc114f462785eb139da474412fd6164c761d89f7faf08ffdc93cc746b0d3df1b57024d69c20303d867bb3ffdd2739869bc075";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/da/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/da/thunderbird-52.6.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "fa501b4febbeefc90ff9ecf4c2dc4468c6fd2dd04559ac886d8e58ea3d4eaf003cb4577197b5b5c391f602b83defe158b8e3405b36edf2a6e48e48719849deeb";
+      sha512 = "4f981281b63ed48e58bee4b7702389dca2bf5497cc74e8603945b25c7ce18e73b7b0ec006df8e48ea5ca8d57c6b874e7cbdeb2f43e214cbb0b99cc7983556790";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/de/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/de/thunderbird-52.6.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "e4c87e3736dcfbe4e8fcce8a101030844cacfe2c20209de4a21cce247b8e80de3e4646c9a84c36d6d73199ea5926c2777a678b8f2b83521078c0c3a10a752b32";
+      sha512 = "4553f9b771e4ee907e2e379eb87ac62143df34cd3777e8dadd74b46839c6cb79f8fec87b4bd48fefdd21a4837611637897232895278ef3bb0337f816c37ce685";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/dsb/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/dsb/thunderbird-52.6.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "eb169f9d2e9836b83edfd8ef8f7af867ac27831bb5aadf5a75f6e652b507dd7c34ca135c278f95d8f967406732d296af3d42a18fa9e91c8ed18216da77824e11";
+      sha512 = "cfb64b6eddcbe54a701c5bca339225bec63e96dc2b1d3d2e358b32820239a970913415e8248ed8852be77d1e64741ab4746476e51a1fb9e9d6510cd6eabcfcb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/el/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/el/thunderbird-52.6.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "dfd0160965fbebdffc217ed171bbb308902e1b0e89d91abe8167d7d26db991a8ce2b40b3161d623441102b2b6379a774b6af4a19bb39c27c59d76840351900b1";
+      sha512 = "4761f016a202abfafd3d249ccca8d05b8697645eb820cb45b1567476cd806c49e9a13d9c5ff28df5c226e1f787abd698cbc610df28e03b5f0d70ad43b90a0ae4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/en-GB/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/en-GB/thunderbird-52.6.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "8c8506a8fe62e6ca55b1d99d8db9ec5fd224fa87ff63f9eae49656001f94124312110a414769d5d396574aa0e1f69a8f0a5298d6ad86146ba40912ebe68393a6";
+      sha512 = "a310e79e4da7a79a0c9d48db19b68e197fa71e4ff3d3b1c1178206ff0bbe883623d97ded1268a8512f370dbb232b8534e503d42bb6fc70583b78e78deb27fcd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/en-US/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/en-US/thunderbird-52.6.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "73e15c04a11190e8968bc64226ae4c677fa00ab460fe3497aab861c92c07ff6a3814673a7773ffc4e735491ac338e9d190e0c7cd626416c2508826000e1df002";
+      sha512 = "10c1147b8509876d3b278df8d362cfb3279086d51ad40de1ffc8814878ba28b051940b347b4ca1a67bad8090ba488426403b219b2add070b704fac200ad4c283";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/es-AR/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/es-AR/thunderbird-52.6.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "6b42efb1bd21fb9c9df67496a09fdba958145d56b185d10187256e45b8891dcf725cecbf1868c7cdba515397085f616328c111301ab1cce584158a17ae47b944";
+      sha512 = "77753858bcba266c6ea44f12eefc5a8fd1b6a7ef39b2e778e01490ff290046415e6a75a56a104dae12b1a6cfc69b179d13f6cf5b80ef20e8120864b7e9447d1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/es-ES/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/es-ES/thunderbird-52.6.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "c1eaa597f18102f93b7621d50b5ebb54f9007ad01b5ce543e3f53cae88a42ce06c7d2332fb0e6b080ac2209403dfe06ce24a17f09c7ae3d5ace8d5e85e1ce603";
+      sha512 = "f9228ef15899197a8defc67cfa8f51e17aa3f2e5b1e8b79cef8b221a012e47b74d5a91dc82ba1a53e97f1518b4d60f08220f870427751c9ee1c477600cfb3a38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/et/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/et/thunderbird-52.6.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "b0386ef97662e21806c15342b68b2224ed3b41a8f1648f1b9869b527eb8b60951f9453a5abbc74e94905799953af5a7289b25c80fc370772368f39a048ef89bc";
+      sha512 = "37cdd026fe48f84b19adf63c6bb642fd2efa72a95125fbf5e2761623c920549c045589dc53892a828bc759630e8cfd1afad5825af7d51d6c7c5fc495e450f401";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/eu/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/eu/thunderbird-52.6.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "d7070db2bac9aabbf5b020f60080d3beb9b1ecb4df73fb541f387435eb9ea80e2297c76a79910af0858ea42882298cfdd5c5016bd2049fdbe91dfe1f4bdb8b70";
+      sha512 = "4827d5f30c5a9bda1aaf5836250d43b41d38d2f882cae61a097c5ae753a7d429a7486d8a47991173ebea15bb70cfdd6b1d4ee4c1e7696b41e9e047786f320b0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/fi/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/fi/thunderbird-52.6.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "2dc49e7ebb96cafb37b600490bbf49a40393ed00cd4889e1bda6331e9dbf377a4cd53cb6cd98e7fb2e7cdf0da75e69e38e9f3894ab289f3ba0894f499e4f83b3";
+      sha512 = "9e40fdfa10cfb24e4983834d72c831b5e94d8a05e51e45e989564c558af6d5c91710da1a63f5a21042da2cca9a4b310a52c1c212db02bcbe77d5579ba600d9fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/fr/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/fr/thunderbird-52.6.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "2ece29dfad71788ee5bf98afa262edc3b9bfaf57a2ea07d669c1003b09c5a5fbefcdb028d4842c53e17c1a63cce16f9296e574b834631cd485d0737cb13b174c";
+      sha512 = "362d689566ac6ad74adcbccb188ca958af5d308090cc13f268be8608f4b20917ed0b1ccc33fd344b6b4434ed2a8a62c212cc25dc85f52f7ab20e0355df06a370";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/fy-NL/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/fy-NL/thunderbird-52.6.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "a84eab825c051666d606fff131542c71bcad7f204db19dc10d54166b499869e43951c9799d05b194f66ff40d5f307957c2d27de17da6ecac48ac24621da7287a";
+      sha512 = "90b553cf697bc488e7f91eca2b9fceda94da72d49ff561af9a2f59dbe830a1ea29a49c9be8c544e1c83503a1902076a2badd7b35656372a18899f579d9455de6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ga-IE/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ga-IE/thunderbird-52.6.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "181fcdb0bae1a2aed16ba61523ec90f89b884d907796e1d1c37c722f68b89dbbabf977446022af6c7050e3e26d995e33891880e875f28247653225479847acfb";
+      sha512 = "8fa91ed0e71961e0850f6acd69ffec0876e4b8f72d19b170429c10bd00681095bf816f7c028afa2f01eb5c32f27b6f8272b1a1e3340bdc87ccc9477bb100fbf1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/gd/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/gd/thunderbird-52.6.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "cc91084f593788da76815f185e2b9a877409537cdf52566000953a008bcb2783c09cd8893cba9f387b731fd636b1d8e7b7208832623d1222b5fef72db8cb4541";
+      sha512 = "8653c7664694898222e1dc292bdc244a6a2bc900b240a7fed30ea5cce47e7fc5524afe7b67795d15f0eafb250a5218ae5f8fa8236b7c6e91e15c3c74808a798c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/gl/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/gl/thunderbird-52.6.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "6491bf74093139c86a5809d02582b6d055ebdb3cbf29a1a24ff7529a6e8c2bb89e26c27e7f65bb588c379566741510d6f8372f7f2a11004350cc7e907a3a6d8d";
+      sha512 = "22e5454c0af357e030dda5a84347eb154524d0337fae6389102ffb0073ff33997dacac9b40dede462f55ea30c1bb4da65cc8e272271611f42ddd80b5ab9dae05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/he/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/he/thunderbird-52.6.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "4235dfe0f51f55dcb905453aadc01baec3b8033384e5085072abb600c71f777699df4b556233ffa9b07f5d62442aefbce6f1eef2a9d557b24b48d797cf03b026";
+      sha512 = "51bddbb2a254849b6dcbfaf1f2faae13454bbb71472c7c95d279b5f83a6b29b1b063d904f02f13295fa32e6b33867856341994db9a2201d8f358b006c0c7752b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/hr/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/hr/thunderbird-52.6.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "4236d464d704ba9c4c60323dd3518a37f71d24cd441404b6ae7a0e97ff17c839e2eff48d100211cf5ce9d3759336e7a0c29abe5f8390facedd769804adb8b956";
+      sha512 = "a08e2a71ac92e317944f09b2f03bbcfc32122493ebc0800534b6f3c714d4af0c431caf97be1818bc284826b88f08db3e4392f0c2b89ac7adba587f2f450cf804";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/hsb/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/hsb/thunderbird-52.6.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "876a6c45e62c1025bf29ad3c626e3d2cbbc7d9d660e8e862b0fb586b73ed42a0bb58611dc69af727571c93f31dca450dd9156ba78b23b9a4a2116e561a8e3763";
+      sha512 = "9539a6c48e60c4c773b735afa6ee544ceceffdca76ceeedd90973145f7deb23f2e449901cdc75190b5bd510537e70fd948775dc66caef8a7b95fc31843cbdb66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/hu/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/hu/thunderbird-52.6.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "7bf7604f08e452f33154ba91cdef8aeda9905470f526f403dd76e19d1010f822cf2f3fb7c5f0525299bd0401139df1a12631f796d603e0ec3af4aa8df73ed0f2";
+      sha512 = "d4d0fca22d430ec037bdf5cf8ccbce99df3cab22e4e6a2c3fb040cd1db960903e503ff2c8f633aa1f037a590b0a48134d949c1c4899de429a0533175fbb4a61b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/hy-AM/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/hy-AM/thunderbird-52.6.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "bd62aedb2c800265fc34c884f1605caa0040794cc49479189dfa4a959d49397ef023efaac0937c9573ef7a114cee16504b5a65f8f8f3f3d4d222f4a173707bfa";
+      sha512 = "362ddd92ceec22ac93d95d721c1806ff0270fccf33f0cc4452ee147b3388f071b6d5aa27a0e7548a35a50453d55be2532d7fde19be611b9f0ecd741b5de59e1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/id/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/id/thunderbird-52.6.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "1dd761bc1bdd865b5ebb494c00dede5e616a1bf7fbe6d7cf88d4f5362eb75435ae162d2e027fb7928783fe255179de00d28a29ab3d90350f75be7a1e4ad428a9";
+      sha512 = "29ba391bbd9b8984850f056d856bcf90c0ac816fb8b831416e5a96f36e9b2dd0517cb5f1caf37998f75f024f3fbdd3b989ca6d4973ded22cbd15568a7b249531";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/is/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/is/thunderbird-52.6.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "12dbca26babd51739fc6505fdd36ad32b5827e1c3e439f3ae4c2c8e0f165528e693af537bec8630146c6c6bbc55b75d7c5bdd3bd84b5255cbf756d627beac2ce";
+      sha512 = "2303d0d74e112bc4f86e6d73fb63fabe8f10aa3486a9d2f61fe16b0b0525bc7b6091c94e27f0ccb548b47bf808c937b83a4609c5c0cd0bd0fc6556c18dc08661";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/it/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/it/thunderbird-52.6.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "9c9b77c70429436b1cb0030c92109343eba9357f58873c13399e9e64f44807e06fc0c429e0748ce9a11f68baf643bec7cf313fe79cbfd35e548ad579b0e6e108";
+      sha512 = "d3d9e95728063bd4e4742619c8ec27d4a0cdc34941ef8e6e3af71f19d59b4db6661366a81f1df7fd1de3a2ce995a1232f39744a825493a0c456d5257d02f7cf0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ja/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ja/thunderbird-52.6.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "2f785ddcb2e16ee1970cb582852ce52e1f3f7cbd58e8f714a18a387019b510cddfa1927f593b61ccc4b662b6e65f3fe20135eed451ba07a1df45b5979743b20d";
+      sha512 = "1d64a298e5b0ec9eaac8f8972ae975a98a5bcbc4823abd59a6cbab251ddcb5ba76263bdae0b55dac15455d8b7d9c8bda71cc54ea0fe67aea5efa5552973be94b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/kab/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/kab/thunderbird-52.6.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "1bbd7b2c79cce7b74614e6f09cd7235d58def667f74bf3276ec928df4f0084704654224f100f227cdb350f839a13e474cbc98e4614ae45cf00969b2706291076";
+      sha512 = "1b351b01ea540b809cad198912853b3f74bc9cb52c33b7fe4ab586f921ea4a2486f28e855d2be95398af6abad2911c5fd3f0ab16938edea85596689799b452b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ko/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ko/thunderbird-52.6.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "e176558707cda5570b020aa0fc3620deae7edc6e7e363e1ba4b51d6cad9f4a9e74a35be5f419fcc0e18dca31b6c887a62112f99b4a60d9026b8dc5f87de45f74";
+      sha512 = "d9895da7e3099c5d9389308ae6982a77387cd7d61c07ec16e4511c00fc3b18bd025b95c6f05a94cd5e990eb9472816bd4af0a1bbe3605561f2bfe2b9f9b207e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/lt/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/lt/thunderbird-52.6.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "f431c57a74e0f8498a9a1ad36e6528d09dccf8b03aaf9e7ab66ddd503bbd78ddd15176a5e6c2358eeb616ee023f78414c30b67fd39c4c2f15f4e377df81759cf";
+      sha512 = "8791ae3c0ee4745449b1690f69de0665f7854288188f1570e4c876b1f936e790d651bb1f9ecfcfe99f01f49026d534e667f262c72290894368579313b8a59615";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/nb-NO/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/nb-NO/thunderbird-52.6.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "5bfae55863550e32ea6581d0c24ae5374e2365d9e5e8f05f91856d0fd2760b761d183b12c9809668730efbba63e6c23408431f4616f6a7cc52ee465ccb939aba";
+      sha512 = "be2e537c4dabfc6070f180205787712317ea3bf1befebb5d99d0be562aac60f728635ab665b6813776d985ff5c5d10e72658dbe20c6441722113ca8f9cf00553";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/nl/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/nl/thunderbird-52.6.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "fd7d35c0205610d868fb0676f3a8aaf328b1906dd1b174124e254ec8b08e5173741853938707dc99b10b4417df4a7010e20cb8a1038bf8f3258dee593cf788bb";
+      sha512 = "20bc3bd3105880541b2dae20b703191cdb499dc7778fe874da5ae9b0b1626d72075631e256bc0c2fee1c4d1d27424cc6168c419afa8bec8a00d5904ae0678f12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/nn-NO/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/nn-NO/thunderbird-52.6.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "1070fbd6c51d68e560fa0eeab66f2baa39d11752018d20d23a3577b12b504355f5729d0d961ffd20256521f54eda69d03fb8efef70f8254685e28b0164201354";
+      sha512 = "2437751b998ee2898bbb8f8187adcbd102d29fc54054fb04efef2e0f7f308c864215bb8468ac42975bbd18c6e4a0c8903e5784a4d203df3643029cff696c2540";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/pa-IN/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/pa-IN/thunderbird-52.6.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "12293c8258f02403c8db220c73cf76b24315268324f2c6ac41dba7d77d9653cd1a21771a4994f7c6dc0db9948a601008e347d908c05dc59b7cf6ddcf95b2e86b";
+      sha512 = "925ffbbd7d9e301c52b60963bced66af8b97a7b24275d73ca923f0d757164faf4ba7c69003286d74a69f1ed328e94347ba63c6ca7e13f47f42b7529af9de5ee6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/pl/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/pl/thunderbird-52.6.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "331b81876aeb162e1f4e838cb00712e971310285febfa669bf7c6d245c1e8353be941b6d1236423e0d835feacaabf859077da1918cf2652f6b79de30c4beaa30";
+      sha512 = "27dfc79cfcfaea36ee50b2249e8e2a5195e9dd2f755b0f9d3274af2e4cb3d0d5214a4065e08678bbfcae4b51f0a0c2c4b4385c2a199a5b65035ac895de08bd63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/pt-BR/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/pt-BR/thunderbird-52.6.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "d69fdae2048b738133fd07c6aa0ab6c264e555a3bc3a899d09fd7fe49435511fd544f3ef04e079c4efd320bc2abfa813f85a5f2a9e477af56aa47495466103b6";
+      sha512 = "b600e2e3dc931ba2db5e4bf36187f971c7c1c710f8535d59c999a9685f551454a6e39f80cf70374aeac41ddace2f80fbe68bcda1675b80c5cc39dd8fccf7625f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/pt-PT/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/pt-PT/thunderbird-52.6.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "fa3286336d47b2216b0ec0c5fb6cba2421cb0cc81d1f815515c637a063b8de167cccfc3dd30b02636ae88e74efb34f8fde1b198924fe864b1fdc08d95b7f0f3d";
+      sha512 = "3ca5ed7c487ca11ef2fc743e8a66eeaa05d2585d2fab0ca40b0d965e10e43d1216de358eb61921578fcdc72b69766f8fe24beb3c548ed47c705ab84a30941c34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/rm/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/rm/thunderbird-52.6.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "b4affea897ac5af177c1fb6e4919f94f5f20860c3f492584c79664d803b7c2d092a96f1a3afe6b3212f689901a52d0ca74abab4910ba291280d52ecef2cf9a33";
+      sha512 = "2d9e51a01175549c712c5bd1e95e08012ed9494a0f6fa5ffec8ee1c311279a6826cee99488a72d86f2cd98d9d9d6d20ef886bd4f69d100a2b589ef8dfc887335";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ro/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ro/thunderbird-52.6.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "3cdcf374f33961484962a6294ad8fd654b006f3472ce6550936a8c00a28943088c9c61049fba278cd304381003b46903a5514ac340b5a85a959edfe17242eb4e";
+      sha512 = "8cfd1503ef3f4a9b4765d6c3fcc3a44aaa2fa557fc2a698452d10b037fdfcca09c462b455c4088b69aa89c153f14b1621d3c87c942a7bbb4627f95bbf0a37738";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ru/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ru/thunderbird-52.6.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "aa1d54fe356ef15d852a9ce3f269deee411d4815f4108c93c832def784c1afa104193e62fd9b47977d20ecfcf3057c05d76f39cc3abeb0341102b7e6e6639763";
+      sha512 = "74d611abaa10d04be342139e19b7f724516a91de07a5f4ae4c4cd3ad927accb5e6668830040defa20878ec1fc884bc983d084729ebcd1fd453c7082a627329ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/si/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/si/thunderbird-52.6.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "543710116d67afb86e316dd17bf9a74a07ee5e3772381d9f0495af4d42075e96b6ff888ce0c3ce68ec779dc051f3ecb6105d51a6e4459cb4907a604662c933b7";
+      sha512 = "292b5da1ea566ebeae2756b659b1f2ad40a4dc57517da926b3f8263a219e734d197d9aa55ce91582bd8818e0434d2a6b3bc40892d0cbd4715fcac50e3aebf7f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sk/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/sk/thunderbird-52.6.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "3ae5ab97172ff0f4d3eaea7a69fa54d9bcf639a8032ee2c5a3fcda2d8b30072d3386c54ef7e8c9bf5417a6030966c1097d69d41dd8c5355e82d048b783aef461";
+      sha512 = "a5f6466d7ff0ceed4fa25c446925e398cd91c29d705ea1e28166bec09834b1f3ac61722823828d97d17b1ce7ac2e67aa98c3d5d94806b7a470d29c5722f37d9b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sl/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/sl/thunderbird-52.6.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "9f3e0724e837608cf4a64a2505af732e4cdf61928bd5dd1237e27d5222147a8ec52870e88c73653de8518e9ab81af4fb8916b067c780b1af25b8f6c208a10684";
+      sha512 = "9167d416f7552b55f8551146a3073757bea4106fea2004ad4303809f0532b85d37fea449ed09f0d162cbda2f429d869b90b5ef14f29784f418c63085a7c9b5b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sq/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/sq/thunderbird-52.6.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "0f2e10a8b9cae1185079af8e37ca9622d9ed29b6bb38377cc2db7523dded8da4969798941ab1e99cc70b36bf2fa59549567cf5c1e1cc40ee0131350d60f8239f";
+      sha512 = "aceb16a89f40243f56611d726a47b15bc6b0e5c1177a4beda6b147749299640742dd9d5f64384e88f4fc065c5f5ab80a7456a81ed63331a99a60e1e2e8b76a08";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sr/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/sr/thunderbird-52.6.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "1f32b2705e4939c5e57f7a6a3eac29ccacbd90bb93361007b208a0eb1aea4f279b50fa17ffb86571cc2aa793742d3ff62caf28047b69c95ce358b6ec2cd24268";
+      sha512 = "c0cefc58703c51d169686bb6c25477ea3116fc9691e0bf971d2a141ee8e93e4e1853911189c2b49d331d8b04c70e3c154083a05179c93a22b043a70918808ba3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/sv-SE/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/sv-SE/thunderbird-52.6.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "887176e1d4d9cb385ce0261a45f22bb67a87a125da737403c6965a6dd57ec7f0763b1245ea0d04b79aff5f41cd1ded3a06dc4ee301a17c01a9417ea2d515dcb0";
+      sha512 = "179429292f73320f33d3cfbdd4b55b65117c8b8f60abadbf8c28537ab1e6e7664f7e2fa1b20ecdb201d7d535a9974638a7c22c2f5ba0fabea580509bd35d2a3e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/ta-LK/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/ta-LK/thunderbird-52.6.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-x86_64";
-      sha512 = "fb981e6175b1f8fe79b65f2c324e376a89c7378074a6ead4cf3444516fd8d566591f942133642830caeef1f342ceb169d2e558171a5675ffc96a82deeca585a5";
+      sha512 = "ccc1e3b1ca1e2a762c840c5e52b33cb3c05b75195576e95f7d28abe53aa6438d83eb185664797be9a0726f51416b4cc70877a4d6e01282d426459820eac59b01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/tr/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/tr/thunderbird-52.6.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "2ce313b74b8512eea958c2c3e303829a3d7452a48efc07afbfbe9ea783c6099e75693b679cddb65802fef5a47f98526b7ceaf4c1e7fdebf9357c91d5a306bd70";
+      sha512 = "55b14f94b1824df5e05d8c8f8c1a86a3d9667123dfb7b86723888ffeab93b8b0ed8dde082c3db0ee33446052e81b6f282e4ac3ae9a2a51ef25e01c6ffc93ad1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/uk/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/uk/thunderbird-52.6.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "dcf852d0c584c3959fe0f7ff72cdd45fa8497aa1ca44ca036e849c3395da470a52376343f4b6e37a343e2f2919245a52e63bb5dfb5651bbf749c72c35a8918b0";
+      sha512 = "94047ef1efc45fcd228012a8833ca1d6d5540ba0549a5f598ca420564e85dd0bfe4995968ba241d57b588db542f6c33445459c77b40eb3b568f66d3ef8e4e91b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/vi/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/vi/thunderbird-52.6.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "2b3c262c1955045bbda194715f4e9fce97872054ca8cc6f7bca3c1c6da303ccda4715336c846d47bc204fadca003ba9f4efdb6798e55c9e928ca822544bfe152";
+      sha512 = "f30ab0cc3b6d4322d9d65150da1b247db12305f8a39acef383048118f30a757ca380134f0f12c238432a23f5d70d173e53e24f46af158ccdcf5eac516267840c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/zh-CN/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/zh-CN/thunderbird-52.6.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "74e7d7f4039d38f6af9590303d173d7293046f897e5b23acf8ff16c7b1ecfc50d0e8896550ee371f19e73518432d137779cba26bad913e8deb9e4af1b0637edc";
+      sha512 = "4dd0923c8258dec6de71aad216dffb2945852f2d6ad20e104599a43a13e7c48bdaaa70a7afb35e3699bbaffc9a69623d6d24e299f1a0e75f604ba9bad96647ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-x86_64/zh-TW/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-x86_64/zh-TW/thunderbird-52.6.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "914af708ab185b76a67e8a2a4c85c14f41bdc05bfbef66c56a8b28820e4eeb866dcb6d60b1b4b61d924af9a6ccfa9ec6a10afd6ffb74794487472d508807b417";
+      sha512 = "39264550d88ad4fbc247b9bb61015b2c0a9e75ffc19ec34e1d7053995e2fcfd65721140f2f4486fe959e67484c6ca6305e997c77b59b98e60e9e979c60e320f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ar/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ar/thunderbird-52.6.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "b749fdc34c15b48bcc0b99af41ac0357fff3a9c4bf774de536caf1fa65b33dfc69a4a14a4cb0c06a82d41e222362cccafb9ff8f4ca64c128cf0a031c1161d74f";
+      sha512 = "b801148b9eccf4425710ff3c5430795d873448ee068dec8e8343ec9094d8c04e317dd0cf6e2d3b69029459d980b841470365441e26d8f71503d9c6f03a52d0fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ast/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ast/thunderbird-52.6.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "f3ddb2b95237e8c505286328369c9f7613e5cb22ede50f8842e936c158aa6cbdb053de6c0f4ef0a9256b394b5510c1733ce0f8cc8423370581ec54b871f59b56";
+      sha512 = "7368be5dab56f03635d3bc06f1d1871893dd8a694388baa90a44cef5f88717a705daeb2230dae8c2bfaf8b40e1f7987aeefc729b4e77ec1055726b0944276c79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/be/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/be/thunderbird-52.6.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "d41e1bcb8460015876d784eccb37aabfeaa8a283f408e6606d84175f3e6b1e7428b8d277d30b250192cede4cb6bf2746945cf6fd4afa698fcb1b4230ee0f6d5b";
+      sha512 = "a39137149f5800b5ea612382b86840b095fd09e38d06ffaeb4a2f5e242b47cac828ffb87c9870a9ebc75b9bd26b0499c2899d5b778267dc6842d21afaab0e7bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/bg/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/bg/thunderbird-52.6.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "e07885f88953dab1a940d21142fc04c7b8b2f807fc424f69b99f90d4a8f5ed034fc00de92d76dd4fb858c669cf6c3e9cb82f93ac3a264ba71f7b644e99849fef";
+      sha512 = "2314afbb259a561e98bffe3d30aaac571b8f7f54de2246af78a012fcbee19fda15c8a921221ebea738fb09be07a1139f5edc14f1f9f55945a63e08c625a6bf52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/bn-BD/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/bn-BD/thunderbird-52.6.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "2cdab1cc1066ab51d8fd0787115568cf70f3d584d2fd5e3908eee0f64037ce61a80a3f19ae31dc8cabca8f05cee51221917c717ea535a5a8085dd3410fa56422";
+      sha512 = "e8cd137f04521293ea60c8f8557b4482baf1d7936c9fca1ea7426ea8a99cae48f3e441a81cf1a779034595eb755009db512f29d31c8ada11391cea0f3962d61d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/br/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/br/thunderbird-52.6.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "0db76f3544b14360bdee64186b9f828dce717d72d23ab59d4568cf079dd1db138e5b79eb500bae6d0043550bb906a0558f07e3b5ac98d0ff67705578d04ebefb";
+      sha512 = "0715d8eda4c144c35b5583bdce6eac058788b761949bcb79f156ba4931c380e33f7810fed55e283e02c5af2d555df471c48383d1ace21da7f88c3b0a8e97213b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ca/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ca/thunderbird-52.6.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "6229309d3e81f374f4f04071843e3a1e7e18ad8316359ba6badd0509284ef59c16085af9a52956a5a2f438bd9cf8c88400e15fb99bcb75001f08fb72c285b3ad";
+      sha512 = "21ec148ddfef69ead9f1b367dce4d6a93a7f1d31fb691035d40132cd4955a66f162a44f0e5b0caaae8cfdb76b0842cd78a630cb6a7949e839611d98d58776a47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/cs/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/cs/thunderbird-52.6.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "12a2df8d37d02076acf6cd2bc86bbc71e38e157e121b1729096c880481a82d23a0c1c8f1c8b1ff53193aefa1eebc64ffa49bebf38dcdee5fdbdf429bff5d9993";
+      sha512 = "f2c7c86db91332b9f38ab4ae732ca44c7f7bfa32e3b8123f7ba9662fe9f74b9f01a58ca63a9954b45aad05272baca385797679103c29a95dcf248fe8cdac5a53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/cy/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/cy/thunderbird-52.6.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "7c71ae8ce62dd271e0202b4e25b52ab9291ff83b920465b9a96c36d55c520ee87a5a348ab9d0ffd495744b787d424741ecf9e89ae4879281d0a6f2cb3742ae2b";
+      sha512 = "f0bdfa8373fc87faa567720c4c998f08ba836f8c26a59e38e92bd641e7efd42010530575bdfe1fa7bc78b7688380eafc274b8954f2a59e60912713afacd42789";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/da/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/da/thunderbird-52.6.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "36861c719370036033286139f5e93d750eb8712afea42df7cc7f8bbfb9a00dde999e3ac4e38bc48b64a343a8091483163914cd362e9e30e0f9a98c6cf6a1783a";
+      sha512 = "80dc629b815c4ec98026f0ee5c2b7f754bc9bf0e5d026775866f502ca55b826ce071470a8713ae98089bf2208e5b0d0771a20307db5351b4af78169bd8efc1ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/de/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/de/thunderbird-52.6.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "8571075c5435ab4763ac1c0f3904ca39b5ad1363390fd78eec9b73115caccb3eb3cc9f2e1a8c4119469ed5cc99d648fc905a8fb4d51c0bd10dc9ecb0338ad59b";
+      sha512 = "bd66cf808f3d5ba73dfb0d314050c5d4ddc59966abc84e904cde2dd73c20086dcbd580c1a0bff4d1dee7ae940e38a53b9a37ed75e05758ff9da799f2ae1f7aab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/dsb/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/dsb/thunderbird-52.6.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "1b873aa804d253786b37a8bd1e85884f12c48292c3703d9c04a9d370e8fff73b0d865495a65de7fe690e34f835220ea88810194385ef50f3b285e8237f3761bc";
+      sha512 = "58e50c2d6c2d42fcd34273ead868753373e054602ab1ea7e9ea9d5ed15b8ae15e6b654fe81b6a56942f1cd4eb3778d11897fc2b9e34e789aff7d83b47bd3c100";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/el/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/el/thunderbird-52.6.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "8f6327796a1e937e0d43f2af23f25292ee3a56b9d173bcbad1bf1d7cd60ca464570ef4a9d8255d2f3897dc862680073146a6509944014d0abeb21395da8c0201";
+      sha512 = "40888eca974a5e9dab7459c790b7e589906da72ca9ea64fa690225d876310239faeff8925366b5fc559a5793efcac01696f22886c9ecbd5dfad5661083b8e63d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/en-GB/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/en-GB/thunderbird-52.6.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "e27a9c743a1d439e3cda7f2924c01044c797f88bd4b90723face80a472c8e0854c747472e5cb72dfe10ab1018188044681e1ae633ea55f4a11aae6f62a3a891b";
+      sha512 = "5a418b8f6b857a4554cddb81b36b5f4885ba694ff08b3b5f3c342491637587719578738eac9abee2735e8d0fa1ab216ee9bb5cce67955c4b7c30c3a063b95477";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/en-US/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/en-US/thunderbird-52.6.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "b20aeac366bbfe257e709133fafa59bc8fd784d33926a167adf24d2c90d2cf5adfb68815e2000de4837be7cf73258d890cef555be82112aaeaef2bcc244f634f";
+      sha512 = "628a5f50871bf44c59e1d8983f520d5ede9f22bff15eb4b03673dc6d4b0f72c84247a5e29ba67e871be449825dde8090a6e9a50501e434bbc17d86aeb846e1cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/es-AR/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/es-AR/thunderbird-52.6.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "a3547d8ea9675970dfe9dc40e1b763558fbb204b8d0940156b97212f2a5af00ca82ea2493f77fe896e257d7e0cb1ce7a1fe05a4c23aaa09222da43cc9b823e88";
+      sha512 = "595419a4c26c8974ada3e9856dcabe863666133a98d5730a1a295f1edc414d1d0b3a159afc94bd927c934d44e9b4ed4282d4211948bcbe8b6d744948e7b48e02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/es-ES/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/es-ES/thunderbird-52.6.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "2ad8177608038799c2ea653ea056c599949972a51493a27a34d4aa0769814106cebc8eac3521c7d6186432fadbf8e17e7b9e5221bdd1bf70de4fa80de163e964";
+      sha512 = "898a14402ab621fb81b563c039db3ae343173cb39872ca6a2985f6a279af7ffaca404af179cef3adb48285b05e24b372c1e8a1918557280ecd10a4368b540f27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/et/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/et/thunderbird-52.6.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "a68d4606e943a4b5841853b1c2d5165f5c97405690d467c0548ef0169fe472e76088c0387f9adabcd5837a3fba72287398453c4e149343bc9130348b5d62c682";
+      sha512 = "b2ce107034b87b9e4459add9e1d6777e58f52465f81720d1a6276dbe0c341c92984fa9979ec8da0544f4699cf98a097098ed14759c38e47a0f9ea4aba6916907";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/eu/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/eu/thunderbird-52.6.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "dfc826d722b7ff331df35b6fc9b82eae9714f8f8e75c1fe3119a3b449a5b2817a8641e939ddf32b4b6605406a7cfeb57de24493b5a4d0cf9992a3dc30f2558cc";
+      sha512 = "a401cb39dd18e83cbe64de9c527ce4d72a951f32c5150a88bb509487f3ed4364624354a6571d41ee18f1061841cfe9bb704bf355893fab6cc44d94f660a5e0b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/fi/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/fi/thunderbird-52.6.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "2676d22c662a5d7b4b3eb32a71b032e76bb609b39a89381054b254ad7a966625af2166b2a5edd9c09ad8d9728933203c99a3c60e03c2fb031b748e94c16eba77";
+      sha512 = "d87a4ff14023c2a20241a920d2fac288d76124ba3734ffcae664cbf46ba3a3d54fe42979c243e6ae231f7b5aa54dfe9c82ad87f3839714aa8a21409a6e87221d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/fr/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/fr/thunderbird-52.6.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "b6ec3f6f2abb0f1ae8de3167e03d9d254959a93881b4cb8202db5880bade5569a53f1b5aaeaec10fb6fcfe453fcbe7cf0c090947c546ec62ae0f858dc0b251d8";
+      sha512 = "5bd14acb63b044b2aa6f2f75fc365b6d65012a504ac3735cd2d72097b65aa61662007e06857f7288329c39517af01e694d19be5498bf4b718fb9b2510c8ed313";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/fy-NL/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/fy-NL/thunderbird-52.6.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "c0e2618f223f5b58d80283b23c38ce703d5fa019444dc2168d1ca88149780e458ed9c5414931457a0a3e7733407eb07b1fd38f3b40c381db2f012c5a1eec7eaf";
+      sha512 = "13baa3c5bf0c24474f6f31291b54ff9c846bc3a6056bf43a74f3e5ad4919879adeadfe583151f55cc721e8aaa0b9011cc8e9c3a402d2fc363b4b2ab97f5aef76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ga-IE/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ga-IE/thunderbird-52.6.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "fb6e815a5690382f1608d20cecb596012677616cfe3de11ba8aacdf32c59314a5e61ade11151965fa4c5f310445700f9fe89e14734f8876ebad4dcde9f46535a";
+      sha512 = "632cc17bb0e9a5ee4e651cde51f71eb6efb6eac35297126ca3c7397e4bbd407f583b70a2aa5cdb4345276b493f3d8161cd376a443b37be3ba6b2782b7d6a534b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/gd/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/gd/thunderbird-52.6.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "3edf7e424f7a21540225d6e30543bb39f395564a3effd5064f3471f7922c19e275fc7b20e1df929a93eb375e0b37937f5beb239003300bff0af8af0d2f7b203d";
+      sha512 = "03b3f6ab1fa5edd9f4c37f1d2ed9ba7a34e4b3d714bdf238f7e4ed8e8c65c432fff5a2815a1993ac8f221a997dab2b0ee22dea46d5a8b566bad35ae1cc9a4f46";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/gl/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/gl/thunderbird-52.6.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "7afea0817603271e8ddfa01374102f8856fa1d090fb3a98ff9e3ef477aeb019f3860e68c6ea72659ea0b65c54967c68bfa0d84a040d7677469ece8460fbf93c3";
+      sha512 = "36398fa1d04ee096c1e2fa1420ca375dc7ff135ff63343e20c916b6ecb03b2adc6e30d26e66ee6ab38cd816d928e8c628a55bb3f6cf921bf7691b6092700200b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/he/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/he/thunderbird-52.6.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "546484c47f925bfb92bab962735cef6a74336d6b282881afce1054caaee559360e2df1d497d857a12ae76b99ce765ac985adf48d17f9a759b262f8b134e9adf0";
+      sha512 = "f819c1bc97298445f3d3d5ef91470a7ff370a5db5e4884e8c2590e06bbfbf9a33c7d1cb9919379a6aa654e47f49b6f9e127584eeb29cb14f2e73efc01d4f8ee7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/hr/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/hr/thunderbird-52.6.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "552ebbc20522633fdd27117a941a0541bc3195b4a650612e6bf9f5e341f09c39efe1a58dcb9b0bf3ebb4797c7cf49e7d8a8d7922d2f3cb83284f9a3dca7e6b68";
+      sha512 = "bdebf02084d98a6279c27d914935e4e8486d86cb27475e99983ab0cd8166f78c82b6815528f7afc10e6aae8f0859c393f6f42b7d1a081925b1fe2053f309052f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/hsb/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/hsb/thunderbird-52.6.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "f92450010bfb1d1620bd4819103d89f0d58af567231219ff106dbd48550e04af2900b362b93bd199482aaeb72a0ac88344e3767d754d6934d401cca13af4b718";
+      sha512 = "b0db8f59739e0ead2d0ec64bf00f6b62854b2b55b34db04e31c27db14b3b67e6af3bc9d857fb528e4e6115e3e1f2da75b685b17a33cf9ea976cca7ef5ebecb56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/hu/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/hu/thunderbird-52.6.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "6a4d10925475f3fc499f49894f6c79de88bd394c9b3359efb326e55aa3e1af9b7d6ee2c853908bedd95e113d697ae3b25e612dff72d81d01addb1fbc39c6ea36";
+      sha512 = "10ca02217736663a1fb44e20430bf2ac3a76fb5f87e57e539361ba12361c2f79aa3892fac02c4365890c6506eb86bde8fc955dd126eeddefb7b27813050d1861";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/hy-AM/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/hy-AM/thunderbird-52.6.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "ecf982393bfc9c826dd74ea6c0452788c34958f031636c4f70bf12388e966a3630cde159f3751540b3b917e52f0b64a2cd572d211ef3b61d97725a80f51b4f5e";
+      sha512 = "a0240daee40e6d8cd76d81bfbc4bd47052f9e20a00b8c687806633eb72e16d9393a6005c16f5391d2caa5a55fb7e0b7e12d1097fe140d6fd664e3ca40358b597";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/id/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/id/thunderbird-52.6.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "a4d735acd212827ceea6205125e8d38f292b0994a5375738857b12531aaa947539033fe3be3e198eae82b77647d243227200a9fafb4ff2729bf4b0028868295f";
+      sha512 = "4450789df3c0176cde9adac0f8b075ca64690c0278b6da9de4040faefa35a9c915de1daec1e1b1ccae2d80c8d55f664c8535d9cc31ade68ef8081fc3f102e992";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/is/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/is/thunderbird-52.6.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "8d4b0a3eef192d42ecc9c65eb692b5c35ead5c1a7ef17f575e96e06f8990a76607b31abafbb03cabbdd4385eefcb09bb0477c7a6cff1b5fc3a60bc9fb1d0518e";
+      sha512 = "9ad56f873a0138d55a34b6058681c9edb185734c3b358aa1ffd91161403cba5fa0a2d02d858fe45ebbb2e991c0a8da1bfcb6516c9836e26a3aec7e2160f292a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/it/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/it/thunderbird-52.6.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "4f2d5c1bd7cc404bb8ab6097bc3dd40424a745f8a6cbc0e73722a28d68a582150acbdab83e02b89811c6617e63a2d56f5f02f6fc463092e8e959a91552a6f3d8";
+      sha512 = "242f2c9b2a7821bbd6601f4aeccbfe8f9c31556a061c0200b1139ce28c613c3781fa0ece4c9674c19a2283f647b2804820f29e26cba9ecfdc53a6b05964e2762";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ja/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ja/thunderbird-52.6.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "78445e5bb7211d7319609edb30e063c3584ed8c92eb4fb2953520720125306c28905e2248eb5825d6bc09399d38e35f37be57707e64edd3aae555b4ea748205f";
+      sha512 = "1686f8cfc156744f2e9c02afa19ca00ac29db0e6f9b07900aae9b068928ff30431350ddb75824918df5a64e076d88b312f1055b74db44ec7cb909d505d2c013d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/kab/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/kab/thunderbird-52.6.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "7ad9d0213a2cd6297cf899f311ea3b8a7493f8596c352c351aa5aae3c7b0639c787dfda9d63adde7b2d920277c09d987b690506c762e24da16d86f985cb8f846";
+      sha512 = "cadfcf6a02732831411f180d0363d3c3cb08e31d7d108b5f55d14bb75b6c48a744b40ec2a964f659904fde4c5e82ea8b89651db55406e5327db41c6f15f74416";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ko/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ko/thunderbird-52.6.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "a76a8acadbf082a7fbaecae8798fbb3fec4d03515db2f0a7d2d10d15ef468c128329e79f68e9b0075c4a7767bf56de5d3f1f5521cfa7beaad2fa2026fecb43f2";
+      sha512 = "4b4e6bc229049210695536a0e12d685995bf439ab8b2b7879142c93cc749882ed79b98063fabd4df97503e771f585cbfc1590b2a3815a6121a7e43417addaaad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/lt/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/lt/thunderbird-52.6.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "cd8911a16d2662f5b80b76b04013113a8e9a231d25404afebe29852b5335d587a1dd22aaa74727c1b74ae5b26ffbd0f4723fc86ecef5c43397485a5199d65b71";
+      sha512 = "5d73c90f57e50500debfccb555183cb616ac9d893a19ee29fe22f4823085bd62aea156fd5c0f0f6ff49291636c4d90af253096416aeb87982da5455bf548a40b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/nb-NO/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/nb-NO/thunderbird-52.6.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "3a82189796c1bbbe4633ef7beb054cd5f324504173678aae2763714b4ca25b04bce479eb63d89abe920c89ce7a4159eefa5e27b6e5959d2bea01a4cd53e13e58";
+      sha512 = "0adf9e6b10010ea5cce216a510e53fc5dc9c2066eceacf3c3c6bda7526b3bfef1083b130c08432dc59f09e02e19f0c4a5b885cb43627771aec00d78828377eb6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/nl/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/nl/thunderbird-52.6.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "63e40217f5abea50375c0fc0060cab6c6291acb25d468edde8a14751c0693f0e9d751cbdee339a2c141269edad6c4ac87ec37f440257b5a78492bc43e66a9cd6";
+      sha512 = "372e39c33a78e70d628fc1bc1a9719b3d902d67eead4e47091b40913a4aa76dac63db003cae8113f7d194cc6fd24cad13c4e87aefd1d6bf425434835c983ca7a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/nn-NO/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/nn-NO/thunderbird-52.6.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "bfa15dfb0606ca225ec370426b983a17c614dc850b665e40ba648504f5d9bf556a2f31ec20533fe739ff94f57f3eb5486f422972c7ed8c08d8cd7c8a023f9937";
+      sha512 = "1c66f021fbdf85e1aaed26e5a6d3abcbc9d71e91126bca10a6f8b62b10abf3927a44ae559136478fd9628dfe3409c4edd83f3336302c84fb0b6be6d4031dbb3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/pa-IN/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/pa-IN/thunderbird-52.6.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "6989775d3e36ec43aeccf3db32627d3f1be13021943a088385313fc7111d4288b8daa32ec37a9679353d68a9f15761fac2f7a4eb7dc1a60e3d15598296b11f82";
+      sha512 = "aba5a6804f08eb303e71aba94b11116f253dd19dd31e10c05ad5469800378ffef678a90a8a33db2da516bb55ea2d1d1b5537c3c11ff9132ce9ce890fb4e8e413";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/pl/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/pl/thunderbird-52.6.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "05d252299552f987641be34e5f3462d56b08b01a66637b2d039d1a39f2fdb1b9b986ecd353bc69290bd64b5858b2e7fb7c928209cdbb98b27fca479ec8f959b4";
+      sha512 = "19559239283420bac401dfefec812bbc18d33483380c44f217b70d9412b3d93f9ab3c2f5d9d518191fd891316e9ccb5b21f901676026f7ad2414a4541d584f98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/pt-BR/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/pt-BR/thunderbird-52.6.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "b40deb4d5239e335f2c2e65d676cb6528c3320ee28bc9d83dd53bae2a486bcce2921726309754cc0bc155d3f8a0f56d69aa98e782bb4b8375cfcebfee5f58320";
+      sha512 = "64ada0291a3da9713eb81cd05ddbcddd70379bf07a14e019580bbb7b5fea4976ad7aeae87a651da070139e975bb52f66271ed3124eeada4d6a90f4afed948d3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/pt-PT/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/pt-PT/thunderbird-52.6.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "0afa965096f5a79b79b3e49af1758dc200ceb8161192a97d260313f9582f1c8b7a1d4e54e093cca6b9c92a9458dd38ba0493fdd1d6567f0505a90fc9bd97f09a";
+      sha512 = "ce57a764ee2a529d7e37b6d620cf7c3825f7af1cc04da0502d64d2a7fb577a27a171a4f5d589c3f5e738192241776be4119d45958b2d77fbe3ae4f82279ab380";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/rm/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/rm/thunderbird-52.6.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "c9babc6d6e85936a251d4f7214991a06a3b92c6ae207a8012fe14cffb277a6b2468213a4ba94672a360bfdf9f4b817b8663cc15ceeafb79a63cbac13310e1aca";
+      sha512 = "04bc57c8360be5917fe2e05b6b672fab614ea5a6ff150c83242ee20e89756f2f24afa096249fad5f2795c47e570815281bce70449385efc5e510c64204e5f7cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ro/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ro/thunderbird-52.6.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "86f303e7878cb988ee1773e6de2ea6b433028d4bfd40d9388384b14b5343b1de9b6b5084f92f1c95b4110ecc7fda669ed98d50dbb6266a775f4e058d5083e24a";
+      sha512 = "86c790e5b3faeface66d001ea9e56006ac2955883337204e5f79764cdf74860df210688f8467c9f7b0051c9efd5cdbc5c98b615656155b99361bbba656254a47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ru/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ru/thunderbird-52.6.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "d262ad2a73ab34bdecf6d180840922bfe16fdd4dc7097ccd900712d99ca915da648f2a196accbf6ff9946d9fc48c674e9eb0f0bafdfc94cd6f9069139cf0f036";
+      sha512 = "cbf316a94b64d02ee83fdafddbb60daac5157ea11c57889703bde88e3c4baec720dde515e9864f021cbb39e6945a33ccf909623fda0abe542e07b11eab8154d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/si/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/si/thunderbird-52.6.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "6b39cd9501b2dc44d033efe9524c5865cad8fdfd8224a51fb04679227e5306d67d05a9acaf4f5810cd67e6d10b1afc69ff80e63a7926616c35c79ecc3f02d93b";
+      sha512 = "cf0dddbe01bddd623ce5052f0a72dee9da4eb5de1932d0a0a656baba55c79eaec51387e37f74c1a1a754ee71def8c972af5dda5a5bf9e78c19a2c11c1cc42e57";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sk/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/sk/thunderbird-52.6.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "356c86279387b023540fba86f73376b1be12413887f8ea2c3b706ccc268aad282d77b7eb863e58d6f15f66516dd4bd8f56a8f413815753dfd6496f81ee842aea";
+      sha512 = "5c70a7e8a47e44a47eac2d00526c4c8da340121c1fc8c136b3b40cbe0809548e9cde6d6dc76d1ad679d7bdedefdaf3fc373b2c124cca6b36a9cdb9f4e6da939a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sl/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/sl/thunderbird-52.6.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "86d035a6b7108fab33582eb665afce9063e3d55b0c468b81569503cdde7ffe169de227024e94a60dd45e39073eaa3c3f313bf061c0ba492b66f75f79941c6100";
+      sha512 = "9bbaf000fd2c1fe28f0f64c31c7736a2595399788498ae8be8fdac8dabc709efeacd8fb1f6ae8a095c130ff7620e1b7c6e909959b9c724b7bde736049664357c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sq/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/sq/thunderbird-52.6.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "f2dd5958774c81710aa59d7c9cf8543c86d82cd21da16b13ad1580cb2680df5caf973cf28a505fb994ad809264deeceea8806641fa27b9df5a7f26c725030515";
+      sha512 = "6f8d71fa87777b11f5ebf14c6811ce9a0c2c380db5b7f3fe774219cc60bea6d4f59de8a3dd193d855725c3a0e5470b36dc0538f94539d637be14de5d8e480c7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sr/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/sr/thunderbird-52.6.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "47a96a821fb825b6624262bbc0138027b842a9a69985af8903a7bfd435f6cbd3211e382899f3cc989cf716759aad927a8be22b2500f42f75362cfad09dbe67fe";
+      sha512 = "0bbcd2a98f767a8836d054a97c797a0ea7eac5c08fed9177189474e47e8dc50d395735c0eaf8c6e839ac608084c6e533a3b20fda5e69ad74ada53636f1181359";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/sv-SE/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/sv-SE/thunderbird-52.6.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "978c8c41034137361663f2b12818477baac0e795e4c1ca7f7a013a8e1bb68534ef2a8a9d73e31c1ded7461bc5dc6298fc628dc6190b3657ce415f9687a3ed85e";
+      sha512 = "22cc597657e44124162a6b8693022bd4086e3b4e0f9e42342c997bd333e1182163f0ca0c67d91cbb5e18c45605c877eb69d00372c86a9378ed2e7846547f3964";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/ta-LK/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/ta-LK/thunderbird-52.6.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-i686";
-      sha512 = "970405c59d2589e49c53f0ab37e959c6f3b94bac41929ac6d5776c7b78b91bc0f8a6c1acee1557338b76bb8fc2a9f62f179a0ad10a0a8c984254d39577402556";
+      sha512 = "902832bf66b2efd39cf038e9361bf0ee8f9682e73a42895ccf6bb637eeabb8d4d5e8b3b3d28bfa52e537ad1babee6bbb8d033c538a61880920ace6a4a7cadf95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/tr/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/tr/thunderbird-52.6.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "cec76a997708b5339d5e49baea40125226f4bd708fa57f43f7812e2c7be686515986b90ab6ee525dadcaccbd9b9ea2c961e1a645b2c9634062e3e0c9c00ce2dc";
+      sha512 = "70dbb015aa4acf35d5cba0e9d8916bed2603c7e44574c98e98e56edfb68db3ab572402fda5c809d838c51a2e3f135cd3b86f2dde44acd2e1ae2f12cecc276655";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/uk/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/uk/thunderbird-52.6.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "be710c5a5d28b34136ad72456ab9893d7c31dc0f3eea8cfc38d70169c37df5c96fb3aa18b72555e081115d0791f3a634325da191ac004ffc6a38d1412e140e95";
+      sha512 = "9fd85a4f4366caea3409cca47df70d2f028c7d85c248ebbe5e7e92005d98d45947639fae2aac8a145e4cad12cc92e368b9f86de4623a7d1a35e0485fb35cff97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/vi/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/vi/thunderbird-52.6.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "7d1f59f1fd78609700b6d6246087b88c5190139c79e7e60f2eaba91908ff0afbac0bce0e2a60594cda0800cf68ab0b5568702e0cfcfd1718e4cf46a88f20bc01";
+      sha512 = "205b22a39b795946f019cbb9e8c1813a0ca9f59551c9ea30c661fbe43bbf1d87069dd3992e71c83226b2559cdb4db2186b37120c847367b6a4e1b16aba24510f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/zh-CN/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/zh-CN/thunderbird-52.6.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "5763d93646a83b8a88e8c4b1c1c72101831f72323b600d576619330e2cf77ac7a9dc668aef5ef59188e0f467db900d1d8f3c2ef299f422f83de51f53519c70be";
+      sha512 = "d1a9247b1db70ddba4f0cf80af7b8606e6bf006b31d3e771a4047dd7ccd121114bab900c38c02f36c4b60636caae75047f153bafd06aacf1b546c3d8af01806a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.5.2/linux-i686/zh-TW/thunderbird-52.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.6.0/linux-i686/zh-TW/thunderbird-52.6.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "cd593b08ed5f31dd89b44e9b79b1db324c51facf63e9d9c0c2ad847b9cc13a0548e831a87078c9c0ae910512c4855e6f3ae22d1c40189e082ff6ff26224c35b4";
+      sha512 = "a92b42e7e1869ad91d8343072d508df6bb8e67ddf7d929d4911457c5bba04fc1ec7d3218685954a4ded7ecf819bfbef975813fb2bbb9d1da60444b83f1f0fdb9";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -22,11 +22,11 @@ let
   wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "52.5.2";
+  version = "52.6.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "d626d3d37959539b15b5d2ae4a580fcc160380974bfc1a69a1fc8ff2435932e90a69fa386d5ecb6721d9154603c6b7d063e3368f6f995fea057eb593c06ef4ff";
+    sha512 = "80742c95ed61d1cb2e72b71bb23bdd211a40240ab4393e9f028a38f902547372084a8f56445e2394484be088a7b9801405f3d6618fb2742601cc968bf34427f0";
   };
 
   # New sed no longer tolerates this mistake.


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes
- Other fixes

https://www.mozilla.org/en-US/thunderbird/52.6.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2018-04/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

