### PR TITLE
pythonPackages.aiohttp: 2.3.9 -> 2.3.10

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -6,30 +6,33 @@
 , multidict
 , async-timeout
 , yarl
+, idna-ssl
 , pytest
 , gunicorn
 , pytest-raisesregexp
+, pytest-mock
 }:
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "2.3.9";
+  version = "2.3.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6003bed78dc591d31bd89ef16e630a1c4fd97a3cd17b975ec945c0f46d6fc881";
+    sha256 = "8adda6583ba438a4c70693374e10b60168663ffa6564c5c75d3c7a9055290964";
   };
 
   disabled = pythonOlder "3.4";
 
-  doCheck = false; # Too many tests fail.
+  checkInputs = [ pytest gunicorn pytest-raisesregexp pytest-mock ];
 
-  checkInputs = [ pytest gunicorn pytest-raisesregexp ];
-  propagatedBuildInputs = [ async-timeout chardet multidict yarl ];
+  propagatedBuildInputs = [ async-timeout chardet multidict yarl ]
+    ++ lib.optional (pythonOlder "3.7") idna-ssl;
 
-  meta = {
-    description = "Http client/server for asyncio";
-    license = with lib.licenses; [ asl20 ];
+  meta = with lib; {
+    description = "Asynchronous HTTP Client/Server for Python and asyncio";
+    license = licenses.asl20;
     homepage = https://github.com/KeepSafe/aiohttp/;
+    maintainers = with maintainers; [ dotlambda ];
   };
 }

--- a/pkgs/development/python-modules/idna-ssl/default.nix
+++ b/pkgs/development/python-modules/idna-ssl/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, idna }:
+
+buildPythonPackage rec {
+  pname = "idna_ssl";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1227e44039bd31e02adaeafdbba61281596d623d222643fb021f87f2144ea147";
+  };
+
+  propagatedBuildInputs = [ idna ];
+
+  # Infinite recursion: tests require aiohttp, aiohttp requires idna-ssl
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Patch ssl.match_hostname for Unicode(idna) domains support";
+    homepage = https://github.com/aio-libs/idna-ssl;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5215,6 +5215,8 @@ in {
     };
   };
 
+  idna-ssl = callPackage ../development/python-modules/idna-ssl/default.nix { };
+
   ijson = callPackage ../development/python-modules/ijson/default.nix {};
 
   imagesize = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/aio-libs/aiohttp/pull/2703 for why idna-ssl is only required for python<3.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

