### PR TITLE
buildRustCrate: add a postInstall hook

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate.nix
@@ -291,6 +291,7 @@ let buildCrate = { crateName, crateVersion, crateAuthors, buildDependencies,
         mkdir -p $out/bin
         cp -P target/bin/* $out/bin # */
       fi
+      runHook postInstall
     '';
 in
 


### PR DESCRIPTION
###### Motivation for this change

Need to add a SONAME for rust shared objects. 
The simplest way is to add a postInstall phase which will allow me to do a `postInstall = "ln -s $out/lib/*.so $out/lib/libagent.so";`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

