### PR TITLE
papis: init at 0.5.2 + dependencies

### DIFF
--- a/pkgs/development/python-modules/arxiv2bib/default.nix
+++ b/pkgs/development/python-modules/arxiv2bib/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage, python, lib, fetchFromGitHub
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "arxiv2bib";
+  version = "1.0.8";
+
+  # Missing tests on Pypi
+  src = fetchFromGitHub {
+    owner = "nathangrigg";
+    repo = "arxiv2bib";
+    rev = version;
+    sha256 = "1kp2iyx20lpc9dv4qg5fgwf83a1wx6f7hj1ldqyncg0kn9xcrhbg";
+  };
+
+  # Required for tests only
+  checkInputs = [ mock ];
+
+  checkPhase = "${python.interpreter} -m unittest discover -s tests";
+
+  meta = with lib; {
+    description = "Get a BibTeX entry from an arXiv id number, using the arxiv.org API";
+    homepage = http://nathangrigg.github.io/arxiv2bib/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.nico202 ];
+  };
+}

--- a/pkgs/development/python-modules/habanero/default.nix
+++ b/pkgs/development/python-modules/habanero/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, lib, fetchFromGitHub
+, requests
+, nose, vcrpy
+}:
+
+buildPythonPackage rec {
+  pname = "habanero";
+  version = "0.6.0";
+
+  # Install from Pypi is failing because of a missing file (Changelog.rst)
+  src = fetchFromGitHub {
+    owner = "sckott";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1l2cgl6iiq8jff2w2pib6w8dwaj8344crhwsni2zzq0p44dwi13d";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [ nose vcrpy ];
+  checkPhase = "make test";
+
+  meta = {
+    description = "Python interface to Library Genesis";
+    homepage = http://habanero.readthedocs.io/en/latest/;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.nico202 ];
+  };
+}

--- a/pkgs/development/python-modules/papis-python-rofi/default.nix
+++ b/pkgs/development/python-modules/papis-python-rofi/default.nix
@@ -1,0 +1,21 @@
+{ buildPythonPackage, lib, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "papis-python-rofi";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13k6mw2nq923zazs77hpmh2s96v6zv13g7p89510qqkvp6fiml1v";
+  };
+
+  # No tests existing
+  doCheck = false;
+
+  meta = {
+    description = "A Python module to make simple GUIs with Rofi";
+    homepage = https://github.com/alejandrogallo/python-rofi;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.nico202 ];
+  };
+}

--- a/pkgs/development/python-modules/pylibgen/default.nix
+++ b/pkgs/development/python-modules/pylibgen/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage, python, lib, fetchPypi
+, isPy3k
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pylibgen";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rviqi3rf62b43cabdy8c2cdznjv034mp0qrfrzvkih4jlkhyfrh";
+  };
+
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [ requests ];
+
+  # It's not using unittest
+  checkPhase = "${python.interpreter} tests/test_pylibgen.py -c 'test_api_endpoints()'";
+
+  meta = {
+    description = "Python interface to Library Genesis";
+    homepage = https://pypi.org/project/pylibgen/;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.nico202 ];
+  };
+}

--- a/pkgs/development/python-modules/pyparser/default.nix
+++ b/pkgs/development/python-modules/pyparser/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage, lib, fetchFromBitbucket
+, parse
+}:
+
+buildPythonPackage rec {
+  pname = "pyparser";
+  version = "1.0";
+
+  # Missing tests on Pypi
+  src = fetchFromBitbucket {
+    owner = "rw_grim";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0aplb4zdpgbpmaw9qj0vr7qip9q5w7sl1m1lp1nc9jmjfij9i0hf";
+  };
+
+  postPatch = "sed -i 's/parse==/parse>=/' requirements.txt";
+
+  propagatedBuildInputs = [ parse ];
+
+  meta = {
+    description = "Simple library that makes it easier to parse files";
+    homepage = https://bitbucket.org/rw_grim/pyparser;
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.nico202 ];
+  };
+}

