### PR TITLE
hcloud: init at 1.3.0

### DIFF
--- a/pkgs/development/tools/hcloud/default.nix
+++ b/pkgs/development/tools/hcloud/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "hcloud-${version}";
+  version = "1.3.0";
+  goPackagePath = "github.com/hetznercloud/cli";
+
+  src = fetchFromGitHub {
+    owner = "hetznercloud";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "1216qz1kk38vkvfrznjwb65vsbhscqvvrsbp2i6pnf0i85p00pqm";
+  };
+
+  buildFlagsArray = [ "-ldflags=" "-X github.com/hetznercloud/cli.Version=${version}" ];
+
+  meta = {
+    description = "A command-line interface for Hetzner Cloud, a provider for cloud virtual private servers";
+    homepage = https://github.com/hetznercloud/cli;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.zauberpony ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7603,6 +7603,8 @@ with pkgs;
     guile = guile_2_0;
   };
 
+  hcloud = callPackage ../development/tools/hcloud { };
+
   help2man = callPackage ../development/tools/misc/help2man {
     inherit (perlPackages) LocaleGettext;
   };


### PR DESCRIPTION
###### Motivation for this change

This PR adds hcloud, a command-line interface for interacting with Hetzner Cloud. Comparable to other tools like doctl (for DigitalOcean), vultr (for vultr) etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

