### PR TITLE
zfs: refactor - adding new option for support of new native encryption format

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -83,38 +83,16 @@ in
         type = types.bool;
         default = false;
         description = ''
-          Use ZFS with latest crypto stability patches. This was merged into
-          zfs master on feb 2, 2018. Those stability patches features a format
-          change for encrypted datasets. Old native encrypted datasets can still
-          be accessed but as read-only.
-          See https://github.com/zfsonlinux/zfs/pull/6864 for more details.
+          Enabling this option will install a development version of ZFS on Linux
+          that contains a format change for encrypted dataset. Once installed and
+          booted, you can still access encrypted datasets that were created prior
+          to this version but they can only be mounted as read-only.
 
-          If you have not created the root dataset as encrypted dataset but
-          used a childset as encryption root like the Nixos Wiki suggested ->
-          zroot/root/nixos (where 'zroot' is not encrypted but 'root' is encryp-
-          ted and nixos is encrypted as well due to inheritance), then updating
-          to the new format is a simlpe matter - you just need to have the free
-          space to do so:
-          0. Create a snapshot:
-                zfs snapshot zpool/root/nixos@now
-          1. Create a custom Nixos iso with crypto stability patch enabled
-          2. Boot into that live environment
-          3. Import the pool and load the key
-          4. Create a new encrypted dataset, e.g.
-                zfs create -o encryption=aes-256-gcm -o keyformat=passphrase
-                -o mountpoint=none zroot/rootNEW
-          5. Use zfs send and receive to copy the data to new format:
-                zfs send zpool/root/nixos@now | zfs receive zpool/rootNew/nixos
-          6. Set correct mountpoint for the newly created dataset:
-                zfs set moutpoint=legacy zpool/root/New/nixos
-          7. Rename the old dataset and the new one:
-                zfs rename zpool/root zpool/rootOLD
-                zfs rename zpool/rootNEW zpool/root
-          8. That should allow to boot Nixos already with new format. If you
-          other encrypted mounts, you will probably need to convert them to new
-          format as well first.
-          If you have encrypted your root dataset you will need to nuke it
-          and re-create completely anew.
+          For migration strategies from old format to this new one, check the Wiki:
+          https://nixos.wiki/wiki/NixOS_on_ZFS#Encrypted_Dataset_Format_Change
+
+          See https://github.com/zfsonlinux/zfs/pull/6864 for more details about
+          the stability patches.
           '';
       };
 

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -31,7 +31,7 @@ let
   } else if config.boot.zfs.enableCryptoStability then {
     spl = kernel.splCryptoStability;
     zfs = kernel.zfsCryptoStability;
-    zfsUser = pkgs.zfsUnstable;
+    zfsUser = pkgs.zfsCryptoStability;
   } else {
     spl = kernel.spl;
     zfs = kernel.zfs;
@@ -88,7 +88,7 @@ in
           change for encrypted datasets. Old native encrypted datasets can still
           be accessed but as read-only.
           See https://github.com/zfsonlinux/zfs/pull/6864 for more details.
-          
+
           If you have not created the root dataset as encrypted dataset but
           used a childset as encryption root like the Nixos Wiki suggested ->
           zroot/root/nixos (where 'zroot' is not encrypted but 'root' is encryp-

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -28,10 +28,10 @@ let
     spl = kernel.splUnstable;
     zfs = kernel.zfsUnstable;
     zfsUser = pkgs.zfsUnstable;
-  } else if config.boot.zfs.enableCryptoStability then {
-    spl = kernel.splCryptoStability;
-    zfs = kernel.zfsCryptoStability;
-    zfsUser = pkgs.zfsCryptoStability;
+  } else if config.boot.zfs.enableLegacyCryptoVersion then {
+    spl = kernel.splLegacyCryptoVersion;
+    zfs = kernel.zfsLegacyCryptoVersion;
+    zfsUser = pkgs.zfsLegacyCryptoVersion;
   } else {
     spl = kernel.spl;
     zfs = kernel.zfs;
@@ -79,14 +79,18 @@ in
           '';
       };
 
-      enableCryptoStability = mkOption {
+      enableLegacyCryptoVersion = mkOption {
         type = types.bool;
         default = false;
         description = ''
-          Enabling this option will install a development version of ZFS on Linux
-          that contains a format change for encrypted dataset. Once installed and
-          booted, you can still access encrypted datasets that were created prior
-          to this version but they can only be mounted as read-only.
+          Enabling this option will allow you to continue to use the old format for
+          encrypted datasets. With the inclusion of stabiity patches the format of
+          encrypted datasets has changed. They can still be access and mounted but
+          in read-only mode mounted. It is highly recommended to convert them to
+          the new format.
+
+          This option is only for convenience to people that cannot convert their
+          datasets to the new format yet and it will be removed in due time.
 
           For migration strategies from old format to this new one, check the Wiki:
           https://nixos.wiki/wiki/NixOS_on_ZFS#Encrypted_Dataset_Format_Change

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -28,10 +28,10 @@ let
     spl = kernel.splUnstable;
     zfs = kernel.zfsUnstable;
     zfsUser = pkgs.zfsUnstable;
-  } else if config.boot.zfs.enableLegacyCryptoVersion then {
-    spl = kernel.splLegacyCryptoVersion;
-    zfs = kernel.zfsLegacyCryptoVersion;
-    zfsUser = pkgs.zfsLegacyCryptoVersion;
+  } else if config.boot.zfs.enableLegacyCrypto then {
+    spl = kernel.splLegacyCrypto;
+    zfs = kernel.zfsLegacyCrypto;
+    zfsUser = pkgs.zfsLegacyCrypto;
   } else {
     spl = kernel.spl;
     zfs = kernel.zfs;
@@ -79,7 +79,7 @@ in
           '';
       };
 
-      enableLegacyCryptoVersion = mkOption {
+      enableLegacyCrypto = mkOption {
         type = types.bool;
         default = false;
         description = ''

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -84,7 +84,7 @@ in
         default = false;
         description = ''
           Enabling this option will allow you to continue to use the old format for
-          encrypted datasets. With the inclusion of stabiity patches the format of
+          encrypted datasets. With the inclusion of stability patches the format of
           encrypted datasets has changed. They can still be access and mounted but
           in read-only mode mounted. It is highly recommended to convert them to
           the new format.

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -72,8 +72,8 @@ in
     };
 
     splLegacyCrypto = common {
-      version = "2017-12-21";
-      rev = "c9821f1ccc647dfbd506f381b736c664d862d126";
-      sha256 = "08r6sa36jaj6n54ap18npm6w85v5yn3x8ljg792h37f49b8kir6c";
+      version = "2018-01-24";
+      rev = "23602fdb39e1254c669707ec9d2d0e6bcdbf1771";
+      sha256 = "09py2dwj77f6s2qcnkwdslg5nxb3hq2bq39zpxpm6msqyifhl69h";
     };
 }

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -71,7 +71,7 @@ in
       sha256 = "09py2dwj77f6s2qcnkwdslg5nxb3hq2bq39zpxpm6msqyifhl69h";
     };
 
-    splLegacyCryptoVersion = common {
+    splLegacyCrypto = common {
       version = "2017-12-21";
       rev = "c9821f1ccc647dfbd506f381b736c664d862d126";
       sha256 = "08r6sa36jaj6n54ap18npm6w85v5yn3x8ljg792h37f49b8kir6c";

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -70,4 +70,10 @@ in
       rev = "c9821f1ccc647dfbd506f381b736c664d862d126";
       sha256 = "08r6sa36jaj6n54ap18npm6w85v5yn3x8ljg792h37f49b8kir6c";
     };
+
+    splCryptoStability = common {
+      version = "2018-01-24";
+      rev = "23602fdb39e1254c669707ec9d2d0e6bcdbf1771";
+      sha256 = "09py2dwj77f6s2qcnkwdslg5nxb3hq2bq39zpxpm6msqyifhl69h";
+    };
 }

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -66,14 +66,14 @@ in
     };
 
     splUnstable = common {
-      version = "2017-12-21";
-      rev = "c9821f1ccc647dfbd506f381b736c664d862d126";
-      sha256 = "08r6sa36jaj6n54ap18npm6w85v5yn3x8ljg792h37f49b8kir6c";
-    };
-
-    splCryptoStability = common {
       version = "2018-01-24";
       rev = "23602fdb39e1254c669707ec9d2d0e6bcdbf1771";
       sha256 = "09py2dwj77f6s2qcnkwdslg5nxb3hq2bq39zpxpm6msqyifhl69h";
+    };
+
+    splLegacyCryptoVersion = common {
+      version = "2017-12-21";
+      rev = "c9821f1ccc647dfbd506f381b736c664d862d126";
+      sha256 = "08r6sa36jaj6n54ap18npm6w85v5yn3x8ljg792h37f49b8kir6c";
     };
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -192,7 +192,7 @@ in {
     extraPatches = [
       # Mic92's patch updated for current zfs master
       (fetchpatch {
-        url = "https://github.com/sjau/zfs/commit/72591199b36e4b4bddb6650717b5bb3121d508da.patch";
+        url = "https://raw.githubusercontent.com/sjau/nix-expressions/master/customPatches/nixos-zfs-2018-02-02.patch";
         sha256 = "1vy0jv8q1zg778j6pf75acy89h2vlc4smy64incp6bdsykvy6xkb";
       })
     ];

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -184,16 +184,17 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2018-01-10";
+    version = "2018-02-01";
 
-    rev = "1d53657bf561564162e2ad6449f80fa0140f1dd6";
-    sha256 = "0ibkhfz06cypgl2c869dzdbdx2i3m8ywwdmnzscv0cin5gm31vhx";
-    isLegacyCrypto = true;
+    rev = "4c46b99d24a6e71b3c72462c11cb051d0930ad60";
+    sha256 = "011lcp2x44jgfzqqk2gjmyii1v7rxcprggv20prxa3c552drsx3c";
+    isUnstable = true;
 
     extraPatches = [
+      # Mic92's patch updated for current zfs master
       (fetchpatch {
-        url = "https://github.com/Mic92/zfs/compare/ded8f06a3cfee...nixos-zfs-2017-09-12.patch";
-        sha256 = "033wf4jn0h0kp0h47ai98rywnkv5jwvf3xwym30phnaf8xxdx8aj";
+        url = "https://raw.githubusercontent.com/sjau/nix-expressions/master/customPatches/nixos-zfs-2018-02-02.patch";
+        sha256 = "1vy0jv8q1zg778j6pf75acy89h2vlc4smy64incp6bdsykvy6xkb";
       })
     ];
 

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -172,7 +172,6 @@ in {
         url = "https://github.com/Mic92/zfs/compare/ded8f06a3cfee...nixos-zfs-2017-09-12.patch";
         sha256 = "033wf4jn0h0kp0h47ai98rywnkv5jwvf3xwym30phnaf8xxdx8aj";
       })
