### PR TITLE
bump {fnotify,fork,power,smem}stat to latest upstream

### DIFF
--- a/pkgs/os-specific/linux/fnotifystat/default.nix
+++ b/pkgs/os-specific/linux/fnotifystat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "fnotifystat-${version}";
-  version = "0.01.17";
+  version = "0.02.00";
   src = fetchurl {
     url = "http://kernel.ubuntu.com/~cking/tarballs/fnotifystat/fnotifystat-${version}.tar.gz";
-    sha256 = "0ncfbrpyb3ak49nrdr4cb3w082n9s181lizfqx51zi9rdgkj1vm3";
+    sha256 = "0sfzmggfhhhp3vxn1s61b5bacr2hz6r7y699n3nysdciaa2scgdq";
   };
   installFlags = [ "DESTDIR=$(out)" ];
   postInstall = ''

--- a/pkgs/os-specific/linux/forkstat/default.nix
+++ b/pkgs/os-specific/linux/forkstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "forkstat-${version}";
-  version = "0.02.00";
+  version = "0.02.02";
   src = fetchurl {
     url = "http://kernel.ubuntu.com/~cking/tarballs/forkstat/forkstat-${version}.tar.gz";
-    sha256 = "07df2lb32lbr2ggi84h9pjy6ig18n2961ksji4x1hhb4cvc175dg";
+    sha256 = "02iqi4xjg2hl4paw88fz9jb88a9p4zprvq3g56cd7jwfx3vmw5a4";
   };
   installFlags = [ "DESTDIR=$(out)" ];
   postInstall = ''

--- a/pkgs/os-specific/linux/powerstat/default.nix
+++ b/pkgs/os-specific/linux/powerstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "powerstat-${version}";
-  version = "0.02.12";
+  version = "0.02.15";
   src = fetchurl {
     url = "http://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-${version}.tar.gz";
-    sha256 = "16ls3rs1wfckl0b2szqqgiv072afy4qjd3r4kz4vf2qj77kjm06w";
+    sha256 = "0m8662qv77nzbwkdpydiz87kd75cjjajgp30j6mc5padyw65bxxx";
   };
   installFlags = [ "DESTDIR=$(out)" ];
   postInstall = ''

--- a/pkgs/os-specific/linux/smemstat/default.nix
+++ b/pkgs/os-specific/linux/smemstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "smemstat-${version}";
-  version = "0.01.17";
+  version = "0.01.18";
   src = fetchurl {
     url = "http://kernel.ubuntu.com/~cking/tarballs/smemstat/smemstat-${version}.tar.gz";
-    sha256 = "093ifrz688cm0kmzz1c6himhbdr75ig1mcaapmqy8jadc1gaw2im";
+    sha256 = "0g262gilj2jk365wj4yl93ifppgvc9rx7dmlw6ychbv72v2pbv6w";
   };
   buildInputs = [ ncurses ];
   installFlags = [ "DESTDIR=$(out)" ];


### PR DESCRIPTION
###### Motivation for this change

bump to latest upstream versions

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).