### PR TITLE
facter: 3.9.0 -> 3.9.3 and dependency libwhereami: 0.1.1 -> 0.1.3

### DIFF
--- a/pkgs/development/libraries/libwhereami/default.nix
+++ b/pkgs/development/libraries/libwhereami/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "libwhereami-${version}";
-  version = "0.1.1";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
-    sha256 = "0nhbmxm626cgawprszw6c03a3hasxjn1i9ldhhj5xyvxp8r5l9q4";
+    sha256 = "0mpy2rkxcm2nz1qvldih01czxlsksqfkzgh58pnrw8yva31wv9q6";
     rev = version;
     repo = "libwhereami";
     owner = "puppetlabs";

--- a/pkgs/tools/system/facter/default.nix
+++ b/pkgs/tools/system/facter/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "facter-${version}";
-  version = "3.9.0";
+  version = "3.9.3";
 
   src = fetchFromGitHub {
-    sha256 = "1picxrmvka57ph4zqgwqdsqvz3mqppg41wkj8dx37hscwwlbdw0s";
+    sha256 = "1qd0xsw49nbj22czddxk90di31gx43hacvnmh08gp3001a8g0qcj";
     rev = version;
     repo = "facter";
     owner = "puppetlabs";


### PR DESCRIPTION
###### Motivation for this change

bump to latest upstream versions

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
