### PR TITLE
notmuch: fix version wildcard

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     [[ -s "$lib" ]] || die "couldn't find libnotmuch"
 
     badname="$(otool -L "$prg" | awk '$1 ~ /libtalloc/ { print $1 }')"
-    goodname="$(find "${talloc}/lib" -name 'libtalloc.?.?.?.dylib')"
+    goodname="$(find "${talloc}/lib" -name 'libtalloc.*.*.*.dylib')"
 
     [[ -n "$badname" ]]  || die "couldn't find libtalloc reference in binary"
     [[ -n "$goodname" ]] || die "couldn't find libtalloc in nix store"


### PR DESCRIPTION
talloc is now 2.1.11 and the find '?' only matches one digit so it fails on 11. This switches it to use the '*' wildcard.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
