### PR TITLE
tasknc: update (0.8 -> 2017-05-15), fix, cleanup and man pages

### DIFF
--- a/pkgs/applications/misc/tasknc/default.nix
+++ b/pkgs/applications/misc/tasknc/default.nix
@@ -1,48 +1,42 @@
-{ stdenv, fetchurl, taskwarrior, perl, ncurses }:
+{ stdenv, fetchFromGitHub, makeWrapper, perl, ncurses, taskwarrior }:
 
 stdenv.mkDerivation rec {
-  version = "0.8";
+  version = "2017-05-15";
   name = "tasknc-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/mjheagle8/tasknc/archive/v${version}.tar.gz";
-    sha256 = "0max5schga9hmf3vfqk2ic91dr6raxglyyjcqchzla280kxn5c28";
+  src = fetchFromGitHub {
+    owner = "lharding";
+    repo = "tasknc";
+    rev = "c41d0240e9b848e432f01de735f28de93b934ae7";
+    sha256 = "0f7l7fy06p33vw6f6sjnjxfhw951664pmwhjl573jvmh6gi2h1yr";
   };
+
+  nativeBuildInputs = [
+    makeWrapper
+    perl # For generating the man pages with pod2man
+  ];
+
+  buildInputs = [ ncurses ];
 
   hardeningDisable = [ "format" ];
 
-  #
-  # I know this is ugly, but the Makefile does strange things in this package,
-  # so we have to:
-  #
-  #   1. Remove the "doc" task dependency from the "all" target
-  #   2. Remove the "tasknc.1" task dependency from the "install" target
-  #   3. Remove the installing of the tasknc.1 file from the install target as
-  #      we just removed the build target for it.
-  #
-  # TODO : One could also provide a patch for the doc/manual.pod file so it
-  # actually builds, but I'm not familiar with this, so this is the faster
-  # approach for me. We have no manpage, though.
-  #
-  preConfigure = ''
-    sed -i -r 's,(all)(.*)doc,\1\2,' Makefile
-    sed -i -r 's,(install)(.*)tasknc\.1,\1\2,' Makefile
-    sed -i -r 's,install\ -D\ -m644\ tasknc\.1\ (.*),,' Makefile
-  '';
+  buildFlags = [ "VERSION=${version}" ];
 
   installPhase = ''
-    mkdir $out/bin/ -p
-    mkdir $out/share/man1 -p
-    mkdir $out/share/tasknc -p
-    DESTDIR=$out PREFIX= MANPREFIX=share make install
+    mkdir -p $out/bin/
+    mkdir -p $out/share/man/man1
+    mkdir -p $out/share/tasknc
+
+    DESTDIR=$out PREFIX= MANPREFIX=/share/man make install
+
+    wrapProgram $out/bin/tasknc --prefix PATH : ${taskwarrior}/bin
   '';
 
-  buildInputs = [ taskwarrior perl ncurses ];
 
-  meta = {
-    homepage = https://github.com/mjheagle8/tasknc;
+  meta = with stdenv.lib; {
+    homepage = https://github.com/lharding/tasknc;
     description = "A ncurses wrapper around taskwarrior";
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
-    platforms = stdenv.lib.platforms.linux; # Cannot test others
+    maintainers = with maintainers; [ matthiasbeyer infinisil ];
+    platforms = platforms.linux; # Cannot test others
   };
 }


### PR DESCRIPTION
###### Motivation for this change
tasknc has been broken for some reason for as long as I can remember, segfaulting at the start. man pages were not available either.

This commit updates tasknc to the most recent version which contains some fixes. Made the manpages work (also removes the makefile hack). Cleaned up dependencies (fixed the taskwarrior dependency, it's a runtime one. Also some nativeBuildInputs stuff). Apparently tasknc changed owners, so I got that changed too.

Ping @matthiasbeyer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

