### PR TITLE
doc: Two cleanups to the cross compilation chapter

### DIFF
--- a/doc/cross-compilation.xml
+++ b/doc/cross-compilation.xml
@@ -253,7 +253,8 @@
     or also with <varname>crossSystem</varname>, in which case packages run on the latter, but all building happens on the former.
     Both parameters take the same schema as the 3 (build, host, and target) platforms defined in the previous section.
     As mentioned above, <literal>lib.systems.examples</literal> has some platforms which are used as arguments for these parameters in practice.
-    You can use them programmatically, or on the command line like <command>nix-build &lt;nixpkgs&gt; --arg crossSystem '(import &lt;nixpkgs/lib&gt;).systems.examples.fooBarBaz'</command>.
+    You can use them programmatically, or on the command line: <programlisting>
+nix-build &lt;nixpkgs&gt; --arg crossSystem '(import &lt;nixpkgs/lib&gt;).systems.examples.fooBarBaz' -A whatever</programlisting>
   </para>
   <para>
     While one is free to pass both parameters in full, there's a lot of logic to fill in missing fields.

--- a/doc/cross-compilation.xml
+++ b/doc/cross-compilation.xml
@@ -256,6 +256,16 @@
     You can use them programmatically, or on the command line: <programlisting>
 nix-build &lt;nixpkgs&gt; --arg crossSystem '(import &lt;nixpkgs/lib&gt;).systems.examples.fooBarBaz' -A whatever</programlisting>
   </para>
+  <note>
+    <para>
+      Eventually we would like to make these platform examples an unnecessary convenience so that <programlisting>
+nix-build &lt;nixpkgs&gt; --arg crossSystem.config '&lt;arch&gt;-&lt;os&gt;-&lt;vendor&gt;-&lt;abi&gt;' -A whatever</programlisting>
+      works in the vast majority of cases.
+      The problem today is dependencies on other sorts of configuration which aren't given proper defaults.
+      We rely on the examples to crudely to set those configuration parameters in some vaguely sane manner on the users behalf.
+      Issue <link xlink:href="https://github.com/NixOS/nixpkgs/issues/34274">#34274</link> tracks this inconvenience along with its root cause in crufty configuration options.
+    </para>
+  </note>
   <para>
     While one is free to pass both parameters in full, there's a lot of logic to fill in missing fields.
     As discussed in the previous section, only one of <varname>system</varname>, <varname>config</varname>, and <varname>parsed</varname> is needed to infer the other two.


### PR DESCRIPTION
###### Motivation for this change

Recent discussion on IRC convinced me the command tag didn't stand out enough. Also, after just making the issue, and I thought we should come clean in the manual.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @Infinisil 