### PR TITLE
fwts: init at 18.01.00

### DIFF
--- a/pkgs/os-specific/linux/fwts/default.nix
+++ b/pkgs/os-specific/linux/fwts/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchzip, autoreconfHook, pkgconfig, glib, libtool, pcre
+, json_c, flex, bison, dtc, pciutils, dmidecode, iasl }:
+
+stdenv.mkDerivation rec {
+  name = "fwts-${version}";
+  version = "18.01.00";
+
+  src = fetchzip {
+    url = "http://fwts.ubuntu.com/release/fwts-V${version}.tar.gz";
+    sha256 = "043wkq4hz5pz79masppya67b8i5jw61p1j8dw17jwc8w6gp8csfb";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig libtool ];
+  buildInputs = [ glib pcre json_c flex bison dtc pciutils dmidecode iasl ];
+
+  postPatch = ''
+    substituteInPlace src/lib/include/fwts_binpaths.h --replace "/usr/bin/lspci"      "${pciutils}/bin/lspci"
+    substituteInPlace src/lib/include/fwts_binpaths.h --replace "/usr/sbin/dmidecode" "${dmidecode}/bin/dmidecode"
+    substituteInPlace src/lib/include/fwts_binpaths.h --replace "/usr/bin/iasl"       "${iasl}/bin/iasl"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://wiki.ubuntu.com/FirmwareTestSuite";
+    description = "Firmware Test Suite";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ tadfisher ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12905,6 +12905,8 @@ with pkgs;
 
   fwupdate = callPackage ../os-specific/linux/firmware/fwupdate { };
 
+  fwts = callPackage ../os-specific/linux/fwts { };
+
   libossp_uuid = callPackage ../development/libraries/libossp-uuid { };
 
   libuuid =


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

