### PR TITLE
electron: 1.7.5 -> 1.7.11

### DIFF
--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, libXScrnSaver, makeWrapper, fetchurl, unzip, atomEnv }:
 
 let
-  version = "1.7.5";
+  version = "1.7.11";
   name = "electron-${version}";
 
   meta = with stdenv.lib; {
@@ -17,7 +17,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
-      sha256 = "1z1dzk6d2mfyms8lj8g6jn76m52izbd1d7c05k8h88m1syfsgav5";
+      sha256 = "0v22xhzbq9lcbc83laqs45pbx8gzv648qfkj01pxfsmv3lb4myrl";
       name = "${name}.zip";
     };
 
@@ -45,7 +45,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-darwin-x64.zip";
-      sha256 = "1d3c3y5j99wbyxlzk1nkry0m1xgxy3mi4a6irvlgyxl729dnwi97";
+      sha256 = "19kfb09ap780ayk7miqfr6gmba9rd10f9q9aphj35yk7cl22znbr";
       name = "${name}.zip";
     };
 


### PR DESCRIPTION
###### Motivation for this change

Same version as #34618, for release branch.

https://github.com/electron/electron/releases/tag/v1.7.6
https://github.com/electron/electron/releases/tag/v1.7.7
https://github.com/electron/electron/releases/tag/v1.7.8
https://github.com/electron/electron/releases/tag/v1.7.9
https://github.com/electron/electron/releases/tag/v1.7.10
https://github.com/electron/electron/releases/tag/v1.7.11

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
