### PR TITLE
mono{48,50,54}: make sure configureFlags are used in configurePhase

### DIFF
--- a/pkgs/development/compilers/mono/generic-cmake.nix
+++ b/pkgs/development/compilers/mono/generic-cmake.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
   # To overcome the bug https://bugzilla.novell.com/show_bug.cgi?id=644723
   dontDisableStatic = true;
 
-  # In fact I think this line does not help at all to what I
-  # wanted to achieve: have mono to find libgdiplus automatically
   configureFlags = [
     "--x-includes=${libX11.dev}/include"
     "--x-libraries=${libX11.out}/lib"
@@ -38,7 +36,7 @@ stdenv.mkDerivation rec {
 
   configurePhase = ''
     patchShebangs ./
-    ./autogen.sh --prefix $out
+    ./autogen.sh --prefix $out $configureFlags
   '';
 
   # Attempt to fix this error when running "mcs --version":
@@ -58,13 +56,13 @@ stdenv.mkDerivation rec {
     substituteInPlace mono/mini/aot-compiler.c --replace "llvm_path = g_strdup (\"\")" "llvm_path = g_strdup (\"${llvm}/bin/\")"
   '';
 
-  # Fix mono DLLMap so it can find libX11 and gdiplus to run winforms apps
+  # Fix mono DLLMap so it can find libX11 to run winforms apps
+  # libgdiplus is correctly handled by the --with-libgdiplus configure flag
   # Other items in the DLLMap may need to be pointed to their store locations, I don't think this is exhaustive
   # http://www.mono-project.com/Config_DllMap
   postBuild = ''
     find . -name 'config' -type f | xargs \
-    sed -i -e "s@libX11.so.6@${libX11.out}/lib/libX11.so.6@g" \
-           -e 's#[^"]*libgdiplus[^"]*"#${libgdiplus}/lib/libgdiplus.so"#' \
+    sed -i -e "s@libX11.so.6@${libX11.out}/lib/libX11.so.6@g"
   '';
 
   # Without this, any Mono application attempting to open an SSL connection will throw with


### PR DESCRIPTION
When copying generic-nix to generic-cmake.nix, an explicit
configurePhase was added, but it doesn't use the existing
configureFlags.

Fixing this allowed removing the postBuild fixup of the path to
libgdiplus.so, since the --with-libgdiplus option already handles that.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

