### PR TITLE
dmd: 2.078.0 -> 2.078.1

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -3,10 +3,10 @@
 , curl, tzdata, gdb, darwin
 , callPackage
 , bootstrapVersion ? false
-, version ? "2.078.0"
-, dmdSha256 ? "1ia4swyq0xqppnpmcalh2yxywdk2gv3kvni2abx1mq6wwqgmwlcr"
-, druntimeSha256 ? "0inyvcjc5qn8277d1zlfvgdgiss86rkjg9mhkw5l31hix8yan372"
-, phobosSha256 ? "1vb5xnysja9l8hvv9gy4c05vihmblz7ga005761jbazxkmlfirj4"
+, version ? "2.078.1"
+, dmdSha256 ? "0b9lphh4g3r9cyzv4wcfppv9j3w952vvwv615za23acgwav3mqg2"
+, druntimeSha256 ? "16jv40m073cflpkyl0vmg1g58cianybfcsgcvwli7pfryxbgsbrr"
+, phobosSha256 ? "08ircpf4ilznz638kra272hz8fi5ccvw2cswj5hqckssl1lyqzs8"
 }:
 
 let


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

