### PR TITLE
libxkbcommon: 0.7.2 → 0.8.0

### DIFF
--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -1,30 +1,35 @@
-{ stdenv, fetchurl, pkgconfig, yacc, flex, xkeyboard_config, libxcb, libX11 }:
+{ stdenv, fetchurl, fetchpatch, meson, ninja, pkgconfig, yacc, xkeyboard_config, libxcb, libX11, doxygen }:
 
 stdenv.mkDerivation rec {
-  name = "libxkbcommon-0.7.2";
+  name = "libxkbcommon-0.8.0";
 
   src = fetchurl {
-    url = "http://xkbcommon.org/download/${name}.tar.xz";
-    sha256 = "1n5rv5n210kjnkyrvbh04gfwaa7zrmzy1393p8nyqfw66lkxr918";
+    url = "https://xkbcommon.org/download/${name}.tar.xz";
+    sha256 = "0vgy84vfbig5bqznr137h5arjidnfwrxrdli0pxyn2jfn1fjcag8";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "doc" ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ yacc flex xkeyboard_config libxcb ];
+  nativeBuildInputs = [ meson ninja pkgconfig yacc doxygen ];
+  buildInputs = [ xkeyboard_config libxcb ];
 
-  configureFlags = [
-    "--with-xkb-config-root=${xkeyboard_config}/etc/X11/xkb"
-    "--with-x-locale-root=${libX11.out}/share/X11/locale"
+  patches = [
+    # darwin compatibility
+    (fetchpatch {
+      url = https://github.com/xkbcommon/libxkbcommon/commit/edb1c662394578a54b7bbed231d918925e5d8150.patch;
+      sha256 = "0ydjlir32r3xfsbqhnsx1bz6ags2m908yhf9i09i1s7sgcimbcx5";
+    })
   ];
 
-  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
-    sed -i 's/,--version-script=.*$//' Makefile
-  '';
+  mesonFlags = [
+    "-Denable-wayland=false"
+    "-Dxkb-config-root=${xkeyboard_config}/etc/X11/xkb"
+    "-Dx-locale-root=${libX11.out}/share/X11/locale"
+  ];
 
   meta = with stdenv.lib; {
     description = "A library to handle keyboard descriptions";
-    homepage = http://xkbcommon.org;
+    homepage = https://xkbcommon.org;
     license = licenses.mit;
     maintainers = with maintainers; [ garbas ttuegel ];
     platforms = with platforms; unix;


### PR DESCRIPTION
###### Motivation for this change
Updated, converted to meson and removed flex (not needed since 0.3.1).

https://github.com/xkbcommon/libxkbcommon/blob/b82e3b764e60df337ca695e8f8642e7bf42b0cca/NEWS#L1-L19

cc @garbas @ttuegel 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

