### PR TITLE
WIP: Fetch sources

### DIFF
--- a/nix-update-src.sh
+++ b/nix-update-src.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jshon diffutils
+#
+# TODO: copy usage from `nix edit`
+# Usage: nix-update-sha [-f <file>]<INSTALLABLE>
+#
+# Example: nix-update-src.sh nixpkgs.hello
+
+# FIXME: find a nix replacement for nix-prefetch-url
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [-f <file>] <INSTALLABLE>" >&2
+  exit 1
+}
+
+main () {
+  set -eu
+
+  ### command-line parsing
+  local nix_args=()
+  while getopts ":f:" o; do
+    case "${o}" in
+      f)
+        nix_args+=(-f "${OPTARG}")
+        ;;
+      *)
+        usage
+        ;;
+    esac
+  done
+  shift $((OPTIND-1))
+
+  local drvAttr=$1
+  [[ -z $drvAttr ]] && usage
+
+  ### drvAttr heuristics
+
+  # add the .src attribute if it exists
+  if nixFile "$drvAttr.src" "${nix_args[@]}" &>/dev/null; then
+    log "switching from $drvAttr to $drvAttr.src"
+    drvAttr=$drvAttr.src
+  fi
+
+  # look if the derivation has multiple sources
+  if nixFile "$drvAttr.sources" "${nix_args[@]}" 2>/dev/null; then
+    nixKeys "$drvAttr.sources" "${nix_args[@]}"
+    for key in $(nixKeys "$drvAttr.sources" "${nix_args[@]}"); do
+      updateSha "$drvAttr.sources.$key" "${nix_args[@]}"
+    done
+  else
+    updateSha "$drvAttr" "${nix_args[@]}"
+  fi
+}
+
+updateSha() {
+  set -eu
+  local drvAttr=$1
+  local oldHash newHash hashMethod hashFile
+  shift
+
+  log "Updating $drvAttr"
+
+  # Get the old hash
+  oldHash=$(nixEval "$drvAttr.outputHash" "$@" --raw)
+
+  log "Fetching source..."
+  newHash=$(nix-prefetch-url -A "$drvAttr")
+
+  if [[ "$oldHash" = "$newHash" ]]; then
+    log "Hash unchanged. All good."
+    return 0
+  fi
+
+  log "Looking for file to update"
+  hashMethod=$(nixEval "$drvAttr.outputHashAlgo" "$@" --raw)
+  hashFile=$(nixFile "$drvAttr.$hashMethod" "$@")
+  if [[ ! -f "$hashFile" ]]; then
+    log "ERROR: file '$hashFile' with method '$hashMethod' not found"
+    return 1
+  fi
+
+  log "Rewriting hash $oldHash to $newHash"
+  replaceSha "$hashFile" "$oldHash" "$newHash"
+}
+
+replaceSha () {
+  local file=$1 old=$2 new=$3
+  diff -U3 "$file" <(sed -e "s/$old/$new/" "$file") --color || true
+  sed -e "s/$old/$new/" -i "$file"
+}
+
+nixKeys () {
+  nixEval "$@" --json | jshon -k
+}
+
+nixEval () {
+  nix eval "$@"
+}
+
+nixFile () {
+  EDITOR=echo nix edit "$@"
+}
+
+log () { echo >&2; echo "$@" >&2; }
+
+# Run the stuff!
+main "$@"

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, freetype, yasm, ffmpeg
+{ stdenv, fetchurl, fetchSources, fetchpatch, pkgconfig, freetype, yasm, ffmpeg
 , aalibSupport ? true, aalib ? null
 , fontconfigSupport ? true, fontconfig ? null, freefont_ttf ? null
 , fribidiSupport ? true, fribidi ? null
@@ -60,16 +60,20 @@ let
     let
       dir = http://www.mplayerhq.hu/MPlayer/releases/codecs/;
     in
-    if stdenv.system == "i686-linux" then fetchurl {
-      url = "${dir}/essential-20071007.tar.bz2";
-      sha256 = "18vls12n12rjw0mzw4pkp9vpcfmd1c21rzha19d7zil4hn7fs2ic";
-    } else if stdenv.system == "x86_64-linux" then fetchurl {
-      url = "${dir}/essential-amd64-20071007.tar.bz2";
-      sha256 = "13xf5b92w1ra5hw00ck151lypbmnylrnznq9hhb0sj36z5wz290x";
-    } else if stdenv.system == "powerpc-linux" then fetchurl {
-      url = "${dir}/essential-ppc-20071007.tar.bz2";
-      sha256 = "18mlj8dp4wnz42xbhdk1jlz2ygra6fbln9wyrcyvynxh96g1871z";
-    } else null;
+    fetchSources {
+      i686-linux = fetchurl {
+        url = "${dir}/essential-20071007.tar.bz2";
+        sha256 = "18vls12n12rjw0mzw4pkp9vpcfmd1c21rzha19d7zil4hn7fs2ic";
+      };
+      x86_64-linux = fetchurl {
+        url = "${dir}/essential-amd64-20071007.tar.bz2";
+        sha256 = "13xf5b92w1ra5hw00ck151lypbmnylrnznq9hhb0sj36z5wz290x";
+      };
+      powerpc-linux = fetchurl {
+        url = "${dir}/essential-ppc-20071007.tar.bz2";
+        sha256 = "18mlj8dp4wnz42xbhdk1jlz2ygra6fbln9wyrcyvynxh96g1871z";
+      };
+    } stdenv.system;
 
   codecs = if codecs_src != null then stdenv.mkDerivation {
     name = "MPlayer-codecs-essential-20071007";

--- a/pkgs/build-support/fetchsources/default.nix
+++ b/pkgs/build-support/fetchsources/default.nix
@@ -1,0 +1,33 @@
+{ system }:
+# fetchSources is useful when multiple sources are available for a package,
+# usually for binary releases.
+#
+# Since all the sources are being exposed back in the "sources" attribute,
+# it allows for hash-updating scripts to update all of them.
+#
+# This effectively reserves the "sources" attribute on all the fetchers.
+#
+# Example usage:
+#
+#    stdenv.mkDerivation {
+#      name = "foo";
+#      version = "1.0.0";
+#
+#      src = fetchSources {
+#        x86_64-linux = fetchurl {
+#          url = "https://foo.com/foo-amd64-${version}.tar.gz";
+#          sha256 = "...";
+#        };
+#
+#        x86_64-darwin = fetchurl {
+#          url = "https://foo.com/foo-darwin-${version}.tar.gz";
+#          sha256 = "...";
+#        };
+#      } pkgs.system;
+#    };
+#
+sources: key:
+  let
+    fetcher = sources."${key}" or (throw "fetcher for key '${key}' not supported");
+  in
+    fetcher // { inherit sources; }

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, patchelf, gmp }:
+{ stdenv, fetchurl, fetchSources, patchelf, gmp }:
 
 let
   version = "20130715";
@@ -13,20 +13,22 @@ in
 stdenv.mkDerivation rec {
   name = "mlton-${version}";
 
-  binSrc =
-    if stdenv.system == "i686-linux" then (fetchurl {
+  binSrc = fetchSources {
+    i686-linux = fetchurl {
       url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}-1.x86-linux.tgz";
       sha256 = "1kxjjmnw4xk2d9hpvz43w9dvyhb3025k4zvjx785c33nrwkrdn4j";
-    })
-    else if stdenv.system == "x86_64-linux" then (fetchurl {
-        url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}-1.amd64-linux.tgz";
-        sha256 = "0fyhwxb4nmpirjbjcvk9f6w67gmn2gkz7xcgz0xbfih9kc015ygn";
-    })
-    else if stdenv.system == "x86_64-darwin" then (fetchurl {
-        url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}-1.amd64-darwin.gmp-macports.tgz";
-        sha256 = "044wnh9hhg6if886xy805683k0as347xd37r0r1yi4x7qlxzzgx9";
-    })
-    else throw "Architecture not supported";
+    };
+
+    x86_64-linux = fetchurl {
+      url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}-1.amd64-linux.tgz";
+      sha256 = "0fyhwxb4nmpirjbjcvk9f6w67gmn2gkz7xcgz0xbfih9kc015ygn";
+    };
+
+    x86_64-darwin = fetchurl {
+      url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}-1.amd64-darwin.gmp-macports.tgz";
+      sha256 = "044wnh9hhg6if886xy805683k0as347xd37r0r1yi4x7qlxzzgx9";
+    };
+  } stdenv.system;
 
   codeSrc =
     fetchurl {

--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, fetchzip, python27, python27Packages, makeWrapper }:
+{ stdenv, fetchzip, fetchSources, python27, python27Packages, makeWrapper }:
 
 with python27Packages;
 
 stdenv.mkDerivation rec {
   name = "google-app-engine-go-sdk-${version}";
   version = "1.9.61";
-  src =
-    if stdenv.system == "x86_64-linux" then
-      fetchzip {
-        url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-${version}.zip";
-        sha256 = "1i2j9ympl1218akwsmm7yb31v0gibgpzlb657bcravi1irfv1hhs";
-      }
-    else
-      fetchzip {
-        url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-${version}.zip";
-        sha256 = "0s8sqyc72lnc7dxd4cl559gyfx83x71jjpsld3i3nbp3mwwamczp";
-      };
+  src = fetchSources {
+    x86_64-linux = fetchzip {
+      url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-${version}.zip";
+      sha256 = "1i2j9ympl1218akwsmm7yb31v0gibgpzlb657bcravi1irfv1hhs";
+    };
+    x86_64-darwin = fetchzip {
+      url = "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-${version}.zip";
+      sha256 = "0s8sqyc72lnc7dxd4cl559gyfx83x71jjpsld3i3nbp3mwwamczp";
+    };
+  } stdenv.system;
+
 
   buildInputs = [python27 makeWrapper];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -281,6 +281,8 @@ with pkgs;
 
   fetchgx = callPackage ../build-support/fetchgx { };
 
+  fetchSources = callPackage ../build-support/fetchsources { };
+
   resolveMirrorURLs = {url}: fetchurl {
     showURLs = true;
     inherit url;


### PR DESCRIPTION
###### Motivation for this change

This is a revival of #19582 but simplified to try to simplify the package update scenario.

The PR also contains an example script adapted from @layus' idea to demonstrate why fetchSource could be nice.

The idea is that you would run `nix edit nixpkgs.hello`, update the version or whatever. Then `nix-update-src hello` to prefetch-url and replace the sha256 directly. This could be combined in a nix-edit, update, build loop further down the road.

At this point I am looking for feedback on the idea and naming.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

