### PR TITLE
pythonPackages.pynacl: 0.3.0 -> 1.2.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -702,6 +702,7 @@
   utdemir = "Utku Demir <me@utdemir.com>";
   #urkud = "Yury G. Kudryashov <urkud+nix@ya.ru>"; inactive since 2012
   uwap = "uwap <me@uwap.name>";
+  va1entin = "Valentin Heidelberger <github@valentinsblog.com>";
   vaibhavsagar = "Vaibhav Sagar <vaibhavsagar@gmail.com>";
   valeriangalliat = "Valérian Galliat <val@codejam.info>";
   vandenoever = "Jos van den Oever <jos@vandenoever.info>";

--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pytest, coverage, libsodium, cffi, six, hypothesis}:
+
+buildPythonPackage rec {
+  pname = "pynacl";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "pyca";
+    repo = pname;
+    rev = version;
+    sha256 = "0z9i1z4hjzmp23igyhvg131gikbrr947506lwfb3fayf0agwfv8f";
+  };
+
+  #remove deadline from tests, see https://github.com/pyca/pynacl/issues/370
+  prePatch = ''
+    sed -i 's/deadline=1500, //' tests/test_pwhash.py
+    sed -i 's/deadline=1500, //' tests/test_aead.py
+  '';
+
+  checkInputs = [ pytest coverage hypothesis ];
+  propagatedBuildInputs = [ libsodium cffi six ];
+
+  checkPhase = ''
+    coverage run --source nacl --branch -m pytest
+  '';
+  
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ va1entin ];
+    description = "Python binding to the Networking and Cryptography (NaCl) library";
+    homepage = https://github.com/pyca/pynacl/;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20342,23 +20342,7 @@ EOF
     propagatedBuildInputs = with self; [ pynacl six ];
   };
 
-  pynacl = buildPythonPackage rec {
-    name = "pynacl-${version}";
-    version = "0.3.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/P/PyNaCl/PyNaCl-0.3.0.tar.gz";
-      sha256 = "1hknxlp3a3f8njn19w92p8nhzl9jkfwzhv5fmxhmyq2m8hqrfj8j";
-    };
-
-    buildInputs = with self; [ pytest coverage ];
-    propagatedBuildInputs = with self; [pkgs.libsodium six cffi pycparser];
-
-    checkPhase = ''
-      coverage run --source nacl --branch -m pytest
-    '';
-
-  };
+  pynacl = callPackage ../development/python-modules/pynacl { };
 
   service-identity = callPackage ../development/python-modules/service_identity { };
 


### PR DESCRIPTION
###### Motivation for this change
python-packages.nix contains version 0.3.0 of pynacl, which is very old.

###### Things done
Created a nix expression for pynacl at version 1.2.1 in it's own file, removed old 0.3.0 version of pynacl from python-packages.nix
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

