### PR TITLE
security.acme: added reload and restart lists for sytemd targets

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -10,6 +10,7 @@ let
     options = {
       webroot = mkOption {
         type = types.str;
+        example = "/var/lib/acme/acme-challenges";
         description = ''
           Where the webroot of the HTTP vhost is located.
           <filename>.well-known/acme-challenge/</filename> directory
@@ -64,7 +65,7 @@ let
         type = types.attrsOf (types.submodule {
           options = {
             action = mkOption {
-              type = enum [ "restart" "reload" ];
+              type = types.enum [ "restart" "reload" ];
               default = null;
               description = ''
                 An action to execute on systemd services after certificates are re-issues.

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -165,7 +165,6 @@ in
       certs = mkOption {
         default = { };
         type = with types; attrsOf (submodule certOpts);
-
         description = ''
           Attribute set of certificates to get signed and renewed.
         '';


### PR DESCRIPTION
###### Motivation for this change

* added a list for systemd reload and restart targets
* using the nixos module system to set the default at the domain option (instead of using code in the `config = ` section which duplicates code and makes it not accessible from outside the acme.nix scope)

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

