### PR TITLE
irods: 4.2.1 -> 4.2.2 + server bugfixes

### DIFF
--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -1,7 +1,10 @@
-{ stdenv, fetchurl, python, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp, boost, jansson, zeromq, openssl , pam, libiodbc, kerberos, gcc, libcxx, which }:
+{ stdenv, fetchurl, python, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp_llvm, boost, jansson, zeromq, openssl , pam, libiodbc, kerberos, gcc, libcxx, which }:
 
 with stdenv;
 
+let
+  avro-cpp=avro-cpp_llvm;
+in
 let
   common = import ./common.nix {
     inherit stdenv bzip2 zlib autoconf automake cmake gnumake
@@ -13,13 +16,13 @@ in rec {
 
   # irods: libs and server package
   irods = stdenv.mkDerivation (common // rec {
-    version = "4.2.1";
+    version = "4.2.2";
     prefix = "irods";
     name = "${prefix}-${version}";
 
     src = fetchurl {
       url = "https://github.com/irods/irods/releases/download/${version}/irods-${version}.tar.gz";
-      sha256 = "07yj5g1mwra4sankhqx967mk4z28kc40rir5cb85x23ljql74abq";
+      sha256 = "0b89hs7sizwrs2ja7jl521byiwb58g297p0p7zg5frxmv4ig8dw7";
     };
 
     # Patches:
@@ -53,11 +56,11 @@ in rec {
 
   # icommands (CLI) package, depends on the irods package
   irods-icommands = stdenv.mkDerivation (common // rec {
-     version = "4.2.1";
+     version = "4.2.2";
      name = "irods-icommands-${version}";
      src = fetchurl {
        url = "http://github.com/irods/irods_client_icommands/archive/${version}.tar.gz";
-       sha256 = "1kg07frv2rf32nf53a1nxscwzgr0rpgxvp5fkmh5439knby10fqw";
+       sha256 = "15zcxrx0q5c3rli3snd0b2q4i0hs3zzcrbpnibbhsip855qvs77h";
      };
 
      buildInputs = common.buildInputs ++ [ irods ];

--- a/pkgs/tools/filesystems/irods/irods_root_path.patch
+++ b/pkgs/tools/filesystems/irods/irods_root_path.patch
@@ -1,5 +1,6 @@
---- a/lib/core/src/irods_default_paths.cpp	2016-10-24 17:09:02.955889536 +0200
-+++ b/lib/core/src/irods_default_paths.cpp	2016-10-24 17:09:43.178722157 +0200
+diff -r -u irods-4.2.0.orig/lib/core/src/irods_default_paths.cpp irods-4.2.0/lib/core/src/irods_default_paths.cpp
+--- irods-4.2.0.orig/lib/core/src/irods_default_paths.cpp	2016-11-15 06:23:55.000000000 +0000
++++ irods-4.2.0/lib/core/src/irods_default_paths.cpp	2016-12-20 18:03:17.156883399 +0000
 @@ -18,7 +18,7 @@
          try {
              boost::filesystem::path path{dl_info.dli_fname};
@@ -9,3 +10,62 @@
              return path;
          } catch(const boost::filesystem::filesystem_error& e) {
              THROW(-1, e.what());
+@@ -27,8 +27,7 @@
+ 
+     boost::filesystem::path
+     get_irods_config_directory() {
+-        boost::filesystem::path path{get_irods_root_directory()};
+-        path.append("etc").append("irods");
++        boost::filesystem::path path("/etc/irods");
+         return path;
+     }
+ 
+diff -r -u irods-4.2.0.orig/scripts/irods/paths.py irods-4.2.0/scripts/irods/paths.py
+--- irods-4.2.0.orig/scripts/irods/paths.py	2016-11-15 06:23:55.000000000 +0000
++++ irods-4.2.0/scripts/irods/paths.py	2016-12-21 15:17:07.437864606 +0000
+@@ -10,7 +10,7 @@
+     return os.path.join(root_directory(), 'var', 'lib', 'irods')
+ 
+ def config_directory():
+-    return os.path.join(root_directory(), 'etc', 'irods')
++    return os.path.join(os.path.abspath('/'), 'etc', 'irods')
+ 
+ def plugins_directory():
+     return os.path.join(root_directory(), 'usr', 'lib', 'irods', 'plugins')
+@@ -37,7 +37,7 @@
+ 
+ def version_path():
+     return os.path.join(
+-        irods_directory(),
++        home_directory(),
+         'VERSION.json')
+ 
+ def hosts_config_path():
+@@ -64,7 +64,7 @@
+ 
+ def log_directory():
+     return os.path.join(
+-        irods_directory(),
++        home_directory(),
+         'log')
+ 
+ def control_log_path():
+@@ -110,8 +110,7 @@
+ def server_bin_directory():
+     return os.path.join(
+         root_directory(),
+-        'usr',
+-        'sbin')
++        'bin')
+ 
+ def server_executable():
+     return os.path.join(
+@@ -132,7 +131,7 @@
+     return os.path.join(config_directory(), 'service_account.config')
+ 
+ def genosauth_path():
+-    return os.path.join(irods_directory(), 'clients', 'bin', 'genOSAuth')
++    return os.path.join(home_directory(), 'clients', 'bin', 'genOSAuth')
+ 
+ def irods_user_and_group_entries():
+     try:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2597,6 +2597,7 @@ with pkgs;
             stdenv = llvmPackages_38.libcxxStdenv;
             libcxx = llvmPackages_38.libcxx;
             boost = boost160.override { inherit stdenv; };
+            avro-cpp_llvm = avro-cpp.override { inherit stdenv boost; };
           })
       irods
       irods-icommands;


### PR DESCRIPTION
###### Motivation for this change
- upgrade
- adaptation of pathes for the irodsServer
- fixed avroccp dependency (boost conflict gcc vs llvm)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

