### PR TITLE
boot.kernel.features: add nixos option for setting kernel features

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -104,6 +104,7 @@
   ./programs/ssh.nix
   ./programs/ssmtp.nix
   ./programs/sysdig.nix
+  ./programs/systemtap.nix
   ./programs/sway.nix
   ./programs/thefuck.nix
   ./programs/tmux.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -75,6 +75,7 @@
   ./programs/cdemu.nix
   ./programs/chromium.nix
   ./programs/command-not-found/command-not-found.nix
+  ./programs/criu.nix
   ./programs/dconf.nix
   ./programs/environment.nix
   ./programs/fish.nix

--- a/nixos/modules/programs/criu.nix
+++ b/nixos/modules/programs/criu.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.criu;
+in {
+
+  options = {
+    programs.criu = {
+      enable = mkOption {
+        default = false;
+        description = ''
+          Install <command>criu</command> along with necessary kernel options.
+        '';
+      };
+    };
+  };
+  config = mkIf cfg.enable {
+    system.requiredKernelConfig = with config.lib.kernelConfig; [
+      (isYes "CHECKPOINT_RESTORE")
+    ];
+    boot.kernel.features.criu = true;
+    environment.systemPackages = [ pkgs.criu ];
+  };
+
+}

--- a/nixos/modules/programs/systemtap.nix
+++ b/nixos/modules/programs/systemtap.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.systemtap;
+in {
+
+  options = {
+    programs.systemtap = {
+      enable = mkOption {
+        default = false;
+        description = ''
+          Install <command>systemtap</command> along with necessary kernel options.
+        '';
+      };
+    };
+  };
+  config = mkIf cfg.enable {
+    system.requiredKernelConfig = with config.lib.kernelConfig; [
+      (isYes "DEBUG")
+    ];
+    boot.kernel.features.debug = true;
+    environment.systemPackages = [
+      config.boot.kernelPackages.systemtap
+    ];
+  };
+
+}

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   inherit (config.boot) kernelPatches;
-
+  inherit (config.boot.kernel) features;
   inherit (config.boot.kernelPackages) kernel;
 
   kernelModulesConf = pkgs.writeText "nixos.conf"
@@ -21,11 +21,21 @@ in
 
   options = {
 
+    boot.kernel.features = mkOption {
+      default = {};
+      example = literalExample "{ debug = true; }";
+      description = ''
+        This option allows to enable or disable certain kernel features.
+        grep features pkgs/os-specific/linux/kernel/common-config.nix
+      '';
+    };
+
     boot.kernelPackages = mkOption {
       default = pkgs.linuxPackages;
       apply = kernelPackages: kernelPackages.extend (self: super: {
         kernel = super.kernel.override {
           kernelPatches = super.kernel.kernelPatches ++ kernelPatches;
+          features = lib.recursiveUpdate super.kernel.features features;
         };
       });
       # We don't want to evaluate all of linuxPackages for the manual

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -24,9 +24,13 @@ in
     boot.kernel.features = mkOption {
       default = {};
       example = literalExample "{ debug = true; }";
+      internal = true;
       description = ''
         This option allows to enable or disable certain kernel features.
-        grep features pkgs/os-specific/linux/kernel/common-config.nix
+        It's not API, because it's about kernel feature sets, that
+        make sense for specific use cases. Mostly along with programs,
+        which would have separate nixos options.
+        `grep features pkgs/os-specific/linux/kernel/common-config.nix`
       '';
     };
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -699,5 +699,9 @@ with stdenv.lib;
     DEBUG_MEMORY_INIT? y
   ''}
 
+  ${optionalString (features.debug or false)  ''
+    DEBUG_INFO y
+  ''}
+
   ${extraConfig}
 ''

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -682,5 +682,22 @@ with stdenv.lib;
     WW_MUTEX_SELFTEST? n
   ''}
 
+  ${optionalString (features.criu or false)  ''
+    EXPERT y
+    CHECKPOINT_RESTORE y
+  ''}
+
+  ${optionalString ((features.criu or false) && (features.criu_revert_expert or true))
+    # Revert some changes, introduced by EXPERT, when necessary for criu
+  ''
+    RFKILL_INPUT? y
+    HID_PICOLCD_FB? y
+    HID_PICOLCD_BACKLIGHT? y
+    HID_PICOLCD_LCD? y
+    HID_PICOLCD_LEDS? y
+    HID_PICOLCD_CIR? y
+    DEBUG_MEMORY_INIT? y
+  ''}
+
   ${extraConfig}
 ''


### PR DESCRIPTION
###### Motivation for this change

The motivation is submitted in the form of additional commits on this PR:
- provide options for installing `systemtap` and `criu`; both profit from / require custom kernel config
- optionally enabling `CONFIG_DEBUG_INFO`, for use with systemtap
- optionally enabling `CONFIG_CHECKPOINT_RESTORE`, which is required by `criu`

###### Review requested

- Is it done the right way?
- What about the section re-enabling flags, that, for some reason, got disabled by `CONFIG_EXPERT` (`EXPERT` is needed for `CHECKPOINT_RESTORE`) https://github.com/NixOS/nixpkgs/pull/34791/commits/d86f2529529f27f19d72e85830748c4a62e9b937#diff-ad3f665c58e343da48fc9981dde5afaeR690

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

