### PR TITLE
mpd_clientlib, ncmpc: fix on Darwin

### DIFF
--- a/pkgs/applications/audio/ncmpc/default.nix
+++ b/pkgs/applications/audio/ncmpc/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib ncurses mpd_clientlib ];
   nativeBuildInputs = [ meson ninja pkgconfig gettext ];
 
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
+
   meta = with stdenv.lib; {
     description = "Curses-based interface for MPD (music player daemon)";
     homepage    = https://www.musicpd.org/clients/ncmpc/;

--- a/pkgs/servers/mpd/clientlib.nix
+++ b/pkgs/servers/mpd/clientlib.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja }:
+{ stdenv, fetchFromGitHub, meson, ninja, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   version = "2.13";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1g1n6rk8kn87mbjqxxj0vi7haj8xx21xmqlzbrx2fvyp5357zvsq";
   };
 
-  nativeBuildInputs = [ meson ninja ];
+  nativeBuildInputs = [ meson ninja ]
+  ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   meta = with stdenv.lib; {
     description = "Client library for MPD (music player daemon)";


### PR DESCRIPTION
###### Motivation for this change

On Darwin, the dynamic library is broken, which make software linked to this library unusable (`mpd`, `ncmpcpp`, etc.):

```
$ nix-build -A mpd_clientlib && otool -L result/lib/libmpdclient.2.dylib
/nix/store/if3cvcqqxv22pgjyk3fk3a95v6gdwv4c-libmpdclient-2.13
result/lib/libmpdclient.2.dylib:
	@rpath/libmpdclient.2.dylib (compatibility version 0.0.0, current version 0.0.0)

$ nix-build -A mpd && ./result/bin/mpd
/nix/store/qlz1pcyf5k4qlwh8jc8rnvv025v3jjny-mpd-0.20.15
dyld: Library not loaded: @rpath/libmpdclient.2.dylib
  Referenced from: …/./result/bin/mpd
  Reason: image not found
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

