### PR TITLE
ghostwriter: init at 1.5.0

### DIFF
--- a/pkgs/applications/editors/ghostwriter/default.nix
+++ b/pkgs/applications/editors/ghostwriter/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, qmake, pkgconfig, qtwebkit, hunspell }:
+
+stdenv.mkDerivation rec {
+  pname = "ghostwriter";
+  version = "1.5.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "wereturtle";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ixw2w2526836lwj4pc0vp7prp1gls7iq37v8m9ql1508b33b9pq";
+  };
+
+  nativeBuildInputs = [ qmake pkgconfig ];
+
+  buildInputs = [ qtwebkit hunspell ];
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform, aesthetic, distraction-free Markdown editor";
+    homepage = src.meta.homepage;
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15142,6 +15142,8 @@ with pkgs;
   geany = callPackage ../applications/editors/geany { };
   geany-with-vte = callPackage ../applications/editors/geany/with-vte.nix { };
 
+  ghostwriter = libsForQt5.callPackage ../applications/editors/ghostwriter { };
+
   gksu = callPackage ../applications/misc/gksu { };
 
   gnss-sdr = callPackage ../applications/misc/gnss-sdr { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

