### PR TITLE
AntTweakBar: init at 1.16

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -564,6 +564,7 @@
   rasendubi = "Alexey Shmalko <rasen.dubi@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";
   ravloony = "Tom Macdonald <ravloony@gmail.com>";
+  razvan = "Răzvan Flavius Panda <razvan.panda@gmail.com>";
   rbasso = "Rafael Basso <rbasso@sharpgeeks.net>";
   redbaron = "Maxim Ivanov <ivanov.maxim@gmail.com>";
   redvers = "Redvers Davies <red@infect.me>";

--- a/pkgs/development/libraries/AntTweakBar/default.nix
+++ b/pkgs/development/libraries/AntTweakBar/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, unzip, xlibs, mesa }:
+
+stdenv.mkDerivation rec {
+  name = "AntTweakBar-1.16";
+
+  buildInputs = [ unzip xlibs.libX11 mesa ];
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/anttweakbar/AntTweakBar_116.zip";
+    sha256 = "0z3frxpzf54cjs07m6kg09p7nljhr7140f4pznwi7srwq4cvgkpv";
+  };
+
+  postPatch = "cd src";
+  installPhase = ''
+    mkdir -p $out/lib/
+    cp ../lib/{libAntTweakBar.so,libAntTweakBar.so.1,libAntTweakBar.a} $out/lib/
+    cp -r ../include $out/
+  '';
+
+  meta = {
+    description = "Add a light/intuitive GUI to OpenGL applications";
+    longDescription = ''
+      A small and easy-to-use C/C++ library that allows to quickly add a light
+      and intuitive graphical user interface into graphic applications based on OpenGL
+      (compatibility and core profiles), DirectX 9, DirectX 10 or DirectX 11
+      to interactively tweak parameters on-screen
+    '';
+    homepage = http://anttweakbar.sourceforge.net/;
+    license = stdenv.lib.licenses.zlib;
+    maintainers = [ stdenv.lib.maintainers.razvan ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8086,6 +8086,8 @@ with pkgs;
 
   amrwb = callPackage ../development/libraries/amrwb { };
 
+  anttweakbar = callPackage ../development/libraries/AntTweakBar { };
+
   appstream = callPackage ../development/libraries/appstream { };
 
   appstream-glib = callPackage ../development/libraries/appstream-glib { };


### PR DESCRIPTION
###### Motivation for this change

This is a lib dependency for Lamdu IDE which I will try to package fully.

###### Things done

- [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Thanks to takoa, cleverca22, puffnfresh and others from #nixos IRC for helping to package this.
