### PR TITLE
fontconfig: Fix for HFS+ 1s date resolution issue

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -39,7 +39,8 @@ stdenv.mkDerivation rec {
   # additionally required for the glibc-2.25 patch; avoid requiring gperf
   postPatch = ''
     sed s/CHAR_WIDTH/CHARWIDTH/g -i src/fcobjshash.{h,gperf}
-    touch src/*
+    sleep 2
+    touch src/fcobjshash.h
   '';
 
   outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config


### PR DESCRIPTION
HFS+ (still common on macOS machines) only has a
date resolution of 1 second.  This change makes sure that
`fcobjshash.h` gets a newer timestamp than `fcobjshash.gperf`.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

