### PR TITLE
zsh-autoenv: init at 2017-12-16

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -114,6 +114,7 @@
   ./programs/yabar.nix
   ./programs/zsh/oh-my-zsh.nix
   ./programs/zsh/zsh.nix
+  ./programs/zsh/zsh-autoenv.nix
   ./programs/zsh/zsh-syntax-highlighting.nix
   ./rename.nix
   ./security/acme.nix

--- a/nixos/modules/programs/zsh/zsh-autoenv.nix
+++ b/nixos/modules/programs/zsh/zsh-autoenv.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.zsh.zsh-autoenv;
+in {
+  options = {
+    programs.zsh.zsh-autoenv = {
+      enable = mkEnableOption "zsh-autoenv";
+      package = mkOption {
+        default = pkgs.zsh-autoenv;
+        defaultText = "pkgs.zsh-autoenv";
+        description = ''
+          Package to install for `zsh-autoenv` usage.
+        '';
+
+        type = types.package;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.zsh.interactiveShellInit = ''
+      source ${cfg.package}/share/zsh-autoenv/autoenv.zsh
+    '';
+  };
+}

--- a/pkgs/tools/misc/zsh-autoenv/default.nix
+++ b/pkgs/tools/misc/zsh-autoenv/default.nix
@@ -1,0 +1,34 @@
+{stdenv, fetchFromGitHub, bash}: stdenv.mkDerivation rec {
+  name = "zsh-autoenv-${version}";
+  version = "2017-12-16";
+  src = fetchFromGitHub {
+    owner = "Tarrasch";
+    repo = "zsh-autoenv";
+    rev = "2c8cfbcea8e7286649840d7ec98d7e9d5e1d45a0";
+    sha256 = "004svkfzhc3ab6q2qvwzgj36wvicg5bs8d2gcibx6adq042di7zj";
+  };
+  buildPhase = "true";
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp -R $src $out/share/zsh-autoenv
+
+    cat <<SCRIPT > $out/bin/zsh-autoenv-share
+    #!${stdenv.shell}
+    # Run this script to find the fzf shared folder where all the shell
+    # integration scripts are living.
+    echo $out/share/zsh-autoenv
+    SCRIPT
+    chmod +x $out/bin/zsh-autoenv-share
+  '';
+  meta = {
+    description = "zsh-autoenv automatically sources whitelisted .autoenv.zsh files";
+    longDescription = ''
+      zsh-autoenv automatically sources (known/whitelisted)
+      .autoenv.zsh files, typically used in project root directories.
+      It handles "enter" and "leave" events, nesting, and stashing of
+      variables (overwriting and restoring).
+    '';
+    homepage = https://github.com/Tarrasch/zsh-autoenv;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/tools/misc/zsh-autoenv/default.nix
+++ b/pkgs/tools/misc/zsh-autoenv/default.nix
@@ -1,13 +1,18 @@
-{stdenv, fetchFromGitHub, bash}: stdenv.mkDerivation rec {
+{ stdenv, fetchFromGitHub, bash }:
+
+stdenv.mkDerivation rec {
   name = "zsh-autoenv-${version}";
   version = "2017-12-16";
+
   src = fetchFromGitHub {
     owner = "Tarrasch";
     repo = "zsh-autoenv";
     rev = "2c8cfbcea8e7286649840d7ec98d7e9d5e1d45a0";
     sha256 = "004svkfzhc3ab6q2qvwzgj36wvicg5bs8d2gcibx6adq042di7zj";
   };
-  buildPhase = "true";
+
+  buildPhase = ":";
+
   installPhase = ''
     mkdir -p $out/{bin,share}
     cp -R $src $out/share/zsh-autoenv
@@ -20,8 +25,9 @@
     SCRIPT
     chmod +x $out/bin/zsh-autoenv-share
   '';
-  meta = {
-    description = "zsh-autoenv automatically sources whitelisted .autoenv.zsh files";
+
+  meta = with stdenv.lib; {
+    description = "Automatically sources whitelisted .autoenv.zsh files";
     longDescription = ''
       zsh-autoenv automatically sources (known/whitelisted)
       .autoenv.zsh files, typically used in project root directories.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5544,6 +5544,8 @@ with pkgs;
   zpaq = callPackage ../tools/archivers/zpaq { };
   zpaqd = callPackage ../tools/archivers/zpaq/zpaqd.nix { };
 
+  zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };
+
   zsh-git-prompt = callPackage ../shells/zsh-git-prompt { };
 
   zsh-navigation-tools = callPackage ../tools/misc/zsh-navigation-tools { };


### PR DESCRIPTION
###### Motivation for this change

`zsh-autoenv` is a tool that automatically sources (known/whitelisted) .autoenv.zsh files, typically used in project root directories. It's a nice tool to have in zsh toolbox.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

