### PR TITLE
lib.maintainers: maintainer is now a set

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -1,12 +1,28 @@
-{ ...}:
-/* List of NixOS maintainers. The format is:
+{ lib }:
+
+with lib;
+
+/* List of NixOS maintainers. Two formats are possible. The first is:
 
     handle = "Real Name <address@example.org>";
 
-  where <handle> is preferred to be your GitHub username (so it's easy
+  where <handle> is assumed to be your GitHub username (so it's easy
   to ping a package @<handle>), and <Real Name> is your real name, not
-  a pseudonym. Please keep the list alphabetically sorted. */
-{
+  a pseudonym.
+
+  The second format is:
+
+    handle = {
+      name = "Real name";
+      email = "address@example.org";
+      github = "handle";
+    };
+
+  Please keep the list alphabetically sorted. */
+
+let
+  maintainers = {
+
   a1russell = "Adam Russell <adamlr6+pub@gmail.com>";
   aaronschif = "Aaron Schif <aaronschif@gmail.com>";
   abaldeau = "Andreas Baldeau <andreas@baldeau.net>";
@@ -782,4 +798,22 @@
   zraexy = "David Mell <zraexy@gmail.com>";
   zx2c4 = "Jason A. Donenfeld <Jason@zx2c4.com>";
   zzamboni = "Diego Zamboni <diego@zzamboni.org>";
-}
+};
+
+  createMaintainer = key: value:
+    let
+      struct = {
+        name = null;
+        email = null;
+        github = null;
+      };
+    in if isAttrs value then
+      (struct // value)
+    else
+      let
+        values = [ key ] ++ (splitString " <" (removeSuffix ">" value));
+        keys = [ "github" "name" "email" ];
+        attrs = listToAttrs (zipListsWith nameValuePair keys values);
+      in (struct // attrs);
+
+in mapAttrs createMaintainer maintainers

--- a/pkgs/development/libraries/java/dbus-java/default.nix
+++ b/pkgs/development/libraries/java/dbus-java/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation {
     sed -i -e "s|all: bin doc man|all: bin|" \
            -e "s|install: install-bin install-man install-doc|install: install-bin|" Makefile
   '';
-  maintainers = [ stdenv.lib.maintainers.sander ];
 
   meta = {
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.sander ];
   };
 }

--- a/pkgs/development/libraries/java/libmatthew-java/default.nix
+++ b/pkgs/development/libraries/java/libmatthew-java/default.nix
@@ -9,9 +9,9 @@ stdenv.mkDerivation {
   JAVA_HOME=jdk;
   PREFIX=''''${out}'';
   buildInputs = [ jdk ];
-  maintainers = [ stdenv.lib.maintainers.sander ];
 
   meta = {
     platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ sander ];
   };
 }


### PR DESCRIPTION
This commit allows values in lib.maintainers to be not only a string,
but also a set. This gives the possibility to obtain the GitHub handle
of maintainers by evaluation, and the possibility to add additional
means for contacting maintainers.

This is based on the suggestion made in
https://github.com/NixOS/nixpkgs/issues/18352#issuecomment-244905440.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

