### PR TITLE
looking-glass-client: restrict to x86_64-linux

### DIFF
--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation rec {
     homepage = https://looking-glass.hostfission.com/;
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.pneumaticat ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
##### Motivation for this change

The [AArch64 build fails](https://hydra.nixos.org/build/68600217) after trying to pull in tmmintrin.h:

```
../common/memcpySSE.h:24:23: fatal error: tmmintrin.h: No such file or directory
 #include <tmmintrin.h>
                       ^
compilation terminated.
make: *** [Makefile:29: .build/renderers/opengl.o] Error 1
```

Which are SSSE3 intrinsics unsupported on ARM. This package also likely would not be useful on ARM, as it requires KVM and a compatible KVM guest running the frame relay (usually Windows).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

