### PR TITLE
make-fonts-cache: remove CACHEDIR.TAG file from Nix store

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -24,4 +24,8 @@ runCommand "fc-cache"
 
     mkdir -p $out
     fc-cache -sv
+
+    # This is not a cache dir in the normal sense -- it won't be automatically
+    # recreated.
+    rm "$out/CACHEDIR.TAG"
   ''


### PR DESCRIPTION
###### Motivation for this change

A CACHEDIR.TAG file indicates that the contents can be automatically
re-generated. This is not really true for Nix store paths. (Well _Nix_
can recreate them, but that's different.)

I noticed this issue as I was restoring full system backup that "for
some reason" always missed /nix/store/*-fc-cache (found by `nix-store
--verify --repair`). Turns out I was excluding caches from my backup...


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

