### PR TITLE
pulp: init at 1.6.0

### DIFF
--- a/pkgs/development/python-modules/pulp/default.nix
+++ b/pkgs/development/python-modules/pulp/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchPypi, buildPythonPackage, pyparsing }:
+
+buildPythonPackage rec {
+  pname = "PuLP";
+  version = "1.6.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1irzpfnnm5f0qf8y9ddxi489nwixyj0q4zlvqafm621bijkxdv6g";
+  };
+
+  buildInputs = [];
+  propagatedBuildInputs = [ pyparsing ];
+
+  # only one test that requires an extra
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/coin-or/pulp;
+    description = "PuLP is an LP modeler written in python";
+    maintainers = with maintainers; [ teto ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22374,6 +22374,8 @@ EOF
 
   pyemd  = callPackage ../development/python-modules/pyemd { };
 
+  pulp  = callPackage ../development/python-modules/pulp { };
+
   behave = callPackage ../development/python-modules/behave { };
 
   pyhamcrest = callPackage ../development/python-modules/pyhamcrest { };


### PR DESCRIPTION
A python Linear Programming API.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
NB: isn't there a way to better automate simple python packages ? like putting them in a whitelist