### PR TITLE
[17.09] qpdf: 6.0.0 -> 7.1.1

### DIFF
--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libjpeg, pcre, zlib, perl }:
+{ stdenv, fetchurl, libjpeg, zlib, perl }:
 
 let version = "7.0.0";
 in
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
 
-  buildInputs = [ pcre zlib libjpeg ];
+  buildInputs = [ zlib libjpeg ];
 
   postPatch = ''
     patchShebangs qpdf/fix-qdf
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://qpdf.sourceforge.net/;
     description = "A C++ library and set of programs that inspect and manipulate the structure of PDF files";
-    license = licenses.artistic2;
+    license = licenses.asl20; # as of 7.0.0, people may stay at artistic2
     maintainers = with maintainers; [ abbradar ];
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, libjpeg, zlib, perl }:
 
-let version = "7.0.0";
+let version = "7.1.1";
 in
 stdenv.mkDerivation rec {
   name = "qpdf-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/qpdf/qpdf/${version}/${name}.tar.gz";
-    sha256 = "0py6p27fx4qrwq9mvcybna42b0bdi359x38lzmggxl5a9khqvl7y";
+    sha256 = "1ypjxm74dhn9c4mj027zzkh0z4kpw9xiqwh3pjmmghm502hby3ca";
   };
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchurl, pcre, zlib, perl }:
+{ stdenv, fetchurl, libjpeg, pcre, zlib, perl }:
 
-let version = "6.0.0";
+let version = "7.0.0";
 in
 stdenv.mkDerivation rec {
   name = "qpdf-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/qpdf/qpdf/${version}/${name}.tar.gz";
-    sha256 = "0csj2p2gkxrc0rk8ykymlsdgfas96vzf1dip3y1x7z1q9plwgzd9";
+    sha256 = "0py6p27fx4qrwq9mvcybna42b0bdi359x38lzmggxl5a9khqvl7y";
   };
 
   nativeBuildInputs = [ perl ];
 
-  buildInputs = [ pcre zlib ];
+  buildInputs = [ pcre zlib libjpeg ];
 
   postPatch = ''
     patchShebangs qpdf/fix-qdf


### PR DESCRIPTION
###### Motivation for this change

This also includes the backporting of security fixes we never ported (CVE-2017-11624,CVE-2017-11625,CVE-2017-11626,CVE-2017-11627,CVE-2017-12595,CVE-2017-9208,CVE-2017-9209,CVE-2017-9210 from 6060847)

The 7.1.1 update just ensures we are at the latest stable version. Since there is not API breakage this should be fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

