### PR TITLE
pythonPackages.aioconsole: init at 0.1.7

### DIFF
--- a/pkgs/development/python-modules/aioconsole/default.nix
+++ b/pkgs/development/python-modules/aioconsole/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+# This package provides a binary "apython" which sometimes invokes
+# [sys.executable, '-m', 'aioconsole'] as a subprocess. If apython is
+# run directly out of this derivation, it won't work, because
+# sys.executable will point to a Python binary that is not wrapped to
+# be able to find aioconsole.
+# However, apython will work fine when using python##.withPackages,
+# because with python##.withPackages the sys.executable is already
+# wrapped to be able to find aioconsole and any other packages.
+buildPythonPackage rec {
+  pname = "aioconsole";
+  version = "0.1.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17bnfcp0gacnmpdam6byb7rwhqibw57f736bbgk45w4cy2lglj3y";
+  };
+
+  # hardcodes a test dependency on an old version of pytest-asyncio
+  doCheck = false;
+
+  meta = {
+    description = "Asynchronous console and interfaces for asyncio";
+    homepage = https://github.com/vxgmichel/aioconsole;
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.catern ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -418,6 +418,8 @@ in {
 
   adal = callPackage ../development/python-modules/adal { };
 
+  aioconsole = callPackage ../development/python-modules/aioconsole { };
+
   aiodns = callPackage ../development/python-modules/aiodns { };
 
   aiofiles = callPackage ../development/python-modules/aiofiles { };


### PR DESCRIPTION
###### Motivation for this change

Adding aioconsole. Note the comment in the expression about the caveat for the "apython" binary this derivation provides.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

