### PR TITLE
ghc841:  bump to alpha3

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -24,7 +24,7 @@
   # platform). Static libs are always built.
   enableShared ? true
 
-, version ? "8.4.20180122"
+, version ? "8.4.0.20180204"
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -73,8 +73,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "git://git.haskell.org/ghc.git";
-    rev = "61db0b8941cfb7ed8941ed29bdb04bd8ef3b71a5";
-    sha256 = "15sbpgkal4854jc1xn3sprvpnxwdj0fyy43y5am0h9vja3pjhjyi";
+    rev = "111737cd218751f06ea58d3cf2c7c144265b5dfc";
+    sha256 = "0ksp0k3sp928aq2cv6whgbfmjnr7l2j10diha13nncksp4byf0s9";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Update GHC 8.4 to alpha3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

