### PR TITLE
archivemount: 0.8.3 -> 0.8.7

### DIFF
--- a/pkgs/tools/filesystems/archivemount/default.nix
+++ b/pkgs/tools/filesystems/archivemount/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, pkgconfig, fuse, libarchive }:
 
 let
-  name = "archivemount-0.8.3";
+  name = "archivemount-0.8.7";
 in
 stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
     url = "http://www.cybernoia.de/software/archivemount/${name}.tar.gz";
-    sha256 = "1zv1fvik76kpp1q5f2dz01f4fwg1m5a8rl168px47jy9nyl9k277";
+    sha256 = "1diiw6pnlnrnikn6l5ld92dx59lhrxjlqms8885vwbynsjl5q127";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
- [x] built on NixOS
- [x] ran binary on NixOS (version output matches 0.8.7)