### PR TITLE
treewide: s/pkgs.fedoraproject.org/src.fedoraproject.org/

### DIFF
--- a/pkgs/applications/misc/pinfo/default.nix
+++ b/pkgs/applications/misc/pinfo/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     # homepage needed you to login to download the tarball
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/pinfo/pinfo-0.6.10.tar.bz2"
+    url = "http://src.fedoraproject.org/repo/pkgs/pinfo/pinfo-0.6.10.tar.bz2"
       + "/fe3d3da50371b1773dfe29bf870dbc5b/pinfo-0.6.10.tar.bz2";
     sha256 = "0p8wyrpz9npjcbx6c973jspm4c3xz4zxx939nngbq49xqah8088j";
   };

--- a/pkgs/applications/version-management/monotone-viz/default.nix
+++ b/pkgs/applications/version-management/monotone-viz/default.nix
@@ -21,15 +21,15 @@ stdenv.mkDerivation rec {
   patchFlags = ["-p0"];
   patches = [
     (fetchurl {
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-dot.patch";
+      url = "http://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-dot.patch";
       sha256 = "0risfy8iqmkr209hmnvpv57ywbd3rvchzzd0jy2lfyqrrrm6zknw";
     })
     (fetchurl {
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-new-stdio.patch";
+      url = "http://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-new-stdio.patch";
       sha256 = "16bj0ppzqd45an154dr7sifjra7lv4m9anxfw3c56y763jq7fafa";
     })
     (fetchurl {
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-typefix.patch";
+      url = "http://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-typefix.patch";
       sha256 = "1gfp82rc7pawb5x4hh2wf7xh1l1l54ib75930xgd1y437la4703r";
     })
   ];

--- a/pkgs/applications/version-management/tailor/default.nix
+++ b/pkgs/applications/version-management/tailor/default.nix
@@ -7,7 +7,7 @@ python2Packages.buildPythonApplication rec {
   src = fetchurl {
     urls = [
       "http://darcs.arstecnica.it/tailor/tailor-${version}.tar.gz"
-      "http://pkgs.fedoraproject.org/repo/pkgs/tailor/tailor-${version}.tar.gz/58a6bc1c1d922b0b1e4579c6440448d1/tailor-${version}.tar.gz"
+      "http://src.fedoraproject.org/repo/pkgs/tailor/tailor-${version}.tar.gz/58a6bc1c1d922b0b1e4579c6440448d1/tailor-${version}.tar.gz"
     ];
     sha256 = "061acapxxn5ab3ipb5nd3nm8pk2xj67bi83jrfd6lqq3273fmdjh";
   };

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     # Ticket: https://bugs.freedesktop.org/show_bug.cgi?id=27222
     (fetchpatch {
       name = "SDL_SetGamma.patch";
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/SDL.git/plain/SDL-1.2.15-x11-Bypass-SetGammaRamp-when-changing-gamma.patch?id=04a3a7b1bd88c2d5502292fad27e0e02d084698d";
+      url = "http://src.fedoraproject.org/cgit/rpms/SDL.git/plain/SDL-1.2.15-x11-Bypass-SetGammaRamp-when-changing-gamma.patch?id=04a3a7b1bd88c2d5502292fad27e0e02d084698d";
       sha256 = "0x52s4328kilyq43i7psqkqg7chsfwh0aawr50j566nzd7j51dlv";
     })
     # Fix a build failure on OS X Mavericks

--- a/pkgs/development/libraries/isl/0.11.1.nix
+++ b/pkgs/development/libraries/isl/0.11.1.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "isl-0.11.1"; # CLooG 0.16.3 fails to build with ISL 0.08.
 
   src = fetchurl {
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/gcc/isl-0.11.1.tar.bz2/bce1586384d8635a76d2f017fb067cd2/isl-0.11.1.tar.bz2";
+    url = "http://src.fedoraproject.org/repo/pkgs/gcc/isl-0.11.1.tar.bz2/bce1586384d8635a76d2f017fb067cd2/isl-0.11.1.tar.bz2";
     sha256 = "13d9cqa5rzhbjq0xf0b2dyxag7pqa72xj9dhsa03m8ccr1a4npq9";
   };
 

--- a/pkgs/development/libraries/java/libmatthew-java/default.nix
+++ b/pkgs/development/libraries/java/libmatthew-java/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libmatthew-java-0.8";
   src = fetchurl {
-    url = http://pkgs.fedoraproject.org/repo/pkgs/libmatthew-java/libmatthew-java-0.8.tar.gz/8455b8751083ce25c99c2840609271f5/libmatthew-java-0.8.tar.gz;
+    url = http://src.fedoraproject.org/repo/pkgs/libmatthew-java/libmatthew-java-0.8.tar.gz/8455b8751083ce25c99c2840609271f5/libmatthew-java-0.8.tar.gz;
     sha256 = "1yldkhsdzm0a41a0i881bin2jklhp85y3ah245jd6fz3npcx7l85";
   };
   JAVA_HOME=jdk;

--- a/pkgs/development/libraries/kyotocabinet/default.nix
+++ b/pkgs/development/libraries/kyotocabinet/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   patches = [(fetchurl {
     name = "gcc6.patch";
-    url = "http://pkgs.fedoraproject.org/rpms/kyotocabinet/raw/master/f/kyotocabinet-1.2.76-gcc6.patch";
+    url = "http://src.fedoraproject.org/rpms/kyotocabinet/raw/master/f/kyotocabinet-1.2.76-gcc6.patch";
     sha256 = "1h5k38mkiq7lz8nd2gbn7yvimcz49g3z7phn1cr560bzjih8rz23";
   })];
 

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -26,15 +26,15 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-agent-leaks.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
+      url = "http://src.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-agent-leaks.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
       sha256 = "1cxnhj0y30g7ldqq1y6zwsbdwcx7h97d3mpd3h5jy7dhg3h9ym91";
     })
     (fetchpatch {
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-polkitpermission-leak.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
+      url = "http://src.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-polkitpermission-leak.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
       sha256 = "1h1rkd4avqyyr8q6836zzr3w10jf521gcqnvhrhzwdpgp1ay4si7";
     })
     (fetchpatch {
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-itstool.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
+      url = "http://src.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-itstool.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
       sha256 = "0bxmjwp8ahy1y5g1l0kxmld0l3mlvb2l0i5n1qabia3d5iyjkyfh";
     })
   ];

