### PR TITLE
Adds modifier option to developPackage

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -161,18 +161,19 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     # : { root : Path
     #   , source-overrides : Defaulted (Either Path VersionNumber)
     #   , overrides : Defaulted (HaskellPackageOverrideSet)
+    #   , modifier : Defaulted
     #   } -> NixShellAwareDerivation
     # Given a path to a haskell package directory whose cabal file is
     # named the same as the directory name, an optional set of
     # source overrides as appropriate for the 'packageSourceOverrides'
-    # function, and an optional set of arbitrary overrides,
-    # return a derivation appropriate for nix-build or nix-shell
-    # to build that package.
-    developPackage = { root, source-overrides ? {}, overrides ? self: super: {} }:
+    # function, an optional set of arbitrary overrides, and an optional
+    # haskell package modifier,  return a derivation appropriate
+    # for nix-build or nix-shell to build that package.
+    developPackage = { root, source-overrides ? {}, overrides ? self: super: {}, modifier ? drv: drv }:
       let name = builtins.baseNameOf root;
           drv =
             (extensible-self.extend (pkgs.lib.composeExtensions (self.packageSourceOverrides source-overrides) overrides)).callCabal2nix name root {};
-      in if pkgs.lib.inNixShell then drv.env else drv;
+      in if pkgs.lib.inNixShell then (modifier drv).env else modifier drv;
 
     ghcWithPackages = selectFrom: withPackages (selectFrom self);
 


### PR DESCRIPTION
###### Motivation for this change
`developPackage` uses the default haskell package settings. While the option to set `(source-)overrides` allows the modification of packages the derivation depends on (e.g. `dontHaddock`, `doBenchmark`, ...), these settings can't be updated for the package itself. Adding the option to pass a `modifier` unlocks this option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

