### PR TITLE
dunst: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "dunst-${version}";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "dunst-project";
     repo = "dunst";
     rev = "v${version}";
-    sha256 = "1085v4193yfj8ksngp4mk5n0nwzr3s5y3cs3c74ymaldfl20x91k";
+    sha256 = "0i518v2z9fklzl5w60gkwwmg30yz3bd0k4rxjrxjabx73pvxm1mz";
   };
 
   nativeBuildInputs = [ perl pkgconfig which systemd ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

