### PR TITLE
uhd: 3.10.2.0 -> 3.10.3.0

### DIFF
--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation rec {
   name = "uhd-${version}";
-  version = "3.10.2.0";
+  version = "3.10.3.0";
 
   # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
   # and xxx.yyy.zzz. Hrmpf...
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "EttusResearch";
     repo = "uhd";
-    rev = "release_003_010_002_000";
-    sha256 = "0g6f4amw7h0vr6faa1nc1zs3bc645binza0zqqx5cwgfxybv8cfy";
+    rev = "release_003_010_003_000";
+    sha256 = "1aj8qizbyz4shwawj3qlhl6pyyda59hhgm9cwrj7s5kfdi4vdlc3";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -7,17 +7,28 @@
 #   SUBSYSTEMS=="usb", ATTRS{idVendor}=="fffe", ATTRS{idProduct}=="0002", MODE:="0666"
 #   SUBSYSTEMS=="usb", ATTRS{idVendor}=="2500", ATTRS{idProduct}=="0002", MODE:="0666"
 
-stdenv.mkDerivation rec {
-  name = "uhd-${version}";
-  version = "3.10.3.0";
+let
+  uhdVer = "003_010_003_000";
+  ImgVer = stdenv.lib.replaceStrings ["_"] ["."] uhdVer;
 
   # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
   # and xxx.yyy.zzz. Hrmpf...
+  version = "3.10.3.0";
+
+  # Firmware images are downloaded (pre-built) from:
+  # http://files.ettus.com/binaries/images/
+  uhdImagesSrc = fetchurl {
+    url = "http://files.ettus.com/binaries/images/uhd-images_${ImgVer}-release.tar.gz";
+    sha256 = "198awvw6zsh19ydgx5qry5yc6yahdval9wjrsqbyj51pnr6s5qvy";
+  };
+
+in stdenv.mkDerivation {
+  name = "uhd-${version}";
 
   src = fetchFromGitHub {
     owner = "EttusResearch";
     repo = "uhd";
-    rev = "release_003_010_003_000";
+    rev = "release_${uhdVer}";
     sha256 = "1aj8qizbyz4shwawj3qlhl6pyyda59hhgm9cwrj7s5kfdi4vdlc3";
   };
 
@@ -30,13 +41,6 @@ stdenv.mkDerivation rec {
 
   # Build only the host software
   preConfigure = "cd host";
-
-  # Firmware images are downloaded (pre-built)
-  uhdImagesName = "uhd-images_003.007.003-release";
-  uhdImagesSrc = fetchurl {
-    url = "http://files.ettus.com/binaries/maint_images/archive/${uhdImagesName}.tar.gz";
-    sha256 = "1pv5c5902041494z0jfw623ca29pvylrw5klybbhklvn5wwlr6cv";
-  };
 
   postPhases = [ "installFirmware" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7971,9 +7971,7 @@ with pkgs;
 
   tweak = callPackage ../applications/editors/tweak { };
 
-  uhd = callPackage ../development/tools/misc/uhd {
-    boost = boost165;
-  };
+  uhd = callPackage ../development/tools/misc/uhd { };
 
   uisp = callPackage ../development/tools/misc/uisp { };
 


### PR DESCRIPTION
###### Motivation for this change
Version update. Includes fix to build against boost 1.66 (see https://github.com/NixOS/nixpkgs/issues/33549 and https://github.com/NixOS/nixpkgs/pull/33552)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

