### PR TITLE
flexget: mark as broken

### DIFF
--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -75,5 +75,6 @@ buildPythonApplication rec {
     description = "Multipurpose automation tool for content like torrents";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ domenkozar tari ];
+    broken = true; # as of 2018-02-09
   };
 }


### PR DESCRIPTION
###### Motivation for this change

... I already had to fix flexget for last two nixos releases.

cc @domenkozar @tari 


something fundamental has to change in packaging of flexget to prevent breakage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

