### PR TITLE
llvm 6: init

### DIFF
--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -37,9 +37,6 @@ let
 
     patches = [ ./purity.patch ];
 
-    # XXX: TODO: This should be removed on next rebuild
-    postBuild = "";
-
     postPatch = ''
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \
              -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' \

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -9,7 +9,7 @@ let
     name = "clang-${version}";
 
     unpackPhase = ''
-      unpackFile ${fetch "cfe" "1mrj0ig9x5dxvglmkyw6i8yb9hvznywqn2g6lqaw7a5fhjjdq0x2"}
+      unpackFile ${fetch "cfe" "1j9pzl71r1bnp0dsxj33p5pvl6njg0bf2yyi9vhci13nw7y71i0x"}
       mv cfe-${version}* clang
       sourceRoot=$PWD/clang
       unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -9,7 +9,7 @@ let
     name = "clang-${version}";
 
     unpackPhase = ''
-      unpackFile ${fetch "cfe" "1zyh4dggxd55lnfg73c8fybnkssqcaa6bq2h4bzimnnj1jdnqpqk"}
+      unpackFile ${fetch "cfe" "1mrj0ig9x5dxvglmkyw6i8yb9hvznywqn2g6lqaw7a5fhjjdq0x2"}
       mv cfe-${version}* clang
       sourceRoot=$PWD/clang
       unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -9,7 +9,7 @@ let
     name = "clang-${version}";
 
     unpackPhase = ''
-      unpackFile ${fetch "cfe" "1j9pzl71r1bnp0dsxj33p5pvl6njg0bf2yyi9vhci13nw7y71i0x"}
+      unpackFile ${fetch "cfe" "1nxx253czzjy7bsrwvk2pyaxwiqwqkjzk0k8x8w7y19mzmmfz883"}
       mv cfe-${version}* clang
       sourceRoot=$PWD/clang
       unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -9,7 +9,7 @@ let
     name = "clang-${version}";
 
     unpackPhase = ''
-      unpackFile ${fetch "cfe" "1nxx253czzjy7bsrwvk2pyaxwiqwqkjzk0k8x8w7y19mzmmfz883"}
+      unpackFile ${fetch "cfe" "0cnznvfyl3hgbg8gj58pmwf0pvd2sv5k3ccbivy6q6ggv7c6szg0"}
       mv cfe-${version}* clang
       sourceRoot=$PWD/clang
       unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -47,6 +47,8 @@ let
 
       # Patch for standalone doc building
       sed -i '1s,^,find_package(Sphinx REQUIRED)\n,' docs/CMakeLists.txt
