### PR TITLE
mapmap: init at 0.5.0

### DIFF
--- a/pkgs/applications/video/mapmap/default.nix
+++ b/pkgs/applications/video/mapmap/default.nix
@@ -1,0 +1,63 @@
+{ stdenv 
+, fetchFromGitHub
+, qttools
+, qtbase
+, qtmultimedia
+, liblo
+, gst_all_1
+, qmake
+, pkgconfig
+}:
+
+with stdenv;
+
+mkDerivation rec {
+
+  version = "0.5.0";
+  name = "mapmap-${version}";
+
+  src = fetchFromGitHub {
+    owner = "mapmapteam";
+    repo = "mapmap";
+    rev = version;
+    sha256 = "1l5iv5h0m2cmzkas22ww8kw5f6db3s40yyql1ayciaxihc6lqcn5";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    qttools
+    qtmultimedia
+    liblo
+    gst_all_1.gstreamer
+    gst_all_1.gstreamermm
+    gst_all_1.gst-libav
+    gst_all_1.gst-vaapi
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp mapmap $out/bin/mapmap
+    mkdir -p $out/share/applications/
+    sed 's|Icon=/usr/share/icons/hicolor/scalable/apps/mapmap.svg|Icon=mapmap|g' resources/texts/mapmap.desktop > $out/share/applications/mapmap.desktop
+    mkdir -p $out/share/icons/hicolor/scalable/apps/
+    cp resources/images/logo/mapmap.* $out/share/icons/hicolor/scalable/apps/
+  '';
+
+  # RPATH in /tmp hack
+  preFixup = ''
+    rm -r $NIX_BUILD_TOP/__nix_qt5__
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open source video mapping software";
+    homepage = https://github.com/mapmapteam/mapmap;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.erictapen ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16166,6 +16166,8 @@ with pkgs;
 
   makeself = callPackage ../applications/misc/makeself { };
 
+  mapmap = libsForQt5.callPackage ../applications/video/mapmap { };
+
   marathon = callPackage ../applications/networking/cluster/marathon { };
   marathonctl = callPackage ../tools/virtualization/marathonctl { } ;
 


### PR DESCRIPTION
The current packaging currently doesn't support video textures, just still images.
When I figure out why video textures don't work I will provide a fix.

###### Motivation for this change

Introduce `mapmap`, one of the few video mapping applications for Linux.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

