### PR TITLE
Tensorflow: revert to wheel-based build and update to 1.5.0

### DIFF
--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "numpy";
-  version = "1.13.3";
+  version = "1.14.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "36ee86d5adbabc4fa2643a073f93d5504bdfed37a149a3a49f4dde259f35a750";
+    sha256 = "1ywrq31sy8hkgis1sv9kgac53v2478r1i01442s0f8r1bf9l7rix";
   };
 
   disabled = isPyPy;

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -1,187 +1,112 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, symlinkJoin, buildPythonPackage, isPy3k, pythonOlder
-, bazel, which, swig, binutils, glibcLocales
-, python, jemalloc, openmpi
-, numpy, six, protobuf, tensorflow-tensorboard, backports_weakref
-, wheel, mock, scipy
-, xlaSupport ? true
-, cudaSupport ? false, nvidia_x11 ? null, cudatoolkit ? null, cudnn ? null
-# Default from ./configure script
-, cudaCapabilities ? [ "3.5" "5.2" ]
-, sse42Support ? false
-, avx2Support ? false
-, fmaSupport ? false
+{ stdenv
+, symlinkJoin
+, lib
+, fetchurl
+, python
+, buildPythonPackage
+, isPy3k, isPy35, isPy36, isPy27
+, cudaSupport ? false
+, nvidia_x11 ? null
+, cudatoolkit ? null
+, cudnn ? null
+, linuxPackages ? null
+, tensorflow-tensorboard
+, six
+, protobuf
+, numpy
+, mock
+, backports_weakref
+, absl-py
+, zlib
 }:
 
 assert cudaSupport -> cudatoolkit != null
-                   && cudnn != null;
+                   && cudnn != null
+                   && linuxPackages != null;
 
 # unsupported combination
 assert ! (stdenv.isDarwin && cudaSupport);
 
-let
+# tensorflow is built from a downloaded wheel, because the upstream
+# project's build system is an arcane beast based on
+# bazel. Untangling it and building the wheel from source is an open
+# problem.
 
