### PR TITLE
firefox-bin: 58.0 -> 58.0.1 [security]

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "58.0";
+  version = "58.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ach/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ach/firefox-58.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "746d50340fff7a198db8430a4fe927a81ebb5fa2527150c78612bd62225133aa06f7dfb657c439d7c2143eb3f3a3d5a0b7edbc019d3fc8337ab268f18c0ae65b";
+      sha512 = "7b32498fed47b1e0a58b399436c54ccb784a870ec0e8ab7f789218b17a168d0968666bb01abb456c4d0f6350a7769e05eaf2a3a6a5f3827a42725bf7704ac941";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/af/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/af/firefox-58.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "fd09ccaf68d21cd299db1d86ee034db8f6ef81b763bce270126c3d51b9e5039411db8efc40666129d9cfad73804698cc64f0bf7f1eb810a9852d1a7b2c7cd5db";
+      sha512 = "12ca5365ea453af0ad4cd4c296c05b3dd99e713e46aa618544573c1023a7e1b6596d91d90fd9bd5a6a332624d985637bb12ffab20548dc808c5dccc0909e3fae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/an/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/an/firefox-58.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "19eeea6f14e4c5457ada42443bb46cfc64019adb0e0d42310357c4fa834c9e0626a18d672276df3a3d8c9b2c3d217514e7cd843f6a71322c8a212bc51379b45a";
+      sha512 = "7da1af63fdfa939724aac8c9def9b179bd2fdb37f2034e9758f4578a682c22bcd0803fc2e67412d2339b722eb269cffa96863b819d6e390ac01009152b00c90e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ar/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ar/firefox-58.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "a3ac0579f614dbc10b81c5058a1182f68a3a16efeb1140cc13dbfcd171263e21f817922517ffe7715ee8af2cc24a41252e00c3c004ed4442fe641ab93159ca61";
+      sha512 = "1e2d9ae0ce968803b6ea6fdf9841328a561c90576a5849e3ef1e89a6f5ea0aa70b2179ca0c04fd89b829ce21f45d3eecdca607a07d64e6c16a8aa06cda8333ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/as/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/as/firefox-58.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "651a08ffeb020ce5d606c49e5d081ca9f97ee51300784d13ba2a12308b1c95074aa3d4e844d88e500db4ad611803c5fe52ac7561e5ad4f7e7bbd2ef4af0058f3";
+      sha512 = "c40af34a01fe616e0924993b267cbf498a21962f77139b5aecebd6e1b6d17464685c44f435a18be018a00761e40ff3473a205d55c111be954f379ff6540645c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ast/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ast/firefox-58.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "1d2766f2100e4a95bd8ae5a890f9619213f9ebff7801df5dbe8cbb13caf8c0de67e25d9c99b714fc43dc98816b920911a71837e5ce1025a98bdd7243195de226";
+      sha512 = "81898690a8c7bbeddc0c89a2e6c91082e37016d86815a79b2488adc36cbea3c0b669221fa9951e4fe4880f777c5c0be9e9728549d01c77e592c8b1afdb4a629d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/az/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/az/firefox-58.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "d7f250df0a62bd5114241e3db96dd961601d0da7c8dc4ceb8cb4d45a147a654a7b1fca9f1dc478cb2dfafffdaa246015ee814b6cbffbd81f57a9b81a7ac76185";
+      sha512 = "73ff9c0be45cd7d5f70abcb8e397e9adc777383b793a78c6907396724c78f9fea5794a8a138c9c19f2d0ab46a0133da69f6e5c98a15a8b120567c22bebefcd27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/be/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/be/firefox-58.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "1b835105b9ab4203e269696c1df29ac65aace7a62e9336a4405831f3483b14cec950d303743862119d96a1a9f57a95f19f5ba643c248c2e644720db8ee705a9b";
+      sha512 = "19b581888cf07fe9cbabba66832fd62a803920f2a39b195bffd8316b3100edb4b0c628d0563e3d6ab76b097f8e038310079d5d1a2bc2722bb78ee5a51b4bfdcd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/bg/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/bg/firefox-58.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "7aea83a33f8e343ef52ebcd9e0e7b3b2a44ee2a93523834dc268ce9ffe5b90516d074403ed8c88c1f4b2ddac252b2078df98233c1f5279617bc38b83693119a4";
+      sha512 = "bb440c3132a75a7fdb0c3886af57b0650609adf3992b086d9ded68be5525c6dea292de0ff51dbab42968348eb8ce8c918869fa40ab26126cfe775b69a40fc5dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/bn-BD/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/bn-BD/firefox-58.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "93b7b7a83e51ac40e11763e947ac8f091eb4a6ad4c7cb3701a1a889a31b725a62daf520e1a1eac5ac1923ad1a11414f386db6b62095bf74bf36a51df2e49e0b3";
+      sha512 = "5d7f7a98bcd0f927d1911e4d1a7eb79640912b2944f7c335ba6c81eb6e8310edb26917b9944272205ab2e90aecc28bd9208ffcd4049aa0a491f3e5671f21be8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/bn-IN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/bn-IN/firefox-58.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "87852a6d1b84cbe83a490232ef571352c05f5f8eda5f7a26d87081e2814ffd5b41d761110aa75503a21989642a9fe1340ba04d7745d4267d129717d0a882e385";
+      sha512 = "96ed7a7c7cef4f88591f6b1f2c4d683d1b39220c8ffdbee9db9b9b470cca1e1902b042b10e62555ec614cb2b0ba560972042c4e65f5b17a2b8bad78d3c456744";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/br/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/br/firefox-58.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "8914a9d5f5bdefc4a681b5766d8333434078e3717dab556f0781b68933fe3fd85b53fe8068cc4796107faed6a7279142e21b8e0a61c90b447d24965704e9f815";
+      sha512 = "9537b2f8edc30d76649e7be50f1ef9576ebd8dbde45c6a0c685d846ad2ee8634b80060449f01ea60926040e1bc6b8d8c49346bcc69fc276c4c6d3142e9dd8d06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/bs/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/bs/firefox-58.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "b6d40c6ae7033eb8b55f3013dd2eff05551ec78009593fa49033adcd8a30362c9aaf7335749ee91899a1203fe5a3ab0cc795a73f80e332c800270d64f34247f4";
+      sha512 = "b9cc1e8d570173f283a77b552ed99fd4546fb1f55a1a5e766d6f441e2589e615445c45317c39043d98ae8c4f77a75d80d0fef9bc20944690fa7c75ffd4bc5ed4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ca/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ca/firefox-58.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "53e774bb1d85ac8229fbc75884b7f781cc7fe0f7ce5235665da115a5a8b2ca4a05a82c1fe51d801daa6a5479e12f8e5531c84891ef922c89bc387699895439d5";
+      sha512 = "dc263ccc27c14d7aaa9fb66a9b9398df48d3685b2e2c3493627f279d5509884293121316cc8ffe3aaeb200287d1e0438852dc9e4c02f2aa525c2f16f9a2b510e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/cak/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/cak/firefox-58.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "7079bc83b9a64c7ef932c7bbe57153d775dcdebaa938d031e1379678e4c127dd767c3296fde3c9a9b81d5f07e93f38bfa5a6ade9179b7e1dd5d790b560469fd2";
+      sha512 = "69026c93cb0e48c3b8790978694642cd6e854203a2d78bba48ac922906cf938781bf1c1dc5316eb887c89b9933132253d378233c3669954a1182d1d7d4145e3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/cs/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/cs/firefox-58.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "9bc5b068b6f6a38e98cf26d43fb0c304603a69013eb0970a9a8b577f3edb59272ab81258544268213906168dd7bc58224032ca956593fe983b7a82ea82934ff0";
+      sha512 = "4dc64d4fa8424b85713a566b0cd7373e352624799055ee7bc0879ebb93008ca6aec9f39f0aa657809f7c7a70f8473e731279ef7b3ffa16ea5132d01c83e5aaed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/cy/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/cy/firefox-58.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "95354ec119944578a047f3cb28de6565e3fc2c6fdd93c3cab6bb3b423dcbbd5b3dd7c002a185e800172e197900ddf07ac767e1bdfdad181d243c92ac6ad9ced2";
+      sha512 = "85b7c7210429d5ac6120629a033347f1c13de5998b83276f3b735ace1f4a62cd0f201e2312e0be6d7f0607062688402f687e593b93e92439fbda14367efaad66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/da/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/da/firefox-58.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "0e0fcf3a449c4c89d86e180391c4cea86a1ffad00857d7fe26f48d6a3958d0474faad236d3148c029e3671216c6941d3a57d4cab29f9ab3058bef7b24fb4fc60";
+      sha512 = "d902f11e93a23dbc4a4e2340926134fadb2a251bb4b00de1d79bbccc9d21de35f99bc2d4469cee812b15d95dbeff6f4388649d27fea020a54b24a59ef3084634";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/de/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/de/firefox-58.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "53ec43f033a987dca6ae5477e58a6bb0a8f2c4299e373f8da674c522057022395c1d1d54e9874eb7e3d0872da12a7121c0edbab42eb404deef8212cac1339c32";
+      sha512 = "558502bf31db14744aac18c3efb8e2b0189a118cdf080621910c9cf15a05b1bd28fe1b2f5e2acad678ccbe9769ceabe9dec0b7016f1570ae888f9c3fad7fd6b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/dsb/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/dsb/firefox-58.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "eb99b4a6aa2c1f4e75cadc7b22f0aa5967bf2e87a7a3071848cb8f9b8ce85be24aa696462acfed9888e3e8b3cb3e6a6c620c256f29b249c340e664c49b70c383";
+      sha512 = "89ad64c3a489a0ef30099581370fffd3743c1857d12fbff65f6387ecf1503e6e394ee91d744847b6db3611800fa195de2e4d1df4a2ec9424436348c36b6731c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/el/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/el/firefox-58.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "ba3281351b57e1727535f1b4979388e6bb9187be1f61a145fd7bbafc30ad5a8da79ce3971520255a597f8333bea7ce55ae472ae5e4698de062cd23c85d06430b";
+      sha512 = "c7f77728e18d63745cc6385f7923e673483df76b6e8e2ba8f39cf635bb94d8243f9ac1728c4ddb5b94e316ebab026a52871e9fad86276dd885e48481a6dc1edb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-GB/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/en-GB/firefox-58.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "53dd1af53def127e697a5cccb1d4b4292870868d480231981586257850c7ae7a4108eb6b9b00582eaf28c7d73273838ada0661d44a6346c5c1b08734e59a380b";
+      sha512 = "f76ea7e2d15016ca779a5b2f1bcdeb3cf1607ba4b570142cebb60caba5728be65ef05179ee7c5a3029ae8e21e26ea759e7b754b3670a0b6debd0da4528720078";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-US/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/en-US/firefox-58.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "df0f86d1169256f73e68594177388afba5aba4d57260ac6b0b1cc1b61a15725ad7ea5a6210c3a60dbd290f8ad3333792353dcc4d3d23ada6bff8c366f75735f8";
+      sha512 = "ad5b2b66a8579ad2f3a9ff97425af7e9c7ab4235cf44a5684ad481879ea953492f0639fc79121be9f808bedba80e3c0205e43433b99a1c8809544fbd1bb3808c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-ZA/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/en-ZA/firefox-58.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "2e158325f50140c085a9886884444f1aa62616e937e32b3ad9c621f62f1b98e642fe9b0d2821bbf8deed627595471a9d139257fc35c478213ca0f487fd7ea884";
+      sha512 = "aaca4fc5bb264e0f2c8a5d783b3e1e53786403d01c157d8ca3a87642a3668e839fb0d5e204e96371dc442f21bd66e589ed55b6a76d3f50271dc0345da8059eb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/eo/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/eo/firefox-58.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "af6129508481db96cb8cde0da39f421516115abc2b96b191bd3d5b60b8804e8eef1a1b406c28687c2d4423e721d0fffcd33a6f1c42dc031dd1c3f8624db60b4f";
+      sha512 = "f49f89c5c6fbfee70e47a6b632de5b92981a23b54e8e9d7b47ac83ef18bf45d98417c73cfbd06b277b67f94f138c37ebbdea4f1c756e4229d8842f49da6a34c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/es-AR/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/es-AR/firefox-58.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "3fa95941bf365061cc72cc1d6f1c9ce6ee8044bf28e64821f23b56d63078772acf125746f2ced274a559dd7d0c1b8827fb03fefa9a7d4c325c3a0aa8e9e60c19";
+      sha512 = "d04e9a28755ec6de2021b20f72b32ad6aca151cbe8300a54ace876878d8df043923b6afb3b186e5ae3db6345216eeebe9f97978a4e50d9a0a854207e5503a3ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/es-CL/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/es-CL/firefox-58.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "45b8e8a40522623dcce5df515be89fcaf030b29ec042674a9e21e0929867a51915eff3bb93503a802ca266aa0c6e1237c433c51cb7b38a5588598fa6f2e58ca5";
+      sha512 = "0251f56864a79cb38ce5c5cb3908bd1691d2dc15b1198d901a6907f47f1a15385c931538b022d45f75ac3ed0eec7244a081b79c1292bee7a35beb24ccc307dc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/es-ES/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/es-ES/firefox-58.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "3dde1cceebde5b8eb599cff69b8c11009cef90d5d2cff5220088b1c25428e27afacaf6058b5e585e795002d3b3a8dad5438602b62b55c48951dce1758c1104fb";
+      sha512 = "93a405ef018010d5097ade9f08c228e31b50e76573b75cd2d04205d89f61363d0b8f24585f4e08b93eb8424367d90213dd32fc85ee2f7e28a1ef2742c1c31b3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/es-MX/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/es-MX/firefox-58.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "80c4e7489be1c319f2d162c75e816d96213c04458f5fdcb4ea171800aef2b39ee5012d9b1b47fda287fe2d7f81526f858927df85cb24fc328ba0b12cc18c4aff";
+      sha512 = "4286767ce5866ea0b6f1b41804d92e54361e4defa8fa59b7721abeeba402b07ec3fef051005c083d65f6fb32dd37edd2253cf8ffcd28ea9109963500e4fa3332";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/et/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/et/firefox-58.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "d08d3b5cbeeb5d5556e961a289fc5af523fa456be29a749d21e258ef3430d5aa61d20071cfab1835dd9febb0d2686ba7f5c457f1e22804899f1bb7d3f23f0515";
+      sha512 = "f9a11e6b738a09a9f1eb8834f4932535b828bb1c8dde449b14794ac03ba4a37089ecb45b015daa2dbdde2adc2531ded5d9eec83e70b1ded4eb642e4dbaf118fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/eu/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/eu/firefox-58.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c53d30e012ff1ae6432ed7c73de986210f955092fd702ae852163d359282ea79f4d3b5469fdfc4bc31cce4d300b84f17ee8246a437272b1fe7cd00232360c557";
+      sha512 = "c6015ccc4598bb2f0d5bfd12a962d457a3868552853ae6b053c3e40c1668fdf140a2bb791ecb6c2fbe283371f8c1e8789fa315e5a6c05b9b593c413dfaba1351";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/fa/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/fa/firefox-58.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "b82f7fcf18f896d4347b3c1830e28a2370f68f06865408bdb39738b78c9f72c99e4818dc4d0579699170d2a38ba3ff9c17230d71814addf5137733f852b016b4";
+      sha512 = "4bfa551b23e62ce7a92136afd09e233763abbf36b536340667ba487e3c491a269bbc5e508d196771edbd1745a294a14d3f51ad3d4d79adcda86394ca2e7e5ad8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ff/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ff/firefox-58.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "01bafe719ea62f3dca7a527057fac6e0b948de79b926f1c834a4d1f402c2f949f8010fc28e024cb5070b3510320b8d86e173ab74086270f36b4e9159c01799d8";
+      sha512 = "e24f247816b7a633c814275a1a858f0580e274285a3875e0509ca65027bf7f39d2f56709af6454187326a7b0a5b20408582b4f16993c3580c5bd67473726d902";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/fi/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/fi/firefox-58.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "58f4ba6eb6580d41cf558b9157bd8853226885fe82caaf7b7a34c129e8a84e63581f59d6b908d7a27ec86662514c2c049e7bbab058805252eb767f447dc79dce";
+      sha512 = "5ff4c6daa231072927b0af6482992859adbfad7645c5c75666c4de69930bb809541c756031b4309fe81b776a434af19badbb285f0f68ebfef4a25a117448e813";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/fr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/fr/firefox-58.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "3cf320b5f85e354f93f09db84a2a33c685cea1aa3a4558f6c404d208e715a1c9d03f2701f8f81bd6bfac9bbae8a82a84b7e1dc6a87aec41683463fd1d182ed11";
+      sha512 = "7ca09555e939136ab336b70343f889832f3dc585aac2f6b3853b628b5db5686f56b97a7c9abba22b5ed7ac0d2eb9bf93ab2fde8ba992d9b9f3d2790130817e43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/fy-NL/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/fy-NL/firefox-58.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "75e992be5eb1c3edb4cb4957e97c7feb239d30de56f26ac97ad694e7ec861e4bf044c5a91376c0f8c382149a8bc35faec5dba2435fa59dec075473c749d59909";
+      sha512 = "a5d2b78ad7cd9e1677cddb3889d74598383585caad7914ee08333e96c7e66b4b81d5d2ac13432f694dfb3ed5f8515473839317b68f06f4b3708fd02994240da8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ga-IE/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ga-IE/firefox-58.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "8da831e7f92fcd6c8fd5fe36be833393fbcf4e7baf6db3b63a911c9a6292cc41095820bf59fdc734e3edfe6a0ea703e791a8f914b7e9105683eb8440f8938ecd";
+      sha512 = "e1b28c3f064c190bb723373326f1f023821a2192836d619f23dc6cbb424e10376d307a895bfb1db5062a85037f78c3877b684ea1014da205caa4bd284370803c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/gd/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/gd/firefox-58.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "0cc1c318df7a9e7a4620f4e5c8de07a4feed524079b4e8e6a48662b285cbf04fe8b3ad26b92459c481d47268c2a80024f5f57d69c9ed99139887d9ed78e0057c";
+      sha512 = "14b98f08cfdbb6ca0c18afef9fbe4d1f283ea2a2635069aa8426ef8075c2e63d4b348c591d556832b3ed8a68dae6e54d9e82dcb9e1dec1b26d6de3189ec6cb9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/gl/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/gl/firefox-58.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "4c6ac835dcb079054d958f19eb68584a74af2cacd151a998c840beab39e22a710b205dad8cf3640718aff658b0a4175f51ef6c698208fdcf1a753e23651f8531";
+      sha512 = "61473be66b6109a156c6fdf73222167825990dc1b85614ca7ec20c10948ed5a3fe6752361255ed73f31c6f1013265aed5d59a5ae0e184d818edf388cf5a33fb0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/gn/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/gn/firefox-58.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "bf3e3fb2b4641f7b82c75cd8f822cd95c86be5f533f889b4a15c9e46a73057f1e9be929a4d63f87188a0c2110290c67064346ba7d50a55b636e4ebe0853a92ea";
+      sha512 = "b1706bee4fbc84365a26f733ead82f95db6865c2d042fc40f97e9e1e2ecd9cdead2bbc8ee3acbf62cf288f5c907ca4b9be5eeba0ad92dd9c25355491c0849696";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/gu-IN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/gu-IN/firefox-58.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "a27e909769a20bb94ab1af19f1443a4257e71e1dc2eb4c4e90f38fb73afe4bd9c0c4b754b290abbaa42c9c6ed69644ae65e7a64dda5236dd5820a8939c0cb1eb";
+      sha512 = "7a04ad824559b04709431e21197aa9c93a6afae05893ed29922b039b4a4c24ed27e1b091d06e948cd83f1b7f25df0a67477e22b9ce288dfb9ad805b3f43f3cd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/he/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/he/firefox-58.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "a577f2d47a31945ec011b9419cc5b8a7c90cfbeccdda4f9ac8e5f204fde458a6cd9b6a5bc53f96414a4d6179368140680370da26d17a24d0da378d382a11aa71";
+      sha512 = "3f00ef9afa945f41b8d84c45c314a76abb2bdd219ab228387c3ac1b548948d9ee6037f1df6cb5b0de294a7920e77c3a16d2c687727087e8c422b2f37ec3beaa4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hi-IN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hi-IN/firefox-58.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "667303f7e268f4e8f9b917bc406b22b4ffe4291ab4ff636413e2101c5bba24b6a8dbb7d6fdf66daa95cb948ebaf995ee2fb855a9056fae26284b1ce3513d227c";
+      sha512 = "068bbfdf10900f244349c65913772e3565510d73805cdb658ec346c4eab670c91e8c886ad085a469df74bbabbf5a1cce5a9b845c24a9b155f96e2b9749856f15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hr/firefox-58.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "ca2b5d5d79bcdd86ea74cbfb5c43041b301bae4e20630a905657a642fb34671bc22c3e04e5942fc3ffb66203331c7048b6b9511cd45ff37fe246975b613e570b";
+      sha512 = "b965b136811d174ee69ab3424fb15b24f39a59b3261eabe83d988cbc8dd639d4b0ec82285163a33cea1be52a3671e2763e7892eccf176cd286cebc8e9453fbb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hsb/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hsb/firefox-58.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "94bda6aef07890518c11c2c05690a030487ae02d33f1f8cb64c4175d8131ba2aa7275b55dde306efaef64f7ceb53f9eaeb898d4105d6e8205e107a41e0834eea";
+      sha512 = "4b3d92d245f9d93980325080b0394ce9877e0a6e4e2337cf941e5e72becc0125e984166ee30e81b45f95ba9a562b040a26f4cb05114beb5ab18dbbcf968a32eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hu/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hu/firefox-58.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "c0151e3f36d227ee4d0d86338011bbb7c6c3fa8f5f4f3d8cf278738ec2936d91230223fa474a7825f07a9a3dc43b1bb20e75493a64fbe4d5d84c63d7df3eb1f0";
+      sha512 = "42b70cff446c60a2e8388fb16ef3d2829e46f420169b73b4849069ccc75812a10d4a74af7ab19ea78566731e51cd86aae0c047f66fa5c9eaafa169dd520900ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/hy-AM/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hy-AM/firefox-58.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "5567885d44b7c88e5f31298a93387c2faddadfbb6a67409320f8df37cead3f0f957e05eaaa8911301508eae3891bfa37201ee56359ae6df27919fa36907d0ce5";
+      sha512 = "84f001a101ea71e8675b4ed7c359a8fcf8b1dea72bb73ff08c6e5a2383abca2e98da32f9d5da31d86291a5ee7f156c04b033259b538656fa17a60b3f66dccfef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/id/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/id/firefox-58.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "eb1fa25f22dfff6074ce87b024c7b353fd628fa61ab6b8f4a2d1267122d362f12b2596240e96747417b728bcd2a37d91913206f3cada58c52a573af9d38168fb";
+      sha512 = "5285ae283ea21e24b0ab04c767bfac4d4db9be66a2716934476ca03755634c333c0e96c367889760137e584b2a58c8cb6e9689996038149ee5b568c2e4eb499c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/is/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/is/firefox-58.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "5dd3d4892b6dbd20ba0dab3cd542bb92f3330cedf6e1e94790b0ba065692ec89f58bfc7cea9d644963ad259a8d9c0bede5973b7c6987e2fa37de6f5ab1ed6ffa";
+      sha512 = "f1e8eab99c650cf0e4c0d836c5143033b7cb2a9f87f81ba5057c511dfe61ac08778db8762a683b38dbaf2fccbb70a38a0650fc01dfdf8d59ea12d7b31235ca39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/it/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/it/firefox-58.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "5192427f9350c2c10161af5772aa16cd7f9db3f156fdf1ae64ace20a250eb2552c14b11f0b96e809a1f70c267fea7ea8057087cdc8bdd3e953a2d14b81f93f27";
+      sha512 = "ac877c6b0783c90ce4c44f96144d28d416af43710fe8ad6ac6c56a4847c748c2411dd817b1809801e4d96dddd301466886f45030e74f7ac1f2afefd162e47dc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ja/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ja/firefox-58.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "f9846b5b6f0687e997dcbfbb739cfc7664b41859a95c5b3c52f247c09a35cef738cf0f26f51f0a073363591a32171eeefadefd3eadc7ce9bab888e8c3c531f4e";
+      sha512 = "8ee911c05a31230df94d7044de5dcc549b5fdb9779fe0acff0d0095fe45caa13fbbbaf6e8018389222281bfd9ae0a416754836105e1f153467abb1e1db6b8245";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ka/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ka/firefox-58.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "8bdbf6ef487c0dd9902158bcb202008be69c6871b1702d78b10ed422b774729bed97d70d02d04daecb6cdbcd8ef25421ad186606abf44098ba893074c2fc4253";
+      sha512 = "3d5399531290e30c746657286d0a01c03009d08b777b0155ff4a7a5ccb4ed8036d7d6d79de8495e75753aa573c4ab14c1462fc73ca4a0cc93cb5a5095cdc5454";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/kab/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/kab/firefox-58.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "f2b52322a311a68afecd91836995da457ba5afbcd66b87e8d297114280c92e73fd442e9c76340ba4298145e50ecdf69449b0a1acefe3c281e1fd6e22156b368d";
+      sha512 = "690cbbbaa4fe9947189623853ef4a1a4d0df2d73ff50118dab40ddbe57ca772d59d85988d8d30216bfba835b827cc33eb96567ff9f2916514497b76a8e4c1c93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/kk/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/kk/firefox-58.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "d1232ce4c4f8c39d90163f4bca6ef73c2a46bcdd53496565678bb448ff538416bb116e1f93bf611d93c2a1d1fa9515975d291638dbf2b4be404d85fe5bc125d0";
+      sha512 = "75199857516c970b0ef13808b2a0a13a837643188c3030378bcb010dbfc8c970c4195af4507e32fe17f94b9e1f12b41ddf80f914ba24b1431e6cd0975a334420";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/km/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/km/firefox-58.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "ed3ca1cea325f223e01073f44ce96036a9e61f097f459a0b32d39dce505995d84e3db51e0511afe90c0285fed8f01b3e59ed7980aeb62758039cc8f4044e24f5";
+      sha512 = "3733a9367ebe2a2082e2d7d1a5e09c13a1a587b13e7cb0bff3b4fa1d9c4fec5077e3b9c5156affae4c90ac035a94acaa3ca5666d6dd59ac6d2dfc6a4e9141f28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/kn/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/kn/firefox-58.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "a9376c1bb8fde80ce16e1f4f6fe97ed326220a5a8a5c3323a7ec07f1c76b30be582cd4236021e320dfd8f1988b6908a32484e9c18fd965da41e5efafb62617aa";
+      sha512 = "767521f281d9a369569c639cf14618f79fcda275cd2f11a6950e91d0d88843a70dfe6845bc9dabce4229597b92e8562a15af2caaaa511e578601cade1a5dd057";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ko/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ko/firefox-58.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "0fce16b8e9f70ad33747523cc825079835a7de27338f4f26ec217662ebda1b85a7db165063c59db28288fee56ffefa35c5cc3cafc6a392af3801bb37cd185dfb";
+      sha512 = "113a28ea22d0a2e79f66680471f8d5974abbca440197590cfee0a934f40403d704ed35bca5be9a4164b740e0eba8292f6e0096707a288735d34a2b77604b8d85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/lij/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/lij/firefox-58.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "d1200b85ef44047dac247406356ec7925cda8fcaa25f89a2c835a25e47841acc7ca0790ccf1b516dde4c0e0f66300557b7028db60f603d66d99fe85807e35809";
+      sha512 = "36f284f3605e55ceef29eb4e88205524df8ef1e92f7d1851427c4a4fbf6859721d6918dd4184315743b7a8108a1b85aa40d90189d46f3763c3fdf6d5b73e0279";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/lt/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/lt/firefox-58.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "34e7a9034ed9520ebdb2a6661404e9e4371866ede502305949faa0216cb029b90a3fc4da41a6d1e37afb50241c7e9675885038e43fc4801ddfa7064bba6ffe72";
+      sha512 = "d56da7e01024210a5ec486c410da70c63728a890c319e4496f6cc33efae41c554aad552c081f3b4777f1fefeec7b6b6d331000608ae4c7b128bcfc726d6be5fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/lv/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/lv/firefox-58.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "45ca64416bfe0f46b187deb05a23cede11e2b62d879a0389b95d30c10f5e6f8c5a480d900095121d69c37f451eb7d1b9cb5247ca90d99f31794f0e3098f5e1db";
+      sha512 = "d5a0f538a1a5860229e1a07d89cd0a7ba6b78ec049d71978bc0791bdb1e3861b8459962e8bdadee996d2abada552abad4f81002e7b042dbe136feee3367fe3e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/mai/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/mai/firefox-58.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "949549354bb7bee16ad78e0f090e72048db2df6735c5a1cf56f2b1ee2ef2f1c10d12f2b1310bff919289110d351ddb2e313c9697b3808d40449684d961a979d5";
+      sha512 = "2c96217b38ec9fc78d025ea79a934e10d1d1553e39480d1dbbd878ef774aacec5ecbd63baaae1c834c44acae417605aaad5e748ca74f5814af83f862812d1d8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/mk/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/mk/firefox-58.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "c01b338cec43207691e01b9ab9735531c597afb04e660262514b3cb70b1967258d03b330d7274bd64a5ceca1e4a6a60e555e8267f07fb22a529152db1dceb20e";
+      sha512 = "64fd2f8f140dab2786063218f1b6074d8c8f9c5dd506a737676afb9a68edf06d9800e3c9bad3dfad8fceb82c321531ca6fff6a97856c952dced721f0d0915913";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ml/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ml/firefox-58.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "07c4b35ed0385ebe5564992527a3eff6d9937ea8fe138997be31ec29cba2f24d067a464d119a46e169c2aa2e74649e44978f2e7a951f5196a44abbdff56a9b37";
+      sha512 = "59036ccacdeff45c27a1b737913e54c0e06ddb12a670c1549ba26da4b1d99fd2338a133e1b15b1fbb673df2471b5cd5d5d4061ce56c631e37c429351da2cbceb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/mr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/mr/firefox-58.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "4ebe741edf2c02d4e1d9fb89d823e048c39b82a45f3af9cfdafb35c80e645c192017becc05e63e1d3f193b8257baf228147dd9814c3d9e432e4edf943659cc18";
+      sha512 = "2fbac808598aa7ce028f2d922fa55b49174507b5ff6e66e1951c3f579cdd051ae4bcd28edfaabd2319dd7286b08d35a0fe33ac2f63c628d217b8f43b89dc23d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ms/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ms/firefox-58.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "9345f2c2daad990cdb61f3e066a5b9b1900af3bc3ab4c268a28b2315f81ec0371daa246b0ecc0caf78a66f61ac06bef57d97196c4186ae450708343031be7071";
+      sha512 = "52f6857cdb97b86cd25b0926d509405a1548dfe310fe088c3b27ca77e87fab585faf4893e8562d55fd2ecff43eff5535ede306abcb57bc2ee31a4890530a27af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/my/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/my/firefox-58.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "138a60fe48fe5cef6879c928da51ba6c9ae70fcb4bba5be4b65e775cc2ab89b4fe550341f4c35359d98fffc1aa8f18a55438581fa6d422d07c4a7fc76247cf2f";
+      sha512 = "1e89a3a595ff4b6a1f1044788e34266af60bd6b6e0cf94c64af5e50ad074e7a2d405ead7210e1b55622aeeca3255f966f7f500e38e639fc2677502385e4ababb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/nb-NO/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/nb-NO/firefox-58.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "610c955b6597d5df47a476df9340342ff5d8d33cb3086dc14e9ec7b6b5519309967b22183c953bab45180f0977f69ffd0e8b103cffbe04712dbc4c183936a2c1";
+      sha512 = "b14c55689f787e4a6d4edb504e701d63b36512ae49008249f1fa34cc7961d58ad0b0c7f1aa76933afbcdb76b8830bbc7620580347502acc0712b500dcfa34f70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ne-NP/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ne-NP/firefox-58.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "bb6c63ffd60e6f239868b6ff74d381a6ff59c0f5534e4cf2e55eab54705e83260d527d4e88762f57c7228a04c9ac05fe0088f3a1f39a443018d6b11b7ece8171";
+      sha512 = "20426cd45c9c2c5517587eb2c6d04426eb6c2d8f7370d690549dcf44ae2d9bfa823ed359655a75be83916cab2505759f1212abb4d5672a2b70d81ec573d1e5e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/nl/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/nl/firefox-58.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "d4fa058c64b30a60f79c466b4cf889548acbaead22d5eb086f055cdc1c3039c2adba968d8d7330f4f43637db0a6a1d23308be2826278271d32a1d623914123fa";
+      sha512 = "a98a214fd2c4cdffc5a85fcc074b8516d90c5d79e23c80f0ad464931b8288395d953ac46e575f66bcf0b0e5cf862fbe16f07060be73d9c7fd28930983ceea72c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/nn-NO/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/nn-NO/firefox-58.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "5be23c6b02affde65852eb39e787eeb6a4c213f635a57b1e37f52d1588735180343185134522e35584c86c288734117881d2f0093aa77f9df3872f0fc122da29";
+      sha512 = "ab5ba866afc67caa89f6794bd93981067ff12684cc307f6fca9f8cb4eb352f96282fd745ef20ff5b2d9911c75f99f78784753d4755623ed3496488a98797db70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/or/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/or/firefox-58.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "4075a64d79757f8bbe50bc1dccaff4229ec8386cded3b60f6dfee4dd4869737f5d8efe1f4c49a36f326dd8fb388f84c7f20006652e5da0306a6ab794cdea7fa3";
+      sha512 = "6c32d13fc0ff2cf68e784d4e4a58e6befca6bbf1aa77a6dea64825a1e9d6c3c3705d6a60e31fb0fbc4b87147e954eedeab4cf194e0f2b500d8aa3462b95adb30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/pa-IN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/pa-IN/firefox-58.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "84de66a473c3dbdc34e375e6eb48ef4ca00e1b884b6beddcb085b06daecbd1eb7bc921da4e1abd1a295e7e8f455e6d66f08f5a78121610327418ae64ddf145c9";
+      sha512 = "483f1b53af7900dcafeba88872ed5b5c5d0d3c703e83d3e080df92ba66467656f43161851474362b8d3a4bfd48ae19a2a21ae244717e55aebbbbed3b55488b96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/pl/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/pl/firefox-58.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "a027461729a5284c31da1edaf9168369f5f921c9812b609a0657c9437c881e09454e9b67d9d593299f33d924fdcde2909c9a2249a5fcf1eeef9c91b3387d917e";
+      sha512 = "bf580678caf2fd653022ed5120f461b87beb47defb323836e40c0e1755adad1e893930a39afa9bf9137a2bbd197d5918b715871056df3cfa9574e684f80fd56b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/pt-BR/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/pt-BR/firefox-58.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "fb7affeefdad0bb12ee5cb6a0e8c54c146079fd09c1670e81040e2887e3d4446d7cfb633c9eaa6d3dd77c4868cb7cacb1f56897889761237abfc1e9456311cb7";
+      sha512 = "8036559e9d83540cfefcc5217550f401d988c626117e42db66d4ccd9c31afd8aa4224bbadd7293c44b3973df7646d36ade1728d24fde3f5e7cbab19e3e83832b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/pt-PT/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/pt-PT/firefox-58.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "a8fa801d18901f9a316c45f66b903f750bbba70ecb7d134a09ede0cf02f2bb2939d7c6b831c1ef77b27425139e3437dbc58e11fcaa80594efe62c767e4e1e186";
+      sha512 = "afa6bdcffd36065c94bb1984ac9734d1091c14bf065e68c2a650e28fb49a5f7d52f19aa83078973dafb7446c2a01aa9fde7ef43e26a7f26963863329b868841f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/rm/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/rm/firefox-58.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "0a1fcb869512557000dd0ce03ff75941e268d59a5843b0873e1c299c9aa307f0a28e4838663c66ca3f85dc7c4ba564d6ddebab3cfc4fae978191fc54e3fec7dc";
+      sha512 = "26b71c4b734bb2bcd7141247894721b2d35e521c5e9da2cd9fa455646f234fec97b55467e80f8d6b36bae62c807c79e7e12a395e65e4c59d464f7b4c3115f3e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ro/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ro/firefox-58.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "891368634e22dba613191c19eb29634a87c49d32dc991bee9044e5f37d51489fd284e45888a8178bb25cf866da6e742e263e361cf0db23cdf100ce8ef3358671";
+      sha512 = "e0a3358a71ae65166bca792a8e60c6319f9a4c277c8369a2563a084dd9fe8b68952df87d1f9ce5270420090d5ac7a6dbb207cd7063b488dae4d0efc8006e46a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ru/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ru/firefox-58.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "94b7b44ce9c724af069314b33512a5535429c56e9f69373c50308f093ba3a7cd28e9aad13d3ad43cce909a1f350976268f2e3c206045693b4c53a851f595db33";
+      sha512 = "adfe22866b6123b537ddaf1dd81d397478e7894c021ad74327c922d85bee8ec132f410509a147bd7f1300df778922ab940c36385db2659c8a356914b908ce9ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/si/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/si/firefox-58.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "c6971203252b25d1c956e327aecc9c6e395b39be2691b53b421c96aa8dc49a1c2dbb16a03140a9d1020225068179e08fb784721137032b4f0d3020a83f89fb28";
+      sha512 = "94892e878fc9feeb9e208aff8096496423e40e42bc22ede273cc5e3e549564861ec31ef9935f1e29d68b51abe79b17a9c6b1e5763917111fe94c95f27c3826b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sk/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sk/firefox-58.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "73b9b3dec958550e015688261375dccf94e7c9e0886f40bb1fdc8bc6fcb75ed5da1416b5ef136811a7bff2f9c8b7b88836d9e92b29876a2748ae01fc300ccab0";
+      sha512 = "26985d29d4cef9fa987d83b873da188b7a776929533aecfd1f1639bc0b7c4393bd9e04cfeb3f7f9f2cfb7b43b5ee14a421791a6024b2eea3707b7c3699594e83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sl/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sl/firefox-58.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "316915484eb9371a656d75ab05fc2616f514a97087126ccf2f2a75d9821641cc4157f019ebf9f946a07d0b1e7b92c464dfe3970dfae0ca375bda282819b7d53e";
+      sha512 = "c8796f686d147774ed4205a04521fb1375d1189575e855b6eeb0db7c35da96aba70803cd477656118f6137658f71d53c188d10653d67f121942d95d81a6a05a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/son/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/son/firefox-58.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "38975465d0b416b3d86c677bcadfc49995d78a943f08704218df29d008ee4dee93ec4b99a6cc0f0c22b0faafffbc96b5dd3dd16891881a342951682f5e9f4018";
+      sha512 = "56f8b81bc5619b88234feef3e17c1a80ce06effc78880b4c9da083530c7f9c037015b6a940914bada62e98711065d6a0c556d90b60125af357ade797403885cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sq/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sq/firefox-58.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "168372d4876ded273268cfc94860548777bc03b471e4da5f28735234e669f23cbb5ba9121a147971af26f78e84d22b2e7fa097b60c33ed7b784ef0dcd1a8e3dc";
+      sha512 = "1bd75656650f34ddcffd38eae46ba84eb18fecd79b9cd7972f96d0906862d37013c48046355530baf5f253985b65922d386ffcaa25339e964db16fca6bf85505";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sr/firefox-58.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "7a8b38f4143b827287e6f629caa0bd5d85b4b28825b620330004be14e4506b7466a8daf80871914179a8001d8351bab30128fac5f5392cdf22b33fd8c2d8256e";
+      sha512 = "abbfc2f50567f4506dabcf8500ca56b369fe6e6502147ced5a52cb2d506c6b28248adeb6564a6a092ae96632ed2fd43356507cc53c6c4a53756df2ae2f6dc735";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/sv-SE/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sv-SE/firefox-58.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "4f3d3b150bc3173a7eff5037fbc10af0d3db734405fde659ddea5981b3f7aeeb7474658e965e3ac4a6f06ea9fa03fabeea0572dd622bbea7dc18458b69939e85";
+      sha512 = "5f19b531d37c8774142a86cf83c678e0ab889c5f22aa792c6bfa881ad9441c02aced2324077137c8ec75c18a1e7a93243b9b87604036b5d29ae4e93871540ea5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ta/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ta/firefox-58.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "5dcd6d2b0a170f359fcdaad2ed9d0ae7696d821ea417c2584b2acb3db8d49f0a2c2951dbc5033507529687eeee54e40da5afadbc909758e04a76e5558c4563b0";
+      sha512 = "f503d38e25cd403f8dca12992258265cd3abd50219655eb51867ee455790e1864dea2a26cb0d72bc311c3685e79836df9c0c1794b499d13fb54689ab9408d484";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/te/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/te/firefox-58.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "179f3f7b4249febb51f1649ade20da83c494eca5f84bc94fc31ba92cf421edcd28bfa10e4f2d0b183a2e64767e6005dff5284f7a68bfcd5ea4781e8ade80ba26";
+      sha512 = "3f68679d85cc1c844fcffccb371424c38406df074c8e21a200e04bcc5fbbfb1199d2202487c660c95ff1941b433d22ef3474580a0de0909dc251092e139b4bf3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/th/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/th/firefox-58.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "257cc1d4d6d25ba3ed8a4194e1bf83bd442b46560b41268828297a95b5009e809b7a0a1a436095a5b15a8d2e2537fa2ae0187a282fe5ec4c158bc6bd4e185953";
+      sha512 = "b3ea54ed6c65b68f39eedad3d4500030de3f53c6b603a15f63a82b2766e023f552869d5d0e05cc5a4ec4eeafeb3dc124ff6ed09a5adc53e44068034247ac0bf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/tr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/tr/firefox-58.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "65b0feb6e1c0e9fa97b5f829060c83e9b1ec3a66e317400673891a2fea2cac3ba46924cd04e87ee0bd98fa6746482ec10d43f6acab541de4224d736ec3f5fbd3";
+      sha512 = "644ffebe355085ccaffe266c2ff50440200adf95a46aa1822f21a160dc982bbdbc8157d9231e1b96c11c573409c620bcff113865d55eba3c3b7f3cea7faf29a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/uk/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/uk/firefox-58.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "a7c9966a5d90e83555315593d8ea76e8fb3077d1142ae42dd21a04664b071c3989b2ccb516b062acd9d54b9b9ded54224e3453052f0421cb1da2a05e853e70f9";
+      sha512 = "20579b4afeb36f5fb07a3a93e4c5837919df959f9ae98e25c39597e2f1446347952fedaa776d40bd606264cf935ff343cf69431e8c8f978dc8fcc60020f669a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/ur/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ur/firefox-58.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "8792ca10de7e917f5f24f432832fae305b695673083b74d369e6a08da80345262612ed884d4506c06ddb16194ce98f12179af40ec6bed86ff582ce09ec306c8b";
+      sha512 = "4466d3f53a1d68df8e7bf6074c2639d84e5a7bcbee32db522f8d3a771266454c1d0c9bad1baf52b27c91a6fbb779c41fbea50a84675e9530ce33b1bafe722c96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/uz/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/uz/firefox-58.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "3bdeb9dbeb58e19222fdcc41360431ee5376b9d8a2e623a028ba3ae734bf8944117b705afdd56b922022587b3cd8976b3790e8db8b1b1fbf9025f9c1ac9162a5";
+      sha512 = "4234f1c10daec449867a4357a123be7d04ed3456b98a2d2e82a3ec3d85f7da167e5dab95ed6c4f4f1f44b9481608a80cb1ff1713bd0abe06606a15bce7df6d6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/vi/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/vi/firefox-58.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "fedbac3c77ba7b2d264cf8f84d16c7e9ac8703e5181a05300168e7e1ab59a192c416e24f61f0de59076019f3fd9c5ebf70ba7fbc8986a922edfc9297c0df2ded";
+      sha512 = "fa5b72aec8b5a845ffe37588424059037ed1121f35047b123d39e7b6b11f0ff54731a974b7ceb3406adaa1705e14477a7ef189ce53305add2712cc7d433daf82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/xh/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/xh/firefox-58.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "9ef362061f74d4a989611f491fd030473f76696f3642fcf5d8f0d6110e7ae7d4b3dadc5ec630ce9016c1117bfc94d234131b709093d793910f036d2344f3fecf";
+      sha512 = "17db5a14e2e9e4a022a6d1048f72e734f41de485f72ce45a6848b69db1a96bbafef25809b79a3f85fa70c6e7f43c9f1fb6f16472c294f13f1b77fcbb45d84dfc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/zh-CN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/zh-CN/firefox-58.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "39c4dd67bda38bdcbc8dce7fc9c416ddbb004c03b2b57f8d5500b2686dde12e3e1661caaf12e800f9276bcb4ed01bf33d509543fb41ca4fd2963e22f4bf1e0c4";
+      sha512 = "e8570e0c589e298e84653302c85ccc46ef7b9362b5449a09a43eaaccaf2d3ba1b55475c5fb190067d596f85d9ac3cc037e5ad400454a2d49c8e9ad878bd8e04a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/zh-TW/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/zh-TW/firefox-58.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "8875690a4f6ba74108887f17fc64d87038a364ce2f603ae184aab36b6b2c11418ea2cbadb9244c8a8cc5e59d831657302f40dd7c94b855473a9bb4a6f7f49abe";
+      sha512 = "51243e1c7a330f0043988904759fa8d7fb67e287ed47a6b6a18a12ade989346f4939874dbc6b15670217436f8132126b29fb641d60e8f338bb8985ee5411498e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ach/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ach/firefox-58.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "96da329d9ee86ba7ee01a99b57997d84b6084eee3c8b3ec9f852c07670798d17ff9b630d385b5b5c363cc45d95497cd36f742446f899c8edad2ccc00c12cb151";
+      sha512 = "a36499123874af16bf33d80ccf2a84dbd21f641155ded9d58e0c064a8cc5d9f034fb64d154f0ab46cebff191e9c9cc46c820026c53408329810a318556be6210";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/af/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/af/firefox-58.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "280be62bbf765bc5123c3148d09597201a84ec40ae7a1643a4eb594f022242c1e9cb0af6f7f9f6b822925e871b800e1b83e7930a4848ef44d7822b944254a982";
+      sha512 = "4c42737bcd7af2f9f0b6ae3415a56d82d360998f8bd0ab01b6b0cd5f72bbc84fff4045b3553a1a87f0c3258f46b526f9e9eb0c3dc8c8c66a2a22d5430fc38499";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/an/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/an/firefox-58.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "c941e17fe3f8caadfc0de7d7254ca75ff7505a1a892bcad0a5a215ed2943cd0390637bb317717a2ed6d1958b22f6baf7ea8eced4649733a40514a75e82cf3524";
+      sha512 = "e821fd76b262744b740ee1a42092b954df2a6a552cfe305ab88e6ca8b2538045654f64f4e1a0e1446906f91896486f204518836148eebf19d306b4af0c2b4d6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ar/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ar/firefox-58.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "15b5362e71032df26df6a8903527a4b39dbc7e84e5c62964f0db08f4918cab97d451290ff92482c9bd99b488d17c06545f1463b98018015776710436358dfb27";
+      sha512 = "de178b0791074179c76a9e0334b5c5f2bb3599e67ccf4c8ab1d9964952b17c2ec0c509e8e37d83332d1cef7b74ee3081eb4092001023c3a2f14d906a8c0e48e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/as/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/as/firefox-58.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "2811aee59e85ab535f0a57c3f286dc6dfbe38c2dc07a9cb103e9f9258bd8514db37db012c48e6afa0935aa573a676f40b0e802e70d81f13931e7a531d4b0134f";
+      sha512 = "a6f3ff8f5f31b5bea725175a27fac0872765f584a91877adc01dd42811b059b61706c53f64e4d1a0b7782c26998bbb2f73e865bed4f4e992762b5f90993265b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ast/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ast/firefox-58.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "efe1404351c824142a49b58adc280b2490752e98a9e87bb3b7d7f1473d8bc2e93564b8b7ef3f8cd99ddb2d0afdf4a5370c97f908858a55f9e76b953fbbd5089d";
+      sha512 = "dcc47a42af28f1814541f71650e24c653b5f99958b495aac3d0408ddd27aeb8d689d6244633c5a397d5f304dad3e8d2778e5a3573497e47c895a9f46365c40ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/az/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/az/firefox-58.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "a70621c70092c9d375cdb8f94f0176341d732989645c2492232f8e664e01484d4c5e18ee45ead3a1c732ad01fb2bd3468e4a723d2a8e3afdfabff82efe9447dd";
+      sha512 = "41212665cbd529e935af5dcb8582b152e84bac8c7055b02f2a43dc6fe53e33bb882908feb71faaa8f34a026a64117a286e59422ba110bff8c04e18229bc418aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/be/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/be/firefox-58.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "bf8089e6df9af11dff0b5cc19b15f0df5aec4b7451fa195fc3ef52f3447dac43c90119779596a4ff2aa61290af4c78f3af1dc10d89a501479b12c90e432fa93a";
+      sha512 = "681e9c68187d9b53880494ab08300bc28b8536f5aae320dc9da6abfc8642c8aea2e2613b48d32c25309589f737743c733b361c543525106ed9373ecd3b40b891";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/bg/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/bg/firefox-58.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "ae1580a6e882d7d4085f30ff35cbe94f97c4ec3aeff6c386fbc002bddab1894a3834ae2c8647c87de00f85e685e0cf06522fde87e20c13643269120246fb4506";
+      sha512 = "742cebc1e646a2d9f5d9d6c406ca1903f81faf21c4a38df0ce6edad8f7b96ee8b22d7ada34fbc24461f5e7644417d37b4dcac6a5a10f8b0ce11fdbfda9c01508";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/bn-BD/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/bn-BD/firefox-58.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "b1f479d2bddd2f240ef150465854e9a49a3e8ef9b9e23dd8254e8fbe902f7b602a05f1f9fc156f1a94aef5edff4c65f59eedb49e268cfa755d7bcd9c88ec13eb";
+      sha512 = "0562b8bc93c1c768ca49e94a6285206e3402b45d9217c6679eec7f30395cfa500c35da7ab0e560a5fff3db5eb60e6085845a6a7b2ba7b695ebdf09990bdce5e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/bn-IN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/bn-IN/firefox-58.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "614e224b18b2c9d698a210a21b21202c98e5bdd8725755edfb5533456fc9a5a74c9e6353db979b07fe5596ff97cdbc7110da88eec8b01701879b5992fe935ff2";
+      sha512 = "d459a21206cf140acff54ccf6d7557090ffb3eb752f62b91ea56a4c4138858ed9146d3edb6ee3252ebdd548f3435cb973c284cd0008207d46dfe5b8b12a6bf55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/br/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/br/firefox-58.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "e99b5b609de56dc21af10f20eed110ddde1c7abd21a0ef79ece2d8e933a39d0dacf20f2ab8296acb885f1432ad5b58ae0cbe291056ac70576b098263c83f8558";
+      sha512 = "c23ee525c1c989264fbd1e00834cd0a1da1c470a54bebb5caf18502499f16917697f3b6de55ecdb9270ae11741420dd1def626603f2f945f2fea8ec6279f4b8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/bs/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/bs/firefox-58.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "f7967e7b9fdab113cd8546c7325276f4d35e760a1bf78ef3c56398bb06d8a98fca82d0fe5d9bf80045bed12edc6c6e8656f5b088e2de4cbd0f1e69cc142695f2";
+      sha512 = "dc254689e74cf7038fefe2b6b911cb75b96fbee105a44713828f8f7c9f1a9fd8624f5ce62205f26b4d287f73004edfde73d4fcc4431d2e4464d36e822f4667ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ca/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ca/firefox-58.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "2680323d28ec219662173d4f3556d9c9780b2c6a4efd7a4adbe92fd99cbe616c86ea154c2a3f3b38314a62663416a630f4efb93bc0845597ed69afd5afefae57";
+      sha512 = "3f358d601c182bdca9e82221e9e6061ee5d610cd42caf722e1597c6e3e47ea005949ce52d0e38d160a02e4f02f210328d631fc095b0a49af71e92919aeddbb37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/cak/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/cak/firefox-58.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "35900e03a398f5ffc48652589789164173366a4f07de1eff90b288b3793146173629baa9b66d587d69e0a26bc57687e61a08879ab66dcbe8436a5f393e968fb0";
+      sha512 = "274ebb0800585fd06dee02bb4a2a88cb4a64d39198e23fe481061b0cd96c281c2bc9983516614eea980c118fb98db01be2c0a387a8cc595da7a2144215f27230";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/cs/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/cs/firefox-58.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "d9aef028c0430dbf5320e4bd12659652dba741f37ab94c48176c6dc380b005f177c6e5c38ade7a78931fe22e9f5840b6aef6f09bffa952966273937f3efd2bfd";
+      sha512 = "dc688379b955cb619e1780c66368ebf5a09415a3b31c8d116c1182051281bec251a06ff15b54816e5f0f11f1c0246f33d2db42009035a7254702bd73d13ca83a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/cy/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/cy/firefox-58.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "405e3b56b1a583066d04e3fd35f9c0ae9094c3e3bf241ed77728ceb41aa3e880c09a89f747ad22a5a0c33db052038053ae4b2b0904d5c40dfbbcc2eb43178093";
+      sha512 = "f20ad279750ec9281ee9a800971a4538e43dc3587df35afe676e7980e965522dba2b6a9deb2d0b9acac31308de3a8a167ec8dcb05934503602483a6eeadf00f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/da/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/da/firefox-58.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "b9402927aa684722cf772b6ce95158776414d5f1555a596f00a957d00123005fb804594001443393572eafcb2cc1c37aa278fe29eebb0931b7eca24751186d81";
+      sha512 = "b9fea0a664a02698423099a963787f8b5aa89f3aae8ce6be9962d9d8316e01547d2d3fe54f05116ad1fc6d7a68d6f72d65adcbe63de98bd4b16c8689190510c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/de/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/de/firefox-58.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "f5d480ac6e2dee9784b34391a289a53d85c5f132baba94a1573179c1183a4a216eab0e2d19067342b4eeeb6248f38f1fa0b8269b1aba2add7d5728d505f70019";
+      sha512 = "13407206fe0fdd88793406c349e4f7a66132f2edbc32af12b7d30026d22cf721970c8e8494228fc80602cd57feb3dcdf17f0490580b2e33806f0b3bf03fc7ff0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/dsb/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/dsb/firefox-58.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "07b8f40225b583186cc680e3269a12e123335f4fd2041f0db67daeb53e72642fc0f91a29074fc11182bbfb50e326d53ce8ceee543f4f93762c664c362e32cb9c";
+      sha512 = "6d6661cc82de4eb37b0326f8cdbc55feaaf85cc44137af1bc217d609f42d97216402927021dbacf81cfe704ec8c1e42c3dd18f39bc1f7e6665984ccf3bd678ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/el/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/el/firefox-58.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "6dbaab9a026c060bbfa286ee2cd7b1ac34d7a50dd33af81f9696148ec11353ce1519005959aface7c6de723dca7bf03055ccaa8fc70177419179116b30a04140";
+      sha512 = "2e8d1ad194159f6d7e56a461d594b1cf998f073da332a1f1bfba46ccd76e0e5733a691608a16ee08207f45d16ca59766e774534024239b8d5b3be9156942b31b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/en-GB/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/en-GB/firefox-58.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "d3890fa00dc159a3a9494a9ae2dac84761ef6bca74c442504428809507196612cd1e362bfb837a93b9bc15ac4b58da10e05c4d8235dfba625e9349cd04c9f37b";
+      sha512 = "f45ccaa1b6684558a1c9b5e43907fb59be0ca466260950d701091e6bc1c6a9d18d1a8dd2b2dec77381450f61f99b632cb0f3c0269ff309321750e16577df697c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/en-US/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/en-US/firefox-58.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "c291f87696212c59624a87530a02b881243b5c7645b3a75aabea574161c488ffe71392d00d18827ab9e4533f272eb44e57d062cfa88a5d14e0eaaad4011b344f";
+      sha512 = "e3d289363aa63cb459e1a1f4f18e893617bfc6f972a49308aacf126698d2dde0baffb3dacaeffae9471a8111eb332c753f376ebbe31aebfbce52c5ea84122a16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/en-ZA/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/en-ZA/firefox-58.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "2935c69302dc079266463058513b816d0631a5477aa535b876b15eb2406bf6c0c4adbd60a83823acec1a6fbeaafc951a9d2a4ad80d2b623d1f2194a79b0099a9";
+      sha512 = "a4c56c45280faf3dc65bba6de159f65b121972da5831664a70369b446aeda44f7614d01dde6a070df058a4bc2d42f32772e1003f64d277cc5bf8361f76fa2816";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/eo/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/eo/firefox-58.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "92e893b038ee0611f85a55b262565982c9941570911c36b5e5fe41d7833596f23f703aad5b606ed266c33a5e1156dacc641f126d8e04ba22db7848c0cf1d0c03";
+      sha512 = "d79405fa9fa01f13a4a98797b3192f1feda51b26568e89746f6b25fed6b73c1f45f3e6bd69427547da19c7eb70508fdea0ff6db21e8d15211faf8da03b088e85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/es-AR/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/es-AR/firefox-58.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "fa000f580bd0c1be1f3e89ce901723d7e11b5d7cc69ad16f7dd31f6b4c07a7c04505165983833c008f4be23b5720211ec8eb9921993e7e6b330347e9f0bc0d7b";
+      sha512 = "f5751dc82ceeff378d78717ee5850edb4f160f3ae26c0efd70557014c96c765fe789fec2a8650f65c9fad67cf1253c00f4bdb75387162db1c914ed45dfb7164d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/es-CL/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/es-CL/firefox-58.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "5d9f4abfc8d66fc3ef0dc08f7dcf84fc430806ca629598edc0e0cdb8c173efb56d1b5c4ed5ba8fcf90878163032a645ce282d6934980b636e8a8c199efe8cf9a";
+      sha512 = "592c5f9a70e28521f75e16b79fa0852815f34b9570ecbab610a96892d9b13fae609a9050a4dd0867bee7b811cac67188c9a756bccc2d6d99821f9ce9db48a509";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/es-ES/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/es-ES/firefox-58.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "d03218163b91ea0f6c478bc33c05676c98de8bfe1a42646f07f2d6daa37439e756031a22e4ff980a34912adeb18ecaf20283a71edb51fe8926bcb4aec22f4ed1";
+      sha512 = "e3fd1f13087eac51a830acc760b83ff9459cf6a1a14136c43c8ab7395b22b01cb2627b077c5f50968023c47f31484818ccf18245d109610dd04e3e5627fdb65f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/es-MX/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/es-MX/firefox-58.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "a55b1c6b88518f0749a349cd527542fadf510e1948b4bd50f141a3abd68e60b8e595503380e7dca6dbd1d80466d206da8e9e418c7ff12bda1e5a41df913978ae";
+      sha512 = "35ea8599e66c29f7fdf1f2ab5a400a0ccae4d0ded4bb3d509d0caf7a6449bb7944c794fe080b1364be055eedc8bac017b8281bd9a76b1d76def573d3191cd011";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/et/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/et/firefox-58.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "43e3eb5c94bcd5c0678b2999d165d65d2996417e0edc3b88fc4c132747049309b6beb8d20d4b51302b7474167b6d03d74e4a76d9b9df505ca305f22468f0b7ed";
+      sha512 = "29e6013843c56fde01478cc871fe15c2f1485d41e87af30daf97e5c0f4e80ae14368601a2df43bbe3618fc878e7503007708b760d1f2a571b4993a99c2411f17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/eu/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/eu/firefox-58.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "fd25b5548cd5de401332c63bd85aa493a60334fd95cf3069d832eb9ac0dcea33d4440594117e396066f827e8ec1737a9afb554904dc3fcd570d805287f2de87f";
+      sha512 = "3f6ef7db13d1b8c8eaded290430a8462aab2172c4e813c9bf2f11f0e417485d88872a66628130987a37286ba474e8bddb9ef01e120dc2c6baf49bf9b5c5e67ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/fa/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/fa/firefox-58.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "3b0fc55a09e4e3bdbcb957116fc301311bebe56a1ef627578bee9972a5e24d7406ebb62899a7e896aaa67cc2d35a6269392846deb306790a25661038c0e12d26";
+      sha512 = "14dc9bfa351de740e46a8a3d59c99d0de7ec5d890783f03a8b260217a02d1cf03a94c6a0d7411698f789e9b77c2e1def24b74d9754be821b1104964308a6322e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ff/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ff/firefox-58.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "3ae6196faf8adcc409abb61eda980652b98a9b4b1eb750626dcc879520019b17486210dc50732eb4beae6910df9876edadd16a7ed001f2442fa0c5fa67d0b3c8";
+      sha512 = "273b3a3c6d32f63de9a8b47cc6eedb7239e42cbf5b8e48191b2d9f9d88731a5da6957ad9bbadfc6bc52e591328a2a89540c4ff880cefda455ce1e5beb35492fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/fi/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/fi/firefox-58.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "6ca46b0e0234984cad7401ee4770b7d121783d5ec6a5aab6cfcdc0c560da23ece1c3c581afe5d2c33d0baea3966d4bca41085b142196dacc96f24bf07bc7c71b";
+      sha512 = "1d71f85cb661c87bbf1c64c2711b45ce912aca629638d2b7953d0ee3256e7e50c920f400c2bcf92ce171be44134a66b28a34a3b38580da3ce2436dae1b0dd44a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/fr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/fr/firefox-58.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "46de1b2996a40bc5401b9e1717465fe8420d4eed26a4c2aab4a20933a3b7ff9bfaa81b1913b587dd0e48c827626eea9ab5ad459d08c1b0f3b6f0c90abf710537";
+      sha512 = "ef15d841348c23f35c2fd6cf93d86657d6e3308bc03935505b99ba1119a02846c2ca2c5c55cc0cde992d4e8af50bc612e086be34cfa61711858f11e6e256f7d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/fy-NL/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/fy-NL/firefox-58.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "f5ed577816da80549fa9c8bc4755c4bab8aa2c9da7174f37606cff62512b0307c54572b87501b440eed66c5727b23d679e749254049c91860e10389794ca2ed7";
+      sha512 = "f42e5dbb7d16828aa2d5fb45faf44ef92b8ef29e5c49dc8a75540959cf6c153f7d423255c4eda765a9db69dbbc18e7b8a04bd3ec1329314c1d69bfa41ea32f93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ga-IE/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ga-IE/firefox-58.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "282d7bc4c2ab46aa7fb2157d21e24295a82e9f28f833b756e96adb640667f611ad460f6102fb58e9e38087ab3c8dff439c942e1fd9536cd2782470622ae8301b";
+      sha512 = "4fea194d08121ce95dc6891b18cbbb031e64f402f31c83b92c9044c8d9337f2b50d76017f4ecfa616f51e8188e6705e8e940fc2fed95b7d21d4c8385b656ece3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/gd/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/gd/firefox-58.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "f11a73f1b2ee2371eef7dd85ce66b7d0fb25b020103003ea326480ebc16c55922967245fd76791cb25a7ab99b96f842394f0fd290c3214174d0bc218a4327bca";
+      sha512 = "614811dae0bd10f809ae048d47543fbdf0459320a8f9926280bdd8467b2859646b7201355777081638b46b77d3def96f8052b55c243ff524a22d2db4e20db864";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/gl/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/gl/firefox-58.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "4f562d3b74ec69ee495d901cc91b2af12b68bad92f7ad66d45a94777fb34559e35aa103effabcd311ecf952acc9939ba16c3a17905684532d7e0f7b2b7c784e3";
+      sha512 = "a20e1f54fd12acd5480bff14d24993c2d58a33618170813980a8a1f0b810140a99c7157d8c8eed3d56f8daaf2fbbd525c1df98e1a90cd0f6f89ec253e4b5b73e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/gn/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/gn/firefox-58.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "fe08fc07cd11c00f932c042aefea193c7d6ffdc000b210117bf39e8f1c01689ed5abb5f26dbc55ee971d53abea2fe209f7359be990263229d43b49ed73cef5be";
+      sha512 = "ccd057d636e8f3884db25ed91186a5c995b02eca0c3c7e07616364ce7d95e42dc1f3d1c6e9eb844c6bab4088127232bdd85e3f33898f681f837c3887ab0415e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/gu-IN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/gu-IN/firefox-58.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "06eb8635eb7ee46f3e9e4bd2444d8beef4da5db534530d4d1572122a617558f27d7e8bee1efbe43e916c58406ad0728f294c2208048331cbe3c54da42a43ffe6";
+      sha512 = "fadc9a802e9322e2ab0f6b66bf8d938a5e3bfc67a1ac901c0d41d5ea82bd87be0165f50b2c5ce7a75c68f8db45eec8b0e7ea3de237f6c6f79d72cdf386cf3e00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/he/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/he/firefox-58.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "b45d06a32d3d6fea1c2093ad21168329137ea4cc1e2aa8133822b4355a67be081b7c5d9afaf01122e474ff43ecf2f802c881cb6da5bafcf1e3765204ae33d011";
+      sha512 = "9fd2d1f4087b247814282e2edab633fd865ebe94fc73906bad065e0af927f298f46306dbe7f36c98875b57bbb66aa5e51f37f5a5308f024eaa9a62f968916c0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hi-IN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hi-IN/firefox-58.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "30cfa4d45da6cb519396ca143e929695b7a2cacae1df4c88ca4ab85acd4ff74afc880f13d23f11f6bdbd99843cdfe88b3becbac15c0add4635ce8c2009996304";
+      sha512 = "7a07dc67e58c295309768e84b2489413b6d8ff71a786d249b977a7bbba245f74c6d88e33beb934444a34de88a205233953f0b7be3a3628950b0c851c35c593d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hr/firefox-58.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "64c6ae787603cd3b1855bdc01a458b3034b7ab959e15312e261c170f5e6435bd47cec560667dd0a1aecb48824df73534540f9e6a91f690f5e50c7b5a3b2fddf2";
+      sha512 = "5db4c7e305856d96899270e20b41c6db2c130abf25bd5eb47cbd2683e8097fb41d37bbd3c577253601c99d2bcedf42472bfce74cc4155a01de3998160b3a139c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hsb/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hsb/firefox-58.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "30da250712f6cf80749350e4c2a0ca069b4b0079d0bce9cbe16657232c1ce76212f962f5891f9cde86f9c88811996e922c2acf7b99a651bf6733fcc3b83613cd";
+      sha512 = "5729719fa57723f4c87c5f63f9c08b552e374d9ed9cc9f39aec49223be7b85d550074f680511c79c5b47cc0219dff687c7ac288781822a5bd10f4365cea88825";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hu/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hu/firefox-58.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "b60242512dcff653d758a9984b66ef77a718836da5b726233f2ba44f09cc6fbcd3f4502446c4c4c1d4c6112cf213ddba40d0078f9f7c7ed4e9cd6305b64d8c71";
+      sha512 = "b0334bd7fdfe6737ca5fa1166c37204a6f0205f6756af31b8aa34da6df759f487a3c1aa88bc9cf2dcab4be8724a203e3d35509af4fcf03581c8c59023db532a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/hy-AM/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hy-AM/firefox-58.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "36afb61bcab97ee12a30c2ac50f366c8b35337ef91d9fca7a935bdc0dbdc4c150c6cba62ddb532ec194df93b4f9df96800d048857790b5c634a9f0bf7faa2570";
+      sha512 = "33ac9a2a7a554c4662a9285124fb8050894c921ec72d7d3655197923e2fe3fadee007afb54a25bafb9ab8c9a0d898af52102bf629a604563d10f462001f08853";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/id/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/id/firefox-58.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "d7e36fad6b94e3a3887b346b863c13c5c3f0bf8c0ad85354cae62724e6f320af2b8afb988b390c7c620f763fe90e9719bbc8033b1b65f516157e569de076662f";
+      sha512 = "7bc77cb0cecd1cb993b158670e448fd22bf982ecec84213c8c32634df32ba538fbee8eb834719dd99ef1087b6f8955effbe1776a3e150bf5fd2ccc90606bc215";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/is/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/is/firefox-58.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "d9e7caad2e362ec7e764d29b4c1052d9dcdf0d329762b8c74fcf54d3542fbd9d9920ec693be45a26eff9d09a713bb2867ad39a9e30196e92716bb21aa09281bc";
+      sha512 = "8a3fd3e89f503fe4c74b85e8ef87e1e332646cd150c95ff8685071bcc456bdeb09de46e256d13a53f5f8f4cd3172a12ec6c8096dbe54a9cf018be857b4997e94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/it/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/it/firefox-58.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "309bc35eebcfbef93b26eefe1a0fcd0aeb16648636857ea2d65dbf89ecfa03dc071ce1e26b2ebcbf64b58f7b5a8aca110fd6f20ab3af306acc7a32195920c0ab";
+      sha512 = "8babf797e0b804e4e8b98a6261dfed27c93832966a66de71ba6794ffd3bf7d3b41ceff7ac4308ec9f978fab310baba5a87dec82f710014cc9dd6f27a520ceaff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ja/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ja/firefox-58.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "61b26b1c808798dcee28d59179f53117981d655b4b50215d53889f029e75eb32dea5e5b291ec6301c77b1578febfafacf0de0e1924153b5c56d2b67287d05924";
+      sha512 = "f3fd18b97b2880b3627e100ae20527eb998c7b9d11b2c38b628fd1372f7811cd40662cb5d199f12982fa35f8fb9e6923e2c8b1ecaf5634b6989e8b89480ff252";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ka/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ka/firefox-58.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "1394a91c94ea06abaae35b82a041667699b4a55977dd7aff2f5dbf39e21d18488db00dd52fe39fdb01af02a753e2f2e5810d456eab3e2c7524cff12f744eaa1e";
+      sha512 = "4f69cc6927a6aea8496283c1c47961a38ed621b4a4563346506e4c138714824cd5bcba2f0c4d1226c643412ac071838693c0b3a2acd6fc9602a6f12060955f75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/kab/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/kab/firefox-58.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "663043b3f1cf1c47be7fa40f8bcb807611df665545041fcd5cce9b93a605abbc52cea6663dfd696ee48a3b462f412d2825d0ffe03e5a35166772090475e167cb";
+      sha512 = "93fb1351b4c6271cbbf04e8bc8750569f5e3a4375559512055f4bdc68b7ef1c7f78c9354d5168e54d49bb0a529a380eacfb25a109e7f7ef2fdddb1bcd7bb9fcc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/kk/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/kk/firefox-58.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "7fd70d200ab915f01f7239d8d84351dcf2f5aff159112f6f60e9ca4eb204b087461d8af00cebf282b4ee05dfd5571ceaa4dc1076c31353635c7eed7dfc8fa464";
+      sha512 = "e4d849284c358bd297b07f557ae304cf9ae681733ee2acd232eda28abb9bfc38ad97916b00f257f56a9a514bfaff9b440ced15194dc3abf56b0af209221a7272";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/km/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/km/firefox-58.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "c8057c8108e588a26737dda5c6244f738f3d9f86334e18f2373072830b99a02cbcef7a5e4961e6adf5bd48e6605064ce0569ab10923b8c7fb649be2ef1fbab28";
+      sha512 = "0fa3bcf4b054c8033ca4ace9446b6062114889a9b3affa730ebf3ee23fdff470676919cc7086b5a13a215ef87b73aae306e667d0b1c18437b6265d5622972a8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/kn/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/kn/firefox-58.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "958c4cd905f2b7fcedf75b819e6136a98577cf8a87b0d20d643d74068332b33003a6a92ca7348f9336cdc5e88333cce2efdfe522817a8450672c8e103212df6f";
+      sha512 = "7ff42d342f103c2b6f4f4050c7c79dd0687f87105e31dd80efedec34dea27dc5c9eeda16b79ea676d43f78a85e55a1e47c400e0faff9006bfefa55f183efb82b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ko/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ko/firefox-58.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "1a50dc600063481468769e8f9ea4f150068e9636b1ee84ef86c7f55e515ffb6124db686b3d2b52a29c12538342f13d9838d7499d89afaf49481d89eb2995fd8c";
+      sha512 = "9fff35314fcb6031923b51db50e779564b7e5aea3068165bec73c6d8833b18579f87e676291a6570827aed29a1074ba54f08255c6125333da2f040c9ac404bb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/lij/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/lij/firefox-58.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "429681a147f3575ac693dd6002579751ca24ddbaa51a9926e303369e2c1273a2f3199889c9ae9db82533f7cce73e177dcbadaffb1be0f189db98327a71260b69";
+      sha512 = "d574c03667da40589736295bad53fe22cc67d3f6dbc5281feba5d76138ecbace6daf7d39145d11ea794730c3606f6586fa58d3058fa7eb3f0d1336acf7958cf2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/lt/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/lt/firefox-58.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "a5c7c999210b05c88c354e0c88cc25e5128da8fb6f399dc05ce512ed0bfafdcc109ea17259772304d99027fb73ad667f091ad312d32cda5b4de0f387c39c3b9c";
+      sha512 = "4c38dd3f72be96b2a7bec60a55e7ac0a75c13036c3b62d4805ac3f32efb6422b2a74807cefb87a3ad10f25d41c14d00055cdf09092ad9068bcddd5a46dded650";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/lv/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/lv/firefox-58.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "d1f95c065173cfe5256e5733d3c4d551623355745cb7de570b5dc4ff2d7dd7da0a31ce2637d96c22556e41b92a637bba07278efa710d4be096ecab1e4476aa80";
+      sha512 = "fca51f322300f18b3e5c988f883fb352593c40988e5f0203008b71c725a162da0a15e67434a91af0e8dc63ad869280f6ead6714e2da1b4b6b83284fc56790688";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/mai/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/mai/firefox-58.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "1a7fab6cd71d67c46022dc8ea0484aae0915b1458e83dd3c5f1bde5daa77ad730da046ab1d1ad7f2cc3d34d418cd7ddfb95747bbf219841ea304bbb615697fcf";
+      sha512 = "650b729a0dc938c2a0375e967e89a2d6e95595bd9c0f8f0e9940dbb51be4ee80257ab7c7006eb933b4d21fb4cad053a4e55e2dee673c8f976a1f038e3ba5c1d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/mk/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/mk/firefox-58.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "ffd6a31976e3dc795e52c6431a2447ca64e4bf39b6bdbaf88e7f9c975678473f36952a33db9f17d80d3086fe0e8a8272bd9a8b1926b3291cb4abbb2d0adc1b2b";
+      sha512 = "3c15491a97cf61676c6dd1705a281b2f85b4e2e4446645b20d7fd46b5968248591d11ec344544b42c00643a9a21bc3cc57665b7effcd03f9a8105d6a89fd876f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ml/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ml/firefox-58.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "21a2c8450e7057a882d2ff901eedd08b21d3ba7c421f8591a0bf2cce8424757298ad608560eada9f3300d387f071fb7b3e199e0878d413d66ba1be5fdc0d01fc";
+      sha512 = "d76726b4d18d114ef391fa65e3396bef3e5d7896b90264e89e82673d0ee8be69633d831220908da30852994f1d5f782e6d6f221b0a93b028f543aa9899d2234d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/mr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/mr/firefox-58.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "3836a86acfe8e7c2e812ac447be62158e6bc2e00e73345d40f288214b703a9399d12f43f909c48aa7ffc32bd8b1b1e592af3595a2fb4369a68ccd801f3085a29";
+      sha512 = "b789f8e68a2020902bddcb95daf854cc784cc2a3319c2a145a5cb877755780699010b4162ffb124d0f5945e722ee6d7b0f0a1baedf277bd8d3c429b9d7870b42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ms/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ms/firefox-58.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "ecfc28fa91aee525e54bde80b0d2d76da9a88b595f6b48dfe93632776228ca79b95f2116eccd585460cd8af6dd90d81352db6f21d86b51582b806721207df31f";
+      sha512 = "76fe657a616e786926740bd10bb8332cc520e08aa6944ecefe98824e5f0d059c6c93cf0e5968c11b153e55bc445a79939ef0b2a765daa69d6c72b8e25010f4ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/my/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/my/firefox-58.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "2d57e9bdcee5a3b1ca91567dd97f98c554d62ae54544ec4b789b5bb75648cc7aaed617aa508897f8e4143c9bec6f79926396b7cabd6a4a9fe86f38f714af5211";
+      sha512 = "618224cff81d80523150cae7c020e8a29569fc7310fa031076ace7006bd8f8efcc4773b450de4ae4965445b277770603a7793287cb85714f0aa057584e636116";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/nb-NO/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/nb-NO/firefox-58.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "9f2b0f925054107eabc00a28f08604aa482694abf70d60d3e7d5f5808485f4e7fbd36289fb87dc8aed090a7cddf1172db6cbe768052aafe3d8d775277808aed2";
+      sha512 = "7f33f1f49e6ac31a022d1ba856e23d1b10a23aa2501550d5ffbdeed05c752c27b3345704bb9d15d8eead5115085b0ed00d5b5d53de9cf2290e753f04a4f3fc1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ne-NP/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ne-NP/firefox-58.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "7e85227c6e3fe28382ae17fca3e2e91a06fe1d6971c9abb8e06c8b4c1b4b9e0d26a1fff88d747c07a9da942f91f95354402f6c12cb992a555af210f01d5e13d1";
+      sha512 = "892223856ff20d4cf7c601066ba6f3620b39fbf4e56fd89207f3d18b10b39bebc236d5eddabde57585f0e0c906dc035ed030d49b53bc346ce630581b9288654f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/nl/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/nl/firefox-58.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "9febb386608d0d7b34c2d00637f85971c00c5395b229b44dd29d2d18bd0007e5f105bacb24f6a9f39c0e2eeb882478bc279b3a18a45cdacee6f697607b411511";
+      sha512 = "f139e9420300a0276f9ff7b70fb1839ae9e2aaf089ccaddca782b8dd1797df80873cb8ebc91d37399c39772d5b381b30ddda8c41395065d2424defb709eae21d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/nn-NO/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/nn-NO/firefox-58.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "8e5bbbbbbc1cc8d195e0503d982d50b92d3ed832e6a8b9662e7a7fc0cce21a0a5b0ad8769026f8d78d8b59a1f5605164fb07059600e7c92bfaf2eb2f2e4d2eaa";
+      sha512 = "50cd63ddb3f83f7c62916299d910d940930f046da612e3cce890310d271822acd87f971b5aee56aebc4011b1c414574c7c96cced936ba6f89a21bb93ea9bd356";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/or/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/or/firefox-58.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "9e7089f9e53d2136805f58d449c697e811b4c81af00e0bb321d2ec96ddf58838dd04b7c357530fde6fd69864c797ce3d4f0db105eb0534a1ea95588b779dea2e";
+      sha512 = "ef73a14c8210d1b82e0ed33109027099a8d5dc3961476eedc31a92bd855a529e2be6411b196d0c4df97124c5be69ec4b6a245a936de1c0e8c609a0d17d51d8d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/pa-IN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/pa-IN/firefox-58.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "5e1ce5092040a3c0ab7e5431dcd6731e16757b49c1dcd48e4520dd3caf728bcfd1dfe7ec75013e2359d9759526a9dfc2e8c87df88dd85708ee023b3a51a51603";
+      sha512 = "53fc6c822192bf96db817d32ea46f0570a83e296b1e4cdfa585503b02b961346b21751e22d50c056a6411ace168844df019e6dcb96346e02bc9deada71c5e237";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/pl/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/pl/firefox-58.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "dd42a424f88c169dc26c0fa4876285440f019e2de936c6737ecc4255953bb44728ee63577d15a3bdb55b9540be5b8560984df936c2dbaa9b6b393efd1af0651f";
+      sha512 = "a009db74e155f4a089501ab96d7c72c2baa2e2ad0e555ffe0ee0baf6b259b5bfbf422ed6bca4b012f7b1799db02dd0d13323b39e6f73c7e5877e8ea080f62335";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/pt-BR/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/pt-BR/firefox-58.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "83256d6c42257eb57b6926c04a1e7adc0a7ae120207477a7e79fe71b342802391ff5844cd1f6b15464a6cba12ea0d3e62dbf2e43ef0e4e275d16bf60c8e3bc5d";
+      sha512 = "c77a8c87942045b959058319fcccc35ff8d054842fc8d7332171f110e82595886746597614ec4884915ba8397c63ebce597dbab648d2f823a1fd803f8c662382";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/pt-PT/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/pt-PT/firefox-58.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "80133f87098b9d2d5855fa87f16b441fa3845d19464dc3a156bab55adb8fb32e2b2055c22883963f37aef9e2051a9e859f02f4ccdf829e02cdd3ac326ea246bb";
+      sha512 = "6c09645104219be720c843f3065617184ac5731f354d4217347c662d2cc7cf66060b7805e16b032914f20e75ebddc72de06c3f7b520656bf7d5afd9c4ca517d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/rm/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/rm/firefox-58.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "c01b84a6e5c087ecc28eec795275a065d7f370ed965ee0c876371dd7e442110bfe4c8c9356d9ae6ca0cd09448e4688901281973536ac0c72092a3ce5550605f3";
+      sha512 = "a232ea477b7b0841eb5dce7efb722b81da8136ec974bbdd7739d0700b163953f0b07e9509b973afa3c09af75b0b08523fe94dee21aec919f40f57e2ffd9dd6f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ro/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ro/firefox-58.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "a00d1c473e0ead438c04c44a7169884d93e488bee068898abc2082570340c747bda7f77a597eef4353488fd94b811e955f1b44ea51e96a49b02b2a51299230d6";
+      sha512 = "887a70aa19415abe5bb2bb10f4e66e293177713612186567e9691b715e8b7b7ec3487509a111e8d9053241bc74d1bc9bcbf930931a14050b7c8b513076ed385d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ru/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ru/firefox-58.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "3e2df508529125004f9e21fa100ab941c5cef0a849dd413fef3a22db67e8c7d3445f26cbbab26e76e716379af2156ab06c9be2b8b6996cbcca55f7966aad8b04";
+      sha512 = "efb8f8746d07a387d094e23c10f8a2ae3697e854b26a9ec78013f4fb2284a359bfa6cac686779fb8e1d72114c59e191f86240f02b61f4c748909dfcea45368a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/si/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/si/firefox-58.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "9e3c4e1f46e528343d9a12555427706b387fa666fad133c1ecd051dd0ae0766f81ac21e90b80ed492dba0f37638211319cbbe6119955dd9daec01b1dd65730e7";
+      sha512 = "9b469c23762a85e1f536928d78df87da8cf2661f78e5a558d8caeaf504ef7ae54c54eb2c3b6ea00381fc2e83348e9f403bd1c106cb518148ebccd113b5e5f442";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sk/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sk/firefox-58.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "bf82820a071ff046d51f3b8e0867f3776976ee9084b0753bb15bab5407d3fde1d8c7ce3ebb57832f3395aa4c228471cd1c6da1d9e5c03610ec1845c4a07db6aa";
+      sha512 = "1ff839d7c631fba2510534032345fcf6397f694d035daff179382270a7889b6c2046b4b2bd6d7666c6e298146ef47cc9fac2b7c525d7c8f563b58b7fe11a5dea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sl/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sl/firefox-58.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "51a54b0ab14636b8a002280589c8dfea6dd3dbc25236432dd774156cba0de2ca814dd4845118934a719e2b0240da0c6a7a38588e2fa2f54301f8625a14cd8a37";
+      sha512 = "766e06e574d0f4933f8bf3e50521b5025915797f25712a29f0961759410272fda59aeb869d4d84cad961b277f5fc8ec78b8c333ee0e60e52e07fbb99822973b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/son/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/son/firefox-58.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "0709b04b9c2d9b316132a5643c951f05cad0adaca9ec8aea9374e3e80019a990fa12419bee06185712e7c100b038d4eee648a12b8fde186f1a7caab472c40cde";
+      sha512 = "60df99153af07b88fd888b232b570eeeb4cafe01ed1c85cd536774b03e121523689d6de3fa3d6335fe7e0c9534273ce571d7a3fa00034e1681b78f4012a8fe7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sq/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sq/firefox-58.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "f5de9ad3600867e039a801642256ce8c0fd2feae4c2072561a7bb3cf2e4af7774fc68d388b884fefdb4a4e9e44bab288da489f9edce2f663926ac4755332fe42";
+      sha512 = "97263478fbeeada0ff397723bd8c4e0935c88c25cfc259bb2906e8d0a2ecce8101f4cb5ea9457b8b0b3276de475e0a8fbe995faa1edb33ced17b98404ac1021b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sr/firefox-58.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "816c6d2e5de45d069506ac6a54c6292c18442ff310397f4f8f8a5bc38e87d9cb9fc02293dc71f94010b01f965de625bd437f245342ee12615966fed3b1e9e3f5";
+      sha512 = "b822f5077378b3c41951aafed6f6b3ab174d9240058d69a05905803c2b8ab74791abfc1ce59550585f0eca9fd97e3c0325c9bfeef47d14b8eca039959ebbbd1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/sv-SE/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sv-SE/firefox-58.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "0b31a68d604c6d8c46c875054bdf60e05afbce7b074c63e2c2dd715a03e77540aab12de27305a9a6215ec138b76b5375e5103ace750bbf78269d838905efa43b";
+      sha512 = "20555a59e733f49b3714cd4517aa952a0e9306681f5ea1f33d9464ee50705187ad0e745ebfa00a64e4cd0aac4d7c3c3257cf04681e74e18037684e675b05df7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ta/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ta/firefox-58.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "69b591bf072db73e8c083f6052b239d4331dc2688ea35b99055ee1938009b198f19de56b12059132c3b4b66cf5fa0e7a171a8c01eb998e0aeb8f1db921246593";
+      sha512 = "2d5721bc3519b766dc70163b8f91988b49512e4709d998239691c382a006bb06fd82b793fce843f976a55cffa8a0ff06711917e35233629945539c1f27453d02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/te/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/te/firefox-58.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "985e78c31ef1c3604d5fd3ffc5cc8871c897522dfff37675a6da6d72bb15c9538caa9cf346ade4304207ccf1dc790f7b353f4a7f76dc8b1ee7df91d0ef912644";
+      sha512 = "28ff1470be8a12212ef2467daa9a363ef929fe8f6741678b5d17ccfa149b122bc2dd74478bb96e721725c87d6a3000878dd7b51d1e38e6242e6e286c3621b25f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/th/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/th/firefox-58.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "9474d8ea5bb99dc0d6cc84f13c70df13f3958b23057a8a4c20180b57e5803ae108add8e8e385c5c6b5a76442adefb20cfa328987d9651e200e9cab5cfe96f8b3";
+      sha512 = "935a7354cca219695f58592b1d6668ee3d305559ad9c30cfc274b63952bb133429528e38bda10d5cdeddb428133712da74ba621e2c831ae14329c22530f9ff91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/tr/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/tr/firefox-58.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "6be02174476b94a899227d93c3ade402f48ac7126e13f896ada068f34ba32f718f6ee28de7eb2475a0190cde1a10f1e08fcd8a95e0216c827457b0d6b5be13d8";
+      sha512 = "9f30bcd90b0c5ae5b55dc74a1e4adf8b029d8b87ba4f2961a4eb47ff4c61decff4abfac4f4664f1e99653f05a1749a17c775ba323ac322ec1fe3e104a4c57cc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/uk/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/uk/firefox-58.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "c6e21ada75939a968eebcc57598844b60a24e155bb540f295d727315b3b91f5533207372ee5826e85d740c77ef134e8dfa779828f8308627b96b57ed58589a21";
+      sha512 = "eca33af02a5f2d7363688aa2636d407822dfe9b70fa003d085ca6b9c3089adb49d080204c5e94d89178ff952dc5ca6a9402446610eb3e4460e55cdb066b965e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/ur/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ur/firefox-58.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "c3e10cb76ec9851a1cd2853e44a57437450d67ff130c6be2c0367c0bef2d2c22bd67966667b71feea2d308ac05a652f72dace7f0436678d2be46ad1361524515";
+      sha512 = "6dc7bb3693fa86305bb50be09c7945f199450c286867f56e66721944a27894e3de7a6452801ef4d04b0339403900b46effb7d2282a81c0b042ccf4c49f758a47";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/uz/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/uz/firefox-58.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "01852bd4d2404270180070b81446679e7467904cb476fbd245ecd086c3f914f01fd61706d7a2d75d903540ac5ca254aeb12470d708fc86e3f475147591eaf479";
+      sha512 = "1ab8b3aefedc0c50c76169c0890cc5e3c381b7f743bb901c5573103761ae67985deae20ac2ef5b5d0f85f848a82a8d60bc87336205e462ddd2f040ba3586f258";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/vi/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/vi/firefox-58.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "3980ad79b0a6b9dd72d882dca046be9c43406e3ac84663af3dd46bf03fded2be303adbbc4669077df7c803546aaabd0ec0d2aac34b6f8a6f03f86955e34f4c83";
+      sha512 = "cca1d12e5f34b78f930d7b7b53afce55567be0e9e6894b2af1d20a5c2c11df0531d06945d812bec956904fbd3ecb4921c282f8a9a520661c4988d2147d370dd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/xh/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/xh/firefox-58.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "3e1664e57115d4d9f817363cbc1c5a68039a7baa3e5b430dcf6b1be4252857daef1806f606f6eddd2bf7cc48542f382aa937915fa6f3dddcd2faf27bb8217943";
+      sha512 = "8ed571a58fe104ef53aa785d10481371adcdf4a38f449bdbc65f6ab532797d9c4d301f6f75868645aca291cdc10ae3b5b8d2fd1f8f116f9ef21b9d91e4264f24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/zh-CN/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/zh-CN/firefox-58.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "e159a96858204f27d76cfecfcff32f400b2cdd8bfd847fb98dddd085f77565d5cd0e280b0f8a5552b397a08578144bda8307563454282de3fc70cb555ccd1554";
+      sha512 = "ca63b214cdd67857d69ba86263e3efeadddbfc0f35a6c13ba9308959bc158d481cd6930246f3b59b7c335399ccfcfe5fbbff5fd1cd62aa1316c1da96403dfae8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0/linux-i686/zh-TW/firefox-58.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/zh-TW/firefox-58.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "66f5978aac39e4be86745570cdc2fe6cbaae233b19b6d2ea710584862580027ac1a6033a2238601e6ca6968b39cf1313b088348c788dce9dbb3bdef9d97d8784";
+      sha512 = "35bcec66fb184dddc9aab83fd91c561c396b6ae48bb9e027e4a64aa7aa60fd264ce4da917255370736ffb08fc42362bba61844ee0295c6b7adf721fb70d93136";
     }
     ];
 }


### PR DESCRIPTION
(cherry picked from commit ba2008938de62bcaeb04ec0b12d08a04da46ba34)

###### Motivation for this change

Security update for firefox-bin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