-
     ];
 
     spl = splUnstable;
@@ -196,7 +195,6 @@ in {
         url = "https://github.com/sjau/zfs/commit/72591199b36e4b4bddb6650717b5bb3121d508da.patch";
         sha256 = "1vy0jv8q1zg778j6pf75acy89h2vlc4smy64incp6bdsykvy6xkb";
       })
-
     ];
 
     spl = splCryptoStability;

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -5,7 +5,7 @@
 , zlib, libuuid, python, attr, openssl
 
 # Kernel dependencies
-, kernel ? null, spl ? null, splUnstable ? null
+, kernel ? null, spl ? null, splUnstable ? null, splCryptoStability ? null
 }:
 
 with stdenv.lib;
@@ -19,6 +19,7 @@ let
     , spl
     , rev ? "zfs-${version}"
     , isUnstable ? false
+    , isCryptoStability ? false
     , incompatibleKernelVersion ? null } @ args:
     if buildKernel &&
       (incompatibleKernelVersion != null) &&
@@ -171,8 +172,34 @@ in {
         url = "https://github.com/Mic92/zfs/compare/ded8f06a3cfee...nixos-zfs-2017-09-12.patch";
         sha256 = "033wf4jn0h0kp0h47ai98rywnkv5jwvf3xwym30phnaf8xxdx8aj";
       })
