### PR TITLE
Add a containerd module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -982,6 +982,7 @@
   ./testing/service-runner.nix
   ./virtualisation/anbox.nix
   ./virtualisation/container-config.nix
+  ./virtualisation/containerd.nix
   ./virtualisation/containers.nix
   ./virtualisation/nixos-containers.nix
   ./virtualisation/oci-containers.nix

--- a/nixos/modules/virtualisation/containerd.nix
+++ b/nixos/modules/virtualisation/containerd.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.virtualisation.containerd;
+in
+{
+  options.virtualisation.containerd = {
+    enable = mkEnableOption "Containerd container runtime";
+
+    listenOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ "/run/containerd/containerd.sock" ];
+      description =
+        ''
+          A list of unix and TCP socket containerd should listen to. The format follows
+          ListenStream as described in systemd.socket(5).
+        '';
+    };
+
+    packages = mkOption {
+      type = types.listOf types.package;
+      default = [ pkgs.runc ];
+      defaultText = "[ pkgs.runc ]";
+      description = "List of packages to be added to containerd service path";
+    };
+
+    extraOptions = mkOption {
+      type = types.separatedString " ";
+      default = "";
+      description =
+        ''
+          The extra command-line options to pass to
+          <command>containerd</command> daemon.
+        '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.containerd ];
+    systemd.packages = [ pkgs.containerd ];
+
+    systemd.services.containerd = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.containerd}/bin/containerd ${cfg.extraOptions}";
+      };
+      path = [ pkgs.containerd ] ++ cfg.packages;
+    };
+
+
+    systemd.sockets.containerd = {
+      description = "Containerd Socket for the API";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = cfg.listenOptions;
+        SocketMode = "0660";
+        SocketUser = "root";
+        SocketGroup = "root";
+      };
+    };
+
+  };
+
+
+}


### PR DESCRIPTION
This add a containerd module so you can have a containerd systemd service
running and using it with other tools. One possibility is to make dockerd
using this containerd service using `--containerd` flag on dockerd

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Have a `containerd` module, that could be used with `dockerd` or `kubernetes` and `cri-containerd`, etc..

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

