### PR TITLE
lib, glibc: Get rid of withTLS

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -14,7 +14,6 @@ rec {
     bigEndian = false;
     arch = "armv5tel";
     float = "soft";
-    withTLS = true;
     libc = "glibc";
     platform = platforms.sheevaplug;
     openssl.system = "linux-generic32";
@@ -26,7 +25,6 @@ rec {
     arch = "armv6l";
     float = "hard";
     fpu = "vfp";
-    withTLS = true;
     libc = "glibc";
     platform = platforms.raspberrypi;
     openssl.system = "linux-generic32";
@@ -38,7 +36,6 @@ rec {
     arch = "armv7-a";
     float = "hard";
     fpu = "vfpv3-d16";
-    withTLS = true;
     libc = "glibc";
     platform = platforms.armv7l-hf-multiplatform;
     openssl.system = "linux-generic32";
@@ -48,7 +45,6 @@ rec {
     config = "aarch64-unknown-linux-gnu";
     bigEndian = false;
     arch = "aarch64";
-    withTLS = true;
     libc = "glibc";
     platform = platforms.aarch64-multiplatform;
   };
@@ -67,7 +63,6 @@ rec {
 
     libc = "glibc";
 
-    withTLS = true;
     openssl.system = "linux-generic32";
   };
 
@@ -76,7 +71,6 @@ rec {
     bigEndian = false;
     arch = "mips";
     float = "hard";
-    withTLS = true;
     libc = "glibc";
     platform = platforms.fuloong2f_n32;
     openssl.system = "linux-generic32";

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -127,7 +127,6 @@ stdenv.mkDerivation ({
     ] ++ lib.optionals withLinuxHeaders [
       "--enable-kernel=3.2.0" # can't get below with glibc >= 2.26
     ] ++ lib.optionals (cross != null) [
-      (if cross.withTLS then "--with-tls" else "--without-tls")
       (if cross ? float && cross.float == "soft" then "--without-fp" else "--with-fp")
     ] ++ lib.optionals (cross != null) [
       "--with-__thread"
@@ -190,8 +189,6 @@ stdenv.mkDerivation ({
     libc_cv_forced_unwind=yes
     libc_cv_c_cleanup=yes
     libc_cv_gnu89_inline=yes
-    # Only due to a problem in gcc configure scripts:
-    libc_cv_sparc64_tls=${if cross.withTLS then "yes" else "no"}
     EOF
 
     export BUILD_CC=gcc

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5364,7 +5364,6 @@ with pkgs;
             bigEndian = true;
             arch = "mips";
             float = "soft";
-            withTLS = true;
             libc = "uclibc";
             platform = {
               name = "ben_nanonote";


### PR DESCRIPTION
glibc removed the underlying flag in 2011 in 83cd14204559abbb52635006832eaf4d2f42514a [1].

This gets us one step closer to fixing #34274: the cross stdenv for aarch64-unknown-linux-gnu at least evals now.

Thanks to @Dezgeg for doing all the research for this.

[1]: https://sourceware.org/git/?p=glibc.git;a=commit;h=83cd14204559abbb52635006832eaf4d2f42514a

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

