### PR TITLE
distrho: 2017-10-10 -> 2018-01-01

### DIFF
--- a/pkgs/applications/audio/distrho/default.nix
+++ b/pkgs/applications/audio/distrho/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, alsaLib, fftwSinglePrec, freetype, libjack2
+{ stdenv, fetchFromGitHub, alsaLib, fftwSinglePrec, freetype, libjack2
 , libxslt, lv2, pkgconfig, premake3, xorg, ladspa-sdk }:
 
 stdenv.mkDerivation rec {
-  name = "distrho-ports-unstable-2017-10-10";
+  name = "distrho-ports-unstable-2018-01-01";
 
-  src = fetchgit {
-    url = "https://github.com/DISTRHO/DISTRHO-Ports.git";
-    rev = "e11e2b204c14b8e370a0bf5beafa5f162fedb8e9";
-    sha256 = "1nd542iian9kr2ldaf7fkkgf900ryzqigks999d1jhms6p0amvfv";
+  src = fetchFromGitHub {
+    owner = "DISTRHO";
+    repo = "DISTRHO-Ports";
+    rev = "b200e7409aa9f6612c4d948932f6ce6f0a087f5a";
+    sha256 = "0672r0a9s6skzkxpjdraziwh5k8ivrfzvi4zcpkcg3zrv2hia2vz";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

