### PR TITLE
busybox-sandbox-shell: extract basic shell to new attribute

### DIFF
--- a/pkgs/os-specific/linux/busybox/sandbox-shell.nix
+++ b/pkgs/os-specific/linux/busybox/sandbox-shell.nix
@@ -1,0 +1,26 @@
+{ busybox }:
+
+# Minimal shell for use as basic /bin/sh in sandbox builds
+busybox.override {
+  useMusl = true;
+  enableStatic = true;
+  enableMinimal = true;
+  extraConfig = ''
+    CONFIG_FEATURE_FANCY_ECHO y
+    CONFIG_FEATURE_SH_MATH y
+    CONFIG_FEATURE_SH_MATH_64 y
+
+    CONFIG_ASH y
+    CONFIG_ASH_OPTIMIZE_FOR_SIZE y
+
+    CONFIG_ASH_ALIAS y
+    CONFIG_ASH_BASH_COMPAT y
+    CONFIG_ASH_CMDCMD y
+    CONFIG_ASH_ECHO y
+    CONFIG_ASH_GETOPTS y
+    CONFIG_ASH_INTERNAL_GLOB y
+    CONFIG_ASH_JOB_CONTROL y
+    CONFIG_ASH_PRINTF y
+    CONFIG_ASH_TEST y
+  '';
+}

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchFromGitHub, perl, curl, bzip2, sqlite, openssl ? null, xz
 , pkgconfig, boehmgc, perlPackages, libsodium, aws-sdk-cpp, brotli
 , autoreconfHook, autoconf-archive, bison, flex, libxml2, libxslt, docbook5, docbook5_xsl
-, libseccomp, busybox
+, libseccomp, busybox-sandbox-shell
 , hostPlatform
 , storeDir ? "/nix/store"
 , stateDir ? "/nix/var"
@@ -10,29 +10,7 @@
 
 let
 
-  sh = busybox.override {
-    useMusl = true;
-    enableStatic = true;
-    enableMinimal = true;
-    extraConfig = ''
-      CONFIG_FEATURE_FANCY_ECHO y
-      CONFIG_FEATURE_SH_MATH y
-      CONFIG_FEATURE_SH_MATH_64 y
-
-      CONFIG_ASH y
-      CONFIG_ASH_OPTIMIZE_FOR_SIZE y
-
-      CONFIG_ASH_ALIAS y
-      CONFIG_ASH_BASH_COMPAT y
-      CONFIG_ASH_CMDCMD y
-      CONFIG_ASH_ECHO y
-      CONFIG_ASH_GETOPTS y
-      CONFIG_ASH_INTERNAL_GLOB y
-      CONFIG_ASH_JOB_CONTROL y
-      CONFIG_ASH_PRINTF y
-      CONFIG_ASH_TEST y
-    '';
-  };
+  sh = busybox-sandbox-shell;
 
   common = { name, suffix ? "", src, fromGit ? false }: stdenv.mkDerivation rec {
     inherit name src;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12593,6 +12593,7 @@ with pkgs;
   bridge-utils = callPackage ../os-specific/linux/bridge-utils { };
 
   busybox = callPackage ../os-specific/linux/busybox { };
+  busybox-sandbox-shell = callPackage ../os-specific/linux/busybox/sandbox-shell.nix { };
 
   cachefilesd = callPackage ../os-specific/linux/cachefilesd { };
 


### PR DESCRIPTION
Nix will use this shell if the attribute is present,
avoiding duplicating changes in the future.

###### Motivation for this change

See https://github.com/NixOS/nix/pull/1843 .

Refactoring only, doesn't (shouldn't!) change hashes of anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

