### PR TITLE
diffpdf: move to using qt5

### DIFF
--- a/pkgs/applications/misc/diffpdf/default.nix
+++ b/pkgs/applications/misc/diffpdf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qt4, poppler_qt4, qmake4Hook }:
+{ stdenv, fetchurl, fetchpatch, qmake, qttools, qtbase, poppler_qt5 }:
 
 stdenv.mkDerivation rec {
   version = "2.1.3";
@@ -9,13 +9,19 @@ stdenv.mkDerivation rec {
     sha256 = "0cr468fi0d512jjj23r5flfzx957vibc9c25gwwhi0d773h2w566";
   };
 
-  patches = [ ./fix_path_poppler_qt4.patch ];
+  patches = [
+    (fetchpatch {
+      url = https://raw.githubusercontent.com/gentoo/gentoo/9b971631588ff46e7c2d501bc35cd0d9ce2d98e2/app-text/diffpdf/files/diffpdf-2.1.3-qt5.patch;
+      sha256 = "0sax8gcqcmzf74hmdr3rarqs4nsxmml9qmh6pqyjmgl3lypxhafg";
+    })
+    ./fix_path_poppler_qt5.patch
+  ];
 
-  buildInputs = [ qt4 poppler_qt4 ];
-  nativeBuildInputs = [ qmake4Hook ];
+  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtbase poppler_qt5 ];
 
   preConfigure = ''
-    substituteInPlace diffpdf.pro --replace @@NIX_POPPLER_QT4@@ ${poppler_qt4.dev}
+    substituteInPlace diffpdf.pro --replace @@NIX_POPPLER_QT5@@ ${poppler_qt5.dev}
     lrelease diffpdf.pro
   '';
 

--- a/pkgs/applications/misc/diffpdf/fix_path_poppler_qt5.patch
+++ b/pkgs/applications/misc/diffpdf/fix_path_poppler_qt5.patch
@@ -2,15 +2,15 @@ diff -uNr diffpdf-2.1.3/diffpdf.pro diffpdf-2.1.3-new/diffpdf.pro
 --- diffpdf-2.1.3/diffpdf.pro	2013-10-15 09:01:22.000000000 +0200
 +++ diffpdf-2.1.3-new/diffpdf.pro	2015-07-07 23:13:36.445572148 +0200
 @@ -47,9 +47,9 @@
- 	INCLUDEPATH += /c/poppler_lib/include/poppler/qt4
+ 	INCLUDEPATH += /c/poppler_lib/include/poppler/qt5
  	LIBS += -Wl,-rpath -Wl,/c/poppler_lib/bin -Wl,-L/c/poppler_lib/bin
      } else {
--	exists(/usr/include/poppler/qt4) {
+-	exists(/usr/include/poppler/qt5) {
 -	    INCLUDEPATH += /usr/include/poppler/cpp
--	    INCLUDEPATH += /usr/include/poppler/qt4
-+	exists(@@NIX_POPPLER_QT4@@/include/poppler/qt4) {
-+	    INCLUDEPATH += @@NIX_POPPLER_QT4@@/include/poppler/cpp
-+	    INCLUDEPATH += @@NIX_POPPLER_QT4@@/include/poppler/qt4
+-	    INCLUDEPATH += /usr/include/poppler/qt5
++	exists(@@NIX_POPPLER_QT5@@/include/poppler/qt5) {
++	    INCLUDEPATH += @@NIX_POPPLER_QT5@@/include/poppler/cpp
++	    INCLUDEPATH += @@NIX_POPPLER_QT5@@/include/poppler/qt5
  	} else {
  	    INCLUDEPATH += /usr/local/include/poppler/cpp
- 	    INCLUDEPATH += /usr/local/include/poppler/qt4
+ 	    INCLUDEPATH += /usr/local/include/poppler/qt5

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16442,7 +16442,7 @@ with pkgs;
 
   mupdf = callPackage ../applications/misc/mupdf { };
 
-  diffpdf = callPackage ../applications/misc/diffpdf { };
+  diffpdf = libsForQt5.callPackage ../applications/misc/diffpdf { };
 
   mlocate = callPackage ../tools/misc/mlocate { };
 


### PR DESCRIPTION
General preference for using qt5 in nixpkgs.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Patch is used by Gentoo, Debian, etc.