### PR TITLE
nixos/installer-tools: Fix missing extraBuildFlags reference

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -157,7 +157,7 @@ mkfifo $system_closure
 
 if [ -z "$closure" ]; then
     expr="(import <nixpkgs/nixos> {}).system"
-    system_root="$(nix-build -E "$expr")"
+    system_root="$(nix-build "${extraBuildFlags[@]}" -E "$expr")"
     system_closure="$(closure "$expr")"
 else
     system_root=$closure


### PR DESCRIPTION
Installations that need special build options or includes did not evaluateduring calling nixos-install due to a missing reference to the extraBuildFlags variable.

###### Motivation for this change

- Be able to use the installer to install arbitrary system configurations that are based on non-`<nixpkgs>` channels.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

