### PR TITLE
lib: Avoid double import

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -1,8 +1,8 @@
 { lib }:
 let
   inherit (lib) lists;
-  parse = import ./parse.nix { inherit lib; };
-  inherit (import ./inspect.nix { inherit lib; }) predicates;
+  inherit (lib.systems) parse;
+  inherit (lib.systems.inspect) predicates;
   inherit (lib.attrsets) matchAttrs;
 
   all = [


### PR DESCRIPTION
###### Motivation for this change

More work (finish?) what @grahamc started.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

