### PR TITLE
autorandr: 1.1 -> 1.4

### DIFF
--- a/pkgs/tools/misc/autorandr/default.nix
+++ b/pkgs/tools/misc/autorandr/default.nix
@@ -8,7 +8,7 @@
 let
   python = python3Packages.python;
   wrapPython = python3Packages.wrapPython;
-  version = "1.1";
+  version = "1.4";
 in
   stdenv.mkDerivation {
     name = "autorandr-${version}";
@@ -49,7 +49,7 @@ in
       owner = "phillipberndt";
       repo = "autorandr";
       rev = "${version}";
-      sha256 = "05jlzxlrdyd4j90srr71fv91c2hf32diw40n9rmybgcdvy45kygd";
+      sha256 = "08i71r221ilc8k1c59w89g3iq5m7zwhnjjzapavhqxlr8y9dcpf5";
     };
 
     meta = {


### PR DESCRIPTION
- Built successfully on NixOS
- Ran autorandr binary