### PR TITLE
astyle: 2.05.1 -> 3.1

### DIFF
--- a/pkgs/development/tools/misc/astyle/default.nix
+++ b/pkgs/development/tools/misc/astyle/default.nix
@@ -2,14 +2,14 @@
 
 let
   name = "astyle";
-  version = "2.05.1";
+  version = "3.1";
 in
 stdenv.mkDerivation {
   name = "${name}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/${name}/${name}_${version}_linux.tar.gz";
-    sha256 = "1b0f4wm1qmgcswmixv9mwbp86hbdqxk754hml8cjv5vajvqwdpzv";
+    sha256 = "1ms54wcs7hg1bsywqwf2lhdfizgbk7qxc9ghasxk8i99jvwlrk6b";
   };
 
   sourceRoot = if stdenv.cc.isClang


### PR DESCRIPTION
###### Motivation for this change
Update astyle to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

