### PR TITLE
xnbd: init at 0.4.0

### DIFF
--- a/pkgs/tools/networking/xnbd/default.nix
+++ b/pkgs/tools/networking/xnbd/default.nix
@@ -1,16 +1,18 @@
-{ stdenv, fetchurl, pkgconfig, glib }:
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, glib, jansson, asciidoc, libxml2, libxslt, docbook_xml_dtd_45 }:
 
 stdenv.mkDerivation rec {
-  name = "xnbd-0.3.0";
+  name = "xnbd-0.4.0";
 
   src = fetchurl {
-    url = "https://bitbucket.org/hirofuchi/xnbd/downloads/${name}.tar.bz2";
-    sha256 = "0jlv6cx85sjn8vjhgzmcs5mz2b6xf18mp0h61v1gl7xkbalw1flb";
+    url = "https://bitbucket.org/hirofuchi/xnbd/downloads/${name}.tgz";
+    sha256 = "00wkvsa0yaq4mabczcbfpj6rjvp02yahw8vdrq8hgb3wpm80x913";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  sourceRoot = "${name}/trunk";
 
-  buildInputs = [ glib ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ glib jansson asciidoc libxml2 libxslt docbook_xml_dtd_45 ];
 
   meta = {
     homepage = https://bitbucket.org/hirofuchi/xnbd;

--- a/pkgs/tools/networking/xnbd/default.nix
+++ b/pkgs/tools/networking/xnbd/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig, glib }:
+
+stdenv.mkDerivation rec {
+  name = "xnbd-0.3.0";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/hirofuchi/xnbd/downloads/${name}.tar.bz2";
+    sha256 = "0jlv6cx85sjn8vjhgzmcs5mz2b6xf18mp0h61v1gl7xkbalw1flb";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ glib ];
+
+  meta = {
+    homepage = https://bitbucket.org/hirofuchi/xnbd;
+    description = "Yet another NBD (Network Block Device) server program";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.volth ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/xnbd/default.nix
+++ b/pkgs/tools/networking/xnbd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook, glib, jansson, asciidoc, libxml2, libxslt, docbook_xml_dtd_45 }:
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, glib, jansson }:
 
 stdenv.mkDerivation rec {
   name = "xnbd-0.4.0";
@@ -12,7 +12,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = [ glib jansson asciidoc libxml2 libxslt docbook_xml_dtd_45 ];
+  buildInputs = [ glib jansson ];
+
+  # do not build docs, it is slow and it fails on Hydra
+  prePatch = ''
+    rm -rf doc
+    substituteInPlace configure.ac --replace "doc/Makefile" ""
+    substituteInPlace Makefile.am --replace "lib doc ." "lib ."
+  '';
 
   meta = {
     homepage = https://bitbucket.org/hirofuchi/xnbd;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3614,6 +3614,7 @@ with pkgs;
   nawk = callPackage ../tools/text/nawk { };
 
   nbd = callPackage ../tools/networking/nbd { };
+  xnbd = callPackage ../tools/networking/xnbd { };
 
   nccl = callPackage ../development/libraries/science/math/nccl {
     cudatoolkit = cudatoolkit8;


### PR DESCRIPTION
###### Motivation for this change

It requires to mount network volumes on scaleway.com (including /-volume on baremetal servers, when ```xnbd-client``` is to be copied to initrd and [run in](https://github.com/scaleway/initrd/blob/51c564e6ac76c3be70622e6c92c6415732e063ec/Linux/tree-common/functions#L264) ```boot.initrd.preLVMCommands```).

Normal ```nbd``` does not work on scaleway (it shows errors about protocol mismatch).

Here are two commits "xnbd: init at 0.3.0" and "xnbd: 0.3.0 -> 0.4.0" to preserve working 0.3.0 derivation in the git history
The distros officially supported by scaleway.com (Ubuntu, etc) still use 0.3.0, so in case of possible issues with 0.4.0, the latter commit could be undone