### PR TITLE
sage: fix non-deterministic build failures

### DIFF
--- a/pkgs/applications/science/math/sage/spkg-giac.patch
+++ b/pkgs/applications/science/math/sage/spkg-giac.patch
@@ -1,10 +1,19 @@
---- old/build/pkgs/giac/spkg-install	2017-07-21 14:10:00.000000000 -0500
-+++ new/build/pkgs/giac/spkg-install	2017-10-15 15:55:55.321237645 -0500
-@@ -4,6 +4,8 @@
+diff --git a/build/pkgs/giac/spkg-install b/build/pkgs/giac/spkg-install
+index bdd8df6cb8..3fd7a3ef8a 100644
+--- a/build/pkgs/giac/spkg-install
++++ b/build/pkgs/giac/spkg-install
+@@ -2,6 +2,15 @@
  ## Giac
  ###########################################
  
-+find . -type f -exec sed -e 's@/bin/cp@cp@g' -i '{}' ';' && echo "Patching input parser" && find . -iname 'input_parser.cc'
++# Fix hardcoded paths, while making sure to only update timestamps of actually
++# changed files (otherwise confuses make)
++grep -rlF '/bin/cp' . | while read file
++do
++	sed -e 's@/bin/cp@cp@g' -i "$file"
++done
++
++# Fix input parser syntax
 +sed -e 's@yylex (&yylval)@yylex (\&yyval, scanner)@gp' -i 'src/src/input_parser.cc'
  
  if [ "$SAGE_LOCAL" = "" ]; then

--- a/pkgs/applications/science/math/sage/spkg-git.patch
+++ b/pkgs/applications/science/math/sage/spkg-git.patch
@@ -1,12 +1,17 @@
 diff --git a/build/pkgs/git/spkg-install b/build/pkgs/git/spkg-install
-index 8469cb58c2..d0dc9a1db9 100755
+index 87874de3d8..b0906245fa 100644
 --- a/build/pkgs/git/spkg-install
 +++ b/build/pkgs/git/spkg-install
-@@ -35,6 +35,8 @@ fi
+@@ -33,6 +33,13 @@ fi
  
  cd src
  
-+find . -type f -exec sed -e 's@/usr/bin/perl@perl@g' -i '{}' ';'
++# Fix hardcoded paths, while making sure to only update timestamps of actually
++# changed files (otherwise confuses make)
++grep -rlF '/usr/bin/perl' . | while read file
++do
++	sed -e 's@/usr/bin/perl@perl@g' -i "$file"
++done
 +
  # We don't want to think about Fink or Macports
  export NO_FINK=1

--- a/pkgs/applications/science/math/sage/spkg-singular.patch
+++ b/pkgs/applications/science/math/sage/spkg-singular.patch
@@ -1,11 +1,17 @@
---- old/build/pkgs/singular/spkg-install	2017-10-15 10:35:41.826540964 -0500
-+++ new/build/pkgs/singular/spkg-install	2017-10-15 10:36:40.613743443 -0500
-@@ -4,6 +4,9 @@
+diff --git a/build/pkgs/singular/spkg-install b/build/pkgs/singular/spkg-install
+index 8caafb1699..3c34e6608a 100644
+--- a/build/pkgs/singular/spkg-install
++++ b/build/pkgs/singular/spkg-install
+@@ -2,6 +2,13 @@
  ## Singular
  ###########################################
  
-+find . -type f -exec sed -e 's@/bin/rm@rm@g' -i '{}' ';'
-+#echo '#!/usr/bin/env bash\nIgnoring missing $1' > src/build-aux/missing
++# Fix hardcoded paths, while making sure to only update timestamps of actually
++# changed files (otherwise confuses make)
++grep -rlF '/bin/rm' . | while read file
++do
++	sed -e 's@/bin/rm@rm@g' -i "$file"
++done
 +
  if [ -z "$SAGE_LOCAL" ]; then
      echo >&2 "Error: SAGE_LOCAL undefined -- exiting..."


### PR DESCRIPTION
The build was failing on some machines because of a `find` command that
touched files in different orders on different machines.

That confused `make`s timestamp mechanism.

###### Motivation for this change

sage didn't build on some computers, including hydra.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (at least `/bin/sage`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

