### PR TITLE
ttwatch: 2017-12-31 -> 2018-02-01

### DIFF
--- a/pkgs/tools/misc/ttwatch/default.nix
+++ b/pkgs/tools/misc/ttwatch/default.nix
@@ -1,18 +1,21 @@
-{ stdenv, fetchFromGitHub, cmake, perl, openssl, curl, libusb1 }:
+{ stdenv, fetchFromGitHub, cmake, perl, openssl, curl, libusb1
+, enableUnsafe ? false }:
 
 stdenv.mkDerivation rec {
   name = "ttwatch-${version}";
-  version = "2017-12-31";
+  version = "2018-02-01";
 
   src = fetchFromGitHub {
     owner = "ryanbinns";
     repo = "ttwatch";
-    rev = "a261851d91e3304a47a04995758f6940747bc54a";
-    sha256 = "0llcai1yxikh8nvzry71rr1zz365rg0k0lwp24np5w74kzza3kwx";
+    rev = "b5c54647ed9b640584e53c4c15ee12d210790021";
+    sha256 = "136sskz9hnbwp49gxp983mswzgpl8yfc25ni79csbsnwp0k4lb94";
   };
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ openssl curl libusb1 ];
+
+  cmakeFlags = stdenv.lib.optional enableUnsafe [ "-Dunsafe=on" ];
 
   preFixup = ''
     chmod +x $out/bin/ttbin2mysports


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

