### PR TITLE
libxc: set platform to x86_64-linux only

### DIFF
--- a/pkgs/development/libraries/libxc/default.nix
+++ b/pkgs/development/libraries/libxc/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation {
     description = "Library of exchange-correlation functionals for density-functional theory";
     homepage = http://octopus-code.org/wiki/Libxc;
     license = licenses.lgpl3;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ markuskowa ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Libxc fails to properly build on aarch64 due to some failed tests (https://hydra.nixos.org/build/68239191). This library is mainly used by scientific software that has traditionally been developed for HPC platforms like x86 and thus I do not expect it to be useful on arm in the near future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

