### PR TITLE
racket-minimal: init at 6.12.0 (same as racket)

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -35,8 +35,13 @@ stdenv.mkDerivation rec {
   name = "racket-${version}";
   version = "6.12";
 
-  src = fetchurl {
-    url = "https://mirror.racket-lang.org/installers/${version}/${name}-src.tgz";
+  src = (stdenv.lib.makeOverridable ({ name, sha256 }:
+    fetchurl rec {
+      url = "https://mirror.racket-lang.org/installers/${version}/${name}-src.tgz";
+      inherit sha256;
+    }
+  )) {
+    inherit name;
     sha256 = "0cwcypzjfl9py1s695mhqkiapff7c1w29llsmdj7qgn58wl0apk5";
   };
 

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -1,0 +1,10 @@
+{ racket
+}:
+
+racket.overrideAttrs (oldAttrs: rec {
+  name = "racket-minimal-${oldAttrs.version}";
+  src = oldAttrs.src.override {
+    inherit name;
+    sha256 = "0c565jy2y3gjl5lncd5adjsrj8c24p4i062kphv26ni5q1nn5ip5";
+  };
+})

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -7,4 +7,11 @@ racket.overrideAttrs (oldAttrs: rec {
     inherit name;
     sha256 = "0c565jy2y3gjl5lncd5adjsrj8c24p4i062kphv26ni5q1nn5ip5";
   };
+
+  description = "Racket without bundled packages, such as Mr Racket.";
+  longDescription = ''The essential package racket-libs is included,
+    as well as libraries that live in collections. In particular, raco
+    and the pkg library are still bundled.
+  '';
+
 })

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -8,7 +8,7 @@ racket.overrideAttrs (oldAttrs: rec {
     sha256 = "0c565jy2y3gjl5lncd5adjsrj8c24p4i062kphv26ni5q1nn5ip5";
   };
 
-  description = "Racket without bundled packages, such as Mr Racket.";
+  description = "Racket without bundled packages, such as Dr. Racket.";
   longDescription = ''The essential package racket-libs is included,
     as well as libraries that live in collections. In particular, raco
     and the pkg library are still bundled.

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -8,10 +8,12 @@ racket.overrideAttrs (oldAttrs: rec {
     sha256 = "0c565jy2y3gjl5lncd5adjsrj8c24p4i062kphv26ni5q1nn5ip5";
   };
 
-  description = "Racket without bundled packages, such as Dr. Racket.";
-  longDescription = ''The essential package racket-libs is included,
-    as well as libraries that live in collections. In particular, raco
-    and the pkg library are still bundled.
-  '';
-
+  meta = oldAttrs.meta // {
+    description = "Racket without bundled packages, such as Dr. Racket.";
+    longDescription = ''The essential package racket-libs is included,
+      as well as libraries that live in collections. In particular, raco
+      and the pkg library are still bundled.
+    '';
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7015,6 +7015,7 @@ with pkgs;
     # https://github.com/NixOS/nixpkgs/pull/31017#issuecomment-343574769
     stdenv = overrideCC stdenv gcc7;
   };
+  racket-minimal = callPackage ../development/interpreters/racket/minimal.nix { };
 
   rakudo = callPackage ../development/interpreters/rakudo {
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;


### PR DESCRIPTION
Racket without the bundled packages, such as Mr Racket.

The essential package racket-libs is included, as well as libraries
that live in collections. In particular, raco and the pkg library are
still bundled.

###### Motivation for this change

I am working on [racket2nix](https://github.com/clacke/racket2nix), which will make `racket-minimal` much more useful. Also, I want to merge a change that makes racket compile on darwin, and currently only racket-minimal works and can verify that the compiled racket works, due to one package in the full racket having a test failure on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [✓] macOS (with the darwin patch)
   - [✓] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [✓] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [✓] Tested execution of all binary files (usually in `./result/bin/`)
- [✓] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

