### PR TITLE
awsebcli: 3.12.1 -> 3.12.2

### DIFF
--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -34,16 +34,6 @@ let
           };
         });
 
-      pathspec = super.pathspec.overridePythonAttrs (oldAttrs: rec {
-        version = "0.5.0";
-
-        src = super.fetchPypi {
-          inherit (oldAttrs) pname;
-          inherit version;
-          sha256 = "07yx1gxj9v1iyyiy5fhq2wsmh4qfbrx158wi7jb0nx6lah80ffma";
-        };
-      });
-
       requests = super.requests.overridePythonAttrs (oldAttrs: rec {
         version = "2.9.1";
 
@@ -77,11 +67,11 @@ let
 in with localPython.pkgs; buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "awsebcli";
-  version = "3.12.1";
+  version = "3.12.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "12v3zz69iql4ggiz9x7h27vyq9y9jlm46yczxyg62j89m2iyr5bl";
+    sha256 = "19sgx43fyq35rqp0q8zbqavgg0k0n46iy1fqsxvw9lf0g0v62pjh";
   };
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

Upstream version bump.

Also drop `pathspec` override since the required version now matches the version in `python-modules`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

