### PR TITLE
magnetophonDSP: remove workarounds for:

### DIFF
--- a/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     faust2jaqt -vec -time -t 99999 CharacterCompressor.dsp
     faust2jaqt -vec -time -t 99999 CharacterCompressorMono.dsp
-    sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "lib/CharacterCompressor.lib"
     faust2lv2 -vec -time -gui -t 99999 CharacterCompressor.dsp
     faust2lv2 -vec -time -gui -t 99999 CharacterCompressorMono.dsp
   '';

--- a/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
       faust2jaqt -time -vec -double -t 99999 $f
     done
 
-    sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "CompBus.lib"
-
     for f in *.dsp;
     do
       faust2lv2  -time -vec -double -gui -t 99999 $f

--- a/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     faust2jaqt -time -vec -t 99999 ConstantDetuneChorus.dsp
-    sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "ConstantDetuneChorus.dsp"
     faust2lv2  -time -vec -t 99999 -gui ConstantDetuneChorus.dsp
   '';
 

--- a/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     faust2jaqt -vec -time -t 99999 LazyLimiter.dsp
-    sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "GUI.lib"
     faust2lv2 -vec -time -t 99999  -gui LazyLimiter.dsp
   '';
 

--- a/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     faust2jaqt -time -vec -t 99999 MBdistortion.dsp
-    sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "MBdistortion.dsp"
     faust2lv2 -time -vec -gui -t 99999 MBdistortion.dsp
   '';
 

--- a/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     faust2jaqt -time -vec -t 99999 RhythmDelay.dsp
-    sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "RhythmDelay.dsp"
     faust2lv2  -time -vec -t 99999 -gui RhythmDelay.dsp
   '';
 

--- a/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
@@ -19,11 +19,9 @@ stdenv.mkDerivation rec {
       faust2jaqt -time -double -t 99999 $f
     done
 
-    sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "compressors.lib"
-
     for f in *.dsp;
     do
-      echo "compiling plugin from" $f
+      echo "Compiling plugin from" $f
       faust2lv2  -time -double -gui -t 99999 $f
     done
   '';

--- a/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
       do
         echo "Building jack standalone for $f"
         faust2jaqt -vec -time -t 99999 "$f"
-        sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "$f"
         echo "Building lv2 for $f"
         faust2lv2 -vec -time -gui -t 99999 "$f"
       done

--- a/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     faust2jaqt -vec -double -time -t 99999 shelfMultiBand.dsp
     faust2jaqt -vec -double -time -t 99999 shelfMultiBandMono.dsp
-    sed -i "s|\[ *scale *: *log *\]||g ; s|\btgroup\b|hgroup|g" "shelfMultiBand.lib"
     faust2lv2 -vec -double -time -gui -t 99999 shelfMultiBandMono.dsp
     faust2lv2 -vec -double -time -gui -t 99999 shelfMultiBand.dsp
   '';


### PR DESCRIPTION
https://bitbucket.org/agraef/faust-lv2/issues/10/tabs-break-lv2s
https://bitbucket.org/agraef/faust-lv2/issues/7/scale-log-breaks-plugins

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

