### PR TITLE
postfix: Correct license

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -200,6 +200,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Eclipse Public License 1.0";
   };
 
+  epl20 = spdx {
+    spdxId = "EPL-2.0";
+    fullName = "Eclipse Public License 2.0";
+  };
+
   epson = {
     fullName = "Seiko Epson Corporation Software License Agreement for Linux";
     url = https://download.ebz.epson.net/dsc/du/02/eula/global/LINUX_EN.html;

--- a/pkgs/servers/mail/postfix/default.nix
+++ b/pkgs/servers/mail/postfix/default.nix
@@ -90,7 +90,7 @@ in stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.postfix.org/;
     description = "A fast, easy to administer, and secure mail server";
-    license = lib.licenses.bsdOriginal;
+    license = with lib.licenses; [ ipl10 epl20 ];
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.rickynils ];
   };


### PR DESCRIPTION
###### Motivation for this change
The postfix derivation incorrectly lists BSD as the license, whereas postfix up to version 3.2.4 is licensed under IBM Public License 1.0. Maybe this should also be corrected in the 17.09 branch.
According to http://www.postfix.org/announcements/postfix-3.2.5.html,

> starting with Postfix 3.2.5, Postfix 3.2 is distributed with a dual license: in addition to the historical IBM Public License 1.0, it is now also distributed with the more recent Eclipse Public License 2.0.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc maintainer @rickynils 