### PR TITLE
wireguard: 0.0.20180118 -> 0.0.20180202

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -6,11 +6,11 @@ assert kernel != null -> stdenv.lib.versionAtLeast kernel.version "3.10";
 let
   name = "wireguard-${version}";
 
-  version = "0.0.20180118";
+  version = "0.0.20180202";
 
   src = fetchurl {
     url    = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "18x8ndnr4lvl3in5sian6f9q69pk8h4xbwldmk7bfrpb5m03ngs6";
+    sha256 = "ee3415b482265ad9e8721aa746aaffdf311058a2d1a4d80e7b6d11bbbf71c722";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Simple version bump.

```
  * curve25519-fiat32: uninline certain functions
  
  This results in much smaller code size and significanat speed gains on smaller
  hardware.
  
  * poly1305: add poly-specific self-tests
  
  Poly is easy to get wrong, so we've added quite a few tests that examine
  certain edge cases and places where other implementations of historically
  failed.
  
  * tools: dedup secret normalization
  * tools: share curve25519 implementations with kernel
  * contrib: keygen-html: share curve25519 implementation with kernel
  
  There is now only one place where we ship 25519 code.
  
  * qemu: disable PIE for compilation
  * qemu: disable AVX-512 in userland
  * qemu: update base versions
  
  Test suite enhancements.
  
  * device: let udev know what kind of device we are
  
  This enables folks to query the device type via udev, which is what systemd's
  networkctl uses.
  
  * tools: fread doesn't change errno
  
  This fixes clearing pre-shared keys on old glibc.
  
  * chacha20poly1305: use existing rol32 function
  * chacha20poly1305: better buffer alignment
  
  Small enhancements.
  
  * curve25519: verify that specialized basepoint implementations are correct
  
  Since some implementations have a specialized function for computing
  basepoints, it's important to do some basic sanity checking with them.
  
  * curve25519: replace hacl64 with fiat64
  
  For about 24 hours, fiat64 was faster.
  
  * curve25519: replace fiat64 with faster hacl64
  
  Then hacl64 caught up, so we moved back to it.
  
  * curve25519: break more things with more test cases
  
  These extra test cases help break the current "rfc7748_precomputed"
  implementation, which we're not using here at the moment, but it is still
  useful to ensure that we don't fall victim to the same bugs.
```