### PR TITLE
distrho: Fix build on non x86_64 platforms

### DIFF
--- a/pkgs/applications/audio/distrho/default.nix
+++ b/pkgs/applications/audio/distrho/default.nix
@@ -21,7 +21,10 @@ stdenv.mkDerivation rec {
     xorg.libXinerama xorg.libXrender ladspa-sdk
   ];
 
-  buildPhase = ''
+  buildPhase = with stdenv; ''
+    # Remove x86_64 specific optimisations
+    ${if system != "x86_64-linux" then "export LINUX_EMBED=1" else ""}
+
     sh ./scripts/premake-update.sh linux
     make lv2
   '';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @magnetophon 