### PR TITLE
gnuradio: fix wrapper

### DIFF
--- a/pkgs/applications/misc/gnuradio/wrapper.nix
+++ b/pkgs/applications/misc/gnuradio/wrapper.nix
@@ -1,7 +1,6 @@
-{ stdenv, gnuradio, makeWrapper, python
-, extraPackages ? [] }:
+{ stdenv, gnuradio, makeWrapper, python, extraPackages ? [] }:
 
-with stdenv.lib;
+with { inherit (stdenv.lib) appendToName makeSearchPath; };
 
 stdenv.mkDerivation {
   name = (appendToName "with-packages" gnuradio).name;
@@ -11,13 +10,15 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     ln -s "${gnuradio}"/bin/* $out/bin/
 
-    for file in $(find $out/bin -type f -executable); do
-        wrapProgram "$file" \
-            --prefix PYTHONPATH : ${stdenv.lib.concatStringsSep ":"
-                                     (map (path: "$(toPythonPath ${path})") extraPackages)} \
-            --prefix GRC_BLOCKS_PATH : ${makeSearchPath "share/gnuradio/grc/blocks" extraPackages}
+    for file in $(find -L $out/bin -type f); do
+        if test -x "$(readlink -f "$file")"; then
+            wrapProgram "$file" \
+                --prefix PYTHONPATH : ${stdenv.lib.concatStringsSep ":"
+                                         (map (path: "$(toPythonPath ${path})") extraPackages)} \
+                --prefix GRC_BLOCKS_PATH : ${makeSearchPath "share/gnuradio/grc/blocks" extraPackages}
+        fi
     done
-
   '';
+
   inherit (gnuradio) meta;
 }


### PR DESCRIPTION
###### Motivation for this change

gnuradio-with-packages was not running makeWrapper on any of the symlinked executables because `find $out/bin -type f -executable` does not resolve symlinks. I don't understand how the old code ever worked on any system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

