### PR TITLE
[WIP] qcachegrind: fix build

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8004,7 +8004,7 @@ with pkgs;
 
   valkyrie = callPackage ../development/tools/analysis/valkyrie { };
 
-  qcachegrind = libsForQt5.callPackage ../development/tools/analysis/qcachegrind {};
+  qcachegrind = libsForQt59.callPackage ../development/tools/analysis/qcachegrind {};
 
   verasco = ocaml-ng.ocamlPackages_4_02.verasco.override {
     coq = coq_8_4;


### PR DESCRIPTION
###### Motivation for this change
qcachegrind doesn't build with anything newer than Qt5.9 with error:

Project ERROR: QCachegrind requires Qt 5.3 or greater

###### Things to do
The actual program still crashes, but the build works.

The build broke with 617c4f4220b6266e5b21341c8cef83431a217d4f, but the program did crash for the same reasons back then as well.

Now it crashes with error:
```
This application failed to start because it could not find or load the Qt platform plugin "xcb"
in "".

Reinstalling the application may fix this problem.
fish: “./result/bin/qcachegrind --help” terminated by signal SIGABRT (Abort)
```

It seems to try to open the xcb plugin in loads of places except the right one:
```
stat("/home/etu/lib/qt-5.9/plugins/platforms/.", 0x7ffe04285880) = -1 ENOENT (No such file or directory)
stat("/run/wrappers/lib/qt-5.9/plugins/platforms/.", 0x7ffe04285880) = -1 ENOENT (No such file or directory)
stat("/etc/profiles/per-user/etu/lib/qt-5.9/plugins/platforms/.", 0x7ffe04285880) = -1 ENOENT (No such file or directory)
stat("/home/etu/.nix-profile/lib/qt-5.9/plugins/platforms/.", 0x7ffe04285880) = -1 ENOENT (No such file or directory)
stat("/nix/var/nix/profiles/default/lib/qt-5.9/plugins/platforms/.", 0x7ffe04285880) = -1 ENOENT (No such file or directory)
stat("/run/current-system/sw/lib/qt-5.9/plugins/platforms/.", 0x7ffe04285880) = -1 ENOENT (No such file or directory)
stat("/nix/store/vhy8wlpbbn18a0pvy98qw7dzvyab9q2b-qcachegrind-17.12.1/bin/platforms/.", 0x7ffe04285880) = -1 ENOENT (No such file or directory)
```

The right one would probably be one of the following:
```
/nix/store/3z2n4f5gs6vjyqxf4xxjjah9gai5vnjd-qtbase-5.9.3-bin/lib/qt-5.9/plugins/platforms/libqxcb.so
/nix/store/s4zphdm9ancaj0c7n0sdmfgk9xbgmpf3-qtbase-5.9.3-bin/lib/qt-5.9/plugins/platforms/libqxcb.so
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

