### PR TITLE
linphone: 3.10.2 -> 3.12.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -1,29 +1,33 @@
 { stdenv, fetchurl, intltool, pkgconfig, readline, openldap, cyrus_sasl, libupnp
 , zlib, libxml2, gtk2, libnotify, speex, ffmpeg, libX11, libsoup, udev
-, ortp, mediastreamer, sqlite, belle-sip, libosip, libexosip
+, ortp, mediastreamer, sqlite, belle-sip, libosip, libexosip, bzrtp
 , mediastreamer-openh264, bctoolbox, makeWrapper, fetchFromGitHub, cmake
 , libmatroska, bcunit, doxygen, gdk_pixbuf, glib, cairo, pango, polarssl
+, python, graphviz, belcard
 }:
 
 stdenv.mkDerivation rec {
   baseName = "linphone";
-  version = "3.10.2";
+  version = "3.12.0";
   name = "${baseName}-${version}";
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
     repo = "${baseName}";
     rev = "${version}";
-    sha256 = "053gad4amdbq5za8f2n9j5q59nkky0w098zbsa3dvpcqvv7ar16p";
+    sha256 = "0az2ywrpx11sqfb4s4r2v726avcjf4k15bvrqj7xvhz7hdndmh0j";
   };
 
   buildInputs = [
     readline openldap cyrus_sasl libupnp zlib libxml2 gtk2 libnotify speex ffmpeg libX11
     polarssl libsoup udev ortp mediastreamer sqlite belle-sip libosip libexosip
-    bctoolbox libmatroska bcunit gdk_pixbuf glib cairo pango
+    bctoolbox libmatroska bcunit gdk_pixbuf glib cairo pango bzrtp belcard
   ];
 
-  nativeBuildInputs = [ intltool pkgconfig makeWrapper cmake doxygen ];
+  nativeBuildInputs = [
+    intltool pkgconfig makeWrapper cmake doxygen graphviz
+    (python.withPackages (ps: [ ps.pystache ps.six ]))
+  ];
 
   NIX_CFLAGS_COMPILE = " -Wno-error -I${glib.dev}/include/glib-2.0
     -I${glib.out}/lib/glib-2.0/include -I${gtk2.dev}/include/gtk-2.0/

