### PR TITLE
dovecot_pigeonhole: 0.4.21 -> 0.5.0.1

### DIFF
--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
-  version = "0.4.21";
+  version = "0.5.0.1";
 
   src = fetchurl {
-    url = "http://pigeonhole.dovecot.org/releases/2.2/dovecot-2.2-pigeonhole-${version}.tar.gz";
-    sha256 = "0snxrx9lk3j0rrcd4jlhwlqk4v31n1qfx2asgwb4scy5i2vrrq2a";
+    url = "http://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-${version}.tar.gz";
+    sha256 = "1lpsdqh9pwqx917z5v23bahhhbrcb3y5ps3l413sli8cn4a6sdan";
   };
 
   buildInputs = [ dovecot openssl ];


### PR DESCRIPTION
###### Motivation for this change

Dovecot was recently updated, this needs to be updated at the same time as Dovecot otherwise it won't build. 😅 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @fpletz 