### PR TITLE
aspellWithDicts: don't --set ASPELL_CONFIG but use --add-flags

### DIFF
--- a/pkgs/development/libraries/aspell/aspell-with-dicts.nix
+++ b/pkgs/development/libraries/aspell/aspell-with-dicts.nix
@@ -28,7 +28,7 @@ in buildEnv {
     pushd "${aspell}/bin"
     for prg in *; do
       if [ -f "$prg" ]; then
-        makeWrapper "${aspell}/bin/$prg" "$out/bin/$prg" --set ASPELL_CONF "dict-dir $out/lib/aspell"
+        makeWrapper "${aspell}/bin/$prg" "$out/bin/$prg" --add-flags "--dict-dir=$out/lib/aspell"
       fi
     done
     popd


### PR DESCRIPTION
Setting `ASPELL_CONF` blocks the user from using a aspell.conf file.
Flags on the other hand can still be overridden.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

