### PR TITLE
nmapsi4: init at 0.5-alpha1

### DIFF
--- a/pkgs/tools/security/nmap/qt.nix
+++ b/pkgs/tools/security/nmap/qt.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, cmake, pkgconfig, makeWrapper
+, dnsutils, nmap
+, qtbase, qtscript, qtwebkit }:
+
+stdenv.mkDerivation rec {
+  name = "nmapsi4-${version}";
+  version = "0.5-alpha1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/nmapsi/${name}.tar.xz";
+    sha256 = "18v9a3l2nmij3gb4flscigxr5c44nphkjfmk07qpyy73fy61mzrs";
+  };
+
+  nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
+
+  buildInputs = [ qtbase qtscript qtwebkit ];
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    for f in \
+      src/platform/digmanager.cpp \
+      src/platform/discover.cpp \
+      src/platform/monitor/monitor.cpp \
+      src/platform/nsemanager.cpp ; do
+
+      substituteInPlace $f \
+        --replace '"dig"'   '"${dnsutils}/bin/dig"'\
+        --replace '"nmap"'  '"${nmap}/bin/nmap"' \
+        --replace '"nping"' '"${nmap}/bin/nping"'
+    done
+  '';
+
+  postInstall = ''
+    mv $out/share/applications/kde4/*.desktop $out/share/applications
+    rmdir $out/share/applications/kde4
+
+    for f in $out/share/applications/* ; do
+      substituteInPlace $f \
+        --replace Qt4                   Qt5 \
+        --replace Exec=nmapsi4          Exec=$out/bin/nmapsi4 \
+        --replace "Exec=kdesu nmapsi4" "Exec=kdesu $out/bin/nmapsi4"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qt frontend for nmap";
+    homepage    = https://www.nmapsi4.org/;
+    license     = licenses.gpl2;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3769,6 +3769,8 @@ with pkgs;
     graphicalSupport = true;
   };
 
+  nmapsi4 = libsForQt5.callPackage ../tools/security/nmap/qt.nix { };
+
   nnn = callPackage ../applications/misc/nnn { };
 
   notary = callPackage ../tools/security/notary { };


### PR DESCRIPTION
###### Motivation for this change

This is a WIP Qt frontend for NMAP.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

