### PR TITLE
dante service: change to network-online.target dep

### DIFF
--- a/nixos/modules/services/networking/dante.nix
+++ b/nixos/modules/services/networking/dante.nix
@@ -47,7 +47,7 @@ in
 
     systemd.services.dante = {
       description   = "Dante SOCKS v4 and v5 compatible proxy server";
-      after         = [ "network.target" ];
+      after         = [ "network-online.target" ];
       wantedBy      = [ "multi-user.target" ];
 
       serviceConfig = {


### PR DESCRIPTION
###### Motivation for this change

Fixes dante sometimes failing to start as a result of a race condition around IP assignment (especially during boot-up).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Built on NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`network-online.target` properly depends on the underlying network
management tool (e.g. NixOS static configuration scripts, dhcpcd,
NetworkManager, networkd) signalling that all interfaces are up and
appropriately configured (to whatever degree possible/required), whereas
`network.target` only indicates that the network management tool itself
has started.