### PR TITLE
bossa: 2014-08-18 -> 1.8

### DIFF
--- a/pkgs/development/tools/misc/bossa/default.nix
+++ b/pkgs/development/tools/misc/bossa/default.nix
@@ -14,12 +14,12 @@ let
 
 in
 stdenv.mkDerivation rec {
-  name = "bossa-2014-08-18";
+  name = "bossa-1.8";
 
   src = fetchgit {
     url = https://github.com/shumatech/BOSSA;
-    rev = "0f0a41cb1c3a65e909c5c744d8ae664e896a08ac"; /* arduino branch */
-    sha256 = "0xg79kli1ypw9zyl90mm6vfk909jinmk3lnl8sim6v2yn8shs9cn";
+    rev = "3be622ca0aa6214a2fc51c1ec682c4a58a423d62";
+    sha256 = "19ik86qbffcb04cgmi4mnascbkck4ynfj87ha65qdk6fmp5q35vm";
   };
 
   patches = [ ./bossa-no-applet-build.patch ];


### PR DESCRIPTION
- [x] built on NixOS
- [x] ran binary on NixOS (checked version number matched)

I also talked to the original package contributor, Ambroz, about why it was using the Arduino branch. He said it might have had some support for the Arduino Due that was not on the master branch. He also said it makes sense to try upgrading to the regular release and he will report back if it has problems.