--- a/pkgs/development/python-modules/python-magic/default.nix
+++ b/pkgs/development/python-modules/python-magic/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage, lib, fetchPypi, file, stdenv }:
+
+buildPythonPackage rec {
+  pname = "python-magic";
+  version = "0.4.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "128j9y30zih6cyjyjnxhghnvpjm8vw40a1q7pgmrp035yvkaqkk0";
+  };
+
+  postPatch = ''
+    substituteInPlace magic.py --replace "ctypes.util.find_library('magic')" "'${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
+  '';
+
+  doCheck = false;
+
+  # TODO: tests are failing
+  #checkPhase = ''
+  #  ${python}/bin/${python.executable} ./test.py
+  #'';
+
+  meta = {
+    description = "A python interface to the libmagic file type identification library";
+    homepage = https://github.com/ahupp/python-magic;
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/tools/misc/papis/default.nix
+++ b/pkgs/tools/misc/papis/default.nix
@@ -1,0 +1,44 @@
+{ buildPythonApplication, lib, fetchFromGitHub
+, argcomplete, arxiv2bib, beautifulsoup4, bibtexparser
+, configparser, habanero, papis-python-rofi, pylibgen
+, prompt_toolkit, pyparser, python_magic, pyyaml
+, requests, unidecode, urwid, vobject, tkinter
+, vim
+}:
+
+buildPythonApplication rec {
+  pname = "papis";
+  version = "0.5.2";
+
+  # Missing tests on Pypi
+  src = fetchFromGitHub {
+    owner = "alejandrogallo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0cw6ajdaknijka3j2bkkkn0bcxqifk825kq0a0rdbbmc6661pgxb";
+  };
+
+  postPatch = "sed -i 's/configparser>=3.0.0/# configparser>=3.0.0/' setup.py";
+
+  propagatedBuildInputs = [
+    argcomplete arxiv2bib beautifulsoup4 bibtexparser
+    configparser habanero papis-python-rofi pylibgen
+    prompt_toolkit pyparser python_magic pyyaml
+    requests unidecode urwid vobject tkinter
+    vim
+  ];
+
+  # Papis tries to create the config folder under $HOME during the tests
+  preCheck = ''
+    mkdir -p check-phase
+    export HOME=$(pwd)/check-phase
+  '';
+
+
+  meta = {
+    description = "Powerful command-line document and bibliography manager";
+    homepage = http://papis.readthedocs.io/en/latest/;
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.nico202 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13985,6 +13985,8 @@ with pkgs;
 
   papirus-icon-theme = callPackage ../data/icons/papirus-icon-theme { };
 
+  papis = python3Packages.callPackage ../tools/misc/papis { };
+
   pecita = callPackage ../data/fonts/pecita {};
 
   paratype-pt-mono = callPackage ../data/fonts/paratype-pt/mono.nix {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14412,6 +14412,8 @@ in {
 
   pylibacl = callPackage ../development/python-modules/pylibacl { };
 
+  pylibgen = callPackage ../development/python-modules/pylibgen { };
+
   pyliblo = buildPythonPackage rec {
     name = "pyliblo-${version}";
     version = "0.9.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -241,6 +241,8 @@ in {
     hdf5 = pkgs.hdf5-mpi;
   };
 
+  habanero = callPackage ../development/python-modules/habanero { };
+
   intelhex = callPackage ../development/python-modules/intelhex { };
 
   lmtpd = callPackage ../development/python-modules/lmtpd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -330,6 +330,8 @@ in {
     callPackage = pkgs.callPackage;
   };
 
+  pyparser = callPackage ../development/python-modules/pyparser { };
+
   pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {
     pythonPackages = self;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5816,6 +5816,8 @@ in {
 
   paperwork-backend = callPackage ../applications/office/paperwork/backend.nix { };
 
+  papis-python-rofi = callPackage ../development/python-modules/papis-python-rofi { };
+
   pathspec = callPackage ../development/python-modules/pathspec { };
 
   pathtools = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9793,32 +9793,7 @@ in {
 
   py_scrypt = callPackage ../development/python-modules/py_scrypt/default.nix { };
 
-  python_magic = buildPythonPackage rec {
-    name = "python-magic-0.4.10";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-magic/${name}.tar.gz";
-      sha256 = "1hx2sjd4fdswswj3yydn2azxb59rjmi9b7jzh94lf1wnxijjizbr";
-    };
-
-    propagatedBuildInputs = with self; [ pkgs.file ];
-
-    patchPhase = ''
-      substituteInPlace magic.py --replace "ctypes.util.find_library('magic')" "'${pkgs.file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
-    '';
-
-    doCheck = false;
-
-    # TODO: tests are failing
-    #checkPhase = ''
-    #  ${python}/bin/${python.executable} ./test.py
-    #'';
-
-    meta = {
-      description = "A python interface to the libmagic file type identification library";
-      homepage = https://github.com/ahupp/python-magic;
-    };
-  };
+  python_magic = callPackage ../development/python-modules/python-magic { };
 
   magic = buildPythonPackage rec {
     name = "${pkgs.file.name}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -598,6 +598,8 @@ in {
 
   area53 = callPackage ../development/python-modules/area53 { };
 
+  arxiv2bib = callPackage ../development/python-modules/arxiv2bib { };
+
   chai = callPackage ../development/python-modules/chai { };
 
   chainmap = callPackage ../development/python-modules/chainmap { };


### PR DESCRIPTION
###### Motivation for this change
Papis is a powerful and highly extensible command-line based document and bibliography manager.
https://github.com/alejandrogallo/papis

###### Things done
Added all papis missing dependencies (arxiv2bib, habanero, papis-python-rofi, pylibgen)
Updated python-magic from 0.4.10 to 0.4.13

(HELP WANTED: I don't know how to check if all packages depending on python-magic still works, how do I check it?
I checked beancount and it installs, relatorio and tests are ok, s3cmd installs (has no tests). How do I ask nix to do this automatically for all the dependencies?)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

