### PR TITLE
cataclysm-dda{,-git}: miscellaneous updates

### DIFF
--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
       substances or radiation, now more closely resemble insects, birds or fish
       than their original form.
     '';
-    homepage = http://en.cataclysmdda.com/;
+    homepage = http://cataclysmdda.org/;
     license = licenses.cc-by-sa-30;
     maintainers = [ maintainers.skeidel ];
     platforms = platforms.unix;

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -1,5 +1,6 @@
 { fetchFromGitHub, stdenv, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
-SDL2_mixer, freetype, gettext, Cocoa, libicns, tiles ? true }:
+SDL2_mixer, freetype, gettext, Cocoa, libicns,
+tiles ? true }:
 
 stdenv.mkDerivation rec {
   version = "0.C";
@@ -15,9 +16,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ]
     ++ stdenv.lib.optionals (tiles && stdenv.isDarwin) [ libicns ];
 
-  buildInputs = [ ncurses lua gettext ]
-    ++ stdenv.lib.optionals tiles [ SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype ]
-    ++ stdenv.lib.optionals (tiles && stdenv.isDarwin) [ Cocoa ];
+  buildInputs = with stdenv.lib; [ ncurses lua gettext ]
+    ++ optionals tiles [ SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype ]
+    ++ optionals (tiles && stdenv.isDarwin) [ Cocoa ];
 
   patches = [ ./patches/fix_locale_dir.patch ];
 
@@ -25,18 +26,23 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  makeFlags = [
-    "PREFIX=$(out) LUA=1 RELEASE=1 USE_HOME_DIR=1"
+  makeFlags = with stdenv.lib; [
+    "PREFIX=$(out)"
+    "LUA=1"
+    "RELEASE=1"
+    "USE_HOME_DIR=1"
     # "LANGUAGES=all"  # vanilla C:DDA installs all translations even without this flag!
-  ] ++ stdenv.lib.optionals tiles [
-    "TILES=1 SOUND=1"
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    "NATIVE=osx CLANG=1"
+  ] ++ optionals tiles [
+    "TILES=1"
+    "SOUND=1"
+  ] ++ optionals stdenv.isDarwin [
+    "NATIVE=osx"
+    "CLANG=1"
     "OSX_MIN=10.6"  # SDL for macOS only supports deploying on 10.6 and above
-  ] ++ stdenv.lib.optionals stdenv.cc.isGNU [
+  ] ++ optionals stdenv.cc.isGNU [
     "WARNINGS+=-Wno-deprecated-declarations"
     "WARNINGS+=-Wno-ignored-attributes"
-  ] ++ stdenv.lib.optionals stdenv.cc.isClang [
+  ] ++ optionals stdenv.cc.isClang [
     "WARNINGS+=-Wno-inconsistent-missing-override"
   ];
 

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -22,11 +22,6 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs .
-    sed -i Makefile \
-      -e 's,-Werror,,g'
-
-    sed '1i#include <cmath>' \
-      -i src/{crafting,skill,weather_data,melee,vehicle,overmap,iuse_actor}.cpp
   '';
 
   makeFlags = [
@@ -35,6 +30,11 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     "NATIVE=osx CLANG=1"
     "OSX_MIN=10.6"  # SDL for macOS only supports deploying on 10.6 and above
+  ] ++ stdenv.lib.optionals stdenv.cc.isGNU [
+    "WARNINGS+=-Wno-deprecated-declarations"
+    "WARNINGS+=-Wno-ignored-attributes"
+  ] ++ stdenv.lib.optionals stdenv.cc.isClang [
+    "WARNINGS+=-Wno-inconsistent-missing-override"
   ];
 
   postBuild = stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs .
+    sed -i data/xdg/com.cataclysmdda.cataclysm-dda.desktop \
+        -e "s,\(Exec=\)\(cataclysm-tiles\),\1$out/bin/\2,"
   '';
 
   makeFlags = [
@@ -31,7 +33,10 @@ stdenv.mkDerivation rec {
     "NATIVE=osx CLANG=1"
   ];
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    install -D -m 444 data/xdg/com.cataclysmdda.cataclysm-dda.desktop -T $out/share/applications/cataclysm-dda.desktop
+    install -D -m 444 data/xdg/cataclysm-dda.svg -t $out/share/icons/hicolor/scalable/apps
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
     app=$out/Applications/Cataclysm.app
     install -D -m 444 data/osx/Info.plist -t $app/Contents
     install -D -m 444 data/osx/AppIcon.icns -t $app/Contents/Resources

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "PREFIX=$(out) LUA=1 TILES=1 SOUND=1 RELEASE=1 USE_HOME_DIR=1"
     "LANGUAGES=all"
+    "VERSION=git-${version}-${stdenv.lib.substring 0 8 src.rev}"
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     "NATIVE=osx CLANG=1"
   ];

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
       substances or radiation, now more closely resemble insects, birds or fish
       than their original form.
     '';
-    homepage = http://en.cataclysmdda.com/;
+    homepage = http://cataclysmdda.org/;
     license = licenses.cc-by-sa-30;
     platforms = platforms.unix;
   };

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -21,11 +21,6 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs .
-    sed -i Makefile \
-      -e 's,-Werror,,g'
-
-    sed '1i#include <cmath>' \
-      -i src/{crafting,skill,weather_data,melee,vehicle,overmap,iuse_actor}.cpp
   '';
 
   makeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18250,6 +18250,7 @@ with pkgs;
 
   cataclysm-dda = callPackage ../games/cataclysm-dda {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
+    ncurses = ncurses5;
   };
 
   cataclysm-dda-git = callPackage ../games/cataclysm-dda/git.nix {


### PR DESCRIPTION
###### Motivation for this change

Basically maintenances of cataclysm-dda{,-git} packages.

###### Things done

- Maintenance things
    - Update homepage
    - Clean up old codes
    - Fix the stable version's dependency to ncurses5
    - Change the git version's version display in the title, as it was still 0.C

- Minor enhancements
    - Add Linux desktop launcher
    - Add option to install the console version (no tiles): e.g., `cataclysm-dda.override { tiles = false; }`

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

