### PR TITLE
RAxML: init at 8.2.11 (SSE3 & MPI)

### DIFF
--- a/pkgs/applications/science/biology/raxml/default.nix
+++ b/pkgs/applications/science/biology/raxml/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchFromGitHub
+, zlib
+, pkgs
+, mpi ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "RAxML";
+  version = "8.2.11";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "stamatak";
+    repo = "standard-${pname}";
+    rev = "v${version}";
+    sha256 = "08fmqrr7y5a2fmmrgfz2p0hmn4mn71l5yspxfcwwsqbw6vmdfkhg";
+  };
+
+  buildInputs = if mpi then [ pkgs.openmpi ] else [];
+
+  # TODO darwin, AVX and AVX2 makefile targets
+  buildPhase = if mpi then ''
+      make -f Makefile.MPI.gcc
+    '' else ''
+      make -f Makefile.SSE3.PTHREADS.gcc
+    '';
+
+  installPhase = if mpi then ''
+    mkdir -p $out/bin && cp raxmlHPC-MPI $out/bin
+  '' else ''
+    mkdir -p $out/bin && cp raxmlHPC-PTHREADS-SSE3 $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool for Phylogenetic Analysis and Post-Analysis of Large Phylogenies";
+    license = licenses.gpl3;
+    homepage = https://sco.h-its.org/exelixis/web/software/raxml/;
+    maintainers = [ maintainers.unode ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19044,6 +19044,12 @@ with pkgs;
 
   plink-ng = callPackage ../applications/science/biology/plink-ng/default.nix { };
 
+  raxml = callPackage ../applications/science/biology/raxml { };
+
+  raxml-mpi = appendToName "mpi" (raxml.override {
+    mpi = true;
+  });
+
   samtools = callPackage ../applications/science/biology/samtools/default.nix { };
 
   snpeff = callPackage ../applications/science/biology/snpeff/default.nix { };


### PR DESCRIPTION
This can potentially be extended to cover all the other compilation targets.
SSE3-PTHREADS and MPI being the most commonly used.

###### Motivation for this change
RAxML is a widely used software for phylogenetic tree inference

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

