### PR TITLE
[17.09] squid: fix CVE-2018-1000024 & CVE-2018-1000027

### DIFF
--- a/pkgs/servers/squid/4.nix
+++ b/pkgs/servers/squid/4.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
     perl openldap pam db cyrus_sasl libcap expat libxml2 openssl
   ];
 
+  prePatch = ''
+    substituteInPlace configure --replace "/usr/local/include/libxml2" "${libxml2.dev}/include/libxml2"
+  '';
+
   configureFlags = [
     "--enable-ipv6"
     "--disable-strict-error-checking"

--- a/pkgs/servers/squid/4.nix
+++ b/pkgs/servers/squid/4.nix
@@ -2,11 +2,11 @@
 , expat, libxml2, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "squid-4.0.21";
+  name = "squid-4.0.23";
 
   src = fetchurl {
     url = "http://www.squid-cache.org/Versions/v4/${name}.tar.xz";
-    sha256 = "0cwfj3qpl72k5l1h2rvkv1xg0720rifk4wcvi49z216hznyqwk8m";
+    sha256 = "0a8g0zs3xayfkxl8maq823b14lckvh9d5lf7ryh9rx303xh1mdqq";
   };
 
   buildInputs = [

--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, openldap, pam, db, cyrus_sasl, libcap
+{ stdenv, fetchurl, fetchpatch, perl, openldap, pam, db, cyrus_sasl, libcap
 , expat, libxml2, openssl }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,19 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     perl openldap pam db cyrus_sasl libcap expat libxml2 openssl
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-1000024.patch";
+      url = http://www.squid-cache.org/Versions/v3/3.5/changesets/SQUID-2018_1.patch;
+      sha256 = "0vzxr4rmybz0w4c1hi3szvqawbzl4r4b8wyvq9vgq1mzkk5invpg";
+    })
+    (fetchpatch {
+      name = "CVE-2018-1000027.patch";
+      url = http://www.squid-cache.org/Versions/v3/3.5/changesets/SQUID-2018_2.patch;
+      sha256 = "1a8hwk9z7h1j0c57anfzp3bwjd4pjbyh8aks4ca79nwz4d0y6wf3";
+    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
fixing CVE-2018-1000024 & CVE-2018-1000027

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

