### PR TITLE
Fixes for extra flags handling in nixos-install

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -163,7 +163,7 @@ mkfifo $system_closure
 
 if [ -z "$closure" ]; then
     expr="(import <nixpkgs/nixos> {}).system"
-    system_root="$(nix-build -E "$expr")"
+    system_root="$(nix-build "${extraBuildFlags[@]}" -E "$expr")"
     system_closure="$(closure "$expr")"
 else
     system_root=$closure


### PR DESCRIPTION
###### Motivation for this change

This allows to use `--option binary-caches` for `nixos-install`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

