### PR TITLE
Fix build failures with DBD-SQLite

### DIFF
--- a/pkgs/development/perl-modules/DBD-SQLite/default.nix
+++ b/pkgs/development/perl-modules/DBD-SQLite/default.nix
@@ -2,11 +2,11 @@
 
 buildPerlPackage rec {
   name = "DBD-SQLite-${version}";
-  version = "1.54";
+  version = "1.55_07";
 
   src = fetchurl {
-    url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/${name}.tar.gz";
-    sha256 = "3929a6dbd8d71630f0cb57f85dcef9588cd7ac4c9fa12db79df77b9d3a4d7269";
+    url = "https://github.com/DBD-SQLite/DBD-SQLite/archive/${version}.tar.gz";
+    sha256 = "0213a31eb7b5afc2d7b3775ca2d1717d07fc7e9ed21ae73b2513a8d54ca222d8";
   };
 
   propagatedBuildInputs = [ DBI ];
@@ -17,8 +17,7 @@ buildPerlPackage rec {
     ./external-sqlite.patch
   ];
 
-  SQLITE_INC = sqlite.dev + "/include";
-  SQLITE_LIB = sqlite.out + "/lib";
+  makeMakerFlags = "SQLITE_INC=${sqlite.dev}/include SQLITE_LIB=${sqlite.out}/lib";
 
   preBuild =
     ''


### PR DESCRIPTION
###### Motivation for this change
This passes the correct compilation flags to the builder so we pick up the path to sqlite, and (despite the fact that it's a development version), also updates to version 1.55_07 to fix https://github.com/DBD-SQLite/DBD-SQLite/issues/28.

Prior to this, we saw the following error (from the linked issue):
```
couldn't eval q{sub {my ($self, $i) = @_; my $row = $self->row($i); (defined($row->[1]) && defined($vals[0]) && $row->[1]  $vals[0])}} : syntax error at (eval 20) line 1, near "]  $vals"
```

And the error `Note (probably harmless): No library found for -lsqlite3` from MakeMaker.

**NOTE:** I still need to try a build of this on NixOS later this evening; currently, this builds on Debian 9 + nix, but I want to confirm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