-  withTensorboard = pythonOlder "3.6";
-
-  cudatoolkit_joined = symlinkJoin {
-    name = "${cudatoolkit.name}-unsplit";
-    paths = [ cudatoolkit.out cudatoolkit.lib ];
-  };
-
-  cudaLibPath = lib.makeLibraryPath [ cudatoolkit.out cudatoolkit.lib nvidia_x11 cudnn ];
-
-  tfFeature = x: if x then "1" else "0";
-
-  common = rec {
-    version = "1.3.1";
-
-    src = fetchFromGitHub {
-      owner = "tensorflow";
-      repo = "tensorflow";
-      rev = "v${version}";
-      sha256 = "0gvi32dvv4ynr05p0gg5i0a6c55pig48k5qm7zslcqnp4sifwx0i";
-    };
-
-    nativeBuildInputs = [ swig which wheel scipy ];
-
-    buildInputs = [ python jemalloc openmpi glibcLocales ]
-      ++ lib.optionals cudaSupport [ cudatoolkit cudnn ];
-
-    propagatedBuildInputs = [ numpy six protobuf ]
-                            ++ lib.optional (!isPy3k) mock
-                            ++ lib.optional (pythonOlder "3.4") backports_weakref
-                            ++ lib.optional withTensorboard tensorflow-tensorboard;
-
-    preConfigure = ''
-      patchShebangs configure
-      export HOME="$NIX_BUILD_TOP"
-
-      export PYTHON_BIN_PATH="${python.interpreter}"
-      export TF_NEED_GCP=1
-      export TF_NEED_HDFS=1
-      export TF_NEED_CUDA=${tfFeature cudaSupport}
-      export TF_NEED_MPI=1
-      export TF_ENABLE_XLA=${tfFeature xlaSupport}
-      ${lib.optionalString cudaSupport ''
-        export CUDA_TOOLKIT_PATH=${cudatoolkit_joined}
-        export TF_CUDA_VERSION=${cudatoolkit.majorVersion}
-        export CUDNN_INSTALL_PATH=${cudnn}
-        export TF_CUDNN_VERSION=${cudnn.majorVersion}
-        export GCC_HOST_COMPILER_PATH=${cudatoolkit.cc}/bin/gcc
-        export TF_CUDA_COMPUTE_CAPABILITIES=${lib.concatStringsSep "," cudaCapabilities}
-      ''}
-
-      # There is _no_ non-interactive mode of configure.
-      sed -i \
-        -e 's,read -p,echo,g' \
-        -e 's,lib64,lib,g' \
-        configure
-    '';
-
-    hardeningDisable = [ "all" ];
-
-    bazelFlags = [ "--config=opt" ]
-                 ++ lib.optional sse42Support "--copt=-msse4.2"
-                 ++ lib.optional avx2Support "--copt=-mavx2"
-                 ++ lib.optional fmaSupport "--copt=-mfma"
-                 ++ lib.optional cudaSupport "--config=cuda";
-
-    bazelTarget = "//tensorflow/tools/pip_package:build_pip_package";
-
-    meta = with stdenv.lib; {
-      description = "Computation using data flow graphs for scalable machine learning";
-      homepage = "http://tensorflow.org";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ jyp abbradar ];
-      platforms = with platforms; if cudaSupport then linux else linux ++ darwin;
-    };
-  };
-
-in buildPythonPackage (common // {
+buildPythonPackage rec {
   pname = "tensorflow";
-  version = common.version;
-  name = "tensorflow-${common.version}";
+  version = "1.5.0";
+  name = "${pname}-${version}";
+  format = "wheel";
+  disabled = ! (isPy35 || isPy36 || isPy27);
 
-  deps = stdenv.mkDerivation (common // {
-    name = "tensorflow-external-${common.version}";
+  # cudatoolkit is split (see https://github.com/NixOS/nixpkgs/commit/bb1c9b027d343f2ce263496582d6b56af8af92e6)
+  # However this means that libcusolver is not loadable by tensor flow. So we undo the split here.
+  cudatoolkit_joined = symlinkJoin {
+    name = "unsplit_cudatoolkit";
+    paths = [ cudatoolkit.out
+              cudatoolkit.lib ];};
 
-    nativeBuildInputs = common.nativeBuildInputs ++ [ bazel ];
+  src = let dls = import ./tf150hashes.nix;
+    in
+    fetchurl (
+      if stdenv.isDarwin then
+        if isPy3k then
+          dls.mac_py_2_cpu
+        else
+          dls.mac_py_3_cpu
+      else
+        if isPy35 then
+          if cudaSupport then
+            dls.linux_py_35_gpu
+          else
+            dls.linux_py_35_cpu
+        else if isPy36 then
+          if cudaSupport then
+            dls.linux_py_36_gpu
+          else
+            dls.linux_py_36_cpu
+        else
+          if cudaSupport then
+            dls.linux_py_27_gpu
+          else
+            dls.linux_py_27_cpu
+    );
 
-    preConfigure = common.preConfigure + ''
-      export PYTHON_LIB_PATH="$(pwd)/site-packages"
-    '';
+  propagatedBuildInputs =
+    [ numpy six protobuf mock backports_weakref absl-py ]
+    ++ lib.optional (!isPy36) tensorflow-tensorboard
+    ++ lib.optionals cudaSupport [ cudatoolkit_joined cudnn stdenv.cc ];
 
-    buildPhase = ''
-      mkdir site-packages
-      bazel --output_base="$(pwd)/output" fetch $bazelFlags $bazelTarget
-    '';
-
-    installPhase = ''
-      rm -rf output/external/{bazel_tools,\@bazel_tools.marker,local_*,\@local_*}
-      # Patching markers to make them deterministic
-      for i in output/external/\@*.marker; do
-        sed -i 's, -\?[0-9][0-9]*$, 1,' "$i"
-      done
-      # Patching symlinks to remove build directory reference
-      find output/external -type l | while read symlink; do
-        ln -sf $(readlink "$symlink" | sed "s,$NIX_BUILD_TOP,NIX_BUILD_TOP,") "$symlink"
-      done
-
-      cp -r output/external $out
-    '';
-
-    dontFixup = true;
-
-    outputHashMode = "recursive";
-    outputHashAlgo = "sha256";
-    outputHash = "0xs2n061gnpizfcnhs5jjpfk2av634j1l2l17zhy10bbmrwn3vrp";
-  });
-
-  nativeBuildInputs = common.nativeBuildInputs ++ [ (bazel.override { enableNixHacks = true; }) ];
-
-  configurePhase = ''
-    runHook preConfigure
-    export PYTHON_LIB_PATH="$out/${python.sitePackages}"
-    ./configure
-    runHook postConfigure
-  '';
-
-  buildPhase = ''
-    mkdir -p output/external
-    cp -r $deps/* output/external
-    chmod -R +w output
-    find output -type l | while read symlink; do
-      ln -sf $(readlink "$symlink" | sed "s,NIX_BUILD_TOP,$NIX_BUILD_TOP,") "$symlink"
-    done
-
-    patchShebangs .
-    find -type f -name CROSSTOOL\* -exec sed -i \
-      -e 's,/usr/bin/ar,${binutils}/bin/ar,g' \
-      {} \;
-
-    mkdir -p $out/${python.sitePackages}
-    bazel --output_base="$(pwd)/output" build $bazelFlags $bazelTarget
-
-    bazel-bin/tensorflow/tools/pip_package/build_pip_package $PWD/dist
-  '';
-
-  # tensorflow depends on tensorflow_tensorboard, which cannot be
+  # tensorflow-gpu depends on tensorflow_tensorboard, which cannot be
   # built at the moment (some of its dependencies do not build
   # [htlm5lib9999999 (seven nines) -> tensorboard], and it depends on an old version of
   # bleach) Hence we disable dependency checking for now.
-  installFlags = lib.optional (!withTensorboard) "--no-dependencies";
+  installFlags = lib.optional isPy36 "--no-dependencies";
 
-  # Tests are slow and impure.
+  # Note that we need to run *after* the fixup phase because the
+  # libraries are loaded at runtime. If we run in preFixup then
+  # patchelf --shrink-rpath will remove the cuda libraries.
+  postFixup = let
+    rpath = stdenv.lib.makeLibraryPath
+      (if cudaSupport then
+        [ stdenv.cc.cc.lib zlib cudatoolkit_joined cudnn nvidia_x11 ]
+      else
+        [ stdenv.cc.cc.lib zlib ]
+      );
+  in
+  ''
+    rrPath="$out/${python.sitePackages}/tensorflow/:${rpath}"
+    internalLibPath="$out/${python.sitePackages}/tensorflow/python/_pywrap_tensorflow_internal.so"
+    find $out -name '*.so' -exec patchelf --set-rpath "$rrPath" {} \;
+  '';
+
   doCheck = false;
 
-  # For some reason, CUDA is not retained in RPATH.
-  postFixup = lib.optionalString cudaSupport ''
-    libPath="$out/${python.sitePackages}/tensorflow/python/_pywrap_tensorflow_internal.so"
-    patchelf --set-rpath "$(patchelf --print-rpath "$libPath"):${cudaLibPath}" "$libPath"
-  '';
-
-  doInstallCheck = true;
-  installCheckPhase = ''
-    cd $NIX_BUILD_TOP
-    ${python.interpreter} -c "import tensorflow"
-  '';
-})
+  meta = with stdenv.lib; {
+    description = "TensorFlow helps the tensors flow";
+    homepage = http://tensorflow.org;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jyp abbradar ];
+    platforms = with platforms; if cudaSupport then linux else linux ++ darwin;
+  };
+}

--- a/pkgs/development/python-modules/tensorflow/tf150hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/tf150hashes.nix
@@ -1,0 +1,67 @@
+{
+linux_py_27_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.0-cp27-none-linux_x86_64.whl";
+  sha256 = "15xiazbkcyhcpym80vwyzr8nvwabjwbzwgmqnwpixnas0mg43bp3";
+};
+linux_py_35_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.0-cp35-cp35m-linux_x86_64.whl";
+  sha256 = "1bpn66ky3nigcxfsyhm2vjdvk3q853flq8p6gy8mgcq5dnnrvi2w";
+};
+linux_py_36_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.0-cp36-cp36m-linux_x86_64.whl";
+  sha256 = "1g2hrwnjrqv567hdd2a8hfj7d0f2smfy78acwf89nwakcaazqv3q";
+};
+linux_py_27_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.0-cp27-none-linux_x86_64.whl";
+  sha256 = "1xkdzbvxkdndhpb06gw87vcisi7206c401zw9wnfaaabamwynjvd";
+};
+linux_py_35_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.0-cp35-cp35m-linux_x86_64.whl";
+  sha256 = "0hxw3daf5m3scnvmkm6943wrzx4xxafn827achxjjknmbxr379sz";
+};
+linux_py_36_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.0-cp36-cp36m-linux_x86_64.whl";
+  sha256 = "1qc0hr20wk409gfd023b2j667vgci2f9hm0p7c0is27mp6vmi2zq";
+};
+mac_py_2_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.5.0-py2-none-any.whl";
+  sha256 = "0irwp59wg1gaknn4x9w6srbdqfv15ds8glg1kk7pfkx8d1sr3kgj";
+};
+mac_py_3_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.5.0-py3-none-any.whl";
+  sha256 = "1mapv45n9wmgcq3i3im0pv0gmhwkxw5z69nsnxb1gfxbj1mz5h9m";
+};
+}
+
+# This file was generated using the following script
+# version=1.5.0
+# hashfile=tf${version}-hashes.nix
+# rm -f $hashfile
+# echo "{" >> $hashfile
+# for sys in "linux" "mac"; do
+#     for tfpref in "cpu/tensorflow" "gpu/tensorflow_gpu"; do
+#         for pykind in "py2-none-any" "py3-none-any" "cp27-none-linux_x86_64" "cp35-cp35m-linux_x86_64" "cp36-cp36m-linux_x86_64"; do
+#             if [ $sys == "mac" ]; then
+#                [[ $pykind =~ py.* ]] && [[ $tfpref =~ cpu.* ]]
+#                result=$?
+#                pyver=${pykind:2:1}
+#                flavour=cpu
+#             else
+#                [[ $pykind =~ .*linux.* ]]
+#                result=$?
+#                pyver=${pykind:2:2}
+#                flavour=${tfpref:0:3}
+#             fi
+#             if [ $result == 0 ]; then
+#                 url=https://storage.googleapis.com/tensorflow/$sys/$tfpref-$version-$pykind.whl
+#                 hash=$(nix-prefetch-url $url)
+#                 echo "${sys}_py_${pyver}_${flavour} = {" >> $hashfile
+#                 echo "  url = \"$url\";" >> $hashfile
+#                 echo "  sha256 = \"$hash\";" >> $hashfile
+#                 echo "};" >> $hashfile
+#             fi
+#         done
+#     done
+# done
+
+# echo "}" >> $hashfile

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21735,11 +21735,10 @@ EOF
   tensorflow-tensorboard = callPackage ../development/python-modules/tensorflow-tensorboard { };
 
   tensorflow = callPackage ../development/python-modules/tensorflow rec {
-    bazel = pkgs.bazel_0_4;
     cudaSupport = pkgs.config.cudaSupport or false;
     inherit (pkgs.linuxPackages) nvidia_x11;
-    cudatoolkit = pkgs.cudatoolkit8;
-    cudnn = pkgs.cudnn6_cudatoolkit8;
+    cudatoolkit = pkgs.cudatoolkit9;
+    cudnn = pkgs.cudnn_cudatoolkit9;
   };
 
   tensorflowWithoutCuda = self.tensorflow.override {


### PR DESCRIPTION
Please note: this PR should not be merged until #33559 is cleared.

###### Motivation for this change
Two motivations:
- Tensorflow does not currently build in master
- Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

