### PR TITLE
charliecloud: init at 0.2.2

### DIFF
--- a/pkgs/applications/virtualization/charliecloud/CONDUCT.md_not_present_into_bats_release.patch
+++ b/pkgs/applications/virtualization/charliecloud/CONDUCT.md_not_present_into_bats_release.patch
@@ -1,0 +1,11 @@
+diff -r -u charliecloud-0.2.2.orig/Makefile charliecloud-0.2.2/Makefile
+--- charliecloud-0.2.2.orig/Makefile	2017-09-18 23:50:55.000000000 +0200
++++ charliecloud-0.2.2/Makefile	2017-11-17 17:28:15.596178797 +0100
+@@ -84,7 +84,6 @@
+ 	chmod 755 $(TEST)/chtest/*.py
+ 	install -d $(TEST)/bats.src
+ 	install -pm 644 -t $(TEST)/bats.src \
+-	        test/bats.src/CONDUCT.md test/bats.src/LICENSE \
+                 test/bats.src/README.md
+ 	install -d $(TEST)/bats.src/libexec
+ 	install -pm 755 -t $(TEST)/bats.src/libexec \

--- a/pkgs/applications/virtualization/charliecloud/default.nix
+++ b/pkgs/applications/virtualization/charliecloud/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, bash, python }:
+
+stdenv.mkDerivation rec {
+
+  version = "0.2.2";
+  name = "charliecloud-${version}";
+  bats_version = "0.4.0";
+
+ srcs = 
+    [ (fetchurl {
+         url = "https://github.com/hpc/charliecloud/archive/v${version}.tar.gz";
+         sha256 = "0djq3j6q7zj4ignf1b87k64bg4h5aw8l0mxnshagsaskwvmhakpi";
+       })
+      (fetchurl {
+         url = "https://github.com/sstephenson/bats/archive/v${bats_version}.tar.gz";
+         sha256 = "1myqq56kzwqc7p3inxiv2wgc06kfy3rjf980s5wfw7k8y5j8s3a8";
+       })
+    ];
+
+  patches = [ ./CONDUCT.md_not_present_into_bats_release.patch ];
+
+  buildInputs = [ bash python ];
+
+  sourceRoot = "${name}";
+
+  preBuild = ''
+    patchShebangs test/make-auto     
+    cp VERSION VERSION.full
+    export PREFIX=$out
+    cp -a ../bats-${bats_version}/* test/bats.src/
+  '';
+
+  meta = {                                                                                   
+    description = "User-defined software stacks (UDSS) for high-performance computing (HPC) centers";
+    longDescription = ''
+      Charliecloud uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources. This simple approach avoids most security risks while maintaining access to the performance and functionality already on offer.''; 
+    homepage = https://hpc.github.io/charliecloud;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    platforms = stdenv.lib.platforms.linux;
+  };                                                                                         
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14479,6 +14479,8 @@ with pkgs;
     amdappsdk = amdappsdk28;
   };
 
+  charliecloud = callPackage ../applications/virtualization/charliecloud { };
+  
   chatzilla = callPackage ../applications/networking/irc/chatzilla { };
 
   chirp = callPackage ../applications/misc/chirp {


### PR DESCRIPTION
###### Motivation for this change
Want to use charliecloud :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

