### PR TITLE
pipewire: init at 0.1.8

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -200,6 +200,7 @@
   ./services/desktops/dleyna-renderer.nix
   ./services/desktops/dleyna-server.nix
   ./services/desktops/geoclue2.nix
+  ./services/desktops/pipewire.nix
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/chrome-gnome-shell.nix
   ./services/desktops/gnome3/evolution-data-server.nix

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -1,0 +1,23 @@
+# pipewire service.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+  options = {
+    services.pipewire = {
+      enable = mkEnableOption "pipewire service";
+    };
+  };
+
+
+  ###### implementation
+  config = mkIf config.services.pipewire.enable {
+    environment.systemPackages = [ pkgs.pipewire ];
+
+    systemd.packages = [ pkgs.pipewire ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ jtojnar ];
+}

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, pkgconfig, gnome3, intltool, gobjectIntrospection, upower, cairo
 , pango, cogl, clutter, libstartup_notification, zenity, libcanberra_gtk3
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
-, libgudev, libwacom, xwayland, autoreconfHook }:
+, pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-x"
     "--disable-static"
+    "--enable-remote-desktop"
     "--enable-shape"
     "--enable-sm"
     "--enable-startup-notification"
@@ -16,6 +17,15 @@ stdenv.mkDerivation rec {
     "--enable-verbose-mode"
     "--with-libcanberra"
     "--with-xwayland-path=${xwayland}/bin/Xwayland"
+  ];
+
+  patches = [
+    # Pipewire 0.1.8 compatibility
+    (fetchurl {
+      name = "mutter-pipewire-0.1.8-compat.patch";
+      url = https://bugzilla.gnome.org/attachment.cgi?id=367356;
+      sha256 = "10bx5zf11wwhhy686w11ggikk56pbxydpbk9fbd947ir385x92cz";
+    })
   ];
 
   propagatedBuildInputs = [
@@ -30,7 +40,7 @@ stdenv.mkDerivation rec {
     gnome_desktop cairo pango cogl clutter zenity libstartup_notification
     gnome3.geocode_glib libinput libgudev libwacom
     libcanberra_gtk3 zenity xkeyboard_config libxkbfile
-    libxkbcommon
+    libxkbcommon pipewire
   ];
 
   preFixup = ''

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, doxygen, graphviz, valgrind
+, glib, dbus, gst_all_1, v4l_utils, alsaLib, ffmpeg, libjack2, libudev, libva, xlibs
+, sbc, SDL2
+}:
+
+let
+  version = "0.1.8";
+in stdenv.mkDerivation rec {
+  name = "pipewire-${version}";
+
+  src = fetchFromGitHub {
+    owner = "PipeWire";
+    repo = "pipewire";
+    rev = version;
+    sha256 = "1nim8d1lsf6yxk97piwmsz686w84b09lk6cagbyjr9m3k2hwybqn";
+  };
+
+  outputs = [ "out" "dev" "doc" ];
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig doxygen graphviz valgrind
+  ];
+  buildInputs = [
+    glib dbus gst_all_1.gst-plugins-base gst_all_1.gstreamer v4l_utils
+    alsaLib ffmpeg libjack2 libudev libva xlibs.libX11 sbc SDL2
+  ];
+
+  patches = [
+    ./fix-paths.patch
+  ];
+
+  mesonFlags = [
+    "-Denable_docs=true"
+    "-Denable_gstreamer=true"
+  ];
+
+  doCheck = true;
+  checkPhase = "meson test";
+
+  meta = with stdenv.lib; {
+    description = "Server and user space API to deal with multimedia pipelines";
+    homepage = http://pipewire.org/;
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/libraries/pipewire/fix-paths.patch
+++ b/pkgs/development/libraries/pipewire/fix-paths.patch
@@ -1,0 +1,8 @@
+--- a/src/daemon/systemd/user/meson.build
++++ b/src/daemon/systemd/user/meson.build
+@@ -1,4 +1,4 @@
+-systemd_user_services_dir = systemd.get_pkgconfig_variable('systemduserunitdir')
++systemd_user_services_dir = join_paths(get_option('prefix'), 'etc', 'systemd', 'user')
+ 
+ install_data(sources : 'pipewire.socket', install_dir : systemd_user_services_dir)
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6975,6 +6975,8 @@ with pkgs;
   pew = callPackage ../development/tools/pew {};
   pipenv = callPackage ../development/tools/pipenv {};
 
+  pipewire = callPackage ../development/libraries/pipewire {};
+
   pyrex = pyrex095;
 
   pyrex095 = callPackage ../development/interpreters/pyrex/0.9.5.nix { };


### PR DESCRIPTION
###### Motivation for this change
Needed for things like screen recording and remote desktop on Wayland.

https://blogs.gnome.org/uraeus/2018/01/26/an-update-on-pipewire-the-multimedia-revolution-an-update/

Mutter closure increased from 288M to 334M.

Closes: #32805

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Enabled the module and successfully ran the example
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

