### PR TITLE
pythonPackages.testtools: clean up dependencies

### DIFF
--- a/pkgs/development/python-modules/testtools/default.nix
+++ b/pkgs/development/python-modules/testtools/default.nix
@@ -4,33 +4,26 @@
 , pbr
 , python_mimeparse
 , extras
-, lxml
 , unittest2
 , traceback2
-, isPy3k
-, fixtures
-, pyrsistent
+, testscenarios
 }:
-
-
 
 buildPythonPackage rec {
   pname = "testtools";
   version = "2.3.0";
-
-  # Python 2 only judging from SyntaxError
-#   disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "5827ec6cf8233e0f29f51025addd713ca010061204fdea77484a2934690a0559";
   };
 
-  propagatedBuildInputs = [ pbr python_mimeparse extras lxml unittest2 pyrsistent ];
+  propagatedBuildInputs = [ pbr python_mimeparse extras unittest2 ];
   buildInputs = [ traceback2 ];
 
-  # No tests in archive
+  # testscenarios has a circular dependency on testtools
   doCheck = false;
+  checkInputs = [ testscenarios ];
 
   # testtools 2.0.0 and up has a circular run-time dependency on futures
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
No idea how lxml ended up in `propagatedBuildInputs`.
The `pyrsistent` dependency was removed upstream a while ago.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

