### PR TITLE
asciidoctor: expose all the bins

### DIFF
--- a/pkgs/tools/typesetting/asciidoctor/default.nix
+++ b/pkgs/tools/typesetting/asciidoctor/default.nix
@@ -1,11 +1,17 @@
-{ stdenv, lib, bundlerEnv, ruby, curl }:
+{ stdenv, lib, bundlerApp, ruby, curl }:
 
-bundlerEnv {
-  pname = "asciidoctor";
-
+bundlerApp {
   inherit ruby;
-
+  pname = "asciidoctor";
   gemdir = ./.;
+
+  exes = [
+    "asciidoctor"
+    "asciidoctor-bespoke"
+    "asciidoctor-latex"
+    "asciidoctor-pdf"
+    "asciidoctor-safe"
+  ];
 
   meta = with lib; {
     description = "A faster Asciidoc processor written in Ruby";


### PR DESCRIPTION
###### Motivation for this change

asciidoctor has multiple binaries, expose them all to the user. Fixes #24293

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

