### PR TITLE
gnome-shell-extension-clipboard-indicator: init at v30

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/clipboard-indicator/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/clipboard-indicator/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-clipboard-indicator-${version}";
+  version = "30";
+
+  src = fetchFromGitHub {
+    owner = "Tudmotu";
+    repo = "gnome-shell-extension-clipboard-indicator";
+    rev = "v${version}";
+    sha256 = "1fmgmxv2y678bj0kmymkgnnglcpqk8ww053izlq46xg7s27jjdf6";
+  };
+
+  uuid = "clipboard-indicator@tudmotu.com";
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r * $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Adds a clipboard indicator to the top panel and saves clipboard history";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonafato ];
+    platforms = platforms.linux;
+    homepage = https://github.com/Tudmotu/gnome-shell-extension-clipboard-indicator;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15010,7 +15010,7 @@ with pkgs;
   inherit (gnome3) evince;
   evolution_data_server = gnome3.evolution_data_server;
 
-  keepass = callPackage ../applications/misc/keepass { 
+  keepass = callPackage ../applications/misc/keepass {
     buildDotnetPackage = buildDotnetPackage.override { mono = mono54; };
   };
 
@@ -18874,6 +18874,7 @@ with pkgs;
 
   gnomeExtensions = {
     caffeine = callPackage ../desktops/gnome-3/extensions/caffeine { };
+    clipboard-indicator = callPackage ../desktops/gnome-3/extensions/clipboard-indicator { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };


### PR DESCRIPTION
###### Motivation for this change

Add the Clipboard Indicator GNOME Shell extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

