### PR TITLE
cpupower, pciutils: enable cross compiling

### DIFF
--- a/pkgs/os-specific/linux/cpupower/default.nix
+++ b/pkgs/os-specific/linux/cpupower/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchurl, kernel, coreutils, pciutils, gettext }:
+{ stdenv, buildPackages, fetchurl, kernel, pciutils, gettext }:
 
 stdenv.mkDerivation {
   name = "cpupower-${kernel.version}";
 
   src = kernel.src;
 
-  buildInputs = [ coreutils pciutils gettext ];
+  nativeBuildInputs = [ gettext ];
+  buildInputs = [ pciutils ];
 
   configurePhase = ''
     cd tools/power/cpupower
-    sed -i 's,/bin/true,${coreutils}/bin/true,' Makefile
-    sed -i 's,/bin/pwd,${coreutils}/bin/pwd,' Makefile
-    sed -i 's,/usr/bin/install,${coreutils}/bin/install,' Makefile
+    sed -i 's,/bin/true,${buildPackages.coreutils}/bin/true,' Makefile
+    sed -i 's,/bin/pwd,${buildPackages.coreutils}/bin/pwd,' Makefile
+    sed -i 's,/usr/bin/install,${buildPackages.coreutils}/bin/install,' Makefile
   '';
 
-  buildPhase = ''
-    make
-  '';
+  makeFlags = [ "CROSS=${stdenv.cc.targetPrefix}" ];
 
   installPhase = ''
     make \

--- a/pkgs/tools/system/pciutils/default.nix
+++ b/pkgs/tools/system/pciutils/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ zlib kmod which ];
 
-  makeFlags = "SHARED=yes PREFIX=\${out}";
+  makeFlags = [ "SHARED=yes" "PREFIX=\${out}" "STRIP=" "HOST=${stdenv.hostPlatform.system}" "CROSS_COMPILE=${stdenv.cc.targetPrefix}" ];
 
   installTargets = "install install-lib";
 


### PR DESCRIPTION
###### Motivation for this change

This PR fixes cross compiling for cpupower and pciutils (a dependency of cpupower).

###### Things done

This PR uses some different flags for pciutils than the commit that was dropped from #34173. Of particular importance is the `HOST` variable, which has to be set correctly for aarch64 cross compiling to work. Coincidentally, the format of this variable is the same as the value of `stdenv.hostPlatform.system` for most architectures and operating systems, (Linux, Darwin, x86_64, aarch64 and armv7l, although it looks like the cpu name should be i386 for i686).

I have tested these changes natively on x86_64 and aarch64, as well as cross compiling for armv7l and aarch64.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

