### PR TITLE
home-assistant: 0.62.1 -> 0.63

### DIFF
--- a/pkgs/development/python-modules/astral/default.nix
+++ b/pkgs/development/python-modules/astral/default.nix
@@ -2,12 +2,11 @@
 
 buildPythonPackage rec {
   pname = "astral";
-  version = "1.4";
+  version = "1.5";
 
   src = fetchPypi {
     inherit pname version;
-    extension = "zip";
-    sha256 = "1zm1ypc6w279gh7lbgsfbzfxk2x4gihlq3rfh59hj70hmhjwiwp7";
+    sha256 = "527628fbfe90c1596c3950ff84ebd07ecc10c8fb1044c903a0519b5057700cb6";
   };
 
   propagatedBuildInputs = [ pytz ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.62.1";
+  version = "0.63";
   components = {
     "nuimo_controller" = ps: with ps; [  ];
     "bbb_gpio" = ps: with ps; [  ];
@@ -23,7 +23,7 @@
     "sensor.dnsip" = ps: with ps; [ aiodns ];
     "emulated_hue" = ps: with ps; [ aiohttp-cors ];
     "http" = ps: with ps; [ aiohttp-cors ];
-    "sensor.imap" = ps: with ps; [  ];
+    "sensor.imap" = ps: with ps; [ aioimaplib ];
     "light.lifx" = ps: with ps; [  ];
     "scene.hunterdouglas_powerview" = ps: with ps; [  ];
     "alarmdecoder" = ps: with ps; [  ];
@@ -160,10 +160,11 @@
     "media_player.liveboxplaytv" = ps: with ps; [  ];
     "lametric" = ps: with ps; [  ];
     "notify.lametric" = ps: with ps; [  ];
-    "sensor.luftdaten" = ps: with ps; [  ];
+    "sensor.luftdaten" = ps: with ps; [ luftdaten ];
     "sensor.lyft" = ps: with ps; [  ];
     "notify.matrix" = ps: with ps; [ matrix-client ];
     "maxcube" = ps: with ps; [  ];
+    "mercedesme" = ps: with ps; [  ];
     "notify.message_bird" = ps: with ps; [  ];
     "sensor.mfi" = ps: with ps; [  ];
     "switch.mfi" = ps: with ps; [  ];
@@ -216,6 +217,7 @@
     "light.rpi_gpio_pwm" = ps: with ps; [  ];
     "canary" = ps: with ps; [  ];
     "sensor.cpuspeed" = ps: with ps; [  ];
+    "melissa" = ps: with ps; [  ];
     "camera.synology" = ps: with ps; [  ];
     "hdmi_cec" = ps: with ps; [  ];
     "light.tplink" = ps: with ps; [  ];
@@ -271,6 +273,7 @@
     "lutron_caseta" = ps: with ps; [  ];
     "lutron" = ps: with ps; [  ];
     "notify.mailgun" = ps: with ps; [  ];
+    "media_player.mediaroom" = ps: with ps; [  ];
     "mochad" = ps: with ps; [  ];
     "modbus" = ps: with ps; [  ];
     "media_player.monoprice" = ps: with ps; [  ];
@@ -288,12 +291,14 @@
     "sensor.otp" = ps: with ps; [  ];
     "sensor.openweathermap" = ps: with ps; [  ];
     "weather.openweathermap" = ps: with ps; [  ];
+    "sensor.pollen" = ps: with ps; [  ];
     "qwikswitch" = ps: with ps; [  ];
     "rainbird" = ps: with ps; [  ];
     "climate.sensibo" = ps: with ps; [  ];
     "sensor.serial" = ps: with ps; [  ];
     "switch.acer_projector" = ps: with ps; [ pyserial ];
     "lock.sesame" = ps: with ps; [  ];
+    "goalfeed" = ps: with ps; [  ];
     "sensor.sma" = ps: with ps; [  ];
     "device_tracker.snmp" = ps: with ps; [ pysnmp ];
     "sensor.snmp" = ps: with ps; [ pysnmp ];
@@ -316,9 +321,10 @@
     "lirc" = ps: with ps; [  ];
     "fan.xiaomi_miio" = ps: with ps; [  ];
     "light.xiaomi_miio" = ps: with ps; [  ];
+    "remote.xiaomi_miio" = ps: with ps; [  ];
     "switch.xiaomi_miio" = ps: with ps; [  ];
     "vacuum.xiaomi_miio" = ps: with ps; [  ];
-    "media_player.mpd" = ps: with ps; [  ];
+    "media_player.mpd" = ps: with ps; [ mpd2 ];
     "light.mystrom" = ps: with ps; [  ];
     "switch.mystrom" = ps: with ps; [  ];
     "nest" = ps: with ps; [  ];
@@ -329,7 +335,7 @@
     "sensor.sochain" = ps: with ps; [  ];
     "sensor.synologydsm" = ps: with ps; [  ];
     "tado" = ps: with ps; [  ];
-    "telegram_bot" = ps: with ps; [  ];
+    "telegram_bot" = ps: with ps; [ python-telegram-bot ];
     "sensor.twitch" = ps: with ps; [  ];
     "velbus" = ps: with ps; [  ];
     "media_player.vlc" = ps: with ps; [  ];
@@ -380,6 +386,7 @@
     "media_player.snapcast" = ps: with ps; [  ];
     "sensor.speedtest" = ps: with ps; [  ];
     "recorder" = ps: with ps; [ sqlalchemy ];
+    "sensor.sql" = ps: with ps; [ sqlalchemy ];
     "statsd" = ps: with ps; [ statsd ];
     "sensor.steam_online" = ps: with ps; [  ];
     "tahoma" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3
+{ lib, fetchFromGitHub, python3
 , extraComponents ? []
 , extraPackages ? ps: []
 , skipPip ? true }:
@@ -8,17 +8,17 @@ let
   py = python3.override {
     packageOverrides = self: super: {
       yarl = super.yarl.overridePythonAttrs (oldAttrs: rec {
-        version = "0.18.0";
+        version = "1.1.0";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "11j8symkxh0ngvpddqpj85qmk6p70p20jca3alxc181gk3vx785s";
+          sha256 = "162630v7f98l27h11msk9416lqwm2mpgxh4s636594nlbfs9by3a";
         };
       });
       aiohttp = super.aiohttp.overridePythonAttrs (oldAttrs: rec {
-        version = "2.3.7";
+        version = "2.3.10";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "0fzfpx5ny7559xrxaawnylq20dvrkjiag0ypcd13frwwivrlsagy";
+          sha256 = "8adda6583ba438a4c70693374e10b60168663ffa6564c5c75d3c7a9055290964";
         };
       });
       pytest = super.pytest.overridePythonAttrs (oldAttrs: rec {
@@ -44,7 +44,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.62.1";
+  hassVersion = "0.63";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -57,7 +57,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "0151prwk2ci6bih0mdmc3r328nrvazn9jwk0w26wmd4cpvnb5h26";
+    sha256 = "0gfdhjydl619jpnflnig5hzglib9385hdk5vw5pris0ksqk27mfk";
   };
 
   propagatedBuildInputs = [
@@ -80,9 +80,9 @@ in with py.pkgs; buildPythonApplication rec {
       tests/components/test_{api,configurator,demo,discovery,frontend,init,introduction,logger,script,shell_command,system_log,websocket_api}.py
   '';
 
-  makeWrapperArgs = [] ++ stdenv.lib.optional skipPip [ "--add-flags --skip-pip" ];
+  makeWrapperArgs = lib.optional skipPip "--add-flags --skip-pip";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://home-assistant.io/;
     description = "Open-source home automation platform running on Python 3";
     license = licenses.asl20;

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -2,10 +2,10 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20180130.0";
+  version = "20180209.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0b9klisl7hh30rml8qlrp9gpz33z9b825pd1vxbck48k0s98z1zi";
+    sha256 = "b85f0e833871408a95619ae38d5344701a6466e8f7b5530e718ccc260b68d3ed";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://home-assistant.io/blog/2018/02/10/release-63/

The pinned versions of aiohttp and yarl are also the ones currently available in pythonPackages. However, I expect them to change sooner or later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @FRidh