### PR TITLE
mpich2: 3.2 -> 3.2.1, update meta data

### DIFF
--- a/pkgs/development/libraries/mpich2/default.nix
+++ b/pkgs/development/libraries/mpich2/default.nix
@@ -1,17 +1,33 @@
-{ stdenv, fetchurl, python, perl, gfortran }:
+{ stdenv, fetchurl, python, perl, gfortran
+, slurm, openssh, hwloc
+} :
 
 stdenv.mkDerivation  rec {
   name = "mpich-${version}";
-  version = "3.2";
+  version = "3.2.1";
 
   src = fetchurl {
-    url = "http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz";
-    sha256 = "0bvvk4n9g4rmrncrgs9jnkcfh142i65wli5qp1akn9kwab1q80z6";
+    url = "http://www.mpich.org/static/downloads/${version}/mpich-${version}.tar.gz";
+    sha256 = "1w9h4g7d46d9l5jbcyfxpaqzpjrc5hyvr9d0ns7278psxpr3pdax";
   };
 
-  configureFlags = "--enable-shared --enable-sharedlib";
+  configureFlags = [
+    "--enable-shared"
+    "--enable-sharedlib"
+  ];
 
-  buildInputs = [ perl gfortran ];
+  buildInputs = [ perl gfortran slurm openssh hwloc ];
+
+  doCheck = true;
+
+  preFixup = ''
+    # /tmp/nix-build... ends up in the RPATH, fix it manually
+    for entry in $out/bin/mpichversion $out/bin/mpivars; do
+      echo "fix rpath: $entry"
+      patchelf --set-rpath "$out/lib" $entry
+    done
+  '';
+
 
   meta = {
     description = "Implementation of the Message Passing Interface (MPI) standard";

--- a/pkgs/development/libraries/mpich2/default.nix
+++ b/pkgs/development/libraries/mpich2/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation  rec {
   '';
 
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Implementation of the Message Passing Interface (MPI) standard";
 
     longDescription = ''
@@ -38,9 +38,11 @@ stdenv.mkDerivation  rec {
       version 2.
     '';
     homepage = http://www.mcs.anl.gov/mpi/mpich2/;
-    license = "free, see http://www.mcs.anl.gov/research/projects/mpich2/downloads/index.php?s=license";
-
-    maintainers = [ ];
-    platforms = stdenv.lib.platforms.unix;
+    license = {
+      url = http://git.mpich.org/mpich.git/blob/a385d6d0d55e83c3709ae851967ce613e892cd21:/COPYRIGHT;
+      fullName = "MPICH license (permissive)";
+    };
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

