### PR TITLE
grv: pass in version, fix "grv -version" to at least include that

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/grv/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/grv/default.nix
@@ -19,6 +19,8 @@ buildGoPackage {
     sha256 = "0q9gvxfw48d4kjpb2jx7lg577vazjg0n961y6ija5saja5n16mk2";
   };
 
+  buildFlagsArray = [ "-ldflags=" "-X main.version=${version}" ];
+
   meta = with stdenv.lib; {
     description = " GRV is a terminal interface for viewing git repositories";
     homepage = https://github.com/rgburke/grv;


### PR DESCRIPTION
Currently:
$ grv -version
GRV - Git Repository Viewer Unknown (commit: Unknown, compiled: Unknown)

After:
$ grv -version
GRV - Git Repository Viewer 0.1.1 (commit: Unknown, compiled: Unknown)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---