### PR TITLE
utillinux: set default wordlist for look

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, pkgconfig, zlib, fetchpatch, shadow
-, ncurses ? null, perl ? null, pam, systemd, minimal ? false }:
+, ncurses ? null, perl ? null, pam, systemd, minimal ? false
+, scowl, makeWrapper }:
 
 let
   version = lib.concatStringsSep "." ([ majorVersion ]
@@ -53,13 +54,15 @@ in stdenv.mkDerivation rec {
 
   makeFlags = "usrbin_execdir=$(bin)/bin usrsbin_execdir=$(bin)/sbin";
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
   buildInputs =
     [ zlib pam ]
     ++ lib.filter (p: p != null) [ ncurses systemd perl ];
 
   postInstall = ''
     rm "$bin/bin/su" # su should be supplied by the su package (shadow)
+    wrapProgram $bin/bin/look \
+      --set "WORDLIST" "${scowl}/share/dict/words.txt"
   '' + lib.optionalString minimal ''
     rm -rf $out/share/{locale,doc,bash-completion}
   '';


### PR DESCRIPTION
###### Motivation for this change
[change introduced in v2.31](https://github.com/karelzak/util-linux/blob/960b779cfb47e93b50b0a1e3015e39b7cb15cae2/Documentation/releases/v2.31-ReleaseNotes#L55)
([kernel.org version](https://www.kernel.org/pub/linux/utils/util-linux/v2.31/v2.31-ReleaseNotes))

right now using look, without specifying a dictionary manually with the `-a` flag just results in the error:
```
look: /usr/share/dict/words: No such file or directory
```

###### Things done
This adds a wrapper for `look` because it uses the environment variable
'WORDLIST', with a fallback to `/usr/share/dict/words` when looking for a dictionary.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---