### PR TITLE
doitlive: init at 3.0.3

### DIFF
--- a/pkgs/tools/misc/doitlive/default.nix
+++ b/pkgs/tools/misc/doitlive/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "doitlive";
+  version = "3.0.3";
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "19i16ca835rb3gal1sxyvpyilj9a80n6nikf0smlzmxck38x86fj";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ click ];
+
+  # disable tests (too many failures)
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Tool for live presentations in the terminal";
+    homepage = https://pypi.python.org/pypi/doitlive;
+    license = licenses.mit;
+    maintainers = with maintainers; [ mbode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1114,6 +1114,8 @@ with pkgs;
 
   dlx = callPackage ../misc/emulators/dlx { };
 
+  doitlive = callPackage ../tools/misc/doitlive { };
+
   dosage = pythonPackages.dosage;
 
   dpic = callPackage ../tools/graphics/dpic { };


### PR DESCRIPTION
###### Motivation for this change
Add package _doitlive_

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

