### PR TITLE
ucl: patch shebang configure so full-featured 'bash' is used, fix

### DIFF
--- a/pkgs/development/libraries/ucl/default.nix
+++ b/pkgs/development/libraries/ucl/default.nix
@@ -10,6 +10,10 @@ stdenv.mkDerivation {
   # needed to successfully compile with gcc 6
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isGNU "-std=c90";
 
+  preConfigure = ''
+    patchShebangs configure
+  '';
+
   meta = {
     homepage = http://www.oberhumer.com/opensource/ucl/;
     description = "Portable lossless data compression library";


### PR DESCRIPTION
`nix-build -A ucl --check` fails when using Nix 2.0,
even (!) when using a more featureful variant
as described here:

https://github.com/NixOS/nix/issues/1832#issuecomment-362523240


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Currently fails to build when /bin/sh in sandbox is busybox-based,
didn't investigate why but this seems to fix it.