### PR TITLE
plasma-integration: Fix font style name bug with Qt >= 5.8

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -47,6 +47,18 @@ in
             ${getBin config.hardware.pulseaudio.package}/bin/pactl load-module module-device-manager "do_routing=1"
           ''}
 
+          if [ -f "$HOME/.config/kdeglobals" ]
+          then
+              # Remove extraneous font style names.
+              # See also: https://phabricator.kde.org/D9070
+              ${getBin pkgs.gnused}/bin/sed -i "$HOME/.config/kdeglobals" \
+                  -e '/^fixed=/ s/,Regular$//' \
+                  -e '/^font=/ s/,Regular$//' \
+                  -e '/^menuFont=/ s/,Regular$//' \
+                  -e '/^smallestReadableFont=/ s/,Regular$//' \
+                  -e '/^toolBarFont=/ s/,Regular$//'
+          fi
+
           exec "${getBin plasma5.plasma-workspace}/bin/startkde"
         '';
       };

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -125,7 +125,7 @@ let
       milou = callPackage ./milou.nix {};
       oxygen = callPackage ./oxygen.nix {};
       plasma-desktop = callPackage ./plasma-desktop {};
-      plasma-integration = callPackage ./plasma-integration.nix {};
+      plasma-integration = callPackage ./plasma-integration {};
       plasma-nm = callPackage ./plasma-nm {};
       plasma-pa = callPackage ./plasma-pa.nix { inherit gconf; };
       plasma-vault = callPackage ./plasma-vault {};

--- a/pkgs/desktops/plasma-5/plasma-integration/D9070.patch
+++ b/pkgs/desktops/plasma-5/plasma-integration/D9070.patch
@@ -1,0 +1,24 @@
+Index: src/platformtheme/kfontsettingsdata.cpp
+===================================================================
+--- src/platformtheme/kfontsettingsdata.cpp
++++ src/platformtheme/kfontsettingsdata.cpp
+@@ -70,15 +70,18 @@
+         const KFontData &fontData = DefaultFontData[fontType];
+         cachedFont = new QFont(QLatin1String(fontData.FontName), fontData.Size, fontData.Weight);
+         cachedFont->setStyleHint(fontData.StyleHint);
+-        cachedFont->setStyleName(QLatin1String(fontData.StyleName));
+ 
+         const KConfigGroup configGroup(mKdeGlobals, fontData.ConfigGroupKey);
+         QString fontInfo = configGroup.readEntry(fontData.ConfigKey, QString());
+ 
+         //If we have serialized information for this font, restore it
+         //NOTE: We are not using KConfig directly because we can't call QFont::QFont from here
+         if (!fontInfo.isEmpty()) {
+             cachedFont->fromString(fontInfo);
++        } else {
++            // set the canonical stylename here, where it cannot override
++            // user-specific font attributes if those do not include a stylename.
++            cachedFont->setStyleName(QLatin1String(fontData.StyleName));
+         }
+ 
+         mFonts[fontType] = cachedFont;

--- a/pkgs/desktops/plasma-5/plasma-integration/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-integration/default.nix
@@ -14,4 +14,11 @@ mkDerivation {
     breeze-qt5 kconfig kconfigwidgets kiconthemes kio knotifications kwayland
     libXcursor qtquickcontrols2
   ];
+  patches = [
+    # See also: https://phabricator.kde.org/D9070
+    # ttuegel: The patch is checked into Nixpkgs because I could not get
+    # Phabricator to give me a stable link to it.
+    ./D9070.patch
+  ];
+  patchFlags = "-p0";
 }


### PR DESCRIPTION
### Motivation

Qt 5.8 corrects a bug in font style name handling. Unfortunately, KDE relies on that bug. As a result, some font styles (bold, italic, etc.) will be unavailable for UI fonts. This is a patch from upstream and a configuration file update.

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

