### PR TITLE
afl: fix build, by switch to gcc as compiler

### DIFF
--- a/pkgs/tools/security/afl/default.nix
+++ b/pkgs/tools/security/afl/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     '';
     homepage    = "http://lcamtuf.coredump.cx/afl/";
     license     = stdenv.lib.licenses.asl20;
-    platforms   = stdenv.lib.platforms.linux;
+    platforms   = ["x86_64-linux" "i686-linux"];
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
   };
 }

--- a/pkgs/tools/security/afl/default.nix
+++ b/pkgs/tools/security/afl/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   # Note: libcgroup isn't needed for building, just for the afl-cgroup
   # script.
-  buildInputs  = [ makeWrapper clang llvm which ];
+  buildInputs  = [ makeWrapper llvm which ];
 
   buildPhase   = ''
     make PREFIX=$out
@@ -53,8 +53,7 @@ stdenv.mkDerivation rec {
     for x in $out/bin/afl-clang-fast $out/bin/afl-clang-fast++; do
       wrapProgram $x \
         --prefix AFL_PATH : "$out/lib/afl" \
-        --prefix AFL_CC   : "${clang}/bin/clang" \
-        --prefix AFL_CXX  : "${clang}/bin/clang++"
+        --run 'export AFL_CC=''${AFL_CC:-${clang}/bin/clang} AFL_CXX=''${AFL_CXX:-${clang}/bin/clang++}'
     done
   '';
 


### PR DESCRIPTION
Apparently they set CFLAGS incompatible with clang.
Also only provide a default value for AFL_CC/AFL_CXX for afl-clang-fast:
User might want to overriding, but this is not a PATH variable that can
be prepended with :.

@thoughtpolice I have tested afl only lightly, maybe I miss something important.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

