### PR TITLE
acpica-tools: init at 20180209

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -669,6 +669,7 @@
   symphorien = "Guillaume Girol <symphorien_nixpkgs@xlumurb.eu>";
   szczyp = "Szczyp <qb@szczyp.com>";
   sztupi = "Attila Sztupak <attila.sztupak@gmail.com>";
+  tadfisher = "Tad Fisher <tadfisher@gmail.com>";
   taeer = "Taeer Bar-Yam <taeer@necsi.edu>";
   tailhook = "Paul Colomiets <paul@colomiets.name>";
   taketwo = "Sergey Alexandrov <alexandrov88@gmail.com>";

--- a/pkgs/tools/system/acpica-tools/default.nix
+++ b/pkgs/tools/system/acpica-tools/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, bison, flex }:
+
+stdenv.mkDerivation rec {
+  name = "acpica-tools-${version}";
+  version = "20180209";
+
+  src = fetchurl {
+    url = "https://acpica.org/sites/acpica/files/acpica-unix-${version}.tar.gz";
+    sha256 = "1rpdfwa4vwnvyxdp9ygqjckmabc3s8kyg3jyq4n4f0rhr1zl4zy5";
+  };
+
+  NIX_CFLAGS_COMPILE = "-O3";
+
+  enableParallelBuilding = true;
+
+  buildFlags = stdenv.lib.concatStringsSep " " [
+    "acpibin"
+    "acpidump"
+    "acpiexec"
+    "acpihelp"
+    "acpinames"
+    "acpixtract"
+  ];
+
+  buildInputs = [ bison flex ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "ACPICA Tools";
+    homepage = "https://www.acpica.org/";
+    license = with licenses; [ gpl2 bsd3 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tadfisher ];
+  };
+}

--- a/pkgs/tools/system/acpica-tools/default.nix
+++ b/pkgs/tools/system/acpica-tools/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildFlags = stdenv.lib.concatStringsSep " " [
+  buildFlags = [
     "acpibin"
     "acpidump"
     "acpiexec"
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     "acpixtract"
   ];
 
-  buildInputs = [ bison flex ];
+  nativeBuildInputs = [ bison flex ];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -396,6 +396,8 @@ with pkgs;
     ffmpeg = ffmpeg_1;
   };
 
+  acpica-tools = callPackage ../tools/system/acpica-tools { };
+
   actdiag = pythonPackages.actdiag;
 
   actkbd = callPackage ../tools/system/actkbd { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

