### PR TITLE
graphviz: Explicitly specify libltdl directories

### DIFF
--- a/pkgs/tools/graphics/graphviz/base.nix
+++ b/pkgs/tools/graphics/graphviz/base.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation rec {
   CPPFLAGS = stdenv.lib.optionalString (xorg != null && stdenv.isDarwin)
     "-I${cairo.dev}/include/cairo";
 
-  configureFlags = optional (xorg == null) "--without-x";
+  configureFlags = [
+    "--with-ltdl-lib=${libtool.lib}/lib"
+    "--with-ltdl-include=${libtool}/include"
+  ] ++ stdenv.lib.optional (xorg == null) [ "--without-x" ];
 
   postPatch = ''
     for f in $(find . -name Makefile.in); do


### PR DESCRIPTION
###### Motivation for this change
When building graphviz on non-NixOS systems without chroot, the autotools-build picks up the library "/usr/lib/libltdl.so" instead of the one provided by nix. Explicitly specifying the library fixes the impurity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

