### PR TITLE
openssh: Document default Kerberos support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -113,6 +113,17 @@ following incompatible changes:</para>
   </listitem>
   <listitem>
     <para>
+      The <literal>openssh</literal> package
+      now includes Kerberos support by default;
+      the <literal>openssh_with_kerberos</literal> package
+      is now a deprecated alias.
+      If you do not want Kerberos support,
+      you can do <literal>openssh.override { withKerboros = false; }</literal>.
+      Note, this also applies to the <literal>openssh_hpn</literal> package.
+    </para>
+  </listitem>
+  <listitem>
+    <para>
       <literal>cc-wrapper</literal> has been split in two; there is now also a <literal>bintools-wrapper</literal>.
       The most commonly used files in <filename>nix-support</filename> are now split between the two wrappers.
       Some commonly used ones, like <filename>nix-support/dynamic-linker</filename>, are duplicated for backwards compatability, even though they rightly belong only in <literal>bintools-wrapper</literal>.


### PR DESCRIPTION
###### Motivation for this change
Follow up to https://github.com/NixOS/nixpkgs/pull/34348#issuecomment-361250676.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @grahamc 