### PR TITLE
nixos: export packages of the current configuration

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -9,8 +9,6 @@ let
     modules = [ configuration ];
   };
 
-  inherit (eval) pkgs;
-
   # This is for `nixos-rebuild build-vm'.
   vmConfig = (import ./lib/eval-config.nix {
     inherit system;
@@ -30,7 +28,7 @@ let
 in
 
 {
-  inherit (eval) config options;
+  inherit (eval) pkgs config options;
 
   system = eval.config.system.build.toplevel;
 


### PR DESCRIPTION
###### Motivation for this change
A trivial patch I frequently miss when testing SLNOS patches with upstream nixpkgs.

This allows one to access a package configured with overrides given in `nixpkgs.config`, e.g.:
`nix-build ./nixos/default.nix -A pkgs.ffmpeg`

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

