### PR TITLE
gnome3.gexiv2: re-enable bindings

### DIFF
--- a/pkgs/desktops/gnome-3/misc/gexiv2/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gexiv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, exiv2, glib, gnome3 }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, exiv2, glib, gnome3, gobjectIntrospection, vala }:
 
 let
   majorVersion = "0.10";
@@ -13,10 +13,15 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # https://bugzilla.gnome.org/show_bug.cgi?id=791941
+    # Darwin compatibility (https://bugzilla.gnome.org/show_bug.cgi?id=791941)
     (fetchurl {
       url = https://bugzilla.gnome.org/attachment.cgi?id=365969;
       sha256 = "06w744acgnz3hym7sm8c245yzlg05ldkmwgiz3yz4pp6h72brizj";
+    })
+    # GIR & Vala bindings fix (https://bugzilla.gnome.org/show_bug.cgi?id=792431)
+    (fetchurl {
+      url = https://bugzilla.gnome.org/attachment.cgi?id=366662;
+      sha256 = "1ljb2pap5v9z3zhx69ghfyrbl2b62ck35nyn7h5h410d008lcb4v";
     })
   ];
 
@@ -24,7 +29,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  nativeBuildInputs = [ meson ninja pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection vala ];
   buildInputs = [ glib ];
   propagatedBuildInputs = [ exiv2 ];
 


### PR DESCRIPTION
###### Motivation for this change
After effa9e40457e801577b672dadbcc169fd1ad20a3, which switched to Meson, the Vala bindings were not built which broke Shotwell. Enabling Vala was not enough due to a bug, though, so we have to patch it.

cc @mdorman

Closes: https://github.com/NixOS/nixpkgs/issues/34512

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

