### PR TITLE
pick: 1.9.0 -> 2.0.1

### DIFF
--- a/pkgs/tools/misc/pick/default.nix
+++ b/pkgs/tools/misc/pick/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pick-${version}";
-  version = "1.9.0";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "calleerlandsson";
     repo = "pick";
     rev = "v${version}";
-    sha256 = "0s0mn9iz17ldhvahggh9rsmgfrjh0kvk5bh4p9xhxcn7rcp0h5ka";
+    sha256 = "0ypawbzpw188rxgv8x044iib3a517j5grgqnxy035ax5zzjavsrr";
   };
 
   buildInputs = [ ncurses ];


### PR DESCRIPTION
###### Motivation for this change

update to latest upstream

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
