### PR TITLE
Undo aws sdk cpp bump

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -14,13 +14,13 @@ let
         else throw "Unsupported system!";
 in stdenv.mkDerivation rec {
   name = "aws-sdk-cpp-${version}";
-  version = "1.3.22";
+  version = "1.1.18";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-sdk-cpp";
     rev = version;
-    sha256 = "0sdgy8kqhxnw7n0sw4m3p3ay7yic3rhad5ab8m5lbx61ad9bq3c2";
+    sha256 = "1i85zpns3gj5by45ppg4rfk9csix8mjazpyj6dqic40b2wshnw8c";
   };
 
   # FIXME: might be nice to put different APIs in different outputs

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -9,6 +9,19 @@
 }:
 
 let
+  # We want the new fixed S3 retry behavior for nixUnstable, but it's a breaking
+  # change so we don't want to update the top-level package.
+  aws-sdk-cpp-1_3 = aws-sdk-cpp.overrideAttrs (_: rec {
+    name = "aws-sdk-cpp-${version}";
+    version = "1.3.22";
+
+    src = fetchFromGitHub {
+      owner = "awslabs";
+      repo = "aws-sdk-cpp";
+      rev = version;
+      sha256 = "0sdgy8kqhxnw7n0sw4m3p3ay7yic3rhad5ab8m5lbx61ad9bq3c2";
+    };
+  });
 
   sh = busybox.override {
     useMusl = true;
@@ -42,7 +55,7 @@ let
       ++ lib.optionals fromGit [ brotli ] # Since 1.12
       ++ lib.optional stdenv.isLinux libseccomp
       ++ lib.optional ((stdenv.isLinux || stdenv.isDarwin) && is112)
-          (aws-sdk-cpp.override {
+          (aws-sdk-cpp-1_3.override {
             apis = ["s3"];
             customMemoryManagement = false;
           });


### PR DESCRIPTION
A less disruptive way to get the S3 retry behavior we all crave in nixUnstable without hurting anyone else.

cc @edolstra @globin 