+
     ];
 
     spl = splUnstable;
   };
+
+  zfsCryptoStability = common {
+    # comment/uncomment if breaking kernel versions are known
+    incompatibleKernelVersion = null;
+
+    # this package should point to a version / git revision compatible with the latest kernel release
+    version = "2018-02-02";
+
+    rev = "fbd42542686af053f0d162ec4630ffd4fff1cc30";
+    sha256 = "0qzkwnnk7kz1hwvcaqlpzi5yspfhhmd2alklc07k056ddzbx52qb";
+    isUnstable = true;
+    isCryptoStability = true;
+
+    extraPatches = [
+      # Mic92's patch updated for current zfs master
+      (fetchpatch {
+        url = "https://github.com/sjau/zfs/commit/72591199b36e4b4bddb6650717b5bb3121d508da.patch";
+        sha256 = "1vy0jv8q1zg778j6pf75acy89h2vlc4smy64incp6bdsykvy6xkb";
+      })
+
+    ];
+
+    spl = splCryptoStability;
+  };
+  
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -5,7 +5,7 @@
 , zlib, libuuid, python, attr, openssl
 
 # Kernel dependencies
-, kernel ? null, spl ? null, splUnstable ? null, splLegacyCryptoVersion ? null
+, kernel ? null, spl ? null, splUnstable ? null, splLegacyCrypto ? null
 }:
 
 with stdenv.lib;
