### PR TITLE
zncModules: backlog init at 2017-06-13

### DIFF
--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -15,6 +15,26 @@ let
 
 in rec {
 
+  backlog = zncDerivation rec {
+    name = "znc-backlog-${version}";
+    version = "git-2017-06-13";
+    module_name = "backlog";
+
+    src = fetchFromGitHub {
+      owner = "FruitieX";
+      repo = "znc-backlog";
+      rev = "42e8f439808882d2dae60f2a161eabead14e4b0d";
+      sha256 = "1k7ifpqqzzf2j7w795q4mx1nvmics2higzjqr3mid3lp43sqg5s6";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Request backlog for IRC channels.";
+      homepage = https://github.com/fruitiex/znc-backlog/;
+      license = licenses.asl20;
+      maintainers = with maintainers; [ infinisil ];
+    };
+  };
+
   clientbuffer = zncDerivation rec {
     name = "znc-clientbuffer-${version}";
     version = "git-2015-08-27";


### PR DESCRIPTION
###### Motivation for this change
I want this module for my znc

###### Things done

I have tested this with my znc, works without problems.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

