### PR TITLE
moreutils: Fix eval

### DIFF
--- a/pkgs/tools/misc/moreutils/default.nix
+++ b/pkgs/tools/misc/moreutils/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.joeyh.name/moreutils";
     rev = "refs/tags/${version}";
-    sha256 = "0sk7rgqsqbdwr69mh7y4v9lv4v0nfmsrqgvbpy2gvy82snhfzar"2;
+    sha256 = "0sk7rgqsqbdwr69mh7y4v9lv4v0nfmsrqgvbpy2gvy82snhfzar2";
   };
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

Was broken in 561b9ca8ac37509213369797fc56437cda2961ca.

Please use @GrahamcOfBorg everyone!!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

