### PR TITLE
pythonPackages.pybase64: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/nose-parameterized/default.nix
+++ b/pkgs/development/python-modules/nose-parameterized/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchPypi, buildPythonPackage, nose, six, glibcLocales, isPy3k }:
+{ fetchPypi, parameterized }:
 
-buildPythonPackage rec {
+parameterized.overrideAttrs (o: rec {
   pname = "nose-parameterized";
   version = "0.6.0";
 
@@ -8,20 +8,4 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1khlabgib4161vn6alxsjaa8javriywgx9vydddi659gp9x6fpnk";
   };
-
-  # Tests require some python3-isms but code works without.
-  doCheck = isPy3k;
-
-  buildInputs = [ nose glibcLocales ];
-  propagatedBuildInputs = [ six ];
-
-  checkPhase = ''
-    LC_ALL="en_US.UTF-8" nosetests -v
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Parameterized testing with any Python test framework";
-    homepage = https://pypi.python.org/pypi/nose-parameterized;
-    license = licenses.bsd3;
-  };
-}
+})

--- a/pkgs/development/python-modules/parameterized/default.nix
+++ b/pkgs/development/python-modules/parameterized/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchPypi, buildPythonPackage, nose, six, glibcLocales, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "parameterized";
+  version = "0.6.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qj1939shm48d9ql6fm1nrdy4p7sdyj8clz1szh5swwpf1qqxxfa";
+  };
+
+  # Tests require some python3-isms but code works without.
+  doCheck = isPy3k;
+
+  checkInputs = [ nose glibcLocales ];
+  propagatedBuildInputs = [ six ];
+
+  checkPhase = ''
+    LC_ALL="en_US.UTF-8" nosetests -v
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Parameterized testing with any Python test framework";
+    homepage = https://pypi.python.org/pypi/parameterized;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/development/python-modules/pybase64/default.nix
+++ b/pkgs/development/python-modules/pybase64/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, stdenv, fetchPypi, parameterized, six, nose }:
+
+buildPythonPackage rec {
+  pname = "pybase64";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hggg69s5r8jyqdwyzri5sn3f19p7ayl0fjhjma0qzgfp7bk6zjc";
+  };
+
+  propagatedBuildInputs = [ six ];
+  checkInputs = [ parameterized nose ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://pypi.python.org/pypi/pybase64;
+    description = "Fast Base64 encoding/decoding";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3839,7 +3839,8 @@ in {
     };
   });
 
-  nose-parameterized = callPackage ../development/python-modules/nose-parameterized {};
+  nose-parameterized = warn "Warning: `nose-parameterized` is deprecated! Use `parameterized` instead."
+    (callPackage ../development/python-modules/nose-parameterized {});
 
   neurotools = buildPythonPackage (rec {
     name = "NeuroTools-${version}";
@@ -12396,6 +12397,8 @@ in {
       '';
     };
   };
+
+  parameterized = callPackage ../development/python-modules/parameterized { };
 
   paramz = callPackage ../development/python-modules/paramz { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12823,6 +12823,8 @@ in {
 
   kmsxx = callPackage ../development/libraries/kmsxx { };
 
+  pybase64 = callPackage ../development/python-modules/pybase64 { };
+
   pylibconfig2 = buildPythonPackage rec {
     name = "pylibconfig2-${version}";
     version = "0.2.4";


### PR DESCRIPTION
###### Motivation for this change

Adds the `pybase64` package, a simple python-based `libbase64` wrapper.
Please have a look at the commit messages for further reference.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

