### PR TITLE
ncurses6: 20171125 -> 6.1

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   name = "ncurses-${version}" + lib.optionalString (abiVersion == "5") "-abi5-compat";
 
   src = fetchurl {
-    url = "mirror://gnu/ncurses/${name}.tar.gz";
+    url = "mirror://gnu/ncurses/ncurses-${version}.tar.gz";
     sha256 = "05qdmbmrrn88ii9f66rkcmcyzp1kb1ymkx7g040lfkd1nkp7w1da";
   };
 
@@ -117,6 +117,8 @@ stdenv.mkDerivation rec {
     moveToOutput "bin/tic" "$out"
     moveToOutput "bin/tput" "$out"
     moveToOutput "bin/tset" "$out"
+    moveToOutput "bin/captoinfo" "$out"
+    moveToOutput "bin/infotocap" "$out"
   '';
 
   preFixup = lib.optionalString (!hostPlatform.isCygwin) ''

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -11,18 +11,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "6.0-20171125";
+  version = "6.1";
   name = "ncurses-${version}" + lib.optionalString (abiVersion == "5") "-abi5-compat";
 
   src = fetchurl {
-    urls = [
-      # Remove this mirror on next upgrade, it's only needed because upstream took ncurses-6.0-20171125.tgz down!
-      "http://bld1.alpinelinux.org/distfiles/v3.5/ncurses-${version}.tgz"
-
-      "ftp://ftp.invisible-island.net/ncurses/current/ncurses-${version}.tgz"
-      "https://invisible-mirror.net/archives/ncurses/current/ncurses-${version}.tgz"
-    ];
-    sha256 = "11adzj0k82nlgpfrflabvqn2m7fmhp2y6pd7ivmapynxqb9vvb92";
+    url = "mirror://gnu/ncurses/${name}.tar.gz";
+    sha256 = "05qdmbmrrn88ii9f66rkcmcyzp1kb1ymkx7g040lfkd1nkp7w1da";
   };
 
   patches = lib.optional (!stdenv.cc.isClang) ./clang.patch;


### PR DESCRIPTION
Release notes are currently available here: https://www.gnu.org/software/ncurses/#h2-release-notes
(that URL is not future-proof, for what it's worth).

More verbose changelog:
https://invisible-island.net/ncurses/NEWS.html#t20180127

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

From my experience on slightly older tree,
a few *old* programs incorrectly rely on ncurses internal details
and may now require setting NCURSES_INTERNAL=1 to allow this badness.