### PR TITLE
Isso: init at 0.10.6 (plus dependencies)

### DIFF
--- a/pkgs/development/python-modules/misaka/default.nix
+++ b/pkgs/development/python-modules/misaka/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchPypi, buildPythonPackage, cffi }:
+buildPythonPackage rec {
+  pname = "misaka";
+  version = "2.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yqrq3a5rracirmvk52n28nn6ckdaz897gnigv89a9gmyn87sqw7";
+  };
+
+  propagatedBuildInputs = [ cffi ];
+
+  # The tests require write access to $out
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A CFFI binding for Hoedown, a markdown parsing library";
+    homepage = "http://misaka.61924.nl/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/servers/isso/default.nix
+++ b/pkgs/servers/isso/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, python2, fetchurl, fetchFromGitHub }:
+
+let python = python2.override {
+  packageOverrides = self: super: {
+    misaka = super.misaka.overridePythonAttrs (old: rec {
+      version = "1.0.2";
+      src = old.src.override {
+        inherit version;
+        sha256 = "05rmjxlfhghj90m1kc55lx3z8igabw5y8wmly66p3hphdy4f95v1";
+      };
+      propagatedBuildInputs = [ ];
+    });
+    html5lib = super.html5lib.overridePythonAttrs (old: rec {
+      version = "0.9999999";
+      src = old.src.override {
+        inherit version;
+        sha256 = "2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868";
+      };
+      checkInputs = with self; [ nose flake8 ];
+      propagatedBuildInputs = with self; [ six ];
+      checkPhase = ''
+        nosetests
+      '';
+    });
+  };
+};
+
+in with python.pkgs; buildPythonApplication rec {
+  pname = "isso";
+  version = "0.10.6";
+
+  # no tests on PyPI
+  src = fetchFromGitHub {
+    owner = "posativ";
+    repo = pname;
+    rev = version;
+    sha256 = "19x9xbwd15fikhchyl4i1wrqx589hdmh279xhnxdszrq898igywb";
+  };
+
+  propagatedBuildInputs = [ misaka werkzeug ipaddr configparser html5lib ];
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    ${python.interpreter} setup.py nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A commenting server similar to Disqus";
+    homepage = https://posativ.org/isso/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9429,6 +9429,8 @@ with pkgs;
     stdenv = llvmPackages_4.stdenv;
   };
 
+  isso = callPackage ../servers/isso { };
+
   itk = callPackage ../development/libraries/itk { };
 
   jasper = callPackage ../development/libraries/jasper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3539,6 +3539,8 @@ in {
     };
   };
 
+  misaka = callPackage ../development/python-modules/misaka {};
+
   mt-940 = callPackage ../development/python-modules/mt-940 { };
 
   mwlib = let


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closes #13587
