### PR TITLE
eschalot: init at 2018-01-19

### DIFF
--- a/pkgs/tools/security/eschalot/default.nix
+++ b/pkgs/tools/security/eschalot/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "eschalot";
+  version = "2018-01-19";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ReclaimYourPrivacy";
+    repo = pname;
+    rev = "56a967b62631cfd3c7ef68541263dbd54cbbc2c4";
+    sha256 = "1iw1jrydasm9dmgpcdimd8dy9n281ys9krvf3fd3dlymkgsj604d";
+  };
+
+  buildInputs = [ openssl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp eschalot worgen $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tor hidden service name generator";
+    homepage = src.meta.homepage;
+    license = licenses.isc;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/tools/security/eschalot/default.nix
+++ b/pkgs/tools/security/eschalot/default.nix
@@ -15,8 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp eschalot worgen $out/bin
+    install -D -t $out/bin eschalot worgen
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1099,6 +1099,8 @@ with pkgs;
 
   envconsul = callPackage ../tools/system/envconsul { };
 
+  eschalot = callPackage ../tools/security/eschalot { };
+
   esptool = callPackage ../tools/misc/esptool { };
 
   esptool-ck = callPackage ../tools/misc/esptool-ck { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

