### PR TITLE
lib: Fix #30902

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -47,7 +47,7 @@ let
     filesystem = callLibs ./filesystem.nix;
 
     # back-compat aliases
-    platforms = systems.doubles;
+    platforms = systems.forMeta;
 
     inherit (builtins) add addErrorContext attrNames
       concatLists deepSeq elem elemAt filter genericClosure genList

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -3,6 +3,7 @@
 
 rec {
   doubles = import ./doubles.nix { inherit lib; };
+  forMeta = import ./for-meta.nix { inherit lib; };
   parse = import ./parse.nix { inherit lib; };
   inspect = import ./inspect.nix { inherit lib; };
   platforms = import ./platforms.nix { inherit lib; };

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -30,14 +30,14 @@ in rec {
   aarch64 = filterDoubles predicates.isAarch64;
   x86     = filterDoubles predicates.isx86;
   i686    = filterDoubles predicates.isi686;
-  mips    = filterDoubles predicates.isMips;
   x86_64  = filterDoubles predicates.isx86_64;
+  mips    = filterDoubles predicates.isMips;
 
   cygwin  = filterDoubles predicates.isCygwin;
   darwin  = filterDoubles predicates.isDarwin;
   freebsd = filterDoubles predicates.isFreeBSD;
   # Should be better, but MinGW is unclear, and HURD is bit-rotted.
-  gnu     = filterDoubles (matchAttrs { kernel = parse.kernels.linux;  abi = parse.abis.gnu; });
+  gnu     = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; });
   illumos = filterDoubles predicates.isSunOS;
   linux   = filterDoubles predicates.isLinux;
   netbsd  = filterDoubles predicates.isNetBSD;

--- a/lib/systems/for-meta.nix
+++ b/lib/systems/for-meta.nix
@@ -1,0 +1,27 @@
+{ lib }:
+let
+  inherit (lib.systems) parse;
+  inherit (lib.systems.inspect) patterns;
+
+in rec {
+  inherit (lib.systems.doubles) all mesaPlatforms;
+  none = [];
+
+  arm     = [ patterns.Arm ];
+  aarch64 = [ patterns.Aarch64 ];
+  x86     = [ patterns.x86 ];
+  i686    = [ patterns.i686 ];
+  x86_64  = [ patterns.x86_64 ];
+  mips    = [ patterns.Mips ];
+
+  cygwin  = [ patterns.Cygwin ];
+  darwin  = [ patterns.Darwin ];
+  freebsd = [ patterns.FreeBSD ];
+  # Should be better, but MinGW is unclear, and HURD is bit-rotted.
+  gnu     = [ { kernel = parse.kernels.linux; abi = parse.abis.gnu; } ];
+  illumos = [ patterns.SunOS ];
+  linux   = [ patterns.Linux ];
+  netbsd  = [ patterns.NetBSD ];
+  openbsd = [ patterns.OpenBSD ];
+  unix    = patterns.Unix; # Actually a list
+}

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -207,7 +207,7 @@ rec {
         inherit lib config meta;
         # Nix itself uses the `system` field of a derivation to decide where
         # to build it. This is a bit confusing for cross compilation.
-        inherit (stdenv) system;
+        inherit (stdenv) hostPlatform;
       } attrs;
 
       # The meta attribute is passed in the resulting attribute set,

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -204,12 +204,11 @@ rec {
         });
 
       validity = import ./check-meta.nix {
-        inherit lib config meta derivationArg;
-        mkDerivationArg = attrs;
+        inherit lib config meta;
         # Nix itself uses the `system` field of a derivation to decide where
         # to build it. This is a bit confusing for cross compilation.
         inherit (stdenv) system;
-      };
+      } attrs;
 
       # The meta attribute is passed in the resulting attribute set,
       # but it's not part of the actual derivation, i.e., it's not

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -98,7 +98,18 @@ rec {
   packagePlatforms = mapAttrs (name: value:
     let res = builtins.tryEval (
       if isDerivation value then
-        value.meta.hydraPlatforms or (value.meta.platforms or [ "x86_64-linux" ])
+        # TODO(@Ericson2314) deduplicate with `checkPlatform` in
+        # `pkgs/stdenv/generic/check-meta.nix`.
+        value.meta.hydraPlatforms or (let
+            raw = value.meta.platforms or [ "x86_64-linux" ];
+            toPattern = x: if builtins.isString x
+                           then { system = x; }
+                           else { parsed = x; };
+            uniform = map toPattern raw;
+            pred = hostPlatform:
+              lib.any (pat: lib.matchAttrs pat hostPlatform) uniform;
+            pred' = system: pred (lib.systems.elaborate { inherit system; });
+         in lib.filter pred' supportedSystems)
       else if value.recurseForDerivations or false || value.recurseForRelease or false then
         packagePlatforms value
       else


### PR DESCRIPTION
###### Motivation for this change

See the "lib, stdenv: Check..." commit for details. 

Work in progress because I need to overhaul `release-lib.nix`, and maybe other uses of `meta.platforms`.

 Fixes #30902

###### Things done

Need to ensure `release-lib.nix` packages still eval fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @bgamari @dtzWill 
