### PR TITLE
Add new package "ncpamixer"

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -656,6 +656,7 @@
   sternenseemann = "Lukas Epple <post@lukasepple.de>";
   stesie = "Stefan Siegl <stesie@brokenpipe.de>";
   steveej = "Stefan Junker <mail@stefanjunker.de>";
+  StijnDW = "Stijn DW <stekke@airmail.cc>";
   StillerHarpo = "Florian Engel <florianengel39@gmail.com>";
   stumoss = "Stuart Moss <samoss@gmail.com>";
   SuprDewd = "Bjarki Ágúst Guðmundsson <suprdewd@gmail.com>";

--- a/pkgs/applications/audio/ncpamixer/default.nix
+++ b/pkgs/applications/audio/ncpamixer/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, cmake, ncurses, libpulseaudio, pkgconfig }:
+
+stdenv.mkDerivation rec {
+
+  name = "ncpamixer-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "fulhax";
+    repo = "ncpamixer";
+    rev = version;
+    sha256 = "01kvd0pg5yraymlln5xdzqj1r6adxfvvza84wxn2481kcxfral54";
+  };
+
+  buildInputs = [ ncurses libpulseaudio ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  configurePhase = ''
+    make PREFIX=$out build/Makefile
+  '';
+
+  buildPhase = ''
+    make build
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An ncurses mixer for PulseAudio inspired by pavucontrol";
+    homepage = https://github.com/fulhax/ncpamixer;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ StijnDW ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16568,6 +16568,8 @@ with pkgs;
 
   pamixer = callPackage ../applications/audio/pamixer { };
 
+  ncpamixer = callPackage ../applications/audio/ncpamixer { };
+
   pan = callPackage ../applications/networking/newsreaders/pan {
     spellChecking = false;
   };


### PR DESCRIPTION
###### Motivation for this change

The only package I know of that has user a user friendly way to adjust pulse audio volume from a command line interface.
It works the same way as alsamixer but mimics the user interface from pavucontrol.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

