### PR TITLE
hubstaff: 1.2.15 → 1.3.0

### DIFF
--- a/pkgs/applications/misc/hubstaff/default.nix
+++ b/pkgs/applications/misc/hubstaff/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchurl, unzip, makeWrapper, libX11, zlib, libSM, libICE, libXext
-, freetype, libXrender, fontconfig, libXft, libXinerama, libnotify, glib
-, gtk3, libappindicator-gtk3, curl }:
+{ stdenv, fetchurl, unzip, makeWrapper, libX11, zlib, libSM, libICE
+, libXext , freetype, libXrender, fontconfig, libXft, libXinerama
+, libXfixes, libXScrnSaver, libnotify, glib , gtk3, libappindicator-gtk3
+, curl }:
 
 let
 
-  version = "1.2.15-590e8bc";
+  version = "1.3.0-9b2ba62";
 
   rpath = stdenv.lib.makeLibraryPath
     [ libX11 zlib libSM libICE libXext freetype libXrender fontconfig libXft
       libXinerama stdenv.cc.cc.lib libnotify glib gtk3 libappindicator-gtk3
-      curl ];
+      curl libXfixes libXScrnSaver ];
 
 in
 
@@ -18,14 +19,14 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/${version}/Hubstaff-${version}.sh";
-    sha256 = "142q8xvwn5gdmpv5x25py2lindr74jqncf8vvw22yb9nj5aqqsi6";
+    sha256 = "1dxzyl3yxbfmbw1pv8k3vhqzbmyyf16zkgrhzsbm866nmbgnqk1s";
   };
 
   nativeBuildInputs = [ unzip makeWrapper ];
 
   unpackCmd = ''
     # MojoSetups have a ZIP file at the end. ZIP’s magic string is
-    # most often PK\x03\x04. This *should* work for future updates,
+    # most often PK\x03\x04. This has worked for all past updates,
     # but feel free to come up with something more reasonable.
     dataZipOffset=$(grep --max-count=1 --byte-offset --only-matching --text ''$'PK\x03\x04' $curSrc | cut -d: -f1)
     dd bs=$dataZipOffset skip=1 if=$curSrc of=data.zip 2>/dev/null
@@ -38,17 +39,18 @@ stdenv.mkDerivation {
   installPhase = ''
     # TODO: handle 32-bit arch?
     rm -r x86
+    rm -r x86_64/lib64
 
     opt=$out/opt/hubstaff
     mkdir -p $out/bin $opt
     cp -r . $opt/
 
-    prog=$opt/x86_64/HubstaffClient.bin.x86_64
+    for f in "$opt/x86_64/"*.bin.x86_64 ; do
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) $f
+      wrapProgram $f --prefix LD_LIBRARY_PATH : ${rpath}
+    done
 
-    patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) $prog
-    wrapProgram $prog --prefix LD_LIBRARY_PATH : ${rpath}
-
-    ln -s $prog $out/bin/HubstaffClient
+    ln -s $opt/x86_64/HubstaffClient.bin.x86_64 $out/bin/HubstaffClient
 
     # Why is this needed? SEGV otherwise.
     ln -s $opt/data/resources $opt/x86_64/resources


### PR DESCRIPTION
###### Motivation for this change

Version bump, new deps.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

