### PR TITLE
autojump: install fish shell completions

### DIFF
--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -22,6 +22,9 @@ in
       mkdir -p "$out/etc/bash_completion.d"
       cp -v $out/share/autojump/autojump.bash "$out/etc/bash_completion.d"
 
+      mkdir -p $out/share/fish/vendor_completions.d/
+      cp -v $out/share/autojump/autojump.fish "$out/share/fish/vendor_completions.d/autojump.fish"
+
       cat <<SCRIPT > $out/bin/autojump-share
       #!/bin/sh
       # Run this script to find the autojump shared folder where all the shell


### PR DESCRIPTION
###### Motivation for this change
fish shell completions should be at `/share/fish/vendor_completions.d/`:
https://github.com/NixOS/nixpkgs/blob/57707ea2caf1b1898c7f8bec59372052ed7e2146/nixos/modules/programs/fish.nix#L168-L172

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

