### PR TITLE
[RDY] buildLinux: Add more overrides

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -16,7 +16,7 @@
 
 */
 
-{ stdenv, version, kernelPlatform, extraConfig, features }:
+{ stdenv, version, extraConfig, features }:
 
 with stdenv.lib;
 
@@ -682,6 +682,5 @@ with stdenv.lib;
     WW_MUTEX_SELFTEST? n
   ''}
 
-  ${kernelPlatform.kernelExtraConfig or ""}
   ${extraConfig}
 ''

--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -13,18 +13,18 @@ use strict;
 use IPC::Open2;
 use Cwd;
 
-my $wd = getcwd;
-
+# exported via nix
 my $debug = $ENV{'DEBUG'};
 my $autoModules = $ENV{'AUTO_MODULES'};
 my $preferBuiltin = $ENV{'PREFER_BUILTIN'};
-    
+my $ignoreConfigErrors = $ENV{'ignoreConfigErrors'};
+my $buildRoot = $ENV{'BUILD_ROOT'};
 $SIG{PIPE} = 'IGNORE';
 
 # Read the answers.
 my %answers;
 my %requiredAnswers;
-open ANSWERS, "<$ENV{KERNEL_CONFIG}" or die;
+open ANSWERS, "<$ENV{KERNEL_CONFIG}" or die "Could not open answer file";
 while (<ANSWERS>) {
     chomp;
     s/#.*//;
@@ -40,7 +40,7 @@ close ANSWERS;
 sub runConfig {
 
     # Run `make config'.
-    my $pid = open2(\*IN, \*OUT, "make -C $ENV{SRC} O=$wd config SHELL=bash ARCH=$ENV{ARCH}");
+    my $pid = open2(\*IN, \*OUT, "make -C $ENV{SRC} O=$buildRoot config SHELL=bash ARCH=$ENV{ARCH}");
 
     # Parse the output, look for questions and then send an
     # appropriate answer.
@@ -122,7 +122,7 @@ runConfig;
 # there.  `make config' often overrides answers if later questions
 # cause options to be selected.
 my %config;
-open CONFIG, "<.config" or die;
+open CONFIG, "<$buildRoot/.config" or die "Could not read .config";
 while (<CONFIG>) {
     chomp;
     if (/^CONFIG_([A-Za-z0-9_]+)="(.*)"$/) {
@@ -137,7 +137,7 @@ while (<CONFIG>) {
 close CONFIG;
 
 foreach my $name (sort (keys %answers)) {
-    my $f = $requiredAnswers{$name} && $ENV{'ignoreConfigErrors'} ne "1"
+    my $f = $requiredAnswers{$name} && $ignoreConfigErrors ne "1"
         ? sub { die "error: " . $_[0]; } : sub { warn "warning: " . $_[0]; };
     &$f("unused option: $name\n") unless defined $config{$name};
     &$f("option not set correctly: $name (wanted '$answers{$name}', got '$config{$name}')\n")

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -1,3 +1,11 @@
+{ buildPackages, runCommand, nettools, bc, perl, gmp, libmpc, mpfr, openssl
+, ncurses
+, libelf
+, utillinux
+, writeTextFile, ubootTools
+, callPackage
+}:
+
 { stdenv, buildPackages, perl, buildLinux
 
 , # The kernel source tarball.
@@ -28,7 +36,7 @@
 , extraMeta ? {}
 , hostPlatform
 , ...
-}:
+} @ args:
 
 assert stdenv.isLinux;
 
@@ -45,8 +53,10 @@ let
   } // features) kernelPatches;
 
   config = import ./common-config.nix {
-    inherit stdenv version extraConfig;
-    kernelPlatform = hostPlatform;
+    inherit stdenv version ;
+    # append extraConfig for backwards compatibility but also means the user can't override the kernelExtraConfig part
+    extraConfig = extraConfig + lib.optionalString (hostPlatform ? kernelExtraConfig ) hostPlatform.kernelExtraConfig;
+
     features = kernelFeatures; # Ensure we know of all extra patches, etc.
   };
 
@@ -68,7 +78,9 @@ let
     nativeBuildInputs = [ perl ];
 
     platformName = hostPlatform.platform.name;
+    # e.g. "defconfig"
     kernelBaseConfig = hostPlatform.platform.kernelBaseConfig;
+    # e.g. "bzImage"
     kernelTarget = hostPlatform.platform.kernelTarget;
     autoModules = hostPlatform.platform.kernelAutoModules;
     preferBuiltin = hostPlatform.platform.kernelPreferBuiltin or false;
@@ -83,25 +95,25 @@ let
     inherit (kernel) src patches preUnpack;
 
     buildPhase = ''
-      cd $buildRoot
+      export buildRoot="''${buildRoot:-build}"
 
       # Get a basic config file for later refinement with $generateConfig.
-      make HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc -C ../$sourceRoot O=$PWD $kernelBaseConfig ARCH=$arch
+      make HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc -C . O="$buildRoot" $kernelBaseConfig ARCH=$arch
 
       # Create the config file.
       echo "generating kernel configuration..."
-      echo "$kernelConfig" > kernel-config
-      DEBUG=1 ARCH=$arch KERNEL_CONFIG=kernel-config AUTO_MODULES=$autoModules \
-           PREFER_BUILTIN=$preferBuiltin SRC=../$sourceRoot perl -w $generateConfig
+      echo "$kernelConfig" > "$buildRoot/kernel-config"
+      DEBUG=1 ARCH=$arch KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
+           PREFER_BUILTIN=$preferBuiltin BUILD_ROOT="$buildRoot" SRC=. perl -w $generateConfig
     '';
 
-    installPhase = "mv .config $out";
+    installPhase = "mv $buildRoot/.config $out";
 
     enableParallelBuilding = true;
   };
 
-  kernel = buildLinux {
-    inherit version modDirVersion src kernelPatches stdenv extraMeta configfile;
+  kernel = (callPackage ./manual-config.nix {}) {
+    inherit version modDirVersion src kernelPatches stdenv extraMeta configfile hostPlatform;
 
     config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
   };

--- a/pkgs/os-specific/linux/kernel/linux-4.13.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+buildLinux (args // rec {
   version = "4.13.16";
   extraMeta.branch = "4.13";
 

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -2,7 +2,7 @@
 
 with stdenv.lib;
 
-import ./generic.nix (args // rec {
+buildLinux (args // rec {
   version = "4.14.17";
 
   # branchVersion needs to be x.y

--- a/pkgs/os-specific/linux/kernel/linux-4.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.15.nix
@@ -2,7 +2,7 @@
 
 with stdenv.lib;
 
-import ./generic.nix (args // rec {
+buildLinux (args // rec {
   version = "4.15.1";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+buildLinux (args // rec {
   version = "4.4.115";
   extraMeta.branch = "4.4";
 

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+buildLinux (args // rec {
   version = "4.9.80";
   extraMeta.branch = "4.9";
 

--- a/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
+++ b/pkgs/os-specific/linux/kernel/linux-beagleboard.nix
@@ -4,7 +4,7 @@ let
   modDirVersion = "4.14.12";
   tag = "r23";
 in
-stdenv.lib.overrideDerivation (import ./generic.nix (args // rec {
+stdenv.lib.overrideDerivation (buildLinux (args // rec {
   version = "${modDirVersion}-ti-${tag}";
   inherit modDirVersion;
 

--- a/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardened-copperhead.nix
@@ -15,7 +15,7 @@ let
 
   modDirVersion = "${modVersion}-hardened";
 in
-import ./generic.nix (args // {
+buildLinux (args // {
   inherit modDirVersion;
 
   version = "${version}-${revision}";

--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,9 +1,10 @@
 { stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (rec {
+buildLinux (rec {
   mptcpVersion = "0.93";
   modDirVersion = "4.9.60";
   version = "${modDirVersion}-mptcp_v${mptcpVersion}";
+  # autoModules= true;
 
   extraMeta = {
     branch = "4.4";
@@ -43,4 +44,4 @@ import ./generic.nix (rec {
     TCP_CONG_BALIA m
 
   '' + (args.extraConfig or "");
-} // args // (args.argsOverride or {}))
+} // args)

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -4,7 +4,7 @@ let
   modDirVersion = "4.9.59";
   tag = "1.20171029";
 in
-stdenv.lib.overrideDerivation (import ./generic.nix (args // rec {
+stdenv.lib.overrideDerivation (buildLinux (args // rec {
   version = "${modDirVersion}-${tag}";
   inherit modDirVersion;
 

--- a/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-samus-4.12.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, ncurses, ... } @ args:
 
-import ./generic.nix (args // rec {
+buildLinux (args // rec {
   version = "4.12.2";
   extraMeta.branch = "4.12-2";
 

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+buildLinux (args // rec {
   version = "4.11.2017.08.23";
   modDirVersion = "4.11.0";
   extraMeta.branch = "master";

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libelf, utillinux, ... } @ args:
 
-import ./generic.nix (args // rec {
+buildLinux (args // rec {
   version = "4.15-rc9";
   modDirVersion = "4.15.0-rc9";
   extraMeta.branch = "4.15";

--- a/pkgs/os-specific/linux/kernel/update.sh
+++ b/pkgs/os-specific/linux/kernel/update.sh
@@ -50,13 +50,13 @@ ls $NIXPKGS/pkgs/os-specific/linux/kernel | while read FILE; do
   # Rewrite the expression
   sed -i -e '/version = /d' -e '/modDirVersion = /d' $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
   if grep -q '^[0-9]\+.[0-9]\+$' <<< "$V"; then
-    sed -i "\#import ./generic.nix (args // rec {#a \  modDirVersion = \"${V}.0\";" $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
+    sed -i "\#buildLinux (args // rec {#a \  modDirVersion = \"${V}.0\";" $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
   fi
-  sed -i "\#import ./generic.nix (args // rec {#a \  version = \"$V\";" $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
+  sed -i "\#buildLinux (args // rec {#a \  version = \"$V\";" $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
 
   # Commit the changes
   git add -u $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
   git commit -m "kernel: $OLDVER -> $V" >/dev/null 2>&1
-  
+
   echo "Updated $OLDVER -> $V"
 done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13197,7 +13197,7 @@ with pkgs;
 
   # A function to build a manually-configured kernel
   linuxManualConfig = pkgs.buildLinux;
-  buildLinux = makeOverridable (callPackage ../os-specific/linux/kernel/manual-config.nix {});
+  buildLinux = makeOverridable (callPackage ../os-specific/linux/kernel/generic.nix {});
 
   keyutils = callPackage ../os-specific/linux/keyutils { };
 


### PR DESCRIPTION
###### Motivation for this change
Make linux kernel packaging easier & nix-shell work smoother, possibly as part of https://github.com/NixOS/nixpkgs/issues/34274#issuecomment-360815413

- adds possibility to override fields that currently belong to the hostSystem part (namely autoModules and preferBuiltin) . Otherwise one has to run this kind of commands https://github.com/NixOS/nixpkgs/pull/29944#issuecomment-360627518. Hopefully this can also allow to Remove "argsOverride" from linux kernel https://github.com/NixOS/nixpkgs/pull/32014 and also address https://github.com/NixOS/nixpkgs/issues/20187
- make it easier to work in a nix-shell, to prevent https://github.com/NixOS/nixpkgs/pull/31463

###### Things done
- Added error message in generate-config.pl
- moved the `$buildRoot` to within the source folder, this way it doesn't have to be created before the unpackPhase and make it easier to work on kernel source without running the unpackPhase.
- defined buildLinux as generic.nix instead of manual-config.nix . This way one can run
```
buildLinux (rec {
  mptcpVersion = "0.93";
  modDirVersion = "4.9.60";
  version = "${modDirVersion}-mptcp_v${mptcpVersion}";
  # autoModules= true;
```
instead of 
```
import ./generic.nix (rec {
  mptcpVersion = "0.93";
  modDirVersion = "4.9.60";

```
which looks more userfriendly (more similar to the rest of nixpkgs, e.g.,buildPythonPackage, buildLua). If allows to merge at a later date the generic.nix and manual-config.nix to simplify the derivation (https://github.com/NixOS/nixpkgs/issues/2296).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@Ericson2314 If you agree with it, I might replace the `./import generic.nix` by `buildLinux` other than mptcp. I added ncurses as a dependancy because I hate not being able to edit my kernel .config manually when in my shell. I could remove it or make it optional.