### PR TITLE
qmediathekview: init at 2017-04-16

### DIFF
--- a/pkgs/applications/video/qmediathekview/default.nix
+++ b/pkgs/applications/video/qmediathekview/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, qtbase, qttools, xz, boost, qmake, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "QMediathekView";
+  version = "2017-04-16";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "adamreichold";
+    repo = pname;
+    rev = "8c69892b95bf6825bd06a8c594168a98fe7cb2d1";
+    sha256 = "1wca1w4iywd3hmiwcqx6fv79p3x5n1cgbw2liw3hs24ch3z54ckm";
+  };
+
+  postPatch = ''
+    substituteInPlace ${pname}.pro \
+      --replace /usr ""
+  '';
+
+  buildInputs = [ qtbase qttools xz boost ];
+
+  nativeBuildInputs = [ qmake pkgconfig ];
+
+  installFlags = [ "INSTALL_ROOT=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "An alternative Qt-based front-end for the database maintained by the MediathekView project";
+    inherit (src.meta) homepage;
+    license = licenses.gpl3Plus;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16781,6 +16781,8 @@ with pkgs;
 
   qmapshack = libsForQt5.callPackage ../applications/misc/qmapshack { };
 
+  qmediathekview = libsForQt5.callPackage ../applications/video/qmediathekview { };
+
   qmetro = callPackage ../applications/misc/qmetro { };
 
   qmidinet = callPackage ../applications/audio/qmidinet { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

