### PR TITLE
getdns: init at 1.3.0

### DIFF
--- a/pkgs/development/libraries/getdns/default.nix
+++ b/pkgs/development/libraries/getdns/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, libtool, unbound, libidn, m4, file
+, openssl, doxygen, autoreconfHook, automake }:
+
+stdenv.mkDerivation rec {
+  pname = "getdns";
+  name = "${pname}-${version}";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "https://getdnsapi.net/releases/${pname}-1-3-0/${pname}-${version}.tar.gz";
+    sha256 = "920fa2e07c72fd0e5854db1820fa777108009fc5cb702f9aa5155ef58b12adb1";
+  };
+
+  nativeBuildInputs = [ libtool m4 autoreconfHook automake file ];
+
+  buildInputs = [ unbound libidn openssl doxygen ];
+
+  patchPhase = ''
+    substituteInPlace m4/acx_openssl.m4 \
+      --replace /usr/local/ssl ${openssl.dev}
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A modern asynchronous DNS API";
+    longDescription = ''
+      getdns is an implementation of a modern asynchronous DNS API; the
+      specification was originally edited by Paul Hoffman. It is intended to make all
+      types of DNS information easily available to application developers and non-DNS
+      experts. DNSSEC offers a unique global infrastructure for establishing and
+      enhancing cryptographic trust relations. With the development of this API the
+      developers intend to offer application developers a modern and flexible
+      interface that enables end-to-end trust in the DNS architecture, and which will
+      inspire application developers to implement innovative security solutions in
+      their applications.
+'';
+    homepage = https://getdnsapi.net;
+    maintainers = with maintainers; [ leenaars ];
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8662,6 +8662,8 @@ with pkgs;
 
   getdata = callPackage ../development/libraries/getdata { };
 
+  getdns = callPackage ../development/libraries/getdns { };
+
   gettext = callPackage ../development/libraries/gettext { };
 
   gflags = callPackage ../development/libraries/gflags { };


### PR DESCRIPTION
###### Motivation for this change

Previous pull request ( #34910) got accidentally trampled because of detached HEAD.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

