### PR TITLE
terraform: add the version component to terraform provider paths

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/providers/default.nix
@@ -11,6 +11,10 @@ let
         inherit owner repo sha256;
         rev = "v${version}";
       };
+
+      # Terraform allow checking the provider versions, but this breaks
+      # if the versions are not provided via file paths.
+      postBuild = "mv go/bin/${repo}{,_v${version}}";
     };
 
   maybeDrv = name: data:


### PR DESCRIPTION
Terraform checks the provider versions, but this breaks if the versions
are not provided, as they can be, if the plugins are provided by nix.

###### Motivation for this change

Fixes #34423.

I'm not sure whether a [quick-fix](https://github.com/siers/nixpkgs/commits/terraform-provider-symlink-versioning-quickfix)(see first commit) would be more appropriate here or not.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` **— no, just a couple**
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---