### PR TITLE
rPackages.pbdZMQ: fix package loading on Darwin

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -285,7 +285,7 @@ let
     pbdMPI = [ pkgs.openmpi ];
     pbdNCDF4 = [ pkgs.netcdf ];
     pbdPROF = [ pkgs.openmpi ];
-    pbdZMQ = [ pkgs.which ];
+    pbdZMQ = lib.optionals stdenv.isDarwin [ pkgs.which ];
     pdftools = [ pkgs.poppler.dev ];
     PKI = [ pkgs.openssl.dev ];
     png = [ pkgs.libpng.dev ];
@@ -393,6 +393,7 @@ let
     nat = [ pkgs.which ];
     nat_nblast = [ pkgs.which ];
     nat_templatebrains = [ pkgs.which ];
+    pbdZMQ = lib.optionals stdenv.isDarwin [ pkgs.binutils.bintools ];
     RMark = [ pkgs.which ];
     RPushbullet = [ pkgs.which ];
     qtpaint = [ pkgs.cmake ];
@@ -774,6 +775,14 @@ let
 
     Mposterior = old.Mposterior.overrideDerivation (attrs: {
       PKG_LIBS = "-L${pkgs.openblasCompat}/lib -lopenblas";
+    });
+
+    pbdZMQ = old.pbdZMQ.overrideDerivation (attrs: {
+      postPatch = lib.optionalString stdenv.isDarwin ''
+        for file in R/*.{r,r.in}; do
+            sed -i 's#system("which \(\w\+\)"[^)]*)#"${pkgs.binutils.bintools}/bin/\1"#g' $file
+        done
+      '';
     });
 
     qtbase = old.qtbase.overrideDerivation (attrs: {


### PR DESCRIPTION
###### Motivation for this change

When loading pbdZMQ on Darwin, R tries to find `otool` and `install_name_tool` dynamically; R invokes `system("which otool", ...)` and `system("which install_name_tool", ...)`.
In a pure environment (`nix-shell --pure`), even if having these dependencies in `buildInputs` of pbdZMQ, they are not visible from the caller, somehow, so that it fails.
Even worse in an impure environment, R calls `/usr/bin/otool`. Without installation of Xcode or Command Line Tools, you'll see a popup message saying "would you like to install the tools now?"

###### Things done

- Replaced each `system("which ...")` call by a static path to each dependency.
- Tested it using the following script:
```nix
#!/usr/bin/env nix-shell --pure

with import <nixpkgs> {};
stdenv.mkDerivation {
  name = "darwin-r-pbdZMQ-test";
  buildInputs = [ (rWrapper.override { packages = [ rPackages.pbdZMQ ]; }) ];
  shellHook = ''
    Rscript -e 'library(pbdZMQ)'
    exit 0
  '';
}

```

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

