### PR TITLE
infamousPlugins: 0.2.03 -> 0.2.04

### DIFF
--- a/pkgs/applications/audio/infamousPlugins/default.nix
+++ b/pkgs/applications/audio/infamousPlugins/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "infamousPlugins-v${version}";
-  version = "0.2.03";
+  version = "0.2.04";
 
   src = fetchFromGitHub {
     owner = "ssj71";
     repo = "infamousPlugins";
     rev = "v${version}";
-    sha256 = "1pb7vmc703j25rnyx81cqlfzi66v7gm4a49s06dbgy8a66s1i2zl";
+    sha256 = "0hmqk80w4qxq09iag7b7srf2g0wigkyhzq0ywxvhz2iz0hq9k0dh";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

