### PR TITLE
lgi: Fix cairo bindings search path

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -9,7 +9,7 @@
 , pcre, oniguruma, gnulib, tre, glibc, sqlite, openssl, expat, cairo
 , perl, gtk2, python, glib, gobjectIntrospection, libevent, zlib, autoreconfHook
 , mysql, postgresql, cyrus_sasl
-, fetchFromGitHub, libmpack, which
+, fetchFromGitHub, libmpack, which, fetchpatch
 }:
 
 let
@@ -670,6 +670,14 @@ let
     preBuild = ''
       sed -i "s|/usr/local|$out|" lgi/Makefile
     '';
+
+    patches = [
+        (fetchpatch {
+            name = "lgi-find-cairo-through-typelib.patch";
+            url = "https://github.com/psychon/lgi/commit/46a163d9925e7877faf8a4f73996a20d7cf9202a.patch";
+            sha256 = "0gfvvbri9kyzhvq3bvdbj2l6mwvlz040dk4mrd5m9gz79f7w109c";
+        })
+    ];
 
     meta = with stdenv.lib; {
       description = "GObject-introspection based dynamic Lua binding to GObject based libraries";


### PR DESCRIPTION
Since commit e44038bccab0cae, cairo-1.0.typelib contains an absolute
path to cairo in the nix store so that no $LD_LIBRARY_PATH hacks are
needed. However, this did not yet work for lgi, because lgi does
dlopen("libcairo.so.2") without a full path, too.

To make this work, this commit ensures that lgi first uses
gobject-introspection to load libcairo. This uses the full path provided
by the typelib. Afterwards, dlopen("libcairo.so.2") does not hit the
filesystem anymore since the library is already loaded.

This commit adds a patch that reorders some code in lgi's cairo
initialisation. Previously, this started with core.module('cairo', 2),
which is where the dlopen happens. Now, this code is moved down and
instead core.gi.cairo.resolve is used to load the definitions of some
enums first. This part of the code goes through gobject-introspection
and causes libcairo to be loaded.

Signed-off-by: Uli Schlachter <psychon@znc.in>

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
This fixes https://github.com/NixOS/nixpkgs/pull/34259#issuecomment-362863738. I tested this via `nix-shell -A awesome` and running `lua -e "print(require('lgi').cairo)"`. Previously this errored out, but with this patch this worked.

Any suggestions how to make this change nicely? I feel like dropping a patch file into `pkgs/top-level` is not a good idea.

CC @dtzWill @vcunat @makefu 