### PR TITLE
Xjump: init at 2.9.3

### DIFF
--- a/pkgs/games/xjump/darwin.patch
+++ b/pkgs/games/xjump/darwin.patch
@@ -1,0 +1,21 @@
+--- xjump/src/main.c	2018-02-20 09:15:15.608807657 +0100
++++ xjump-patched/src/main.c	2018-02-20 09:15:34.148949100 +0100
+@@ -604,18 +604,6 @@
+    * optimistic privilege dropping function. */
+   setgroups(0, NULL);
+ 
+-  if (setresgid(-1, realgid, realgid) != 0) {
+-    perror("Could not drop setgid privileges.  Aborting.");
+-    exit(1);
+-  }
+-
+-  /* Dropping user privileges must come last.
+-   * Otherwise we won't be able to drop group privileges anymore */
+-  if (setresuid(-1, realuid, realuid) != 0) {
+-    perror("Could not drop setuid privileges.  Aborting.");
+-    exit(1);
+-  }
+-
+   /* From now on we run with regular user privileges */
+ 
+   static XtActionsRec a_table[] = {

--- a/pkgs/games/xjump/default.nix
+++ b/pkgs/games/xjump/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gcc, autoconf, automake, xorg, ... }:
+{ stdenv, fetchFromGitHub, autoconf, automake, libX11, libXt, libXpm, libXaw, localStateDir?"/var" }:
 
 stdenv.mkDerivation rec {
   name = "xjump-${version}";
@@ -9,19 +9,13 @@ stdenv.mkDerivation rec {
     rev = "e7f20fb8c2c456bed70abb046c1a966462192b80";
     sha256 = "0hq4739cvi5a47pxdc0wwkj2lmlqbf1xigq0v85qs5bq3ixmq2f7";
   };
-  buildInputs = [ gcc autoconf automake xorg.libX11 xorg.libXt xorg.libXpm xorg.libXaw ];
-  preConfigure = ''
-    autoreconf --install
-  '';
-  installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/xjump
-    install -m 755 xjump $out/bin
-    cp -R themes $out/share/xjump
-  '';
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libX11 libXt libXpm libXaw ];
+  preConfigure = "autoreconf --install";
+  configureFlags = ["--localstatedir=${localStateDir}"];
+
   meta = with stdenv.lib; {
     description = "The falling tower game";
     maintainers = with maintainers; [ pmeunier ];
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/games/xjump/default.nix
+++ b/pkgs/games/xjump/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, gcc, autoconf, automake, xorg, ... }:
+
+stdenv.mkDerivation rec {
+  name = "xjump-${version}";
+  version = "2.9.3";
+  src = fetchFromGitHub {
+    owner = "hugomg";
+    repo = "xjump";
+    rev = "e7f20fb8c2c456bed70abb046c1a966462192b80";
+    sha256 = "0hq4739cvi5a47pxdc0wwkj2lmlqbf1xigq0v85qs5bq3ixmq2f7";
+  };
+  buildInputs = [ gcc autoconf automake xorg.libX11 xorg.libXt xorg.libXpm xorg.libXaw ];
+  preConfigure = ''
+    autoreconf --install
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/xjump
+    install -m 755 xjump $out/bin
+    cp -R themes $out/share/xjump
+  '';
+  meta = with stdenv.lib; {
+    description = "The falling tower game";
+    maintainers = with maintainers; [ pmeunier ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/xjump/default.nix
+++ b/pkgs/games/xjump/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The falling tower game";
+    license = licenses.gpl2;
     maintainers = with maintainers; [ pmeunier ];
   };
 }

--- a/pkgs/games/xjump/default.nix
+++ b/pkgs/games/xjump/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libX11, libXt, libXpm, libXaw, localStateDir?"/var" }:
+{ stdenv, buildPlatform, fetchFromGitHub, autoconf, automake, libX11, libXt, libXpm, libXaw, localStateDir?null }:
 
 stdenv.mkDerivation rec {
   name = "xjump-${version}";
@@ -12,7 +12,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake ];
   buildInputs = [ libX11 libXt libXpm libXaw ];
   preConfigure = "autoreconf --install";
-  configureFlags = ["--localstatedir=${localStateDir}"];
+  patches = if buildPlatform.isDarwin then [ ./darwin.patch ] else [];
+  configureFlags =
+    if localStateDir != null then
+      ["--localstatedir=${localStateDir}"]
+    else
+      [];
 
   meta = with stdenv.lib; {
     description = "The falling tower game";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18846,6 +18846,7 @@ with pkgs;
     tk = tk-8_5;
   };
 
+  xjump = callPackage ../games/xjump { };
   # TODO: the corresponding nix file is missing
   # xracer = callPackage ../games/xracer { };
 


### PR DESCRIPTION
###### Motivation for this change

I had too much time in my life, so I decided to waste it playing this classic addictive game.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

