### PR TITLE
xz: set CONFIG_SHELL to /bin/sh, fix retained reference to bootstrap

### DIFF
--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   # In stdenv-linux, prevent a dependency on bootstrap-tools.
-  preConfigure = "unset CONFIG_SHELL";
+  preConfigure = "CONFIG_SHELL=/bin/sh";
 
   postInstall = "rm -rf $out/share/doc";
 


### PR DESCRIPTION
stdenv should be buildable cleanly with new Nix!

I ran into this while working on the musl PR (#34645)
but this is reproducible on master with Nix 2
(AFAIK not with Nix 1.11).

Please review and test.  And yes this will require rebuilding all the things.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Using CONFIG_SHELL since that's what is checked first.
Don't force the shell to use, let xz test what it finds
and come to its own conclusions about suitability.

As-is our stdenv fails to build with Nix 2.0 due to references
in xz's scripts to bootstrap tools' "sh".

Try `nix-build -A xz --check` and look at what configure detects
for the POSIX-compat shell: it needs to be /bin/sh, and if
it instead is a path with the word "bootstrap" then you've reproduced.