### PR TITLE
pythonPackages.pyyaml: move derivation

### DIFF
--- a/pkgs/development/python-modules/pyyaml/default.nix
+++ b/pkgs/development/python-modules/pyyaml/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, libyaml }:
+
+buildPythonPackage rec {
+  pname = "PyYAML";
+  version = "3.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab";
+  };
+
+  propagatedBuildInputs = [ libyaml ];
+
+  meta = with lib; {
+    description = "The next generation YAML parser and emitter for Python";
+    homepage = https://github.com/yaml/pyyaml;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15026,23 +15026,7 @@ in {
 
   pyaml = callPackage ../development/python-modules/pyaml { };
 
-  pyyaml = buildPythonPackage (rec {
-    name = "PyYAML-3.12";
-
-    src = pkgs.fetchurl {
-      url = "http://pyyaml.org/download/pyyaml/${name}.zip";
-      sha256 = "19s1lxi0idq4a0bpvld866pv5b16lqxypyswmsdi5ys4210jxj2s";
-    };
-
-    buildInputs = with self; [ pkgs.pyrex ];
-    propagatedBuildInputs = with self; [ pkgs.libyaml ];
-
-    meta = {
-      description = "The next generation YAML parser and emitter for Python";
-      homepage = http://pyyaml.org;
-      license = licenses.free; # !?
-    };
-  });
+  pyyaml = callPackage ../development/python-modules/pyyaml { };
 
   rabbitpy = buildPythonPackage rec {
     version = "0.26.2";


### PR DESCRIPTION
###### Motivation for this change
Switch to pname/version scheme.

Changed hash because I'm using the tarball instead of zip now.

Dependency on pyrex was removed a while ago: https://github.com/yaml/pyyaml/blob/802c4a6dac5b0a02ba670dba20d5c8d6b7fe5a5e/CHANGES#L48

Homepage changed because http://pyyaml.org/ states

> PyYAML is now maintained at https://github.com/yaml/pyyaml. This page is left for historical purposes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

