### PR TITLE
Upgrade kernel compiler to GCC 7.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13159,7 +13159,10 @@ with pkgs;
 
   # A function to build a manually-configured kernel
   linuxManualConfig = pkgs.buildLinux;
-  buildLinux = makeOverridable (callPackage ../os-specific/linux/kernel/manual-config.nix {});
+  buildLinux = makeOverridable (callPackage ../os-specific/linux/kernel/manual-config.nix {
+    # Build kernel with gcc 7.3.0 (or later) to have a retpoline enabled compiler.
+    buildPackages = buildPackages // { stdenv = overrideCC buildPackages.stdenv gcc7; };
+  });
 
   keyutils = callPackage ../os-specific/linux/keyutils { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12974,6 +12974,7 @@ with pkgs;
     callPackage = newScope self;
 
     inherit kernel;
+    stdenv = overrideCC pkgs.stdenv kernel.buildCc;
 
     acpi_call = callPackage ../os-specific/linux/acpi-call {};
 


### PR DESCRIPTION
###### Motivation for this change
Kernel spectre v2 hardening, see
https://github.com/NixOS/nixpkgs/issues/34383

###### Things done
* Compiled and booted into.
* Check that `modinfo zfs` shows `vermagic: 4.14.15 SMP mod_unload retpoline`.
* Check the output of `grep . /sys/devices/system/cpu/vulnerabilities/*`:
```
/sys/devices/system/cpu/vulnerabilities/meltdown:Not affected
/sys/devices/system/cpu/vulnerabilities/spectre_v1:Vulnerable
/sys/devices/system/cpu/vulnerabilities/spectre_v2:Mitigation: Full AMD retpoline
```

This is only PR is only for discussion. I found the use of stdenvKernelCc a bit ugly, but couldn't find a more idiomatic expression. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

