### PR TITLE
pythonPackages.i3ipc: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/i3ipc/default.nix
+++ b/pkgs/development/python-modules/i3ipc/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, enum-compat
+, xorgserver, pytest, i3, python
+}:
+
+buildPythonPackage rec {
+  pname = "i3ipc";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner  = "acrisci";
+    repo   = "i3ipc-python";
+    rev    = "v${version}";
+    sha256 = "15drq16ncmjrgsri6gjzp0qm8abycm92nicm78q3k7vy7rqpvfnh";
+  };
+
+  propagatedBuildInputs = [ enum-compat ];
+
+  checkInputs = [ xorgserver pytest i3 ];
+
+  checkPhase = ''${python.interpreter} run-tests.py'';
+
+  meta = with stdenv.lib; {
+    description = "An improved Python library to control i3wm";
+    homepage    = https://github.com/acrisci/i3ipc-python;
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ vanzef ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -243,6 +243,8 @@ in {
 
   habanero = callPackage ../development/python-modules/habanero { };
 
+  i3ipc = callPackage ../development/python-modules/i3ipc { };
+
   intelhex = callPackage ../development/python-modules/intelhex { };
 
   lmtpd = callPackage ../development/python-modules/lmtpd { };


### PR DESCRIPTION
closes #34828

###### Motivation for this change
[Request](https://github.com/NixOS/nixpkgs/issues/34828) from @cypher1.


###### Things done

Added package `pythonPackages.i3ipc`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

