### PR TITLE
yokadi: init at 1.1.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -493,6 +493,7 @@
   nicknovitski = "Nick Novitski <nixpkgs@nicknovitski.com>";
   nico202 = "Nicolò Balzarotti <anothersms@gmail.com>";
   NikolaMandic = "Ratko Mladic <nikola@mandic.email>";
+  nipav = "Niko Pavlinek <niko.pavlinek@gmail.com>";
   nixy = "Andrew R. M. <nixy@nixy.moe>";
   nmattia = "Nicolas Mattia <nicolas@nmattia.com>";
   nocoolnametom = "Tom Doggett <nocoolnametom@gmail.com>";

--- a/pkgs/applications/misc/yokadi/default.nix
+++ b/pkgs/applications/misc/yokadi/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, buildPythonApplication, dateutil,
+  sqlalchemy, setproctitle, icalendar, pycrypto }:
+
+buildPythonApplication rec {
+  pname = "yokadi";
+  version = "1.1.1";
+
+  src = fetchurl {
+    url = "https://yokadi.github.io/download/${pname}-${version}.tar.bz2";
+    sha256 = "af201da66fd3a8435b2ccd932082ab9ff13f5f2e3d6cd3624f1ab81c577aaf17";
+  };
+
+  propagatedBuildInputs = [
+    dateutil
+    sqlalchemy
+    setproctitle
+    icalendar
+    pycrypto
+  ];
+
+  # Yokadi doesn't have any tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A command line oriented, sqlite powered, todo-list";
+    homepage = https://yokadi.github.io/index.html;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.nipav ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18200,6 +18200,8 @@ with pkgs;
 
   inherit (gnome3) yelp;
 
+  yokadi = python3Packages.callPackage ../applications/misc/yokadi {};
+
   yoshimi = callPackage ../applications/audio/yoshimi { };
 
   inherit (pythonPackages) youtube-dl;


### PR DESCRIPTION
###### Motivation for this change

Yokadi is an easy-to-use TODO manager.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

