### PR TITLE
Freeplane: init at 1.6.13

### DIFF
--- a/pkgs/applications/misc/freeplane/default.nix
+++ b/pkgs/applications/misc/freeplane/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, jdk, jre, gradle, git, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "freeplane-1.6.13";
+
+  src = fetchFromGitHub {
+    owner = "freeplane";
+    repo = "freeplane";
+    rev = "d0767ea431177cbd58929901afb1e9938e4756bf";
+    sha256 = "0lcr968xvj1zl5v33ih243lyd82gfh7hplj3drdsdi5rh6d2a57y";
+  };
+
+  buildInputs = [ jdk gradle git makeWrapper ];
+
+  buildPhase = ''
+    export GRADLE_USER_HOME="/tmp"
+    gradle dist
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,nix-support}
+    cp -r BIN $out/nix-support
+    sed -i 's/which/type -p/' $out/nix-support/BIN/freeplane.sh
+
+    makeWrapper $out/nix-support/BIN/freeplane.sh $out/bin/freeplane --set JAVA_HOME ${jre}
+    chmod +x $out/nix-support/BIN/freeplane.sh
+
+    mkdir $out/share
+    mkdir $out/share/applications
+    mkdir $out/share/icons
+    cp freeplane/resources/linux/freeplane.desktop $out/share/applications
+    cp freeplane/resources/images/Freeplane_app_menu_128.png $out/share/icons/freeplane.png
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Mind-mapping software";
+    homepage = https://www.freeplane.org/wiki/index.php/Home;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15295,6 +15295,8 @@ with pkgs;
 
   freenet = callPackage ../applications/networking/p2p/freenet { };
 
+  freeplane = callPackage ../applications/misc/freeplane { };
+
   freepv = callPackage ../applications/graphics/freepv { };
 
   xfontsel = callPackage ../applications/misc/xfontsel { };
@@ -17466,7 +17468,7 @@ with pkgs;
   testssl = callPackage ../applications/networking/testssl { };
 
   umurmur = callPackage ../applications/networking/umurmur { };
-  
+
   udocker = pythonPackages.callPackage ../tools/virtualization/udocker { };
 
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };


### PR DESCRIPTION
Packaged Freeplane based on the expression from Freemind. Freeplane is a project based on Freemind but made to be better in some ways.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).