### PR TITLE
rdma-core: fix rxe_cfg and platforms flags

### DIFF
--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig
-, ethtool, libnl, libudev, python, perl
+, ethtool, nettools, libnl, libudev, python, perl
 } :
 
 let
@@ -16,10 +16,13 @@ in stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libnl ethtool libudev python perl ];
+  buildInputs = [ libnl ethtool nettools libudev python perl ];
 
-  postFixup = ''
-    substituteInPlace $out/bin/rxe_cfg --replace ethtool "${ethtool}/bin/ethtool"
+  postPatch = ''
+    substituteInPlace providers/rxe/rxe_cfg.in \
+      --replace '@CMAKE_INSTALL_FULL_SHAREDSTATEDIR@' '/run' \
+      --replace ethtool "${ethtool}/bin/ethtool" \
+      --replace ifconfig "${nettools}/bin/ifconfig"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -18,9 +18,13 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ libnl ethtool nettools libudev python perl ];
 
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_RUNDIR=/run"
+    "-DCMAKE_INSTALL_SHAREDSTATEDIR=/var/lib"
+  ];
+
   postPatch = ''
     substituteInPlace providers/rxe/rxe_cfg.in \
-      --replace '@CMAKE_INSTALL_FULL_SHAREDSTATEDIR@' '/run' \
       --replace ethtool "${ethtool}/bin/ethtool" \
       --replace ifconfig "${nettools}/bin/ifconfig"
   '';

--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -29,6 +29,7 @@ in stdenv.mkDerivation {
     description = "RDMA Core Userspace Libraries and Daemons";
     homepage = https://github.com/linux-rdma/rdma-core;
     license = licenses.gpl2;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ markuskowa ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Fix a path in `rxe_cfg` for persistent config data (script crashes when location in /nix/store) 
- proper path for `ifconfig`
- Set platform flag to linux

###### Things done
rxe_cfg can now be used to add RDMA transport to network interface
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

