### PR TITLE
libproxy: fix building on darwin

### DIFF
--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake
-, dbus, networkmanager, spidermonkey_38, pcre, python2, python3 }:
+{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake, zlib
+, dbus, networkmanager, spidermonkey_38, pcre, python2, python3
+, SystemConfiguration, CoreFoundation, JavaScriptCore }:
 
 stdenv.mkDerivation rec {
   name = "libproxy-${version}";
@@ -16,7 +17,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  buildInputs = [ dbus networkmanager spidermonkey_38 pcre python2 python3 ];
+  buildInputs = [ pcre python2 python3 zlib ]
+        ++ (if stdenv.hostPlatform.isDarwin
+            then [ SystemConfiguration CoreFoundation JavaScriptCore ]
+            else [ spidermonkey_38 dbus networkmanager ]);
 
   preConfigure = ''
     cmakeFlagsArray+=(
@@ -27,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     license = licenses.lgpl21;
     homepage = http://libproxy.github.io/libproxy/;
     description = "A library that provides automatic proxy configuration management";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9894,9 +9894,7 @@ with pkgs;
   };
 
   libproxy = callPackage ../development/libraries/libproxy {
-    stdenv = if stdenv.isDarwin
-      then overrideCC stdenv gcc
-      else stdenv;
+    inherit (darwin.apple_sdk.frameworks) SystemConfiguration CoreFoundation JavaScriptCore;
   };
 
   libpseudo = callPackage ../development/libraries/libpseudo { };


### PR DESCRIPTION
###### Motivation for this change

Update libproxy to build on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
