### PR TITLE
top-level: Duplicate overlaying unless stdenvOverrides comes last

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -116,7 +116,9 @@ let
     lib.optionalAttrs allowCustomOverrides
       ((config.packageOverrides or (super: {})) super);
 
-  # The complete chain of package set builders, applied from top to bottom
+  # The complete chain of package set builders, applied from top to bottom.
+  # stdenvOverlays must be last as it brings package forward from the
+  # previous bootstrapping phases which have already been overlayed.
   toFix = lib.foldl' (lib.flip lib.extends) (self: {}) ([
     stdenvBootstappingAndPlatforms
     platformCompat
@@ -125,9 +127,9 @@ let
     splice
     allPackages
     aliases
-    stdenvOverrides
     configOverrides
-  ] ++ overlays);
+  ] ++ overlays ++ [
+    stdenvOverrides ]);
 
 in
   # Return the complete set of packages.


### PR DESCRIPTION
The stdenvOverrides overlay is used to bring packages forward during bootstrapping via stdenv.overrides.  These packages have already had the overlays applied to them in the previous boostrapping stage.  If stdenvOverrides is not last in the overlays stack, all remaining overlays will windup being applied again to these packages.

closes #34086

###### Motivation for this change

See #34086 and above description.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

