### PR TITLE
[17.09] 57.0.4 -> 58.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "57.0.4";
+    version = "58.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "58846037aebbf14b85e6b3a46dbe617c780c6916e437ea4ee32a2502a6b55e3689921a0be28b920dedf2f966195df04ac8e45411caeb2601a168ec08b4827cf0";
+      sha512 = "08xgv1qm2xx5wjczqg1ldf0yqm939zsghhr4acbkwnymv5apfak3vx0kcr9iwqkmdqjdjmggxz439kjn510f92fik33zjfsjn7sd9k5";
     };
 
     patches =

--- a/pkgs/development/compilers/rust/1.21.0-bin.nix
+++ b/pkgs/development/compilers/rust/1.21.0-bin.nix
@@ -16,13 +16,13 @@ let
   # then running `print-hashes.sh 1.16.0`
   bootstrapHash =
     if stdenv.system == "i686-linux"
-    then "657b78f3c1a1b4412e12f7278e20cc318022fa276a58f0d38a0d15b515e39713"
+    then "b7caed0f602cdb8ef22e0bfa9125a65bec411e15c0b8901d937e43303ec7dbee"
     else if stdenv.system == "x86_64-linux"
-    then "30ff67884464d32f6bbbde4387e7557db98868e87fb2afbb77c9b7716e3bff09"
+    then "b41e70e018402bc04d02fde82f91bea24428e6be432f0df12ac400cfb03108e8"
     else if stdenv.system == "i686-darwin"
-    then "bdfd2189245dc5764c9f26bdba1429c2bf9d57477d8e6e3f0ba42ea0dc63edeb"
+    then "c8b0fabeebcde66b683f3a871187e614e07305adda414c2862cb332aecb2b3bf"
     else if stdenv.system == "x86_64-darwin"
-    then "5c668fb60a3ba3e97dc2cb8967fc4bb9422b629155284dcb89f94d116bb17820"
+    then "75a7f4bd7c72948030bb9e421df27e8a650dea826fb5b836cf59d23d6f985a0d"
     else throw "missing bootstrap hash for platform ${stdenv.system}";
 
   src = fetchurl {
@@ -32,7 +32,7 @@ let
 
   # Note: the version  MUST be one version prior to the version we're
   # building
-  version = "1.19.0";
+  version = "1.21.0";
 in import ./binaryBuild.nix
   { inherit stdenv fetchurl makeWrapper cacert zlib buildRustPackage curl;
     inherit version src platform;

--- a/pkgs/development/libraries/libpng/default.nix
+++ b/pkgs/development/libraries/libpng/default.nix
@@ -5,12 +5,12 @@
 assert zlib != null;
 
 let
-  version = "1.6.31";
-  patchVersion = "1.6.31";
-  sha256 = "0hcbxv9qf4f9q7brrk0ndag526glr8lii43grssv45j9w0nn0ai3";
+  version = "1.6.34";
+  patchVersion = "1.6.34";
+  sha256 = "1xjr0v34fyjgnhvaa1zixcpx5yvxcg4zwvfh0fyklfyfj86rc7ig";
   patch_src = fetchurl {
     url = "mirror://sourceforge/libpng-apng/libpng-${patchVersion}-apng.patch.gz";
-    sha256 = "0f10ih658j514vpvsli0pk378vcmjn78g52cssyg92r4k1r19rla";
+    sha256 = "1ha4npf9mfrzp0srg8a5amks5ww84xzfpjbsj8k3yjjpai798qg6";
   };
   whenPatched = stdenv.lib.optionalString apngSupport;
 

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -9,11 +9,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "nss-${version}";
-  version = "3.33";
+  version = "3.34.1";
 
   src = fetchurl {
-    url = "mirror://mozilla/security/nss/releases/NSS_3_33_RTM/src/${name}.tar.gz";
-    sha256 = "1r44qa4j7sri50mxxbnrpm6fxprwrhv76whi7bfq73j06syxmw4q";
+    url = "mirror://mozilla/security/nss/releases/NSS_3_34_1_RTM/src/${name}.tar.gz";
+    sha256 = "186x33wsk4mzjz7dzbn8p0py9a0nzkgzpfkdv4rlyy5gghv5vhd3";
   };
 
   buildInputs = [ perl zlib sqlite ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6161,9 +6161,9 @@ with pkgs;
     inherit (llvmPackages_4) llvm;
   };
 
-  rust119bin = lowPrio (callPackage ../development/compilers/rust/1.19.0-bin.nix {
+  rust121bin = lowPrio (callPackage ../development/compilers/rust/1.21.0-bin.nix {
      buildRustPackage = callPackage ../build-support/rust {
-       rust = rust119bin;
+       rust = rust121bin;
      };
   });
   rustBeta = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/beta.nix {}));
@@ -14545,8 +14545,8 @@ with pkgs;
       python = python2;
       gnused = gnused_422;
       icu = icu59;
-      cargo = rust119bin.cargo;
-      rustc = rust119bin.rustc;
+      cargo = rust121bin.cargo;
+      rustc = rust121bin.rustc;
     };
   });
 


### PR DESCRIPTION
###### Motivation for this change

This is a pretty simple port of #34436. Probably needs some polishing and some of the lib changes might need to be moved into  separated derivations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

