### PR TITLE
catfish: 1.4.2 -> 1.4.4

### DIFF
--- a/pkgs/applications/search/catfish/default.nix
+++ b/pkgs/applications/search/catfish/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, file, which, intltool, findutils, xdg_utils,
-  gnome3, pythonPackages, wrapGAppsHook }:
+{ stdenv, fetchurl, file, which, intltool, gobjectIntrospection,
+  findutils, xdg_utils, gnome3, pythonPackages, hicolor_icon_theme,
+  wrapGAppsHook
+}:
 
 pythonPackages.buildPythonApplication rec {
   majorver = "1.4";
-  minorver = "2";
+  minorver = "4";
   version = "${majorver}.${minorver}";
-  name = "catfish-${version}";
+  pname = "catfish";
 
   src = fetchurl {
-    url = "https://launchpad.net/catfish-search/${majorver}/${version}/+download/${name}.tar.bz2";
-    sha256 = "0j3by9yfs4j9za3s5qdxrsm7idmps69pimc9d0mjyakvviy0izm3";
+    url = "https://launchpad.net/catfish-search/${majorver}/${version}/+download/${pname}-${version}.tar.gz";
+    sha256 = "1mw7py6si6y88jblmzm04hf049bpww7h87k2wypq07zm1dw55m52";
   };
 
   nativeBuildInputs = [
@@ -17,6 +19,7 @@ pythonPackages.buildPythonApplication rec {
     file
     which
     intltool
+    gobjectIntrospection
     wrapGAppsHook
   ];
 
@@ -26,6 +29,7 @@ pythonPackages.buildPythonApplication rec {
     pythonPackages.pyxdg
     pythonPackages.ptyprocess
     pythonPackages.pycairo
+    hicolor_icon_theme
   ];
 
   propagatedBuildInputs = [
@@ -35,17 +39,20 @@ pythonPackages.buildPythonApplication rec {
     findutils
   ];
 
-  preFixup = ''
-    rm "$out/${pythonPackages.python.sitePackages}/catfish_lib/catfishconfig.pyc"
-    for f in \
-      "$out/${pythonPackages.python.sitePackages}/catfish_lib/catfishconfig.py" \
-      "$out/share/applications/catfish.desktop"
-    do
-      substituteInPlace $f --replace "${pythonPackages.python}" "$out"
-    done
+  # Explicitly set the prefix dir in "setup.py" because setuptools is
+  # not using "$out" as the prefix when installing catfish data. In
+  # particular the variable "__catfish_data_directory__" in
+  # "catfishconfig.py" is being set to a subdirectory in the python
+  # path in the store.
+  postPatch = ''
+    sed -i "/^        if self.root/i\\        self.prefix = \"$out\"" setup.py
   '';
 
+  # Disable check because there is no test in the source distribution
+  doCheck = false;
+
   meta = with stdenv.lib; {
+    homepage = https://launchpad.net/catfish-search;
     description = "A handy file search tool";
     longDescription = ''
       Catfish is a handy file searching tool. The interface is
@@ -53,7 +60,6 @@ pythonPackages.buildPythonApplication rec {
       You can configure it to your needs by using several command line
       options.
     '';
-    homepage = https://launchpad.net/catfish-search;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14466,9 +14466,7 @@ with pkgs;
 
   carddav-util = callPackage ../tools/networking/carddav-util { };
 
-  catfish = callPackage ../applications/search/catfish {
-    pythonPackages = python2Packages;
-  };
+  catfish = callPackage ../applications/search/catfish { };
 
   cava = callPackage ../applications/audio/cava { };
 


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.4.4](https://bluesabre.org/2018/01/28/catfish-1-4-4-released/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).