### PR TITLE
lttng-ust: refactor

### DIFF
--- a/pkgs/development/tools/misc/lttng-ust/default.nix
+++ b/pkgs/development/tools/misc/lttng-ust/default.nix
@@ -20,11 +20,13 @@ stdenv.mkDerivation rec {
     sha256 = "1avx4p71g9m3zvynhhhysxnpkqyhhlv42xiv9502bvp3nwfkgnqs";
   };
 
-  buildInputs = [ liburcu python ];
+  buildInputs = [ python ];
 
   preConfigure = ''
     patchShebangs .
   '';
+  
+  propagatedBuildInputs = [ liburcu ];
 
   meta = with stdenv.lib; {
     description = "LTTng Userspace Tracer libraries";


### PR DESCRIPTION


###### Motivation for this change
liburcu appears in the public API of LTTNG: it should be a
propagatedBuildInputs.

This was causing a compilation error with a recent ceph build, depending on LTTNG.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

