### PR TITLE
gnutls: fix (failing) p11-kit test

### DIFF
--- a/pkgs/development/libraries/gnutls/3.6.nix
+++ b/pkgs/development/libraries/gnutls/3.6.nix
@@ -11,9 +11,10 @@ callPackage ./generic.nix (args // rec {
   # Skip two tests introduced in 3.5.11.  Probable reasons of failure:
   #  - pkgconfig: building against the result won't work before installing
   #  - trust-store: default trust store path (/etc/ssl/...) is missing in sandbox
+  # Change p11-kit test to use pkg-config to find p11-kit
   postPatch = ''
     sed '2iexit 77' -i tests/pkgconfig.sh
     sed '/^void doit(void)/,$s/{/{ exit(77);/; t' -i tests/trust-store.c
-    # TODO: remove just this line on some rebuild
+    sed 's:/usr/lib64/pkcs11/ /usr/lib/pkcs11/ /usr/lib/x86_64-linux-gnu/pkcs11/:`pkg-config --variable=p11_module_path p11-kit-1`:' -i tests/p11-kit-trust.sh
   '';
 })


### PR DESCRIPTION
The p11-kit-trust test looks in /usr/lib for pkcs11 modules.  As a result it is unnecessarily skipped on sandboxed builds, and fails on unsandboxed builds with a system p11-kit.  Replace hard-coded /usr/lib paths with pkg-config.

###### Motivation for this change

p11-kit-trust test was failing on my unsandboxed build because the system p11-kit-trust module was found instead, and skipped on normal builds because it wasn't looking in p11_kit.  pkg-config knows where it is and tests pass in both cases.

Happy to change if there's a better way to search for this library (e.g., `$buildInputs` or patch in hard-coded path) or it would be better to just force skip the test regardless.

This test does not exist (in this form anyway) in gnutls 3.5.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

