### PR TITLE
pythonnet: Init at 2.3.0

### DIFF
--- a/pkgs/development/python-modules/pythonnet/default.nix
+++ b/pkgs/development/python-modules/pythonnet/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, fetchPypi
+, fetchNuGet
+, buildPythonPackage
+, python
+, pytest
+, pycparser
+, pkgconfig
+, dotnetbuildhelpers
+, clang
+, mono
+}:
+
+let
+
+  UnmanagedExports127 = fetchNuGet {
+    baseName = "UnmanagedExports";
+    version = "1.2.7";
+    sha256 = "0bfrhpmq556p0swd9ssapw4f2aafmgp930jgf00sy89hzg2bfijf";
+    outputFiles = [ "*" ];
+  };
+
+  NUnit360 = fetchNuGet {
+    baseName = "NUnit";
+    version = "3.6.0";
+    sha256 = "0wz4sb0hxlajdr09r22kcy9ya79lka71w0k1jv5q2qj3d6g2frz1";
+    outputFiles = [ "*" ];
+  };
+
+in
+
+buildPythonPackage rec {
+  pname = "pythonnet";
+  version = "2.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hxnkrfj8ark9sbamcxzd63p98vgljfvdwh79qj3ac8pqrgghq80";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace 'self._install_packages()' '#self._install_packages()'
+  '';
+
+  preConfigure = ''
+    [ -z "$dontPlacateNuget" ] && placate-nuget.sh
+    [ -z "$dontPlacatePaket" ] && placate-paket.sh
+  '';
+
+  nativeBuildInputs = [
+    pytest
+    pycparser
+
+    pkgconfig
+    dotnetbuildhelpers
+    clang
+
+    NUnit360
+    UnmanagedExports127
+  ];
+
+  buildInputs = [
+    mono
+  ];
+
+  preBuild = ''
+    rm -rf packages
+    mkdir packages
+
+    ln -s ${NUnit360}/lib/dotnet/NUnit/ packages/NUnit.3.6.0
+    ln -s ${UnmanagedExports127}/lib/dotnet/NUnit/ packages/UnmanagedExports.1.2.7
+  '';
+
+  checkPhase = ''
+    ${python.interpreter} -m pytest
+  '';
+
+  meta = with lib; {
+    description = ".Net and Mono integration for Python";
+    homepage = https://pythonnet.github.io;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14845,6 +14845,11 @@ in {
     };
   };
 
+  pythonnet = callPackage ../development/python-modules/pythonnet {
+    # `mono >= 4.6` required to prevent crashes encountered with earlier versions.
+    mono = pkgs.mono46;
+  };
+
   pytz = callPackage ../development/python-modules/pytz { };
 
   pytzdata = callPackage ../development/python-modules/pytzdata { };


### PR DESCRIPTION
###### Motivation for this change

Package for interop between CPython and mono / .NET. Was not available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

All pytest are run in checkphase and pass using both python27 and python3.

And manually:

~~~
nix-shell -p 'python3.withPackages (pp: [pp.pythonnet pp.ipython])'
ipython
import clr
clr.AddReference("System.Runtime.InteropServices")
from System.Runtime.InteropServices import GCHandle, GCHandleType
from System import Array, Byte from System import Array, Byte
cs_array = Array.CreateInstance(Byte, 1000)
handler = GCHandle.Alloc(cs_array, GCHandleType.Pinned)
~~~
