### PR TITLE
python.pkgs: msgpack changes and neovim update

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "04sgns9qczzw2152gqdr6bjyy4fmgs26cz8n3qck94l0j51rxhz8";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ msgpack pyqt4 numpy pyopencl ] ++ [ openssl ];
+  propagatedBuildInputs = with pythonPackages; [ msgpack-python pyqt4 numpy pyopencl ] ++ [ openssl ];
 
   preConfigure = ''
     # Remove interaction and misleading output

--- a/pkgs/development/python-modules/locustio/default.nix
+++ b/pkgs/development/python-modules/locustio/default.nix
@@ -2,7 +2,7 @@
 , fetchPypi
 , mock
 , unittest2
-, msgpack
+, msgpack-python
 , requests
 , flask
 , gevent
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     sed -i s/"pyzmq=="/"pyzmq>="/ setup.py
   '';
 
-  propagatedBuildInputs = [ msgpack requests flask gevent pyzmq ];
+  propagatedBuildInputs = [ msgpack-python requests flask gevent pyzmq ];
   buildInputs = [ mock unittest2 ];
 
   meta = {

--- a/pkgs/development/python-modules/msgpack/default.nix
+++ b/pkgs/development/python-modules/msgpack/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, fetchPypi
+, pytest
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "msgpack";
+  version = "0.5.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13ckbs2qc4dww7fddnm9cw116j4spgxqab49ijmj6jr178ypwl80";
+  };
+
+  checkPhase = ''
+    py.test
+  '';
+
+  checkInputs = [ pytest ];
+
+  meta = {
+    homepage = https://github.com/msgpack/msgpack-python;
+    description = "MessagePack serializer implementation for Python";
+    license = lib.licenses.asl20;
+    # maintainers =  ?? ;
+  };
+}

--- a/pkgs/development/python-modules/neovim/default.nix
+++ b/pkgs/development/python-modules/neovim/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, nose
+, msgpack
+, greenlet
+, trollius
+, pythonOlder
+, isPyPy
+}:
+
+buildPythonPackage rec {
+  pname = "neovim";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16vzxmp7f6dl20n30j5cwwvrjj5h3c2ch8ldbss31anf36nirsdp";
+  };
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  # Tests require pkgs.neovim,
+  # which we cannot add because of circular dependency.
+  doCheck = false;
+
+  propagatedBuildInputs = [ msgpack ]
+    ++ lib.optional (!isPyPy) greenlet
+    ++ lib.optional (pythonOlder "3.4") trollius;
+
+  meta = {
+    description = "Python client for Neovim";
+    homepage = "https://github.com/neovim/python-client";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ garbas ];
+  };
+}

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -42,7 +42,7 @@ in pythonPackages.buildPythonApplication rec {
     pydenticon pymacaroons-pynacl pynacl pyopenssl pysaml2 pytz requests
     signedjson systemd twisted ujson unpaddedbase64 pyyaml
     matrix-angular-sdk bleach netaddr jinja2 psycopg2
-    psutil msgpack lxml matrix-synapse-ldap3
+    psutil msgpack-python lxml matrix-synapse-ldap3
     phonenumbers jsonschema affinity bcrypt
   ];
 

--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
     lz4 openssl python3Packages.setuptools_scm
   ] ++ stdenv.lib.optionals stdenv.isLinux [ acl ];
   propagatedBuildInputs = with python3Packages; [
-    cython msgpack
+    cython msgpack-python
   ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [ llfuse ];
 
   preConfigure = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10553,21 +10553,11 @@ in {
 
   msgpack = callPackage ../development/python-modules/msgpack {};
 
-  msgpack-python = buildPythonPackage rec {
-    name = "msgpack-python-${version}";
-    version = "0.4.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/m/msgpack-python/${name}.tar.gz";
-      sha256 = "0syd7bs83qs9qmxw540jbgsildbqk4yb57fmrlns1021llli402y";
-    };
-
-    checkPhase = ''
-      py.test
+  msgpack-python = self.msgpack.overridePythonAttrs {
+    pname = "msgpack-python";
+    postPatch = ''
+      substituteInPlace setup.py --replace "TRANSITIONAL = False" "TRANSITIONAL = True"
     '';
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ ];
   };
 
   msrplib = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3642,7 +3642,7 @@ in {
 
     buildInputs = with self; [ pytest docutils ];
     propagatedBuildInputs = with self; [
-      dask six boto3 s3fs tblib locket msgpack click cloudpickle tornado
+      dask six boto3 s3fs tblib locket msgpack-python click cloudpickle tornado
       psutil botocore zict lz4 sortedcollections sortedcontainers
     ] ++ (if !isPy3k then [ singledispatch ] else []);
 
@@ -10551,7 +10551,7 @@ in {
     };
   };
 
-  msgpack = buildPythonPackage rec {
+  msgpack-python = buildPythonPackage rec {
     name = "msgpack-python-${version}";
     version = "0.4.7";
 
@@ -20440,7 +20440,7 @@ EOF
     # which we cannot add because of circular dependency.
     doCheck = false;
 
-    propagatedBuildInputs = with self; [ msgpack ]
+    propagatedBuildInputs = with self; [ msgpack-python ]
       ++ optional (!isPyPy) greenlet
       ++ optional (pythonOlder "3.4") trollius;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20413,36 +20413,7 @@ EOF
 
   trollius = callPackage ../development/python-modules/trollius {};
 
-  neovim = buildPythonPackage rec {
-    version = "0.2.0";
-    name = "neovim-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/n/neovim/${name}.tar.gz";
-      sha256 = "1ywkgbrxd95cwlglihydmffcw2d2aji6562aqncymxs3ld5y02yn";
-    };
-
-    buildInputs = with self; [ nose ];
-
-    checkPhase = ''
-      nosetests
-    '';
-
-    # Tests require pkgs.neovim,
-    # which we cannot add because of circular dependency.
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ msgpack-python ]
-      ++ optional (!isPyPy) greenlet
-      ++ optional (pythonOlder "3.4") trollius;
-
-    meta = {
-      description = "Python client for Neovim";
-      homepage = "https://github.com/neovim/python-client";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ garbas ];
-    };
-  };
+  neovim = callPackage ../development/python-modules/neovim {};
 
   neovim_gui = buildPythonPackage rec {
     name = "neovim-pygui-${self.neovim.version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10551,6 +10551,8 @@ in {
     };
   };
 
+  msgpack = callPackage ../development/python-modules/msgpack {};
+
   msgpack-python = buildPythonPackage rec {
     name = "msgpack-python-${version}";
     version = "0.4.7";


### PR DESCRIPTION
###### Motivation for this change

provide pythonPackages.neovim at 0.2.1 so CheckHealth in nvim doesn't complain any more.
(And deoplete-clang2 works as expected with this.)

As pythonPackages.neovim at 0.2.1 needs msgpack >= 5.0.0, bump msgpack to 0.5.4

This changed the package name (in the python ecosystem) from msgpack-python to msgpack,
so provide msgpack-transitional which provides the python package msgpack under its
deprecated name msgpack-python and change referrers to depend on that instead.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [?] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
   * some, not all, as many failed on my because of async-timeout or libQt<something>
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

