### PR TITLE
amdgpu-pro: 17.10 -> 17.50

### DIFF
--- a/pkgs/os-specific/linux/amdgpu-pro/default.nix
+++ b/pkgs/os-specific/linux/amdgpu-pro/default.nix
@@ -29,20 +29,18 @@ let
   ncurses5 = ncurses.override { abiVersion = "5"; };
 
 in stdenv.mkDerivation rec {
-
-  version = "17.10";
+  version = "17.50";
   pname = "amdgpu-pro";
-  build = "${version}-401251";
+  build = "${version}-511655";
 
   libCompatDir = "/run/lib/${libArch}";
 
   name = pname + "-" + version + (optionalString (!libsOnly) "-${kernelDir.version}");
 
   src = fetchurl {
-    url =
-    "https://www2.ati.com/drivers/linux/ubuntu/amdgpu-pro-${build}.tar.xz";
-    sha256 = "004n0df8acjpjz72z3bjxb2a0b7qwln13jlknfn7xxqvhhwwy40a";
-    curlOpts = "--referer http://support.amd.com/en-us/kb-articles/Pages/AMD-Radeon-GPU-PRO-Linux-Beta-Driver%e2%80%93Release-Notes.aspx";
+    url = "https://www2.ati.com/drivers/linux/ubuntu/amdgpu-pro-${build}.tar.xz";
+    sha256 = "01zaf3z3wyc0np2jsw0b4dyq5y23g57k0c5x34g9ibfvgddzj8x6";
+    curlOpts = "--referer https://support.amd.com/en-us/kb-articles/Pages/Radeon-Software-for-Linux-Release-Notes.aspx";
   };
 
   hardeningDisable = [ "pic" "format" ];


### PR DESCRIPTION
###### Motivation for this change
Update, fix for kernel 4.14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

It would seem that the AMD server has a corrupted copy today.
Yesterday, this worked -.-