--- a/pkgs/development/libraries/bctoolbox/default.nix
+++ b/pkgs/development/libraries/bctoolbox/default.nix
@@ -2,13 +2,13 @@
 stdenv.mkDerivation rec {
   name = "${baseName}-${version}";
   baseName = "bctoolbox";
-  version = "0.2.0";
+  version = "0.6.0";
   buildInputs = [cmake mbedtls bcunit srtp];
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
     repo = "${baseName}";
     rev = "${version}";
-    sha256 = "09mjqdfjxy4jy1z68b2i99hgkbnhhk7vnbfhj9sdpd1p3jk2ha33";
+    sha256 = "1cxx243wyzkd4xnvpyqf97n0rjhfckpvw1vhwnbwshq3q6fra909";
   };
 
   meta = {

--- a/pkgs/development/libraries/belcard/default.nix
+++ b/pkgs/development/libraries/belcard/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, cmake, fetchFromGitHub, bctoolbox, belr }:
+
+stdenv.mkDerivation rec {
+  baseName = "belcard";
+  version = "1.0.2";
+  name = "${baseName}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "BelledonneCommunications";
+    repo = "${baseName}";
+    rev = "${version}";
+    sha256 = "1pwji83vpsdrfma24rnj3rz1x0a0g6zk3v4xjnip7zf2ys3zcnlk";
+  };
+
+  buildInputs = [ bctoolbox belr ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib;{
+    description = "Belcard is a C++ library to manipulate VCard standard format";
+    homepage = https://github.com/BelledonneCommunications/belcard;
+    license = licenses.lgpl21;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   baseName = "belle-sip";
-  version = "1.5.0";
+  version = "1.6.3";
   name = "${baseName}-${version}";
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
     repo = "${baseName}";
     rev = "${version}";
-    sha256 = "0hnm64hwgq003wicz6c485fryjfhi820fgin8ndknq60kvwxsrzn";
+    sha256 = "0q70db1klvhca1af29bm9paka3gyii5hfbzrj4178gclsg7cj8fk";
   };
 
   nativeBuildInputs = [ jre cmake ];

--- a/pkgs/development/libraries/belr/default.nix
+++ b/pkgs/development/libraries/belr/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, cmake, fetchFromGitHub, bctoolbox }:
+
+stdenv.mkDerivation rec {
+  baseName = "belr";
+  version = "0.1.3";
+  name = "${baseName}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "BelledonneCommunications";
+    repo = "${baseName}";
+    rev = "${version}";
+    sha256 = "0mf8lsyq1z3b5p47c00lnwc8n7v9nzs1fd2g9c9hnz6fjd2ka44w";
+  };
+
+  buildInputs = [ bctoolbox ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib;{
+    description = "Belr is Belledonne Communications' language recognition library";
+    homepage = https://github.com/BelledonneCommunications/belr;
+    license = licenses.lgpl21;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/bzrtp/default.nix
+++ b/pkgs/development/libraries/bzrtp/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, cmake, fetchFromGitHub, bctoolbox, sqlite }:
+
+stdenv.mkDerivation rec {
+  baseName = "bzrtp";
+  version = "1.0.6";
+  name = "${baseName}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "BelledonneCommunications";
+    repo = "${baseName}";
+    rev = "${version}";
+    sha256 = "0438zzxp82bj5fmvqnwlljkgrz9ab5qm5lgpwwgmg1cp78bp2l45";
+  };
+
+  buildInputs = [ bctoolbox sqlite ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "BZRTP is an opensource implementation of ZRTP keys exchange protocol";
+    homepage = https://github.com/BelledonneCommunications/bzrtp;
+    license = licenses.lgpl21;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -1,22 +1,29 @@
 { stdenv, fetchurl, pkgconfig, intltool, alsaLib, libpulseaudio, speex, gsm
 , libopus, ffmpeg, libX11, libXv, mesa, glew, libtheora, libvpx, SDL, libupnp
 , ortp, libv4l, libpcap, srtp, fetchFromGitHub, cmake, bctoolbox, doxygen
-, python, libXext, libmatroska, openssl
+, python, libXext, libmatroska, openssl, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   baseName = "mediastreamer2";
-  version = "2.14.0";
+  version = "2.16.1";
   name = "${baseName}-${version}";
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
     repo = "${baseName}";
     rev = "${version}";
-    sha256 = "1b59rzsaw54mhy4pz9hndmim4rgidkn7s6c4iyl34mz58lwxpmqp";
+    sha256 = "02745bzl2r1jqvdqzyv94fjd4w92zr976la4c4nfvsy52waqah7j";
   };
 
-  patches = [ ./plugins_dir.patch ];
+  patches = [
+    (fetchpatch {
+      name = "allow-build-without-git.patch";
+      url = "https://github.com/BelledonneCommunications/mediastreamer2/commit/de3a24b795d7a78e78eab6b974e7ec5abf2259ac.patch";
+      sha256 = "1zqkrab42n4dha0knfsyj4q0wc229ma125gk9grj67ps7r7ipscy";
+    })
+    ./plugins_dir.patch
+  ];
 
   nativeBuildInputs = [ pkgconfig intltool cmake doxygen python ];
 

--- a/pkgs/development/libraries/ortp/default.nix
+++ b/pkgs/development/libraries/ortp/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   baseName = "ortp";
-  version = "0.27.0";
+  version = "1.0.2";
   name = "${baseName}-${version}";
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
     repo = "${baseName}";
     rev = "${version}";
-    sha256 = "0gjaaph4pamay9gn1yn7ky5wyzhj93r53rwak7h8s48vf08fqyv7";
+    sha256 = "12cwv593bsdnxs0zfcp07vwyk7ghlz2wv7vdbs1ksv293w3vj2rv";
   };
 
   buildInputs = [ bctoolbox ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8180,6 +8180,8 @@ with pkgs;
 
   beecrypt = callPackage ../development/libraries/beecrypt { };
 
+  belcard = callPackage ../development/libraries/belcard { };
+
   belr = callPackage ../development/libraries/belr { };
 
   beignet = callPackage ../development/libraries/beignet {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8180,6 +8180,8 @@ with pkgs;
 
   beecrypt = callPackage ../development/libraries/beecrypt { };
 
+  belr = callPackage ../development/libraries/belr { };
+
   beignet = callPackage ../development/libraries/beignet {
     inherit (llvmPackages_39) llvm clang-unwrapped;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8219,6 +8219,8 @@ with pkgs;
 
   bwidget = callPackage ../development/libraries/bwidget { };
 
+  bzrtp = callPackage ../development/libraries/bzrtp { };
+
   c-ares = callPackage ../development/libraries/c-ares {
     fetchurl = fetchurlBoot;
   };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/34669 broke the `linphone` build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ryantm @peti 