### PR TITLE
poppler: 0.56.0 → 0.62.0

### DIFF
--- a/pkgs/data/misc/poppler-data/default.nix
+++ b/pkgs/data/misc/poppler-data/default.nix
@@ -1,18 +1,14 @@
-{ fetchurl, stdenv }:
+{ fetchurl, stdenv, cmake, ninja }:
 
 stdenv.mkDerivation rec {
-  name = "poppler-data-0.4.7";
+  name = "poppler-data-0.4.8";
 
   src = fetchurl {
     url = "http://poppler.freedesktop.org/${name}.tar.gz";
-    sha256 = "1pm7wg6xqj4sppb5az4pa7psfdk4yxxkw52j85bm9fksibcb0lp7";
+    sha256 = "0wi8yyynladny51r4q53z7ygh7y491ayp8nqqv6wqqzjc60s35hh";
   };
 
-  postPatch = ''
-    sed -i 's,$(datadir)/pkgconfig,$(prefix)/lib/pkgconfig,g' Makefile
-  '';
-
-  installFlags = [ "prefix=$(out)" ];
+  nativeBuildInputs = [ cmake ninja ];
 
   meta = with stdenv.lib; {
     homepage = https://poppler.freedesktop.org/;

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, lib, fetchurl, fetchpatch, pkgconfig, libiconv, libintlOrEmpty
+{ stdenv, lib, fetchurl, cmake, ninja, pkgconfig, libiconv, libintlOrEmpty
 , zlib, curl, cairo, freetype, fontconfig, lcms, libjpeg, openjpeg
 , withData ? true, poppler_data
-, qt4Support ? false, qt4 ? null
 , qt5Support ? false, qtbase ? null
 , introspectionSupport ? false, gobjectIntrospection ? null
 , utils ? false
 , minimal ? false, suffix ? "glib"
-, hostPlatform
 }:
 
 let # beware: updates often break cups-filters build
-  version = "0.56.0";
-  sha256 = "0wviayidfv2ix2ql0d4nl9r1ia6qi5kc1nybd9vjx27dk7gvm7c6";
+  version = "0.62.0";
+  mkFlag = optset: flag: "-DENABLE_${flag}=${if optset then "on" else "off"}";
 in
 stdenv.mkDerivation rec {
   name = "poppler-${suffix}-${version}";
 
   src = fetchurl {
     url = "${meta.homepage}/poppler-${version}.tar.xz";
-    inherit sha256;
+    sha256 = "1ii9ly1pngyvs0aiq2wxpya08hidpl54y7nsb8b1vxnnskgp76jv";
   };
 
   outputs = [ "out" "dev" ];
@@ -29,36 +27,19 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = with lib;
     [ zlib freetype fontconfig libjpeg openjpeg ]
     ++ optionals (!minimal) [ cairo lcms curl ]
-    ++ optional qt4Support qt4
     ++ optional qt5Support qtbase
     ++ optional introspectionSupport gobjectIntrospection;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake ninja pkgconfig ];
 
-  NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
-
-  CXXFLAGS = lib.optional qt5Support "-std=c++11";
-
-  configureFlags = with lib;
-    [
-      "--enable-xpdf-headers"
-      "--enable-libcurl"
-      "--enable-zlib"
-      "--enable-build-type=release"
-    ]
-    ++ optionals minimal [
-      "--disable-poppler-glib" "--disable-poppler-cpp"
-      "--disable-libcurl"
-    ]
-    ++ optional (!utils) "--disable-utils"
-    ++ optional introspectionSupport "--enable-introspection";
-
-  enableParallelBuilding = true;
-
-  crossAttrs.postPatch =
-    # there are tests using `strXXX_s` functions that are missing apparently
-    stdenv.lib.optionalString (hostPlatform.libc or null == "msvcrt")
-      "sed '/^SUBDIRS =/s/ test / /' -i Makefile.in";
+  cmakeFlags = [
+    (mkFlag true "XPDF_HEADERS")
+    (mkFlag (!minimal) "GLIB")
+    (mkFlag (!minimal) "CPP")
+    (mkFlag (!minimal) "LIBCURL")
+    (mkFlag utils "UTILS")
+    (mkFlag qt5Support "QT5")
+  ];
 
   meta = with lib; {
     homepage = https://poppler.freedesktop.org/;

--- a/pkgs/development/libraries/poppler/qt4.nix
+++ b/pkgs/development/libraries/poppler/qt4.nix
@@ -1,0 +1,44 @@
+# TODO: get rid of this (https://github.com/NixOS/nixpkgs/issues/32883)
+{ stdenv, lib, fetchurl, cmake, ninja, pkgconfig, libiconv, libintlOrEmpty
+, zlib, curl, cairo, freetype, fontconfig, lcms2, libjpeg, openjpeg
+, poppler_data, qt4
+}:
+
+let
+  # Last version supporting QT4
+  version = "0.61.1";
+in
+stdenv.mkDerivation rec {
+  name = "poppler-qt4-${version}";
+
+  src = fetchurl {
+    url = "${meta.homepage}/poppler-${version}.tar.xz";
+    sha256 = "1afdrxxkaivvviazxkg5blsf2x24sjkfj92ib0d3q5pm8dihjrhj";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  buildInputs = [ libiconv poppler_data ] ++ libintlOrEmpty;
+
+  propagatedBuildInputs = [ zlib freetype fontconfig libjpeg openjpeg cairo lcms2 curl qt4 ];
+
+  nativeBuildInputs = [ cmake ninja pkgconfig ];
+
+  cmakeFlags = [
+    "-DENABLE_XPDF_HEADERS=on"
+    "-DENABLE_UTILS=off"
+  ];
+
+  meta = with lib; {
+    homepage = https://poppler.freedesktop.org/;
+    description = "A PDF rendering library";
+
+    longDescription = ''
+      Poppler is a PDF rendering library based on the xpdf-3.0 code base.
+    '';
+
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ttuegel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10573,10 +10573,7 @@ with pkgs;
     suffix = "min";
   };
 
-  poppler_qt4 = poppler.override {
-    qt4Support = true;
-    suffix = "qt4";
-  };
+  poppler_qt4 = callPackage ../development/libraries/poppler/qt4.nix { };
 
   poppler_utils = poppler.override { suffix = "utils"; utils = true; };
 


### PR DESCRIPTION
###### Motivation for this change
Long overdue update:

* Switches to CMake
* Removes QT4 – for now I am also keeping 0.61 but we should get rid of it ASAP (https://github.com/NixOS/nixpkgs/issues/32883)

[Full changelog](https://poppler.freedesktop.org/releases.html)

~~This breaks cups-filters even with the update, cc @layus.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

