### PR TITLE
udocker: init at 1.1.1

### DIFF
--- a/pkgs/tools/virtualization/udocker/default.nix
+++ b/pkgs/tools/virtualization/udocker/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, proot, patchelf, fakechroot, runc, simplejson, pycurl, coreutils, nose, mock, buildPythonApplication }:
+
+buildPythonApplication rec {
+
+  version = "1.1.1";
+  pname = "udocker";
+
+  src = fetchFromGitHub rec {
+    owner = "indigo-dc";
+    repo = "udocker" ;
+    rev = "v${version}";
+    sha256 = "134xk7rfj0xki9znryk5qf1nsfa318ahrrsi1k6ia7kipp7i3hb4";
+  };
+
+  buildInputs = [ proot patchelf fakechroot runc simplejson pycurl coreutils nose mock ];
+
+  postPatch = ''
+      substituteInPlace udocker.py --replace /usr/sbin:/sbin:/usr/bin:/bin $PATH
+      substituteInPlace udocker.py --replace /bin/chmod ${coreutils}/bin/chmod
+      substituteInPlace udocker.py --replace /bin/rm ${coreutils}/bin/rm
+      substituteInPlace tests/unit_tests.py --replace /bin/rm ${coreutils}/bin/rm
+      substituteInPlace udocker.py --replace "autoinstall = True" "autoinstall = False"
+  '';
+
+  checkPhase = ''
+    NOSE_EXCLUDE=test_03_create_repo,test_04_is_repo,test_02__get_group_from_host nosetests -v tests/unit_tests.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "basic user tool to execute simple docker containers in user space without root privileges";
+    homepage = https://www.gitbook.com/book/indigo-dc/udocker;
+    license = licenses.asl20;
+    maintainers = [ maintainers.bzizou ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17453,6 +17453,8 @@ with pkgs;
   testssl = callPackage ../applications/networking/testssl { };
 
   umurmur = callPackage ../applications/networking/umurmur { };
+  
+  udocker = pythonPackages.callPackage ../tools/virtualization/udocker { };
 
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };
 


### PR DESCRIPTION
###### Motivation for this change
udocker may be useful for HPC environments using NIX

This package works at image-creation-time (docker should be installed) and  at runtime with at least P1 and P2 modes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

