### PR TITLE
qgit: 2.6 -> 2.7

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchurl, cmake, qtbase }:
+{ stdenv, fetchgit, cmake, qtbase }:
 
 stdenv.mkDerivation rec {
-  name = "qgit-2.6";
+  name = "qgit-2.7";
 
-  src = fetchurl {
-    url = "http://libre.tibirna.org/attachments/download/12/${name}.tar.gz";
-    sha256 = "1brrhac6s6jrw3djhgailg5d5s0vgrfvr0sczqgzpp3i6pxf8qzl";
+  src = fetchgit {
+    url = "http://repo.or.cz/qgit4/redivivus.git";
+    rev = name;
+    sha256 = "0c0zxykpgkxb8gpgzz5i6b8nrzg7cdxikvpg678x7gsnxhlwjv3a";
   };
 
   buildInputs = [ qtbase ];

--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     license = licenses.gpl2;
     homepage = http://libre.tibirna.org/projects/qgit/wiki/QGit;


### PR DESCRIPTION
See changelog.  2.7 was released almost a year ago, FWIW.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Changelog:
http://libre.tibirna.org/projects/qgit/wiki/27