### PR TITLE
pythonPackages.vobject: 0.9.3 -> 0.9.5

### DIFF
--- a/pkgs/development/python-modules/vobject/default.nix
+++ b/pkgs/development/python-modules/vobject/default.nix
@@ -1,0 +1,24 @@
+{lib, buildPythonPackage, fetchPypi, isPyPy, dateutil}:
+
+buildPythonPackage rec {
+  pname = "vobject";
+  version = "0.9.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hqjgf3ay1m5w1c0k00g5yfpdz1zni5qnr5rh9b8fg9hjvhwlmhg";
+  };
+
+  disabled = isPyPy;
+
+  propagatedBuildInputs = [ dateutil ];
+
+  checkPhase = "python tests.py";
+
+  meta = {
+    description = "Module for reading vCard and vCalendar files";
+    homepage = http://eventable.github.io/vobject/;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13302,33 +13302,6 @@ in {
     };
   };
 
-
-
-  vobject = buildPythonPackage rec {
-    version = "0.9.3";
-    name = "vobject-${version}";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "eventable";
-      repo = "vobject";
-      sha256 = "00vbii5awwqwfh5hfklj1q79w7d85gjigvf2imgyb71g03sb8cjv";
-      rev = version;
-    };
-
-    disabled = isPyPy;
-
-    propagatedBuildInputs = with self; [ dateutil ];
-
-    checkPhase = "${python.interpreter} tests.py";
-
-    meta = {
-      description = "Module for reading vCard and vCalendar files";
-      homepage = http://eventable.github.io/vobject/;
-      license = licenses.asl20;
-      maintainers = with maintainers; [ ];
-    };
-  };
-
   pycarddav = buildPythonPackage rec {
     version = "0.7.0";
     name = "pycarddav-${version}";
@@ -22247,6 +22220,8 @@ EOF
   versioneer = callPackage ../development/python-modules/versioneer { };
 
   vine = callPackage ../development/python-modules/vine { };
+
+  vobject = callPackage ../development/python-modules/vobject { };
 
   whitenoise = callPackage ../development/python-modules/whitenoise { };
 


### PR DESCRIPTION
###### Motivation for this change

I ran nox-review but it failed. Not sure if it's because of this change or whether those packages were broken anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

