### PR TITLE
add plotinus and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -92,6 +92,7 @@
   ./programs/nano.nix
   ./programs/npm.nix
   ./programs/oblogout.nix
+  ./programs/plotinus.nix
   ./programs/qt5ct.nix
   ./programs/rootston.nix
   ./programs/screen.nix

--- a/nixos/modules/programs/plotinus.nix
+++ b/nixos/modules/programs/plotinus.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.plotinus;
+in
+{
+  meta = {
+    maintainers = pkgs.plotinus.meta.maintainers;
+    doc = ./plotinus.xml;
+  };
+
+  ###### interface
+
+  options = {
+    programs.plotinus = {
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable the Plotinus GTK+3 plugin.  Plotinus provides a
+          popup (triggered by Ctrl-Shift-P) to search the menus of a
+          compatible application.
+        '';
+        type = types.bool;
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    environment.variables.XDG_DATA_DIRS = [ "${pkgs.plotinus}/share/gsettings-schemas/${pkgs.plotinus.name}" ];
+    environment.variables.GTK3_MODULES = [ "${pkgs.plotinus}/lib/libplotinus.so" ];
+  };
+}

--- a/nixos/modules/programs/plotinus.xml
+++ b/nixos/modules/programs/plotinus.xml
@@ -1,0 +1,25 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="module-program-plotinus">
+
+<title>Plotinus</title>
+
+<para><emphasis>Source:</emphasis> <filename>modules/programs/plotinus.nix</filename></para>
+
+<para><emphasis>Upstream documentation:</emphasis> <link xlink:href="https://github.com/p-e-w/plotinus"/></para>
+
+<para>Plotinus is a searchable command palette in every modern GTK+ application.</para>
+
+<para>When in a GTK+3 application and Plotinus is enabled, you can press <literal>Ctrl+Shift+P</literal> to open the command palette.  The command palette provides a searchable list of of all menu items in the application.</para>
+
+<para>To enable Plotinus, add the following to your <filename>configuration.nix</filename>:
+
+<programlisting>
+programs.plotinus.enable = true;
+</programlisting>
+
+</para>
+
+</chapter>

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -277,6 +277,7 @@ in rec {
   tests.ipv6 = callTest tests/ipv6.nix {};
   tests.jenkins = callTest tests/jenkins.nix {};
   tests.plasma5 = callTest tests/plasma5.nix {};
+  tests.plotinus = callTest tests/plotinus.nix {};
   tests.keymap = callSubTests tests/keymap.nix {};
   tests.initrdNetwork = callTest tests/initrd-network.nix {};
   tests.kafka_0_9 = callTest tests/kafka_0_9.nix {};

--- a/nixos/tests/plotinus.nix
+++ b/nixos/tests/plotinus.nix
@@ -1,0 +1,27 @@
+import ./make-test.nix ({ pkgs, ... }: {
+  name = "plotinus";
+  meta = {
+    maintainers = pkgs.plotinus.meta.maintainers;
+  };
+
+  machine =
+    { config, pkgs, ... }:
+
+    { imports = [ ./common/x11.nix ];
+      programs.plotinus.enable = true;
+      environment.systemPackages = [ pkgs.gnome3.gnome-calculator pkgs.xdotool ];
+    };
+
+  testScript =
+    ''
+      $machine->waitForX;
+      $machine->execute("xterm -e 'gnome-calculator' &");
+      $machine->waitForWindow(qr/Calculator/);
+      $machine->execute("xdotool key ctrl+shift+p");
+      $machine->sleep(1); # wait for the popup
+      $machine->execute("xdotool key p r e f e r e n c e s Return");
+      $machine->waitForWindow(qr/Preferences/);
+      $machine->screenshot("screen");
+    '';
+
+})

--- a/pkgs/tools/misc/plotinus/default.nix
+++ b/pkgs/tools/misc/plotinus/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchFromGitHub
+, gettext
+, libxml2
+, pkgconfig
+, gtk3
+, cmake
+, ninja
+, vala
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "plotinus-${version}";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "p-e-w";
+    repo = "plotinus";
+    rev = "v${version}";
+    sha256 = "19k6f6ivg4ab57m62g6fkg85q9sv049snmzq1fyqnqijggwshxfz";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    wrapGAppsHook
+    vala
+    cmake
+    ninja
+    gettext
+    libxml2
+  ];
+  buildInputs = [
+    gtk3
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A searchable command palette in every modern GTK+ application";
+    homepage = https://github.com/p-e-w/plotinus;
+    maintainers = with maintainers; [ samdroid-apps ];
+    platforms = platforms.linux;
+    # No COPYING file, but headers in the source code
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4190,6 +4190,8 @@ with pkgs;
     libpng = libpng12;
   };
 
+  plotinus = callPackage ../tools/misc/plotinus { };
+
   plotutils = callPackage ../tools/graphics/plotutils { };
 
   plowshare = callPackage ../tools/misc/plowshare { };


### PR DESCRIPTION
###### Motivation for this change

[Plotinus](https://github.com/p-e-w/plotinus) add a menu search feature to all Gtk+3 applications.  Packaging the app is quite simple.  However, users of plotinus usually want to enable it for all applications; and add it to the environment in some way.

This PR is marked as WIP because I'm not sure if this is the best/correct way to add something to the environment.

Currently, the approach is to add the required variables (eg. `GTK3_MODULES`) to the environment when starting session via the display manager.  This was chosen as it would not affect other packages (eg. conditionally compiling it into GTK3 would cause mass rebuilds). 

Looking for an opinion on if this is the correct way to do it.

###### Testing

`vm.nix`:
```nix
{ pkgs, config, ... }:
{
  services.xserver = {
    autorun = true;
    enable = true;

    windowManager.openbox.enable = true;
    displayManager.auto = {
      enable = true;
      user = "test";
    };
  };

  programs.plotinus.enable = true;

  users.extraUsers.test = {
    isNormalUser = true;
    uid = 1000;
    extraGroups = [ "wheel" ];
    password = "";
  };

  environment.systemPackages = with pkgs; [
    xterm
    gnome3.gnome-calculator
  ];
}
```

Then run:

```sh
nixos-rebuild build-vm -I nixpkgs=$HOME/nixpkgs -I nixos-config=vm.nix
./result/bin/run-nixos-vm
```

Inside the VM, open gnome-calculator.  Press `Ctrl-Shift-P` to open the menu searcher.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) -- N/A
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

