### PR TITLE
ranger: 1.8.1 -> 1.9.0

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, file, less
+{ stdenv, fetchFromGitHub, pythonPackages, file, less
 , imagePreviewSupport ? true, w3m ? null}:
 
 with stdenv.lib;
@@ -6,18 +6,14 @@ with stdenv.lib;
 assert imagePreviewSupport -> w3m != null;
 
 pythonPackages.buildPythonApplication rec {
-  name = "ranger-1.8.1";
+  name = "ranger-v${version}";
+  version = "1.9.0";
 
-  meta = {
-    description = "File manager with minimalistic curses interface";
-    homepage = http://ranger.nongnu.org/;
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.unix;
-  };
-
-  src = fetchurl {
-    url = "http://ranger.nongnu.org/${name}.tar.gz";
-    sha256 = "1d11qw0mr9aj22a7nhr6p2c3yzf359xbffmjsjblq44bjpwzjcql";
+  src = fetchFromGitHub {
+    owner = "ranger";
+    repo = "ranger";
+    rev = "v${version}";
+    sha256= "0h3qz0sr21390xdshhlfisvscja33slv1plzcisg1wrdgwgyr5j6";
   };
 
   checkInputs = with pythonPackages; [ pytest ];
@@ -50,4 +46,11 @@ pythonPackages.buildPythonApplication rec {
       --replace "set preview_images false" "set preview_images true" \
   '';
 
+  meta =  with stdenv.lib; {
+    description = "File manager with minimalistic curses interface";
+    homepage = http://ranger.github.io/;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.magnetophon ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

