### PR TITLE
pythonPackages.tensorflow: 1.3.1 -> 1.4.1

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -1,151 +1,110 @@
-{ stdenv, buildBazelPackage, lib, fetchFromGitHub, fetchpatch, symlinkJoin
-, buildPythonPackage, isPy3k, pythonOlder, pythonAtLeast
-, which, swig, binutils, glibcLocales
-, python, jemalloc, openmpi
-, numpy, six, protobuf, tensorflow-tensorboard, backports_weakref, mock, enum34, absl-py
-, xlaSupport ? true
-, cudaSupport ? false, nvidia_x11 ? null, cudatoolkit ? null, cudnn ? null
-# Default from ./configure script
-, cudaCapabilities ? [ "3.5" "5.2" ]
-, sse42Support ? false
-, avx2Support ? false
-, fmaSupport ? false
+{ stdenv
+, symlinkJoin
+, lib
+, fetchurl
+, python
+, buildPythonPackage
+, isPy3k, isPy35, isPy36, isPy27
+, cudaSupport ? false
+, nvidia_x11 ? null
+, cudatoolkit ? null
+, cudnn ? null
+, linuxPackages ? null
+, tensorflow-tensorboard
+, six
+, protobuf
+, numpy
+, mock
+, backports_weakref
+, absl-py
+, zlib
 }:
 
-assert cudaSupport -> nvidia_x11 != null
-                   && cudatoolkit != null
-                   && cudnn != null;
+assert cudaSupport -> cudatoolkit != null
+                   && cudnn != null
+                   && linuxPackages != null;
 
 # unsupported combination
 assert ! (stdenv.isDarwin && cudaSupport);
 
+# tensorflow is built from a downloaded wheel, because the upstream
+# project's build system is an arcane beast based on
+# bazel. Untangling it and building the wheel from source is an open
+# problem.
 let
-
-  withTensorboard = pythonOlder "3.6";
-
+  # cudatoolkit is split (see https://github.com/NixOS/nixpkgs/commit/bb1c9b027d343f2ce263496582d6b56af8af92e6)
+  # However this means that libcusolver is not loadable by tensor flow. So we undo the split here.
   cudatoolkit_joined = symlinkJoin {
-    name = "${cudatoolkit.name}-unsplit";
-    paths = [ cudatoolkit.out cudatoolkit.lib ];
-  };
-
-  tfFeature = x: if x then "1" else "0";
-
-  version = "1.5.0";
-
-  pkg = buildBazelPackage rec {
-    name = "tensorflow-build-${version}";
-
-    src = fetchFromGitHub {
-      owner = "tensorflow";
-      repo = "tensorflow";
-      rev = "v${version}";
-      sha256 = "1c4djsaip901nasm7a6dsimr02bsv70a7b1g0kysb4n39qpdh22q";
-    };
-
-    patches = [
-      # Fix build with Bazel >= 0.10
-      (fetchpatch {
-        url = "https://github.com/tensorflow/tensorflow/commit/6fcfab770c2672e2250e0f5686b9545d99eb7b2b.patch";
-        sha256 = "0p61za1mx3a7gj1s5lsps16fcw18iwnvq2b46v1kyqfgq77a12vb";
-      })
-      (fetchpatch {
-        url = "https://github.com/tensorflow/tensorflow/commit/3f57956725b553d196974c9ad31badeb3eabf8bb.patch";
-        sha256 = "11dja5gqy0qw27sc9b6yw9r0lfk8dznb32vrqqfcnypk2qmv26va";
-      })
+    name = "unsplit_cudatoolkit";
+    paths = [
+      cudatoolkit.out
+      cudatoolkit.lib
     ];
-
-    nativeBuildInputs = [ swig which ];
-
-    buildInputs = [ python jemalloc openmpi glibcLocales numpy ]
-      ++ lib.optionals cudaSupport [ cudatoolkit cudnn nvidia_x11 ];
-
-    preConfigure = ''
-      patchShebangs configure
-
-      export PYTHON_BIN_PATH="${python.interpreter}"
-      export PYTHON_LIB_PATH="$NIX_BUILD_TOP/site-packages"
-      export TF_NEED_GCP=1
-      export TF_NEED_HDFS=1
-      export TF_ENABLE_XLA=${tfFeature xlaSupport}
-      export CC_OPT_FLAGS=" "
-      # https://github.com/tensorflow/tensorflow/issues/14454
-      export TF_NEED_MPI=${tfFeature cudaSupport}
-      export TF_NEED_CUDA=${tfFeature cudaSupport}
-      ${lib.optionalString cudaSupport ''
-        export CUDA_TOOLKIT_PATH=${cudatoolkit_joined}
-        export TF_CUDA_VERSION=${cudatoolkit.majorVersion}
-        export CUDNN_INSTALL_PATH=${cudnn}
-        export TF_CUDNN_VERSION=${cudnn.majorVersion}
-        export GCC_HOST_COMPILER_PATH=${cudatoolkit.cc}/bin/gcc
-        export TF_CUDA_COMPUTE_CAPABILITIES=${lib.concatStringsSep "," cudaCapabilities}
-      ''}
-
-      mkdir -p "$PYTHON_LIB_PATH"
-    '';
-
-    NIX_LDFLAGS = lib.optionals cudaSupport [ "-lcublas" "-lcudnn" "-lcuda" "-lcudart" ];
-
-    hardeningDisable = [ "all" ];
-
-    bazelFlags = [ "--config=opt" ]
-                 ++ lib.optional sse42Support "--copt=-msse4.2"
-                 ++ lib.optional avx2Support "--copt=-mavx2"
-                 ++ lib.optional fmaSupport "--copt=-mfma"
-                 ++ lib.optional cudaSupport "--config=cuda";
-
-    bazelTarget = "//tensorflow/tools/pip_package:build_pip_package";
-
-    fetchAttrs = {
-      preInstall = ''
-        rm -rf $bazelOut/external/{bazel_tools,\@bazel_tools.marker,local_*,\@local_*}
-      '';
-
-      sha256 = "1nc98aqrp14q7llypcwaa0kdn9xi7r0p1mnd3vmmn1m299py33ca";
-    };
-
-    buildAttrs = {
-      preBuild = ''
-        patchShebangs .
-        find -type f -name CROSSTOOL\* -exec sed -i \
-          -e 's,/usr/bin/ar,${binutils.bintools}/bin/ar,g' \
-          {} \;
-      '';
-
-      installPhase = ''
-        sed -i 's,.*bdist_wheel.*,cp -rL . "$out"; exit 0,' bazel-bin/tensorflow/tools/pip_package/build_pip_package 
-        bazel-bin/tensorflow/tools/pip_package/build_pip_package $PWD/dist
-      '';
-    };
-
-    dontFixup = true;
-  };
+   };
 
 in buildPythonPackage rec {
   pname = "tensorflow";
-  inherit version;
+  version = "1.4.1";
   name = "${pname}-${version}";
+  format = "wheel";
+  disabled = ! (isPy35 || isPy36 || isPy27);
 
-  src = pkg;
 
-  installFlags = lib.optional (!withTensorboard) "--no-dependencies";
+  src = let dls = import ./tf1.4.1-hashes.nix;
+    in
+    fetchurl (
+      if stdenv.isDarwin then
+        if isPy3k then
+          dls.mac_py_3_cpu
+        else
+          dls.mac_py_2_cpu
+      else
+        if isPy35 then
+          if cudaSupport then
+            dls.linux_py_35_gpu
+          else
+            dls.linux_py_35_cpu
+        else if isPy36 then
+          if cudaSupport then
+            dls.linux_py_36_gpu
+          else
+            dls.linux_py_36_cpu
+        else
+          if cudaSupport then
+            dls.linux_py_27_gpu
+          else
+            dls.linux_py_27_cpu
+    );
 
-  postPatch = lib.optionalString (pythonAtLeast "3.4") ''
-    sed -i '/enum34/d' setup.py
+  propagatedBuildInputs =
+    [ numpy six protobuf mock backports_weakref absl-py ]
+    ++ lib.optional (!isPy36) tensorflow-tensorboard
+    ++ lib.optionals cudaSupport [ cudatoolkit_joined cudnn stdenv.cc ];
+
+  # tensorflow-gpu depends on tensorflow_tensorboard, which cannot be
+  # built at the moment (some of its dependencies do not build
+  # [htlm5lib9999999 (seven nines) -> tensorboard], and it depends on an old version of
+  # bleach) Hence we disable dependency checking for now.
+  installFlags = lib.optional isPy36 "--no-dependencies";
+
+  # Note that we need to run *after* the fixup phase because the
+  # libraries are loaded at runtime. If we run in preFixup then
+  # patchelf --shrink-rpath will remove the cuda libraries.
+  postFixup = let
+    rpath = stdenv.lib.makeLibraryPath
+      ([ stdenv.cc.cc.lib zlib ] ++ lib.optionals cudaSupport [ cudatoolkit_joined cudnn nvidia_x11 ]);
+  in
+  ''
+    rrPath="$out/${python.sitePackages}/tensorflow/:${rpath}"
+    internalLibPath="$out/${python.sitePackages}/tensorflow/python/_pywrap_tensorflow_internal.so"
+    find $out -name '*.so' -exec patchelf --set-rpath "$rrPath" {} \;
   '';
 
-  propagatedBuildInputs = [ numpy six protobuf absl-py ]
-                 ++ lib.optional (!isPy3k) mock
-                 ++ lib.optionals (pythonOlder "3.4") [ backports_weakref enum34 ]
-                 ++ lib.optional withTensorboard tensorflow-tensorboard;
-
-  # Actual tests are slow and impure.
-  checkPhase = ''
-    ${python.interpreter} -c "import tensorflow"
-  '';
+  doCheck = false;
 
   meta = with stdenv.lib; {
-    description = "Computation using data flow graphs for scalable machine learning";
-    homepage = "http://tensorflow.org";
+    description = "TensorFlow helps the tensors flow";
+    homepage = http://tensorflow.org;
     license = licenses.asl20;
     maintainers = with maintainers; [ jyp abbradar ];
     platforms = with platforms; if cudaSupport then linux else linux ++ darwin;

--- a/pkgs/development/python-modules/tensorflow/tf1.4.1-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/tf1.4.1-hashes.nix
@@ -1,0 +1,34 @@
+{
+linux_py_27_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp27-none-linux_x86_64.whl";
+  sha256 = "0jdk8mizk1p0gwznhfbl7wwg13i442yc32bwgcxrm7hpa9iwdch2";
+};
+linux_py_35_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp35-cp35m-linux_x86_64.whl";
+  sha256 = "18c2xjzn8d8vmavkyklwxsmv1nbpwawj404aawzg2xvgx7lh3aai";
+};
+linux_py_36_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp36-cp36m-linux_x86_64.whl";
+  sha256 = "1476fbr9nbfdfa51vf80hgsp1bzyz127as8li30nxcvqykncyvhi";
+};
+linux_py_27_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.4.1-cp27-none-linux_x86_64.whl";
+  sha256 = "115ckd8vp533a014kahhx2liq6d25fsk581hfr7qwdg4i2z98s9x";
+};
+linux_py_35_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.4.1-cp35-cp35m-linux_x86_64.whl";
+  sha256 = "1sg5hnn557cj1nx07gbl7dik2wmg3aj9h8fhvvlslvv7ppbp0dvi";
+};
+linux_py_36_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.4.1-cp36-cp36m-linux_x86_64.whl";
+  sha256 = "1dv064zji2fn3sil9j3glg8lhz14wsnafgl6mz9gpaid4186z27i";
+};
+mac_py_2_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.4.1-py2-none-any.whl";
+  sha256 = "1nrphds8ls4xnk4fbym0qlq2hqwpnz709fbz2wz91b16bp63mh7r";
+};
+mac_py_3_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.4.1-py3-none-any.whl";
+  sha256 = "0dl7v7ga9gibhn2qda78sy0snj9iz1zjsccss7zhi9ayjwwq9syc";
+};
+}

