### PR TITLE
graph-tool: 2.16 -> 2.26

### DIFF
--- a/pkgs/development/python-modules/graph-tool/2.x.x.nix
+++ b/pkgs/development/python-modules/graph-tool/2.x.x.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, python, cairomm, sparsehash, pycairo, autoreconfHook,
 pkgconfig, boost, expat, scipy, numpy, cgal, gmp, mpfr, lndir,
-gobjectIntrospection, pygobject3, gtk3, matplotlib, ncurses }:
+gobjectIntrospection, pygobject3, gtk3, matplotlib, ncurses,
+buildPythonPackage }:
 
-stdenv.mkDerivation rec {
+buildPythonPackage rec {
+  format = "other";
   version = "2.26";
   name = "${python.libPrefix}-graph-tool-${version}";
-
-  pythonModule = python;
 
   meta = with stdenv.lib; {
     description = "Python module for manipulation and statistical analysis of graphs";

--- a/pkgs/development/python-modules/graph-tool/2.x.x.nix
+++ b/pkgs/development/python-modules/graph-tool/2.x.x.nix
@@ -1,10 +1,12 @@
 { stdenv, fetchurl, python, cairomm, sparsehash, pycairo, autoreconfHook,
 pkgconfig, boost, expat, scipy, numpy, cgal, gmp, mpfr, lndir,
-gobjectIntrospection, pygobject3, gtk3, matplotlib }:
+gobjectIntrospection, pygobject3, gtk3, matplotlib, ncurses }:
 
 stdenv.mkDerivation rec {
-  version = "2.16";
+  version = "2.26";
   name = "${python.libPrefix}-graph-tool-${version}";
+
+  pythonModule = python;
 
   meta = with stdenv.lib; {
     description = "Python module for manipulation and statistical analysis of graphs";
@@ -16,16 +18,19 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${version}.tar.bz2";
-    sha256 = "03b1pmh2gvsgyq491gvskx8fwgqy9k942faymdnhwpbbbfhx911p";
+    sha256 = "0w7pd2h8ayr88kjl82c8fdshnk6f3xslc77gy7ma09zkbvf76qnz";
   };
 
   configureFlags = [
     "--with-python-module-path=$(out)/${python.sitePackages}"
+    "--with-boost-libdir=${boost}/lib"
+    "--with-expat=${expat}"
+    "--with-cgal=${cgal}"
     "--enable-openmp"
   ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ ];
+  buildInputs = [ ncurses ];
 
   propagatedBuildInputs = [
     boost

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7970,9 +7970,7 @@ in {
     };
   };
 
-  # py3k disabled, see https://travis-ci.org/NixOS/nixpkgs/builds/48759067
-  graph-tool = if isPy3k then throw "graph-tool in Nix doesn't support py3k yet"
-    else callPackage ../development/python-modules/graph-tool/2.x.x.nix { boost = pkgs.boost159; };
+  graph-tool = callPackage ../development/python-modules/graph-tool/2.x.x.nix { };
 
   grappelli_safe = buildPythonPackage rec {
     version = "0.3.13";


### PR DESCRIPTION
###### Motivation for this change

Reenable support for graph-tool in python3 environments and update to newest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions (inside Docker container)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Details:
- add ncurses: configure links against ncurses and fails otherwise
    configure: error: Could not link test program to Python.
    https://travis-ci.org/NixOS/nixpkgs/builds/48759067
    The given hint (Maybe the main Python library has been installed
    in some non-standard library path) is misleading.
    The config.log reveals that the failure is due to missing ncurses link option
- with-boost-libdir is need to find Boost::IOStreams/regex/etc.
- expat/cgal are detected in /usr/lib when not specified explicitly
- boost > boost159 is needed to have -lboost_python3 (and -lboost_python)

- set pythonModule = Python;
  => inorder to be used in python.buildEnv { extraLibs = [..]; }

tested on MacOSX and in a linux Docker container with:
```
> nix-shell -I nixpkgs=. -p python2.pkgs.graph-tool
> nix-shell -I nixpkgs=. -p python3.pkgs.graph-tool
and created a simple graph
>>> import graph_tool
>>> from graph_tool.all import *
>>> g = Graph()
>>> v1 = g.add_vertex()
>>> graph_draw(g, vertex_text=g.vertex_index, vertex_font_size=18,output="one-nodes.png")
```
---
