### PR TITLE
massren: init at 1.5.4

### DIFF
--- a/pkgs/tools/misc/massren/default.nix
+++ b/pkgs/tools/misc/massren/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "massren-${version}";
+  version = "1.5.4";
+
+  src = fetchFromGitHub {
+    owner = "laurent22";
+    repo = "massren";
+    rev = "v${version}";
+    sha256 = "1bn6qy30kpxi3rkr3bplsc80xnhj0hgfl0qaczbg3zmykfmsl3bl";
+  };
+
+  goPackagePath = "github.com/laurent22/massren";
+
+  meta = with lib; {
+    description = "Easily rename multiple files using your text editor";
+    license = licenses.mit;
+    homepage = https://github.com/laurent22/massren;
+    maintainers = with maintainers; [ andrew-d ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1245,6 +1245,8 @@ with pkgs;
 
   masscan = callPackage ../tools/security/masscan { };
 
+  massren = callPackage ../tools/misc/massren { };
+
   meritous = callPackage ../games/meritous { };
 
   meson = callPackage ../development/tools/build-managers/meson { };


### PR DESCRIPTION
###### Motivation for this change
[massren][m] is a pretty helpful tool for editing a bunch of files all at once in your editor, and I use it ~every day.  I figured I'd try upstreaming the package!

[m]: https://github.com/laurent22/massren/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

