### PR TITLE
gnome-shell-extension-icon-hider: init at v19

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/icon-hider/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/icon-hider/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-icon-hider-${version}";
+  version = "19";
+
+  src = fetchFromGitHub {
+    owner = "ikalnytskyi";
+    repo = "gnome-shell-extension-icon-hider";
+    rev = "v${version}";
+    sha256 = "0cifm6cmxwxrrrva41wvjvrzsdqaczfbillf2vv3wsb60dqr6h39";
+  };
+
+  uuid = "icon-hider@kalnitsky.org";
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ${uuid} $out/share/gnome-shell/extensions
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Icon Hider is a GNOME Shell extension for managing status area items";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jonafato ];
+    platforms = platforms.linux;
+    homepage = https://github.com/ikalnytskyi/gnome-shell-extension-icon-hider;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18876,6 +18876,7 @@ with pkgs;
     caffeine = callPackage ../desktops/gnome-3/extensions/caffeine { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
+    icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     mediaplayer = callPackage ../desktops/gnome-3/extensions/mediaplayer { };
     nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
     pixel-saver = callPackage ../desktops/gnome-3/extensions/pixel-saver { };


### PR DESCRIPTION
###### Motivation for this change

Add the Icon Hider GNOME Shell extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

