### PR TITLE
vivaldi: 1.13.1008.34-1 -> 1.14.1077.45-1

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -4,7 +4,7 @@
 , freetype, fontconfig, libXft, libXrender, libxcb, expat, libXau, libXdmcp
 , libuuid, xz
 , gstreamer, gst-plugins-base, libxml2
-, glib, gtk3, pango, gdk_pixbuf, cairo, atk, gnome3
+, glib, gtk3, pango, gdk_pixbuf, cairo, atk, at_spi2_atk, gnome3
 , nss, nspr
 , patchelf, makeWrapper
 , proprietaryCodecs ? false, vivaldi-ffmpeg-codecs ? null
@@ -13,11 +13,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi";
-  version = "1.13.1008.34-1";
+  version = "1.14.1077.45-1";
 
   src = fetchurl {
     url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
-    sha256 = "18p5n87n5rkd6dhdsf2lvcyhg6ipn0k4p6a79dy93vsgjmk4bvw2";
+    sha256 = "0b4iviar927jx6xqyrzgzb3p4p617zm4an1np8jnldadq2a0p56d";
   };
 
   unpackPhase = ''
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     stdenv.cc.cc stdenv.cc.libc zlib libX11 libXt libXext libSM libICE libxcb
     libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
-    atk alsaLib dbus_libs cups gtk3 gdk_pixbuf libexif ffmpeg systemd
+    atk at_spi2_atk alsaLib dbus_libs cups gtk3 gdk_pixbuf libexif ffmpeg systemd
     freetype fontconfig libXrender libuuid expat glib nss nspr
     gstreamer libxml2 gst-plugins-base pango cairo gnome3.gconf
   ] ++ stdenv.lib.optional proprietaryCodecs vivaldi-ffmpeg-codecs;


### PR DESCRIPTION
###### Motivation for this change

Update to version 1.14.1077.45-1

[Vivaldi 1.14 – Three years of continuous innovation](https://vivaldi.com/blog/vivaldi-1-14-three-years-of-continuous-innovation/)

[Minor update to Vivaldi 1.14](https://vivaldi.com/blog/minor-update-to-vivaldi-1-14/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).