### PR TITLE
ipxe: enable parallel building; allow embed script

### DIFF
--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchgit, perl, cdrkit, syslinux, xz, openssl }:
+{ stdenv, lib, fetchgit, perl, cdrkit, syslinux, xz, openssl
+, embedScript ? null
+}:
 
 let
   date = "20170922";
@@ -24,7 +26,7 @@ stdenv.mkDerivation {
   makeFlags =
     [ "ECHO_E_BIN_ECHO=echo" "ECHO_E_BIN_ECHO_E=echo" # No /bin/echo here.
       "ISOLINUX_BIN_LIST=${syslinux}/share/syslinux/isolinux.bin"
-    ];
+    ] ++ lib.optional (embedScript != null) "EMBED=${embedScript}";
 
 
   enabledOptions = [ "DOWNLOAD_PROTO_HTTPS" ];
@@ -45,6 +47,8 @@ stdenv.mkDerivation {
     # let's provide it as a symlink to be compatible in this case.
     ln -s undionly.kpxe $out/undionly.kpxe.0
   '';
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib;
     { description = "Network boot firmware";


### PR DESCRIPTION
###### Motivation for this change
Faster builds, and support for embedded scripts.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).