### PR TITLE
glibc: Remove two tiny old cross hacks

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -155,8 +155,7 @@ stdenv.mkDerivation ({
 // (removeAttrs args [ "withLinuxHeaders" "withGd" ]) //
 
 {
-  name = name + "-${version}${patchSuffix}" +
-    lib.optionalString (cross != null) "-${cross.config}";
+  name = name + "-${version}${patchSuffix}";
 
   src = fetchurl {
     url = "mirror://gnu/glibc/glibc-${version}.tar.xz";
@@ -190,11 +189,6 @@ stdenv.mkDerivation ({
     libc_cv_c_cleanup=yes
     libc_cv_gnu89_inline=yes
     EOF
-
-    export BUILD_CC=gcc
-    export CC="$crossConfig-gcc"
-    export AR="$crossConfig-ar"
-    export RANLIB="$crossConfig-ranlib"
   '';
 
   preBuild = lib.optionalString withGd "unset NIX_DONT_SET_RPATH";


### PR DESCRIPTION
###### Motivation for this change

 - Name is already suffixed
 - Env vars are already exported

###### Things done

https://hydra.nixos.org/jobset/nixpkgs/ericson2314-cross-trunk

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

