### PR TITLE
dendropy: init at 4.3.0

### DIFF
--- a/pkgs/development/python-modules/dendropy/default.nix
+++ b/pkgs/development/python-modules/dendropy/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, pkgs
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname   = "DendroPy";
+  version = "4.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bd5b35ce1a1c9253209b7b5f3939ac22beaa70e787f8129149b4f7ffe865d510";
+  };
+
+  prePatch = ''
+    # Test removed/disabled and reported upstream: https://github.com/jeetsukumaran/DendroPy/issues/74
+    rm -f dendropy/test/test_dataio_nexml_reader_tree_list.py
+  '';
+
+  preCheck = ''
+    # Needed for unicode python tests
+    export LC_ALL="en_US.UTF-8"
+  '';
+
+  checkInputs = [ pkgs.glibcLocales ];
+
+  meta = {
+    homepage = http://dendropy.org/;
+    description = "A Python library for phylogenetic computing";
+    maintainers = with lib.maintainers; [ unode ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -201,6 +201,8 @@ in {
 
   bugseverywhere = callPackage ../applications/version-management/bugseverywhere {};
 
+  dendropy = callPackage ../development/python-modules/dendropy { };
+
   dbf = callPackage ../development/python-modules/dbf { };
 
   dbfread = callPackage ../development/python-modules/dbfread { };


### PR DESCRIPTION
###### Motivation for this change
Dendropy is a versatile python module to handle several phylogenetic formats and build phylogenetic pipelines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

