### PR TITLE
vim_configurable: enable overrides

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -325,11 +325,14 @@ rec {
 
   # add a customize option to a vim derivation
   makeCustomizable = vim: vim // {
-    customize = {name, vimrcConfig}: vimWithRC {
+    customize = { name, vimrcConfig }: vimWithRC {
       vimExecutable = "${vim}/bin/vim";
       inherit name;
       vimrcFile = vimrcFile vimrcConfig;
     };
+
+    override = f: makeCustomizable (vim.override f);
+    overrideAttrs = f: makeCustomizable (vim.overrideAttrs f);
   };
 
   pluginnames2Nix = {name, namefiles} : vim_configurable.customize {


### PR DESCRIPTION
###### Motivation for this change

Sometimes it's needed to override parts of `vim_configurable`, for
instance when using ENSIME (http://ensime.github.io/), in this case you
need a Python interpreter and the modules `sexpdata` and
`websocket_client`.

However overriding `vim_configurable` is quite hard as we run
`vimUtils.makeCustomizable` over the default comming from
`configurable.nix`. Therefore it's necessary to copy the code from
`all-packages.nix` and alter the parts you need: https://nixos.org/nix-dev/2017-April/023364.html

In order to simplify overriding `vim_configurable` I added an
`override` and an `overrideAttrs` function to `vimutils.makeCustomizable`
to ensure that the customization capabilities won't be lost after
altering the derivation.

Now it's possible to write expressions like this without evaluation
failures:

```
with pkgs;

let
  vimPy3 = vim_configurable.override {
    python = python3;
  };
in vimPy3.customize { ... }
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

