### PR TITLE
pythonPackages.jinja2: 2.9.6 -> 2.10

### DIFF
--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -1,16 +1,13 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
+{ stdenv, buildPythonPackage, fetchPypi
 , pytest, markupsafe }:
 
 buildPythonPackage rec {
   pname = "Jinja2";
-  version = "2.9.6";
-  name = "${pname}-${version}";
+  version = "2.10";
 
-  src = fetchFromGitHub {
-    owner = "pallets";
-    repo = "jinja";
-    rev = version;
-    sha256 = "1xxc5vdhz214aawmllv0fi4ak6d7zac662yb7gn1xfgqfz392pg5";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4";
   };
 
   checkInputs = [ pytest ];
@@ -29,7 +26,6 @@ buildPythonPackage rec {
       Django inspired non-XML syntax but supports inline expressions and
       an optional sandboxed environment.
     '';
-    platforms = platforms.all;
     maintainers = with maintainers; [ pierron garbas sjourdois ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Needed for upcoming homeassistant==0.63.0 (will be released in about a week)
See https://github.com/home-assistant/home-assistant/pull/12118

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc maintainers @nbp @garbas @sjourdois 