+    '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+      sed -i -e 's/lgcc_s/lgcc_eh/' lib/Driver/ToolChains/*.cpp
     '';
 
     outputs = [ "out" "lib" "python" ];

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -1,0 +1,109 @@
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, release_version, clang-tools-extra_src, python
+, fixDarwinDylibNames
+, enableManpages ? false
+}:
+
+let
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  self = stdenv.mkDerivation ({
+    name = "clang-${version}";
+
+    unpackPhase = ''
+      unpackFile ${fetch "cfe" "1zyh4dggxd55lnfg73c8fybnkssqcaa6bq2h4bzimnnj1jdnqpqk"}
+      mv cfe-${version}* clang
+      sourceRoot=$PWD/clang
+      unpackFile ${clang-tools-extra_src}
+      mv clang-tools-extra-* $sourceRoot/tools/extra
+    '';
+
+    nativeBuildInputs = [ cmake python ]
+      ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+
+    buildInputs = [ libedit libxml2 llvm ]
+      ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+    cmakeFlags = [
+      "-DCMAKE_CXX_FLAGS=-std=c++11"
+    ] ++ stdenv.lib.optionals enableManpages [
+      "-DCLANG_INCLUDE_DOCS=ON"
+      "-DLLVM_ENABLE_SPHINX=ON"
+      "-DSPHINX_OUTPUT_MAN=ON"
+      "-DSPHINX_OUTPUT_HTML=OFF"
+      "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
+    ]
+    # Maybe with compiler-rt this won't be needed?
+    ++ stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}"
+    ++ stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include";
+
+    patches = [ ./purity.patch ];
+
+    # XXX: TODO: This should be removed on next rebuild
+    postBuild = "";
+
+    postPatch = ''
+      sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \
+             -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' \
+             lib/Driver/ToolChains/*.cpp
+
+      # Patch for standalone doc building
+      sed -i '1s,^,find_package(Sphinx REQUIRED)\n,' docs/CMakeLists.txt
+    '';
+
+    outputs = [ "out" "lib" "python" ];
+
+    # Clang expects to find LLVMgold in its own prefix
+    # Clang expects to find sanitizer libraries in its own prefix
+    postInstall = ''
+      ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+      ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
+      ln -sv $out/bin/clang $out/bin/cpp
+
+      # Move libclang to 'lib' output
+      moveToOutput "lib/libclang.*" "$lib"
+      substituteInPlace $out/lib/cmake/clang/ClangTargets-release.cmake \
+          --replace "\''${_IMPORT_PREFIX}/lib/libclang." "$lib/lib/libclang."
+
+      mkdir -p $python/bin $python/share/clang/
+      mv $out/bin/{git-clang-format,scan-view} $python/bin
+      if [ -e $out/bin/set-xcode-analyzer ]; then
+        mv $out/bin/set-xcode-analyzer $python/bin
+      fi
+      mv $out/share/clang/*.py $python/share/clang
+      rm $out/bin/c-index-test
+    '';
+
+    enableParallelBuilding = true;
+
+    passthru = {
+      isClang = true;
+      inherit llvm;
+    } // stdenv.lib.optionalAttrs stdenv.isLinux {
+      inherit gcc;
+    };
+
+    meta = {
+      description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
+      homepage    = http://llvm.org/;
+      license     = stdenv.lib.licenses.ncsa;
+      platforms   = stdenv.lib.platforms.all;
+    };
+  } // stdenv.lib.optionalAttrs enableManpages {
+    name = "clang-manpages-${version}";
+
+    buildPhase = ''
+      make docs-clang-man
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share/man/man1
+      # Manually install clang manpage
+      cp docs/man/*.1 $out/share/man/man1/
+    '';
+
+    outputs = [ "out" ];
+
+    doCheck = false;
+
+    meta.description = "man page for Clang ${version}";
+  });
+in self

--- a/pkgs/development/compilers/llvm/6/clang/purity.patch
+++ b/pkgs/development/compilers/llvm/6/clang/purity.patch
@@ -1,0 +1,30 @@
+From 4add81bba40dcec62c4ea4481be8e35ac53e89d8 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Thu, 18 May 2017 11:56:12 -0500
+Subject: [PATCH] "purity" patch for 5.0
+
+---
+ lib/Driver/ToolChains/Gnu.cpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/lib/Driver/ToolChains/Gnu.cpp b/lib/Driver/ToolChains/Gnu.cpp
+index fe3c0191bb..c6a482bece 100644
+--- a/lib/Driver/ToolChains/Gnu.cpp
++++ b/lib/Driver/ToolChains/Gnu.cpp
+@@ -494,13 +494,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+   if (!Args.hasArg(options::OPT_static)) {
+     if (Args.hasArg(options::OPT_rdynamic))
+       CmdArgs.push_back("-export-dynamic");
+-
+-    if (!Args.hasArg(options::OPT_shared)) {
+-      const std::string Loader =
+-          D.DyldPrefix + ToolChain.getDynamicLinker(Args);
+-      CmdArgs.push_back("-dynamic-linker");
+-      CmdArgs.push_back(Args.MakeArgString(Loader));
+-    }
+   }
+ 
+   CmdArgs.push_back("-o");
+-- 
+2.11.0
+

--- a/pkgs/development/compilers/llvm/6/compiler-rt-codesign.patch
+++ b/pkgs/development/compilers/llvm/6/compiler-rt-codesign.patch
@@ -1,0 +1,155 @@
+From 3dec5f3475a26aeb4678627795c4b67c6b7b4785 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 19 Sep 2017 13:13:06 -0500
+Subject: [PATCH] remove codesign use on Apple, disable ios sim testing that
+ needs it
+
+---
+ cmake/Modules/AddCompilerRT.cmake |  8 ------
+ test/asan/CMakeLists.txt          | 52 ---------------------------------------
+ test/tsan/CMakeLists.txt          | 47 -----------------------------------
+ 3 files changed, 107 deletions(-)
+
+diff --git a/cmake/Modules/AddCompilerRT.cmake b/cmake/Modules/AddCompilerRT.cmake
+index bc5fb9ff7..b64eb4246 100644
+--- a/cmake/Modules/AddCompilerRT.cmake
++++ b/cmake/Modules/AddCompilerRT.cmake
+@@ -210,14 +210,6 @@ function(add_compiler_rt_runtime name type)
+         set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
+         set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
+       endif()
+-      if(APPLE)
+-        # Ad-hoc sign the dylibs
+-        add_custom_command(TARGET ${libname}
+-          POST_BUILD  
+-          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
+-          WORKING_DIRECTORY ${COMPILER_RT_LIBRARY_OUTPUT_DIR}
+-        )
+-      endif()
+     endif()
+     install(TARGETS ${libname}
+       ARCHIVE DESTINATION ${COMPILER_RT_LIBRARY_INSTALL_DIR}
+diff --git a/test/asan/CMakeLists.txt b/test/asan/CMakeLists.txt
+index 8bfc15b5c..f23d0f71a 100644
+--- a/test/asan/CMakeLists.txt
++++ b/test/asan/CMakeLists.txt
+@@ -83,58 +83,6 @@ foreach(arch ${ASAN_TEST_ARCH})
+   endif()
+ endforeach()
+ 
+-# iOS and iOS simulator test suites
+-# These are not added into "check-all", in order to run these tests, use
+-# "check-asan-iossim-x86_64" and similar. They also require that an extra env
+-# variable to select which iOS device or simulator to use, e.g.:
+-# SANITIZER_IOSSIM_TEST_DEVICE_IDENTIFIER="iPhone 6"
+-if(APPLE)
+-  set(EXCLUDE_FROM_ALL ON)
+-
+-  set(ASAN_TEST_TARGET_CC ${COMPILER_RT_TEST_COMPILER})
+-  set(ASAN_TEST_IOS "1")
+-  pythonize_bool(ASAN_TEST_IOS)
+-  set(ASAN_TEST_DYNAMIC True)
+-
+-  foreach(arch ${DARWIN_iossim_ARCHS})
+-    set(ASAN_TEST_IOSSIM "1")
+-    pythonize_bool(ASAN_TEST_IOSSIM)
+-    set(ASAN_TEST_TARGET_ARCH ${arch})
+-    set(ASAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_iossim_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-    set(ASAN_TEST_CONFIG_SUFFIX "-${arch}-iossim")
+-    get_bits_for_arch(${arch} ASAN_TEST_BITS)
+-    string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-    set(CONFIG_NAME "IOSSim${ARCH_UPPER_CASE}Config")
+-    configure_lit_site_cfg(
+-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-      )
+-    add_lit_testsuite(check-asan-iossim-${arch} "AddressSanitizer iOS Simulator ${arch} tests"
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-      DEPENDS ${ASAN_TEST_DEPS})
+-  endforeach()
+-
+-  foreach (arch ${DARWIN_ios_ARCHS})
+-    set(ASAN_TEST_IOSSIM "0")
+-    pythonize_bool(ASAN_TEST_IOSSIM)
+-    set(ASAN_TEST_TARGET_ARCH ${arch})
+-    set(ASAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_ios_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-    set(ASAN_TEST_CONFIG_SUFFIX "-${arch}-ios")
+-    get_bits_for_arch(${arch} ASAN_TEST_BITS)
+-    string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-    set(CONFIG_NAME "IOS${ARCH_UPPER_CASE}Config")
+-    configure_lit_site_cfg(
+-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-      )
+-    add_lit_testsuite(check-asan-ios-${arch} "AddressSanitizer iOS ${arch} tests"
+-      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-      DEPENDS ${ASAN_TEST_DEPS})
+-  endforeach()
+-
+-  set(EXCLUDE_FROM_ALL OFF)
+-endif()
+-
+ # Add unit tests.
+ if(COMPILER_RT_INCLUDE_TESTS)
+   set(ASAN_TEST_DYNAMIC False)
+diff --git a/test/tsan/CMakeLists.txt b/test/tsan/CMakeLists.txt
+index a68908612..cde0accb5 100644
+--- a/test/tsan/CMakeLists.txt
++++ b/test/tsan/CMakeLists.txt
+@@ -42,53 +42,6 @@ foreach(arch ${TSAN_TEST_ARCH})
+   list(APPEND TSAN_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
+ endforeach()
+ 
+-# iOS and iOS simulator test suites
+-# These are not added into "check-all", in order to run these tests, use
+-# "check-tsan-iossim-x86_64" and similar. They also require an extra environment
+-# variable to select which iOS device or simulator to use, e.g.:
+-# SANITIZER_IOSSIM_TEST_DEVICE_IDENTIFIER="iPhone 6"
+-if(APPLE)
+-  set(EXCLUDE_FROM_ALL ON)
+-
+-  set(TSAN_TEST_TARGET_CC ${COMPILER_RT_TEST_COMPILER})
+-  set(TSAN_TEST_IOS "1")
+-  pythonize_bool(TSAN_TEST_IOS)
+-
+-  set(arch "x86_64")
+-  set(TSAN_TEST_IOSSIM "1")
+-  pythonize_bool(TSAN_TEST_IOSSIM)
+-  set(TSAN_TEST_TARGET_ARCH ${arch})
+-  set(TSAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_iossim_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-  set(TSAN_TEST_CONFIG_SUFFIX "-${arch}-iossim")
+-  string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-  set(CONFIG_NAME "IOSSim${ARCH_UPPER_CASE}Config")
+-  configure_lit_site_cfg(
+-    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-    )
+-  add_lit_testsuite(check-tsan-iossim-${arch} "ThreadSanitizer iOS Simulator ${arch} tests"
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-    DEPENDS ${TSAN_TEST_DEPS})
+-
+-  set(arch "arm64")
+-  set(TSAN_TEST_IOSSIM "0")
+-  pythonize_bool(TSAN_TEST_IOSSIM)
+-  set(TSAN_TEST_TARGET_ARCH ${arch})
+-  set(TSAN_TEST_TARGET_CFLAGS "-arch ${arch} -isysroot ${DARWIN_ios_SYSROOT} ${COMPILER_RT_TEST_COMPILER_CFLAGS}")
+-  set(TSAN_TEST_CONFIG_SUFFIX "-${arch}-ios")
+-  string(TOUPPER ${arch} ARCH_UPPER_CASE)
+-  set(CONFIG_NAME "IOS${ARCH_UPPER_CASE}Config")
+-  configure_lit_site_cfg(
+-    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg
+-    )
+-  add_lit_testsuite(check-tsan-ios-${arch} "ThreadSanitizer iOS Simulator ${arch} tests"
+-    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/
+-    DEPENDS ${TSAN_TEST_DEPS})
+-
+-  set(EXCLUDE_FROM_ALL OFF)
+-endif()
+-
+ if(COMPILER_RT_INCLUDE_TESTS)
+   configure_lit_site_cfg(
+     ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.in
+-- 
+2.14.1
+

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -1,0 +1,78 @@
+{ lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun
+, darwin
+}:
+
+let
+  callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+
+  release_version = "5.0.1";
+  version = release_version; # differentiating these is important for rc's
+
+  fetch = name: sha256: fetchurl {
+    url = "http://llvm.org/releases/${release_version}/${name}-${version}.src.tar.xz";
+    inherit sha256;
+  };
+
+  compiler-rt_src = fetch "compiler-rt" "1nlmm0b3wpdwxkldqp1klzv3rpqf94q2a248xgqb7aapyhbi9paf";
+  clang-tools-extra_src = fetch "clang-tools-extra" "09fjii7w43kvxvsxxs6gig9vz95vnvx1779rqd36h8kksvws3bcs";
+
+  # Add man output without introducing extra dependencies.
+  overrideManOutput = drv:
+    let drv-manpages = drv.override { enableManpages = true; }; in
+    drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
+
+  llvm = callPackage ./llvm.nix {
+    inherit compiler-rt_src stdenv;
+  };
+
+  clang-unwrapped = callPackage ./clang {
+    inherit clang-tools-extra_src stdenv;
+  };
+
+  self = {
+    llvm = overrideManOutput llvm;
+    clang-unwrapped = overrideManOutput clang-unwrapped;
+
+    libclang = self.clang-unwrapped.lib;
+    llvm-manpages = lowPrio self.llvm.man;
+    clang-manpages = lowPrio self.clang-unwrapped.man;
+
+    clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
+
+    libstdcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
+      extraPackages = [ libstdcxxHook ];
+    };
+
+    libcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
+      extraPackages = [ self.libcxx self.libcxxabi ];
+    };
+
+    stdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.clang;
+    });
+
+    libcxxStdenv = stdenv.override (drv: {
+      allowedRequisites = null;
+      cc = self.libcxxClang;
+    });
+
+    lld = callPackage ./lld.nix {};
+
+    lldb = callPackage ./lldb.nix {};
+
+    libcxx = callPackage ./libc++ {};
+
+    libcxxabi = callPackage ./libc++abi.nix {};
+
+    openmp = callPackage ./openmp.nix {};
+  };
+
+in self

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -6,16 +6,16 @@
 let
   callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
 
-  release_version = "5.0.1";
-  version = release_version; # differentiating these is important for rc's
+  release_version = "6.0.0";
+  version = "6.0.0rc1"; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "http://llvm.org/releases/${release_version}/${name}-${version}.src.tar.xz";
+    url = "http://prereleases.llvm.org/${release_version}/rc1/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 
-  compiler-rt_src = fetch "compiler-rt" "1nlmm0b3wpdwxkldqp1klzv3rpqf94q2a248xgqb7aapyhbi9paf";
-  clang-tools-extra_src = fetch "clang-tools-extra" "09fjii7w43kvxvsxxs6gig9vz95vnvx1779rqd36h8kksvws3bcs";
+  compiler-rt_src = fetch "compiler-rt" "08dwlax5sfmpzwfbzdwig9hbmrqzlq2332rb5yh0l5xrp0y5869z";
+  clang-tools-extra_src = fetch "clang-tools-extra" "1rj4b6cqn05s2b3qiw7iadc8a1hrn4vs6g06nwxmqwpx3790dqyn";
 
   # Add man output without introducing extra dependencies.
   overrideManOutput = drv:

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -7,15 +7,15 @@ let
   callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
 
   release_version = "6.0.0";
-  version = "6.0.0rc1"; # differentiating these is important for rc's
+  version = "6.0.0rc2"; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "http://prereleases.llvm.org/${release_version}/rc1/${name}-${version}.src.tar.xz";
+    url = "http://prereleases.llvm.org/${release_version}/rc2/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 
-  compiler-rt_src = fetch "compiler-rt" "08dwlax5sfmpzwfbzdwig9hbmrqzlq2332rb5yh0l5xrp0y5869z";
-  clang-tools-extra_src = fetch "clang-tools-extra" "1rj4b6cqn05s2b3qiw7iadc8a1hrn4vs6g06nwxmqwpx3790dqyn";
+  compiler-rt_src = fetch "compiler-rt" "1ajk4iykgppc3wxij552m0qnj4rx3z1yyxj2yxhffwpsf973x68j";
+  clang-tools-extra_src = fetch "clang-tools-extra" "0vhaq3yq97w82jvq3w6ccvciwg7zp78b7s1246f3xdai6ijgk8g3";
 
   # Add man output without introducing extra dependencies.
   overrideManOutput = drv:

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -7,15 +7,15 @@ let
   callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
 
   release_version = "6.0.0";
-  version = "6.0.0rc2"; # differentiating these is important for rc's
+  version = "6.0.0rc3"; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "http://prereleases.llvm.org/${release_version}/rc2/${name}-${version}.src.tar.xz";
+    url = "http://prereleases.llvm.org/${release_version}/rc3/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 
-  compiler-rt_src = fetch "compiler-rt" "1ajk4iykgppc3wxij552m0qnj4rx3z1yyxj2yxhffwpsf973x68j";
-  clang-tools-extra_src = fetch "clang-tools-extra" "0vhaq3yq97w82jvq3w6ccvciwg7zp78b7s1246f3xdai6ijgk8g3";
+  compiler-rt_src = fetch "compiler-rt" "1lv5xawwn0spisa7jknq247pdndh4mlj22z1s0d7a5gqy9y0rlwv";
+  clang-tools-extra_src = fetch "clang-tools-extra" "0qv7rl8cpsj0l2xl5iym6ymxi3906mb2yx95mcf5ihlwjcms5klf";
 
   # Add man output without introducing extra dependencies.
   overrideManOutput = drv:

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -7,15 +7,15 @@ let
   callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
 
   release_version = "6.0.0";
-  version = "6.0.0rc3"; # differentiating these is important for rc's
+  version = release_version; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "http://prereleases.llvm.org/${release_version}/rc3/${name}-${version}.src.tar.xz";
+    url = "http://releases.llvm.org/${release_version}/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 
-  compiler-rt_src = fetch "compiler-rt" "1lv5xawwn0spisa7jknq247pdndh4mlj22z1s0d7a5gqy9y0rlwv";
-  clang-tools-extra_src = fetch "clang-tools-extra" "0qv7rl8cpsj0l2xl5iym6ymxi3906mb2yx95mcf5ihlwjcms5klf";
+  compiler-rt_src = fetch "compiler-rt" "16m7rvh3w6vq10iwkjrr1nn293djld3xm62l5zasisaprx117k6h";
+  clang-tools-extra_src = fetch "clang-tools-extra" "1ll9v6r29xfdiywbn9iss49ad39ah3fk91wiv0sr6k6k9i544fq5";
 
   # Add man output without introducing extra dependencies.
   overrideManOutput = drv:

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetch, cmake, llvm, libcxxabi, fixDarwinDylibNames, version }:
+{ lib, stdenv, fetch, cmake, python, llvm, libcxxabi, fixDarwinDylibNames, version }:
 
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
     export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
   '';
 
+  # on next rebuild, this can be replaced with optionals; for now set to null to avoid
+  # patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+  patches = if stdenv.hostPlatform.isMusl then [
+    ../../libcxx-0001-musl-hacks.patch
+  ] else null;
+
   prePatch = ''
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
   '';
@@ -17,9 +23,10 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
     cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")
+  '' + lib.optionalString stdenv.hostPlatform.isMusl ''
+    patchShebangs utils/cat_files.py
   '';
-
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl python;
 
   buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
@@ -27,7 +34,7 @@ stdenv.mkDerivation rec {
     "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
     "-DLIBCXX_LIBCPPABI_VERSION=2"
     "-DLIBCXX_CXX_ABI=libcxxabi"
-  ];
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetch, cmake, llvm, libcxxabi, fixDarwinDylibNames, version }:
+
+stdenv.mkDerivation rec {
+  name = "libc++-${version}";
+
+  src = fetch "libcxx" "003wwniwlikgh38cbqbcshc5gkiv3a2jkmbn6am9s46y5gfrk3zs";
+
+  postUnpack = ''
+    unpackFile ${libcxxabi.src}
+    export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
+  '';
+
+  prePatch = ''
+    substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
+  '';
+
+  preConfigure = ''
+    # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
+    cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+  cmakeFlags = [
+    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+    "-DLIBCXX_LIBCPPABI_VERSION=2"
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ];
+
+  enableParallelBuilding = true;
+
+  linkCxxAbi = stdenv.isLinux;
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    homepage = http://libcxx.llvm.org/;
+    description = "A new implementation of the C++ standard library, targeting C++11";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "1dvnvxx588wdyxbn18fwpyjxgypn316arz48zqll03z6zi2rqisa";
+  src = fetch "libcxx" "1n8d0iadkk9fdpplvxkdgrgh2szc6msrx1mpdjpmilz9pn3im4vh";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "0rpgd25v4h7dgvmqjnksgjmss3lhqzah57lfirpskdllcj9cfa9z";
+  src = fetch "libcxx" "1dvnvxx588wdyxbn18fwpyjxgypn316arz48zqll03z6zi2rqisa";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "0l026xx364a6zbx8sbd3280wbag0pkmj342v8zh1lg0661w52l8d";
+  src = fetch "libcxx" "0rpgd25v4h7dgvmqjnksgjmss3lhqzah57lfirpskdllcj9cfa9z";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "003wwniwlikgh38cbqbcshc5gkiv3a2jkmbn6am9s46y5gfrk3zs";
+  src = fetch "libcxx" "0l026xx364a6zbx8sbd3280wbag0pkmj342v8zh1lg0661w52l8d";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/6/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/6/libc++/setup-hook.sh
@@ -1,0 +1,3 @@
+linkCxxAbi="@linkCxxAbi@"
+export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/6/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/6/libc++abi.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
     export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
+  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
   '';
 
   installPhase = if stdenv.isDarwin

--- a/pkgs/development/compilers/llvm/6/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/6/libc++abi.nix
@@ -1,0 +1,47 @@
+{ stdenv, cmake, fetch, libcxx, libunwind, llvm, version }:
+
+stdenv.mkDerivation {
+  name = "libc++abi-${version}";
+
+  src = fetch "libcxxabi" "0m78yr4arlz2b9m96xcygk15m2pbz8i10snk78i3q7pjnwn1a9as";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
+
+  postUnpack = ''
+    unpackFile ${libcxx.src}
+    unpackFile ${llvm.src}
+    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export TRIPLE=x86_64-apple-darwin
+  '';
+
+  installPhase = if stdenv.isDarwin
+    then ''
+      for file in lib/*.dylib; do
+        # this should be done in CMake, but having trouble figuring out
+        # the magic combination of necessary CMake variables
+        # if you fancy a try, take a look at
+        # http://www.cmake.org/Wiki/CMake_RPATH_handling
+        install_name_tool -id $out/$file $file
+      done
+      make install
+      install -d 755 $out/include
+      install -m 644 ../include/*.h $out/include
+    ''
+    else ''
+      install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.so.1.0 $out/lib
+      install -m 644 ../include/cxxabi.h $out/include
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
+    '';
+
+  meta = {
+    homepage = http://libcxxabi.llvm.org/;
+    description = "A new implementation of low level support for a standard C++ library";
+    license = with stdenv.lib.licenses; [ ncsa mit ];
+    maintainers = with stdenv.lib.maintainers; [ vlstill ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/6/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/6/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "10rc7r33bhz4fflnqdian9jvgf1r85p9qxkkgr78wxc7680f0ccx";
+  src = fetch "libcxxabi" "04m1w7a1cxwr6dqlilp0vn6jfjwd9al3nv1sfmypi01r90w69n0r";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;

--- a/pkgs/development/compilers/llvm/6/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/6/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "04m1w7a1cxwr6dqlilp0vn6jfjwd9al3nv1sfmypi01r90w69n0r";
+  src = fetch "libcxxabi" "06v4dnqh6q0r3p5h2jznlgb69lg79126lzb2s0lcw1k38b2xkili";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;

--- a/pkgs/development/compilers/llvm/6/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/6/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "0kmfmxm3iph9l1ndj2z7gj52n8bmy0rnnxzidfbliays2qzbwrsk";
+  src = fetch "libcxxabi" "10rc7r33bhz4fflnqdian9jvgf1r85p9qxkkgr78wxc7680f0ccx";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;

--- a/pkgs/development/compilers/llvm/6/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/6/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "0m78yr4arlz2b9m96xcygk15m2pbz8i10snk78i3q7pjnwn1a9as";
+  src = fetch "libcxxabi" "0kmfmxm3iph9l1ndj2z7gj52n8bmy0rnnxzidfbliays2qzbwrsk";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;

--- a/pkgs/development/compilers/llvm/6/lld.nix
+++ b/pkgs/development/compilers/llvm/6/lld.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, llvm
+, python
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "lld-${version}";
+
+  src = fetch "lld" "15fq2zvkliyiw5qi7ig2r8bshgbz4kzvs5in16mhfkw20l06rcym";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ llvm ];
+
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    moveToOutput include "$dev"
+    moveToOutput lib "$dev"
+  '';
+
+  meta = {
+    description = "The LLVM Linker";
+    homepage    = http://lld.llvm.org/;
+    license     = stdenv.lib.licenses.ncsa;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/6/lld.nix
+++ b/pkgs/development/compilers/llvm/6/lld.nix
@@ -1,7 +1,7 @@
 { stdenv
 , fetch
 , cmake
-, zlib
+, libxml2
 , llvm
 , python
 , version
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   src = fetch "lld" "1yzq762bh375sskjgkcr0vqlhlii2br86z8wi2jbxmml0pj0xn99";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvm ];
+  buildInputs = [ llvm libxml2 ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/compilers/llvm/6/lld.nix
+++ b/pkgs/development/compilers/llvm/6/lld.nix
@@ -10,7 +10,7 @@
 stdenv.mkDerivation {
   name = "lld-${version}";
 
-  src = fetch "lld" "16nzzi233kknb3sz0hvwypfp6wa1d6rc7izf0v5zzhgrcr86yy98";
+  src = fetch "lld" "02qfkjkjq0snmf8dw9c255xkh8dg06ndny1x470300pk7j1lm33b";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/6/lld.nix
+++ b/pkgs/development/compilers/llvm/6/lld.nix
@@ -10,7 +10,7 @@
 stdenv.mkDerivation {
   name = "lld-${version}";
 
-  src = fetch "lld" "15fq2zvkliyiw5qi7ig2r8bshgbz4kzvs5in16mhfkw20l06rcym";
+  src = fetch "lld" "1yzq762bh375sskjgkcr0vqlhlii2br86z8wi2jbxmml0pj0xn99";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm ];

--- a/pkgs/development/compilers/llvm/6/lld.nix
+++ b/pkgs/development/compilers/llvm/6/lld.nix
@@ -10,7 +10,7 @@
 stdenv.mkDerivation {
   name = "lld-${version}";
 
-  src = fetch "lld" "0wj8rwd4bqh32p03hksy9bngv5pwrwmlxglslm8clwlxrc2rkb1f";
+  src = fetch "lld" "16nzzi233kknb3sz0hvwypfp6wa1d6rc7izf0v5zzhgrcr86yy98";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/6/lld.nix
+++ b/pkgs/development/compilers/llvm/6/lld.nix
@@ -10,7 +10,7 @@
 stdenv.mkDerivation {
   name = "lld-${version}";
 
-  src = fetch "lld" "1yzq762bh375sskjgkcr0vqlhlii2br86z8wi2jbxmml0pj0xn99";
+  src = fetch "lld" "0wj8rwd4bqh32p03hksy9bngv5pwrwmlxglslm8clwlxrc2rkb1f";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/6/lldb.nix
+++ b/pkgs/development/compilers/llvm/6/lldb.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, ncurses
+, swig
+, which
+, libedit
+, libxml2
+, llvm
+, clang-unwrapped
+, python
+, version
+, darwin
+}:
+
+stdenv.mkDerivation {
+  name = "lldb-${version}";
+
+  src = fetch "lldb" "0sipv8k37ai44m7jcf6wsbm2q41dgk3sk9m3i6823jkmg7kckhdp";
+
+  postPatch = ''
+    # Fix up various paths that assume llvm and clang are installed in the same place
+    sed -i 's,".*ClangConfig.cmake","${clang-unwrapped}/lib/cmake/clang/ClangConfig.cmake",' \
+      cmake/modules/LLDBStandalone.cmake
+    sed -i 's,".*tools/clang/include","${clang-unwrapped}/include",' \
+      cmake/modules/LLDBStandalone.cmake
+    sed -i 's,"$.LLVM_LIBRARY_DIR.",${llvm}/lib ${clang-unwrapped}/lib,' \
+      cmake/modules/LLDBStandalone.cmake
+  '';
+
+  nativeBuildInputs = [ cmake python which swig ];
+  buildInputs = [ ncurses zlib libedit libxml2 llvm ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.libobjc darwin.apple_sdk.libs.xpc darwin.apple_sdk.frameworks.Foundation darwin.bootstrap_cmds darwin.apple_sdk.frameworks.Carbon darwin.apple_sdk.frameworks.Cocoa ];
+
+  CXXFLAGS = "-fno-rtti";
+  hardeningDisable = [ "format" ];
+
+  cmakeFlags = [
+    "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
+  ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    mkdir -p $out/share/man/man1
+    cp ../docs/lldb.1 $out/share/man/man1/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A next-generation high-performance debugger";
+    homepage    = http://llvm.org/;
+    license     = licenses.ncsa;
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/6/lldb.nix
+++ b/pkgs/development/compilers/llvm/6/lldb.nix
@@ -17,7 +17,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "118yj804rgg5fwdj9j2yydamgfqx7c585ahiyap26x09cz5g2l1v";
+  src = fetch "lldb" "00gkkxsmz1dgj00mcv8ghxgi51skwbrfdw5rxqx27ay1pqbwa1zl";
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place

--- a/pkgs/development/compilers/llvm/6/lldb.nix
+++ b/pkgs/development/compilers/llvm/6/lldb.nix
@@ -17,7 +17,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "0sipv8k37ai44m7jcf6wsbm2q41dgk3sk9m3i6823jkmg7kckhdp";
+  src = fetch "lldb" "1a0bmk0p4rclk0wvfg2ga4wkqp8lm6l3wx6g4g4dgiavd4bgsgl4";
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place

--- a/pkgs/development/compilers/llvm/6/lldb.nix
+++ b/pkgs/development/compilers/llvm/6/lldb.nix
@@ -17,7 +17,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "1a0bmk0p4rclk0wvfg2ga4wkqp8lm6l3wx6g4g4dgiavd4bgsgl4";
+  src = fetch "lldb" "118yj804rgg5fwdj9j2yydamgfqx7c585ahiyap26x09cz5g2l1v";
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place

--- a/pkgs/development/compilers/llvm/6/lldb.nix
+++ b/pkgs/development/compilers/llvm/6/lldb.nix
@@ -17,7 +17,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "00gkkxsmz1dgj00mcv8ghxgi51skwbrfdw5rxqx27ay1pqbwa1zl";
+  src = fetch "lldb" "0m6l2ks4banfmdh7xy7l77ri85kmzavgfy81gkc4gl6wg8flrxa6";
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place

--- a/pkgs/development/compilers/llvm/6/llvm-outputs.patch
+++ b/pkgs/development/compilers/llvm/6/llvm-outputs.patch
@@ -1,0 +1,26 @@
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 94d426b..37f7794 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }
+ 
++  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  if (!IsInDevelopmentTree) {
++    bool WantShared = true;
++    for (int i = 1; i < argc; ++i) {
++      StringRef Arg = argv[i];
++      if (Arg == "--link-shared")
++        WantShared = true;
++      else if (Arg == "--link-static")
++        WantShared = false; // the last one wins
++    }
++
++    if (WantShared)
++      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++  }
++
+   /// We only use `shared library` mode in cases where the static library form
+   /// of the components provided are not available; note however that this is
+   /// skipped if we're run from within the build dir. However, once installed,

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -1,8 +1,6 @@
 { stdenv
 , fetch
 , fetchpatch
-, perl
-, groff
 , cmake
 , python
 , libffi
@@ -41,7 +39,7 @@ in stdenv.mkDerivation (rec {
   outputs = [ "out" "python" ]
     ++ stdenv.lib.optional enableSharedLibraries "lib";
 
-  nativeBuildInputs = [ perl groff cmake python ]
+  nativeBuildInputs = [ cmake python ]
     ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
 
   buildInputs = [ libxml2 libffi ]

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -20,7 +20,7 @@
 }:
 
 let
-  src = fetch "llvm" "1jnk30b7csdldar88pws2b000k3n1484k6gg2sxgz2fc6j7ldkzn";
+  src = fetch "llvm" "10qwr79kgkziqsaymszx36n265k0rpcr5c86xasi46rcigy59x4a";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -20,7 +20,7 @@
 }:
 
 let
-  src = fetch "llvm" "10qwr79kgkziqsaymszx36n265k0rpcr5c86xasi46rcigy59x4a";
+  src = fetch "llvm" "0224xvfg6h40y5lrbnb9qaq3grmdc5rg00xq03s1wxjfbf8krx8z";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation (rec {
     mv compiler-rt-* $sourceRoot/projects/compiler-rt
   '';
 
-  outputs = [ "out" ]
+  outputs = [ "out" "python" ]
     ++ stdenv.lib.optional enableSharedLibraries "lib";
 
   nativeBuildInputs = [ perl groff cmake python ]
@@ -120,7 +120,11 @@ in stdenv.mkDerivation (rec {
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
   '';
 
-  postInstall = stdenv.lib.optionalString enableSharedLibraries ''
+  postInstall = ''
+    mkdir -p $python/share
+    mv $out/share/opt-viewer $python/share/opt-viewer
+  ''
+  + stdenv.lib.optionalString enableSharedLibraries ''
     moveToOutput "lib/libLLVM-*" "$lib"
     moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -22,7 +22,7 @@
 }:
 
 let
-  src = fetch "llvm" "0dsik1l6jshd617fh4qs1373s6dfkq4gsjhyf6zq2qb6kyisy2vd";
+  src = fetch "llvm" "1jnk30b7csdldar88pws2b000k3n1484k6gg2sxgz2fc6j7ldkzn";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -74,6 +74,11 @@ in stdenv.mkDerivation (rec {
 
     # Revert compiler-rt commit that makes codesign mandatory
     patch -p1 -i ${./compiler-rt-codesign.patch} -d projects/compiler-rt
+  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    patch -p1 -i ${../TLI-musl.patch}
+    substituteInPlace unittests/Support/CMakeLists.txt \
+      --replace "add_subdirectory(DynamicLibrary)" ""
+    rm unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
   '';
 
   # hacky fix: created binaries need to be run before installation
@@ -104,6 +109,14 @@ in stdenv.mkDerivation (rec {
   ++ stdenv.lib.optionals (isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"
+  ]
+  ++ stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+    "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+
+    "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
+    "-DCOMPILER_RT_BUILD_XRAY=OFF"
   ];
 
   postBuild = ''

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -22,7 +22,7 @@
 }:
 
 let
-  src = fetch "llvm" "1c07i0b61j69m578lgjkyayg419sh7sn40xb3j112nr2q2gli9sz";
+  src = fetch "llvm" "0dsik1l6jshd617fh4qs1373s6dfkq4gsjhyf6zq2qb6kyisy2vd";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -74,8 +74,6 @@ in stdenv.mkDerivation (rec {
 
     # Revert compiler-rt commit that makes codesign mandatory
     patch -p1 -i ${./compiler-rt-codesign.patch} -d projects/compiler-rt
-  '' + stdenv.lib.optionalString stdenv.isAarch64 ''
-    patch -p0 < ${../aarch64.patch}
   '';
 
   # hacky fix: created binaries need to be run before installation

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -1,0 +1,171 @@
+{ stdenv
+, fetch
+, fetchpatch
+, perl
+, groff
+, cmake
+, python
+, libffi
+, libbfd
+, libxml2
+, valgrind
+, ncurses
+, version
+, release_version
+, zlib
+, compiler-rt_src
+, libcxxabi
+, debugVersion ? false
+, enableManpages ? false
+, enableSharedLibraries ? true
+, darwin
+}:
+
+let
+  src = fetch "llvm" "1c07i0b61j69m578lgjkyayg419sh7sn40xb3j112nr2q2gli9sz";
+
+  # Used when creating a version-suffixed symlink of libLLVM.dylib
+  shortVersion = with stdenv.lib;
+    concatStringsSep "." (take 2 (splitString "." release_version));
+in stdenv.mkDerivation (rec {
+  name = "llvm-${version}";
+
+  unpackPhase = ''
+    unpackFile ${src}
+    mv llvm-${version}* llvm
+    sourceRoot=$PWD/llvm
+    unpackFile ${compiler-rt_src}
+    mv compiler-rt-* $sourceRoot/projects/compiler-rt
+  '';
+
+  outputs = [ "out" ]
+    ++ stdenv.lib.optional enableSharedLibraries "lib";
+
+  nativeBuildInputs = [ perl groff cmake python ]
+    ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+
+  buildInputs = [ libxml2 libffi ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi ];
+
+  propagatedBuildInputs = [ ncurses zlib ];
+
+  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
+  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
+  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
+  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
+  # a flag and turn the flag off during the stdenv build.
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace ./projects/compiler-rt/cmake/config-ix.cmake \
+      --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+
+    substituteInPlace cmake/modules/AddLLVM.cmake \
+      --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir INSTALL_NAME_DIR "$lib/lib")" \
+      --replace 'set(_install_rpath "@loader_path/../lib" ''${extra_libdir})' ""
+  ''
+  # Patch llvm-config to return correct library path based on --link-{shared,static}.
+  + stdenv.lib.optionalString (enableSharedLibraries) ''
+    substitute '${./llvm-outputs.patch}' ./llvm-outputs.patch --subst-var lib
+    patch -p1 < ./llvm-outputs.patch
+  '' + ''
+    # FileSystem permissions tests fail with various special bits
+    substituteInPlace unittests/Support/CMakeLists.txt \
+      --replace "Path.cpp" ""
+    rm unittests/Support/Path.cpp
+
+    # Revert compiler-rt commit that makes codesign mandatory
+    patch -p1 -i ${./compiler-rt-codesign.patch} -d projects/compiler-rt
+  '' + stdenv.lib.optionalString stdenv.isAarch64 ''
+    patch -p0 < ${../aarch64.patch}
+  '';
+
+  # hacky fix: created binaries need to be run before installation
+  preBuild = ''
+    mkdir -p $out/
+    ln -sv $PWD/lib $out
+  '';
+
+  cmakeFlags = with stdenv; [
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
+    "-DLLVM_INSTALL_UTILS=ON"  # Needed by rustc
+    "-DLLVM_BUILD_TESTS=ON"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_ENABLE_RTTI=ON"
+    "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
+  ]
+  ++ stdenv.lib.optional enableSharedLibraries
+    "-DLLVM_LINK_LLVM_DYLIB=ON"
+  ++ stdenv.lib.optionals enableManpages [
+    "-DLLVM_BUILD_DOCS=ON"
+    "-DLLVM_ENABLE_SPHINX=ON"
+    "-DSPHINX_OUTPUT_MAN=ON"
+    "-DSPHINX_OUTPUT_HTML=OFF"
+    "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
+  ]
+  ++ stdenv.lib.optional (!isDarwin)
+    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
+  ++ stdenv.lib.optionals (isDarwin) [
+    "-DLLVM_ENABLE_LIBCXX=ON"
+    "-DCAN_TARGET_i386=false"
+  ];
+
+  postBuild = ''
+    rm -fR $out
+
+    paxmark m bin/{lli,llvm-rtdyld}
+    paxmark m unittests/ExecutionEngine/MCJIT/MCJITTests
+    paxmark m unittests/ExecutionEngine/Orc/OrcJITTests
+    paxmark m unittests/Support/SupportTests
+    paxmark m bin/lli-child-target
+  '';
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+  '';
+
+  postInstall = stdenv.lib.optionalString enableSharedLibraries ''
+    moveToOutput "lib/libLLVM-*" "$lib"
+    moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
+  ''
+  + stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib"
+    ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${shortVersion}.dylib
+    ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${release_version}.dylib
+  '';
+
+  doCheck = stdenv.isLinux && (!stdenv.isi686);
+
+  checkTarget = "check-all";
+
+  enableParallelBuilding = true;
+
+  passthru.src = src;
+
+  meta = {
+    description = "Collection of modular and reusable compiler and toolchain technologies";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.ncsa;
+    maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric dtzWill ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+} // stdenv.lib.optionalAttrs enableManpages {
+  name = "llvm-manpages-${version}";
+
+  buildPhase = ''
+    make docs-llvm-man
+  '';
+
+  propagatedBuildInputs = [];
+
+  installPhase = ''
+    make -C docs install
+  '';
+
+  outputs = [ "out" ];
+
+  doCheck = false;
+
+  meta.description = "man pages for LLVM ${version}";
+})

--- a/pkgs/development/compilers/llvm/6/openmp.nix
+++ b/pkgs/development/compilers/llvm/6/openmp.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, llvm
+, perl
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "openmp-${version}";
+
+  src = fetch "openmp" "0lr6r87xzg87w1q9rrh04nqpyr8c929dh4qy3csjiy7rsb6kbdmd";
+
+  nativeBuildInputs = [ cmake perl ];
+  buildInputs = [ llvm ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Components required to build an executable OpenMP program";
+    homepage    = http://openmp.llvm.org/;
+    license     = stdenv.lib.licenses.mit;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/6/openmp.nix
+++ b/pkgs/development/compilers/llvm/6/openmp.nix
@@ -10,7 +10,7 @@
 stdenv.mkDerivation {
   name = "openmp-${version}";
 
-  src = fetch "openmp" "0infci57hr89nxgs3v34z87kaqdw9pdkr6apyywkb8av032rhhpf";
+  src = fetch "openmp" "1jz7i7gw8yazkn9hxsnq2lw9mj60g4wff4529yhx956jq1g1mr0k";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];

--- a/pkgs/development/compilers/llvm/6/openmp.nix
+++ b/pkgs/development/compilers/llvm/6/openmp.nix
@@ -10,7 +10,7 @@
 stdenv.mkDerivation {
   name = "openmp-${version}";
 
-  src = fetch "openmp" "1jz7i7gw8yazkn9hxsnq2lw9mj60g4wff4529yhx956jq1g1mr0k";
+  src = fetch "openmp" "1lgsn70rsmmc52qynd2r05bq34cllzyxb40vsqqv2vl3kicjis5k";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];

--- a/pkgs/development/compilers/llvm/6/openmp.nix
+++ b/pkgs/development/compilers/llvm/6/openmp.nix
@@ -10,7 +10,7 @@
 stdenv.mkDerivation {
   name = "openmp-${version}";
 
-  src = fetch "openmp" "1lgsn70rsmmc52qynd2r05bq34cllzyxb40vsqqv2vl3kicjis5k";
+  src = fetch "openmp" "1z1qghx6drdvnlp406q1cp3mgikxxmwymcwzaxbv18vxbw6ha3kw";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];

--- a/pkgs/development/compilers/llvm/6/openmp.nix
+++ b/pkgs/development/compilers/llvm/6/openmp.nix
@@ -10,7 +10,7 @@
 stdenv.mkDerivation {
   name = "openmp-${version}";
 
-  src = fetch "openmp" "0lr6r87xzg87w1q9rrh04nqpyr8c929dh4qy3csjiy7rsb6kbdmd";
+  src = fetch "openmp" "0infci57hr89nxgs3v34z87kaqdw9pdkr6apyywkb8av032rhhpf";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20904,6 +20904,8 @@ with pkgs;
     cc-wrapper-libcxx-4 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_4.libcxxStdenv; };
     cc-wrapper-clang-5 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_5.stdenv; };
     cc-wrapper-libcxx-5 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_5.libcxxStdenv; };
+    cc-wrapper-clang-6 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_6.stdenv; };
+    cc-wrapper-libcxx-6 = callPackage ../test/cc-wrapper { stdenv = llvmPackages_6.libcxxStdenv; };
     stdenv-inputs = callPackage ../test/stdenv-inputs { };
 
     cc-multilib-gcc = callPackage ../test/cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5780,6 +5780,7 @@ with pkgs;
     };
   };
 
+  clang_6  = llvmPackages_6.clang;
   clang_5  = llvmPackages_5.clang;
   clang_4  = llvmPackages_4.clang;
   clang_39 = llvmPackages_39.clang;
@@ -6465,13 +6466,16 @@ with pkgs;
   lld = llvmPackages.lld;
   lld_4 = llvmPackages_4.lld;
   lld_5 = llvmPackages_5.lld;
+  lld_6 = llvmPackages_6.lld;
 
   lldb = llvmPackages.lldb;
   lldb_4 = llvmPackages_4.lldb;
   lldb_5 = llvmPackages_5.lldb;
+  lldb_6 = llvmPackages_6.lldb;
 
   llvm = llvmPackages.llvm;
 
+  llvm_6  = llvmPackages_6.llvm;
   llvm_5  = llvmPackages_5.llvm;
   llvm_4  = llvmPackages_4.llvm;
   llvm_39 = llvmPackages_39.llvm;
@@ -6535,6 +6539,9 @@ with pkgs;
     stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
   });
 
+  llvmPackages_6 = callPackage ../development/compilers/llvm/6 {
+    inherit (stdenvAdapters) overrideCC;
+  };
   manticore = callPackage ../development/compilers/manticore { };
 
   mentorToolchains = recurseIntoAttrs (

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -119,7 +119,11 @@ let
               jobs.tests.cc-wrapper-clang-5.x86_64-linux
               jobs.tests.cc-wrapper-clang-5.x86_64-darwin
               jobs.tests.cc-wrapper-libcxx-5.x86_64-linux
-              jobs.tests.cc-wrapper-libcxx-5.x86_64-darwin
+              jobs.tests.cc-wrapper-libcxx-6.x86_64-darwin
+              jobs.tests.cc-wrapper-clang-6.x86_64-linux
+              jobs.tests.cc-wrapper-clang-6.x86_64-darwin
+              jobs.tests.cc-wrapper-libcxx-6.x86_64-linux
+              jobs.tests.cc-wrapper-libcxx-6.x86_64-darwin
               jobs.tests.cc-multilib-gcc.x86_64-linux
               jobs.tests.cc-multilib-clang.x86_64-linux
               jobs.tests.stdenv-inputs.x86_64-linux


### PR DESCRIPTION
###### Motivation for this change

Start building and testing LLVM 6, currently on RC1.

Helps ensure release doesn't have bugs re:NixOS / our projects, and hopefully enables us to at least make LLVM 6 available after final release and update the default shortly after.

Anyway, test test please! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

