### PR TITLE
trivial: nixos: doc: efficient comparisons

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -85,6 +85,7 @@ rec {
     concatMap (opt:
       let
         docOption = rec {
+          loc = opt.loc;
           name = showOption opt.loc;
           description = opt.description or (throw "Option `${name}' has no description.");
           declarations = filter (x: x != unknownModule) opt.declarations;

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -66,15 +66,14 @@ let
   # and ".package"
   optionListLess = a: b:
     let
-      splt = lib.splitString ".";
       ise = lib.hasPrefix "enable";
       isp = lib.hasPrefix "package";
       cmp = lib.splitByAndCompare ise lib.compare
                                  (lib.splitByAndCompare isp lib.compare lib.compare);
-    in lib.compareLists cmp (splt a) (splt b) < 0;
+    in lib.compareLists cmp a.loc b.loc < 0;
 
   # Customly sort option list for the man page.
-  optionsList = lib.sort (a: b: optionListLess a.name b.name) optionsListDesc;
+  optionsList = lib.sort optionListLess optionsListDesc;
 
   # Convert the list of options into an XML file.
   optionsXML = builtins.toFile "options.xml" (builtins.toXML optionsList);

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -63,8 +63,8 @@ let
   stripAnyPrefixes = lib.flip (lib.fold lib.removePrefix) prefixesToStrip;
 
   # Custom "less" that pushes up all the things ending in ".enable*"
-  # and ".package"
-  optionListLess = a: b:
+  # and ".package*"
+  optionLess = a: b:
     let
       ise = lib.hasPrefix "enable";
       isp = lib.hasPrefix "package";
@@ -73,7 +73,7 @@ let
     in lib.compareLists cmp a.loc b.loc < 0;
 
   # Customly sort option list for the man page.
-  optionsList = lib.sort optionListLess optionsListDesc;
+  optionsList = lib.sort optionLess optionsListDesc;
 
   # Convert the list of options into an XML file.
   optionsXML = builtins.toFile "options.xml" (builtins.toXML optionsList);


### PR DESCRIPTION
###### Motivation for this change

Me eating up all of the precious hydra memory and much of its time with a7d75ab6489dc5834e8402db374b4d0f1e774d53 of #33898. See that PR for discussion.

###### Things done

- [X] Trivial.
- [X] Makes things much better.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
