### PR TITLE
mailpile: 0.4.1 -> 1.0.0rc1

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -1,27 +1,39 @@
-{ stdenv, fetchgit, python2Packages, gnupg1orig, makeWrapper, openssl }:
+{ stdenv, fetchFromGitHub, python2Packages, gnupg1orig, makeWrapper, openssl, git }:
 
 python2Packages.buildPythonApplication rec {
   name = "mailpile-${version}";
-  version = "0.4.1";
+  version = "1.0.0rc1";
 
-  src = fetchgit {
-    url = "git://github.com/pagekite/Mailpile";
-    rev = "refs/tags/${version}";
-    sha256 = "118b5zwfwmzj38p0mkj3r1s09jxg8x38y0a42b21imzpmli5vpb5";
+  src = fetchFromGitHub {
+    owner = "mailpile";
+    repo = "Mailpile";
+    rev = "${version}";
+    sha256 = "0hl42ljdzk57ndndff9f1yh08znxwj01kjdmx019vmml0arv0jga";
   };
 
-  patchPhase = ''
-    substituteInPlace setup.py --replace "data_files.append((dir" "data_files.append(('lib/${python2Packages.python.libPrefix}/site-packages/' + dir"
+  postPatch = ''
+    patchShebangs scripts
   '';
 
+  nativeBuildInputs = with python2Packages; [ pbr git ];
+  PBR_VERSION=version;
+
   propagatedBuildInputs = with python2Packages; [
-    makeWrapper pillow jinja2 spambayes python2Packages.lxml
-    pgpdump gnupg1orig
+    appdirs
+    cryptography
+    fasteners
+    gnupg1orig
+    jinja2
+    pgpdump
+    pillow
+    python2Packages.lxml
+    spambayes
   ];
 
   postInstall = ''
     wrapProgram $out/bin/mailpile \
-      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1orig openssl ]}"
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1orig openssl ]}" \
+      --set-default MAILPILE_SHARED "$out/share/mailpile"
   '';
 
   # No tests were found

--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -2,13 +2,13 @@
 
 python2Packages.buildPythonApplication rec {
   name = "mailpile-${version}";
-  version = "1.0.0rc1";
+  version = "1.0.0rc2";
 
   src = fetchFromGitHub {
     owner = "mailpile";
     repo = "Mailpile";
     rev = "${version}";
-    sha256 = "0hl42ljdzk57ndndff9f1yh08znxwj01kjdmx019vmml0arv0jga";
+    sha256 = "1z5psh00fjr8gnl4yjcl4m9ywfj24y1ffa2rfb5q8hq4ksjblbdj";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Adaptation of #23058 by @spinus to 1.0.0rc1. See #23058 and #28111 for discussion.
This patch keeps the warnings. But I think it is useful to have a sanely working
version in nixpkgs, even if it is still considered insecure, just to follow the
upstream development by actually running it instead of reading the log.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
