### PR TITLE
remove profpatsch from maintainer list of a few packages

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/cutegram/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/cutegram/default.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation rec {
     description = "Telegram client forked from sigram";
     homepage = http://aseman.co/en/products/cutegram/;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ profpatsch AndersonTorres ];
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;
   };
 }
-#TODO: appindicator, for system tray plugin (by @profpatsch)
+#TODO: appindicator, for system tray plugin

--- a/pkgs/development/python-modules/yolk/default.nix
+++ b/pkgs/development/python-modules/yolk/default.nix
@@ -17,7 +17,7 @@ buildPythonApplication rec {
   meta = {
     description = "Command-line tool for querying PyPI and Python packages installed on your system";
     homepage = https://github.com/cakebread/yolk;
-    maintainer = with maintainers; [ profpatsch ];
+    maintainer = with maintainers; [];
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/tools/compile-daemon/default.nix
+++ b/pkgs/development/tools/compile-daemon/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     description = "Very simple compile daemon for Go";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ profpatsch ];
+    maintainers = with maintainers; [ ];
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     description = "Version Control for your database";
     homepage = http://www.liquibase.org/;
     license = licenses.asl20;
-    maintainers = with maintainers; [ nequissimus profpatsch ];
+    maintainers = with maintainers; [ nequissimus ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -42,6 +42,6 @@ buildPythonApplication rec {
     homepage = https://github.com/asciimoo/searx;
     description = "A privacy-respecting, hackable metasearch engine";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ matejc fpletz profpatsch ];
+    maintainers = with maintainers; [ matejc fpletz ];
   };
 }

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -224,7 +224,7 @@ in pythonPackages.buildPythonApplication rec {
     description = "Music tagger and library organizer";
     homepage = http://beets.radbox.org;
     license = licenses.mit;
-    maintainers = with maintainers; [ aszlig domenkozar pjones profpatsch ];
+    maintainers = with maintainers; [ aszlig domenkozar pjones ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -491,7 +491,7 @@ in {
       homepage = https://github.com/pazz/alot;
       description = "Terminal MUA using notmuch mail";
       platforms = platforms.linux;
-      maintainers = with maintainers; [ garbas profpatsch ];
+      maintainers = with maintainers; [ garbas ];
     };
   };
 
@@ -17837,7 +17837,7 @@ in {
     meta = {
       description = "Tree widgets for urwid";
       license = licenses.gpl3;
-      maintainers = with maintainers; [ profpatsch ];
+      maintainers = with maintainers; [ ];
     };
   };
 


### PR DESCRIPTION
I don’t actively follow updates for these packages, mostly because I don’t use them (anymore).