### PR TITLE
haskell modules: Make 17.09 forwards compatible

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -5,7 +5,6 @@
 , initialPackages ? import ./hackage-packages.nix
 , configurationCommon ? import ./configuration-common.nix
 , configurationNix ? import ./configuration-nix.nix
-, ...
 }:
 
 let

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -5,6 +5,7 @@
 , initialPackages ? import ./hackage-packages.nix
 , configurationCommon ? import ./configuration-common.nix
 , configurationNix ? import ./configuration-nix.nix
+, ...
 }:
 
 let

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -22,6 +22,8 @@
 , # The final, fully overriden package set usable with the nixpkgs fixpoint
   # overriding functionality
   extensible-self
+
+, ...
 }:
 
 # return value: a function from self to the package set

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -23,7 +23,10 @@
   # overriding functionality
   extensible-self
 
-, ...
+, # When argument list is extended in master, ellipsis prevent
+  # 'called with unexpected argument' errors and allows us to support
+  # both release and master versions
+  ...
 }:
 
 # return value: a function from self to the package set

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -23,10 +23,10 @@
   # overriding functionality
   extensible-self
 
-, # When argument list is extended in master, ellipsis prevent
-  # 'called with unexpected argument' errors and allows us to support
-  # both release and master versions
-  ...
+, # A haskell package set for Setup.hs, compiler plugins, and similar
+  # build-time uses.
+  # dummy argument for compatibility with nixpkgs-unstable channel
+  buildHaskellPackages ? null
 }:
 
 # return value: a function from self to the package set


### PR DESCRIPTION
###### Motivation for this change

Recent commit 81553124cf32e9d515da5f1c2f1b07e09886d8cf introduced new `buildHaskellPackages` argument and broke compatibility with _17.09_

Now if we call `makePackageSet` in _17.09_ with the new argument it fails with `called with unexpected argument ‘buildHaskellPackages’`.

This PR adds an ellipsis `(...)` to prevent `called with unexpected argument` errors in the future:

```
error: anonymous function at /nix/store/bfbxsw3jma333xv6x4r2kglwwa3f9zx8-nixpkgs-channels-c1d9aff56e0ae52ee4705440fe09291a51e91977-src/pkgs/development/haskell-modules/make-package-set.nix:4:1 called with unexpected argument ‘buildHaskellPackages’, at /nix/store/bfbxsw3jma333xv6x4r2kglwwa3f9zx8-nixpkgs-channels-c1d9aff56e0ae52ee4705440fe09291a51e91977-src/lib/customisation.nix:74:12
(use ‘--show-trace’ to show detailed location information)
```

cc @Ericson2314 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

