### PR TITLE
grpc: 1.8.3 -> 1.9.1

### DIFF
--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -1,19 +1,26 @@
 { stdenv, fetchurl, cmake, zlib, c-ares, pkgconfig, openssl, protobuf, gflags }:
 
-stdenv.mkDerivation rec
-  { name = "grpc-1.8.3";
-    src = fetchurl
-      { url = "https://github.com/grpc/grpc/archive/v1.8.3.tar.gz";
-        sha256 = "14ichjllvhkbv8sjh9j5njnagpqw2sl12n41ga90jnj7qvfwwjy1";
-      };
-    nativeBuildInputs = [ cmake pkgconfig ];
-    buildInputs = [ zlib c-ares c-ares.cmake-config openssl protobuf gflags ];
-    cmakeFlags =
-      [ "-DgRPC_ZLIB_PROVIDER=package"
-        "-DgRPC_CARES_PROVIDER=package"
-        "-DgRPC_SSL_PROVIDER=package"
-        "-DgRPC_PROTOBUF_PROVIDER=package"
-        "-DgRPC_GFLAGS_PROVIDER=package"
-      ];
-    enableParallelBuilds = true;
-  }
+stdenv.mkDerivation rec {
+  version = "1.9.1";
+  name = "grpc-${version}";
+  src = fetchurl {
+    url = "https://github.com/grpc/grpc/archive/v${version}.tar.gz";
+    sha256 = "0h2w0dckxydngva9kl7dpilif8k9zi2ajnlanscr7s5kkza3dhps";
+  };
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ zlib c-ares c-ares.cmake-config openssl protobuf gflags ];
+  cmakeFlags =
+    [ "-DgRPC_ZLIB_PROVIDER=package"
+      "-DgRPC_CARES_PROVIDER=package"
+      "-DgRPC_SSL_PROVIDER=package"
+      "-DgRPC_PROTOBUF_PROVIDER=package"
+      "-DgRPC_GFLAGS_PROVIDER=package"
+    ];
+  enableParallelBuilds = true;
+
+  meta = with stdenv.lib; {
+    description = "The C based gRPC (C++, Python, Ruby, Objective-C, PHP, C#)";
+    license = licenses.asl20;
+    homepage = https://grpc.io/;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Updating to latest release, and adding metadata and license information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
CC @shlevy 
