### PR TITLE
Add presentation app Spice Up

### DIFF
--- a/pkgs/applications/office/spice-up/default.nix
+++ b/pkgs/applications/office/spice-up/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, fetchFromGitHub
+, gettext
+, libxml2
+, pkgconfig
+, gtk3
+, granite
+, gnome3
+, json_glib
+, cmake
+, ninja
+, libgudev
+, libevdev
+, vala
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "spice-up-${version}";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "Philip-Scott";
+    repo = "Spice-up";
+    rev = version;
+    sha256 = "0cbyhi6d99blv33183j6nakzcqxz5hqy9ijykiasbmdycfd5q0fh";
+  };
+  USER = "nix-build-user";
+
+  XDG_DATA_DIRS = stdenv.lib.concatStringsSep ":" [
+    "${granite}/share"
+    "${gnome3.libgee}/share"
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    wrapGAppsHook
+    vala
+    cmake
+    ninja
+    gettext
+    libxml2
+  ];
+  buildInputs = [
+    gtk3
+    granite
+    gnome3.libgee
+    json_glib
+    libgudev
+    libevdev
+    gnome3.gnome_themes_standard
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Create simple and beautiful presentations on the Linux desktop";
+    homepage = https://github.com/Philip-Scott/Spice-up;
+    maintainers = with maintainers; [ samdroid-apps ];
+    platforms = platforms.linux;
+    # The COPYING file has GPLv3; some files have GPLv2+ and some have GPLv3+
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, cmake, vala, pkgconfig, gobjectIntrospection, glib, gtk3, gnome3, gettext }:
+{ stdenv, fetchFromGitHub, perl, cmake, ninja, vala, pkgconfig, gobjectIntrospection, glib, gtk3, gnome3, gettext }:
 
 stdenv.mkDerivation rec {
   name = "granite-${version}";
@@ -11,16 +11,32 @@ stdenv.mkDerivation rec {
     sha256 = "15l8z1jkqhvappnr8jww27lfy3dwqybgsxk5iccyvnvzpjdh2s0h";
   };
 
-  cmakeFlags = "-DINTROSPECTION_GIRDIR=share/gir-1.0/ -DINTROSPECTION_TYPELIBDIR=lib/girepository-1.0";
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [perl cmake vala gobjectIntrospection glib gtk3 gnome3.libgee gettext];
+  cmakeFlags = [
+    "-DINTROSPECTION_GIRDIR=share/gir-1.0/"
+    "-DINTROSPECTION_TYPELIBDIR=lib/girepository-1.0"
+  ];
 
-  meta = {
+  nativeBuildInputs = [
+    vala
+    pkgconfig
+    cmake
+    ninja
+    perl
+    gettext
+    gobjectIntrospection
+  ];
+  buildInputs = [
+    glib
+    gtk3
+    gnome3.libgee
+  ];
+
+  meta = with stdenv.lib; {
     description = "An extension to GTK+ used by elementary OS";
     longDescription = "An extension to GTK+ that provides several useful widgets and classes to ease application development. Designed for elementary OS.";
     homepage = https://github.com/elementary/granite;
-    license = stdenv.lib.licenses.lgpl3;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.vozz ];
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.vozz ];
   };
 }

--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -1,20 +1,24 @@
-{ stdenv, fetchurl, perl, cmake, vala, pkgconfig, gobjectIntrospection, glib, gtk3, gnome3, gettext }:
+{ stdenv, fetchFromGitHub, perl, cmake, vala, pkgconfig, gobjectIntrospection, glib, gtk3, gnome3, gettext }:
 
 stdenv.mkDerivation rec {
-  majorVersion = "0.4";
-  minorVersion = "1";
-  name = "granite-${majorVersion}.${minorVersion}";
-  src = fetchurl {
-    url = "https://launchpad.net/granite/${majorVersion}/${majorVersion}.${minorVersion}/+download/${name}.tar.xz";
-    sha256 = "177h5h1q4qd7g99mzbczvz78j8c9jf4f1gwdj9f6imbc7r913d4b";
+  name = "granite-${version}";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "elementary";
+    repo = "granite";
+    rev = version;
+    sha256 = "15l8z1jkqhvappnr8jww27lfy3dwqybgsxk5iccyvnvzpjdh2s0h";
   };
+
   cmakeFlags = "-DINTROSPECTION_GIRDIR=share/gir-1.0/ -DINTROSPECTION_TYPELIBDIR=lib/girepository-1.0";
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [perl cmake vala gobjectIntrospection glib gtk3 gnome3.libgee gettext];
+
   meta = {
     description = "An extension to GTK+ used by elementary OS";
     longDescription = "An extension to GTK+ that provides several useful widgets and classes to ease application development. Designed for elementary OS.";
-    homepage = https://launchpad.net/granite;
+    homepage = https://github.com/elementary/granite;
     license = stdenv.lib.licenses.lgpl3;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.vozz ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11090,6 +11090,8 @@ with pkgs;
 
   spice_protocol = callPackage ../development/libraries/spice-protocol { };
 
+  spice-up = callPackage ../applications/office/spice-up { };
+
   sratom = callPackage ../development/libraries/audio/sratom { };
 
   srm = callPackage ../tools/security/srm { };


### PR DESCRIPTION
###### Motivation for this change

Spice Up is a nice presentations app:  https://medium.com/elementaryos/appcenter-spotlight-spice-up-65b7c169b3bd

It required also updating the dependency `granite` derivation.  The only other user of granite is `pantheon.pantheon-terminal`, which was also tested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

