### PR TITLE
init libdmg-hfsplus, use instead of xpwn to fix Linux xcode extraction

### DIFF
--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile, xpwn }:
+{ stdenv, requireFile, libdmg-hfsplus }:
 
 with stdenv.lib;
 
@@ -17,13 +17,15 @@ in stdenv.mkDerivation rec {
   phases = [ "unpackPhase" "patchPhase" "installPhase" "fixupPhase" ];
   outputs = [ "out" "toolchain" ];
 
+  nativeBuildInputs = [ libdmg-hfsplus ];
+
 
   unpackCmd = let
     basePath = "Xcode.app/Contents/Developer/Platforms/MacOSX.platform";
     sdkPath = "${basePath}/Developer/SDKs";
   in ''
-    ${xpwn}/bin/dmg extract "$curSrc" main.hfs > /dev/null
-    ${xpwn}/bin/hfsplus main.hfs extractall "${sdkPath}" > /dev/null
+    dmg extract "$curSrc" main.hfs > /dev/null
+    hfsplus main.hfs extractall "${sdkPath}" > /dev/null
   '';
 
   setSourceRoot = "sourceRoot=MacOSX${osxVersion}.sdk";
@@ -38,7 +40,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p "$toolchain"
     pushd "$toolchain"
-    ${xpwn}/bin/hfsplus "$(dirs +1)/../main.hfs" extractall \
+    hfsplus "$(dirs +1)/../main.hfs" extractall \
       Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr \
       > /dev/null
     popd

--- a/pkgs/tools/filesystems/libdmg-hfsplus/default.nix
+++ b/pkgs/tools/filesystems/libdmg-hfsplus/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, zlib, bzip2, libpng, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "libdmg-hfsplus-${version}";
+  version = "2016-01-31";
+
+  src = fetchFromGitHub {
+    owner = "andreas56";
+    repo = "libdmg-hfsplus";
+    rev = "81dd75fd1549b24bf8af9736ac25518b367e6b63";
+    sha256 = "0109zmz7nkydkrka98wmj0bjkskmxghw0k39a60ampywmsdi1vkh";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ zlib bzip2 libpng openssl ];
+
+  meta = with stdenv.lib; src.meta // {
+    description = "Portable libraries and utilities that manipulate HFS+ volumes and Apple's DMG images";
+    license     = licenses.gpl3Plus;
+    platforms   = with platforms; linux ++ darwin;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3052,6 +3052,8 @@ with pkgs;
 
   libcpuid = callPackage ../tools/misc/libcpuid { };
 
+  libdmg-hfsplus = callPackage ../tools/filesystems/libdmg-hfsplus { };
+
   libscrypt = callPackage ../development/libraries/libscrypt { };
 
   libsmi = callPackage ../development/libraries/libsmi { };


### PR DESCRIPTION
See commit messages.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

TODO:
* [ ] Test on Darwin
* [ ] Compare against current extraction w/Darwin to ensure things are good.
* [ ] Possibly avoid Darwin rebuild by only using these tools on Linux