### PR TITLE
pdns-recursor: 4.0.8 -> 4.1.1

### DIFF
--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -1,28 +1,25 @@
 { stdenv, fetchurl, pkgconfig, boost
 , openssl, systemd, lua, luajit, protobuf
-, enableLua ? false
 , enableProtoBuf ? false
 }:
-
-assert enableLua      -> lua != null && luajit != null;
 assert enableProtoBuf -> protobuf != null;
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "pdns-recursor-${version}";
-  version = "4.0.8";
+  version = "4.1.1";
 
   src = fetchurl {
     url = "https://downloads.powerdns.com/releases/pdns-recursor-${version}.tar.bz2";
-    sha256 = "04v5y6mfdhn8ikigqmm3k5k0zz5l8d3k1a7ih464n1161q7z0vww";
+    sha256 = "0srrw726qpwg69v75dwbxab9hk73x1wia4rcnmf7g5qr2k3h7swg";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     boost openssl systemd
-  ] ++ optional enableLua [ lua luajit ]
-    ++ optional enableProtoBuf protobuf;
+    lua luajit
+  ] ++ optional enableProtoBuf protobuf;
 
   configureFlags = [
     "--enable-reproducible"


### PR DESCRIPTION
###### Motivation for this change
4.0.8 introduced an issue with DNSSEC, this version, among other things, fixes that.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change`
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @vcunat
