### PR TITLE
lib/systems: musl "ABI"s, examples

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -26,8 +26,7 @@ rec {
       libc =
         /**/ if final.isDarwin then "libSystem"
         else if final.isMinGW  then "msvcrt"
-        else if final.isLinux && final.isGlibc then "glibc"
-        else if final.isLinux && final.isMusl  then "musl"
+        else if final.isMusl  then "musl"
         else if final.isLinux /* default */    then "glibc"
         # TODO(@Ericson2314) think more about other operating systems
         else                        "native/impure";

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -26,7 +26,9 @@ rec {
       libc =
         /**/ if final.isDarwin then "libSystem"
         else if final.isMinGW  then "msvcrt"
-        else if final.isLinux  then "glibc"
+        else if final.isLinux && final.isGlibc then "glibc"
+        else if final.isLinux && final.isMusl  then "musl"
+        else if final.isLinux /* default */    then "glibc"
         # TODO(@Ericson2314) think more about other operating systems
         else                        "native/impure";
       extensions = {

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -13,7 +13,6 @@ rec {
     config = "armv5tel-unknown-linux-gnueabi";
     arch = "armv5tel";
     float = "soft";
-    libc = "glibc";
     platform = platforms.sheevaplug;
   };
 
@@ -22,7 +21,6 @@ rec {
     arch = "armv6l";
     float = "hard";
     fpu = "vfp";
-    libc = "glibc";
     platform = platforms.raspberrypi;
   };
 
@@ -31,14 +29,12 @@ rec {
     arch = "armv7-a";
     float = "hard";
     fpu = "vfpv3-d16";
-    libc = "glibc";
     platform = platforms.armv7l-hf-multiplatform;
   };
 
   aarch64-multiplatform = rec {
     config = "aarch64-unknown-linux-gnu";
     arch = "aarch64";
-    libc = "glibc";
     platform = platforms.aarch64-multiplatform;
   };
 
@@ -51,7 +47,6 @@ rec {
     arch = "armv5tel";
     config = "armv5tel-unknown-linux-gnueabi";
     float = "soft";
-    libc = "glibc";
     platform = platforms.pogoplug4;
   };
 
@@ -59,9 +54,19 @@ rec {
     config = "mips64el-unknown-linux-gnu";
     arch = "mips";
     float = "hard";
-    libc = "glibc";
     platform = platforms.fuloong2f_n32;
   };
+
+  muslpi = raspberryPi // {
+    config = "armv6l-unknown-linux-musleabihf";
+  };
+
+  aarch64-multiplatform-musl = aarch64-multiplatform // {
+    config = "aarch64-unknown-linux-musl";
+  };
+
+  musl64 = { config = "x86_64-unknown-linux-musl"; };
+  musl32  = { config = "i686-unknown-linux-musl"; };
 
   #
   # Darwin

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -35,7 +35,6 @@ rec {
     MinGW        = { kernel = kernels.windows; abi = abis.gnu; };
 
     Musl         = with abis; map (a: { abi = a; }) [ musl musleabi musleabihf ];
-    Glibc        = with abis; map (a: { abi = a; }) [ gnu gnueabi gnueabihf ];
   };
 
   matchAnyAttrs = patterns:

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -33,6 +33,9 @@ rec {
     Windows      = { kernel = kernels.windows; };
     Cygwin       = { kernel = kernels.windows; abi = abis.cygnus; };
     MinGW        = { kernel = kernels.windows; abi = abis.gnu; };
+
+    Musl         = with abis; map (a: { abi = a; }) [ musl musleabi musleabihf ];
+    Glibc        = with abis; map (a: { abi = a; }) [ gnu gnueabi gnueabihf ];
   };
 
   matchAnyAttrs = patterns:

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -180,6 +180,9 @@ rec {
     androideabi = {};
     gnueabi = {};
     gnueabihf = {};
+    musleabi = {};
+    musleabihf = {};
+    musl = {};
 
     unknown = {};
   };


### PR DESCRIPTION
Pull out the changes to lib.systems from the musl PR (#34645).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---