### PR TITLE
graph-easy: init at 0.76

### DIFF
--- a/pkgs/tools/graphics/graph-easy/default.nix
+++ b/pkgs/tools/graphics/graph-easy/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPerlPackage, fetchurl }:
+
+buildPerlPackage rec {
+  name = "Graph-Easy-${version}";
+  version = "0.76";
+  src = fetchurl {
+    url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+    sha256 = "d4a2c10aebef663b598ea37f3aa3e3b752acf1fbbb961232c3dbe1155008d1fa";
+  };
+  
+  meta = with stdenv.lib; {
+    homepage = http://search.cpan.org/~tels/Graph-Easy/bin/graph-easy;
+    description = "Render/convert graphs in/from various formats";
+    license = licenses.gpl1;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.jensbin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -167,6 +167,8 @@ with pkgs;
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  graph-easy = callPackage ../tools/graphics/graph-easy { };
+
   packer = callPackage ../development/tools/packer { };
 
   mht2htm = callPackage ../tools/misc/mht2htm { };


### PR DESCRIPTION
###### Motivation for this change
graph-easy is a small tools which converts between graph formats and layout/render graphs.

It also helps to create handy ASCII graphs:
```
$ echo "[ Bonn ] -- car --> [ Berlin ], [ Ulm ]" | graph-easy

        +--------+  car   +-----+
        |  Bonn  | -----> | Ulm |
        +--------+        +-----+
          |
          | car
          v
        +--------+
        | Berlin |
        +--------+
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

