### PR TITLE
pmidi: init at 1.7.1

### DIFF
--- a/pkgs/applications/audio/pmidi/default.nix
+++ b/pkgs/applications/audio/pmidi/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, alsaLib
+, version ? "1.7.1"
+, sourceSha256 ? "051mv6f13c8y13c1iv3279k1hhzpz4fm9sfczhgp9sim2bjdj055"
+}:
+stdenv.mkDerivation {
+  name = "pmidi-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/pmidi/${version}/pmidi-${version}.tar.gz";
+    sha256 = sourceSha256;
+  };
+
+  buildInputs = [ alsaLib ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.parabola.me.uk/alsa/pmidi.html;
+    description = "A straightforward command line program to play midi files through the ALSA sequencer";
+    maintainers = with maintainers; [ lheckemann ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17070,6 +17070,8 @@ with pkgs;
 
   peru = callPackage ../applications/version-management/peru {};
 
+  pmidi = callPackage ../applications/audio/pmidi { };
+
   printrun = callPackage ../applications/misc/printrun { };
 
   sddm = libsForQt5.callPackage ../applications/display-managers/sddm { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build pmidi