### PR TITLE
[WIP] singular: run autoreconfHook

### DIFF
--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -5,20 +5,24 @@
 
 stdenv.mkDerivation rec {
   name = "singular-${version}";
-  version="3-1-7";
+  version="4-1-0";
 
   src = fetchurl {
-    url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${version}/Singular-${version}.tar.gz";
-    sha256 = "1j4mcpnwzdp3h4qspk6ww0m67rmx4s11cy17pvzbpf70lm0jzzh2";
+    url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${version}/singular-4.1.0p3.tar.gz";
+    sha256 = "105zs3zk46b1cps403ap9423rl48824ap5gyrdgmg8fma34680a4";
   };
 
   buildInputs = [ autoreconfHook gmp perl ncurses readline ];
   nativeBuildInputs = [ bison pkgconfig ];
 
+  postPatch=''
+    patchShebangs libpolys/tests/cxxtestgen.pl
+    patchShebangs git-version-gen
+  '';
+
   preConfigure = ''
     find . -type f -exec sed -e 's@/bin/rm@${coreutils}&@g' -i '{}' ';'
     find . -type f -exec sed -e 's@/bin/uname@${coreutils}&@g' -i '{}' ';'
-    ${stdenv.lib.optionalString asLibsingular ''NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -DLIBSINGULAR"''}
   '';
 
   hardeningDisable = stdenv.lib.optional stdenv.isi686 "stackprotector";
@@ -29,7 +33,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out"
     cp -r Singular/LIB "$out/LIB"
-    make install${stdenv.lib.optionalString asLibsingular "-libsingular"}
+    make install
 
     binaries="$(find "$out"/* \( -type f -o -type l \) -perm -111 \! -name '*.so' -maxdepth 1)"
     ln -s "$out"/*/{include,lib} "$out"

--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, gmp, bison, perl, autoconf, ncurses, readline, coreutils, pkgconfig
 , asLibsingular ? false
+, autoreconfHook
 }:
 
 stdenv.mkDerivation rec {
@@ -11,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1j4mcpnwzdp3h4qspk6ww0m67rmx4s11cy17pvzbpf70lm0jzzh2";
   };
 
-  buildInputs = [ gmp perl ncurses readline ];
-  nativeBuildInputs = [ autoconf bison pkgconfig ];
+  buildInputs = [ autoreconfHook gmp perl ncurses readline ];
+  nativeBuildInputs = [ bison pkgconfig ];
 
   preConfigure = ''
     find . -type f -exec sed -e 's@/bin/rm@${coreutils}&@g' -i '{}' ';'
@@ -48,6 +49,6 @@ stdenv.mkDerivation rec {
     platforms = subtractLists platforms.i686 platforms.linux;
     license = licenses.gpl3; # Or GPLv2 at your option - but not GPLv4
     homepage = http://www.singular.uni-kl.de/index.php;
-    downloadPage = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/";
+    downloadPage = http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/;
   };
 }


### PR DESCRIPTION

###### Motivation for this change
I was trying to install sage on nixos-unstable but the current singular package complains if you use a different version of automake:
```
aclocal.m4:70: AM_PROG_AR is expanded from...
configure.ac:25: the top level
configure.ac:23: error: version mismatch.  This is Automake 1.15.1,
configure.ac:23: but the definition used by this AM_INIT_AUTOMAKE
configure.ac:23: comes from Automake 1.15.  You should recreate
configure.ac:23: aclocal.m4 with aclocal and run automake again.
WARNING: 'automake-1.15' is probably too old.
         You should only need it if you modified 'Makefile.am' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'automake' program is part of the GNU Automake package:
         <http://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <http://www.gnu.org/software/autoconf>
         <http://www.gnu.org/software/m4/>
         <http://www.perl.org/>
```

run autoreconfHook allows for more flexibility.

Using it ends up with this problem currently.
```
prompt> nix-build -A singular ~/nixpkgs                                                                             
these derivations will be built:
  /nix/store/x25q7qjygyyl02w1p7lz3agp52m98c4x-singular-3-1-7.drv
building path(s) ‘/nix/store/vjsfmv8a7a2xfa2dfmlnl94lcqnwiv4i-singular-3-1-7’
unpacking sources
unpacking source archive /nix/store/rafrq97i4wmpnks005jb1dnsifhrjk8s-Singular-3-1-7.tar.gz
source root is Singular-3-1-7
setting SOURCE_DATE_EPOCH to timestamp 1407340755 of file Singular-3-1-7/warn_not_found.sh
patching sources
autoreconfPhase
autoreconf: Entering directory `.'
autoreconf: configure.in: not using Gettext
autoreconf: running: aclocal --force 
aclocal: warning: autoconf input should be named 'configure.ac', not 'configure.in'
configure.in:425: error: m4_defn: undefined macro: _AC_LANG
../../lib/autoconf/lang.m4:107: AC_LANG_POP is expanded from...
../../lib/autoconf/lang.m4:134: AC_LANG_RESTORE is expanded from...
configure.in:425: the top level
```
Should I propose to rename the file upstream @raskin ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

