### PR TITLE
discover: init at 5.15.3

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -102,6 +102,7 @@ let
       breeze-qt5 = callPackage ./breeze-qt5.nix {};
       breeze-grub = callPackage ./breeze-grub.nix {};
       breeze-plymouth = callPackage ./breeze-plymouth {};
+      discover = callPackage ./discover.nix {};
       kactivitymanagerd = callPackage ./kactivitymanagerd.nix {};
       kde-cli-tools = callPackage ./kde-cli-tools.nix {};
       kde-gtk-config = callPackage ./kde-gtk-config { inherit gsettings-desktop-schemas; };

--- a/pkgs/desktops/plasma-5/discover.nix
+++ b/pkgs/desktops/plasma-5/discover.nix
@@ -1,0 +1,20 @@
+{
+  mkDerivation,
+  extra-cmake-modules, gettext, kdoctools, python,
+  appstream-qt, discount, flatpak, fwupd, ostree, packagekit-qt, pcre, utillinux,
+  qtquickcontrols2,
+  karchive, kconfig, kcrash, kdbusaddons, kdeclarative, kio, kirigami2, kitemmodels,
+  knewstuff, kwindowsystem, kxmlgui, plasma-framework
+}:
+
+mkDerivation {
+  name = "discover";
+  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python ];
+  buildInputs = [
+    # discount is needed for libmarkdown
+    appstream-qt discount flatpak fwupd ostree packagekit-qt pcre utillinux
+    qtquickcontrols2
+    karchive kconfig kcrash kdbusaddons kdeclarative kio kirigami2 kitemmodels knewstuff kwindowsystem kxmlgui
+    plasma-framework
+  ];
+}

--- a/pkgs/development/libraries/appstream/qt.nix
+++ b/pkgs/development/libraries/appstream/qt.nix
@@ -1,5 +1,7 @@
 { stdenv, appstream, qtbase, qttools }:
 
+# TODO: look into using the libraries from the regular appstream derivation as we keep duplicates here
+
 stdenv.mkDerivation rec {
   name = "appstream-qt-${version}";
   inherit (appstream) version src prePatch;
@@ -9,15 +11,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = appstream.nativeBuildInputs ++ [ qttools ];
 
   mesonFlags = appstream.mesonFlags ++ [ "-Dqt=true" ];
-
-  postInstall = ''
-    rm -rf $out/{bin,etc,include/appstream,lib/pkgconfig,lib/libappstream.so*,share}
-  '';
-
-  preFixup = ''
-    patchelf --add-needed ${appstream}/lib/libappstream.so.4 \
-      $out/lib/libAppStreamQt.so
-  '';
 
   meta = appstream.meta // {
     description = "Software metadata handling library - Qt";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21785,7 +21785,7 @@ in
   inherit (kdeFrameworks) kded kinit frameworkintegration;
 
   inherit (plasma5)
-    bluedevil breeze-gtk breeze-qt5 breeze-grub breeze-plymouth
+    bluedevil breeze-gtk breeze-qt5 breeze-grub breeze-plymouth discover
     kactivitymanagerd kde-cli-tools kde-gtk-config kdeplasma-addons kgamma5
     kinfocenter kmenuedit kscreen kscreenlocker ksshaskpass ksysguard
     kwallet-pam kwayland-integration kwin kwrited milou oxygen plasma-browser-integration


### PR DESCRIPTION
###### Motivation for this change

Is this worth merging considering discover doesn't actually do anything on NixOS?

Cc: @bkchr @adisbladis @ttuegel 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

