### PR TITLE
slic3r-prusa3d: init at 1.38.7

### DIFF
--- a/pkgs/applications/misc/slic3r-prusa3d/default.nix
+++ b/pkgs/applications/misc/slic3r-prusa3d/default.nix
@@ -1,0 +1,93 @@
+{ stdenv, fetchFromGitHub, makeWrapper, which, cmake, perl, perlPackages,
+  boost, tbb, wxGTK30, pkgconfig, gtk3, fetchurl, gtk2, bash, mesa_glu }:
+let
+  AlienWxWidgets = perlPackages.buildPerlPackage rec {
+    name = "Alien-wxWidgets-0.69";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MD/MDOOTSON/${name}.tar.gz";
+      sha256 = "075m880klf66pbcfk0la2nl60vd37jljizqndrklh5y4zvzdy1nr";
+    };
+    propagatedBuildInputs = [
+      pkgconfig perlPackages.ModulePluggable perlPackages.ModuleBuild
+      gtk2 gtk3 wxGTK30
+    ];
+  };
+
+  Wx = perlPackages.Wx.overrideAttrs (oldAttrs: {
+    propagatedBuildInputs = [
+      perlPackages.ExtUtilsXSpp
+      AlienWxWidgets
+    ];
+  });
+
+  WxGLCanvas = perlPackages.buildPerlPackage rec {
+    name = "Wx-GLCanvas-0.09";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MB/MBARBON/${name}.tar.gz";
+      sha256 = "1q4gvj4gdx4l8k4mkgiix24p9mdfy1miv7abidf0my3gy2gw5lka";
+    };
+    propagatedBuildInputs = [ Wx perlPackages.OpenGL mesa_glu ];
+    doCheck = false;
+  };
+in
+stdenv.mkDerivation rec {
+  name = "slic3r-prusa-edition-${version}";
+  version = "1.38.7";
+
+  buildInputs = [
+    cmake
+    perl
+    makeWrapper
+    tbb
+    which
+    Wx
+    WxGLCanvas
+  ] ++ (with perlPackages; [
+    boost
+    ClassXSAccessor
+    EncodeLocale
+    ExtUtilsMakeMaker
+    ExtUtilsXSpp
+    GrowlGNTP
+    ImportInto
+    IOStringy
+    locallib
+    LWP
+    MathClipper
+    MathConvexHullMonotoneChain
+    MathGeometryVoronoi
+    MathPlanePath
+    ModuleBuild
+    Moo
+    NetDBus
+    OpenGL
+    threads
+    XMLSAX
+  ]);
+
+  postInstall = ''
+    echo 'postInstall'
+    wrapProgram "$out/bin/slic3r-prusa3d" \
+    --prefix PERL5LIB : "$out/lib/slic3r-prusa3d:$PERL5LIB"
+
+    # it seems we need to copy the icons...
+    mkdir -p $out/bin/var
+    cp ../resources/icons/* $out/bin/var/
+    cp -r ../resources $out/bin/
+  '';
+
+  src = fetchFromGitHub {
+    owner = "prusa3d";
+    repo = "Slic3r";
+    sha256 = "1nrryd2bxmk4y59bq5fp7n2alyvc5a9xvnbx5j4fg4mqr91ccs5c";
+    rev = "version_${version}";
+  };
+
+  meta = with stdenv.lib; {
+    description = "G-code generator for 3D printer";
+    homepage = https://github.com/prusa3d/Slic3r;
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tweber ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17141,6 +17141,8 @@ with pkgs;
 
   slic3r = callPackage ../applications/misc/slic3r { };
 
+  slic3r-prusa3d = callPackage ../applications/misc/slic3r-prusa3d { };
+
   curaengine_stable = callPackage ../applications/misc/curaengine/stable.nix { };
   cura_stable = callPackage ../applications/misc/cura/stable.nix {
     curaengine = curaengine_stable;


### PR DESCRIPTION
###### Motivation for this change
The prusa fork brings a lot of nice improvements over the original Slic3r.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

