### PR TITLE
python3Packages.pyhomematic: 0.1.38 -> 0.1.39

### DIFF
--- a/pkgs/development/python-modules/pyhomematic/default.nix
+++ b/pkgs/development/python-modules/pyhomematic/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, buildPythonPackage, isPy3k, fetchPypi }:
+{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub }:
 
 buildPythonPackage rec {
   pname = "pyhomematic";
-  version = "0.1.38";
+  version = "0.1.39";
 
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "15b09ppn5sn3vpnwfb7gygrvn5v65k3zvahkfx2kqpk1xah0mqbf";
+  # PyPI tarball does not include tests/ directory
+  src = fetchFromGitHub {
+    owner = "danielperna84";
+    repo = pname;
+    rev = version;
+    sha256 = "1g181x2mrhxcaswr6vi2m7if97wv4rf2g2pny60334sciga8njfz";
   };
-
-  # Tests reuire network access
-  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Python 3 Interface to interact with Homematic devices";


### PR DESCRIPTION
###### Motivation for this change
They now have non-manual tests :tada: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

