### PR TITLE
rtl8812au: 4.3.20 -> 5.2.20_25672.20171213

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -1,39 +1,20 @@
-{ stdenv, fetchFromGitHub, fetchpatch, kernel }:
+{ stdenv, fetchFromGitHub, fetchpatch, kernel, bc }:
 
 stdenv.mkDerivation rec {
   name = "rtl8812au-${kernel.version}-${version}";
-  version = "4.3.20";
+  version = "5.2.20_25672.20171213";
 
   src = fetchFromGitHub {
-    owner = "Grawp";
-    repo = "rtl8812au_rtl8821au";
-    rev = "d716b38abf5ca7da72d2be0adfcebe98cceeda8f";
-    sha256 = "01z5p2vps3an69bbzca7ig14llc5rd6067pgs47kkhfjbsbws4ry";
+    owner = "zebulon2";
+    repo = "rtl8812au-driver-5.2.20";
+    rev = "aca1e0677bfe56c6c4914358df007c97486e7095";
+    sha256 = "19av8fkh3mvs2f57iibrg0cfyhjnnx4cbnfzv5aj7v5gb0j3dp0p";
   };
 
-  patches = [
-    (fetchpatch { # From PR # 42
-      name = "rtl8812au-4.11.x-fix.patch";
-      url = https://github.com/Grawp/rtl8812au_rtl8821au/commit/3224e74ad9c230b74a658e80dad66ab95c9e2ef5.patch;
-      sha256 = "12g4yvivg4d0qm5cgxs7k54p3y7h1dc2jw6rp1xbppwf3j1z6xks";
-    })
-    (fetchpatch { # From PR #46
-      name = "rtl8812au-4.11.9-fix.patch";
-      url = https://github.com/Grawp/rtl8812au_rtl8821au/commit/58fc45a4511b8b9d6b52813168e3eee657517b1f.patch;
-      sha256 = "18bag2mif5112lap2xvx2bb0wxrd13f9y9cwqv1qzp5nyqiniziz";
-    })
-    (fetchpatch { # From PR #43
-      name = "rtl8812au-4.12-fix.patch";
-      url = https://github.com/Grawp/rtl8812au_rtl8821au/commit/a5475c9f1f54099ca35c8680f2dedee11fa9edec.patch;
-      sha256 = "01xa51whq1xa0sh3y2bhm65f0cryzmv46v530axqjrpnd924432d";
-    })
-  ];
-
+  nativeBuildInputs = [ bc ];
   buildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
-
-  NIX_CFLAGS_COMPILE="-Wno-error=incompatible-pointer-types";
+  hardeningDisable = [ "pic" "format" ];
 
   prePatch = ''
     substituteInPlace ./Makefile --replace /lib/modules/ "${kernel.dev}/lib/modules/"
@@ -46,10 +27,11 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Driver for Realtek 802.11ac, rtl8812au, provides the 8812au mod";
-    homepage = https://github.com/Grawp/rtl8812au_rtl8821au;
-    license = stdenv.lib.licenses.gpl2;
+    homepage = https://github.com/zebulon2/rtl8812au-driver-5.2.20;
+    license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ danielfullmer ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update rtl8812au to latest version.

I noticed the previous version did not build with 4.15 kernels. The [Grawp/rtl8812au_rtl8821au](https://github.com/Grawp/rtl8812au_rtl8821au) repo is no longer being maintained, so I've switched to the repo found from AUR: https://aur.archlinux.org/packages/rtl8812au-dkms-git/

Realtek's changelog: (which is where I got the more precise version string)
https://github.com/zebulon2/rtl8812au-driver-5.2.20/blob/master/Realtek_Changelog.txt
Note also that this latest version includes a fix for KRACK attacks.

I've tested this with my own TP-LINK AC1200 USB wifi adapter on 4.15 and it seems to be working fine. `nox-review` also ensures this builds against all the other kernel versions currently in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

