### PR TITLE
R: add libcxx to default LDFLAGS and CPPFLAGS on Darwin

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, bzip2, gfortran, libX11, libXmu, libXt, libjpeg, libpng
 , libtiff, ncurses, pango, pcre, perl, readline, tcl, texLive, tk, xz, zlib
 , less, texinfo, graphviz, icu, pkgconfig, bison, imake, which, jdk, openblas
-, curl, Cocoa, Foundation, cf-private, libobjc, tzdata, fetchpatch
+, curl, Cocoa, Foundation, cf-private, libobjc, libcxx, tzdata, fetchpatch
 , withRecommendedPackages ? true
 , enableStrictBarrier ? false
 }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     pango pcre perl readline texLive xz zlib less texinfo graphviz icu
     pkgconfig bison imake which jdk openblas curl
   ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [ tcl tk ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa Foundation libobjc ];
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa Foundation libobjc libcxx ];
 
   patches = [ ./no-usr-local-search-paths.patch ];
 
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
       --without-aqua
       --disable-R-framework
       OBJC="clang"
+      CPPFLAGS="-isystem ${libcxx}/include/c++/v1"
+      LDFLAGS="-L${libcxx}/lib"
   '' + ''
     )
     echo >>etc/Renviron.in "TCLLIBPATH=${tk}/lib"


### PR DESCRIPTION
###### Motivation for this change

I am not sure this is the best solution for #34615 but it is sufficient to change LDFLAGS and CPPFLAGS in `lib/R/etc/Makeconf`:
```diff
@@ -15,7 +15,7 @@
 CC = /nix/store/cslvigh4a1656g9z9j1ndvzalx7v2s4k-clang-wrapper-4.0.1/bin/cc
 CFLAGS = -g -O2 $(LTO)
 CPICFLAGS = -fPIC
-CPPFLAGS = 
+CPPFLAGS = -isystem /nix/store/942hw6bhnppjqy7szdyfrr0fiiaj7818-libc++-4.0.1/include/c++/v1
 CXX = /nix/store/cslvigh4a1656g9z9j1ndvzalx7v2s4k-clang-wrapper-4.0.1/bin/c++ 
 CXXCPP = $(CXX) -E
 CXXFLAGS = -g -O2 $(LTO)
@@ -78,7 +78,7 @@
 ## needed by R CMD config
 LIBnn = lib
 LIBTOOL = $(SHELL) "$(R_HOME)/bin/libtool"
-LDFLAGS = 
+LDFLAGS = -L/nix/store/942hw6bhnppjqy7szdyfrr0fiiaj7818-libc++-4.0.1/lib
 LTO = 
 ## needed to build applications linking to static libR
 MAIN_LD = $(CC)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

