### PR TITLE
vifm: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/misc/vifm/default.nix
+++ b/pkgs/applications/misc/vifm/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "vifm-${version}";
-  version = "0.9";
+  version = "0.9.1";
 
   src = fetchurl {
     url = "https://github.com/vifm/vifm/releases/download/v${version}/vifm-${version}.tar.bz2";
-    sha256 = "1zd72vcgir3g9rhs2iyca13qf5fc0b1f22y20f5gy92c3sfwj45b";
+    sha256 = "1cz7vjjmghgdxd1lvsdwv85gvx4kz8idq14qijpwkpfrf2va9f98";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Updated vifm to the last version
https://vifm.info/news/2018-02-05.shtml


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---