### PR TITLE
nixos/vswitches : Fix vswitch-netdev.service going down just after startup

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -317,12 +317,16 @@ let
             serviceConfig.Type = "oneshot";
             serviceConfig.RemainAfterExit = true;
             path = [ pkgs.iproute config.virtualisation.vswitch.package ];
-            script = ''
+            preStart = ''
               echo "Removing old Open vSwitch ${n}..."
               ovs-vsctl --if-exists del-br ${n}
 
               echo "Adding Open vSwitch ${n}..."
-              ovs-vsctl -- add-br ${n} ${concatMapStrings (i: " -- add-port ${n} ${i}") v.interfaces} \
+              ovs-vsctl -- add-br ${n} 
+            '';
+            script = ''
+              echo "Configuring Open vSwitch ${n}..."
+              ovs-vsctl ${concatMapStrings (i: " -- add-port ${n} ${i}") v.interfaces} \
                 ${concatMapStrings (x: " -- set-controller ${n} " + x)  v.controllers} \
                 ${concatMapStrings (x: " -- " + x) (splitString "\n" v.extraOvsctlCmds)}
 


### PR DESCRIPTION
The service has a 'BindsTo' Dependency to sys-subsystem-vsiwtch.device
which causes the service to stop immediately after startup because the
add-br commands make the device flap somehow.

This patch moves creation of the device to 'ExecStartPre=' phase of the
service, where 'BindsTo' does not apply (tested, bu could not find docs
about this).

See https://github.com/NixOS/nixpkgs/issues/34336 for details

###### Motivation for this change

Configuring `networking.vswitches` did not work before.
Also, as we remove the device in postStop, it makes sense to create it in preStart.

###### Things done

Tested in the virtualbox VM (see related issue for logs and details).

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
