### PR TITLE
bundler app: add support for man pages

### DIFF
--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -16,6 +16,9 @@
 , gemdir
   # Exes is the list of executables provided by the gems in the Gemfile
 , exes ? []
+  # List of manpages in "dir/name.N" format where N is a man section.
+  # If package provides man/ls.1. Then set bundlerApp.manpages = [ "man/ls.1" ].
+, manpages ? []
   # Scripts are ruby programs depend on gems in the Gemfile (e.g. scripts/rails)
 , scripts ? []
 , ruby ? defs.ruby
@@ -38,6 +41,9 @@ in
    runCommand basicEnv.name cmdArgs ''
     mkdir -p $out/bin;
       ${(lib.concatMapStrings (x: "ln -s '${basicEnv}/bin/${x}' $out/bin/${x};\n") exes)}
+      ${(lib.concatMapStrings (x: "manSection=$(basename ${x} | grep -o '[0-9]\$');\n" +
+              "mkdir -p $out/share/man/man$manSection;\n" +
+              "ln -s '${basicEnv}/${ruby.gemPath}/gems/${basicEnv.name}/${x}' $out/share/man/man$manSection/;\n") manpages)}
       ${(lib.concatMapStrings (s: "makeWrapper $out/bin/$(basename ${s}) $srcdir/${s} " +
               "--set BUNDLE_GEMFILE ${basicEnv.confFiles}/Gemfile "+
               "--set BUNDLE_PATH ${basicEnv}/${ruby.gemPath} "+

--- a/pkgs/tools/text/bcat/default.nix
+++ b/pkgs/tools/text/bcat/default.nix
@@ -4,6 +4,7 @@ bundlerApp {
   pname = "bcat";
   gemdir = ./.;
   exes = [ "bcat" "btee" "a2h" ];
+  manpages = [ "man/bcat.1" "man/btee.1" "man/a2h.1" ];
 
   meta = with lib; {
     description = "Pipe to browser utility";


### PR DESCRIPTION
Expected gem directory structure is `man/manN/name.N` where `N` is man section,
e.g. `man/man1/ls.1`. Then set `bundlerApp.manpages = [ "man1/ls.1" ]`.

###### Motivation for this change

Support for manpages in `bundlerApp` projects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

