### PR TITLE
nixos/tests: add predictable-interface-names.nix

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -440,8 +440,12 @@ rec {
   init = list: assert list != []; take (length list - 1) list;
 
 
-  /* FIXME(zimbatm) Not used anywhere
-   */
+  /* return the image of the cross product of some lists by a function
+
+    Example:
+      crossLists (x:y: "${toString x}${toString y}") [[1 2] [3 4]]
+      => [ "13" "14" "23" "24" ]
+  */
   crossLists = f: foldl (fs: args: concatMap (f: map f args) fs) [f];
 
 

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -41,6 +41,7 @@ in rec {
         nfs3
         openssh
         php-pcre
+        predictable-interface-names
         proxy
         simple;
       installer = {

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -325,6 +325,7 @@ in rec {
   tests.pgmanage = callTest tests/pgmanage.nix {};
   tests.postgis = callTest tests/postgis.nix {};
   #tests.pgjwt = callTest tests/pgjwt.nix {};
+  tests.predictable-interface-names = callSubTests tests/predictable-interface-names.nix {};
   tests.printing = callTest tests/printing.nix {};
   tests.prometheus = callTest tests/prometheus.nix {};
   tests.proxy = callTest tests/proxy.nix {};

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -1,0 +1,16 @@
+{ system ? builtins.currentSystem }:
+with import ../lib/testing.nix { inherit system; };
+let testWhenSetTo = status:
+makeTest {
+  name = "predictableInterfaceNames-${if status then "true" else "false"}";
+
+  machine = { config, pkgs, ... }: {
+    networking.usePredictableInterfaceNames = pkgs.stdenv.lib.mkForce status;
+  };
+
+  testScript = ''
+    print $machine->succeed("ip link show ${if status then "ens3" else "eth0"}");
+    print $machine->fail("ip link show ${if status then "eth0" else "ens3"}");
+  '';
+}; in
+map testWhenSetTo [ true false ]

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -5,7 +5,7 @@ with import ../lib/testing.nix { inherit system; };
 let boolToString = x: if x then "yes" else "no"; in
 let testWhenSetTo = predictable: withNetworkd:
 makeTest {
-  name = "predictableInterfaceNames-${boolToString predictable}-with-networkd-${boolToString withNetworkd}";
+  name = "${if predictable then "" else "un"}predictableInterfaceNames${if withNetworkd then "-with-networkd" else ""}";
   meta = {};
 
   machine = { config, pkgs, ... }: {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/33738

###### Things done

I tested that the revision incriminated in the issue makes the test fail, and that the test succeeds on current revision.

I think this test should be added to "release critical tests" as well, but I don't know how to do it (if it is in
nixpkgs).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

