### PR TITLE
openmpi: fix broken modules, disable dsos

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
 
-  configureFlags = with stdenv; []
+  configureFlags = with stdenv; [ "--disable-mca-dso" ]
     ++ lib.optional isLinux  "--with-libnl=${libnl.dev}"
     ++ lib.optional enableSGE "--with-sge"
     ++ lib.optional enablePrefix "--enable-mpirun-prefix-by-default"


### PR DESCRIPTION
###### Motivation for this change
Some modules fail to resolve some symbols which seem to reside in other modules. This problem can be solved disabling `mca-dso`. All modules are then linked into one library thus eliminating the problem (see https://www.open-mpi.org/faq/?category=building#avoid-dso). 

```
[lf5:23608] mca: base: component_find: unable to open /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_btl_openib: /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_btl_openib.so: undefined symbol: mca_mpool_grdma_evict (ignored)
[lf5:23608] mca: base: component_find: unable to open /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_dynamic: /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_dynamic.so: undefined symbol: ompi_io_ompio_allgatherv_array (ignored)
[lf5:23608] mca: base: component_find: unable to open /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_individual: /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_individual.so: undefined symbol: mca_io_ompio_file_write (ignored)
[lf5:23608] mca: base: component_find: unable to open /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_static: /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_static.so: undefined symbol: ompi_io_ompio_allgather_array (ignored)
[lf5:23608] mca: base: component_find: unable to open /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_two_phase: /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_two_phase.so: undefined symbol: ompi_io_ompio_set_aggregator_props (ignored)
[lf5:23608] mca: base: component_find: unable to open /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_ylib: /nix/store/igiz5k6hyn9lc2704ipbbpfm77424cib-openmpi-1.10.7/lib/openmpi/mca_fcoll_ylib.so: undefined symbol: ompi_io_ompio_scatter_data (ignored)
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

