### PR TITLE
bonfire: bump arrow dependency (fixes build)

### DIFF
--- a/pkgs/tools/misc/bonfire/default.nix
+++ b/pkgs/tools/misc/bonfire/default.nix
@@ -19,7 +19,7 @@ buildPythonApplication rec {
   postPatch = ''
     # https://github.com/blue-yonder/bonfire/pull/24
     substituteInPlace requirements.txt \
-      --replace "arrow>=0.5.4,<0.8" "arrow>=0.5.4,<0.11" \
+      --replace "arrow>=0.5.4,<0.8" "arrow>=0.5.4,<0.13" \
       --replace "keyring>=9,<10"    "keyring>=9,<11"
     # pip fails when encountering the git hash for the package version
     substituteInPlace setup.py \


### PR DESCRIPTION
###### Motivation for this change

package on master is broken due to a newer arrow package

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).