### PR TITLE
godot: 2.1.4 -> 3.0

### DIFF
--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name    = "godot-${version}";
-  version = "2.1.4";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner  = "godotengine";
     repo   = "godot";
     rev    = "${version}-stable";
-    sha256 = "0d2zczn5k7296sky5gllq55cxd586nx134y2iwjpkqqjr62g0h48";
+    sha256 = "1pgs2hghjhs3vkgxsi50i5myr7yac3jhpk4vi4bcra1cvdmkgr39";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   buildPhase = ''
-    scons platform=x11 prefix=$out -j $NIX_BUILD_CORES
+    # Disable touch because it's complaining about missing Xge.h during compilation.
+    scons platform=x11 touch=false prefix=$out -j $NIX_BUILD_CORES
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Godot 3.0 is released!

###### Things done

Version bump to a new major stable version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

