### PR TITLE
meme: init at 2017-09-10

### DIFF
--- a/pkgs/applications/graphics/meme/default.nix
+++ b/pkgs/applications/graphics/meme/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "meme-unstable-${version}";
+  version = "2017-09-10";
+
+  owner = "nomad-software";
+  repo = "meme";
+  goPackagePath = "github.com/${owner}/${repo}";
+
+  src = fetchFromGitHub {
+    inherit owner repo;
+    rev = "a6521f2eecb0aac22937b0013747ed9cb40b81ea";
+    sha256 = "1gbsv1d58ck6mj89q31s5b0ppw51ab76yqgz39jgwqnkidvzdfly";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A command line utility for creating image macro style memes";
+    homepage = "https://github.com/nomad-software/meme";
+    license = licenses.mit;
+    maintainers = [ maintainers.fgaz ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16013,6 +16013,8 @@ with pkgs;
 
   meld = callPackage ../applications/version-management/meld { };
 
+  meme = callPackage ../applications/graphics/meme { };
+
   mcomix = callPackage ../applications/graphics/mcomix { };
 
   mendeley = libsForQt5.callPackage ../applications/office/mendeley {


### PR DESCRIPTION
###### Motivation for this change

![An example of a meme generated with this program](https://user-images.githubusercontent.com/8182846/35447558-516efa1e-02b8-11e8-9512-2110e4b400f8.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

