### PR TITLE
looking-glass-client: init at a10

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -543,6 +543,7 @@
   pmahoney = "Patrick Mahoney <pat@polycrystal.org>";
   pmeunier = "Pierre-Étienne Meunier <pierre-etienne.meunier@inria.fr>";
   pmiddend = "Philipp Middendorf <pmidden@secure.mailbox.org>";
+  pneumaticat = "Kevin Liu <kevin@potatofrom.space>";
   polyrod = "Maurizio Di Pietro <dc1mdp@gmail.com>";
   pradeepchhetri = "Pradeep Chhetri <pradeep.chhetri89@gmail.com>";
   prikhi = "Pavan Rikhi <pavan.rikhi@gmail.com>";

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, SDL2, SDL, SDL2_ttf, openssl, spice_protocol, fontconfig
+, libX11, freefont_ttf
+}:
+
+stdenv.mkDerivation rec {
+  name = "looking-glass-client-${version}";
+  version = "a10";
+
+  src = fetchFromGitHub {
+    owner = "gnif";
+    repo = "LookingGlass";
+    rev = version;
+    sha256 = "10jxnkrvskjzkg86iz3hnb5v91ykzx6pvcnpy1v4436g5f2d62wn";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    SDL SDL2 SDL2_ttf openssl spice_protocol fontconfig
+    libX11 freefont_ttf
+  ];
+
+  enableParallelBuilding = true;
+
+  sourceRoot = "source/client";
+
+  installPhase = ''
+    mkdir -p $out
+    mv bin $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A KVM Frame Relay (KVMFR) implementation";
+    longDescription = ''
+      Looking Glass is an open source application that allows the use of a KVM
+      (Kernel-based Virtual Machine) configured for VGA PCI Pass-through
+      without an attached physical monitor, keyboard or mouse. This is the final
+      step required to move away from dual booting with other operating systems
+      for legacy programs that require high performance graphics.
+    '';
+    homepage = https://looking-glass.hostfission.com/;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.pneumaticat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16038,6 +16038,8 @@ with pkgs;
     flavour = "git";
   };
 
+  looking-glass-client = callPackage ../applications/virtualization/looking-glass-client { };
+
   lumail = callPackage ../applications/networking/mailreaders/lumail { };
 
   lv2bm = callPackage ../applications/audio/lv2bm { };


### PR DESCRIPTION
###### Motivation for this change

An application to relay frames from a KVM VFIO virtual machine (e.g. running Windows) to a window on the Linux host using shared memory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

