### PR TITLE
Updated Electrum-Dash Wallet Package

### DIFF
--- a/pkgs/applications/misc/electrum-dash/default.nix
+++ b/pkgs/applications/misc/electrum-dash/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchurl, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
+  version = "2.9.3.1";
   name = "electrum-dash-${version}";
-  version = "2.4.1";
 
   src = fetchurl {
-    url = "https://github.com/dashpay/electrum-dash/releases/download/v${version}/Electrum-DASH-${version}.tar.gz";
-    sha256 = "02k7m7fyn0cvlgmwxr2gag7rf2knllkch1ma58shysp7zx9jb000";
+    url = "https://github.com/akhavr/electrum-dash/releases/download/${version}/Electrum-DASH-${version}.tar.gz";
+    #"https://github.com/dashpay/electrum-dash/releases/download/v${version}/Electrum-DASH-${version}.tar.gz";
+    sha256 = "9b7ac205f63fd4bfb15d77a34a4451ef82caecf096f31048a7603bd276dfc33e";
   };
 
   propagatedBuildInputs = with python2Packages; [
@@ -20,10 +21,11 @@ python2Packages.buildPythonApplication rec {
     pyqt4
     qrcode
     requests
-    slowaes
+    pyaes
     tlslite
     x11_hash
     mnemonic
+    jsonrpclib
 
     # plugins
     trezor


### PR DESCRIPTION
###### Motivation for this change
The existing electrum-dash package is quite a few version numbers behind (2.4.1 vs 2.9.3.1). The list of default servers it provides are no longer active, and there are, I believe, at least one or two security vulnerabilities in the old code. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

