### PR TITLE
python.pkgs.ptyprocess: 0.5 -> 0.5.2 

### DIFF
--- a/pkgs/development/python-modules/ptyprocess/default.nix
+++ b/pkgs/development/python-modules/ptyprocess/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "ptyprocess";
-  version = "0.5";
+  version = "0.5.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256= "dcb78fb2197b49ca1b7b2f37b047bc89c0da7a90f90bd5bc17c3ce388bb6ef59";
+    sha256= "e64193f0047ad603b71f202332ab5527c5e52aa7c8b609704fc28c0dc20c4365";
   };
 
   meta = {

--- a/pkgs/development/python-modules/ptyprocess/default.nix
+++ b/pkgs/development/python-modules/ptyprocess/default.nix
@@ -1,0 +1,20 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "ptyprocess";
+  version = "0.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256= "dcb78fb2197b49ca1b7b2f37b047bc89c0da7a90f90bd5bc17c3ce388bb6ef59";
+  };
+
+  meta = {
+    description = "Run a subprocess in a pseudo terminal";
+    homepage = https://github.com/pexpect/ptyprocess;
+    license = lib.licenses.isc;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14626,21 +14626,7 @@ in {
     };
   };
 
-  ptyprocess = buildPythonPackage rec {
-    name = "ptyprocess-${version}";
-    version = "0.5";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/ptyprocess/${name}.tar.gz";
-      sha256= "dcb78fb2197b49ca1b7b2f37b047bc89c0da7a90f90bd5bc17c3ce388bb6ef59";
-    };
-
-    meta = {
-      description = "Run a subprocess in a pseudo terminal";
-      homepage = https://github.com/pexpect/ptyprocess;
-      license = licenses.isc;
-    };
-  };
+  ptyprocess = callPackage ../development/python-modules/ptyprocess { };
 
   pylibacl = callPackage ../development/python-modules/pylibacl { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

