### PR TITLE
python.pkgs.awesome-slugify: fix build

### DIFF
--- a/pkgs/development/python-modules/awesome-slugify/default.nix
+++ b/pkgs/development/python-modules/awesome-slugify/default.nix
@@ -10,6 +10,11 @@ buildPythonPackage rec {
     sha256 = "0wgxrhr8s5vk2xmcz9s1z1aml4ppawmhkbggl9rp94c747xc7pmv";
   };
 
+  prePatch = ''
+    substituteInPlace setup.py \
+        --replace 'Unidecode>=0.04.14,<0.05' 'Unidecode>=0.04.14'
+  '';
+
   patches = [
     ./slugify_filename_test.patch # fixes broken test by new unidecode
   ];

--- a/pkgs/development/python-modules/awesome-slugify/default.nix
+++ b/pkgs/development/python-modules/awesome-slugify/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "awesome-slugify";
   version = "1.6.5";
-  name  = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
It broke because Unidecode went out of
its defined range (Unidecode>=0.04.14,<0.05)
with commit 57e9ed3719e5cef086a3463513e8805c761c3cf4

###### Motivation for this change

fix octoprint

###### Things done

- [ x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

