### PR TITLE
Ocaml Janestreet Packages: fix installation path of stub dlls.

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -238,6 +238,10 @@ rec {
     name = "ppx_expect";
     hash = "1bik53k51wcqv088f0h10n3ms9h51yvg6ha3g1s903i2bxr3xs6b";
     propagatedBuildInputs = [ ppx_inline_test ppx_fields_conv ppx_custom_printf ppx_assert ppx_variants_conv re ];
+    moveStubs = ''
+      mv "$out/lib/ocaml/${ocaml.version}/site-lib/stubslibs/dllexpect_test_collector_stubs.so" "$out/lib/ocaml/${ocaml.version}/site-lib/ppx_expect/collector/dllexpect_test_collector_stubs.so"
+    '';
+
     meta.description = "Cram like framework for OCaml";
   };
 

--- a/pkgs/development/ocaml-modules/janestreet/janePackage.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchFromGitHub, ocaml, jbuilder, findlib }:
+{ stdenv, fetchFromGitHub, ocaml, jbuilder, findlib, opam }:
 
-{ name, version ? "0.9.0", buildInputs ? [], hash, meta, ...}@args:
+{ name, version ? "0.9.0", buildInputs ? [], hash, meta, moveStubs ? null,
+  ...}@args:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.03"
 then throw "${name}-${version} is not available for OCaml ${ocaml.version}" else
@@ -18,7 +19,22 @@ stdenv.mkDerivation (args // {
 
   buildInputs = [ ocaml jbuilder findlib ] ++ buildInputs;
 
-  inherit (jbuilder) installPhase;
+  installPhase =
+    let defaultMoveStubs = ''
+    stubslibs="$out/lib/ocaml/${ocaml.version}/site-lib/stubslibs"
+    if [ -d $stubslibs ]
+    then
+      for dll in $stubslibs/dll*.so
+      do
+        mv $dll $OCAMLFIND_DESTDIR/${name}
+      done
+    fi
+    '';
+    in
+    ''
+    ${opam}/bin/opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR
+    '' +
+    args.moveStubs or defaultMoveStubs;
 
   meta = {
     license = stdenv.lib.licenses.asl20;


### PR DESCRIPTION
###### Motivation for this change

The install phase of Jane Street's ocaml packages puts any .so libs in site-lib/stublibs, while findlib (?) looks for them in site-lib/$name. This moves the .so where they should be.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

