### PR TITLE
pysam: init at 0.13

### DIFF
--- a/pkgs/development/python-modules/pysam/default.nix
+++ b/pkgs/development/python-modules/pysam/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, bzip2
+, bcftools
+, curl
+, cython
+, htslib
+, lzma
+, pytest
+, samtools
+, zlib
+}:
+
+buildPythonPackage rec {
+  pname   = "pysam";
+  version = "0.13.0";
+
+  # Fetching from GitHub instead of PyPi cause the 0.13 src release on PyPi is
+  # missing some files which cause test failures.
+  # Tracked at: https://github.com/pysam-developers/pysam/issues/616
+  src = fetchFromGitHub {
+    owner = "pysam-developers";
+    repo = "pysam";
+    rev = "v${version}";
+    sha256 = "1lwbcl38w1x0gciw5psjp87msmv9zzkgiqikg9b83dqaw2y5az1i";
+  };
+
+  buildInputs = [ bzip2 curl cython lzma zlib ];
+
+  checkInputs = [ pytest bcftools htslib samtools ];
+
+  checkPhase = "py.test";
+
+  preInstall = ''
+    export HOME=$(mktemp -d)
+    make -C tests/pysam_data
+    make -C tests/cbcf_data
+  '';
+
+  meta = {
+    homepage = http://pysam.readthedocs.io/;
+    description = "A python module for reading, manipulating and writing genome data sets";
+    maintainers = with lib.maintainers; [ unode ];
+    license = lib.licenses.mit;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13226,6 +13226,8 @@ in {
     };
   };
 
+  pysam = callPackage ../development/python-modules/pysam { };
+
   pysaml2 = buildPythonPackage rec {
     name = "pysaml2-${version}";
     version = "3.0.2";


### PR DESCRIPTION
A python library to interact with SAM/BAM/CRAM files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

