### PR TITLE
pythonPackages.pytest-cram: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/pytest-cram/default.nix
+++ b/pkgs/development/python-modules/pytest-cram/default.nix
@@ -1,8 +1,7 @@
 {lib, buildPythonPackage, fetchPypi, pytest, cram, bash, writeText}:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
-  version = "0.1.1";
+  version = "0.2.0";
   pname = "pytest-cram";
 
   buildInputs = [ pytest ];
@@ -10,7 +9,8 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ad05999iqzyjay9y5lc0cnd3jv8qxqlzsvxzp76shslmhrv0c4f";
+    sha256 = "006p5dr3q794sbwwmxmdls3nwq0fvnyrxxmc03pgq8n74chl71qn";
+    extension = "zip";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

This fixes pytest-cram after the recent pytest upgrading broke it.

I ran `nox-review` but the problem is that some packages that depend on this package are still broken because of other reasons (probably pytest upgrade). I did manage to build this package with `nix-shell -p pythonPackages.pytest-cram`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

