### PR TITLE
sacad: init at 2.0.6

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -70,6 +70,7 @@
   auntie = "Jonathan Glines <auntieNeo@gmail.com>";
   avnik = "Alexander V. Nikolaev <avn@avnik.info>";
   aycanirican = "Aycan iRiCAN <iricanaycan@gmail.com>";
+  ayyjayess = "Andrew Scott <3648487+ayyjayess@users.noreply.github.com>";
   bachp = "Pascal Bach <pascal.bach@nextrem.ch>";
   backuitist = "Bruno Bieth";
   badi = "Badi' Abdul-Wahid <abdulwahidc@gmail.com>";

--- a/pkgs/development/python-modules/web_cache/default.nix
+++ b/pkgs/development/python-modules/web_cache/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchPypi, buildPythonPackage, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "web_cache";
+  version = "1.0.2";
+  name = "${pname}-${version}";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05mmxf5f312mi9g417zad20f8v76wjm36b0v75x96diffccaafp0";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Simple Python key-value storage backed up by sqlite3 database";
+    homepage = https://github.com/desbma/web_cache;
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/python-modules/web_cache/default.nix
+++ b/pkgs/development/python-modules/web_cache/default.nix
@@ -12,6 +12,7 @@ buildPythonPackage rec {
     sha256 = "05mmxf5f312mi9g417zad20f8v76wjm36b0v75x96diffccaafp0";
   };
 
+  # ModuleNotFoundError: No module named 'tests'
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/sacad/default.nix
+++ b/pkgs/tools/misc/sacad/default.nix
@@ -1,0 +1,37 @@
+{ pkgs, jpegoptim, optipng }:
+
+let
+  inherit (pkgs.python3.pkgs) buildPythonApplication fetchPypi;
+in
+buildPythonApplication rec {
+  pname = "sacad";
+  version = "2.0.6";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vb2y18lmsm742pwff9164plbji3vjmx06accc84vws1nv7d1rzg";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = with pkgs.python3.pkgs; [
+    aiohttp
+    appdirs
+    cssselect
+    lxml
+    mutagen
+    pillow
+    tqdm
+    web_cache
+    jpegoptim
+    optipng
+  ];
+
+  meta = {
+    description = "Smart Automatic Cover Art Downloader";
+    license = pkgs.stdenv.lib.licenses.mpl20;
+    homepage = https://github.com/desbma/sacad;
+    maintainers = with pkgs.stdenv.lib.maintainers; [ ayyjayess ];
+  };
+}

--- a/pkgs/tools/misc/sacad/default.nix
+++ b/pkgs/tools/misc/sacad/default.nix
@@ -1,7 +1,7 @@
-{ pkgs, jpegoptim, optipng }:
-
+{ stdenv, python3, jpegoptim, optipng }:
+with python3.pkgs;
 let
-  inherit (pkgs.python3.pkgs) buildPythonApplication fetchPypi;
+  inherit (python3.pkgs) buildPythonApplication fetchPypi;
 in
 buildPythonApplication rec {
   pname = "sacad";
@@ -13,9 +13,7 @@ buildPythonApplication rec {
     sha256 = "1vb2y18lmsm742pwff9164plbji3vjmx06accc84vws1nv7d1rzg";
   };
 
-  doCheck = false;
-
-  propagatedBuildInputs = with pkgs.python3.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     aiohttp
     appdirs
     cssselect
@@ -28,10 +26,12 @@ buildPythonApplication rec {
     optipng
   ];
 
+  doCheck = false;
+
   meta = {
     description = "Smart Automatic Cover Art Downloader";
-    license = pkgs.stdenv.lib.licenses.mpl20;
+    license = stdenv.lib.licenses.mpl20;
     homepage = https://github.com/desbma/sacad;
-    maintainers = with pkgs.stdenv.lib.maintainers; [ ayyjayess ];
+    maintainers = with stdenv.lib.maintainers; [ ayyjayess ];
   };
 }

--- a/pkgs/tools/misc/sacad/default.nix
+++ b/pkgs/tools/misc/sacad/default.nix
@@ -28,6 +28,7 @@ buildPythonApplication rec {
   ]
   ++ stdenv.lib.optional enableCompression [ jpegoptim optipng ];
 
+  # ModuleNotFoundError: No module named 'tests'
   doCheck = false;
 
   meta = {

--- a/pkgs/tools/misc/sacad/default.nix
+++ b/pkgs/tools/misc/sacad/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, python3, jpegoptim, optipng }:
+{ stdenv, python3, enableCompression ? true, jpegoptim, optipng }:
+
+assert enableCompression -> jpegoptim != null && optipng != null;
+
 with python3.pkgs;
 let
   inherit (python3.pkgs) buildPythonApplication fetchPypi;
@@ -22,9 +25,8 @@ buildPythonApplication rec {
     pillow
     tqdm
     web_cache
-    jpegoptim
-    optipng
-  ];
+  ]
+  ++ stdenv.lib.optional enableCompression [ jpegoptim optipng ];
 
   doCheck = false;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4502,6 +4502,8 @@ with pkgs;
 
   sablotron = callPackage ../tools/text/xml/sablotron { };
 
+  sacad = callPackage ../tools/misc/sacad { };
+
   safecopy = callPackage ../tools/system/safecopy { };
 
   safe-rm = callPackage ../tools/system/safe-rm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18313,6 +18313,8 @@ EOF
 
   waitress-django = callPackage ../development/python-modules/waitress-django { };
 
+  web_cache = callPackage ../development/python-modules/web_cache { };
+
   webassets = buildPythonPackage rec {
     name = "webassets-${version}";
     version = "0.12.1";


### PR DESCRIPTION
SACAD is a multi platform command line tool to download album covers without manual intervention, ideal for integration in scripts, audio players, etc.

Also includes: web_cache: init at 1.0.2

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

