### PR TITLE
pythonPackages.hbmqtt: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/hbmqtt/default.nix
+++ b/pkgs/development/python-modules/hbmqtt/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, transitions, websockets, passlib, docopt, pyyaml, nose }:
+
+buildPythonPackage rec {
+  pname = "hbmqtt";
+  version = "0.9.1";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04lqqcy84f9gcwqhrlvzp689r3mkdd8ipsnfzw8gryfny4lh8wrx";
+  };
+
+  propagatedBuildInputs = [ transitions websockets passlib docopt pyyaml ];
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests -e test_connect_tcp
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/beerfactory/hbmqtt;
+    description = "MQTT client/broker using Python asynchronous I/O";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/transitions/default.nix
+++ b/pkgs/development/python-modules/transitions/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, six, nose, mock, dill, pycodestyle }:
+
+buildPythonPackage rec {
+  pname = "transitions";
+  version = "0.6.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ikxsjg7vil0yhiwhiimnjzcb1ig6g6g79sdhs9v8rnrszk1mi2n";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "dill<0.2.7" dill
+  '';
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ nose mock dill pycodestyle ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pytransitions/transitions;
+    description = "A lightweight, object-oriented finite state machine implementation in Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17533,6 +17533,8 @@ in {
 
   traitlets = callPackage ../development/python-modules/traitlets { };
 
+  transitions = callPackage ../development/python-modules/transitions { };
+
   python_mimeparse = buildPythonPackage rec {
     name = "python-mimeparse-${version}";
     version = "0.1.4";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5090,6 +5090,8 @@ in {
   then callPackage ../development/python-modules/gurobipy/linux.nix {}
   else throw "gurobipy not yet supported on ${stdenv.system}";
 
+  hbmqtt = callPackage ../development/python-modules/hbmqtt { };
+
   helper = buildPythonPackage rec {
     pname = "helper";
     version = "2.4.1";


### PR DESCRIPTION
Hbmqtt is Python 3 only, while transitions works with Python 2 as well.
The disabled tests require network access in the case of hbmqtt and optional dependencies in the case of transitions.
Running the hbmqtt tests yields some ignored excptions, which seems to be perfectly normal: https://travis-ci.org/beerfactory/hbmqtt/jobs/307132698

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

