### PR TITLE
nixos/containers: Enable use of the network.useHostResolvConf option

### DIFF
--- a/nixos/modules/virtualisation/container-config.nix
+++ b/nixos/modules/virtualisation/container-config.nix
@@ -11,7 +11,7 @@ with lib;
     services.udisks2.enable = mkDefault false;
     powerManagement.enable = mkDefault false;
 
-    networking.useHostResolvConf = true;
+    networking.useHostResolvConf = mkDefault true;
 
     # Containers should be light-weight, so start sshd on demand.
     services.openssh.startWhenNeeded = mkDefault true;


### PR DESCRIPTION
###### Motivation for this change

Currently `containers.<name>.networking.useHostResolvConf = false;` can never be set as it's in conflict with the `true` value in container-config.nix. This PR enables setting the option to false.

/etc/resolv.conf from the host will still always be copied. nspawn does this only when private networking is not enabled but NixOS does it unconditionally.
https://github.com/NixOS/nixpkgs/blob/5eb4a8339c7f33e4239aebe0ebfa7b0cdceee6b6/nixos/modules/virtualisation/containers.nix#L85

Therefore useHostResolvConf=false relies on resolvconf to overwrite /etc/resolv.conf in the container.
https://github.com/NixOS/nixpkgs/blob/b4820d49489a8b832cb9148bd23c4ddab03dce5a/nixos/modules/system/boot/stage-2-init.sh#L109-L112
https://github.com/NixOS/nixpkgs/blob/07e0c0e0a2f237639600f2a0d62f6eac748b1e6e/nixos/modules/tasks/network-interfaces-scripted.nix#L113-L117


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

