### PR TITLE
heaptrack: 2017-10-30 -> 2018-01-28, enable chart goodness

### DIFF
--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "heaptrack-${version}";
-  version = "2017-10-30";
+  version = "2018-01-28";
 
   src = fetchFromGitHub {
     owner = "KDE";
     repo = "heaptrack";
-    rev = "2bf49bc4fed144e004a9cabd40580a0f0889758f";
-    sha256 = "0sqxk5cc8r2vsj5k2dj9jkd1f2x2yj3mxgsp65g7ls01bgga0i4d";
+    rev = "a4534d52788ab9814efca1232d402b2eb319342c";
+    sha256 = "00xfv51kavvcmwgfmcixx0k5vhd06gkj5q0mm8rwxiw6215xp41a";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];

--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv, fetchFromGitHub, cmake, extra-cmake-modules,
   zlib, boost, libunwind, elfutils, sparsehash,
-  qtbase, kio, kitemmodels, threadweaver, kconfigwidgets, kcoreaddons,
+  qtbase, kio, kitemmodels, threadweaver, kconfigwidgets, kcoreaddons, kdiagram
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [
     zlib boost libunwind elfutils sparsehash
-    qtbase kio kitemmodels threadweaver kconfigwidgets kcoreaddons
+    qtbase kio kitemmodels threadweaver kconfigwidgets kcoreaddons kdiagram
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -1,6 +1,6 @@
 {
   stdenv, fetchFromGitHub, cmake, extra-cmake-modules,
-  zlib, boost162, libunwind, elfutils, sparsehash,
+  zlib, boost, libunwind, elfutils, sparsehash,
   qtbase, kio, kitemmodels, threadweaver, kconfigwidgets, kcoreaddons,
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [
-    zlib boost162 libunwind elfutils sparsehash
+    zlib boost libunwind elfutils sparsehash
     qtbase kio kitemmodels threadweaver kconfigwidgets kcoreaddons
   ];
 


### PR DESCRIPTION
Upgrade, but mostly enable charting goodness by adding kdiagram dep.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---