### PR TITLE
postman: init at 5.5.2

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -482,6 +482,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "PostgreSQL License";
   };
 
+  postman = {
+    fullName = "Postman EULA";
+    url = https://www.getpostman.com/licenses/postman_base_app;
+    free = false;
+  };
+
   psfl = spdx {
     spdxId = "Python-2.0";
     fullName = "Python Software Foundation License version 2";

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, lib, gnome2, fetchurl, pkgs, xlibs, udev, makeWrapper, makeDesktopItem }:
+
+stdenv.mkDerivation rec {
+  name = "postman-${version}";
+  version = "5.5.2";
+
+  src = fetchurl {
+    url = "https://dl.pstmn.io/download/version/${version}/linux64";
+    sha1 = "68886197A8375E860AB880547838FEFC9E12FC64";
+    name = "${name}.tar.gz";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontPatchELF = true;
+
+  buildPhase = ":";   # nothing to build
+
+  desktopItem = makeDesktopItem {
+    name = "postman";
+    exec = "postman";
+    icon = "$out/share/postman/resources/app/assets/icon.png";
+    comment = "API Development Environment";
+    desktopName = "Postman";
+    genericName = "Postman";
+    categories = "Application;Development;";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/postman
+    mkdir -p $out/share/applications
+    cp -R * $out/share/postman
+    mkdir -p $out/bin
+    ln -s $out/share/postman/Postman $out/bin/postman
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+  '';
+
+  preFixup = let
+    libPath = lib.makeLibraryPath [
+      stdenv.cc.cc.lib
+      gnome2.pango
+      gnome2.GConf
+      pkgs.atk
+      pkgs.alsaLib
+      pkgs.cairo
+      pkgs.cups
+      pkgs.dbus_daemon.lib
+      pkgs.expat
+      pkgs.gdk_pixbuf
+      pkgs.glib
+      pkgs.gtk2-x11
+      pkgs.freetype
+      pkgs.fontconfig
+      pkgs.nss
+      pkgs.nspr
+      pkgs.udev.lib
+      xlibs.libX11
+      xlibs.libxcb
+      xlibs.libXi
+      xlibs.libXcursor
+      xlibs.libXdamage
+      xlibs.libXrandr
+      xlibs.libXcomposite
+      xlibs.libXext
+      xlibs.libXfixes
+      xlibs.libXrender
+      xlibs.libX11
+      xlibs.libXtst
+      xlibs.libXScrnSaver
+    ];
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}:$out/share/postman" \
+      $out/share/postman/Postman
+    patchelf --set-rpath "${libPath}" $out/share/postman/libnode.so
+    patchelf --set-rpath "${libPath}" $out/share/postman/libffmpeg.so
+
+    wrapProgram $out/share/postman/Postman --prefix LD_LIBRARY_PATH : ${libPath}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.getpostman.com;
+    description = "API Development Environment";
+    license = stdenv.lib.licenses.postman;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ xurei ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7835,6 +7835,8 @@ with pkgs;
 
   postiats-utilities = callPackage ../development/tools/postiats-utilities {};
 
+  postman = callPackage ../development/web/postman {};
+
   pprof = callPackage ../development/tools/profiling/pprof { };
 
   pyprof2calltree = pythonPackages.callPackage ../development/tools/profiling/pyprof2calltree { };


### PR DESCRIPTION
###### Motivation for this change
New package, latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

