### PR TITLE
psol, ngx_pagespeed: 1.13.35.1 -> 1.13.35.2

### DIFF
--- a/pkgs/development/libraries/psol/default.nix
+++ b/pkgs/development/libraries/psol/default.nix
@@ -1,5 +1,5 @@
 { callPackage }:
 callPackage ./generic.nix {} {
-  version = "1.13.35.1"; # Latest beta, 2017-11-08
-  sha256  = "126823gpr3rdqakwixmr887rbvwhksr3xg14jnyzlp84q4hg1p0n";
+  version = "1.13.35.2"; # Latest beta, 2018-01-11
+  sha256  = "1z8m0qgvk5gqj37p4kps3y4h7jwaqk0rw0y513nlsb163z4b05f5";
 }

--- a/pkgs/development/libraries/psol/default.nix
+++ b/pkgs/development/libraries/psol/default.nix
@@ -1,5 +1,5 @@
 { callPackage }:
 callPackage ./generic.nix {} {
-  version = "1.13.35.2"; # Latest beta, 2018-01-11
-  sha256  = "1z8m0qgvk5gqj37p4kps3y4h7jwaqk0rw0y513nlsb163z4b05f5";
+  version = "1.13.35.2"; # Latest stable, 2018-02-05
+  sha256  = "0xi2srf9gx0x2sz9r45zb35k2n0iv457if1lqzvbanls3f935cmr";
 }

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -153,7 +153,7 @@
         owner  = "pagespeed";
         repo   = "ngx_pagespeed";
         rev    = "v${version}-beta";
-        sha256 = "176skx7zmi7islc1hmdxcynix4lkvgmr78lknn13s9gskc7qi25w";
+        sha256 = "0ry7vmkb2bx0sspl1kgjlrzzz6lbz07313ks2lr80rrdm2zb16wp";
       };
 
       ngx_pagespeed = pkgs.runCommand

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -152,7 +152,7 @@
       moduleSrc = fetchFromGitHub {
         owner  = "pagespeed";
         repo   = "ngx_pagespeed";
-        rev    = "v${version}-beta";
+        rev    = "v${version}-stable";
         sha256 = "0ry7vmkb2bx0sspl1kgjlrzzz6lbz07313ks2lr80rrdm2zb16wp";
       };
 


### PR DESCRIPTION
https://www.modpagespeed.com/doc/release_notes#release_1.13.35.2-beta


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested with NixOps deployment using it,
as well as with functionality and NixOS test added in #33708.