### PR TITLE
lib: make use of visible variable in doRename

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -664,6 +664,7 @@ rec {
     in
       { config, options, ... }:
       { options = setAttrByPath from (mkOption {
+          inherit visible;
           description = "Alias of <option>${showOption to}</option>.";
           apply = x: use (toOf config);
         });


### PR DESCRIPTION
This hooks up the `visible` argument to `doRename` in the `modules.nix` library since it was previously not used in the function. This argument determines whether the renamed option should be shown in the documentation.