### PR TITLE
lib: Platform attribute cleanup

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -15,7 +15,6 @@ rec {
     float = "soft";
     libc = "glibc";
     platform = platforms.sheevaplug;
-    openssl.system = "linux-generic32";
   };
 
   raspberryPi = rec {
@@ -25,7 +24,6 @@ rec {
     fpu = "vfp";
     libc = "glibc";
     platform = platforms.raspberrypi;
-    openssl.system = "linux-generic32";
   };
 
   armv7l-hf-multiplatform = rec {
@@ -35,7 +33,6 @@ rec {
     fpu = "vfpv3-d16";
     libc = "glibc";
     platform = platforms.armv7l-hf-multiplatform;
-    openssl.system = "linux-generic32";
   };
 
   aarch64-multiplatform = rec {
@@ -54,12 +51,8 @@ rec {
     arch = "armv5tel";
     config = "armv5tel-unknown-linux-gnueabi";
     float = "soft";
-
-    platform = platforms.pogoplug4;
-
     libc = "glibc";
-
-    openssl.system = "linux-generic32";
+    platform = platforms.pogoplug4;
   };
 
   fuloongminipc = rec {
@@ -68,7 +61,6 @@ rec {
     float = "hard";
     libc = "glibc";
     platform = platforms.fuloong2f_n32;
-    openssl.system = "linux-generic32";
   };
 
   #

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -11,7 +11,6 @@ rec {
 
   sheevaplug = rec {
     config = "armv5tel-unknown-linux-gnueabi";
-    bigEndian = false;
     arch = "armv5tel";
     float = "soft";
     libc = "glibc";
@@ -21,7 +20,6 @@ rec {
 
   raspberryPi = rec {
     config = "armv6l-unknown-linux-gnueabihf";
-    bigEndian = false;
     arch = "armv6l";
     float = "hard";
     fpu = "vfp";
@@ -32,7 +30,6 @@ rec {
 
   armv7l-hf-multiplatform = rec {
     config = "arm-unknown-linux-gnueabihf";
-    bigEndian = false;
     arch = "armv7-a";
     float = "hard";
     fpu = "vfpv3-d16";
@@ -43,7 +40,6 @@ rec {
 
   aarch64-multiplatform = rec {
     config = "aarch64-unknown-linux-gnu";
-    bigEndian = false;
     arch = "aarch64";
     libc = "glibc";
     platform = platforms.aarch64-multiplatform;
@@ -68,7 +64,6 @@ rec {
 
   fuloongminipc = rec {
     config = "mips64el-unknown-linux-gnu";
-    bigEndian = false;
     arch = "mips";
     float = "hard";
     libc = "glibc";

--- a/pkgs/build-support/vm/windows/cygwin-iso/default.nix
+++ b/pkgs/build-support/vm/windows/cygwin-iso/default.nix
@@ -21,7 +21,6 @@ let
     crossSystem = {
       libc = "msvcrt";
       platform = {};
-      openssl.system = "mingw64";
       inherit arch;
       config = "${arch}-w64-mingw32";
     };

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildPackages, perl
-, hostPlatform
+, buildPlatform, hostPlatform
 , fetchpatch
 , withCryptodev ? false, cryptodevHeaders
 , enableSSL2 ? false
@@ -8,10 +8,6 @@
 with stdenv.lib;
 
 let
-
-  opensslCrossSystem = hostPlatform.openssl.system or
-    (throw "openssl needs its platform name cross building");
-
   common = args@{ version, sha256, patches ? [] }: stdenv.mkDerivation rec {
     name = "openssl-${version}";
 
@@ -24,23 +20,34 @@ let
       (args.patches or [])
       ++ [ ./nix-ssl-cert-file.patch ]
       ++ optional (versionOlder version "1.1.0")
-          (if stdenv.isDarwin then ./use-etc-ssl-certs-darwin.patch else ./use-etc-ssl-certs.patch)
+          (if hostPlatform.isDarwin then ./use-etc-ssl-certs-darwin.patch else ./use-etc-ssl-certs.patch)
       ++ optional (versionOlder version "1.0.2" && hostPlatform.isDarwin)
            ./darwin-arch.patch;
 
     outputs = [ "bin" "dev" "out" "man" ];
     setOutputFlags = false;
-    separateDebugInfo = stdenv.isLinux;
+    separateDebugInfo = hostPlatform.isLinux;
 
     nativeBuildInputs = [ perl ];
     buildInputs = stdenv.lib.optional withCryptodev cryptodevHeaders;
 
-    # On x86_64-darwin, "./config" misdetects the system as
-    # "darwin-i386-cc".  So specify the system type explicitly.
-    configureScript =
-      if stdenv.system == "x86_64-darwin" then "./Configure darwin64-x86_64-cc"
-      else if stdenv.system == "x86_64-solaris" then "./Configure solaris64-x86_64-gcc"
-      else "./config";
+    # TODO(@Ericson2314): Improve with mass rebuild
+    configureScript = {
+        "x86_64-darwin"  = "./Configure darwin64-x86_64-cc";
+        "x86_64-solaris" = "./Configure solaris64-x86_64-gcc";
+      }.${hostPlatform.system} or (
+        if hostPlatform == buildPlatform
+          then "./config"
+        else if hostPlatform.isMinGW
+          then "./Configure mingw${toString hostPlatform.parsed.cpu.bits}"
+        else if hostPlatform.isLinux
+          then "./Configure linux-generic${toString hostPlatform.parsed.cpu.bits}"
+        else
+          throw "Not sure what configuration to use for ${hostPlatform.config}"
+      );
+
+    # TODO(@Ericson2314): Make unconditional on mass rebuild
+    ${if buildPlatform != hostPlatform then "configurePlatforms" else null} = [];
 
     configureFlags = [
       "shared"
@@ -50,7 +57,7 @@ let
       "-DHAVE_CRYPTODEV"
       "-DUSE_CRYPTODEV_DIGESTS"
     ] ++ stdenv.lib.optional enableSSL2 "enable-ssl2"
-      ++ stdenv.lib.optional (versionAtLeast version "1.1.0" && stdenv.isAarch64) "no-afalgeng";
+      ++ stdenv.lib.optional (versionAtLeast version "1.1.0" && hostPlatform.isAarch64) "no-afalgeng";
 
     makeFlags = [ "MANDIR=$(man)/share/man" ];
 
@@ -83,18 +90,6 @@ let
         exit 1
       fi
     '';
-
-    crossAttrs = {
-      # upstream patch: https://rt.openssl.org/Ticket/Display.html?id=2558
-      postPatch = ''
-         sed -i -e 's/[$][(]CROSS_COMPILE[)]windres/$(WINDRES)/' Makefile.shared
-      '';
-      preConfigure=''
-        # It's configure does not like --build or --host
-        export configureFlags="${concatStringsSep " " (configureFlags ++ [ opensslCrossSystem ])}"
-      '';
-      configureScript = "./Configure";
-    };
 
     meta = {
       homepage = https://www.openssl.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5363,7 +5363,6 @@ with pkgs;
           # Ben Nanonote system
           crossSystem = {
             config = crossPrefix;
-            bigEndian = true;
             arch = "mips";
             float = "soft";
             libc = "uclibc";


### PR DESCRIPTION
###### Motivation for this change

Progress towards #34274

###### Things done

No native hashes should be changed. Only cross openssl's hash should be changed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

