### PR TITLE
uudeview: init at 0.5.20

### DIFF
--- a/pkgs/tools/misc/uudeview/default.nix
+++ b/pkgs/tools/misc/uudeview/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, tcl, tk }:
+
+stdenv.mkDerivation rec {
+  name = "uudeview-0.5.20";
+  src = fetchurl {
+    url = "http://www.fpx.de/fp/Software/UUDeview/download/${name}.tar.gz";
+    sha256 = "0dg4v888fxhmf51vxq1z1gd57fslsidn15jf42pj4817vw6m36p4";
+  };
+
+  buildInputs = [ tcl tk ];
+  hardeningDisable = [ "format" ];
+  configureFlags = [ "--enable-tk=${tk.dev}" "--enable-tcl=${tcl}" ];
+  postPatch = ''
+    substituteInPlace tcl/xdeview --replace "exec uuwish" "exec $out/bin/uuwish"
+  '';
+
+  meta = {
+    description = "The Nice and Friendly Decoder";
+    homepage = http://www.fpx.de/fp/Software/UUDeview/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ woffs ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1969,6 +1969,8 @@ with pkgs;
 
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
+  uudeview = callPackage ../tools/misc/uudeview { };
+
   zabbix-cli = callPackage ../tools/misc/zabbix-cli { };
 
   ### DEVELOPMENT / EMSCRIPTEN


### PR DESCRIPTION
###### Motivation for this change
automatically extract attachments from mails
TODO: make tcl optional

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

