### PR TITLE
pythonPackages.pytest-sugar: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/pytest-sugar/default.nix
+++ b/pkgs/development/python-modules/pytest-sugar/default.nix
@@ -1,16 +1,19 @@
 { stdenv, buildPythonPackage, fetchPypi, termcolor, pytest }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "pytest-sugar";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "11lni9kn0r1y896xg20qjv4yjcyr56h0hx9dprdgjnam4dqcl6lg";
+    sha256 = "ab8cc42faf121344a4e9b13f39a51257f26f410e416c52ea11078cdd00d98a2c";
   };
 
   propagatedBuildInputs = [ termcolor pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
 
   meta = with stdenv.lib; {
     description = "A plugin that changes the default look and feel of py.test";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

