### PR TITLE
fastjet: Fix build w/clang5

### DIFF
--- a/pkgs/development/libraries/physics/fastjet/default.nix
+++ b/pkgs/development/libraries/physics/fastjet/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ python2 ];
 
+  postPatch = ''
+    substituteInPlace plugins/SISCone/SISConeBasePlugin.cc \
+      --replace 'structure_of<UserScaleBase::StructureType>()' \
+                'structure_of<UserScaleBase>()'
+  '';
+
   configureFlags = [
     "--enable-allcxxplugins"
     "--enable-pyext"


### PR DESCRIPTION
Otherwise build fails, as per evaluation over on #33374.

Builds successfully with normal CC (gcc6) as well.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Clang5 failure details:

https://hydra.nixos.org/build/68588849/nixlog/1

```
libtool: compile:  clang++ -DHAVE_CONFIG_H -I. -I../../include/fastjet -O2 -Wall -g -Woverloaded-virtual -DDROP_CGAL -I. -I./siscone -I./../../include -I./siscone -c SISConeBasePlugin.cc  -fno-common -DPIC -o .libs/libSISConePlugin_la-SISConeBasePlugin.o
SISConeBasePlugin.cc:12:12: error: no matching member function for call to 'structure_of'
  return a.structure_of<UserScaleBase::StructureType>().ordering_var2()
         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../../include/fastjet/PseudoJet.hh:1012:60: note: candidate template ignored: substitution failure [with TransformerType = fastjet::SISConeBasePlugin::UserScaleBase::StructureType]: ISO C++ specifies that qualified reference to 'StructureType' is a constructor name rather than a type in this context, despite preceding 'typename' keyword
const typename TransformerType::StructureType & PseudoJet::structure_of() const{
      ~~~~~~~~                                             ^
```
----

Packages using fastjet that confirmed to build:

* fastnlo
* herwig
* mcgrid
* pythia
* rivet
* sacrifice
* thepeg

FWIW I'll be sending fix to upstream, will let you know how that goes.