### PR TITLE
vagrant: Make bsdtar available to extract boxes

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildRubyGem, bundlerEnv, ruby }:
+{ lib, fetchurl, buildRubyGem, bundlerEnv, ruby, libarchive }:
 
 let
   version = "2.0.1";
@@ -36,9 +36,12 @@ in buildRubyGem rec {
     ./unofficial-installation-nowarn.patch
   ];
 
+  # PATH additions:
+  #   - libarchive: Make `bsdtar` available for extracting downloaded boxes
   postInstall = ''
     wrapProgram "$out/bin/vagrant" \
-      --set GEM_PATH "${deps}/lib/ruby/gems/${ruby.version.libDir}"
+      --set GEM_PATH "${deps}/lib/ruby/gems/${ruby.version.libDir}" \
+      --prefix PATH ':' "${lib.getBin libarchive}/bin"
   '';
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change
Fix extracting downloaded boxes in Vagrant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).