### PR TITLE
Filter out "null" from nix-buffer packages

### DIFF
--- a/pkgs/build-support/emacs/buffer.nix
+++ b/pkgs/build-support/emacs/buffer.nix
@@ -4,7 +4,8 @@
 { lib, writeText, inherit-local }:
 
 rec {
-  withPackages = pkgs: let
+  withPackages = pkgs': let
+      pkgs = builtins.filter (x: x != null) pkgs';
       extras = map (x: x.emacsBufferSetup pkgs) (builtins.filter (builtins.hasAttr "emacsBufferSetup") pkgs);
     in writeText "dir-locals.el" ''
       (require 'inherit-local "${inherit-local}/share/emacs/site-lisp/elpa/inherit-local-${inherit-local.version}/inherit-local.elc")


### PR DESCRIPTION
Null packages cause an error. This adds a filter to prevent "makeSearchPath" from sending an error.

We can't guarantee that every package is going to be nonnull in some cases. See reflex-frp/reflex-platform#240

/cc @shlevy 
