### PR TITLE
maloader: fix hash (currently broken)

### DIFF
--- a/pkgs/os-specific/darwin/maloader/default.nix
+++ b/pkgs/os-specific/darwin/maloader/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   src = fetchgit {
     url = "git://github.com/shinh/maloader.git";
     rev = "5f220393e0b7b9ad0cf1aba0e89df2b42a1f0442";
-    sha256 = "07j9b7n0grrbxxyn2h8pnk6pa8b370wq5z5zwbds8dlhi7q37rhn";
+    sha256 = "0dd1pn07x1y8pyn5wz8qcl1c1xwghyya4d060m3y9vx5dhv9xmzw";
   };
 
   postPatch = ''


### PR DESCRIPTION
Broken hashes are not as good as correct hashes! :)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
$ nix-build -A darwin.maloader.src
```