### PR TITLE
pythonPackages.discordpy: Use websockets==3.4

### DIFF
--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -1,22 +1,27 @@
 { lib
-, fetchurl
-, buildPythonPackage
-, pythonOlder
+, python
 , withVoice ? true, libopus
-, asyncio
-, aiohttp
-, websockets
-, pynacl
 }:
 
 let
+  py = python.override {
+    packageOverrides = self: super: {
+      websockets = super.websockets.overridePythonAttrs (oldAttrs: rec {
+        version = "3.4";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "1idwcdxd36q7ks5w1yjgg15d2sw81kg2lvk4dx60l06h3psvkra3";
+        };
+      });
+    };
+  };
+
+in with py.pkgs; buildPythonPackage rec {
   pname = "discord.py";
   version = "0.16.12";
-in buildPythonPackage rec {
-  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "17fb8814100fbaf7a79468baa432184db6cef3bbea4ad194fe297c7407d50108";
   };
 

--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -1,17 +1,15 @@
 { lib
-, fetchurl
+, fetchPypi
 , buildPythonPackage
 , pythonOlder
 }:
 
-let
+buildPythonPackage rec {
   pname = "websockets";
   version = "4.0.1";
-in buildPythonPackage rec {
-  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "da4d4fbe059b0453e726d6d993760065d69b823a27efc3040402a6fcfe6a1ed9";
   };
 


### PR DESCRIPTION
###### Motivation for this change
discord.py only works with websockets<4
See Rapptz/discord.py#973

I have not tested this, since I have no use for discord.py.
I only came across the problem using `nox-review` on #34352.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

