### PR TITLE
nettools: 1.60_p20161110235919 -> 1.60_p20170221182432

### DIFF
--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "net-tools-1.60_p20161110235919";
+  name = "net-tools-${version}";
+  version = "1.60_p20170221182432";
 
   src = fetchurl {
     url = "mirror://gentoo/distfiles/${name}.tar.xz";
-    sha256 = "1kbgwkys45kb5wqhchi1kf0sfw93c1cl0hgyw7yhacxzdfxjmdfr";
+    sha256 = "08r4r2a24g5bm8jwgfa998gs1fld7fgbdf7pilrpsw1m974xn04a";
   };
 
   preBuild =


### PR DESCRIPTION
Nothing critical, here's the highlights:

* ROSE fixes
* arp scanf/output fix
* linux header compat:
  https://sourceforge.net/p/net-tools/code/ci/ea3935bd7c0f36c86c40e5785326698fa3336c6a/

Commit log (short):
https://sourceforge.net/p/net-tools/code/ci/479bb4a7e11a4084e2935c0a576388f92469225b/log/


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---