@@ -19,7 +19,7 @@ let
     , spl
     , rev ? "zfs-${version}"
     , isUnstable ? false
-    , isLegacyCryptoVersion ? false
+    , isLegacyCrypto ? false
     , incompatibleKernelVersion ? null } @ args:
     if buildKernel &&
       (incompatibleKernelVersion != null) &&
@@ -45,7 +45,7 @@ let
            optionals buildKernel [ spl ]
         ++ optionals buildUser [ zlib libuuid python attr ]
         ++ optionals (buildUser && isUnstable) [ openssl ]
-        ++ optionals (buildUser && isLegacyCryptoVersion) [ openssl ];
+        ++ optionals (buildUser && isLegacyCrypto) [ openssl ];
 
       # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
       NIX_CFLAGS_LINK = "-lgcc_s";
@@ -179,7 +179,7 @@ in {
     spl = splUnstable;
   };
 
-  zfsLegacyCryptoVersion = common {
+  zfsLegacyCrypto = common {
     # comment/uncomment if breaking kernel versions are known
     incompatibleKernelVersion = null;
 
@@ -188,7 +188,7 @@ in {
 
     rev = "1d53657bf561564162e2ad6449f80fa0140f1dd6";
     sha256 = "0ibkhfz06cypgl2c869dzdbdx2i3m8ywwdmnzscv0cin5gm31vhx";
-    isLegacyCryptoVersion = true;
+    isLegacyCrypto = true;
 
     extraPatches = [
       (fetchpatch {
@@ -197,7 +197,7 @@ in {
       })
     ];
 
-    spl = splLegacyCryptoVersion;
+    spl = splLegacyCrypto;
   };
   
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -5,7 +5,7 @@
 , zlib, libuuid, python, attr, openssl
 
 # Kernel dependencies
-, kernel ? null, spl ? null, splUnstable ? null, splCryptoStability ? null
+, kernel ? null, spl ? null, splUnstable ? null, splLegacyCryptoVersion ? null
 }:
 
 with stdenv.lib;
@@ -19,7 +19,7 @@ let
     , spl
     , rev ? "zfs-${version}"
     , isUnstable ? false
-    , isCryptoStability ? false
+    , isLegacyCryptoVersion ? false
     , incompatibleKernelVersion ? null } @ args:
     if buildKernel &&
       (incompatibleKernelVersion != null) &&
@@ -44,7 +44,8 @@ let
       buildInputs =
            optionals buildKernel [ spl ]
         ++ optionals buildUser [ zlib libuuid python attr ]
-        ++ optionals (buildUser && isUnstable) [ openssl ];
+        ++ optionals (buildUser && isUnstable) [ openssl ]
+        ++ optionals (buildUser && isLegacyCryptoVersion) [ openssl ];
 
       # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
       NIX_CFLAGS_LINK = "-lgcc_s";
@@ -161,33 +162,11 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2018-01-10";
-
-    rev = "1d53657bf561564162e2ad6449f80fa0140f1dd6";
-    sha256 = "0ibkhfz06cypgl2c869dzdbdx2i3m8ywwdmnzscv0cin5gm31vhx";
-    isUnstable = true;
-
-    extraPatches = [
-      (fetchpatch {
-        url = "https://github.com/Mic92/zfs/compare/ded8f06a3cfee...nixos-zfs-2017-09-12.patch";
-        sha256 = "033wf4jn0h0kp0h47ai98rywnkv5jwvf3xwym30phnaf8xxdx8aj";
-      })
-    ];
-
-    spl = splUnstable;
-  };
-
-  zfsCryptoStability = common {
-    # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = null;
-
-    # this package should point to a version / git revision compatible with the latest kernel release
     version = "2018-02-02";
 
     rev = "fbd42542686af053f0d162ec4630ffd4fff1cc30";
     sha256 = "0qzkwnnk7kz1hwvcaqlpzi5yspfhhmd2alklc07k056ddzbx52qb";
     isUnstable = true;
-    isCryptoStability = true;
 
     extraPatches = [
       # Mic92's patch updated for current zfs master
@@ -197,7 +176,28 @@ in {
       })
     ];
 
