### PR TITLE
infamousPlugins: init at 0.2.03

### DIFF
--- a/pkgs/applications/audio/infamousPlugins/default.nix
+++ b/pkgs/applications/audio/infamousPlugins/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cairomm, cmake, lv2, libpthreadstubs, libXdmcp, libXft, ntk, pcre, fftwFloat, zita-resampler }:
+
+stdenv.mkDerivation rec {
+  name = "infamousPlugins-v${version}";
+  version = "0.2.03";
+
+  src = fetchFromGitHub {
+    owner = "ssj71";
+    repo = "infamousPlugins";
+    rev = "v${version}";
+    sha256 = "1pb7vmc703j25rnyx81cqlfzi66v7gm4a49s06dbgy8a66s1i2zl";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ cairomm lv2 libpthreadstubs libXdmcp libXft ntk pcre fftwFloat zita-resampler ];
+
+  meta = with stdenv.lib; {
+    homepage = https://ssj71.github.io/infamousPlugins;
+    description = "A collection of open-source LV2 plugins";
+    longDescription = ''
+      These are audio plugins in the LV2 format, developed for linux. Most are suitable for live use.
+      This collection contains:
+        * Cellular Automaton Synth - additive synthesizer, where 16 harmonics are added according to rules of elementary cellular automata
+        * Envelope Follower - a fully featured envelope follower plugin
+        * Hip2B - a distortion/destroyer plugin
+        * cheap distortion - another distortion plugin, but this one I wanted to get it as light as possible
+        * stuck - a clone of the electro-harmonix freeze
+        * power cut - this effect is commonly called tape stop
+        * power up - the opposite of the power cut
+        * ewham - a whammy style pitchshifter
+        * lushlife - a simulated double tracking plugin capable of everything from a thin beatle effect to thick lush choruses to weird outlandish effects
+    '';
+    license = licenses.gpl2;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2846,6 +2846,8 @@ with pkgs;
 
   inform7 = callPackage ../development/compilers/inform7 { };
 
+  infamousPlugins = callPackage ../applications/audio/infamousPlugins { };
+
   innoextract = callPackage ../tools/archivers/innoextract { };
 
   intecture-agent = callPackage ../tools/admin/intecture/agent.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

