### PR TITLE
beegfs: add beeond, enable RDMA

### DIFF
--- a/pkgs/os-specific/linux/beegfs/default.nix
+++ b/pkgs/os-specific/linux/beegfs/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, unzip, which
-, libuuid, attr, xfsprogs, cppunit
+, libuuid, attr, xfsprogs, cppunit, rdma-core
 , zlib, openssl, sqlite, jre, openjdk, ant
 } :
 
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ which unzip pkgconfig cppunit openjdk ant];
-  buildInputs = [ libuuid attr xfsprogs zlib openssl sqlite jre ];
+  buildInputs = [ libuuid attr xfsprogs zlib openssl sqlite jre rdma-core ];
 
   postPatch = ''
     patchShebangs ./
@@ -42,9 +42,9 @@ in stdenv.mkDerivation rec {
 
   buildPhase = ''
     for i in ${toString subdirs}; do
-      make -C $i
+      make -C $i BEEGFS_OPENTK_IBVERBS=1
     done
-    make -C beegfs_admon/build admon_gui
+    make -C beegfs_admon/build admon_gui BEEGFS_OPENTK_IBVERBS=1
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
- Enable compilation of beeond feature. BeeOND sets up a beegfs  on demand across as set of nodes and mounts it.
- Add` rdma-core` to inputs and enable RDMA transport option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Tested BeeOND setup and tear down in virtualbox environment

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
beegfs test suceeds
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

