### PR TITLE
ocamlPackages.lwt_ssl: init at 1.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/lwt_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_ssl/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip, ocaml, findlib, jbuilder, ssl, lwt }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.2";
+  name = "ocaml${ocaml.version}-lwt_ssl-${version}";
+
+  src = fetchzip {
+    url = "https://github.com/aantron/lwt_ssl/archive/${version}.tar.gz";
+    sha256 = "1q0an3djqjxv83v3iswi7m81braqx93kcrcwrxwmf6jzhdm4pn15";
+  };
+
+  buildInputs = [ ocaml findlib jbuilder ];
+  propagatedBuildInputs = [ ssl lwt ];
+
+  inherit (jbuilder) installPhase;
+
+  meta = {
+    homepage = "https://github.com/aantron/lwt_ssl";
+    description = "OpenSSL binding with concurrent I/O";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -375,6 +375,10 @@ let
       lwt = lwt3;
     };
 
+    lwt_ssl = callPackage ../development/ocaml-modules/lwt_ssl {
+      lwt = lwt3;
+    };
+
     macaque = callPackage ../development/ocaml-modules/macaque { };
 
     magic-mime = callPackage ../development/ocaml-modules/magic-mime { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

