### PR TITLE
 pythonPackages.pytest-mock: 1.6.0 -> 1.6.3

### DIFF
--- a/pkgs/development/python-modules/Nikola/default.nix
+++ b/pkgs/development/python-modules/Nikola/default.nix
@@ -7,6 +7,7 @@
 , pytest
 , pytestcov
 , pytest-mock
+, mock
 , pygments
 , pillow
 , dateutil
@@ -28,7 +29,6 @@
 }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "Nikola";
   version = "7.8.11";
 
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   # other hand doesn't support Python 3.3). So, just disable Python 2.
   disabled = !isPy3k;
 
-  buildInputs = [ pytest pytestcov pytest-mock glibcLocales ];
+  checkInputs = [ pytest pytestcov pytest-mock mock glibcLocales ];
 
   propagatedBuildInputs = [
     pygments pillow dateutil docutils Mako unidecode lxml Yapsy PyRSS2Gen

--- a/pkgs/development/python-modules/pytest-mock/default.nix
+++ b/pkgs/development/python-modules/pytest-mock/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k, pytest, mock, setuptools_scm }:
+
+buildPythonPackage rec {
+  pname = "pytest-mock";
+  version = "1.6.3";
+ 
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "920d1167af5c2c2ad3fa0717d0c6c52e97e97810160c15721ac895cac53abb1c";
+  };
+
+  propagatedBuildInputs = [ pytest ] ++ lib.optional (!isPy3k) mock;
+  nativeBuildInputs = [ setuptools_scm ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    description = "Thin-wrapper around the mock package for easier use with py.test.";
+    homepage    = https://github.com/pytest-dev/pytest-mock;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ nand0p ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3261,27 +3261,7 @@ in {
     };
   };
 
-  pytest-mock = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "pytest-mock";
-    version = "1.6.0";
-
-    buildInputs = with self; [ pytest setuptools_scm ];
-    propagatedBuildInputs = with self; [ mock ];
-
-    meta = {
-      description = "Thin-wrapper around the mock package for easier use with py.test.";
-      homepage    = "https://github.com/pytest-dev/pytest-mock";
-      license     = licenses.mit;
-      maintainers = with maintainers; [ nand0p ];
-      platforms   = platforms.all;
-    };
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "07qccww4bq9jxlc0fbhlspr13kcsixchsnl8vk4wdiyvsjy7r8c3";
-    };
-  };
+  pytest-mock = callPackage ../development/python-modules/pytest-mock { };
 
   pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` *(fixed Nikola with the second commit)*
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc pytest-mock maintainer @nand0p
/cc Nikola maintainer @jluttine