### PR TITLE
buildLinux: add overrides for modules

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -1,12 +1,10 @@
-{ buildPackages, runCommand, nettools, bc, bison, flex, perl, gmp, libmpc, mpfr, openssl
+{ buildPackages
 , ncurses
-, libelf
-, utillinux
-, writeTextFile, ubootTools
 , callPackage
-}:
-
-{ stdenv, buildPackages, perl, buildLinux
+, perl
+, bison ? null
+, flex ? null
+, stdenv
 
 , # The kernel source tarball.
   src

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13445,7 +13445,7 @@ with pkgs;
 
   # A function to build a manually-configured kernel
   linuxManualConfig = makeOverridable (callPackage ../os-specific/linux/kernel/manual-config.nix {});
-  buildLinux = makeOverridable (callPackage ../os-specific/linux/kernel/generic.nix {});
+  buildLinux = attrs: callPackage ../os-specific/linux/kernel/generic.nix attrs;
 
   keyutils = callPackage ../os-specific/linux/keyutils { };
 


### PR DESCRIPTION
Follow up PR of https://github.com/NixOS/nixpkgs/pull/34351

- Easy override of autoModules and preferBuiltin parameters (currently living in `hostSystem` set).

###### Motivation for this change
Make it easier to configure the kernel (overriding platforms is 'hard').
One question in the previous PR was should we delete kernelAutoModules/kernelPreferBuiltin from the hostPlatform.platform.* ?
Some platforms may prefer to have builtin modules because crosscompiling is faster and having to install modules separataly would be a pain so it might make sense. Not too sure though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

