### PR TITLE
electron: 1.7.9 -> 1.7.11

### DIFF
--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, libXScrnSaver, makeWrapper, fetchurl, unzip, atomEnv }:
 
 let
-  version = "1.7.9";
+  version = "1.7.11";
   name = "electron-${version}";
 
   throwSystem = throw "Unsupported system: ${stdenv.system}";
@@ -20,15 +20,15 @@ let
     src = {
       i686-linux = fetchurl {
         url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-ia32.zip";
-        sha256 = "0m87n7hqimg93z3m8pa1ggs69f3h5mjrsrrl7x80hxmp3w142krc";
+        sha256 = "0mxrayczs6fc2a53fzfbgs88l71wm7hadq9ir510kicakblmdbyx";
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
-        sha256 = "17ii0x6326mwjd0x5dj2693r67y0jra88hkqcpddcq08vf1knr2f";
+        sha256 = "0v22xhzbq9lcbc83laqs45pbx8gzv648qfkj01pxfsmv3lb4myrl";
       };
       armv7l-linux = fetchurl {
         url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-armv7l.zip";
-        sha256 = "17jkma50d6az8dbyrym8z2lsw2n0r6jhdlm8pb5c928bzgshryqm";
+        sha256 = "02n2y69zwzacigqp6f4vg47cmjzf8gvbbispmzkg3pnzk4qc9473";
       };
     }.${stdenv.system} or throwSystem;
 
@@ -56,7 +56,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-darwin-x64.zip";
-      sha256 = "1s8kslp101xyaffb3rf8p5cw3p6zij2mn19fa68ykx4naykkwaly";
+      sha256 = "19kfb09ap780ayk7miqfr6gmba9rd10f9q9aphj35yk7cl22znbr";
     };
 
     buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

Upstream releases:
https://github.com/electron/electron/releases/tag/v1.7.10
https://github.com/electron/electron/releases/tag/v1.7.11


###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS x86_64 and i686
   - [ ] macOS
   - [ ] arm
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` --- tested one dependent app: `marp`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
