### PR TITLE
fd: install fish shell completions

### DIFF
--- a/pkgs/tools/misc/fd/default.nix
+++ b/pkgs/tools/misc/fd/default.nix
@@ -17,9 +17,9 @@ rustPlatform.buildRustPackage rec {
     mkdir -p "$out/man/man1"
     cp "$src/doc/fd.1" "$out/man/man1"
 
-    mkdir -p "$out/share/"{bash-completion/completions,fish/completions,zsh/site-functions}
+    mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
     cp target/release/build/fd-find-*/out/fd.bash "$out/share/bash-completion/completions/"
-    cp target/release/build/fd-find-*/out/fd.fish "$out/share/fish/completions/"
+    cp target/release/build/fd-find-*/out/fd.fish "$out/share/fish/vendor_completions.d/"
     cp target/release/build/fd-find-*/out/_fd "$out/share/zsh/site-functions/"
   '';
 


### PR DESCRIPTION
###### Motivation for this change
fish shell completions should be at `/share/fish/vendor_completions.d/`:
https://github.com/NixOS/nixpkgs/blob/57707ea2caf1b1898c7f8bec59372052ed7e2146/nixos/modules/programs/fish.nix#L168-L172

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

