### PR TITLE
diff-pdf: init at 2017-12-30.

### DIFF
--- a/pkgs/applications/misc/diff-pdf/default.nix
+++ b/pkgs/applications/misc/diff-pdf/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig, cairo, poppler, wxGTK }:
+
+stdenv.mkDerivation rec {
+  name = "diff-pdf-${version}";
+  version = "2017-12-30";
+
+  src = fetchFromGitHub {
+    owner = "vslavik";
+    repo = "diff-pdf";
+    rev = "c4d67226ec4c29b30a7399e75f80636ff8a6f9fc";
+    sha256 = "1c3ig7ckrg37p5vzvgjnsfdzdad328wwsx0r31lbs1d8pkjkgq3m";
+  };
+
+  nativeBuildInputs = [ autoconf automake pkgconfig ];
+  buildInputs = [ cairo poppler wxGTK ];
+
+  preConfigure = "./bootstrap";
+
+  meta = with stdenv.lib; {
+    homepage = http://vslavik.github.io/diff-pdf;
+    description = "Simple tool for visually comparing two PDF files";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/applications/misc/diff-pdf/default.nix
+++ b/pkgs/applications/misc/diff-pdf/default.nix
@@ -1,5 +1,12 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig, cairo, poppler, wxGTK }:
+{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig, cairo, poppler, wxGTK ? null, wxmac ? null, darwin ? null }:
 
+let
+  wxInputs =
+    if stdenv.isDarwin then
+      [ wxmac darwin.apple_sdk.frameworks.Cocoa ]
+    else
+      [ wxGTK ];
+in
 stdenv.mkDerivation rec {
   name = "diff-pdf-${version}";
   version = "2017-12-30";
@@ -12,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoconf automake pkgconfig ];
-  buildInputs = [ cairo poppler wxGTK ];
+  buildInputs = [ cairo poppler ] ++ wxInputs;
 
   preConfigure = "./bootstrap";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16444,6 +16444,8 @@ with pkgs;
 
   diffpdf = callPackage ../applications/misc/diffpdf { };
 
+  diff-pdf = callPackage ../applications/misc/diff-pdf { wxGTK = wxGTK31; };
+
   mlocate = callPackage ../tools/misc/mlocate { };
 
   mypaint = callPackage ../applications/graphics/mypaint { };


### PR DESCRIPTION
Looking for alternatives to diffpdf, found this :).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---