### PR TITLE
[RDY] protocol: module to application

### DIFF
--- a/pkgs/applications/networking/protocol/default.nix
+++ b/pkgs/applications/networking/protocol/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub }:
+{ stdenv, buildPythonApplication, fetchFromGitHub }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   pname = "protocol";
   version = "20171226";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20118,6 +20118,8 @@ with pkgs;
 
   pt = callPackage ../applications/misc/pt { };
 
+  protocol = python3Packages.callPackage ../applications/networking/protocol { };
+
   pykms = callPackage ../tools/networking/pykms { };
 
   pyload = callPackage ../applications/networking/pyload {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20998,8 +20998,6 @@ EOF
 
   trezor = callPackage ../development/python-modules/trezor { };
 
-  protocol = callPackage ../development/python-modules/protocol { };
-
   trezor_agent = buildPythonPackage rec{
     name = "${pname}-${version}";
     pname = "trezor_agent";


### PR DESCRIPTION
protocol really is a "buildPythonApplication" rather than a
buildPythonPackage".

###### Motivation for this change
I want to install it globally without having python globally available.

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