--- a/pkgs/development/python-modules/tensorflow/tf150hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/tf150hashes.nix
@@ -1,0 +1,67 @@
+{
+linux_py_27_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.0-cp27-none-linux_x86_64.whl";
+  sha256 = "15xiazbkcyhcpym80vwyzr8nvwabjwbzwgmqnwpixnas0mg43bp3";
+};
+linux_py_35_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.0-cp35-cp35m-linux_x86_64.whl";
+  sha256 = "1bpn66ky3nigcxfsyhm2vjdvk3q853flq8p6gy8mgcq5dnnrvi2w";
+};
+linux_py_36_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.0-cp36-cp36m-linux_x86_64.whl";
+  sha256 = "1g2hrwnjrqv567hdd2a8hfj7d0f2smfy78acwf89nwakcaazqv3q";
+};
+linux_py_27_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.0-cp27-none-linux_x86_64.whl";
+  sha256 = "1xkdzbvxkdndhpb06gw87vcisi7206c401zw9wnfaaabamwynjvd";
+};
+linux_py_35_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.0-cp35-cp35m-linux_x86_64.whl";
+  sha256 = "0hxw3daf5m3scnvmkm6943wrzx4xxafn827achxjjknmbxr379sz";
+};
+linux_py_36_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.0-cp36-cp36m-linux_x86_64.whl";
+  sha256 = "1qc0hr20wk409gfd023b2j667vgci2f9hm0p7c0is27mp6vmi2zq";
+};
+mac_py_2_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.5.0-py2-none-any.whl";
+  sha256 = "0irwp59wg1gaknn4x9w6srbdqfv15ds8glg1kk7pfkx8d1sr3kgj";
+};
+mac_py_3_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.5.0-py3-none-any.whl";
+  sha256 = "1mapv45n9wmgcq3i3im0pv0gmhwkxw5z69nsnxb1gfxbj1mz5h9m";
+};
+}
+
+# This file was generated using the following script
+# version=1.5.0
+# hashfile=tf${version}-hashes.nix
+# rm -f $hashfile
+# echo "{" >> $hashfile
+# for sys in "linux" "mac"; do
+#     for tfpref in "cpu/tensorflow" "gpu/tensorflow_gpu"; do
+#         for pykind in "py2-none-any" "py3-none-any" "cp27-none-linux_x86_64" "cp35-cp35m-linux_x86_64" "cp36-cp36m-linux_x86_64"; do
+#             if [ $sys == "mac" ]; then
+#                [[ $pykind =~ py.* ]] && [[ $tfpref =~ cpu.* ]]
+#                result=$?
+#                pyver=${pykind:2:1}
+#                flavour=cpu
+#             else
+#                [[ $pykind =~ .*linux.* ]]
+#                result=$?
+#                pyver=${pykind:2:2}
+#                flavour=${tfpref:0:3}
+#             fi
+#             if [ $result == 0 ]; then
+#                 url=https://storage.googleapis.com/tensorflow/$sys/$tfpref-$version-$pykind.whl
+#                 hash=$(nix-prefetch-url $url)
+#                 echo "${sys}_py_${pyver}_${flavour} = {" >> $hashfile
+#                 echo "  url = \"$url\";" >> $hashfile
+#                 echo "  sha256 = \"$hash\";" >> $hashfile
+#                 echo "};" >> $hashfile
+#             fi
+#         done
+#     done
+# done
+
+# echo "}" >> $hashfile


### PR DESCRIPTION
Also revert to a wheel-based build (the bazel-based build is broken
and it is unclear how to repair it)

###### Motivation for this change

Two motivations:

- Tensorflow does not currently build in master
- Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

