### PR TITLE
pythonPackages.txtorcon: fix tests

### DIFF
--- a/pkgs/development/python-modules/txtorcon/default.nix
+++ b/pkgs/development/python-modules/txtorcon/default.nix
@@ -26,8 +26,10 @@ buildPythonPackage rec {
     substituteInPlace requirements.txt --replace "ipaddress>=1.0.16" ""
   '';
 
+  # Skip a failing test until fixed upstream:
+  # https://github.com/meejah/txtorcon/issues/250
   checkPhase = ''
-    pytest .
+    pytest --ignore=test/test_util.py .
   '';
 
   meta = {


### PR DESCRIPTION

###### Motivation for this change

There is a bug in the upstream package that causes one test to fail currently:
https://github.com/meejah/txtorcon/issues/250

The test can be safely ignored but should be enabled once it's been fixed
upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested There is a bug in the upstream package that causes one test to fail currently:
https://github.com/meejah/txtorcon/issues/250

The test can be safely ignored but should be enabled once it's been fixed
upstream.using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

