### PR TITLE
menu-cache: 1.0.2 -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/menu-cache/default.nix
+++ b/pkgs/development/libraries/menu-cache/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, glib, pkgconfig, libfm-extra }:
 
-let name = "menu-cache-1.0.2";
+let name = "menu-cache-1.1.0";
 in
 stdenv.mkDerivation {
   inherit name;
   src = fetchurl {
     url = "mirror://sourceforge/lxde/${name}.tar.xz";
-    sha256 = "1m8j40npykfcfqs43kc0fmksal2jfmfi8lnb3mq3xy1lvvrfv0vg";
+    sha256 = "1iry4zlpppww8qai2cw4zid4081hh7fz8nzsp5lqyffbkm2yn0pd";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update `menu-cache` to version [1.1.0](https://github.com/lxde/menu-cache/blob/master/NEWS)

~~Update `jgmenu` to version [0.8.1](https://github.com/johanmalm/jgmenu/releases/tag/v0.8.1)~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).