### PR TITLE
nixos/tor: add hiddenServices.<name>.authorizeClient

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -256,6 +256,10 @@ rec {
       functor = (defaultFunctor name) // { wrapped = elemType; };
     };
 
+    nonEmptyListOf = elemType: 
+      let list = addCheck (types.listOf elemType) (l: l != []);
+      in list // { description = "non-empty " + list.description; };
+
     attrsOf = elemType: mkOptionType rec {
       name = "attrsOf";
       description = "attribute set of ${elemType.description}s";


### PR DESCRIPTION
###### Motivation for this change
This is useful for restricting access to a hidden service, preventing DOS, ...
See https://tor.stackexchange.com/a/13418 for a nice explanation.
I initially discovered this over at the Home Assistant documentation: https://home-assistant.io/docs/ecosystem/tor/
The official documentation for `HiddenServiceAuthorizeClient` can be found here: https://www.torproject.org/docs/tor-manual.html.en

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) Sadly, there is no Tor test rigt now. Maybe I'll add one in the future.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