--- a/pkgs/development/libraries/qtscriptgenerator/qt-4.8.patch
+++ b/pkgs/development/libraries/qtscriptgenerator/qt-4.8.patch
@@ -1,4 +1,4 @@
-Origin: http://pkgs.fedoraproject.org/gitweb/?p=qtscriptgenerator.git;a=blob_plain;f=qtscriptgenerator-src-0.1.0-no_QFileOpenEvent.patch;h=f397b5ab13bcfc268e6d7b7ba4c6bc66ae38b5c0;hb=HEAD
+Origin: http://src.fedoraproject.org/gitweb/?p=qtscriptgenerator.git;a=blob_plain;f=qtscriptgenerator-src-0.1.0-no_QFileOpenEvent.patch;h=f397b5ab13bcfc268e6d7b7ba4c6bc66ae38b5c0;hb=HEAD
 diff -up qtscriptgenerator-src-0.1.0/generator/typesystem_gui-common.xml.no_QFileOpenEvent qtscriptgenerator-src-0.1.0/generator/typesystem_gui-common.xml
 --- qtscriptgenerator-src-0.1.0/generator/typesystem_gui-common.xml.no_QFileOpenEvent	2011-12-22 11:34:52.615149619 -0600
 +++ qtscriptgenerator-src-0.1.0/generator/typesystem_gui-common.xml	2011-12-22 11:35:31.808659632 -0600

