### PR TITLE
libqalculate: fix build with clang

### DIFF
--- a/pkgs/development/libraries/libqalculate/default.nix
+++ b/pkgs/development/libraries/libqalculate/default.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
     substituteInPlace libqalculate/Calculator.cc \
       --replace 'commandline = "gnuplot"' 'commandline = "${gnuplot}/bin/gnuplot"' \
       --replace '"gnuplot -"' '"${gnuplot}/bin/gnuplot -"'
+  '' + stdenv.lib.optionalString stdenv.cc.isClang ''
+    substituteInPlace src/qalc.cc \
+      --replace 'printf(_("aborted"))' 'printf("%s", _("aborted"))'
   '';
 
   preBuild = ''


### PR DESCRIPTION
This addresses a security complaint clang makes about the source code,
and allows the build to succeed on darwin.

###### Motivation for this change
Address compilation errors of the form:

```
error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
