### PR TITLE
qmediathekview: set platforms to unix

### DIFF
--- a/pkgs/applications/video/qmediathekview/default.nix
+++ b/pkgs/applications/video/qmediathekview/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "An alternative Qt-based front-end for the database maintained by the MediathekView project";
     inherit (src.meta) homepage;
     license = licenses.gpl3Plus;
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = platforms.linux;
     maintainers = with maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I hope the recent update of the aarch64 builder solved the issues I had in https://github.com/NixOS/nixpkgs/pull/34566.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

