### PR TITLE
 firefox: 58.0.1 -> 58.0.2 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "58.0.1";
+  version = "58.0.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ach/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ach/firefox-58.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "7b32498fed47b1e0a58b399436c54ccb784a870ec0e8ab7f789218b17a168d0968666bb01abb456c4d0f6350a7769e05eaf2a3a6a5f3827a42725bf7704ac941";
+      sha512 = "4f974e90d5db09a02c61a634f7309ba479f8699d1d61f4c21a7bb6ae5f520332292031ce0988605f8e727da5161de1b3a055da59d5f8bf220c1b369f9c453f17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/af/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/af/firefox-58.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "12ca5365ea453af0ad4cd4c296c05b3dd99e713e46aa618544573c1023a7e1b6596d91d90fd9bd5a6a332624d985637bb12ffab20548dc808c5dccc0909e3fae";
+      sha512 = "d821bf5c1fa1bc38f64195d1bfbc7ce5205b50139710fde6e1db37c4a429a0df16ede8411a618d8e339f369dac699a38651c3aec9952d7c20fb84e1eaf1f59de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/an/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/an/firefox-58.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "7da1af63fdfa939724aac8c9def9b179bd2fdb37f2034e9758f4578a682c22bcd0803fc2e67412d2339b722eb269cffa96863b819d6e390ac01009152b00c90e";
+      sha512 = "7238e49735bab7983a478c217b128d7cc8b07e90fc5e2739eaf07e35be054a354c5c0006bae6fdb29ef71855c33ea531e84c1617832412315eb2e07ad7310d14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ar/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ar/firefox-58.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "1e2d9ae0ce968803b6ea6fdf9841328a561c90576a5849e3ef1e89a6f5ea0aa70b2179ca0c04fd89b829ce21f45d3eecdca607a07d64e6c16a8aa06cda8333ec";
+      sha512 = "f505930eed9262e595a8969dc86ed43c04f32ba62301b2fa8d1246ef956f3075d5633112e6129707ddb02d3047b93a5c9f5ce16f958a06ad928c59d64c8a1e75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/as/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/as/firefox-58.0.2.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "c40af34a01fe616e0924993b267cbf498a21962f77139b5aecebd6e1b6d17464685c44f435a18be018a00761e40ff3473a205d55c111be954f379ff6540645c9";
+      sha512 = "e1b876dee0ac09a391c53f066f5bf56fa6b0b4bcb389beb0844670a7f14ff422a230f58389f3c3d2a1f8b7486fe528a7abbe3b6abfb86c330ea13cab0cc67a7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ast/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ast/firefox-58.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "81898690a8c7bbeddc0c89a2e6c91082e37016d86815a79b2488adc36cbea3c0b669221fa9951e4fe4880f777c5c0be9e9728549d01c77e592c8b1afdb4a629d";
+      sha512 = "1c47fae696cfcbdd4f7fbbc8ddeacbfa1ae1b9a624bec9f512527b99c7ddd63c99fd55b60ae9a3ea1104fb5b943c8c029b19b93e6426de793788c2a5354a0d57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/az/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/az/firefox-58.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "73ff9c0be45cd7d5f70abcb8e397e9adc777383b793a78c6907396724c78f9fea5794a8a138c9c19f2d0ab46a0133da69f6e5c98a15a8b120567c22bebefcd27";
+      sha512 = "5c3bab4ba81967b957c14152f6461ccb129396562ece07a34644f88b67185f9d6639ce3bd709a463816efe531c6e8bf3aa6414828feb37ae54564d1c9ae237fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/be/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/be/firefox-58.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "19b581888cf07fe9cbabba66832fd62a803920f2a39b195bffd8316b3100edb4b0c628d0563e3d6ab76b097f8e038310079d5d1a2bc2722bb78ee5a51b4bfdcd";
+      sha512 = "8c719a8fcaef9f2f3ae50d0ecd999972649b5814c1bab45a418c474b6090bbcb47d58a32012f3ccb6c785ca9a1c76cb2f69e370714e1533349806c3db0364dd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/bg/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/bg/firefox-58.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "bb440c3132a75a7fdb0c3886af57b0650609adf3992b086d9ded68be5525c6dea292de0ff51dbab42968348eb8ce8c918869fa40ab26126cfe775b69a40fc5dc";
+      sha512 = "b871aa3dc5e4721174e73081e4c551f802a16cb54690ea1850e549c37c1160000b9eb0e312fe03e43d8e254cfc063d971625624a6d0d7a8de14f731d1e139135";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/bn-BD/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/bn-BD/firefox-58.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "5d7f7a98bcd0f927d1911e4d1a7eb79640912b2944f7c335ba6c81eb6e8310edb26917b9944272205ab2e90aecc28bd9208ffcd4049aa0a491f3e5671f21be8f";
+      sha512 = "53cfa7aa2bcdebb6770d1d993d71a0fd039eb540884d0dbe3d0fc953260a850bcdf72b20eb67d11630aafa9f282cab279776fa9d5cb45aeb7280dfd064b0199b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/bn-IN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/bn-IN/firefox-58.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "96ed7a7c7cef4f88591f6b1f2c4d683d1b39220c8ffdbee9db9b9b470cca1e1902b042b10e62555ec614cb2b0ba560972042c4e65f5b17a2b8bad78d3c456744";
+      sha512 = "a47f5c6bb46f6f4a2af27a8dd1556339ba5efd1b2c23494b0913033580dc735097eeefd58a6c0253d74c8fab30fa628d106a0f4111b0b5af5f98b1dd2d9d111d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/br/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/br/firefox-58.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "9537b2f8edc30d76649e7be50f1ef9576ebd8dbde45c6a0c685d846ad2ee8634b80060449f01ea60926040e1bc6b8d8c49346bcc69fc276c4c6d3142e9dd8d06";
+      sha512 = "b4dade4de1e40f8ef6c1af9fa260f7e06bbae6790a87813032c35317fa462f15905fa8b66c8b08bae640186f1fe6d10c15c87d64085d6fd23e5dd7a33cb9326d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/bs/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/bs/firefox-58.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "b9cc1e8d570173f283a77b552ed99fd4546fb1f55a1a5e766d6f441e2589e615445c45317c39043d98ae8c4f77a75d80d0fef9bc20944690fa7c75ffd4bc5ed4";
+      sha512 = "d32cd117524343cf451b30526466b84f84a7ab99f6e716ccff5c1c7e768003409723df93ee8839ca00d3e0a52cd9cba270f78033124809e4d18942bae9c736e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ca/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ca/firefox-58.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "dc263ccc27c14d7aaa9fb66a9b9398df48d3685b2e2c3493627f279d5509884293121316cc8ffe3aaeb200287d1e0438852dc9e4c02f2aa525c2f16f9a2b510e";
+      sha512 = "c4063632526c6936e71e50a898077568cf678a8f9275258311bda91ca0a150b7c30b19b86cb12bbf786624675ed3f383ba21b52545b36f8ef7032ef9001136e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/cak/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/cak/firefox-58.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "69026c93cb0e48c3b8790978694642cd6e854203a2d78bba48ac922906cf938781bf1c1dc5316eb887c89b9933132253d378233c3669954a1182d1d7d4145e3b";
+      sha512 = "cb1f2142d698226ff881e9b3a1037ddbea1bc3ffca8ae98a7526bc3a6b728a3e30957196d809d523a638d7482db3e60b774de8f7f274c76982962026cebc0b9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/cs/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/cs/firefox-58.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "4dc64d4fa8424b85713a566b0cd7373e352624799055ee7bc0879ebb93008ca6aec9f39f0aa657809f7c7a70f8473e731279ef7b3ffa16ea5132d01c83e5aaed";
+      sha512 = "8b17ed6a66081f445319a6e329710350f79751388e1cc6eb6f5945e0c0e6145053904ee2a1c1a562407299518eb8d97a52d86a0d4807f8711ee3ba6521f23820";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/cy/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/cy/firefox-58.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "85b7c7210429d5ac6120629a033347f1c13de5998b83276f3b735ace1f4a62cd0f201e2312e0be6d7f0607062688402f687e593b93e92439fbda14367efaad66";
+      sha512 = "a679e779b6afda954fde1bfdf079eca62e4541bb5c0398e8fe797e3ab8341922c279d1eb5d4f237995d01d39261f9b6f814540532c646558b10cef178870d5bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/da/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/da/firefox-58.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "d902f11e93a23dbc4a4e2340926134fadb2a251bb4b00de1d79bbccc9d21de35f99bc2d4469cee812b15d95dbeff6f4388649d27fea020a54b24a59ef3084634";
+      sha512 = "81771c6a78ff9349ac8086dce32900544d0a8b79eca55a61bc1efde34788a77fd41607c43403bf1df18f2f6aee8b61460e113ee301c2888494a970600fb4a371";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/de/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/de/firefox-58.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "558502bf31db14744aac18c3efb8e2b0189a118cdf080621910c9cf15a05b1bd28fe1b2f5e2acad678ccbe9769ceabe9dec0b7016f1570ae888f9c3fad7fd6b8";
+      sha512 = "cef7eebf9dd55af3d7245161c6f41153b99cefdb73e71c5cfaab1d8f1037c8da7ee2f36836e51416c36f7a7472b113bab23fa6a35ce30269733889ecd4aa1d5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/dsb/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/dsb/firefox-58.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "89ad64c3a489a0ef30099581370fffd3743c1857d12fbff65f6387ecf1503e6e394ee91d744847b6db3611800fa195de2e4d1df4a2ec9424436348c36b6731c0";
+      sha512 = "986c25e9f994ab766f4017f664304c03cc0a26c8ea50f892d48ff571322aeaa6b76eb1f4c7f1133a68783a9f55ce0e56a6cc599fb6eae0431e5bccec639504d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/el/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/el/firefox-58.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "c7f77728e18d63745cc6385f7923e673483df76b6e8e2ba8f39cf635bb94d8243f9ac1728c4ddb5b94e316ebab026a52871e9fad86276dd885e48481a6dc1edb";
+      sha512 = "8d352b56ef049e2bb94952ebaca276dbfa4d7ea34ad368907406b67391d618e8aa2f908c19f3c7210220237d3721021686bc8fa0702c748680035a48b9ff2c4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/en-GB/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/en-GB/firefox-58.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "f76ea7e2d15016ca779a5b2f1bcdeb3cf1607ba4b570142cebb60caba5728be65ef05179ee7c5a3029ae8e21e26ea759e7b754b3670a0b6debd0da4528720078";
+      sha512 = "318a67d7d875a350e561a2a4e0f2d6278ce3a9f7e2db9ce307c58b5a2ffd40753edbfce01438c7b02421efa84129f95caf3887ca2929271ce5fe95f9321db11a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/en-US/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/en-US/firefox-58.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "ad5b2b66a8579ad2f3a9ff97425af7e9c7ab4235cf44a5684ad481879ea953492f0639fc79121be9f808bedba80e3c0205e43433b99a1c8809544fbd1bb3808c";
+      sha512 = "71f5d1d3779eab4025ab57aef1795f9d6c509a50c5397df6a8ec741584d441acb9f7cbf8c8c002cb367c9c42b72dd6d29710fcf0cfead3a4525f2ccf39f3b930";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/en-ZA/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/en-ZA/firefox-58.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "aaca4fc5bb264e0f2c8a5d783b3e1e53786403d01c157d8ca3a87642a3668e839fb0d5e204e96371dc442f21bd66e589ed55b6a76d3f50271dc0345da8059eb5";
+      sha512 = "07604a360c8a932fdc161b4c2762e953812eef7cca765db29bcf0514027a8db3c22bbd879de6a1222eadbfb817540ef55e136df0df858a21c55ab4150cb3d5a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/eo/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/eo/firefox-58.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "f49f89c5c6fbfee70e47a6b632de5b92981a23b54e8e9d7b47ac83ef18bf45d98417c73cfbd06b277b67f94f138c37ebbdea4f1c756e4229d8842f49da6a34c1";
+      sha512 = "cdcb32f4b5e14a11033f62ec7e4ba00fab689dde93978cec405d55a497fb6a59a9c06839e04b8cd550557d37f1801bc6f9a9440e4a59f3d4b32cd2a27ddbac9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/es-AR/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/es-AR/firefox-58.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "d04e9a28755ec6de2021b20f72b32ad6aca151cbe8300a54ace876878d8df043923b6afb3b186e5ae3db6345216eeebe9f97978a4e50d9a0a854207e5503a3ce";
+      sha512 = "aaf28d1b93d1eba50eafdc112f51fe261a0a38bb9e28ba4d86c12cb1f509d5fb375986e7a7e7a81483aa64bcf16f09620ff325674c29738ff62335d8ad1d1c7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/es-CL/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/es-CL/firefox-58.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "0251f56864a79cb38ce5c5cb3908bd1691d2dc15b1198d901a6907f47f1a15385c931538b022d45f75ac3ed0eec7244a081b79c1292bee7a35beb24ccc307dc6";
+      sha512 = "f30c318fa51c551fc03bf9f962cad8fce4795094d1389c1a35096e8e229fd1d78dae43cfb6c01f2600e7f5fd8efd02345f2c18578e3bc0378fedb947abf5904a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/es-ES/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/es-ES/firefox-58.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "93a405ef018010d5097ade9f08c228e31b50e76573b75cd2d04205d89f61363d0b8f24585f4e08b93eb8424367d90213dd32fc85ee2f7e28a1ef2742c1c31b3c";
+      sha512 = "08fc4a475fdf2e91550de0b5127df679f4011cc79af6125fb117aec44f97936f794fc0135fd381abaae4370b7343c200308e0cc659828fa8f8e665f39c4109cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/es-MX/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/es-MX/firefox-58.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "4286767ce5866ea0b6f1b41804d92e54361e4defa8fa59b7721abeeba402b07ec3fef051005c083d65f6fb32dd37edd2253cf8ffcd28ea9109963500e4fa3332";
+      sha512 = "baf9277fe32334b88be4bb6aa5b714e86d6d316866088173d0bfb221ab989708e3b67dfdd934c0df80ddbbcef8b2d78c35b33b1420332b094442b31aa62b6ca7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/et/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/et/firefox-58.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "f9a11e6b738a09a9f1eb8834f4932535b828bb1c8dde449b14794ac03ba4a37089ecb45b015daa2dbdde2adc2531ded5d9eec83e70b1ded4eb642e4dbaf118fe";
+      sha512 = "eed1be0068e6efba0130658c7fe5104ca0fd9c7485da0715113ac82665a153836e6d0eed083c91a89b4f8c11eec0fe2c0f8ef161f2bf7f565b6689f5978a454a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/eu/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/eu/firefox-58.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c6015ccc4598bb2f0d5bfd12a962d457a3868552853ae6b053c3e40c1668fdf140a2bb791ecb6c2fbe283371f8c1e8789fa315e5a6c05b9b593c413dfaba1351";
+      sha512 = "d0bd609308813d99a79b393dc4fe0960da01ab032ada1d4c2933c89acdc7a1016ac25ca67205aa29106ca12b34fe7dee42316ed457a4e0cee9fc43e3acc2011e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/fa/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/fa/firefox-58.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "4bfa551b23e62ce7a92136afd09e233763abbf36b536340667ba487e3c491a269bbc5e508d196771edbd1745a294a14d3f51ad3d4d79adcda86394ca2e7e5ad8";
+      sha512 = "cde046bc147e860c40f979f8fe1bb39cc3391939f2b04f572d6db5a61be8be9574c1ddde1a400d16c06c2c6dd87a9b19830f2591809439820a27349d10860801";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ff/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ff/firefox-58.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "e24f247816b7a633c814275a1a858f0580e274285a3875e0509ca65027bf7f39d2f56709af6454187326a7b0a5b20408582b4f16993c3580c5bd67473726d902";
+      sha512 = "047d9b2af90da36699cec77ba419db42cf6ac63fd3d9185150973fa6aaa20cb4bf23538e50154f03bb3edee4f16985baa4332e247ccf7d756f358f81afb2c329";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/fi/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/fi/firefox-58.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "5ff4c6daa231072927b0af6482992859adbfad7645c5c75666c4de69930bb809541c756031b4309fe81b776a434af19badbb285f0f68ebfef4a25a117448e813";
+      sha512 = "5c2955e5c1e54bc0b2bfa08051ec61745765b7d9c970c7ea905e41d4ccb22b32caa3011a64a152d997db1f0b6451b10116060914c601aaa7a240f23cecff166c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/fr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/fr/firefox-58.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "7ca09555e939136ab336b70343f889832f3dc585aac2f6b3853b628b5db5686f56b97a7c9abba22b5ed7ac0d2eb9bf93ab2fde8ba992d9b9f3d2790130817e43";
+      sha512 = "e32448bc068d0c816c16ec1b4c53d462da430ca7ebca484dd363253e9d47277a0eb40ef0291b58e7dadd3457f49fd69d452c2e7728e45a1473472a2523c24028";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/fy-NL/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/fy-NL/firefox-58.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "a5d2b78ad7cd9e1677cddb3889d74598383585caad7914ee08333e96c7e66b4b81d5d2ac13432f694dfb3ed5f8515473839317b68f06f4b3708fd02994240da8";
+      sha512 = "9501fc459c883b3d7c3299243288aa5210755d78238af2f6d79e15104ba575b4a7cffebc9c067dc23bbc0941bc5f4a786909a194bac9f1f59244715f8b3cea2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ga-IE/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ga-IE/firefox-58.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "e1b28c3f064c190bb723373326f1f023821a2192836d619f23dc6cbb424e10376d307a895bfb1db5062a85037f78c3877b684ea1014da205caa4bd284370803c";
+      sha512 = "d7696ae4b38bfdcd93ffc6796bb2fdd6b952a5892a4a753b0a0717c0448ff59263516896dac2830aabc7b2df5719856f077450d29a48e25fec77bde00cb25d4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/gd/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/gd/firefox-58.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "14b98f08cfdbb6ca0c18afef9fbe4d1f283ea2a2635069aa8426ef8075c2e63d4b348c591d556832b3ed8a68dae6e54d9e82dcb9e1dec1b26d6de3189ec6cb9f";
+      sha512 = "ebe7526f32d43572538bde521b4df30aff91eb1a30148e20a164cfa044d7391bd7259486c72e68f9c110745e9013f36fa8c1f5be7519551c303cfdb06d4b6008";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/gl/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/gl/firefox-58.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "61473be66b6109a156c6fdf73222167825990dc1b85614ca7ec20c10948ed5a3fe6752361255ed73f31c6f1013265aed5d59a5ae0e184d818edf388cf5a33fb0";
+      sha512 = "a071ecc811b90c102dd5c7b4174d6cd65e7e07bed16566e71740cc3d29446757f220330910aa3a321809de3417a64641ee74b788bd27975c7ad75cc4e777116a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/gn/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/gn/firefox-58.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "b1706bee4fbc84365a26f733ead82f95db6865c2d042fc40f97e9e1e2ecd9cdead2bbc8ee3acbf62cf288f5c907ca4b9be5eeba0ad92dd9c25355491c0849696";
+      sha512 = "1bc8f57884cd4af64e1a99defaca501561d84a70aaa3f4ee71c3c1497a4829248e2f5fea5b09c89eaf8d3701fd4f9753bdb50f6133850d2baa1708e942d8281a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/gu-IN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/gu-IN/firefox-58.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "7a04ad824559b04709431e21197aa9c93a6afae05893ed29922b039b4a4c24ed27e1b091d06e948cd83f1b7f25df0a67477e22b9ce288dfb9ad805b3f43f3cd4";
+      sha512 = "230b2c609b5ff96385b93ece8ac197910fe332ca76300dada12a0687b025ee7781ded47bb1a13816bb2fbd6c7e250bd0af8f4b40dd78c1d75a77a66391d7bccf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/he/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/he/firefox-58.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "3f00ef9afa945f41b8d84c45c314a76abb2bdd219ab228387c3ac1b548948d9ee6037f1df6cb5b0de294a7920e77c3a16d2c687727087e8c422b2f37ec3beaa4";
+      sha512 = "f52add938bcf862c8d417709298eae9e502aa5845d01a349b9a8d29ab790ed342b7bbbe615fee6db7e939150a15a2e46895d162544ce4028806bd68c0c832186";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hi-IN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/hi-IN/firefox-58.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "068bbfdf10900f244349c65913772e3565510d73805cdb658ec346c4eab670c91e8c886ad085a469df74bbabbf5a1cce5a9b845c24a9b155f96e2b9749856f15";
+      sha512 = "10406b782c3343fcb63420cf98690ac6eb1eaf9024eff226066587c356edf32006e288e8ce6373f6fc1475dd08c30da2b38cd284ccfd610c33c3726c91dc7691";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/hr/firefox-58.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "b965b136811d174ee69ab3424fb15b24f39a59b3261eabe83d988cbc8dd639d4b0ec82285163a33cea1be52a3671e2763e7892eccf176cd286cebc8e9453fbb4";
+      sha512 = "8fdfd613b9ee56a9da8f8c1ed1e9c9a6ece04bbffb1dc197120c9d3aeef2c36d9d660a44539f4c1820273be91dcc30d89652a9d9ecabe9bfa88b146fdaef18a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hsb/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/hsb/firefox-58.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "4b3d92d245f9d93980325080b0394ce9877e0a6e4e2337cf941e5e72becc0125e984166ee30e81b45f95ba9a562b040a26f4cb05114beb5ab18dbbcf968a32eb";
+      sha512 = "4e1cce7f55a3b66b21c0f8f16661855b2946a403d6f29e3725aa300fce49bc065dd7719b9203e79b3ead73dc92220a40d2f99d9079eecc8ae44a38b87086394d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hu/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/hu/firefox-58.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "42b70cff446c60a2e8388fb16ef3d2829e46f420169b73b4849069ccc75812a10d4a74af7ab19ea78566731e51cd86aae0c047f66fa5c9eaafa169dd520900ab";
+      sha512 = "b636ff6691834dbab712be03bd3dfa92f8a0bcf5e4807ef77e81d0a602acfd1f5df37e0c5a2237518305e4a9150fa592204f84e93ef83273f84a4ec34f65d3f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/hy-AM/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/hy-AM/firefox-58.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "84f001a101ea71e8675b4ed7c359a8fcf8b1dea72bb73ff08c6e5a2383abca2e98da32f9d5da31d86291a5ee7f156c04b033259b538656fa17a60b3f66dccfef";
+      sha512 = "909f565a687d6676175105584b2042af8cea66a2da1a2d529954c1a3f5f98807f655a20b1b16d1d80a9af05c02997d543055bd2edcffaec4fb0df0da6e610ab7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/id/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/id/firefox-58.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "5285ae283ea21e24b0ab04c767bfac4d4db9be66a2716934476ca03755634c333c0e96c367889760137e584b2a58c8cb6e9689996038149ee5b568c2e4eb499c";
+      sha512 = "1338acae5fb5d477f51d09c8e49bf29ea4a7ac1a86d2b8bbfd431af2faa7a2db19fe5ae61650127c0f10a40b37a464bf7c67e4a4d2930bdb0dd04160013f5ead";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/is/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/is/firefox-58.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "f1e8eab99c650cf0e4c0d836c5143033b7cb2a9f87f81ba5057c511dfe61ac08778db8762a683b38dbaf2fccbb70a38a0650fc01dfdf8d59ea12d7b31235ca39";
+      sha512 = "6bf296d0e64ded43518b30f2b064cc99ddad031e8ff6129a6a9bda4736e93cfee1d2a9c0df96e86754762cc0ef38fa9cf7d79caf154c1db8c5ba57d88abfce0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/it/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/it/firefox-58.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "ac877c6b0783c90ce4c44f96144d28d416af43710fe8ad6ac6c56a4847c748c2411dd817b1809801e4d96dddd301466886f45030e74f7ac1f2afefd162e47dc2";
+      sha512 = "c46ab44a51aa21b23b50763a6f35c5418a03a847584a1aad3560f62a828d2f859c912ead26d1a1206cfde73d411bad31bc87f19c5203850712bae911dc86fa44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ja/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ja/firefox-58.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "8ee911c05a31230df94d7044de5dcc549b5fdb9779fe0acff0d0095fe45caa13fbbbaf6e8018389222281bfd9ae0a416754836105e1f153467abb1e1db6b8245";
+      sha512 = "4765ad23e91c8599b6d1144533b7b24cac68b77a91c197e6e505a3be0bdb74f60bec2c49b7e7338ba994619d3969c00e5b9c7ba872da4958be37ab69b772d786";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ka/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ka/firefox-58.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "3d5399531290e30c746657286d0a01c03009d08b777b0155ff4a7a5ccb4ed8036d7d6d79de8495e75753aa573c4ab14c1462fc73ca4a0cc93cb5a5095cdc5454";
+      sha512 = "2a8aee12fead92872c5c94a319926aec87a95e891fa280588737b66814aa7378c5d7240a3c5f50145ff23c7673767037160d043b655b2a96ccdded6015254f4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/kab/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/kab/firefox-58.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "690cbbbaa4fe9947189623853ef4a1a4d0df2d73ff50118dab40ddbe57ca772d59d85988d8d30216bfba835b827cc33eb96567ff9f2916514497b76a8e4c1c93";
+      sha512 = "6518ac1276db195c2435160e619dbc1ec7494e51b06971fe409f46ead4af6367567a99356f6b5e353c024a8b9e51d2c2f99983d50709fba2e12342b0084c39f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/kk/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/kk/firefox-58.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "75199857516c970b0ef13808b2a0a13a837643188c3030378bcb010dbfc8c970c4195af4507e32fe17f94b9e1f12b41ddf80f914ba24b1431e6cd0975a334420";
+      sha512 = "2d515605c00f1cf2e76b26dfba3d4fbca00da18bddc5ed39f66d15568b15a2bbee0f1676d2b1b5058e11399ecb3e7cc593ff040757fce76d82ca859ca7b9ce81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/km/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/km/firefox-58.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "3733a9367ebe2a2082e2d7d1a5e09c13a1a587b13e7cb0bff3b4fa1d9c4fec5077e3b9c5156affae4c90ac035a94acaa3ca5666d6dd59ac6d2dfc6a4e9141f28";
+      sha512 = "6bcba0015fd5753f7ab6725197fc164723d64de0790927115a0c06d0d1d92fd39bd41d83ffe59a5e9eaec48224c24e39f26cab3ac1bef6265eff8ad9a70c46c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/kn/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/kn/firefox-58.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "767521f281d9a369569c639cf14618f79fcda275cd2f11a6950e91d0d88843a70dfe6845bc9dabce4229597b92e8562a15af2caaaa511e578601cade1a5dd057";
+      sha512 = "5fbbffed20a48328d2b199626a9810dfa6bf9cc84f358d429e7986d813c1ffa37fc95eb20a37b10bbf728e4bddd3ce8635c096b7fc4a4dabe462a32606a6dd96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ko/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ko/firefox-58.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "113a28ea22d0a2e79f66680471f8d5974abbca440197590cfee0a934f40403d704ed35bca5be9a4164b740e0eba8292f6e0096707a288735d34a2b77604b8d85";
+      sha512 = "2e7f5b385fb65b167ef1784288a68fdde29a3345ade9eb873a6e07a340c5bf76df5769c7771fbf9049eb31bfc5978e20c143a2e753614237b25a065e0735313d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/lij/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/lij/firefox-58.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "36f284f3605e55ceef29eb4e88205524df8ef1e92f7d1851427c4a4fbf6859721d6918dd4184315743b7a8108a1b85aa40d90189d46f3763c3fdf6d5b73e0279";
+      sha512 = "fe436e3ab07f3b139460ff385e73147572a1becbda1ccacc0da6a6cf1c49ab3e1424e9b9d8e26a14a2748e5ac9b0c67fc8970f14f5d64975ace3c6e9949f702a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/lt/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/lt/firefox-58.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "d56da7e01024210a5ec486c410da70c63728a890c319e4496f6cc33efae41c554aad552c081f3b4777f1fefeec7b6b6d331000608ae4c7b128bcfc726d6be5fc";
+      sha512 = "b6e3d248f7a76c4a202c767710151067031e34a08ebcc460f4d6bd95fb395533414d6267daa1d9d8172097aa4ae0155ae693e027757c93b1cba50ad9a94f3cc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/lv/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/lv/firefox-58.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "d5a0f538a1a5860229e1a07d89cd0a7ba6b78ec049d71978bc0791bdb1e3861b8459962e8bdadee996d2abada552abad4f81002e7b042dbe136feee3367fe3e8";
+      sha512 = "7bd3844aedf8112d396f07e1d57ec915e48bec1c375c8489057d7a3f2aa5f93c738d2d361848b977243b95b79a821848c2b27b3117a26fce9054d26e4621522e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/mai/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/mai/firefox-58.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "2c96217b38ec9fc78d025ea79a934e10d1d1553e39480d1dbbd878ef774aacec5ecbd63baaae1c834c44acae417605aaad5e748ca74f5814af83f862812d1d8c";
+      sha512 = "d5e6a53c7744ab267404d9107665e6f55acf584c11123d0e9b4a82f6572ef815fb87f52ce9e0be9352ed7c4af901819fa186ed57e4a313349ddee680727b0343";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/mk/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/mk/firefox-58.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "64fd2f8f140dab2786063218f1b6074d8c8f9c5dd506a737676afb9a68edf06d9800e3c9bad3dfad8fceb82c321531ca6fff6a97856c952dced721f0d0915913";
+      sha512 = "7c49cc95a233c4662265e3fe57e87f4320ed120309599f0f78655a9e70b87ae36dad915afad2445cbf55c84e906c3fd2df4b7f84db59323f4629f662f6f2af31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ml/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ml/firefox-58.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "59036ccacdeff45c27a1b737913e54c0e06ddb12a670c1549ba26da4b1d99fd2338a133e1b15b1fbb673df2471b5cd5d5d4061ce56c631e37c429351da2cbceb";
+      sha512 = "d1aed7e78433d3b427c215ed0b2c8455a8a0374bd4e2d88d7dca59c2a3d0402ce1670f1dc1c8675cf7953416fd4be584df59ab646783240f3aef14cb9474c91c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/mr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/mr/firefox-58.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "2fbac808598aa7ce028f2d922fa55b49174507b5ff6e66e1951c3f579cdd051ae4bcd28edfaabd2319dd7286b08d35a0fe33ac2f63c628d217b8f43b89dc23d0";
+      sha512 = "3244354a154372149da8b0564645ac5b827176c6eb79a88a2a182d2ae7a5e320fc1f843c1576eee86dec62d2866f6648403bc9c687322eade1f943717b655771";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ms/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ms/firefox-58.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "52f6857cdb97b86cd25b0926d509405a1548dfe310fe088c3b27ca77e87fab585faf4893e8562d55fd2ecff43eff5535ede306abcb57bc2ee31a4890530a27af";
+      sha512 = "3f753476dcd5f128d7a660dfb9e1003f706ba2b2a135df629bdd68c8580e9bd47f23b5fe3ef77136c8e6611f434bc502f96eef4b7f7d6185ce7630bfd1f32e24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/my/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/my/firefox-58.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "1e89a3a595ff4b6a1f1044788e34266af60bd6b6e0cf94c64af5e50ad074e7a2d405ead7210e1b55622aeeca3255f966f7f500e38e639fc2677502385e4ababb";
+      sha512 = "b83f6807c08c08e7245bc1c5309e2bb2d3d434a577f672a9ea9e95017b61993acbd0df9c339a4fff4c5e65c589d939c57477ba206194e7d09ff140a8882d2e52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/nb-NO/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/nb-NO/firefox-58.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "b14c55689f787e4a6d4edb504e701d63b36512ae49008249f1fa34cc7961d58ad0b0c7f1aa76933afbcdb76b8830bbc7620580347502acc0712b500dcfa34f70";
+      sha512 = "e59931df86dff00b3ee55f93b01e4828a60de0f693de412c4825dfe7957c0bda8b9644040657036d5228fd7b6f4e3a93273d561f14fc5e9d3d81cc5c708f0f84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ne-NP/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ne-NP/firefox-58.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "20426cd45c9c2c5517587eb2c6d04426eb6c2d8f7370d690549dcf44ae2d9bfa823ed359655a75be83916cab2505759f1212abb4d5672a2b70d81ec573d1e5e3";
+      sha512 = "4dc88c6895264f50639e17eddd5df76de7689208d6094b0d4a51586fa45b359a0ebddc2d58cffbb952cda0a3c199ca287dac278f2a9cd517b923c60398fea449";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/nl/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/nl/firefox-58.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "a98a214fd2c4cdffc5a85fcc074b8516d90c5d79e23c80f0ad464931b8288395d953ac46e575f66bcf0b0e5cf862fbe16f07060be73d9c7fd28930983ceea72c";
+      sha512 = "30f623d07fba2688b8f4c4958817ca208bb8981d1c5a64a232568c301aa8b95dec9406bc064b5c629c357381b5c41bcaed9d652d7e25b3a4f537717d79302361";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/nn-NO/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/nn-NO/firefox-58.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "ab5ba866afc67caa89f6794bd93981067ff12684cc307f6fca9f8cb4eb352f96282fd745ef20ff5b2d9911c75f99f78784753d4755623ed3496488a98797db70";
+      sha512 = "ddb85b71a86ad20a363edbdc9e0e79f6c485b4da02cb803142a717d297e58c10a4ada476a57dee01d5834246a53051b9e65b95eafae081b5b43648b2ac914acd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/or/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/or/firefox-58.0.2.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "6c32d13fc0ff2cf68e784d4e4a58e6befca6bbf1aa77a6dea64825a1e9d6c3c3705d6a60e31fb0fbc4b87147e954eedeab4cf194e0f2b500d8aa3462b95adb30";
+      sha512 = "8161a5ccf70f5b370d1bdfb9b849a2761eb4c25f6d821d39e63f45cd29d9be82be81f523bdb9b1f1b2ea134a8672b9153ff14ece3af6ed7e5a2339c9a43d71a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/pa-IN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/pa-IN/firefox-58.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "483f1b53af7900dcafeba88872ed5b5c5d0d3c703e83d3e080df92ba66467656f43161851474362b8d3a4bfd48ae19a2a21ae244717e55aebbbbed3b55488b96";
+      sha512 = "fc0424027788746b0c8b68c553b7d989e60af2a29e4fa733bea440f31d277c1e64fba06a74c915986dfb3c8da13405689121a8771fb0a47f091e27185cfd7a28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/pl/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/pl/firefox-58.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "bf580678caf2fd653022ed5120f461b87beb47defb323836e40c0e1755adad1e893930a39afa9bf9137a2bbd197d5918b715871056df3cfa9574e684f80fd56b";
+      sha512 = "f39a26cbc41739b250bb92bf2daf6ba835639e5751e1dd0893013e1541ec43de7e747b3ec754894a56362263b3ace8d5f105ace5654c30657ad9e44195cd42ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/pt-BR/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/pt-BR/firefox-58.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "8036559e9d83540cfefcc5217550f401d988c626117e42db66d4ccd9c31afd8aa4224bbadd7293c44b3973df7646d36ade1728d24fde3f5e7cbab19e3e83832b";
+      sha512 = "2d3fb878c286a750fa10413545f0d2ce5efeebea5f8c4192dd5b53131edcaa6a54940f242ea002d9a79f41a14e70095cc79526773dc95d3550bc0e0291185a5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/pt-PT/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/pt-PT/firefox-58.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "afa6bdcffd36065c94bb1984ac9734d1091c14bf065e68c2a650e28fb49a5f7d52f19aa83078973dafb7446c2a01aa9fde7ef43e26a7f26963863329b868841f";
+      sha512 = "a2eb5b43c3d87ea8193fdb1f0ecb0e1a317a71f10af4f3184484536dfc1f7f09fdfb498bbf073f68847f7c2cbf9383adf9ad9e92371c8a835e4e3651a0546ce7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/rm/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/rm/firefox-58.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "26b71c4b734bb2bcd7141247894721b2d35e521c5e9da2cd9fa455646f234fec97b55467e80f8d6b36bae62c807c79e7e12a395e65e4c59d464f7b4c3115f3e8";
+      sha512 = "8dd38ae11781013a03fae2b3cd5fc1b033c45050ed4245fca2302e1818135f1e754cb6c8ecbc535d253104ebafc0792dbabe78f7f336f12297b7b4b8c4a9f2a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ro/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ro/firefox-58.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "e0a3358a71ae65166bca792a8e60c6319f9a4c277c8369a2563a084dd9fe8b68952df87d1f9ce5270420090d5ac7a6dbb207cd7063b488dae4d0efc8006e46a7";
+      sha512 = "e9958818254c1b5577a83960e1136541c8ebf2cd4f43ba06d73c2e40990fb6da958aeb423c640ae988057d3782db145ba8e8cd7816b8aac8dfb7f58c2eb0060a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ru/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ru/firefox-58.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "adfe22866b6123b537ddaf1dd81d397478e7894c021ad74327c922d85bee8ec132f410509a147bd7f1300df778922ab940c36385db2659c8a356914b908ce9ce";
+      sha512 = "abcd9a548335648d84ed3856a89275c62ef7d883e18d52dca053b4d8f80deff8fdab7336a2aa9382e55e110ded2d4bd9cf147b3f482f3b0ebb972ac696562645";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/si/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/si/firefox-58.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "94892e878fc9feeb9e208aff8096496423e40e42bc22ede273cc5e3e549564861ec31ef9935f1e29d68b51abe79b17a9c6b1e5763917111fe94c95f27c3826b3";
+      sha512 = "53a7b139ba28103b88359eb450c033fbc8bd3a0c95048aadbd058e505ec85b652054968304d113826a5fcdb6abcb47e8498d9750023a899fd83d5c0dc8b3ed63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sk/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/sk/firefox-58.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "26985d29d4cef9fa987d83b873da188b7a776929533aecfd1f1639bc0b7c4393bd9e04cfeb3f7f9f2cfb7b43b5ee14a421791a6024b2eea3707b7c3699594e83";
+      sha512 = "05d4f52e87bf24884caa888c14dbb6e46bce2de967fa4524090df63b2d9f2f4f82b926842544d2ce7ee46f0196a62e8dbe26e7b07176f5c13886ab2a1b2cd184";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sl/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/sl/firefox-58.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "c8796f686d147774ed4205a04521fb1375d1189575e855b6eeb0db7c35da96aba70803cd477656118f6137658f71d53c188d10653d67f121942d95d81a6a05a5";
+      sha512 = "655b4fae25e42cd1678e49b555508ddba2da83a24f04d7d66f5d25a124fa2818368adc851258dd78915a2998272cf8e7bb7a5e918e01228e735d3ad0caa8edc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/son/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/son/firefox-58.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "56f8b81bc5619b88234feef3e17c1a80ce06effc78880b4c9da083530c7f9c037015b6a940914bada62e98711065d6a0c556d90b60125af357ade797403885cd";
+      sha512 = "cb555d1465c5ce0a7db10e5117081e682425aaf00221b93a66d23ca9217cb2cd2b3835007961f572a39d93a02d12f9a62acc75f1ce3d8c3bd6cd057afd750f79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sq/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/sq/firefox-58.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "1bd75656650f34ddcffd38eae46ba84eb18fecd79b9cd7972f96d0906862d37013c48046355530baf5f253985b65922d386ffcaa25339e964db16fca6bf85505";
+      sha512 = "5afe4996a2c66d220d038cc041fba4a3bb5e411c0d1c4962b2a3f28ee16c5f23d1d8609a7d492a10b16d508c2781b7bdfb884d810ae5d8c5fdadee8120a34659";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/sr/firefox-58.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "abbfc2f50567f4506dabcf8500ca56b369fe6e6502147ced5a52cb2d506c6b28248adeb6564a6a092ae96632ed2fd43356507cc53c6c4a53756df2ae2f6dc735";
+      sha512 = "641e3173693e73018154f5f3fdeefc0b0fdc0b1939ccac19b73769476a8827b7244a4088cc83fc651694e9c82fa5231b114fc05c80371469e63926494906aa83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/sv-SE/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/sv-SE/firefox-58.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "5f19b531d37c8774142a86cf83c678e0ab889c5f22aa792c6bfa881ad9441c02aced2324077137c8ec75c18a1e7a93243b9b87604036b5d29ae4e93871540ea5";
+      sha512 = "873f11216e002fc9eb4bd6389774c21d1f3aa17baf0f38770c18db541b30334a84cf2c33b478d009227b1ef48a7c45183d7df9991878daee78c139f6964c8b3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ta/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ta/firefox-58.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "f503d38e25cd403f8dca12992258265cd3abd50219655eb51867ee455790e1864dea2a26cb0d72bc311c3685e79836df9c0c1794b499d13fb54689ab9408d484";
+      sha512 = "1d91749d41fdd5d5f3988803563e083f3d65ed6c70fed197f38fffa7847c10d2b0f355fd46a1fb7f84d8c94dce096d2b84ff692fc6f5f33be4ee1dc63a4efcd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/te/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/te/firefox-58.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "3f68679d85cc1c844fcffccb371424c38406df074c8e21a200e04bcc5fbbfb1199d2202487c660c95ff1941b433d22ef3474580a0de0909dc251092e139b4bf3";
+      sha512 = "2b779beaee906278903dc12bf679f0d8ed51d622a1f790a956d039faa71c11abf1b4d462527e330dfb92dabd87aaaa70b3d84a295f21e1a701b4a308c85dc821";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/th/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/th/firefox-58.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "b3ea54ed6c65b68f39eedad3d4500030de3f53c6b603a15f63a82b2766e023f552869d5d0e05cc5a4ec4eeafeb3dc124ff6ed09a5adc53e44068034247ac0bf9";
+      sha512 = "82bf20ace51794807f6460ae4142869fc2efb1b4bcef66cc5d68fe8812d4cb89578a45cfe0cb7927c45ab0d1e057f30d4388093678213187bbbb6f209babad2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/tr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/tr/firefox-58.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "644ffebe355085ccaffe266c2ff50440200adf95a46aa1822f21a160dc982bbdbc8157d9231e1b96c11c573409c620bcff113865d55eba3c3b7f3cea7faf29a7";
+      sha512 = "65766e0207ea300dae4d95023ddc732cf5f59662a894689e87620e6e08a3f658234293b666467eb1f76afffda29716b128d72286b1c9cd68cf574f7121b71792";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/uk/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/uk/firefox-58.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "20579b4afeb36f5fb07a3a93e4c5837919df959f9ae98e25c39597e2f1446347952fedaa776d40bd606264cf935ff343cf69431e8c8f978dc8fcc60020f669a6";
+      sha512 = "01aab08b333c16ac7156ca35580fc6502aaccdc269c6be29e20ea3ecf97104a3d0214d16bb65f1e3e7aab5b17ef3c637d948a2767594c36ab920c7086e11607d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/ur/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/ur/firefox-58.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "4466d3f53a1d68df8e7bf6074c2639d84e5a7bcbee32db522f8d3a771266454c1d0c9bad1baf52b27c91a6fbb779c41fbea50a84675e9530ce33b1bafe722c96";
+      sha512 = "b282916667060259bb90452d08a2bb65cb1225cc45494c2c18c4982e710abbd345744b08bb9c2bd200073c2b470c3b3bddf7f9b6d652563e3c4a8cf6a6248391";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/uz/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/uz/firefox-58.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "4234f1c10daec449867a4357a123be7d04ed3456b98a2d2e82a3ec3d85f7da167e5dab95ed6c4f4f1f44b9481608a80cb1ff1713bd0abe06606a15bce7df6d6d";
+      sha512 = "9339ec640a3d4920fba39e69520477d9c00cdda5f1617067f19fb13b1c17cabd1cf1917001a49604686cd835839adcf3f206dcde14e7c4a98d579c7d8a19386d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/vi/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/vi/firefox-58.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "fa5b72aec8b5a845ffe37588424059037ed1121f35047b123d39e7b6b11f0ff54731a974b7ceb3406adaa1705e14477a7ef189ce53305add2712cc7d433daf82";
+      sha512 = "c318398809637623e4ecb187f4b531bfc1b9abe093cfecfefe2faa75990dad09b505d8f88e2556476c92cdfda491161af8e7fc27c68c8bbedf5d4abee8eda941";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/xh/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/xh/firefox-58.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "17db5a14e2e9e4a022a6d1048f72e734f41de485f72ce45a6848b69db1a96bbafef25809b79a3f85fa70c6e7f43c9f1fb6f16472c294f13f1b77fcbb45d84dfc";
+      sha512 = "08caf6844c3900624093ada61c92f7c74dc5533818745b8e85b15a093b640eda9686bb0d5d86cfec0c90df49e782c942693d4e0a169b7cdfecfd13827ae27ea8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/zh-CN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/zh-CN/firefox-58.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "e8570e0c589e298e84653302c85ccc46ef7b9362b5449a09a43eaaccaf2d3ba1b55475c5fb190067d596f85d9ac3cc037e5ad400454a2d49c8e9ad878bd8e04a";
+      sha512 = "3046e58285f220ef7ecaea81c44063b8573f59ffc64dc12f698a184ad2f11bed3a4cb5d03a2bc105083b0fd84335d7477f81d3eac4bb28b961d38d9c886a9376";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-x86_64/zh-TW/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-x86_64/zh-TW/firefox-58.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "51243e1c7a330f0043988904759fa8d7fb67e287ed47a6b6a18a12ade989346f4939874dbc6b15670217436f8132126b29fb641d60e8f338bb8985ee5411498e";
+      sha512 = "cc453128e4720181d147552fe2452b5142b959e3e0cfd3e340159def69be169d272980066f9a34206da5f815ea54b8e4a062bf95ec4b1cd7ec7b3b83e2ae13b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ach/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ach/firefox-58.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "a36499123874af16bf33d80ccf2a84dbd21f641155ded9d58e0c064a8cc5d9f034fb64d154f0ab46cebff191e9c9cc46c820026c53408329810a318556be6210";
+      sha512 = "c26386414dd416bee1e4fe505da524a4c1de34ba8c25b2978a20c66a09f8e3c7339dfc4b5fa00f0d2c052fea1574e5ef1a5d74e67d39c7e717b54439d7dbb852";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/af/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/af/firefox-58.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "4c42737bcd7af2f9f0b6ae3415a56d82d360998f8bd0ab01b6b0cd5f72bbc84fff4045b3553a1a87f0c3258f46b526f9e9eb0c3dc8c8c66a2a22d5430fc38499";
+      sha512 = "a8c4485e579f127882c0f00a4a90bff5d02bee5f28642257bfe0d6638fe9156ab10a00dfd48052aa4995dcecbe10b7247f1d4e6d9b424bf06e431a782b46b95c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/an/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/an/firefox-58.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "e821fd76b262744b740ee1a42092b954df2a6a552cfe305ab88e6ca8b2538045654f64f4e1a0e1446906f91896486f204518836148eebf19d306b4af0c2b4d6c";
+      sha512 = "29e91d4e5ff020241ac81b810b893bdea9fc194090c78fc857d507d7bec8651f15a3c70f3fc245f0d5faa21a3cc44b6327c1a32444eeff3ae4d93a723e230e16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ar/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ar/firefox-58.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "de178b0791074179c76a9e0334b5c5f2bb3599e67ccf4c8ab1d9964952b17c2ec0c509e8e37d83332d1cef7b74ee3081eb4092001023c3a2f14d906a8c0e48e8";
+      sha512 = "d1d936284a12f1718b69b279334aecd49a68e5dbabc65a5ade2af277ac7b8ea342ba4b580df95040ae057525d28a7c1852222ab2bd273c2aae74409a5533f74b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/as/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/as/firefox-58.0.2.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "a6f3ff8f5f31b5bea725175a27fac0872765f584a91877adc01dd42811b059b61706c53f64e4d1a0b7782c26998bbb2f73e865bed4f4e992762b5f90993265b8";
+      sha512 = "49f8e1e8cbe6910a9fc8a812b3dcb7e694c2785fca1c65639d70a5d0fc82dcda9630a1e311df9bdf148d684c2173c761b6aa3926a425730dc35fe99b14124992";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ast/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ast/firefox-58.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "dcc47a42af28f1814541f71650e24c653b5f99958b495aac3d0408ddd27aeb8d689d6244633c5a397d5f304dad3e8d2778e5a3573497e47c895a9f46365c40ef";
+      sha512 = "a01eb17a9952055aedc3eb29126a826ef812c75f5f5b5a22af3125ab37b63e3e0ad6de0a5f68d0a5bf0b3d1c8fb1f721d4331f1afd30b6a3ee94a502d5931ff1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/az/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/az/firefox-58.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "41212665cbd529e935af5dcb8582b152e84bac8c7055b02f2a43dc6fe53e33bb882908feb71faaa8f34a026a64117a286e59422ba110bff8c04e18229bc418aa";
+      sha512 = "7117993a67c2d0f3c0438afcbd87f22ce141063dbc66a1fea997f5145603f8e9d28b62473add81475bdfbad350d6e683d0c483ec2287f0a47f4e9b3bfbe92ec7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/be/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/be/firefox-58.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "681e9c68187d9b53880494ab08300bc28b8536f5aae320dc9da6abfc8642c8aea2e2613b48d32c25309589f737743c733b361c543525106ed9373ecd3b40b891";
+      sha512 = "9b3486fdb08f0aae375a74701e7904dc13b1e4db7a1489c4538d523bd4af91b882b9785fc4fbc3da2f6ac67745216ffaf7c48c173f840288c6e39b2fb8e78b62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/bg/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/bg/firefox-58.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "742cebc1e646a2d9f5d9d6c406ca1903f81faf21c4a38df0ce6edad8f7b96ee8b22d7ada34fbc24461f5e7644417d37b4dcac6a5a10f8b0ce11fdbfda9c01508";
+      sha512 = "a917bd437926c8854786b4169ddb2a132bf4ca0e51c17a99a3cb814a1c1fa7fbc7c2ca46a0c7c91ada117ce4b2e89c955e1d60502c6eaefc9c57e0011459609e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/bn-BD/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/bn-BD/firefox-58.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "0562b8bc93c1c768ca49e94a6285206e3402b45d9217c6679eec7f30395cfa500c35da7ab0e560a5fff3db5eb60e6085845a6a7b2ba7b695ebdf09990bdce5e7";
+      sha512 = "51032301e619fdf9e9ac99c52f771e39425e9e8f063f71c491f0802f02993bda668e0e18196f4d10125ffc66fec760df0f98c19713f8b54b5b05c502067fa4ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/bn-IN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/bn-IN/firefox-58.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "d459a21206cf140acff54ccf6d7557090ffb3eb752f62b91ea56a4c4138858ed9146d3edb6ee3252ebdd548f3435cb973c284cd0008207d46dfe5b8b12a6bf55";
+      sha512 = "b76ea76976ade5df4866c2c54bef553924ec9d3bc229cc7513530ca81c4c4e118bbbbadbea8a64f27a061d0ccb061d7ec0e1a398a428892a2c59761b0a7392e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/br/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/br/firefox-58.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "c23ee525c1c989264fbd1e00834cd0a1da1c470a54bebb5caf18502499f16917697f3b6de55ecdb9270ae11741420dd1def626603f2f945f2fea8ec6279f4b8e";
+      sha512 = "7ba73fb0068862700bf64248987796837c44bb59ffec052638956fe205bb52780bf2ce9bc6b1a5347b173255e893de8b9380dbbb245d8a3552dfd1a6fb73f7cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/bs/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/bs/firefox-58.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "dc254689e74cf7038fefe2b6b911cb75b96fbee105a44713828f8f7c9f1a9fd8624f5ce62205f26b4d287f73004edfde73d4fcc4431d2e4464d36e822f4667ca";
+      sha512 = "5f2aa4be25f279212541716777012f87f5e65a57deb3b4dd84d4187d84db80ef3f8dede2adf971dae1fd9f4e6398db81f956f59df2f51f35f1893f581266fe0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ca/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ca/firefox-58.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "3f358d601c182bdca9e82221e9e6061ee5d610cd42caf722e1597c6e3e47ea005949ce52d0e38d160a02e4f02f210328d631fc095b0a49af71e92919aeddbb37";
+      sha512 = "2995ed991ab118d5e318f085a340113a0e71801cb2b781890dec674bf3a8142b9bd8b0bc23ee23bed72b1b7bdc7f0181abd4f4d23fc88b7930f710934d2943c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/cak/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/cak/firefox-58.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "274ebb0800585fd06dee02bb4a2a88cb4a64d39198e23fe481061b0cd96c281c2bc9983516614eea980c118fb98db01be2c0a387a8cc595da7a2144215f27230";
+      sha512 = "dce6a70f1c59b01a2d3ac65c6f44adb9baa8e483dba84989e40d7388f9ffaea894e3107cc4a82ba6aa730770c681bd73b50d0ae2f248477f0b63192c45f142d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/cs/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/cs/firefox-58.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "dc688379b955cb619e1780c66368ebf5a09415a3b31c8d116c1182051281bec251a06ff15b54816e5f0f11f1c0246f33d2db42009035a7254702bd73d13ca83a";
+      sha512 = "3c84b185de63520d430ef541cc95290868fb8ccb09829ef8887ee0559fc5da8182e890155e3d1bf4e82966c82837d05253fdf2d2115f376c4bb0d09c21cef339";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/cy/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/cy/firefox-58.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "f20ad279750ec9281ee9a800971a4538e43dc3587df35afe676e7980e965522dba2b6a9deb2d0b9acac31308de3a8a167ec8dcb05934503602483a6eeadf00f9";
+      sha512 = "1561488521608643f3ce97da23052b8e968c1b8ad7ca38b966fd088368932976be0f503942ef65617248d3ae572afa4ecda3499c427845de32572d163d577c9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/da/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/da/firefox-58.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "b9fea0a664a02698423099a963787f8b5aa89f3aae8ce6be9962d9d8316e01547d2d3fe54f05116ad1fc6d7a68d6f72d65adcbe63de98bd4b16c8689190510c7";
+      sha512 = "fda58e6fbf5243d5fed1b386ac8014efefa856ea3f8cdfca4e723f646dda2a8825356818bc8f06183a57337a5449ae3907bb3ac4c81bd7f9590d94bbc32749a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/de/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/de/firefox-58.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "13407206fe0fdd88793406c349e4f7a66132f2edbc32af12b7d30026d22cf721970c8e8494228fc80602cd57feb3dcdf17f0490580b2e33806f0b3bf03fc7ff0";
+      sha512 = "d56395a97002f31ead2523179eec912dea7035a86c80a8788b21f272c6e6ac4095caff5520feed261f5ab5a2a2366cd12e223b23d276e01d1ef318b8c15db860";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/dsb/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/dsb/firefox-58.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "6d6661cc82de4eb37b0326f8cdbc55feaaf85cc44137af1bc217d609f42d97216402927021dbacf81cfe704ec8c1e42c3dd18f39bc1f7e6665984ccf3bd678ec";
+      sha512 = "97538fdf8a2a1cc3c485210583d9c80db10b2d599d2b34bfffd5e3b29c092a8573f100cee5c69dbbc69fe67ba6e2c648715fbb9271704dc26e6b2fa98a8512c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/el/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/el/firefox-58.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "2e8d1ad194159f6d7e56a461d594b1cf998f073da332a1f1bfba46ccd76e0e5733a691608a16ee08207f45d16ca59766e774534024239b8d5b3be9156942b31b";
+      sha512 = "4a12302d67b830098e74ecc5a2e785829c1602dfc3cdc20c1e4be5a2e58854128a68ef9fe459dc4baf7f1f87e8ac2a065061a259c9625f09098b364c6d12a393";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/en-GB/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/en-GB/firefox-58.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "f45ccaa1b6684558a1c9b5e43907fb59be0ca466260950d701091e6bc1c6a9d18d1a8dd2b2dec77381450f61f99b632cb0f3c0269ff309321750e16577df697c";
+      sha512 = "0ef9e96b43154f3b6d8e620183c092d38b8a5dfd7b762416b090e2754baee4564f6876bba9765cbf7499f5c658f2d352bb45769d852a683fd528573b53eff2d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/en-US/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/en-US/firefox-58.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "e3d289363aa63cb459e1a1f4f18e893617bfc6f972a49308aacf126698d2dde0baffb3dacaeffae9471a8111eb332c753f376ebbe31aebfbce52c5ea84122a16";
+      sha512 = "05046233531db36a9c9c16cf6247401ec662254e8e1b896abf557bb2f4043ee2ec1f83a04c9b1199877d66b50b41d47bef1ebe6236e21998406616b8251001ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/en-ZA/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/en-ZA/firefox-58.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "a4c56c45280faf3dc65bba6de159f65b121972da5831664a70369b446aeda44f7614d01dde6a070df058a4bc2d42f32772e1003f64d277cc5bf8361f76fa2816";
+      sha512 = "7ff1777a3aab71e9bdac1d41f777837cf91ca5f9ae353e6289812899fd10a4f58c13938cef0f33cb3d3a0e80b42c70034f7af22783e0b22495fe279cc497fa5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/eo/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/eo/firefox-58.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "d79405fa9fa01f13a4a98797b3192f1feda51b26568e89746f6b25fed6b73c1f45f3e6bd69427547da19c7eb70508fdea0ff6db21e8d15211faf8da03b088e85";
+      sha512 = "3b4a8b0fb29abbebb224cbdc4dd9ca62457d88394f653388915898fba9eed6d1cbed43f6b8fb7bebbf18963d368fbea6aeef5bf681c14d2d5e09747fbd42fbe1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/es-AR/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/es-AR/firefox-58.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "f5751dc82ceeff378d78717ee5850edb4f160f3ae26c0efd70557014c96c765fe789fec2a8650f65c9fad67cf1253c00f4bdb75387162db1c914ed45dfb7164d";
+      sha512 = "9409072b8aaffe4ed914832d0b545fefd20b9930e0529c38255f19a0ad524b66127d9704eae2b8623696560fb78169aa66d1b5bde358885dad4d00e010189841";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/es-CL/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/es-CL/firefox-58.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "592c5f9a70e28521f75e16b79fa0852815f34b9570ecbab610a96892d9b13fae609a9050a4dd0867bee7b811cac67188c9a756bccc2d6d99821f9ce9db48a509";
+      sha512 = "0bcdfe996b3a8f4810d464bbca0690d12f6262032a21e0716f86f793faa4e707d3c308e79aac5657d619ebca204d5f67667c6d3d09e405e887c338a859ea1faf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/es-ES/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/es-ES/firefox-58.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "e3fd1f13087eac51a830acc760b83ff9459cf6a1a14136c43c8ab7395b22b01cb2627b077c5f50968023c47f31484818ccf18245d109610dd04e3e5627fdb65f";
+      sha512 = "1f2aa1ec1c97cfdaff07b7aabf75b5e1bfc628fd8ee71c988af5471e570574453889a7bf40f9d3a4ec06889a4672518c986c3bc6fd35d7436d45c5c74507d801";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/es-MX/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/es-MX/firefox-58.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "35ea8599e66c29f7fdf1f2ab5a400a0ccae4d0ded4bb3d509d0caf7a6449bb7944c794fe080b1364be055eedc8bac017b8281bd9a76b1d76def573d3191cd011";
+      sha512 = "366dc93d1e6508b00987163e44ac2d6fd318bc9c80487a13d581926be7d3a88a6fbc6438effcefcfbe6a1a9794f2a692c385fec7503ea96feeabc5fe10cc7a4b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/et/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/et/firefox-58.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "29e6013843c56fde01478cc871fe15c2f1485d41e87af30daf97e5c0f4e80ae14368601a2df43bbe3618fc878e7503007708b760d1f2a571b4993a99c2411f17";
+      sha512 = "82b25a2e1ab4d61d89f5944495f69fcc7db33b3a7bb7822758b588ea7c3fe9ce3d728ba838760b93975cc52b105de77cd980d20997f642839680a20ccd5e1d4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/eu/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/eu/firefox-58.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "3f6ef7db13d1b8c8eaded290430a8462aab2172c4e813c9bf2f11f0e417485d88872a66628130987a37286ba474e8bddb9ef01e120dc2c6baf49bf9b5c5e67ce";
+      sha512 = "6eacc4b6069f6bda6b08fca871c7cf08bd666f974bedff6c511652801e3718ef60ab97425c8ce6d1cf5aaac1b5b9a62990ab086ebfd9e76f646d491a19325b34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/fa/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/fa/firefox-58.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "14dc9bfa351de740e46a8a3d59c99d0de7ec5d890783f03a8b260217a02d1cf03a94c6a0d7411698f789e9b77c2e1def24b74d9754be821b1104964308a6322e";
+      sha512 = "e3f4c57555c415a4d3830a6751c5444e07987fdf85ed0e122312bc4bfd0fbaf841cda7aeeb6aa161d48070844aaab316ffc163755481479f5d421ab8967aac15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ff/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ff/firefox-58.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "273b3a3c6d32f63de9a8b47cc6eedb7239e42cbf5b8e48191b2d9f9d88731a5da6957ad9bbadfc6bc52e591328a2a89540c4ff880cefda455ce1e5beb35492fb";
+      sha512 = "695b44de161563727097da1d969c0a98fdbda51613ae8631a757410a502ab25038a9c356338b1178f7d35e0110e9772b3e2fb705e20d81787317b528ffd709c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/fi/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/fi/firefox-58.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "1d71f85cb661c87bbf1c64c2711b45ce912aca629638d2b7953d0ee3256e7e50c920f400c2bcf92ce171be44134a66b28a34a3b38580da3ce2436dae1b0dd44a";
+      sha512 = "1227a6e57a68c0ffc60f6d9eda20a41fe70e7da130bc705fa15e428539e0380e1f65739e791ec699f216588ba54e558ddb6242862396837229c3ef3b028a6346";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/fr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/fr/firefox-58.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "ef15d841348c23f35c2fd6cf93d86657d6e3308bc03935505b99ba1119a02846c2ca2c5c55cc0cde992d4e8af50bc612e086be34cfa61711858f11e6e256f7d4";
+      sha512 = "c15980e0a1b4b9709416d362e36a3dab26502af4788b7c74d68e0ebd2f3ada6039d10af1e1d49885604c4c3b41356519e53c278f04b14729502d8044bc106384";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/fy-NL/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/fy-NL/firefox-58.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "f42e5dbb7d16828aa2d5fb45faf44ef92b8ef29e5c49dc8a75540959cf6c153f7d423255c4eda765a9db69dbbc18e7b8a04bd3ec1329314c1d69bfa41ea32f93";
+      sha512 = "dd38e22a986b558aea005900c2da53cbf28ea68a77bff428aea6ebaa09318439232cc2d5c8d0599fd8512ee4ca2488080297ffa61f2cac9547fd5257a01abd3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ga-IE/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ga-IE/firefox-58.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "4fea194d08121ce95dc6891b18cbbb031e64f402f31c83b92c9044c8d9337f2b50d76017f4ecfa616f51e8188e6705e8e940fc2fed95b7d21d4c8385b656ece3";
+      sha512 = "97ff02536814db1310bcf53adac31fd9e84a5e39d58f9d81dc2f70d40e6b608c450dbdb38edc83abbaeb0535f1a1c0b1511c77a161e6d0ec22b8cde71501be08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/gd/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/gd/firefox-58.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "614811dae0bd10f809ae048d47543fbdf0459320a8f9926280bdd8467b2859646b7201355777081638b46b77d3def96f8052b55c243ff524a22d2db4e20db864";
+      sha512 = "7e8d8dc8c341ab3990b550392f92029b70f6d947119de13843e11a8067c2edcd10a02dc088396beb52b1d069e8f42732db8c514f822706de3f309061e649caa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/gl/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/gl/firefox-58.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "a20e1f54fd12acd5480bff14d24993c2d58a33618170813980a8a1f0b810140a99c7157d8c8eed3d56f8daaf2fbbd525c1df98e1a90cd0f6f89ec253e4b5b73e";
+      sha512 = "31b57462e13e43e31e0e9073b353e1f5a3c32ffcf5c5fded188a1a61a973510479d5e04dc26437eba5445baca51f82311ee9470e3bed9a6309d40cd456da4763";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/gn/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/gn/firefox-58.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "ccd057d636e8f3884db25ed91186a5c995b02eca0c3c7e07616364ce7d95e42dc1f3d1c6e9eb844c6bab4088127232bdd85e3f33898f681f837c3887ab0415e5";
+      sha512 = "d54e50b52870747013ba457d205fd9d2632302309b9850171b968d66dc537357bf747e322420e70e5c029532b053e557da86076a25fe8c5f1a3491acc9906b37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/gu-IN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/gu-IN/firefox-58.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "fadc9a802e9322e2ab0f6b66bf8d938a5e3bfc67a1ac901c0d41d5ea82bd87be0165f50b2c5ce7a75c68f8db45eec8b0e7ea3de237f6c6f79d72cdf386cf3e00";
+      sha512 = "d18427e64b54eb6aa1a1ee7ebfe4bdc3b219af28e7cedde55ae384d475ba88b83b9c6fe701ff849aeec32f8e6b184f2e3f910b407a9d200fd45ceaa18fc7d61f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/he/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/he/firefox-58.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "9fd2d1f4087b247814282e2edab633fd865ebe94fc73906bad065e0af927f298f46306dbe7f36c98875b57bbb66aa5e51f37f5a5308f024eaa9a62f968916c0c";
+      sha512 = "a7ac2db737ddeb870bbd136f8dea08306e8bc7158d7e880655cf15541ed26382086d270a6ff2bbfb332fcc3e53c7348a403bb889aa8ae5dd1cc6fd1b7844e768";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hi-IN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/hi-IN/firefox-58.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "7a07dc67e58c295309768e84b2489413b6d8ff71a786d249b977a7bbba245f74c6d88e33beb934444a34de88a205233953f0b7be3a3628950b0c851c35c593d1";
+      sha512 = "18263b33d5fff4154db809fed79fc2ae20590cc2ad609e2abe90b036420bcd38fda629c613750432ca4c06684c772cf567368ba2bf098719b501e329e55caf51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/hr/firefox-58.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "5db4c7e305856d96899270e20b41c6db2c130abf25bd5eb47cbd2683e8097fb41d37bbd3c577253601c99d2bcedf42472bfce74cc4155a01de3998160b3a139c";
+      sha512 = "f75aa782b03335b0197cbea1446cca56cedeb4be0282dff8bc0f1d6f6c8bf596113edcab650b6c8b7bf5a9ffe6bd14e0e29f2e82002a5c720cbf82f9dfca1b08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hsb/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/hsb/firefox-58.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "5729719fa57723f4c87c5f63f9c08b552e374d9ed9cc9f39aec49223be7b85d550074f680511c79c5b47cc0219dff687c7ac288781822a5bd10f4365cea88825";
+      sha512 = "c0b987b299ba764ff5418be38e68c52b7caaf61480edc34d575ef58807b5289fabc25cb22d7d87dc8ba708d6fa4157d46237e0a31dafcbbe5f463fc945a620e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hu/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/hu/firefox-58.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "b0334bd7fdfe6737ca5fa1166c37204a6f0205f6756af31b8aa34da6df759f487a3c1aa88bc9cf2dcab4be8724a203e3d35509af4fcf03581c8c59023db532a1";
+      sha512 = "58c7c346d0fdb16efee21d8802d3bc668ff4fd9497ceef1b7a96cb8bff01df647c32819a5606891e2b7a9283677bfa9624e33423f7ed1a9c6acd1c19414276fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/hy-AM/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/hy-AM/firefox-58.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "33ac9a2a7a554c4662a9285124fb8050894c921ec72d7d3655197923e2fe3fadee007afb54a25bafb9ab8c9a0d898af52102bf629a604563d10f462001f08853";
+      sha512 = "79e733f8be50ce4cab74d80dd8e4ea667ac9b2973bce27fc1f70a37b879e19b52ee423c2b360433d1e5e15a4143050e7943a3bdcbf709bc34e89302bb0ad7f35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/id/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/id/firefox-58.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "7bc77cb0cecd1cb993b158670e448fd22bf982ecec84213c8c32634df32ba538fbee8eb834719dd99ef1087b6f8955effbe1776a3e150bf5fd2ccc90606bc215";
+      sha512 = "5f49f449fd68cd4513ccbb541d3884e190b2a9897ba6267f348f4e7df9415a63e58a254d18f116cecd33f0e34a9022f4e34472bf2486e29b0ff17702f4790e0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/is/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/is/firefox-58.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "8a3fd3e89f503fe4c74b85e8ef87e1e332646cd150c95ff8685071bcc456bdeb09de46e256d13a53f5f8f4cd3172a12ec6c8096dbe54a9cf018be857b4997e94";
+      sha512 = "6c5028ec47a18d9de6bfb4d99d54815b174ed51ccb74f84e0e1d69ad10940847d4655eb76b13281296575fdbb972d32df34e8e9849c8db4fd46a6dac4b4f0d62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/it/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/it/firefox-58.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "8babf797e0b804e4e8b98a6261dfed27c93832966a66de71ba6794ffd3bf7d3b41ceff7ac4308ec9f978fab310baba5a87dec82f710014cc9dd6f27a520ceaff";
+      sha512 = "dd4e79563c63cfcd76906dad9b28162bc9df443964a10fb0be7c2a201621d394d45ace33dbdf85d7acd040175528d58da243333d06ced80bfa96f8c6226aa3de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ja/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ja/firefox-58.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "f3fd18b97b2880b3627e100ae20527eb998c7b9d11b2c38b628fd1372f7811cd40662cb5d199f12982fa35f8fb9e6923e2c8b1ecaf5634b6989e8b89480ff252";
+      sha512 = "472f544038dce535691db40eae8cb06dcd77a468059a261cfe04186bedb4403ca209efd51a5b5efdedca323f70f4a69140614d13380fae0e01b49c85e5fffb8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ka/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ka/firefox-58.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "4f69cc6927a6aea8496283c1c47961a38ed621b4a4563346506e4c138714824cd5bcba2f0c4d1226c643412ac071838693c0b3a2acd6fc9602a6f12060955f75";
+      sha512 = "8337bbc594e6d7c0f862a99b8ad67fa7b86e55d372c5db850657eb7952f9abe2640c7bccf69568790099c8f9e7dcda65ecb28bbf2c18eeeb6760f3274f343513";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/kab/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/kab/firefox-58.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "93fb1351b4c6271cbbf04e8bc8750569f5e3a4375559512055f4bdc68b7ef1c7f78c9354d5168e54d49bb0a529a380eacfb25a109e7f7ef2fdddb1bcd7bb9fcc";
+      sha512 = "8d46fdff00c65f503f87b1d478b71621a2051c7ea7c24747f0793f6f6b7ebccaa39e8a61b35299078e2b49f07a17f7c4f744c97ee3767f598503faf7bae4a17d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/kk/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/kk/firefox-58.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "e4d849284c358bd297b07f557ae304cf9ae681733ee2acd232eda28abb9bfc38ad97916b00f257f56a9a514bfaff9b440ced15194dc3abf56b0af209221a7272";
+      sha512 = "617ce9bd37cd1ef36251cae9a0738ab93bfc4eeac2f54912011343905047ea5d181c25fc891b8abe178f3632189fe62c38ea00910a1c4bea3d47907c0a2caa07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/km/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/km/firefox-58.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "0fa3bcf4b054c8033ca4ace9446b6062114889a9b3affa730ebf3ee23fdff470676919cc7086b5a13a215ef87b73aae306e667d0b1c18437b6265d5622972a8d";
+      sha512 = "38ee6522276cd186ae63053fb15978f6eb5bfa8b2e78b3f2e4233d58ef53ac32307c936c454eb76e86e9f5d4845632a7b58e6209851a775c93629d0bad1473d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/kn/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/kn/firefox-58.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "7ff42d342f103c2b6f4f4050c7c79dd0687f87105e31dd80efedec34dea27dc5c9eeda16b79ea676d43f78a85e55a1e47c400e0faff9006bfefa55f183efb82b";
+      sha512 = "462349b1bf91686f8212deb580166a3e0ca5dafb947c74b9786809626af68e43c4ac6e51c8351d028acb3c86d1f687ea9f94cf34c9b5085801c242d136a19383";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ko/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ko/firefox-58.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "9fff35314fcb6031923b51db50e779564b7e5aea3068165bec73c6d8833b18579f87e676291a6570827aed29a1074ba54f08255c6125333da2f040c9ac404bb6";
+      sha512 = "78e8eb72d89173676a0b65d7295f37b656791595c4def454604a83ad76e2fdf8ce40976bc91ee17219a320242e9a41568157f3754719ab9f9e0a7ce6cb4f66ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/lij/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/lij/firefox-58.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "d574c03667da40589736295bad53fe22cc67d3f6dbc5281feba5d76138ecbace6daf7d39145d11ea794730c3606f6586fa58d3058fa7eb3f0d1336acf7958cf2";
+      sha512 = "f51136d2e8e29af14aee4cc20e3fba6546effa40c681d3831a9ced7008a845e27e9bb80ada996d0d77c2c9ecc0825f6c7bbf1063797f71a153fe298be06e7da4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/lt/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/lt/firefox-58.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "4c38dd3f72be96b2a7bec60a55e7ac0a75c13036c3b62d4805ac3f32efb6422b2a74807cefb87a3ad10f25d41c14d00055cdf09092ad9068bcddd5a46dded650";
+      sha512 = "e1ba1b26612c2622853987fb802c4fd5e7433481b6721950813f76b6463b1320484383b25574733d75c5c4e547b52b3ad9d8687c1a28b511b07bacb9186f22f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/lv/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/lv/firefox-58.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "fca51f322300f18b3e5c988f883fb352593c40988e5f0203008b71c725a162da0a15e67434a91af0e8dc63ad869280f6ead6714e2da1b4b6b83284fc56790688";
+      sha512 = "894b82ffe22425e1c95c4e148c7dd58f5b14e2ec11a5a27594e0a00b8d5d57364080caf4da38f73c0af3962600d0051f6d6d436687f485cc178e6eab1d5733d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/mai/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/mai/firefox-58.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "650b729a0dc938c2a0375e967e89a2d6e95595bd9c0f8f0e9940dbb51be4ee80257ab7c7006eb933b4d21fb4cad053a4e55e2dee673c8f976a1f038e3ba5c1d3";
+      sha512 = "7240f90b5a4b6cd68135b3436fa796de0e799316b8abc06c1c62bbe22ef9b6ae38bdcf1c60a5df97354ec5b0b69f64635ad6a88321a34a6b15e035bbee19fd53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/mk/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/mk/firefox-58.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "3c15491a97cf61676c6dd1705a281b2f85b4e2e4446645b20d7fd46b5968248591d11ec344544b42c00643a9a21bc3cc57665b7effcd03f9a8105d6a89fd876f";
+      sha512 = "30769e066f1c0cc71f0e5139c893b3e887f4618640b762b666f85c208fc8bdddc53afd7f0beb0421e9c84f82a6b332321840c93ecc9635dff784185f2122527c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ml/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ml/firefox-58.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "d76726b4d18d114ef391fa65e3396bef3e5d7896b90264e89e82673d0ee8be69633d831220908da30852994f1d5f782e6d6f221b0a93b028f543aa9899d2234d";
+      sha512 = "6c3f77d4fd7fbc05b7812eff2e8c5ebb75d4fd97a1cb8797260da5d2e53e10def88cfe107131097e6b72968b4c827b998abc42df0443c24330be3a0b0622b715";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/mr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/mr/firefox-58.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "b789f8e68a2020902bddcb95daf854cc784cc2a3319c2a145a5cb877755780699010b4162ffb124d0f5945e722ee6d7b0f0a1baedf277bd8d3c429b9d7870b42";
+      sha512 = "60d8c8824ee7b414ada656310218cc87ad347b36e7192196b2d5c6a5e0958f9786589a3c3f896f1a99b19aa2419431e6aaafaf69b877240872f9ea89178ea699";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ms/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ms/firefox-58.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "76fe657a616e786926740bd10bb8332cc520e08aa6944ecefe98824e5f0d059c6c93cf0e5968c11b153e55bc445a79939ef0b2a765daa69d6c72b8e25010f4ab";
+      sha512 = "114c337fdceec43c1482ee60467526d7fc422f720400e2cd66259cb11c1aed46fc800b1b3fc32ca5e08ad85667bdff31cb31ecd19f66e63d29bdf8696f8e4477";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/my/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/my/firefox-58.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "618224cff81d80523150cae7c020e8a29569fc7310fa031076ace7006bd8f8efcc4773b450de4ae4965445b277770603a7793287cb85714f0aa057584e636116";
+      sha512 = "430ed92df431653d7c2f3750c6a7e3987424d9bc49359dcbe6f9c2b66c601e263cdb26f2428c9a1948de78ea51a78e0f1e6fc1538c4cdbc39a126c76050ea51d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/nb-NO/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/nb-NO/firefox-58.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "7f33f1f49e6ac31a022d1ba856e23d1b10a23aa2501550d5ffbdeed05c752c27b3345704bb9d15d8eead5115085b0ed00d5b5d53de9cf2290e753f04a4f3fc1d";
+      sha512 = "c0b00789726e8020a5d8f853b73280720ba650f81cb4559e17578c862ab3d45aadd6a1948ff26e502bacd34d8c0cffa8d46ad6fd35d968ddcb4f8300dfcf44b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ne-NP/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ne-NP/firefox-58.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "892223856ff20d4cf7c601066ba6f3620b39fbf4e56fd89207f3d18b10b39bebc236d5eddabde57585f0e0c906dc035ed030d49b53bc346ce630581b9288654f";
+      sha512 = "b90dc1fd628689c45f06800b3cadee034d6da54a3695959a927ac0466ba70378f4197bc5b17b39d9572a8369897aebb589d1ce7d2dcc0972a371100938704f9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/nl/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/nl/firefox-58.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "f139e9420300a0276f9ff7b70fb1839ae9e2aaf089ccaddca782b8dd1797df80873cb8ebc91d37399c39772d5b381b30ddda8c41395065d2424defb709eae21d";
+      sha512 = "ab802fa78343b4a2074d2a09187cc96b66c03a26d26f21eb158e90b30bbbafe6dd40d563c9a65c3b6c99f79edcca3615e1322dd9a4fe3ddf1ea527ae41b4b25d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/nn-NO/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/nn-NO/firefox-58.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "50cd63ddb3f83f7c62916299d910d940930f046da612e3cce890310d271822acd87f971b5aee56aebc4011b1c414574c7c96cced936ba6f89a21bb93ea9bd356";
+      sha512 = "4ca2889f2e0a7f19ff1e1f7fa95ef692188f78289e1830df5c72e27db761f599dc1022ce1f9b8c8f30eab92aa70381a1e721deff07fe130b1685e968cd3aaa68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/or/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/or/firefox-58.0.2.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "ef73a14c8210d1b82e0ed33109027099a8d5dc3961476eedc31a92bd855a529e2be6411b196d0c4df97124c5be69ec4b6a245a936de1c0e8c609a0d17d51d8d1";
+      sha512 = "f2da13fc423beccb7044af1b8ad8ae5b8728aeff5ad0bccf52625936b59040aa6db6fd8fec112be8cfa0baf5448ff4b9d0e179b35302c235e6b4dae01500660d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/pa-IN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/pa-IN/firefox-58.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "53fc6c822192bf96db817d32ea46f0570a83e296b1e4cdfa585503b02b961346b21751e22d50c056a6411ace168844df019e6dcb96346e02bc9deada71c5e237";
+      sha512 = "ab193a72db52ab2208f7c6b5b5eca4756231cc31a7fc9f6adf434169ece5df5cca8800c952bca285f989dd2b5c8d7f825b0a0e99d2fa6a698a70a11fc63b1602";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/pl/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/pl/firefox-58.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "a009db74e155f4a089501ab96d7c72c2baa2e2ad0e555ffe0ee0baf6b259b5bfbf422ed6bca4b012f7b1799db02dd0d13323b39e6f73c7e5877e8ea080f62335";
+      sha512 = "31954e6be8bc114fab04c45f5ffa1f38c74ca147d790bf63130dac4fbc6f8213cf485216d5f50ceb87e60d587fbdb82fe7034c04182017b8120ec6995a9278a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/pt-BR/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/pt-BR/firefox-58.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "c77a8c87942045b959058319fcccc35ff8d054842fc8d7332171f110e82595886746597614ec4884915ba8397c63ebce597dbab648d2f823a1fd803f8c662382";
+      sha512 = "5cfe1e7d703cfa42a1033df3509db3e91788160079c9396d55356b3c7f0b848b59e6a8f704866dd14f2f0714e89830ad541da615c7d4209249ccc46b01eb11ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/pt-PT/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/pt-PT/firefox-58.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "6c09645104219be720c843f3065617184ac5731f354d4217347c662d2cc7cf66060b7805e16b032914f20e75ebddc72de06c3f7b520656bf7d5afd9c4ca517d1";
+      sha512 = "124ce2632b461e53b2cd3474e4fbcb92554006bee72498356886a451800a15d91ffe32ac87451b61d32e6f9d60b04dd14f4ba081a535124c7e2816edc11ac287";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/rm/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/rm/firefox-58.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "a232ea477b7b0841eb5dce7efb722b81da8136ec974bbdd7739d0700b163953f0b07e9509b973afa3c09af75b0b08523fe94dee21aec919f40f57e2ffd9dd6f3";
+      sha512 = "847f41ff0293f82425bfba1af30deb4858c066f738f0f9d3db5303092406358e9b11f6207ed732903b860f60c1c1b1f622c5c1d2113eed073d70d039dac4a6bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ro/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ro/firefox-58.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "887a70aa19415abe5bb2bb10f4e66e293177713612186567e9691b715e8b7b7ec3487509a111e8d9053241bc74d1bc9bcbf930931a14050b7c8b513076ed385d";
+      sha512 = "ccd5ac724cd810dec2e1ddb3e48139d9f5768d56ded09c0e6576c0dae898df310a4c5815635f646c0aa91caaad696c0ec6338bf21dacde33b4675f320fb4bca8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ru/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ru/firefox-58.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "efb8f8746d07a387d094e23c10f8a2ae3697e854b26a9ec78013f4fb2284a359bfa6cac686779fb8e1d72114c59e191f86240f02b61f4c748909dfcea45368a3";
+      sha512 = "d003f707e4a481ddaeab11dffccbc46d0d7173afb081a5007b3efbb6e1ce8d081a4eb23017b87d7e22fc3741e117bdcddbd2393b578bae2d07a2c2c2bbe2d0a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/si/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/si/firefox-58.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "9b469c23762a85e1f536928d78df87da8cf2661f78e5a558d8caeaf504ef7ae54c54eb2c3b6ea00381fc2e83348e9f403bd1c106cb518148ebccd113b5e5f442";
+      sha512 = "80e0e8c1ee6483a5b70140e4a6c0eb694f24dbce0a638700866ea8759063bba3f42c33ffaf465c7e8266fc764fe2983a2d6b098356dc6f4420eff9089c22331a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sk/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/sk/firefox-58.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "1ff839d7c631fba2510534032345fcf6397f694d035daff179382270a7889b6c2046b4b2bd6d7666c6e298146ef47cc9fac2b7c525d7c8f563b58b7fe11a5dea";
+      sha512 = "9aec4b3085ac757137a8ead6829bee1ae26cc02a494f60a3aa44daa56f5cbe1201c7588a60682b3bdccccad75782bade43d092352c015213e5f16212f9fb2800";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sl/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/sl/firefox-58.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "766e06e574d0f4933f8bf3e50521b5025915797f25712a29f0961759410272fda59aeb869d4d84cad961b277f5fc8ec78b8c333ee0e60e52e07fbb99822973b7";
+      sha512 = "2dc5d855eaedd125f8a3d828d85bc12ae47123f2f4be2bbf1e262c678cbd2607ee48c61e6fa70402da5e7ad549e2580e7d9a0a696e89ac5fee1da2154443f289";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/son/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/son/firefox-58.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "60df99153af07b88fd888b232b570eeeb4cafe01ed1c85cd536774b03e121523689d6de3fa3d6335fe7e0c9534273ce571d7a3fa00034e1681b78f4012a8fe7b";
+      sha512 = "7a1c4f86a4e459e80725b250b3a54be7c78397bd909c7a2081723571378578b7e672af380305ff9dae714e911fb209833833fd7cb3fb8a850f9d6a3b14f41cba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sq/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/sq/firefox-58.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "97263478fbeeada0ff397723bd8c4e0935c88c25cfc259bb2906e8d0a2ecce8101f4cb5ea9457b8b0b3276de475e0a8fbe995faa1edb33ced17b98404ac1021b";
+      sha512 = "45d20dcd82c6648c0429dfa0009aaf2d807efb7e9468ded4491a04dced5957d3bc9c1491c09c7f85ea63991283e2c38b2c906ebb338dffba1d0db4748e56246a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/sr/firefox-58.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "b822f5077378b3c41951aafed6f6b3ab174d9240058d69a05905803c2b8ab74791abfc1ce59550585f0eca9fd97e3c0325c9bfeef47d14b8eca039959ebbbd1c";
+      sha512 = "799f0548e18cbf77a6daf6ec0f9c12e904fde3235e9d8a5564e06df45bc037f4a04de0f5bfb9e74f9fa7053e8fc7b39b5c55b03dba5e78cf4e1400c033077f5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/sv-SE/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/sv-SE/firefox-58.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "20555a59e733f49b3714cd4517aa952a0e9306681f5ea1f33d9464ee50705187ad0e745ebfa00a64e4cd0aac4d7c3c3257cf04681e74e18037684e675b05df7b";
+      sha512 = "c2c693ab974b4c26a0c786955cff61f3b0689bd272b00fe4cbdbd7701a57481724f0ebf8aeb8427c7b50f4419875e9ca10d79c534c0e3ca8db132bcf6436e013";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ta/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ta/firefox-58.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "2d5721bc3519b766dc70163b8f91988b49512e4709d998239691c382a006bb06fd82b793fce843f976a55cffa8a0ff06711917e35233629945539c1f27453d02";
+      sha512 = "0771a9cbb44102291142fab34dbfd704461da5c6c013b48c1ee22cd7cc92ebfaad7ccac5b87bf764489d66e8cec2e4056e9fcd62c3ddb734753a48022f7f8914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/te/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/te/firefox-58.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "28ff1470be8a12212ef2467daa9a363ef929fe8f6741678b5d17ccfa149b122bc2dd74478bb96e721725c87d6a3000878dd7b51d1e38e6242e6e286c3621b25f";
+      sha512 = "699d8d52cc8e1bac02fbca3caa6504a028100d76fc9fe2492dfe214c5a96f0d3425bf541d2873133dd00e501dcc9d27894e613c44fc3cf9adedc0e08104524f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/th/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/th/firefox-58.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "935a7354cca219695f58592b1d6668ee3d305559ad9c30cfc274b63952bb133429528e38bda10d5cdeddb428133712da74ba621e2c831ae14329c22530f9ff91";
+      sha512 = "13cf7e1740ab2f508983617ce27f991db8049070061cb4d31299b372a801abf7292edd185fafc73dd58c46d009c32a6b5103a77834b2ddb0cc420cd98f747e9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/tr/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/tr/firefox-58.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "9f30bcd90b0c5ae5b55dc74a1e4adf8b029d8b87ba4f2961a4eb47ff4c61decff4abfac4f4664f1e99653f05a1749a17c775ba323ac322ec1fe3e104a4c57cc0";
+      sha512 = "a3439d157762eddcc1c09c4b687028b97004ac49144a3f26ea2a05a8eccc0a8b04659147ae7e8972ac16299d262586cc1d0c1bc69e5a309a0c82086cf61202ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/uk/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/uk/firefox-58.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "eca33af02a5f2d7363688aa2636d407822dfe9b70fa003d085ca6b9c3089adb49d080204c5e94d89178ff952dc5ca6a9402446610eb3e4460e55cdb066b965e3";
+      sha512 = "7767a4549265131e29a142c6f2a914b8699f2042a9da5831192668300acc564fbfe94009b3ea33a7bedc469a7585029685fa91dc752b46d7d7be5425776bc7c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/ur/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/ur/firefox-58.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "6dc7bb3693fa86305bb50be09c7945f199450c286867f56e66721944a27894e3de7a6452801ef4d04b0339403900b46effb7d2282a81c0b042ccf4c49f758a47";
+      sha512 = "b85f5c3067cf897079ff1de7c0de84756fb2224f703ec6825108efff52bed3a6e780b8410a58ed756e926a6033cd10c888743642f997b9c9d7390096c3b5e7c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/uz/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/uz/firefox-58.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "1ab8b3aefedc0c50c76169c0890cc5e3c381b7f743bb901c5573103761ae67985deae20ac2ef5b5d0f85f848a82a8d60bc87336205e462ddd2f040ba3586f258";
+      sha512 = "3febb16ceabdcf7395196f1aef6c5ecc6a09f45e63485207816e95dd5ec0ac9729c3644b8afa75d68241ad203459239bd7f5693c6d8aa7e59afb1a1f661015ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/vi/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/vi/firefox-58.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "cca1d12e5f34b78f930d7b7b53afce55567be0e9e6894b2af1d20a5c2c11df0531d06945d812bec956904fbd3ecb4921c282f8a9a520661c4988d2147d370dd8";
+      sha512 = "d117eca28279af133e2dde8dc25d3f7c4dcdc97f683f4570aa9cb8965200dfd8799271958ed6113b9bee488fc3e17d772b1aa4a4d657a49f72914890752af13c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/xh/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/xh/firefox-58.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "8ed571a58fe104ef53aa785d10481371adcdf4a38f449bdbc65f6ab532797d9c4d301f6f75868645aca291cdc10ae3b5b8d2fd1f8f116f9ef21b9d91e4264f24";
+      sha512 = "4ce7c4627a7db67ebe85ddb134cadca8cc4ecd3a01d8895dcb8b691f85e01911818404cc7243b4f5e1df0133a204a1ce5289168cae0b7e1b0b2674a659fc6684";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/zh-CN/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/zh-CN/firefox-58.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "ca63b214cdd67857d69ba86263e3efeadddbfc0f35a6c13ba9308959bc158d481cd6930246f3b59b7c335399ccfcfe5fbbff5fd1cd62aa1316c1da96403dfae8";
+      sha512 = "d0a73f00af50d70b055a1b2e89dc942b56d8d6e3a297407060a88a994dfcbd52fd60ec221e3afd9b6036500d27d861415ab0b25ceb443210321823e4e3b189e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.1/linux-i686/zh-TW/firefox-58.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/58.0.2/linux-i686/zh-TW/firefox-58.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "35bcec66fb184dddc9aab83fd91c561c396b6ae48bb9e027e4a64aa7aa60fd264ce4da917255370736ffb08fc42362bba61844ee0295c6b7adf721fb70d93136";
+      sha512 = "a855e8de90b5b26e8d4fed05b48c5efd6626c9d793f30c1f0b71d9b062a4e253b8c417a44e581ea8edd7babf5bd536b4384dd494dbb2fa36d7f585e555cdd655";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "58.0.1";
+    version = "58.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "08xgv1qm2xx5wjczqg1ldf0yqm939zsghhr4acbkwnymv5apfak3vx0kcr9iwqkmdqjdjmggxz439kjn510f92fik33zjfsjn7sd9k5";
+      sha512 = "ff748780492fc66b3e44c7e7641f16206e4c09514224c62d37efac2c59877bdf428a3670bfb50407166d7b505d4e2ea020626fd776b87f6abb6bc5d2e54c773f";
     };
 
     patches =


### PR DESCRIPTION
###### Motivation for this change

- bug fixes

https://www.mozilla.org/en-US/firefox/58.0.2/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

