### PR TITLE
grobi: init at 0.3.0

### DIFF
--- a/pkgs/tools/X11/grobi/default.nix
+++ b/pkgs/tools/X11/grobi/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  version = "0.3.0";
+  name = "grobi-${version}";
+
+  goPackagePath = "github.com/fd0/grobi";
+
+  src = fetchFromGitHub {
+    rev = "78a0639ffad765933a5233a1c94d2626e24277b8";
+    owner = "fd0";
+    repo = "grobi";
+    sha256 = "16q7vnhb1p6ds561832sfdszvlafww67bjn3lc0d18v7lyak2l3i";
+  };
+
+   meta = with stdenv.lib; {
+    homepage = https://github.com/fd0/grobi;
+    description = "Automatically configure monitors/outputs for Xorg via RANDR";
+    license = with licenses; [ bsd2 ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1191,6 +1191,8 @@ with pkgs;
 
   gringo = callPackage ../tools/misc/gringo { scons = scons_2_5_1; };
 
+  grobi = callPackage ../tools/X11/grobi { };
+
   gti = callPackage ../tools/misc/gti { };
 
   heatseeker = callPackage ../tools/misc/heatseeker { };


### PR DESCRIPTION
###### Motivation for this change

Add [grobi](https://github.com/fd0/grobi) package to nixpkgs.

###### Things done

- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


**Note**: It will make sense to also provide a nixos module to run a grobi systemd service but i will provide this through a separate PR.