### PR TITLE
nixops-dns: init at f6c3f79

### DIFF
--- a/pkgs/tools/package-management/nixops/deps.nix
+++ b/pkgs/tools/package-management/nixops/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "github.com/mattn/go-sqlite3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-sqlite3";
+      rev = "b4142c444a8941d0d92b0b7103a24df9cd815e42";
+      sha256 = "0xq2y4am8dz9w9aaq24s1npg1sn8pf2gn4nki73ylz2fpjwq9vla";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "75229eecb7af00b2736e93b779a78429dcb19472";
+      sha256 = "1vsjy07kkyx11iz4qsihhykac3ddq3ywdgv6bwrv407504f7x6wl";
+    };
+  }
+]

--- a/pkgs/tools/package-management/nixops/nixops-dns.nix
+++ b/pkgs/tools/package-management/nixops/nixops-dns.nix
@@ -1,0 +1,26 @@
+{ lib
+, stdenv
+, buildGoPackage
+, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "nixops-dns";
+  version = "1.0";
+
+  goDeps = ./deps.nix;
+  goPackagePath = "github.com/kamilchm/nixops-dns";
+
+  src = fetchFromGitHub {
+    owner = "kamilchm";
+    repo = "nixops-dns";
+    rev = "v${version}";
+    sha256 = "1fyqwk2knrv40zpf71a56bjyaycr3p6fzrqq7gaan056ydy83cai";
+  };
+
+  meta = with lib; {
+    homepage = https://github.com/kamilchm/nixops-dns/;
+    description = "DNS server for resolving NixOps machines";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kamilchm sorki ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19832,6 +19832,8 @@ with pkgs;
 
   nixopsUnstable = lowPrio (callPackage ../tools/package-management/nixops/unstable.nix { });
 
+  nixops-dns = callPackage ../tools/package-management/nixops/nixops-dns.nix { };
+
   nixui = callPackage ../tools/package-management/nixui { node_webkit = nwjs_0_12; };
 
   nix-bundle = callPackage ../tools/package-management/nix-bundle { nix = nixUnstable; };


### PR DESCRIPTION
###### Motivation for this change

Easy DNS resolution for nixops vms.

CC @kamilchm 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