--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -17,12 +17,12 @@ stdenv.mkDerivation rec {
     # the following three patches fix CVE-2016-9577 and CVE-2016-9578
     (fetchpatch {
       name = "0001-Prevent-possible-DoS-attempts-during-protocol-handsh.patch";
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/spice.git/plain/0001-Prevent-possible-DoS-attempts-during-protocol-handsh.patch?id=d919d639ae5f83a9735a04d843eed675f9357c0d";
+      url = "http://src.fedoraproject.org/cgit/rpms/spice.git/plain/0001-Prevent-possible-DoS-attempts-during-protocol-handsh.patch?id=d919d639ae5f83a9735a04d843eed675f9357c0d";
       sha256 = "11x5566lx5zyl7f39glwsgpzkxb7hpcshx8va5ab3imrns07130q";
     })
     (fetchpatch {
       name = "0002-Prevent-integer-overflows-in-capability-checks.patch";
-      url = "http://pkgs.fedoraproject.org/cgit/rpms/spice.git/plain/0002-Prevent-integer-overflows-in-capability-checks.patch?id=d919d639ae5f83a9735a04d843eed675f9357c0d";
+      url = "http://src.fedoraproject.org/cgit/rpms/spice.git/plain/0002-Prevent-integer-overflows-in-capability-checks.patch?id=d919d639ae5f83a9735a04d843eed675f9357c0d";
       sha256 = "1r1bhq98w93cvvrlrz6jwdfsy261xl3xqs0ppchaa2igyxvxv5z5";
     })
     (fetchpatch {

--- a/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
+++ b/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/ocaml-omake/${pname}-${version}.tar.gz/fe39a476ef4e33b7ba2ca77a6bcaded2/${pname}-${version}.tar.gz";
+    url = "http://src.fedoraproject.org/repo/pkgs/ocaml-omake/${pname}-${version}.tar.gz/fe39a476ef4e33b7ba2ca77a6bcaded2/${pname}-${version}.tar.gz";
     sha256 = "1sas02pbj56m7wi5vf3vqrrpr4ynxymw2a8ybvfj2dkjf7q9ii13";
   };
   patchFlags = "-p0";

--- a/pkgs/games/rogue/default.nix
+++ b/pkgs/games/rogue/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     urls = [
-      "http://pkgs.fedoraproject.org/repo/pkgs/rogue/rogue5.4.4-src.tar.gz/033288f46444b06814c81ea69d96e075/rogue5.4.4-src.tar.gz"
+      "http://src.fedoraproject.org/repo/pkgs/rogue/rogue5.4.4-src.tar.gz/033288f46444b06814c81ea69d96e075/rogue5.4.4-src.tar.gz"
       "http://ftp.vim.org/ftp/pub/ftp/os/Linux/distr/slitaz/sources/packages-cooking/r/rogue5.4.4-src.tar.gz"
       "http://rogue.rogueforge.net/files/rogue5.4/rogue5.4.4-src.tar.gz"
     ];

--- a/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   name = "intel2200BGFirmware-${version}";
 
   src = fetchurl {
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-${version}.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-${version}.tgz";
+    url = "http://src.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-${version}.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-${version}.tgz";
     sha256 = "c6818c11c18cc030d55ff83f64b2bad8feef485e7742f84f94a61d811a6258bd";
   };
 

--- a/pkgs/os-specific/linux/gogoclient/default.nix
+++ b/pkgs/os-specific/linux/gogoclient/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     #url = http://gogo6.com/downloads/gogoc-1_2-RELEASE.tar.gz;
-    url = http://pkgs.fedoraproject.org/repo/pkgs/gogoc/gogoc-1_2-RELEASE.tar.gz/41177ed683cf511cc206c7782c37baa9/gogoc-1_2-RELEASE.tar.gz;
+    url = http://src.fedoraproject.org/repo/pkgs/gogoc/gogoc-1_2-RELEASE.tar.gz/41177ed683cf511cc206c7782c37baa9/gogoc-1_2-RELEASE.tar.gz;
     sha256 = "a0ef45c0bd1fc9964dc8ac059b7d78c12674bf67ef641740554e166fa99a2f49";
   };
   patches = [./gcc46-include-fix.patch ./config-paths.patch ];

--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.300";
 
   src = fetchurl {
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/hwdata/v0.300.tar.gz/sha512/34294fcf65c3cb17c19d625732d1656ec1992dde254a68ee35681ad2f310bc05028a85889efa2c1d1e8a2d10885ccc00185475a00f6f2fb82d07e2349e604a51/v0.300.tar.gz";
+    url = "http://src.fedoraproject.org/repo/pkgs/hwdata/v0.300.tar.gz/sha512/34294fcf65c3cb17c19d625732d1656ec1992dde254a68ee35681ad2f310bc05028a85889efa2c1d1e8a2d10885ccc00185475a00f6f2fb82d07e2349e604a51/v0.300.tar.gz";
     sha256 = "03xlj05qyixhnsybq1qnr7j5q2nvirs4jxpgg4sbw8swsqj3dgqi";
   };
 

--- a/pkgs/os-specific/linux/lm-sensors/default.nix
+++ b/pkgs/os-specific/linux/lm-sensors/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     urls = [
       "http://dl.lm-sensors.org/lm-sensors/releases/lm_sensors-${version}.tar.bz2"
-      "http://pkgs.fedoraproject.org/repo/pkgs/lm_sensors/lm_sensors-${version}.tar.bz2/c03675ae9d43d60322110c679416901a/lm_sensors-${version}.tar.bz2"
+      "http://src.fedoraproject.org/repo/pkgs/lm_sensors/lm_sensors-${version}.tar.bz2/c03675ae9d43d60322110c679416901a/lm_sensors-${version}.tar.bz2"
     ];
     sha256 = "07q6811l4pp0f7pxr8bk3s97ippb84mx5qdg7v92s9hs10b90mz0";
   };

--- a/pkgs/tools/archivers/unarj/default.nix
+++ b/pkgs/tools/archivers/unarj/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     sha256 = "0r027z7a0azrd5k885xvwhrxicpd0ah57jzmaqlypxha2qjw7p6p";
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/unarj/${name}.tar.gz/c6fe45db1741f97155c7def322aa74aa/${name}.tar.gz";
+    url = "http://src.fedoraproject.org/repo/pkgs/unarj/${name}.tar.gz/c6fe45db1741f97155c7def322aa74aa/${name}.tar.gz";
   };
 
   preInstall = ''

