### PR TITLE
ibus-kkc engine support

### DIFF
--- a/pkgs/data/misc/libkkc-data/default.nix
+++ b/pkgs/data/misc/libkkc-data/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, marisa, libkkc }:
+
+stdenv.mkDerivation rec {
+  pname = "libkkc-data";
+  version = "0.2.7";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "${meta.homepage}/releases/download/v${libkkc.version}/${name}.tar.xz";
+    sha256 = "16avb50jasq2f1n9xyziky39dhlnlad0991pisk3s11hl1aqfrwy";
+  };
+
+  nativeBuildInputs = [ marisa ];
+
+  meta = with stdenv.lib; {
+    description = "Language model data package for libkkc";
+    homepage    = https://github.com/ueno/libkkc;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vanzef ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/marisa/default.nix
+++ b/pkgs/development/python-modules/marisa/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, marisa, swig }:
+
+buildPythonPackage rec {
+  pname = "marisa";
+  version = "1.3.40";
+
+  src = fetchFromGitHub {
+    owner = "s-yata";
+    repo  = "marisa-trie";
+    rev   = "59e410597981475bae94d9d9eb252c1d9790dc2f";
+    sha256 = "0z4bf55np08q3cbi6gvj3cpw3zp8kf2d0jq6k74pjk066m7rapbb";
+  };
+
+  nativeBuildInputs = [ swig marisa ];
+  buildinputs = [ marisa ];
+
+  sourceRoot = "${src.name}/bindings/python";
+
+  meta = with stdenv.lib; {
+    description = "Python binding for marisa package (do not confuse with marisa-trie python bindings)";
+    homepage    = https://github.com/s-yata/marisa-trie;
+    license     = with licenses; [ bsd2 lgpl2 ];
+    maintainers = with maintainers; [ vanzef ];
+  };
+}

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-kkc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-kkc/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl
+, vala, intltool, pkgconfig
+, libkkc, ibus, skk-dicts
+, gtk3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ibus-kkc";
+  version = "1.5.22";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "${meta.homepage}/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "1kj74c9zy9yxkjx7pz96mzqc13cf10yfmlgprr8sfd4ay192bzi2";
+  };
+
+  nativeBuildInputs = [
+    vala intltool pkgconfig
+  ];
+
+  buildInputs = [ libkkc ibus skk-dicts gtk3 ];
+
+  postInstall = ''
+    ln -s ${skk-dicts}/share $out/share/skk
+  '';
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description  = "libkkc (Japanese Kana Kanji input method) engine for ibus";
+    homepage     = https://github.com/ueno/ibus-kkc;
+    license      = licenses.gpl2;
+    platforms    = platforms.linux;
+    maintainers  = with maintainers; [ vanzef ];
+  };
+}

--- a/pkgs/tools/inputmethods/libkkc/default.nix
+++ b/pkgs/tools/inputmethods/libkkc/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl
+, vala, gobjectIntrospection, intltool, python2Packages, glib
+, pkgconfig
+, libgee, json_glib, marisa, libkkc-data
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libkkc";
+  version = "0.3.5";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "${meta.homepage}/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "89b07b042dae5726d306aaa1296d1695cb75c4516f4b4879bc3781fe52f62aef";
+  };
+
+  nativeBuildInputs = [
+    vala gobjectIntrospection
+    python2Packages.python python2Packages.marisa
+    intltool glib pkgconfig
+  ];
+
+  buildInputs = [ marisa libkkc-data ];
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = [ libgee json_glib ];
+
+  postInstall = ''
+    ln -s ${libkkc-data}/lib/libkkc/models $out/share/libkkc/models
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Japanese Kana Kanji conversion input method library";
+    homepage    = https://github.com/ueno/libkkc;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vanzef ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1586,6 +1586,10 @@ with pkgs;
     inherit (pythonPackages) marisa;
   };
 
+  libkkc = callPackage ../tools/inputmethods/libkkc {
+    inherit (gnome3) libgee;
+  };
+
   ibus = callPackage ../tools/inputmethods/ibus {
     inherit (gnome3) dconf gconf glib;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1601,6 +1601,8 @@ with pkgs;
 
     hangul = callPackage ../tools/inputmethods/ibus-engines/ibus-hangul { };
 
+    kkc = callPackage ../tools/inputmethods/ibus-engines/ibus-kkc { };
+
     libpinyin = callPackage ../tools/inputmethods/ibus-engines/ibus-libpinyin { };
 
     m17n = callPackage ../tools/inputmethods/ibus-engines/ibus-m17n { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1582,6 +1582,10 @@ with pkgs;
   skktools = callPackage ../tools/inputmethods/skk/skktools { };
   skk-dicts = callPackage ../tools/inputmethods/skk/skk-dicts { };
 
+  libkkc-data = callPackage ../data/misc/libkkc-data {
+    inherit (pythonPackages) marisa;
+  };
+
   ibus = callPackage ../tools/inputmethods/ibus {
     inherit (gnome3) dconf gconf glib;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10042,6 +10042,10 @@ in {
   mozversion = callPackage ../development/python-modules/marionette-harness/mozversion.nix {};
   marionette-harness = callPackage ../development/python-modules/marionette-harness {};
 
+  marisa = callPackage ../development/python-modules/marisa {
+    marisa = pkgs.marisa;
+  };
+
   markupsafe = buildPythonPackage rec {
     name = "markupsafe-${version}";
     version = "1.0";


### PR DESCRIPTION
###### Motivation for this change
This PR adds support for ibus-kkc IME, based on libkkc.

###### Things done

Added packages `pythonPackages.marisa` (python bindings, generated by swig), `libkkc`, `libkkc-data` and `ibus-kkc`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

