### PR TITLE
teleport: init at 2.4.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -354,6 +354,7 @@
   KibaFox = "Kiba Fox <kiba.fox@foxypossibilities.com>";
   kierdavis = "Kier Davis <kierdavis@gmail.com>";
   kiloreux = "Kiloreux Emperex <kiloreux@gmail.com>";
+  kimburgess = "Kim Burgess <kim@acaprojects.com>";
   kini = "Keshav Kini <keshav.kini@gmail.com>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
   knedlsepp = "Josef Kemetmüller <josef.kemetmueller@gmail.com>";

--- a/pkgs/tools/misc/teleport/default.nix
+++ b/pkgs/tools/misc/teleport/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl }:
+stdenv.mkDerivation rec {
+  name = "teleport-v${version}";
+  version = "2.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/gravitational/teleport/releases/download/v${version}/${name}-linux-amd64-bin.tar.gz";
+    sha256 = "ab00de7d7f09a0768ebf40fe075ebfaa81891ae0238abc30bc5662fe25d881e9";
+  };
+  sourceRoot = ".";
+  unpackCmd = ''
+    tar -zxf $src teleport/{tctl,teleport,tsh}
+  '';
+
+  buildPhase = ":";   # nothing to build
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R teleport/* $out/bin
+  '';
+  preFixup = ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      $out/bin/*
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://gravitational.com/teleport/;
+    description = "Modern SSH server for clusters and teams";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.kimburgess ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4834,6 +4834,8 @@ with pkgs;
 
   telegraf = callPackage ../servers/monitoring/telegraf { };
 
+  teleport = callPackage ../tools/misc/teleport { };
+
   telepresence = callPackage ../tools/networking/telepresence { };
 
   tewisay = callPackage ../tools/misc/tewisay { };


### PR DESCRIPTION
###### Motivation for this change

Teleport was did not have a pre-existing package for Nix.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

