### PR TITLE
Python CAN support

### DIFF
--- a/pkgs/development/python-modules/can/default.nix
+++ b/pkgs/development/python-modules/can/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pyserial
+, nose
+, mock }:
+
+buildPythonPackage rec {
+  pname = "python-can";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1c6zfd29ck9ffdklfb5xgxvfl52xdaqd89isykkypm1ll97yk2fs";
+  };
+
+  propagatedBuildInputs = [ pyserial ];
+  checkInputs = [ nose mock ];
+
+  meta = with lib; {
+    homepage = https://github.com/hardbyte/python-can;
+    description = "CAN support for Python";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ sorki ];
+  };
+}

--- a/pkgs/development/python-modules/canmatrix/default.nix
+++ b/pkgs/development/python-modules/canmatrix/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, lxml
+, xlwt
+, xlrd
+, XlsxWriter
+, pyyaml
+, future }:
+
+buildPythonPackage rec {
+  pname = "canmatrix";
+  version = "0.6";
+
+  # uses fetchFromGitHub as PyPi release misses test/ dir
+  src = fetchFromGitHub {
+    owner = "ebroecker";
+    repo = pname;
+    rev = version;
+    sha256 = "1lb0krhchja2jqfsh5lsfgmqcchs1pd38akvc407jfmll96f4yqz";
+  };
+
+  checkPhase = ''
+    cd test
+    ${python.interpreter} ./test.py
+  '';
+
+  propagatedBuildInputs =
+    [ lxml
+      xlwt
+      xlrd
+      XlsxWriter
+      pyyaml
+      future
+    ];
+
+  meta = with lib; {
+    homepage = https://github.com/ebroecker/canmatrix;
+    description = "Support and convert several CAN (Controller Area Network) database formats .arxml .dbc .dbf .kcd .sym fibex xls(x)";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sorki ];
+  };
+}
+

--- a/pkgs/development/python-modules/canopen/default.nix
+++ b/pkgs/development/python-modules/canopen/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, fetchFromGitHub
+, nose
+, can
+, canmatrix }:
+
+buildPythonPackage rec {
+  pname = "canopen";
+  version = "0.5.1";
+
+  # use fetchFromGitHub until version containing test/sample.eds
+  # is available on PyPi
+  # https://github.com/christiansandberg/canopen/pull/57
+
+  src = fetchFromGitHub {
+    owner = "christiansandberg";
+    repo = "canopen";
+    rev = "b20575d84c3aef790fe7c38c5fc77601bade0ea4";
+    sha256 = "1qg47qrkyvyxiwi13sickrkk89jp9s91sly2y90bz0jhws2bxh64";
+  };
+
+  #src = fetchPypi {
+  #  inherit pname version;
+  #  sha256 = "0806cykarpjb9ili3mf82hsd9gdydbks8532nxgz93qzg4zdbv2g";
+  #};
+
+  # test_pdo failure https://github.com/christiansandberg/canopen/issues/58
+  doCheck = false;
+
+  propagatedBuildInputs =
+    [ can
+      canmatrix
+    ];
+
+  checkInputs = [ nose ];
+
+  meta = with lib; {
+    homepage = https://github.com/christiansandberg/canopen/;
+    description = "CANopen stack implementation";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ sorki ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2016,6 +2016,8 @@ in {
 
   can = callPackage ../development/python-modules/can {};
 
+  canmatrix = callPackage ../development/python-modules/canmatrix {};
+
   cairocffi = buildPythonPackage rec {
     name = "cairocffi-0.7.2";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2014,6 +2014,7 @@ in {
     doCheck = false;
   });
 
+  can = callPackage ../development/python-modules/can {};
 
   cairocffi = buildPythonPackage rec {
     name = "cairocffi-0.7.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2016,6 +2016,8 @@ in {
 
   can = callPackage ../development/python-modules/can {};
 
+  canopen = callPackage ../development/python-modules/canopen {};
+
   canmatrix = callPackage ../development/python-modules/canmatrix {};
 
   cairocffi = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

CAN/CANOpen python stack

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

