### PR TITLE
fpdf: init at 1.7.2

### DIFF
--- a/pkgs/development/python-modules/fpdf/default.nix
+++ b/pkgs/development/python-modules/fpdf/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, writeText, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "fpdf";
+  version = "1.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0yb73c2clv581sgak5jvlvkj4wy3jav6ms5ia8jx3rw969w40n0j";
+  };
+
+  # No tests available
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/reingart/pyfpdf;
+    description = "Simple PDF generation for Python";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4611,6 +4611,8 @@ in {
     };
   };
 
+  fpdf = callPackage ../development/python-modules/fpdf { };
+
   fritzconnection = callPackage ../development/python-modules/fritzconnection { };
 
   frozendict = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change
Adds the [pyfpdf](https://github.com/reingart/pyfpdf)-package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

