### PR TITLE
pythonPackages.dateparser: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -1,47 +1,40 @@
-{ stdenv, fetchFromGitHub, buildPythonPackage, isPy3k
+{ lib, fetchPypi, buildPythonPackage, isPy3k
 , nose
 , parameterized
 , mock
 , glibcLocales
 , six
 , jdatetime
-, pyyaml
 , dateutil
 , umalqurra
 , pytz
 , tzlocal
 , regex
 , ruamel_yaml }:
+
 buildPythonPackage rec {
   pname = "dateparser";
-  version = "0.6.0";
+  version = "0.7.0";
 
-  src = fetchFromGitHub {
-    owner = "scrapinghub";
-    repo = pname;
-    rev = "refs/tags/v${version}";
-    sha256 = "0q2vyzvlj46r6pr0s6m1a0md1cpg9nv1n3xw286l4x2cc7fj2g3y";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "940828183c937bcec530753211b70f673c0a9aab831e43273489b310538dff86";
   };
 
-  # Replace nose-parameterized by parameterized
-  prePatch = ''
-    sed -i s/nose_parameterized/parameterized/g tests/*.py
-    sed -i s/nose-parameterized/parameterized/g tests/requirements.txt
-  '';
-
-  # Upstream Issue: https://github.com/scrapinghub/dateparser/issues/364
-  disabled = isPy3k;
-
-  checkInputs = [ nose parameterized mock glibcLocales ];
+  checkInputs = [ nose mock parameterized six glibcLocales ];
   preCheck =''
     # skip because of missing convertdate module, which is an extra requirement
     rm tests/test_jalali.py
   '';
 
-  propagatedBuildInputs = [ six jdatetime pyyaml dateutil
-            umalqurra pytz tzlocal regex ruamel_yaml ];
+  propagatedBuildInputs = [
+    # install_requires
+    dateutil pytz regex tzlocal
+    # extra_requires
+    jdatetime ruamel_yaml umalqurra
+  ];
 
-  meta = with stdenv.lib;{
+  meta = with lib; {
     description = "Date parsing library designed to parse dates from HTML pages";
     homepage = https://github.com/scrapinghub/dateparser;
     license = licenses.bsd3;


### PR DESCRIPTION
###### Motivation for this change
YAML was replaced by ruamel: https://github.com/scrapinghub/dateparser/commit/fee300c3983c3192f462398908c8b175cd28eaa8
Also did some further refactoring.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @makefu