### PR TITLE
xpwn: build usb-based tools by replacing libusb1 dep with libusb

### DIFF
--- a/pkgs/development/mobile/xpwn/default.nix
+++ b/pkgs/development/mobile/xpwn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, zlib, libpng, bzip2, libusb1, openssl }:
+{ stdenv, fetchgit, cmake, zlib, libpng, bzip2, libusb, openssl }:
 
 stdenv.mkDerivation {
   name = "xpwn-0.5.8git";
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     sed -i -e '/install/d' CMakeLists.txt
   '';
 
-  buildInputs = [ cmake zlib libpng bzip2 libusb1 openssl ];
+  buildInputs = [ cmake zlib libpng bzip2 libusb openssl ];
 
   cmakeFlags = [
     "-DCMAKE_OSX_DEPLOYMENT_TARGET="


### PR DESCRIPTION
Drive-by, noticed libusb wasn't being detected.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Otherwise the build fails to detect libusb and doesn't build
the 'xpwn' and 'dfu-util' tools.

New tools run but I don't have any suitable devices to test :).

(I believe latest iGadgets need a newer version of xpwn anyway)