### PR TITLE
move texstudio from qt4 to qt5

### DIFF
--- a/pkgs/applications/editors/texstudio/default.nix
+++ b/pkgs/applications/editors/texstudio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qt4, qmake4Hook, poppler_qt4, zlib, pkgconfig}:
+{ stdenv, fetchurl, qt5, poppler_qt5, zlib, pkgconfig}:
 
 stdenv.mkDerivation rec {
   pname = "texstudio";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "18rxd7ra5k2f7s4c296b3v3pqhxjmfix9xpy9i1g4jm87ygqrbnd";
   };
 
-  nativeBuildInputs = [ qmake4Hook pkgconfig ];
-  buildInputs = [ qt4 poppler_qt4 zlib ];
+  nativeBuildInputs = [ qt5.qmake pkgconfig ];
+  buildInputs = [ qt5.qtbase qt5.qtscript qt5.qtsvg poppler_qt5 zlib ];
 
   qmakeFlags = [ "NO_APPDATA=True" ];
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 	'';
     homepage = http://texstudio.sourceforge.net;
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ cfouche ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The move from qt4 to qt5 is motivated by #32883, because poppler_qt4 is deprecated.

Texstudio is one of the 4 remaining packages using poppler_qt4, but it also supports qt5.
I also tried upgrading texmaker to version 5.0.2 and fix the same issue for it, but could not get it to compile.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

