### PR TITLE
descent 1 & 2: use assets from gog.com with the dxx-rebirth project

### DIFF
--- a/pkgs/build-support/setup-hooks/gog-unpack.sh
+++ b/pkgs/build-support/setup-hooks/gog-unpack.sh
@@ -1,0 +1,11 @@
+unpackPhase="unpackGog"
+
+unpackGog() {
+    runHook preUnpackGog
+
+    innoextract --silent --extract --exclude-temp "${src}"
+
+    find . -depth -print -execdir rename -f 'y/A-Z/a-z/' '{}' \;
+
+    runHook postUnpackGog
+}

--- a/pkgs/games/dxx-rebirth/assets.nix
+++ b/pkgs/games/dxx-rebirth/assets.nix
@@ -1,0 +1,55 @@
+{ stdenv, requireFile, gogUnpackHook }:
+
+let
+  generic = ver: source: let
+    pname = "descent${toString ver}";
+  in stdenv.mkDerivation rec {
+    name = "${pname}-assets-${version}";
+    version = "2.0.0.7";
+
+    src = requireFile rec {
+      name = "setup_descent12_${version}.exe";
+      sha256 = "1r1drbfda6czg21f9qqiiwgnkpszxgmcn5bafp5ljddh34swkn3f";
+      message = ''
+        While the Descent ${toString ver} game engine is free, the game assets are not.
+
+        Please purchase the game on gog.com and download the Windows installer.
+
+        Once you have downloaded the file, please use the following command and re-run the
+        installation:
+
+        nix-prefetch-url file://\$PWD/${name}
+      '';
+    };
+
+    nativeBuildInputs = [ gogUnpackHook ];
+
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/{games/${pname},doc/${pname}/examples}
+      pushd "app/${source}"
+      mv dosbox*.conf $out/share/doc/${pname}/examples
+      mv *.txt *.pdf  $out/share/doc/${pname}
+      cp -r * $out/share/games/descent${toString ver}
+      popd
+
+      runHook postInstall
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Descent ${toString ver} assets from GOG";
+      homepage    = http://www.dxx-rebirth.com/;
+      license     = licenses.unfree;
+      maintainers = with maintainers; [ peterhoeg ];
+      hydraPlatforms = [];
+    };
+  };
+
+in {
+  descent1-assets = generic 1 "descent";
+  descent2-assets = generic 2 "descent 2";
+}

--- a/pkgs/games/dxx-rebirth/full.nix
+++ b/pkgs/games/dxx-rebirth/full.nix
@@ -1,0 +1,30 @@
+{ stdenv, makeWrapper
+, dxx-rebirth, descent1-assets, descent2-assets }:
+
+let
+  generic = ver: assets: stdenv.mkDerivation rec {
+    name = "d${toString ver}x-rebirth-full-${assets.version}";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    buildCommand = ''
+      mkdir -p $out/bin
+
+      makeWrapper ${dxx-rebirth}/bin/d${toString ver}x-rebirth $out/bin/descent${toString ver} \
+        --add-flags "-hogdir ${assets}/share/games/descent${toString ver}"
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Descent ${toString ver} using the DXX-Rebirth project engine and game assets from GOG";
+      homepage    = http://www.dxx-rebirth.com/;
+      license     = with licenses; [ free unfree ];
+      maintainers = with maintainers; [ peterhoeg ];
+      platforms   = with platforms; linux;
+      hydraPlatforms = [];
+    };
+  };
+
+in {
+  d1x-rebirth-full = generic 1 descent1-assets;
+  d2x-rebirth-full = generic 2 descent2-assets;
+}

--- a/pkgs/tools/filesystems/file-rename/default.nix
+++ b/pkgs/tools/filesystems/file-rename/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, perlPackages, makeWrapper }:
+
+perlPackages.buildPerlPackage rec {
+  name = "File-Rename-0.20";
+
+  src = fetchurl {
+    url = "mirror://cpan/authors/id/R/RM/RMBARKER/${name}.tar.gz";
+    sha256 = "1cf6xx2hiy1xalp35fh8g73j67r0w0g66jpcbc6971x9jbm7bvjy";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/rename \
+      --prefix PERL5LIB : $out/lib/perl5/site_perl
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Perl extension for renaming multiple files";
+    homepage = http://search.cpan.org/~rmbarker;
+    license = licenses.artistic1;
+    maintainer = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -92,6 +92,11 @@ with pkgs;
     { substitutions = { gnu_config = gnu-config;}; }
     ../build-support/setup-hooks/update-autotools-gnu-config-scripts.sh;
 
+  gogUnpackHook = makeSetupHook {
+    name = "gog-unpack-hook";
+    deps = [ innoextract file-rename ]; }
+    ../build-support/setup-hooks/gog-unpack.sh;
+
   buildEnv = callPackage ../build-support/buildenv { }; # not actually a package
 
   buildFHSUserEnv = callPackage ../build-support/build-fhs-userenv { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18285,9 +18285,17 @@ with pkgs;
     physfs = physfs_2;
   };
 
+  # these are here for compatibility
   d1x_rebirth = dxx-rebirth;
-
   d2x_rebirth = dxx-rebirth;
+
+  inherit (callPackages ../games/dxx-rebirth/assets.nix { })
+    descent1-assets
+    descent2-assets;
+
+  inherit (callPackages ../games/dxx-rebirth/full.nix { })
+    d1x-rebirth-full
+    d2x-rebirth-full;
 
   easyrpg-player = callPackage ../games/easyrpg-player { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3212,6 +3212,8 @@ with pkgs;
 
   npm2nix = nodePackages.npm2nix;
 
+  file-rename = callPackage ../tools/filesystems/file-rename { };
+
   kea = callPackage ../tools/networking/kea {
     boost = boost165;
   };
@@ -15009,7 +15011,7 @@ with pkgs;
   inherit (gnome3) evince;
   evolution_data_server = gnome3.evolution_data_server;
 
-  keepass = callPackage ../applications/misc/keepass { 
+  keepass = callPackage ../applications/misc/keepass {
     buildDotnetPackage = buildDotnetPackage.override { mono = mono54; };
   };
 


### PR DESCRIPTION
###### Motivation for this change

This contains a few items:

1. Package the Perl "File-Rename" utility for downcasing all the file names
2. A hook for GOG games that unpacks and downcases
3. A set of asset derivations
4. Launchers

A couple of questions:

a. Should the "downcase the file names" logic be separated out into its own build-support tool?
b. Any better suggestions than adding "-full" for the combined assets/binary derivation?

Cc: @viric 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

