### PR TITLE
bfs: init at 1.2.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -79,6 +79,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = ''Beerware License'';
   };
 
+  bsd0 = spdx {
+    spdxId = "0BSD";
+    fullName = "BSD Zero Clause License";
+  };
+
   bsd2 = spdx {
     spdxId = "BSD-2-Clause";
     fullName = ''BSD 2-clause "Simplified" License'';

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -757,6 +757,7 @@
   y0no = "Yoann Ono <y0no@y0no.fr>";
   yarr = "Dmitry V. <savraz@gmail.com>";
   yegortimoshenko = "Yegor Timoshenko <yegortimoshenko@gmail.com>";
+  yesbox = "Jesper Geertsen Jonsson <jesper.geertsen.jonsson@gmail.com>";
   ylwghst = "Burim Augustin Berisa <ylwghst@onionmail.info>";
   yochai = "Yochai <yochai@titat.info>";
   yorickvp = "Yorick van Pelt <yorickvanpelt@gmail.com>";

--- a/pkgs/tools/system/bfs/default.nix
+++ b/pkgs/tools/system/bfs/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, bash }:
+
+stdenv.mkDerivation rec {
+  name = "bfs-${version}";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    repo = "bfs";
+    owner = "tavianator";
+    rev = version;
+    sha256 = "1dgc31l5d20i0v78c51xga4lr78b5x8dz6yzsvbhlgs0abi0nynx";
+  };
+
+  # Disable fstype test, tries to read /etc/mtab
+  patches = [ ./tests.patch ];
+  postPatch = ''
+    # Patch tests (both shebangs and usage in scripts)
+    for f in $(find -type f -name '*.sh'); do
+      substituteInPlace $f --replace "/bin/bash" "${bash}/bin/bash"
+    done
+  '';
+  doCheck = true;
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  buildFlags = [ "release" ]; # "release" enables compiler optimizations
+
+  meta = with stdenv.lib; {
+    description = "A breadth-first version of the UNIX find command";
+    longDescription = ''
+      bfs is a variant of the UNIX find command that operates breadth-first rather than
+      depth-first. It is otherwise intended to be compatible with many versions of find.
+    '';
+    homepage = https://github.com/tavianator/bfs;
+    license = licenses.bsd0;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ yesbox ];
+  };
+}

--- a/pkgs/tools/system/bfs/tests.patch
+++ b/pkgs/tools/system/bfs/tests.patch
@@ -1,0 +1,10 @@
+--- a/tests.sh
++++ b/tests.sh
+@@ -369,7 +369,6 @@
+     test_printf_nul
+     test_quit_after_print
+     test_quit_before_print
+-    test_fstype
+     test_not
+     test_and
+     test_or

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1390,6 +1390,8 @@ with pkgs;
 
   bfg-repo-cleaner = gitAndTools.bfg-repo-cleaner;
 
+  bfs = callPackage ../tools/system/bfs { };
+
   bgs = callPackage ../tools/X11/bgs { };
 
   biber = callPackage ../tools/typesetting/biber {


### PR DESCRIPTION
Adds the bfs package; a breadth-first version of the UNIX find command.
https://github.com/tavianator/bfs

This patch also introduces the "BSD Zero Clause License".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

