### PR TITLE
ocamlPackages.bitv: init at 1.3

### DIFF
--- a/pkgs/development/ocaml-modules/bitv/default.nix
+++ b/pkgs/development/ocaml-modules/bitv/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchzip, autoreconfHook, which, ocaml, findlib }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "bitv is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-bitv-${version}";
+  version = "1.3";
+
+  src = fetchzip {
+    url = "https://github.com/backtracking/bitv/archive/${version}.tar.gz";
+    sha256 = "0vkh1w9fpi5m1sgiqg6r38j3fqglhdajmbyiyr91113lrpljm75i";
+  };
+
+  buildInputs = [ autoreconfHook which ocaml findlib ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "A bit vector library for OCaml";
+    license = stdenv.lib.licenses.lgpl21;
+    homepage = "https://github.com/backtracking/bitv";
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -60,6 +60,8 @@ let
 
     bitstring = callPackage ../development/ocaml-modules/bitstring { };
 
+    bitv = callPackage ../development/ocaml-modules/bitv { };
+
     bolt = callPackage ../development/ocaml-modules/bolt { };
 
     bos = callPackage ../development/ocaml-modules/bos { };


### PR DESCRIPTION
bitv is a bit vector library for OCaml.

Homepage: https://github.com/backtracking/bitv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

