### PR TITLE
pythonPackages.pynacl: fix tests

### DIFF
--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   };
 
   #remove deadline from tests, see https://github.com/pyca/pynacl/issues/370
-  prePatch = ''
+  preCheck = ''
     sed -i 's/deadline=1500, //' tests/test_pwhash.py
     sed -i 's/deadline=1500, //' tests/test_aead.py
   '';


### PR DESCRIPTION
###### Motivation for this change
It was requested to change a required modification of pynacl tests from preCheck to prePatch in  https://github.com/NixOS/nixpkgs/pull/34826#pullrequestreview-95637800
This breaks the build, because the files that shall be changed don't exist in that stage

###### Things done
Changed modifications to pynacl tests from prePatch to preCheck
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

