### PR TITLE
json-glib: fixup darwin install_name

### DIFF
--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, fetchpatch, glib, meson, ninja, pkgconfig, gettext, gobjectIntrospection, dbus, libintlOrEmpty }:
+{ stdenv, fetchurl, fetchpatch, glib, meson, ninja, pkgconfig, gettext
+, gobjectIntrospection, dbus, libintlOrEmpty
+, fixDarwinDylibNames
+}:
 
 stdenv.mkDerivation rec {
   name = "json-glib-${minVer}.2";
@@ -11,7 +14,8 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib ];
   nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection ];
-  buildInputs = libintlOrEmpty;
+  buildInputs = libintlOrEmpty
+    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 


### PR DESCRIPTION
###### Motivation for this change

Couldn't figure out how to fix it durning the build.

Fixes the rpath issues in #34428


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
