### PR TITLE
home-assistant: remove dependencies which should be loaded via autoExtraComponents

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -63,8 +63,8 @@ in with py.pkgs; buildPythonApplication rec {
   propagatedBuildInputs = [
     # From setup.py
     requests pyyaml pytz pip jinja2 voluptuous typing aiohttp yarl async-timeout chardet astral certifi
-    # From the components that are part of the default configuration.yaml
-    sqlalchemy aiohttp-cors hass-frontend user-agents distro mutagen xmltodict netdisco
+    # From http, frontend and recorder components
+    sqlalchemy aiohttp-cors hass-frontend user-agents
   ] ++ componentBuildInputs ++ extraBuildInputs;
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change
I especially want to get rid of mutagen in order to avoid the dependency on libvorbis.

Regarding the recorder component: It is depended upon by the history component. But in `parse-requirements.py`, there is currently no way to detect such dependencies. I will have to come up with a better way to generate `component-packages.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

