### PR TITLE
muscle: init at 3.8.31

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -698,6 +698,7 @@
   tvorog = "Marsel Zaripov <marszaripov@gmail.com>";
   tweber = "Thorsten Weber <tw+nixpkgs@360vier.de>";
   twey = "James ‘Twey’ Kay <twey@twey.co.uk>";
+  unode = "Renato Alves <alves.rjc@gmail.com>";
   uralbash = "Svintsov Dmitry <root@uralbash.ru>";
   utdemir = "Utku Demir <me@utdemir.com>";
   #urkud = "Yury G. Kudryashov <urkud+nix@ya.ru>"; inactive since 2012

--- a/pkgs/applications/science/biology/muscle/default.nix
+++ b/pkgs/applications/science/biology/muscle/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  _name   = "muscle";
+  name    = "${_name}-${version}";
+  version = "3.8.31";
+
+  src = fetchurl {
+    url = "https://www.drive5.com/muscle/downloads${version}/${_name}${version}_src.tar.gz";
+    sha256 = "1b89z0x7h098g99g00nqadgjnb2r5wpi9s11b7ddffqkh9m9dia3";
+  };
+
+  patches = [
+    ./muscle-3.8.31-no-static.patch
+  ];
+
+  preBuild = ''
+    cd ./src/
+    patchShebangs mk
+  '';
+
+  installPhase = ''
+    install -vD muscle $out/bin/muscle
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A multiple sequence alignment method with reduced time and space complexity";
+    license     = licenses.publicDomain;
+    homepage    = https://www.drive5.com/muscle/;
+    maintainers = [ maintainers.unode ];
+    # NOTE: Supposed to be compatible with darwin/intel & PPC but currently fails.
+    # Anyone with access to these platforms is welcome to give it a try
+    platforms   = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/science/biology/muscle/muscle-3.8.31-no-static.patch
+++ b/pkgs/applications/science/biology/muscle/muscle-3.8.31-no-static.patch
@@ -1,0 +1,21 @@
+--- a/src/mk	2010-05-02 01:15:42.000000000 +0200
++++ b/src/mk	2018-01-27 17:07:23.539092748 +0100
+@@ -5,14 +5,14 @@
+ rm -f *.o muscle.make.stdout.txt muscle.make.stderr.txt
+ for CPPName in $CPPNames
+ do
+-  echo $CPPName >> /dev/tty
++  echo $CPPName
+   g++ $ENV_GCC_OPTS -c -O3 -msse2 -mfpmath=sse -D_FILE_OFFSET_BITS=64 -DNDEBUG=1 $CPPName.cpp -o $CPPName.o  >> muscle.make.stdout.txt 2>> muscle.make.stderr.txt
+ done
+ 
+ LINK_OPTS=
+-if [ `uname -s` == Linux ] ; then
+-    LINK_OPTS=-static
+-fi
++#if [ `uname -s` == Linux ] ; then
++#    LINK_OPTS=-static
++#fi
+ g++ $LINK_OPTS $ENV_LINK_OPTS -g -o muscle $ObjNames  >> muscle.make.stdout.txt 2>> muscle.make.stderr.txt
+ tail muscle.make.stderr.txt
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18962,6 +18962,8 @@ with pkgs;
 
   kallisto = callPackage ../applications/science/biology/kallisto { };
 
+  muscle = callPackage ../applications/science/biology/muscle/default.nix { };
+
   neuron = callPackage ../applications/science/biology/neuron {
     python = null;
   };


### PR DESCRIPTION
###### Motivation for this change
Introduces MUSCLE, a commonly used bioinformatics tool for multiple sequence alignments.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

