### PR TITLE
buildah: init at 0.11

### DIFF
--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, runCommand
+, gpgme, libgpgerror, devicemapper, btrfs-progs, pkgconfig, ostree, libselinux
+, go-md2man }:
+
+let
+  version = "0.11";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "projectatomic";
+    repo = "buildah";
+    sha256 = "0rq3dw6p9rcqc99jk93j0qwg1p8fh4pwqvzylcqlcyqhv46426zf";
+  };
+  goPackagePath = "github.com/projectatomic/buildah";
+
+in buildGoPackage rec {
+  name = "buildah-${version}";
+  inherit src;
+
+  outputs = [ "bin" "man" "out" ];
+
+  inherit goPackagePath;
+  excludedPackages = [ "tests" ];
+
+  nativeBuildInputs = [ pkgconfig go-md2man.bin ];
+  buildInputs = [ gpgme libgpgerror devicemapper btrfs-progs ostree libselinux ];
+
+  # Copied from the skopeo package, doesn’t seem to make a difference?
+  # If something related to these libs failed, uncomment these lines.
+  /*preBuild = with lib; ''
+    export CGO_CFLAGS="-I${getDev gpgme}/include -I${getDev libgpgerror}/include -I${getDev devicemapper}/include -I${getDev btrfs-progs}/include"
+    export CGO_LDFLAGS="-L${getLib gpgme}/lib -L${getLib libgpgerror}/lib -L${getLib devicemapper}/lib"
+  '';*/
+
+  postBuild = ''
+    # depends on buildGoPackage not changing …
+    pushd ./go/src/${goPackagePath}/docs
+    make docs
+    make install PREFIX="$man"
+    popd
+  '';
+
+  meta = {
+    description = "A tool which facilitates building OCI images";
+    homepage = https://github.com/projectatomic/buildah;
+    maintainers = with stdenv.lib.maintainers; [ Profpatsch ];
+    license = stdenv.lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -863,6 +863,8 @@ with pkgs;
 
   btfs = callPackage ../os-specific/linux/btfs { };
 
+  buildah = callPackage ../development/tools/buildah { };
+
   burpsuite = callPackage ../tools/networking/burpsuite {};
 
   c3d = callPackage ../applications/graphics/c3d {


### PR DESCRIPTION
###### Motivation for this change

Since we already have `skopeo`, `buildah` might also be a good idea.
Builds the manpages, haven’t yet found out what parts of this thing should be considered the test suite.

A few subcommands might break because of missing runtime dependencies, let’s patch should it happen.

p.p. Containers Workgroup (https://nixos.wiki/wiki/Workgroup:Container)

cc @moretea @nlewo @vdemeester 

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
