### PR TITLE
python3Packages.luftdaten: init at 0.1.4

### DIFF
--- a/pkgs/development/python-modules/luftdaten/default.nix
+++ b/pkgs/development/python-modules/luftdaten/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, isPy3k, fetchPypi, aiohttp, async-timeout }:
+
+buildPythonPackage rec {
+  pname = "luftdaten";
+  version = "0.1.4";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d3e3af830ad2b731c36af223bbb5d47d68aa3786b2965411216917a7381e1179";
+  };
+
+  propagatedBuildInputs = [ aiohttp async-timeout ];
+
+  # No tests implemented
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python API for interacting with luftdaten.info";
+    homepage = https://github.com/fabaff/python-luftdaten;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5624,6 +5624,8 @@ in {
     };
   };
 
+  luftdaten = callPackage ../development/python-modules/luftdaten { };
+
   m2r = callPackage ../development/python-modules/m2r { };
 
   mailchimp = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

