### PR TITLE
libinput-gestures: init at 2.32

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -691,6 +691,7 @@
   TealG = "Teal Gaure <~@Teal.Gr>";
   teh = "Tom Hunger <tehunger@gmail.com>";
   telotortium = "Robert Irelan <rirelan@gmail.com>";
+  teozkr = "Teo Klestrup Röijezon <teo@nullable.se>";
   teto = "Matthieu Coudron <mcoudron@hotmail.com>";
   tex = "Milan Svoboda <milan.svoboda@centrum.cz>";
   thall = "Niclas Thall <niclas.thall@gmail.com>";

--- a/pkgs/tools/inputmethods/libinput-gestures/0001-hardcode-name.patch
+++ b/pkgs/tools/inputmethods/libinput-gestures/0001-hardcode-name.patch
@@ -1,0 +1,13 @@
+diff --git a/libinput-gestures b/libinput-gestures
+index f337ba3..fe56d66 100755
+--- a/libinput-gestures
++++ b/libinput-gestures
+@@ -6,7 +6,7 @@ from collections import OrderedDict
+ from pathlib import Path
+ from distutils.version import LooseVersion as Version
+ 
+-PROG = Path(sys.argv[0]).stem
++PROG = "libinput-gestures"
+ 
+ # Conf file containing gesture commands.
+ # Search first for user file then system file.

--- a/pkgs/tools/inputmethods/libinput-gestures/0002-paths.patch
+++ b/pkgs/tools/inputmethods/libinput-gestures/0002-paths.patch
@@ -1,0 +1,43 @@
+diff --git a/libinput-gestures b/libinput-gestures
+index f337ba3..5f5b05d 100755
+--- a/libinput-gestures
++++ b/libinput-gestures
+@@ -75,17 +75,13 @@ def get_libinput_vers():
+     'Return the libinput installed version number string'
+     # Try to use newer libinput interface then fall back to old
+     # (depreciated) interface.
+-    res = run(('libinput', '--version'), check=False)
++    res = run(('@libinput@', '--version'), check=False)
+     return res.strip() if res else run(('libinput-list-devices', '--version'))
+ 
+ # Libinput changed the way in which it's utilities are called
+ libvers = get_libinput_vers()
+-if Version(libvers) >= Version('1.8'):
+-    cmd_debug_events = 'libinput debug-events'
+-    cmd_list_devices = 'libinput list-devices'
+-else:
+-    cmd_debug_events = 'libinput-debug-events'
+-    cmd_list_devices = 'libinput-list-devices'
++cmd_debug_events = '@libinput@ debug-events'
++cmd_list_devices = '@libinput@ list-devices'
+ 
+ def get_devices_list():
+     'Get list of devices and their attributes (as a dict) from libinput'
+@@ -187,7 +183,7 @@ class COMMAND_internal(COMMAND):
+ 
+     def run(self):
+         'Get list of current workspaces and select next one'
+-        stdout = run(('wmctrl', '-d'), check=False)
++        stdout = run(('@wmctrl@', '-d'), check=False)
+         if not stdout:
+             # This command can fail on GNOME when you have only a single
+             # dynamic workspace using Xorg (probably a GNOME bug) so let's
+@@ -220,7 +216,7 @@ class COMMAND_internal(COMMAND):
+ 
+         # Switch to desired workspace
+         if index >= minindex and index < maxindex:
+-            run(('wmctrl', '-s', str(index)))
++            run(('@wmctrl@', '-s', str(index)))
+ 
+ # Table of gesture handlers
+ handlers = OrderedDict()

--- a/pkgs/tools/inputmethods/libinput-gestures/default.nix
+++ b/pkgs/tools/inputmethods/libinput-gestures/default.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper,
+  libinput, wmctrl,
+  xdotool ? null,
+  extraUtilsPath ? lib.optional (xdotool != null) xdotool
+}:
+stdenv.mkDerivation rec {
+  pname = "libinput-gestures";
+  version = "2.32";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "bulletmark";
+    repo = "libinput-gestures";
+    rev = version;
+    sha256 = "1by6sabx0s8sd9w5675gc26q7yccxnxxsjg4dqlb6nbs0vcg81s7";
+  };
+  patches = [
+    ./0001-hardcode-name.patch
+    ./0002-paths.patch
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch =
+    ''
+      substituteInPlace libinput-gestures-setup --replace /usr/ /
+
+      substituteInPlace libinput-gestures \
+        --replace      /etc     "$out/etc" \
+        --subst-var-by libinput "${libinput}/bin/libinput" \
+        --subst-var-by wmctrl   "${wmctrl}/bin/wmctrl"
+    '';
+  installPhase =
+    ''
+      runHook preInstall
+      ${stdenv.shell} libinput-gestures-setup -d "$out" install
+      runHook postInstall
+    '';
+  postFixup =
+    ''
+      rm "$out/bin/libinput-gestures-setup"
+      substituteInPlace "$out/share/applications/libinput-gestures.desktop" --replace "/usr" "$out"
+      chmod +x "$out/share/applications/libinput-gestures.desktop"
+      wrapProgram "$out/bin/libinput-gestures" --prefix PATH : "${lib.makeBinPath extraUtilsPath}"
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/bulletmark/libinput-gestures;
+    description = "Gesture mapper for libinput";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ teozkr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9929,6 +9929,8 @@ with pkgs;
     graphviz = graphviz-nox;
   };
 
+  libinput-gestures = callPackage ../tools/inputmethods/libinput-gestures {};
+
   libisofs = callPackage ../development/libraries/libisofs { };
 
   libisoburn = callPackage ../development/libraries/libisoburn { };


### PR DESCRIPTION
###### Motivation for this change

xf86-input-synaptics is unmaintained, and touchegg doesn't work with
the latest synaptics driver or libinput. Ideally DEs would implement this
themselves, but at least KDE/Plasma doesn't (yet)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

