### PR TITLE
manual/options-to-docbook: remove string escaping

### DIFF
--- a/nixos/doc/manual/options-to-docbook.xsl
+++ b/nixos/doc/manual/options-to-docbook.xsl
@@ -116,11 +116,11 @@
 
   <xsl:template match="string">
     <xsl:choose>
-      <xsl:when test="(contains(@value, '&quot;') or contains(@value, '\')) and not(contains(@value, '&#010;'))">
-        <xsl:text>''</xsl:text><xsl:value-of select='str:replace(@value, "${", "&apos;&apos;${")' /><xsl:text>''</xsl:text>
+      <xsl:when test="contains(@value, '&#xA;')">
+        <xsl:text>''</xsl:text><xsl:value-of select='@value' /><xsl:text>''</xsl:text>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:text>"</xsl:text><xsl:value-of select="str:replace(str:replace(str:replace(str:replace(@value, '\', '\\'), '&quot;', '\&quot;'), '&#010;', '\n'), '$', '\$')" /><xsl:text>"</xsl:text>
+        <xsl:text>"</xsl:text><xsl:value-of select="@value" /><xsl:text>"</xsl:text>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>


### PR DESCRIPTION
This removes escaping of strings which lead to a false presentation in the
resulting manpages (e.g. "${someExpression}" in an option's default
value resulted in "\\${someExpression}" in the manpages) which cannot be copied as is
and thus might be misleading in a manual.

Multiline-strings are now identified by the contained newlines and escaping them
is not necessary as they already have to be escaped in the module's definition.

-> [example of escaped default value](https://nixos.org/nixos/manual/options.html#opt-services.mpd.musicDirectory)
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---