-    spl = splCryptoStability;
+    spl = splUnstable;
+  };
+
+  zfsLegacyCryptoVersion = common {
+    # comment/uncomment if breaking kernel versions are known
+    incompatibleKernelVersion = null;
+
+    # this package should point to a version / git revision compatible with the latest kernel release
+    version = "2018-01-10";
+
+    rev = "1d53657bf561564162e2ad6449f80fa0140f1dd6";
+    sha256 = "0ibkhfz06cypgl2c869dzdbdx2i3m8ywwdmnzscv0cin5gm31vhx";
+    isLegacyCryptoVersion = true;
+
+    extraPatches = [
+      (fetchpatch {
+        url = "https://github.com/Mic92/zfs/compare/ded8f06a3cfee...nixos-zfs-2017-09-12.patch";
+        sha256 = "033wf4jn0h0kp0h47ai98rywnkv5jwvf3xwym30phnaf8xxdx8aj";
+      })
+    ];
+
+    spl = splLegacyCryptoVersion;
   };
   
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -169,10 +169,9 @@ in {
     isUnstable = true;
 
     extraPatches = [
-      # Mic92's patch updated for current zfs master
       (fetchpatch {
-        url = "https://raw.githubusercontent.com/sjau/nix-expressions/master/customPatches/nixos-zfs-2018-02-02.patch";
-        sha256 = "1vy0jv8q1zg778j6pf75acy89h2vlc4smy64incp6bdsykvy6xkb";
+        url = "https://github.com/Mic92/zfs/compare/fbd42542686af053f0d162ec4630ffd4fff1cc30...nixos-zfs-2018-02-02.patch";
+        sha256 = "05wqwjm9648x60vkwxbp8l6z1q73r2a5l2ni28i2f4pla8s3ahln";
       })
     ];
 
@@ -191,14 +190,13 @@ in {
     isUnstable = true;
 
     extraPatches = [
-      # Mic92's patch updated for current zfs master
       (fetchpatch {
-        url = "https://raw.githubusercontent.com/sjau/nix-expressions/master/customPatches/nixos-zfs-2018-02-02.patch";
-        sha256 = "1vy0jv8q1zg778j6pf75acy89h2vlc4smy64incp6bdsykvy6xkb";
+        url = "https://github.com/Mic92/zfs/compare/4c46b99d24a6e71b3c72462c11cb051d0930ad60...nixos-zfs-2018-02-01.patch";
+        sha256 = "1gqmgqi39qhk5kbbvidh8f2xqq25vj58i9x0wjqvcx6a71qj49ch";
       })
     ];
 
     spl = splLegacyCrypto;
   };
-  
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13100,7 +13100,7 @@ with pkgs;
     sch_cake = callPackage ../os-specific/linux/sch_cake { };
 
     inherit (callPackage ../os-specific/linux/spl {})
-      splStable splUnstable splCryptoStability;
+      splStable splUnstable splLegacyCryptoVersion;
 
     spl = splStable;
 
@@ -13131,7 +13131,7 @@ with pkgs;
     inherit (callPackage ../os-specific/linux/zfs {
       configFile = "kernel";
       inherit kernel spl;
-     }) zfsStable zfsUnstable zfsCryptoStability;
+     }) zfsStable zfsUnstable zfsLegacyCryptoVersion;
 
      zfs = zfsStable;
   });
