### PR TITLE
pythonPackages.pwntools: fix build

### DIFF
--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -1,23 +1,31 @@
 { stdenv, buildPythonPackage, fetchPypi, isPy3k
 , Mako, packaging, pysocks, pygments, ROPGadget
 , capstone, paramiko, pip, psutil
-, pyelftools, pypandoc, pyserial, dateutil
-, requests, tox, pandoc, unicorn, intervaltree }:
+, pyelftools, pyserial, dateutil
+, requests, tox, unicorn, intervaltree, fetchpatch }:
 
 buildPythonPackage rec {
   version = "3.11.0";
   pname = "pwntools";
-  name = pname + "-" + version;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "609b3f0ba47c975f4dbedd3da2af4c5ca1b3a2aa13fb99240531b6a68edb87be";
   };
 
-  propagatedBuildInputs = [ Mako packaging pysocks pygments ROPGadget capstone paramiko pip psutil pyelftools pypandoc pyserial dateutil requests tox pandoc unicorn intervaltree ];
+  propagatedBuildInputs = [ Mako packaging pysocks pygments ROPGadget capstone paramiko pip psutil pyelftools pyserial dateutil requests tox unicorn intervaltree ];
 
   disabled = isPy3k;
   doCheck = false; # no setuptools tests for the package
+
+  # Can be removed when 3.12.0 is released
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/Gallopsled/pwntools/pull/1098.patch";
+      sha256 = "0p0h87npn1mwsd8ciab7lg74bk3ahlk5r0mjbvx4jhihl2gjc3z2";
+    })
+  ];
+
 
   meta = with stdenv.lib; {
     homepage = "http://pwntools.com";

--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "Thin wrapper for pandoc";
     homepage = https://github.com/bebraw/pypandoc;
     license = licenses.mit;
-    maintainers = with maintainers; [ bennofs kristoff3r ];
+    maintainers = with maintainers; [ bennofs ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

pypandoc is broken (it does not work properly with pandoc 2), so we
remove the dependency as it was only used for generating PyPI docs.
The patch will be included upstream in the next version, so it should
be removed next time this package is updated.

I'm not sure what should be done about pypandoc itself. It doesn't look like it will get pandoc 2 support, and it still has another package depending on it. Mark as broken?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

