### PR TITLE
Add setting to configure group for systemd in Traefik

### DIFF
--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -65,7 +65,7 @@ in {
     };
 
     group = mkOption {
-      default = "docker";
+      default = "traefik";
       type = types.string;
       description = "set the group that traefik runs under";
     };

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -85,7 +85,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         PermissionsStartOnly = true;
-        ExecStart = ''${cfg.package.bin}/bin/traefik --configfile=${configFile} -l debug'';
+        ExecStart = ''${cfg.package.bin}/bin/traefik --configfile=${configFile}'';
         ExecStartPre = [
           ''${pkgs.coreutils}/bin/mkdir -p "${cfg.dataDir}"''
           ''${pkgs.coreutils}/bin/chmod 700 "${cfg.dataDir}"''

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -67,7 +67,11 @@ in {
     group = mkOption {
       default = "traefik";
       type = types.string;
-      description = "set the group that traefik runs under";
+      example = "docker";
+      description = ''
+        Set the group that traefik runs under.
+        For the docker backend this needs to be set to <literal>docker</literal> instead.
+      '';
     };
 
     package = mkOption {

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -64,6 +64,12 @@ in {
       '';
     };
 
+    group = mkOption {
+      default = "docker";
+      type = types.string;
+      description = "set the group that traefik runs under";
+    };
+
     package = mkOption {
       default = pkgs.traefik;
       defaultText = "pkgs.traefik";
@@ -79,7 +85,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         PermissionsStartOnly = true;
-        ExecStart = ''${cfg.package.bin}/bin/traefik --configfile=${configFile}'';
+        ExecStart = ''${cfg.package.bin}/bin/traefik --configfile=${configFile} -l debug'';
         ExecStartPre = [
           ''${pkgs.coreutils}/bin/mkdir -p "${cfg.dataDir}"''
           ''${pkgs.coreutils}/bin/chmod 700 "${cfg.dataDir}"''
@@ -87,7 +93,7 @@ in {
         ];
         Type = "simple";
         User = "traefik";
-        Group = "traefik";
+        Group = cfg.group;
         Restart = "on-failure";
         StartLimitInterval = 86400;
         StartLimitBurst = 5;


### PR DESCRIPTION
###### Motivation for this change

Using the Docker backend with traefik doesn't work as the socket is owned by the docker group. The traefik service is running in the traefik group.

This is a backward-compatible change which allows for changing the group so that the docker socket can be read.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

