### PR TITLE
pythonPackages.pynacl: ignore timeout in tests

### DIFF
--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -11,11 +11,8 @@ buildPythonPackage rec {
     sha256 = "0z9i1z4hjzmp23igyhvg131gikbrr947506lwfb3fayf0agwfv8f";
   };
 
-  #remove deadline from tests, see https://github.com/pyca/pynacl/issues/370
-  preCheck = ''
-    sed -i 's/deadline=1500, //' tests/test_pwhash.py
-    sed -i 's/deadline=1500, //' tests/test_aead.py
-  '';
+  #set timeout to unlimited, remove deadline from tests, see https://github.com/pyca/pynacl/issues/370
+  patches = [ ./pynacl-no-timeout-and-deadline.patch ];
 
   checkInputs = [ pytest coverage hypothesis ];
   propagatedBuildInputs = [ libsodium cffi six ];

--- a/pkgs/development/python-modules/pynacl/pynacl-no-timeout-and-deadline.patch
+++ b/pkgs/development/python-modules/pynacl/pynacl-no-timeout-and-deadline.patch
@@ -1,0 +1,49 @@
+diff --git a/tests/test_pwhash.py b/tests/test_pwhash.py
+index 9634c85..7f20316 100644
+--- a/tests/test_pwhash.py
++++ b/tests/test_pwhash.py
+@@ -20,7 +20,7 @@ import os
+ import sys
+ import unicodedata as ud
+ 
+-from hypothesis import given, settings
++from hypothesis import given, settings, unlimited
+ from hypothesis.strategies import integers, text
+ 
+ import pytest
+@@ -411,7 +411,7 @@ def test_str_verify_argon2_ref_fail(password_hash, password):
+        integers(min_value=1024 * 1024,
+                 max_value=16 * 1024 * 1024)
+        )
+-@settings(deadline=1500, max_examples=20)
++@settings(timeout=unlimited, deadline=None, max_examples=20)
+ def test_argon2i_str_and_verify(password, ops, mem):
+     _psw = password.encode('utf-8')
+     pw_hash = nacl.pwhash.argon2i.str(_psw, opslimit=ops, memlimit=mem)
+@@ -425,7 +425,7 @@ def test_argon2i_str_and_verify(password, ops, mem):
+        integers(min_value=1024 * 1024,
+                 max_value=16 * 1024 * 1024)
+        )
+-@settings(deadline=1500, max_examples=20)
++@settings(timeout=unlimited, deadline=None, max_examples=20)
+ def test_argon2id_str_and_verify(password, ops, mem):
+     _psw = password.encode('utf-8')
+     pw_hash = nacl.pwhash.argon2id.str(_psw, opslimit=ops, memlimit=mem)
+@@ -439,7 +439,7 @@ def test_argon2id_str_and_verify(password, ops, mem):
+        integers(min_value=1024 * 1024,
+                 max_value=16 * 1024 * 1024)
+        )
+-@settings(deadline=1500, max_examples=20)
++@settings(timeout=unlimited, deadline=None, max_examples=20)
+ def test_argon2i_str_and_verify_fail(password, ops, mem):
+     _psw = password.encode('utf-8')
+     pw_hash = nacl.pwhash.argon2i.str(_psw, opslimit=ops, memlimit=mem)
+@@ -448,7 +448,7 @@ def test_argon2i_str_and_verify_fail(password, ops, mem):
+ 
+ 
+ @given(text(alphabet=PASSWD_CHARS, min_size=5, max_size=20))
+-@settings(deadline=1500, max_examples=5)
++@settings(timeout=unlimited, deadline=None, max_examples=5)
+ def test_pwhash_str_and_verify(password):
+     _psw = password.encode('utf-8')
+ 


### PR DESCRIPTION
###### Motivation for this change
In addition to a deadline there is also a timeout in pynacl tests, which might result in failing builds on slow machines. The new prePatch phase turns both off.

###### Things done
Set timeout to unlimited and deadline to None in hypothesis tests for pynacl
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

