### PR TITLE
uutils-coreutils: init at 2018-02-09

### DIFF
--- a/pkgs/tools/misc/uutils-coreutils/default.nix
+++ b/pkgs/tools/misc/uutils-coreutils/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, rustPlatform, cargo, cmake, sphinx, lib, prefix ? "uutils-" }:
+
+rustPlatform.buildRustPackage {
+  name = "uutils-coreutils-2018-02-09";
+  src = fetchFromGitHub {
+    owner = "uutils";
+    repo = "coreutils";
+    rev = "f333ab26b03294a32a10c1c203a03c6b5cf8a89a";
+    sha256 = "0nkggs5nqvc1mxzzgcsqm1ahchh4ll11xh0xqmcljrr5yg1rhhzf";
+  };
+
+  # too many impure/platform-dependent tests
+  doCheck = false;
+
+  cargoSha256 = "0qv2wz1bxhm5xhzbic7cqmn8jj8fyap0s18ylia4fbwpmv89nkc5";
+
+  makeFlags =
+    [ "CARGO=${cargo}/bin/cargo" "PREFIX=$(out)" "PROFILE=release" "INSTALLDIR_MAN=$(out)/share/man/man1" ]
+    ++ lib.optional (prefix != null) [ "PROG_PREFIX=${prefix}" ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ cargo sphinx ];
+
+  # empty {build,install}Phase to use defaults of `stdenv.mkDerivation` rather than rust defaults
+  buildPhase = "";
+  installPhase = "";
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform Rust rewrite of the GNU coreutils";
+    longDescription = ''
+      uutils is an attempt at writing universal (as in cross-platform)
+      CLI utils in Rust. This repo is to aggregate the GNU coreutils rewrites.
+    '';
+    homepage = https://github.com/uutils/coreutils;
+    maintainers = with maintainers; [ ma27 ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2035,6 +2035,10 @@ with pkgs;
 
   uudeview = callPackage ../tools/misc/uudeview { };
 
+  uutils-coreutils = callPackage ../tools/misc/uutils-coreutils {
+    inherit (pythonPackages) sphinx;
+  };
+
   zabbix-cli = callPackage ../tools/misc/zabbix-cli { };
 
   ### DEVELOPMENT / EMSCRIPTEN


### PR DESCRIPTION
###### Motivation for this change
    
`uutils-coreutils` is an a cross-platform rewrite of GNU/coreutils based
on Rust. It aims to increase portability and improve Windows support
(see https://github.com/uutils/coreutils#why).
    
Since the derivation provides the same binaries as `coreutils` does a
`prefix` argument as been added to the function to avoid any conflicts
that can be used like this:
   
``` nix
self: super:
{
  uutils-coreutils = self.uutils-coreutils.override { prefix = "uutils"; };
}
```
   
Resolves #28114 /cc @NeQuissimus
    
-----
Important notice: the patch depends on #34505 which needs to be merged
*FIRST* as it fixes a bug in the `rustc` setup of nixpkgs (see the PR's
discussion and https://github.com/rust-lang/cargo/commit/5c9665f41c6b4d3b99d3b9f8b48a286f5f154692#commitcomment-27271420 for further reference).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

