### PR TITLE
retdec: split up, greatly reduce in size (by default)

### DIFF
--- a/pkgs/development/tools/analysis/retdec/default.nix
+++ b/pkgs/development/tools/analysis/retdec/default.nix
@@ -105,9 +105,8 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A retargetable machine-code decompiler based on LLVM";
-    inherit (src.meta) homepage;
+    homepage = https://retdec.com;
     license = licenses.mit;
     maintainers = with maintainers; [ dtzWill ];
   };
 }
-

--- a/pkgs/development/tools/analysis/retdec/default.nix
+++ b/pkgs/development/tools/analysis/retdec/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchurl,
+{ stdenv, fetchFromGitHub, fetchurl, fetchzip,
 # Native build inputs
 cmake,
 autoconf, automake, libtool,
@@ -15,6 +15,8 @@ ncurses,
 libffi,
 libxml2,
 zlib,
+# PE (Windows) data, huge space savings if not needed
+withPEPatterns ? false,
 }:
 
 let
@@ -53,9 +55,14 @@ let
     sha256 = "0r97n4n552ns571diz54qsgarihrxvbn7kvyv8wjyfs9ybrldxqj";
   };
 
-  retdec-support = fetchurl {
+  retdec-support = fetchzip {
     url = "https://github.com/avast-tl/retdec-support/releases/download/2017-12-12/retdec-support_2017-12-12.tar.xz";
-    sha256 = "6376af57a77147f1363896963d8c1b3745ddb9a6bcec83d63a5846c3f78aeef9";
+    sha256 = if withPEPatterns then "0pchl7hb42dm0sdbmpr8d3c6xc0lm6cs4p6g6kdb2cr9c99gjzn3"
+                               else "1hcyq6bf4wk739kb53ic2bs71gsbx6zd07pc07lzfnxf8k497mhv";
+    # Removing PE signatures reduces this from 3.8GB -> 642MB (uncompressed)
+    extraPostFetch = stdenv.lib.optionalString (!withPEPatterns) ''
+      rm -rf $out/generic/yara_patterns/static-code/pe
+    '';
   };
 in stdenv.mkDerivation rec {
   name = "retdec-${version}";
@@ -90,12 +97,13 @@ in stdenv.mkDerivation rec {
     find . -wholename "*/deps/openssl/CMakeLists.txt" -print0 | \
       xargs -0 sed -i -e 's|OPENSSL_URL .*)|OPENSSL_URL ${openssl})|'
 
+    cat > cmake/install-share.sh <<EOF
+      #!/bin/sh
+      mkdir -p $out/share/retdec/
+      ln -s ${retdec-support} $out/share/retdec/support
+    EOF
     chmod +x cmake/*.sh
     patchShebangs cmake/*.sh
-
-    sed -i cmake/install-share.sh \
-      -e 's|WGET_PARAMS.*|cp ${retdec-support} "$INSTALL_PATH/$ARCH_NAME"|' \
-      -e '/echo "RUN: wget/,+7d'
 
     substituteInPlace scripts/unpack.sh --replace '	upx -d' '	${upx}/bin/upx -d'
     substituteInPlace scripts/config.sh --replace /usr/bin/time ${time}/bin/time

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7862,6 +7862,9 @@ with pkgs;
   remake = callPackage ../development/tools/build-managers/remake { };
 
   retdec = callPackage ../development/tools/analysis/retdec { };
+  retdec-full = callPackage ../development/tools/analysis/retdec {
+    withPEPatterns = true;
+  };
 
   rhc = callPackage ../development/tools/rhc { };
 


### PR DESCRIPTION
Due almost entirely to signatures in "retdec-support",
retdec is too large for the binary cache :(.

This makes retdec much less convenient to install/use,
requiring both a giant download followed by building
LLVM and the many vendored dependencies.

Upstream has improved the dependency situation
significantly (not in a tagged release yet),
leaving the signatures to account for.

This PR significantly reduces the footprint by
optionally removing the PE (Windows) signatures
which brings the uncompressed signature size
down from 3.8GB to a much more manageable 642MB.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

In the future it might be neat to split the signatures into multiple packages
(ELF, PE, maybe by architecture...) and use a setup-hook or something to
convince retdec to use whatever has been installed; this would also
make it possible to add/remove/update signatures independently from
building/upgrading retdec itself.

(at least within signature compatibility limits, not sure)

Anyway that's a possible future :).

for now, let's just make this sane for folks to use :).