### PR TITLE
audiofile: Update Patch File Location

### DIFF
--- a/pkgs/development/libraries/audiofile/default.nix
+++ b/pkgs/development/libraries/audiofile/default.nix
@@ -5,7 +5,7 @@ let
   fetchDebianPatch = { name, debname, sha256 }:
     fetchpatch {
       inherit sha256 name;
-      url = "https://anonscm.debian.org/cgit/pkg-multimedia/audiofile.git/plain/debian/patches/${debname}?h=debian/0.3.6-4";
+      url = "https://salsa.debian.org/multimedia-team/audiofile/raw/debian/0.3.6-4/debian/patches/${debname}";
     };
 
 in


### PR DESCRIPTION
###### Motivation for this change

Debian changed git servers for pkg-multimedia, and the patches are no longer available:

```
$ curl -Lv https://anonscm.debian.org/cgit/pkg-multimedia/audiofile.git/plain/debian/patches/04_clamp-index-values-to-fix-index-overflow-in-IMA.cpp.patch?h=debian/0.3.6-4

< HTTP/1.1 404 Not found
< Date: Fri, 02 Feb 2018 18:13:41 GMT
< Server: Apache/2.2.22 (Debian)
< Expires: Thu, 01 Jan 1970 00:00:05 GMT
< Last-Modified: Fri, 02 Feb 2018 18:13:41 GMT
< X-Robots-Tag: noindex, nofollow
< Vary: Accept-Encoding
< Transfer-Encoding: chunked
< Content-Type: text/html; charset=UTF-8
```

This is causing my builds to fail, the issue has not been detected in nixpkgs/trunk due to caching.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

