### PR TITLE
memo: refactoring dependency paths

### DIFF
--- a/pkgs/applications/misc/memo/default.nix
+++ b/pkgs/applications/misc/memo/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, ack , tree, stdenv, ... }:
+{ fetchFromGitHub, ag, tree, stdenv, ... }:
 
 stdenv.mkDerivation rec {
 
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/{bin,share/man/man1,share/bash-completion/completions}
+    substituteInPlace memo \
+      --replace "ack "  "${ag}/bin/ag " \
+      --replace "tree " "${tree}/bin/tree "
     mv memo $out/bin/
     mv doc/memo.1 $out/share/man/man1/memo.1
     mv completion/memo.bash $out/share/bash-completion/completions/memo.sh


### PR DESCRIPTION
###### Motivation for this change
The previous version did not replace the dependent binary paths in the program. This one does and uses `ag` instead of `ack` for speed reasons.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