--- a/pkgs/tools/archivers/zip/default.nix
+++ b/pkgs/tools/archivers/zip/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   src = fetchurl {
     urls = [
       ftp://ftp.info-zip.org/pub/infozip/src/zip30.tgz
-      http://pkgs.fedoraproject.org/repo/pkgs/zip/zip30.tar.gz/7b74551e63f8ee6aab6fbc86676c0d37/zip30.tar.gz
+      http://src.fedoraproject.org/repo/pkgs/zip/zip30.tar.gz/7b74551e63f8ee6aab6fbc86676c0d37/zip30.tar.gz
     ];
     sha256 = "0sb3h3067pzf3a7mlxn1hikpcjrsvycjcnj9hl9b1c3ykcgvps7h";
   };

--- a/pkgs/tools/filesystems/nixpart/0.4/pyblock.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pyblock.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   md5_path = "f6d33a8362dee358517d0a9e2ebdd044";
 
   src = fetchurl rec {
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/python-pyblock/"
+    url = "http://src.fedoraproject.org/repo/pkgs/python-pyblock/"
         + "${name}.tar.bz2/${md5_path}/${name}.tar.bz2";
     sha256 = "f6cef88969300a6564498557eeea1d8da58acceae238077852ff261a2cb1d815";
   };

--- a/pkgs/tools/filesystems/nixpart/0.4/pykickstart.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pykickstart.nix
@@ -6,7 +6,7 @@ buildPythonApplication rec {
   md5_path = "d249f60aa89b1b4facd63f776925116d";
 
   src = fetchurl rec {
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/pykickstart/"
+    url = "http://src.fedoraproject.org/repo/pkgs/pykickstart/"
         + "${name}.tar.gz/${md5_path}/${name}.tar.gz";
     sha256 = "e0d0f98ac4c5607e6a48d5c1fba2d50cc804de1081043f9da68cbfc69cad957a";
   };

--- a/pkgs/tools/system/hardlink/default.nix
+++ b/pkgs/tools/system/hardlink/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   name = "hardlink-2012.9.${rev}";
 
   src = fetchurl {
-    url = "http://pkgs.fedoraproject.org/cgit/hardlink.git/snapshot/hardlink-${rev}.zip";
+    url = "http://src.fedoraproject.org/cgit/hardlink.git/snapshot/hardlink-${rev}.zip";
     sha256 = "fea1803170b538d5fecf6a8d312ded1d25d516e9386a3797441a247487551647";
     name = "hardlink-${rev}.zip";
   };
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   buildInputs = [ unzip ];
 
   meta = {
-    homepage = http://pkgs.fedoraproject.org/cgit/hardlink.git/;
+    homepage = http://src.fedoraproject.org/cgit/hardlink.git/;
     description = "Consolidate duplicate files via hardlinks";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13094,7 +13094,7 @@ in {
 
     patches = singleton (pkgs.fetchurl {
       name = "libnotify07.patch";
-      url = "http://pkgs.fedoraproject.org/cgit/notify-python.git/plain/"
+      url = "http://src.fedoraproject.org/cgit/notify-python.git/plain/"
           + "libnotify07.patch?id2=289573d50ae4838a1658d573d2c9f4c75e86db0c";
       sha256 = "1lqdli13mfb59xxbq4rbq1f0znh6xr17ljjhwmzqb79jl3dig12z";
     });
@@ -16334,7 +16334,7 @@ in {
     md5_path = "f6d33a8362dee358517d0a9e2ebdd044";
 
     src = pkgs.fetchurl rec {
-      url = "http://pkgs.fedoraproject.org/repo/pkgs/python-pyblock/"
+      url = "http://src.fedoraproject.org/repo/pkgs/python-pyblock/"
           + "${name}.tar.bz2/${md5_path}/${name}.tar.bz2";
       sha256 = "f6cef88969300a6564498557eeea1d8da58acceae238077852ff261a2cb1d815";
     };
@@ -17187,7 +17187,7 @@ in {
     md5_path = "d249f60aa89b1b4facd63f776925116d";
 
     src = pkgs.fetchurl rec {
-      url = "http://pkgs.fedoraproject.org/repo/pkgs/pykickstart/"
+      url = "http://src.fedoraproject.org/repo/pkgs/pykickstart/"
           + "${name}.tar.gz/${md5_path}/${name}.tar.gz";
       sha256 = "e0d0f98ac4c5607e6a48d5c1fba2d50cc804de1081043f9da68cbfc69cad957a";
     };


### PR DESCRIPTION
Upstream killed the pkgs server but src continues to serve up the exact same content, so we can just point there and all hashes should be unchanged.

see also #34750 

(morally a cherry-pick of dfd300c81dfb7292d26cfbce3df9717ea408e410)
