### PR TITLE
squashfuse: init at 0.1.101

### DIFF
--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -32,9 +32,13 @@ stdenv.mkDerivation rec {
     description = "FUSE filesystem to mount squashfs archives";
     homepage = https://github.com/vasi/squashfuse;
     maintainers = [ maintainers.genesis ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux;
     license = "BSD-2-Clause";
   };
+
+  # platforms.darwin should be supported : see PLATFORMS file in src.
+  # we could use a nix fuseProvider, and let the derivation choose the OS
+  # specific implementation. 
 
 	src = fetchurl {
 	    url = "https://github.com/vasi/squashfuse/archive/${version}.tar.gz";

--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchurl, automake, autoconf, libtool, fuse, pkgconfig, pcre,
+
+# Optional Dependencies
+lz4 ? null, xz ? null, zlib ? null, lzo ? null, zstd ? null}:
+
+with stdenv.lib;
+let
+  mkFlag = trueStr: falseStr: cond: name: val: "--"
+    + (if cond then trueStr else falseStr)
+    + name
+    + optionalString (val != null && cond != false) "=${val}";
+  mkEnable = mkFlag "enable-" "disable-";
+  mkWith = mkFlag "with-" "--without-";
+  mkOther = mkFlag "" "" true;
+
+  shouldUsePkg = pkg: if pkg != null && any (x: x == stdenv.system) pkg.meta.platforms then pkg else null;
+
+  optLz4 = shouldUsePkg lz4;
+  optLzma = shouldUsePkg xz;
+  optZlib = shouldUsePkg zlib;
+  optLzo = shouldUsePkg lzo;
+	optZstd = shouldUsePkg zstd;
+in
+
+stdenv.mkDerivation rec {
+
+  pname = "squashfuse";
+  version = "0.1.101";
+  name = "${pname}-${version}";
+
+  meta = {
+    description = "FUSE filesystem to mount squashfs archives";
+    homepage = https://github.com/vasi/squashfuse;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux ++ platforms.darwin;
+    license = "BSD-2-Clause";
+  };
+
+	src = fetchurl {
+	    url = "https://github.com/vasi/squashfuse/archive/${version}.tar.gz";
+	    sha256 = "08d1j1a73dhhypbk0q20qkrz564zpmvkpk3k3s8xw8gd9nvy2xa2";
+	  };
+
+  nativeBuildInputs = [ automake autoconf libtool pkgconfig];
+  buildInputs = [ optLz4 optLzma optZlib optLzo optZstd fuse ];
+
+	# We can do it far better i guess, ignoring -with option
+	# but it should be safer like that.
+	# TODO: Improve writing nix expression mkWithLib.
+  configureFlags = [
+    (mkWith (optLz4  != null) "lz4=${lz4}/lib"  null)
+    (mkWith (optLzma != null) "xz=${xz}/lib" null)
+    (mkWith (optZlib != null) "zlib=${zlib}/lib" null)
+    (mkWith (optLzo  != null) "lzo=${lzo}/lib"  null)
+		(mkWith (optZstd != null) "zstd=${zstd}/lib"  null)
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4690,6 +4690,8 @@ with pkgs;
 
   squashfsTools = callPackage ../tools/filesystems/squashfs { };
 
+  squashfuse = callPackage ../tools/filesystems/squashfuse { };
+
   srcml = callPackage ../applications/version-management/srcml { };
 
   sshfs-fuse = callPackage ../tools/filesystems/sshfs-fuse { };


### PR DESCRIPTION
###### Motivation for this change

new package, latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

