### PR TITLE
samtools-old: init at 0.1.19

### DIFF
--- a/pkgs/applications/science/biology/samtools/samtools-0.1.19-no-curses.patch
+++ b/pkgs/applications/science/biology/samtools/samtools-0.1.19-no-curses.patch
@@ -1,0 +1,22 @@
+diff --git a/Makefile b/Makefile
+index 2f51bfc..395d6f1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ CC=			gcc
+ CFLAGS=		-g -Wall -O2
+ #LDFLAGS=		-Wl,-rpath,\$$ORIGIN/../lib
+-DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_LIB=1
++DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE # -D_CURSES_LIB=1
+ KNETFILE_O=	knetfile.o
+ LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
+ 			bam_pileup.o bam_lpileup.o bam_md.o razf.o faidx.o bedidx.o \
+@@ -15,7 +15,7 @@ PROG=		samtools
+ INCLUDES=	-I.
+ SUBDIRS=	. bcftools misc
+ LIBPATH=
+-LIBCURSES=	-lcurses # -lXCurses
++LIBCURSES=	# -lcurses # -lXCurses
+ 
+ .SUFFIXES:.c .o
+ .PHONY: all lib

--- a/pkgs/applications/science/biology/samtools/samtools_0_1_19.nix
+++ b/pkgs/applications/science/biology/samtools/samtools_0_1_19.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "samtools";
+  version = "0.1.19";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/samtools/${name}.tar.bz2";
+    sha256 = "d080c9d356e5f0ad334007e4461cbcee3c4ca97b8a7a5a48c44883cf9dee63d4";
+  };
+
+  patches = [
+    ./samtools-0.1.19-no-curses.patch
+  ];
+
+  buildInputs = [ zlib ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man
+
+    cp samtools $out/bin
+    cp samtools.1 $out/share/man
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tools for manipulating SAM/BAM/CRAM format";
+    license = licenses.mit;
+    homepage = http://samtools.sourceforge.net/;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.unode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19045,6 +19045,7 @@ with pkgs;
   plink-ng = callPackage ../applications/science/biology/plink-ng/default.nix { };
 
   samtools = callPackage ../applications/science/biology/samtools/default.nix { };
+  samtools_0_1_19 = callPackage ../applications/science/biology/samtools/samtools_0_1_19.nix { };
 
   snpeff = callPackage ../applications/science/biology/snpeff/default.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
nixpkgs already contains samtools-1.5 but some software still requires the older 0.1.19 version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

