### PR TITLE
Add autoStart option for Kafka and Zookeeper services

### DIFF
--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -54,13 +54,13 @@ in {
       default = [ "/tmp/kafka-logs" ];
       type = types.listOf types.path;
     };
-    
+
     zookeeper = mkOption {
       description = "Zookeeper connection string";
       default = "localhost:2181";
       type = types.string;
     };
- 
+
     extraProperties = mkOption {
       description = "Extra properties for server.properties.";
       type = types.nullOr types.lines;
@@ -79,8 +79,8 @@ in {
     log4jProperties = mkOption {
       description = "Kafka log4j property configuration.";
       default = ''
-        log4j.rootLogger=INFO, stdout 
-        
+        log4j.rootLogger=INFO, stdout
+
         log4j.appender.stdout=org.apache.log4j.ConsoleAppender
         log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
         log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
@@ -118,6 +118,11 @@ in {
       type = types.package;
     };
 
+    autoStart = mkOption {
+      default = true;
+      type = types.bool;
+      description = "Whether the Kafka service should be started automatically.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -133,7 +138,7 @@ in {
 
     systemd.services.apache-kafka = {
       description = "Apache Kafka Daemon";
-      wantedBy = [ "multi-user.target" ];
+      wantedBy = optional cfg.autoStart "multi-user.target";
       after = [ "network.target" ];
       serviceConfig = {
         ExecStart = ''

--- a/nixos/modules/services/misc/zookeeper.nix
+++ b/nixos/modules/services/misc/zookeeper.nix
@@ -106,13 +106,19 @@ in {
       '';
     };
 
+    autoStart = mkOption {
+      default = true;
+      type = types.bool;
+      description = "Whether the Zookeeper service should be started automatically.";
+    };
+
   };
 
 
   config = mkIf cfg.enable {
     systemd.services.zookeeper = {
       description = "Zookeeper Daemon";
-      wantedBy = [ "multi-user.target" ];
+      wantedBy = optional cfg.autoStart "multi-user.target";
       after = [ "network.target" ];
       environment = { ZOOCFGDIR = configDir; };
       serviceConfig = {


### PR DESCRIPTION
###### Motivation for this change

I prefer to define them in my configuration, but not have them started automatically.  I took the approach from the openvpn service and added options to disable auto start.

I tried to test this, but a 
```
nixos-rebuild switch -I nixpkgs=/my/nixpkgs
```

failed with:

```
The unique option `powerManagement.cpuFreqGovernor' is defined multiple times, in `/etc/nixos/hardware-configuration.nix' and `/my/nixpkgs/nixos/modules/config/power-management.nix'.       
```

**So please take a careful look** (See comment, was able to test)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

