### PR TITLE
tp_smapi: 0.42 -> unstable-2017-12-04

### DIFF
--- a/pkgs/os-specific/linux/tp_smapi/default.nix
+++ b/pkgs/os-specific/linux/tp_smapi/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "tp_smapi-${version}-${kernel.version}";
-  version = "0.42";
+  version = "unstable-2017-12-04";
 
   src = fetchFromGitHub {
     owner = "evgeni";
     repo = "tp_smapi";
-    rev = "tp-smapi/${version}";
-    sha256 = "12lnig90lrmkmqwl386q7ssqs9p0jikqhwl2wsmcmii1gn92hzfy";
+    rev = "76c5120f7be4880cf2c6801f872327e4e70c449f";
+    sha256 = "0g8l7rmylspl17qnqpa2h4yj7h3zvy6xlmj5nlnixds9avnbz2vy";
     name = "tp-smapi-${version}";
   };
 
@@ -39,11 +39,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "IBM ThinkPad hardware functions driver";
-    homepage = https://github.com/evgeni/tp_smapi/tree/tp-smapi/0.41;
+    homepage = https://github.com/evgeni/tp_smapi;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.garbas ];
     # driver is only ment for linux thinkpads i think  bellow platforms should cover it.
     platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }
-


### PR DESCRIPTION
make it build for kernel 4.15
see https://github.com/evgeni/tp_smapi/issues/31 and https://github.com/evgeni/tp_smapi/issues/32

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

