### PR TITLE
loccount: 1.1 -> 1.2

### DIFF
--- a/pkgs/development/tools/misc/loccount/default.nix
+++ b/pkgs/development/tools/misc/loccount/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, buildGoPackage, fetchFromGitLab }:
 buildGoPackage rec {
   name = "loccount-${version}";
-  version = "1.1";
+  version = "1.2";
 
   goPackagePath = "gitlab.com/esr/loccount";
   excludedPackages = "tests";
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "esr";
     repo = "loccount";
     rev = version;
-    sha256 = "1wx31hraxics8x8w42jy5b10wdx1368zp2p6gplcfmpjssf9pacr";
+    sha256 = "18z7ai7wy2k9yd3w65d37apfqs3h9bc2c15y7v1bydppi44zfsdk";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Version bump.

Fixes a bug with relative paths.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

