### PR TITLE
glib: Fix Darwin build

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -75,7 +75,9 @@ stdenv.mkDerivation rec {
   # internal pcre would only add <200kB, but it's relatively common
   configureFlags = [ "--with-pcre=system" ]
     ++ optional stdenv.isDarwin "--disable-compile-warnings"
-    ++ optional (stdenv.hostPlatform.libc != "glibc") "--with-libiconv=gnu"
+    # glibc inclues GNU libiconv, but Darwin's iconv function is good enonugh.
+    ++ optional (stdenv.hostPlatform.libc != "glibc" && !stdenv.hostPlatform.isDarwin)
+      "--with-libiconv=gnu"
     ++ optional stdenv.isSunOS "--disable-dtrace"
     # Can't run this test when cross-compiling
     ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform)


### PR DESCRIPTION
###### Motivation for this change

Fix the failure caused in #34198 by a suggested change of mine. @vcunat reported  in https://github.com/NixOS/nixpkgs/pull/34198#issuecomment-361075911.

###### Things done

Restored how flags were before so its bound to work.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---