### PR TITLE
exfat: 1.2.7 -> 1.2.8

### DIFF
--- a/pkgs/tools/filesystems/exfat/default.nix
+++ b/pkgs/tools/filesystems/exfat/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "exfat-${version}";
-  version = "1.2.7";
+  version = "1.2.8";
 
   src = fetchFromGitHub {
     owner = "relan";
     repo = "exfat";
     rev = "v${version}";
-    sha256 = "1sk4z133djh8sdvx2vvmd8kf4qfly2i3hdar4zpg0s41jpbzdx69";
+    sha256 = "0q02g3yvfmxj70h85a69d8s4f6y7jask268vr87j44ya51lzndd9";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