@@ -13637,7 +13637,7 @@ with pkgs;
 
   inherit (callPackage ../os-specific/linux/zfs {
     configFile = "user";
-  }) zfsStable zfsUnstable zfsCryptoStability;
+  }) zfsStable zfsUnstable zfsLegacyCryptoVersion;
 
   zfs = zfsStable;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13100,7 +13100,7 @@ with pkgs;
     sch_cake = callPackage ../os-specific/linux/sch_cake { };
 
     inherit (callPackage ../os-specific/linux/spl {})
-      splStable splUnstable;
+      splStable splUnstable splCryptoStability;
 
     spl = splStable;
 
@@ -13131,7 +13131,7 @@ with pkgs;
     inherit (callPackage ../os-specific/linux/zfs {
       configFile = "kernel";
       inherit kernel spl;
-     }) zfsStable zfsUnstable;
+     }) zfsStable zfsUnstable zfsCryptoStability;
 
      zfs = zfsStable;
   });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13100,7 +13100,7 @@ with pkgs;
     sch_cake = callPackage ../os-specific/linux/sch_cake { };
 
     inherit (callPackage ../os-specific/linux/spl {})
-      splStable splUnstable splLegacyCryptoVersion;
+      splStable splUnstable splLegacyCrypto;
 
     spl = splStable;
 
@@ -13131,7 +13131,7 @@ with pkgs;
     inherit (callPackage ../os-specific/linux/zfs {
       configFile = "kernel";
       inherit kernel spl;
-     }) zfsStable zfsUnstable zfsLegacyCryptoVersion;
+     }) zfsStable zfsUnstable zfsLegacyCrypto;
 
      zfs = zfsStable;
   });
@@ -13637,7 +13637,7 @@ with pkgs;
 
   inherit (callPackage ../os-specific/linux/zfs {
     configFile = "user";
-  }) zfsStable zfsUnstable zfsLegacyCryptoVersion;
+  }) zfsStable zfsUnstable zfsLegacyCrypto;
 
   zfs = zfsStable;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13637,7 +13637,7 @@ with pkgs;
 
   inherit (callPackage ../os-specific/linux/zfs {
     configFile = "user";
-  }) zfsStable zfsUnstable;
+  }) zfsStable zfsUnstable zfsCryptoStability;
 
   zfs = zfsStable;
 


### PR DESCRIPTION
###### Motivation for this change

In zfsUnstable there's native encryption available for zfs. However this has some issues and there was a stability patch applied to it on feb 2. That stability patch however forces a new dataset format. Meaning old datasets can only be mounted in read-only mode.

Because of that I did add a new option for the configuration.nix: `    boot.zfs.enableCryptoStability = true;
` (probably should use a better name but couldn't think of it - feel free to make sugestions). This will use latest zfs/spl master with the included stability patches.

Also, I had to update Mic92's patch for NixOS.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

