### PR TITLE
bfg-repo-cleaner: 1.12.15 -> 1.13.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, jre, makeWrapper }:
 
 let
-  version = "1.12.15";
+  version = "1.13.0";
   jarName = "bfg-${version}.jar";
   mavenUrl = "http://central.maven.org/maven2/com/madgag/bfg/${version}/${jarName}";
 in
@@ -12,7 +12,7 @@ in
 
     src = fetchurl {
       url = mavenUrl;
-      sha256 = "17dh25jambkk55khknlhy8wa9s1i1xmh9hdgj72j1lzyl0ag42ik";
+      sha256 = "1kn84rsvms1v5l1j2xgrk7dc7mnsmxkc6sqd94mnim22vnwvl8mz";
     };
 
     buildInputs = [ jre makeWrapper ];


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---