### PR TITLE
nixos/sshd: added missing systemd controls

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -257,7 +257,8 @@ in
         service =
           { description = "SSH Daemon";
             wantedBy = optional (!cfg.startWhenNeeded) "multi-user.target";
-            after = [ "network.target" ];
+            after = [ "network-online.target" ];
+            requires = [ "network-online.target" ];
             stopIfChanged = false;
             path = [ cfgc.package pkgs.gawk ];
             environment.LD_LIBRARY_PATH = nssModulesPath;


### PR DESCRIPTION
Added after= and requires= systemd order options.
Without the two options, sshd fails to start if
ip binding is configured in ssh_config (because
ip address is not defined when sshd starts)

This fixes issue #30903 for sshd service.

###### Motivation for this change

Without this change, sshd fails to start when ip binding is configured in sshd.

###### Things done

Tested in my personal nixos setup (sshd wouldn't start without this).
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

