### PR TITLE
nixos/lxd: partial fix for lxd breakage

### DIFF
--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -38,6 +38,15 @@ in
     environment.systemPackages =
       [ pkgs.lxd ];
 
+    security.apparmor = {
+      enable = true;
+      profiles = [
+        "${pkgs.lxc}/etc/apparmor.d/usr.bin.lxc-start"
+        "${pkgs.lxc}/etc/apparmor.d/lxc-containers"
+      ];
+      packages = [ pkgs.lxc ];
+    };
+
     systemd.services.lxd =
       { description = "LXD Container Management Daemon";
 
@@ -46,6 +55,10 @@ in
 
         # TODO(wkennington): Add lvm2 and thin-provisioning-tools
         path = with pkgs; [ acl rsync gnutar xz btrfs-progs gzip dnsmasq squashfsTools iproute iptables ];
+
+        preStart = ''
+          mkdir -m 0755 -p /var/lib/lxc/rootfs
+        '';
 
         serviceConfig.ExecStart = "@${pkgs.lxd.bin}/bin/lxd lxd --syslog --group lxd";
         serviceConfig.Type = "simple";


### PR DESCRIPTION
###### Motivation for this change

Creates directory `/var/lib/lxc/rootfs` and adds AppArmor profiles for lxc, partially addressing the issues discussed at https://github.com/NixOS/nixpkgs/issues/25280.
Note `lxd init` and step 2 of https://github.com/NixOS/nixpkgs/issues/25280#issuecomment-364625022 are still required; ideally, both probably should be done in this module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

