### PR TITLE
Wrapped ${mailbox.name} in "s to allow for space in mailbox names.

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -104,7 +104,7 @@ let
   };
 
   mailboxConfig = mailbox: ''
-    mailbox ${mailbox.name} {
+    mailbox "${mailbox.name}" {
       auto = ${toString mailbox.auto}
   '' + optionalString (mailbox.specialUse != null) ''
       special_use = \${toString mailbox.specialUse}


### PR DESCRIPTION
###### Motivation for this change

Without this fix the following nix expression:

```
{
  name = "Trashy McTrashface";
  auto = "subscribe";
  specialUse = "Trash";
}
```

becomes

```
mailbox Trashy McTrashface {
  auto = subscribe
  special_use = \Trash
}
```

but it should be

```
mailbox "Trashy McTrashface" {
  auto = subscribe
  special_use = \Trash
}
```

or else dovecot2 won't start

`Feb 05 16:00:28 nixos dovecot2-pre-start[20738]: doveconf: Fatal: Error in configuration file /etc/dovecot/dovecot.conf line 36: Expecting '{'`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

