### PR TITLE
pythonPackages.pytest-httpbin: actually run tests

### DIFF
--- a/pkgs/development/python-modules/pytest-httpbin/default.nix
+++ b/pkgs/development/python-modules/pytest-httpbin/default.nix
@@ -24,6 +24,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ flask decorator httpbin six requests ];
 
+  checkPhase = ''
+    py.test
+  '';
+
   meta = {
     description = "Easily test your HTTP library against a local copy of httpbin.org";
     homepage = https://github.com/kevin1024/pytest-httpbin;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

