### PR TITLE
python3Packages.aiohttp: 2.3.10 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, attrs
 , chardet
 , multidict
 , async-timeout
@@ -14,24 +15,24 @@
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "2.3.10";
+  version = "3.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8adda6583ba438a4c70693374e10b60168663ffa6564c5c75d3c7a9055290964";
+    sha256 = "7aee5c0750584946fde40da70f0b28fe769f85182f1171acef18a35fd8ecd221";
   };
 
   disabled = pythonOlder "3.4";
 
   checkInputs = [ pytest gunicorn pytest-mock ];
 
-  propagatedBuildInputs = [ async-timeout chardet multidict yarl ]
+  propagatedBuildInputs = [ attrs chardet multidict async-timeout yarl ]
     ++ lib.optional (pythonOlder "3.7") idna-ssl;
 
   meta = with lib; {
     description = "Asynchronous HTTP Client/Server for Python and asyncio";
     license = licenses.asl20;
-    homepage = https://github.com/KeepSafe/aiohttp/;
+    homepage = https://github.com/aio-libs/aiohttp;
     maintainers = with maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
Judging from nox-review, it seems like gns3 needs to pin the aiohttp version.
/cc @primeos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

