### PR TITLE
kde_frameworks: 5.42 -> 5.43

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.42/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.43/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/kglobalaccel.nix
+++ b/pkgs/development/libraries/kde-frameworks/kglobalaccel.nix
@@ -13,8 +13,4 @@ mkDerivation {
     qtx11extras
   ];
   propagatedBuildInputs = [ qtbase ];
-  postPatch = ''
-    sed -i src/runtime/org.kde.kglobalaccel.service.in \
-        -e "s|@CMAKE_INSTALL_PREFIX@|''${!outputBin}|"
-  '';
 }

--- a/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
+++ b/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
@@ -4,7 +4,7 @@
   kactivities, karchive, kconfig, kconfigwidgets, kcoreaddons, kdbusaddons,
   kdeclarative, kglobalaccel, kguiaddons, ki18n, kiconthemes, kio,
   knotifications, kpackage, kservice, kwayland, kwindowsystem, kxmlgui,
-  qtbase, qtdeclarative, qtscript, qtx11extras, kirigami2
+  qtbase, qtdeclarative, qtscript, qtx11extras, kirigami2, qtquickcontrols2
 }:
 
 mkDerivation {
@@ -15,6 +15,7 @@ mkDerivation {
     kactivities karchive kconfig kconfigwidgets kcoreaddons kdbusaddons
     kdeclarative kglobalaccel kguiaddons ki18n kiconthemes kio knotifications
     kwayland kwindowsystem kxmlgui qtdeclarative qtscript qtx11extras kirigami2
+    qtquickcontrols2
   ];
   propagatedBuildInputs = [ kpackage kservice qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,611 +3,627 @@
 
 {
   attica = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/attica-5.42.0.tar.xz";
-      sha256 = "0icjsk5sbri6nwybb2301wc6ysc1h4p35rxqp0adifyksq8akyxd";
-      name = "attica-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/attica-5.43.0.tar.xz";
+      sha256 = "1vvf5d0dnfm69gahrhndy9jqxk7hkh5vj6z9pyprpl3zp5z1ki1a";
+      name = "attica-5.43.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/baloo-5.42.0.tar.xz";
-      sha256 = "18yknkcls1ypsp8n5l254bhlffiq4as5w1wgcjzhnf49cacys8nl";
-      name = "baloo-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/baloo-5.43.0.tar.xz";
+      sha256 = "095z6w5qyq4z2hkdxq0vizfgv1v6g9w960wrh78b6bi1bf4ig2np";
+      name = "baloo-5.43.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/bluez-qt-5.42.0.tar.xz";
-      sha256 = "0pbb0nn70hbsnp9q8jvqr3s85gh4bnnh1mp8xfkia2hp4c63ws9f";
-      name = "bluez-qt-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/bluez-qt-5.43.0.tar.xz";
+      sha256 = "04bsrp0biyn7b630hywk82rwn8kl8c2rwh8iwhjz35b51jjqm2b5";
+      name = "bluez-qt-5.43.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/breeze-icons-5.42.0.tar.xz";
-      sha256 = "0mrj0b022yfy669qqby09k4ij6aqyky23gpnjcp85df9saq0x44r";
-      name = "breeze-icons-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/breeze-icons-5.43.0.tar.xz";
+      sha256 = "19yy6pcqjfbjxlkkf4g1hcgl3lv4m640sl26nblrydn9qyj5iniy";
+      name = "breeze-icons-5.43.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/extra-cmake-modules-5.42.0.tar.xz";
-      sha256 = "1ml6s3ssr5izm3vnzlg5gn2nkcbz5l5nmapvyr4ml7n0089b43a3";
-      name = "extra-cmake-modules-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/extra-cmake-modules-5.43.0.tar.xz";
+      sha256 = "1zgzjh5q1ppgfzj4mhprgd4848iwjnzqsnilb0dk5rgdrvfsamsp";
+      name = "extra-cmake-modules-5.43.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/frameworkintegration-5.42.0.tar.xz";
-      sha256 = "17fyny3c5chv7bipr19ayfjmd1amp2nms4ba5r7mwjp97xkphry7";
-      name = "frameworkintegration-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/frameworkintegration-5.43.0.tar.xz";
+      sha256 = "0qjpk4lslpxqj5aisczm5kl201g4z3grgjhx38r1ih4hyp805vw0";
+      name = "frameworkintegration-5.43.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kactivities-5.42.0.tar.xz";
-      sha256 = "0z0ac426npq99s1b8yzrqkjjjc34nbxlpw8pw388yj7fa41hw21r";
-      name = "kactivities-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kactivities-5.43.0.tar.xz";
+      sha256 = "0rmmyjfgz8ybvdgpbqndsn0gxizxpmwhvglnnl8ia1s4sna6sjby";
+      name = "kactivities-5.43.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kactivities-stats-5.42.0.tar.xz";
-      sha256 = "0si70hayf4brr83jzdjdsfvp8nc1sb7vdk0q532liafhf8hw9mq8";
-      name = "kactivities-stats-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kactivities-stats-5.43.0.tar.xz";
+      sha256 = "1rrn1dxsiyvyf3pa5fyxa0sfbamv5c6g95s4f144xwrx2b130rh1";
+      name = "kactivities-stats-5.43.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kapidox-5.42.0.tar.xz";
-      sha256 = "0izyd66p5403gl09l7irzy97mb9b14n4zyjrwap800zjlpwh41pz";
-      name = "kapidox-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kapidox-5.43.0.tar.xz";
+      sha256 = "0c358ply0qzg269vxyg6py6l8z5j8l4h6apqcynyql4dbbbm8941";
+      name = "kapidox-5.43.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/karchive-5.42.0.tar.xz";
-      sha256 = "1vq2ngdxmdl6hzjwdcrv66ban8v9s5jiqwy1mgdqv4ak14l31qbi";
-      name = "karchive-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/karchive-5.43.0.tar.xz";
+      sha256 = "1f3pqhpdgn00ni05iflyydkmsf3vd403ma5f42zj00kh30l9lqqf";
+      name = "karchive-5.43.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kauth-5.42.0.tar.xz";
-      sha256 = "04kqb2hhr9lkpkxiaqlnyk0kmk6p89z5fgp5i5g83hsi8maz7swi";
-      name = "kauth-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kauth-5.43.0.tar.xz";
+      sha256 = "05w8vx45mrf32kzcyjmay1k9dw3j8axbrrp6infg0hhfsgk04w1f";
+      name = "kauth-5.43.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kbookmarks-5.42.0.tar.xz";
-      sha256 = "08q413mr5ib04gwnqznvm9vkkfmnh16rgf6rqdvclnci9w7ml5x2";
-      name = "kbookmarks-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kbookmarks-5.43.0.tar.xz";
+      sha256 = "0i7rfahn32m6xpbwra5m5nnpgq8l56jm0ijsq6f80cx8ww3nkcq5";
+      name = "kbookmarks-5.43.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kcmutils-5.42.0.tar.xz";
-      sha256 = "1q67b0m6w3xvm22kq8b0b0rib1jzf25gf6dz7h286987zfbbs5n7";
-      name = "kcmutils-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kcmutils-5.43.0.tar.xz";
+      sha256 = "1dshx859k64yp00s5xx7z6x0wlawxyq41rg795nqizhk2s76agr2";
+      name = "kcmutils-5.43.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kcodecs-5.42.0.tar.xz";
-      sha256 = "0b19z432r9dnyjknvwffhcmrg969yhydjvy4qrkrf22026f4smwc";
-      name = "kcodecs-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kcodecs-5.43.0.tar.xz";
+      sha256 = "0ncrzxvy2l324yvlzha9hkyp5qq75wfb9cbnxb5mygispxhrgh2v";
+      name = "kcodecs-5.43.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kcompletion-5.42.0.tar.xz";
-      sha256 = "0yqci2v0dk5v1mz4n3gca599a7mpihy563zc6sl8hsa30ld8li0f";
-      name = "kcompletion-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kcompletion-5.43.0.tar.xz";
+      sha256 = "065nzw26ps367lf3m1j6x95swk0f6grap71wjjv688gablcaz699";
+      name = "kcompletion-5.43.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kconfig-5.42.0.tar.xz";
-      sha256 = "08gg0d20c09j7hyxm8ydpzk2yf30c87g9ag7a9nfykrmi6cqirdq";
-      name = "kconfig-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kconfig-5.43.0.tar.xz";
+      sha256 = "1na1b2dsajl9b9rn2990fd8cqqaj2iwddrxjacbf0ib5mray1sr2";
+      name = "kconfig-5.43.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kconfigwidgets-5.42.0.tar.xz";
-      sha256 = "191zm24q2n001b65hcnfh2639k4iqhxwdmgdw29php3n2648xq4z";
-      name = "kconfigwidgets-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kconfigwidgets-5.43.0.tar.xz";
+      sha256 = "1qxv8m614y0j687gwcsqqkwcdwsbbwc7ivwx6l9djll4r7r1d43w";
+      name = "kconfigwidgets-5.43.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kcoreaddons-5.42.0.tar.xz";
-      sha256 = "17qv7r6z72mm9a0hyx5dgk90ikhhgm41bkvnq2hjal0py2lsnrs9";
-      name = "kcoreaddons-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kcoreaddons-5.43.0.tar.xz";
+      sha256 = "10pgja1v2x5q6jyajld3yq116g1m90djnbf6p35i6n9ng65h0zy6";
+      name = "kcoreaddons-5.43.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kcrash-5.42.0.tar.xz";
-      sha256 = "049y0xdyw37y0qid3d3plj8szfys5gw98j7lhcakiini8mn5cins";
-      name = "kcrash-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kcrash-5.43.0.tar.xz";
+      sha256 = "1hvfhr3s0igc1n37w5fxx0jivsgvcdvpa5iywnkk4g1r1l6snx1b";
+      name = "kcrash-5.43.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kdbusaddons-5.42.0.tar.xz";
-      sha256 = "1613pc3r70jnzvpwm1xjdbdsmcpx28jwvcs2qq9swlywr5qr9hbd";
-      name = "kdbusaddons-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kdbusaddons-5.43.0.tar.xz";
+      sha256 = "1h4m6ra1cangvqyzmkxkh1fld4rlvxnzz8wny53drgbyrsq2xxv5";
+      name = "kdbusaddons-5.43.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kdeclarative-5.42.0.tar.xz";
-      sha256 = "1w604jy6vg2247vggz0ivl7wy2h5iapkz2z86mah3aw99f7dqa22";
-      name = "kdeclarative-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kdeclarative-5.43.0.tar.xz";
+      sha256 = "0jbm2ih9hzpnfaqc867fvwr414q78f9jjk6yyf1cjgq8vx8rmjq1";
+      name = "kdeclarative-5.43.0.tar.xz";
     };
   };
   kded = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kded-5.42.0.tar.xz";
-      sha256 = "0w25dl4pnvby28gz0yvij32vi9n3p8si4nm4x45j7zsi2cb70j4l";
-      name = "kded-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kded-5.43.0.tar.xz";
+      sha256 = "1kfli2f4hxc9a0hk75kgln3x374y4av6hfajhncwyq37zd4wxq3r";
+      name = "kded-5.43.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/portingAids/kdelibs4support-5.42.0.tar.xz";
-      sha256 = "0aiig8akn6bdxrqdl96xjjy2pxw8hhfrsalbkkzyhh06j794snfb";
-      name = "kdelibs4support-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/portingAids/kdelibs4support-5.43.0.tar.xz";
+      sha256 = "1rwk436vpny3sq12bjqwapjicc3inyrq6dn34a6mr6gjcd5p2mch";
+      name = "kdelibs4support-5.43.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kdesignerplugin-5.42.0.tar.xz";
-      sha256 = "004axa1fkj954d65x7l9z8dmw04209hb368rwa4gjzb8naf13ib6";
-      name = "kdesignerplugin-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kdesignerplugin-5.43.0.tar.xz";
+      sha256 = "0pk95vsgj67jw0qaalcrfvzkr9flxh6shkkmlaxclrz6yhnf9axz";
+      name = "kdesignerplugin-5.43.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kdesu-5.42.0.tar.xz";
-      sha256 = "0402p1h7wifk6sppg7ca9w0zfjllbhc1j5gsxj7ypq55g94np7hx";
-      name = "kdesu-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kdesu-5.43.0.tar.xz";
+      sha256 = "1mll18ms5zk7i4lpkj6qdcxwaf0h52h9mi47y882hzqkvvbnk4d6";
+      name = "kdesu-5.43.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kdewebkit-5.42.0.tar.xz";
-      sha256 = "1csd4p996im7ygxc5rfdkzgdpngjgzyqakj12rl9rnfbsd15i8kb";
-      name = "kdewebkit-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kdewebkit-5.43.0.tar.xz";
+      sha256 = "0yi7dv77flz7z1yjzlvrfvlybp7knz808hpfbr6hxgrp1gwi7h6b";
+      name = "kdewebkit-5.43.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kdnssd-5.42.0.tar.xz";
-      sha256 = "1k1rz62h3mafliik5n0k98dc56b5v2v6qyqj40696mcyc2d1yvll";
-      name = "kdnssd-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kdnssd-5.43.0.tar.xz";
+      sha256 = "0d58aaii1r2x3nmw9s2hnk178sr54yvrqi22ry3xm3v7yvx9jr3b";
+      name = "kdnssd-5.43.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kdoctools-5.42.0.tar.xz";
-      sha256 = "1bby3avdllch1mji0mxzcix8q5yir5a0i6wpjs5lwckv1glh6kmz";
-      name = "kdoctools-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kdoctools-5.43.0.tar.xz";
+      sha256 = "1llif166p17ffjwsgvb0n9lq8ip3if0hqma9zm9jpghm5j21q1jh";
+      name = "kdoctools-5.43.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kemoticons-5.42.0.tar.xz";
-      sha256 = "0f6an1bwxnga41a2b35b2pdcni4p0hh76k4jvanl3g046v07f2wr";
-      name = "kemoticons-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kemoticons-5.43.0.tar.xz";
+      sha256 = "161n9xg82gxvl4a4by328llxz0x4w643vcxi88414zg1bm1z1cfb";
+      name = "kemoticons-5.43.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kfilemetadata-5.42.0.tar.xz";
-      sha256 = "03wk38q3sq354ykz9dwbgykn73ldf94ryx6hxvpr66bq3a59jmwz";
-      name = "kfilemetadata-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kfilemetadata-5.43.0.tar.xz";
+      sha256 = "1lxbj8fnaf6sybxgyq6h1qnic65l0mdhhxlw1djd16c7ih7ghrnq";
+      name = "kfilemetadata-5.43.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kglobalaccel-5.42.0.tar.xz";
-      sha256 = "0nlza73i0qd79yhwhpnvgbh2xa9lvd1n2xg25p3bvfzwidcfdxg6";
-      name = "kglobalaccel-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kglobalaccel-5.43.0.tar.xz";
+      sha256 = "00ygkszkklaz7k4hkshcb5gfynha8rncwvj7z9jvhd9chmwkiffc";
+      name = "kglobalaccel-5.43.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kguiaddons-5.42.0.tar.xz";
-      sha256 = "193i8b4f13dkgp88m3pk9wzi0dhx7qmsnmpizxia3457gg016wn7";
-      name = "kguiaddons-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kguiaddons-5.43.0.tar.xz";
+      sha256 = "0z6sf4pr4ykhlzdckyfap2f41y2chrl2kwlrb4djflfxf7q2xcqr";
+      name = "kguiaddons-5.43.0.tar.xz";
+    };
+  };
+  kholidays = {
+    version = "5.43.0";
+    src = fetchurl {
+      url = "${mirror}/stable/frameworks/5.43/kholidays-5.43.0.tar.xz";
+      sha256 = "0zkjh7y0gdwakil6dj0z8yi2zzczzvdfhmnsd54s5yn0fvv37xbk";
+      name = "kholidays-5.43.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/portingAids/khtml-5.42.0.tar.xz";
-      sha256 = "1bfslndxvad0zgzr22w2mz1xwavix9bh5qrrv8dpshlh043bwr3l";
-      name = "khtml-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/portingAids/khtml-5.43.0.tar.xz";
+      sha256 = "034aycdi7i6pvwkwz632nzk3vp8040hlvmzpp38nsy4idl4klh46";
+      name = "khtml-5.43.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/ki18n-5.42.0.tar.xz";
-      sha256 = "1rpriflb2a48j94zxgh63l6rzq4nlnlkvy89ns1vkdw42bnqrjx9";
-      name = "ki18n-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/ki18n-5.43.0.tar.xz";
+      sha256 = "1zspxv6z4a3rarrn9n38g7rp0gc48bl4kih91m3r2nkap83jb04a";
+      name = "ki18n-5.43.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kiconthemes-5.42.0.tar.xz";
-      sha256 = "1nbxxpf8bv835xl35b17rk8s3zs110bh31078kqqh7dhvwzlxic7";
-      name = "kiconthemes-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kiconthemes-5.43.0.tar.xz";
+      sha256 = "105c892d4np4lshmd5f5x74m1ib3fbmvwgjzf6j317mq261r3rsw";
+      name = "kiconthemes-5.43.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kidletime-5.42.0.tar.xz";
-      sha256 = "019r41r28pcrcn1kwxsll53za705jkc9n23b6sr2lplgjk05bcxh";
-      name = "kidletime-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kidletime-5.43.0.tar.xz";
+      sha256 = "1jm2rdbzffnw0fv1pzfyz5lvzaa3x2pfp12zm9kl7skyj39z5vbj";
+      name = "kidletime-5.43.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kimageformats-5.42.0.tar.xz";
-      sha256 = "1k67yrmszx7azjzrg478rimbz991lghx4d6dmg22p6dknajd78a6";
-      name = "kimageformats-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kimageformats-5.43.0.tar.xz";
+      sha256 = "1bn4rx5xx68m101n3ba774pd8qddaw3bwf2bc7zp7gi6d8bprh9i";
+      name = "kimageformats-5.43.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kinit-5.42.0.tar.xz";
-      sha256 = "05vpac41pw1n8y58l2z08vyknzv950x8dxxw66dnymm2v31w07ia";
-      name = "kinit-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kinit-5.43.0.tar.xz";
+      sha256 = "1jrzr4kv84rvf214wszd2zdnvlx2qxvr1ah9f564h23vvdrg79gd";
+      name = "kinit-5.43.0.tar.xz";
     };
   };
   kio = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kio-5.42.0.tar.xz";
-      sha256 = "1526a89x11ank55dp3rfp7xd04w8x7prjg3y6i7n2q9nabwhw7gc";
-      name = "kio-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kio-5.43.0.tar.xz";
+      sha256 = "1mbjld1kh5hhslfm4rx9nddghkcgrxbw2pf39c7niq0r1llx5v76";
+      name = "kio-5.43.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kirigami2-5.42.0.tar.xz";
-      sha256 = "11gqn7amp0r9bgh8ldgisfc2lrkzkn5mq2a1madf24nvjbkvqnqv";
-      name = "kirigami2-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kirigami2-5.43.0.tar.xz";
+      sha256 = "0vshabb1q5pjscw0g57l7lpaal69g1mdpf01w0yskmbiqnzzpjl0";
+      name = "kirigami2-5.43.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kitemmodels-5.42.0.tar.xz";
-      sha256 = "0mcdzdqwmvf9pwirsrnjbhrgqphnfmanbl9zij4qsmin8n866mhc";
-      name = "kitemmodels-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kitemmodels-5.43.0.tar.xz";
+      sha256 = "1yw7h7g0knlljizsf9cir196v22cqhlaazmrbm6jqz198g47sqdd";
+      name = "kitemmodels-5.43.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kitemviews-5.42.0.tar.xz";
-      sha256 = "1j1q0b08f8mnfc3r2a7rplyb2nv9f0aq5a3fxskinvg70c6y248w";
-      name = "kitemviews-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kitemviews-5.43.0.tar.xz";
+      sha256 = "19w6xhhxr7w40baw6i6lfq0fd7bahxfzr7pj10mrwb5i6bcbsk1h";
+      name = "kitemviews-5.43.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kjobwidgets-5.42.0.tar.xz";
-      sha256 = "1m3csdl7wh18ywv5p0qpbjpixvflgjcq3yvk3vlvh0sxxlwcz8k4";
-      name = "kjobwidgets-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kjobwidgets-5.43.0.tar.xz";
+      sha256 = "1kri6z737abwsglh29bh4kckbf1ici8n162lcyvw8b3w91l4dyc6";
+      name = "kjobwidgets-5.43.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/portingAids/kjs-5.42.0.tar.xz";
-      sha256 = "1m26sb2qyrcgmpkw76k2yv5my2pkhld96vw6aaqm77q90faw734g";
-      name = "kjs-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/portingAids/kjs-5.43.0.tar.xz";
+      sha256 = "1jdqdy1kxarv6k31yd0k280jyfy7y3qwgd9c7is7aya1ns46nx59";
+      name = "kjs-5.43.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/portingAids/kjsembed-5.42.0.tar.xz";
-      sha256 = "10w4w4ncwr245bv1ii4sh154w91ghfz0l60k89j50lsydpcqcp3a";
-      name = "kjsembed-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/portingAids/kjsembed-5.43.0.tar.xz";
+      sha256 = "11hcwwhkrl7sns4s36nxnp550n9xvky1rkrissm0mqh76309g6hy";
+      name = "kjsembed-5.43.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/portingAids/kmediaplayer-5.42.0.tar.xz";
-      sha256 = "1k1pjc0cz36gs0pl2pxw8f9f82xkbqyy320nfyhan5waxbl1qd5n";
-      name = "kmediaplayer-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/portingAids/kmediaplayer-5.43.0.tar.xz";
+      sha256 = "1q1s5v3fqnmxx58ixgdhkhrgkrdxy8mq8hg4ll7l6038lgycfsxf";
+      name = "kmediaplayer-5.43.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/knewstuff-5.42.0.tar.xz";
-      sha256 = "0i2gmyp67xzf2m5wnv7v574q3gsp1yxfflv1jgl0wy57vchwn9g6";
-      name = "knewstuff-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/knewstuff-5.43.0.tar.xz";
+      sha256 = "1v3wzydi1jqb9an2bnxzfhwxhlb2lj8l735mdhym4859njj8x7w7";
+      name = "knewstuff-5.43.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/knotifications-5.42.0.tar.xz";
-      sha256 = "0awmwypmd104vhaj2v9k83niflxj26d4mbl6mzfcj75lgka6kffc";
-      name = "knotifications-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/knotifications-5.43.0.tar.xz";
+      sha256 = "0kgn5h38z9xd5a210w989j3z0khs4l9ahf19lqfara1ziwl4gaiv";
+      name = "knotifications-5.43.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/knotifyconfig-5.42.0.tar.xz";
-      sha256 = "1h07bjj71611v6912m5ajli6qszh9w925zqbk3vih8rn6pd2s3mc";
-      name = "knotifyconfig-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/knotifyconfig-5.43.0.tar.xz";
+      sha256 = "0nrjxs263sp64h9pmrmr7fjkbpkalzr6crpyq0aqclciwfjpj326";
+      name = "knotifyconfig-5.43.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kpackage-5.42.0.tar.xz";
-      sha256 = "10amhh07x8d0jkyylb19cyzjs71k8dq1y8isfahqzb2kd43vijqa";
-      name = "kpackage-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kpackage-5.43.0.tar.xz";
+      sha256 = "1nr7zkqp7zbvyrhc7iqznyqnfhmnqhhaqs30ig4gwsagq3x2a02b";
+      name = "kpackage-5.43.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kparts-5.42.0.tar.xz";
-      sha256 = "1mb5gp2ckmmrb4ym7cqvyl81wnp7cryk85gmizl7cnn69svlf40h";
-      name = "kparts-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kparts-5.43.0.tar.xz";
+      sha256 = "09i2ds6xgkbm9k9nd9yj1p3qw9xl3a25lh97ln9c39ccx32i32wd";
+      name = "kparts-5.43.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kpeople-5.42.0.tar.xz";
-      sha256 = "050km3rpx58acx2341si46lxc2hywa59m8rwd849c2dnsxw3w1hm";
-      name = "kpeople-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kpeople-5.43.0.tar.xz";
+      sha256 = "0xi6sxprqvmjc30cw1rfpryahid9dswql6b1wrdv5wsmci8k4xmq";
+      name = "kpeople-5.43.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kplotting-5.42.0.tar.xz";
-      sha256 = "109b9grshrwralyp8ilkbf1k0akaggygqh6wafqdf0ris0ps13l9";
-      name = "kplotting-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kplotting-5.43.0.tar.xz";
+      sha256 = "0d5mf5xaysw837ninvdx1hfra8qjaxd9lcm28fyjfm506iq8v09f";
+      name = "kplotting-5.43.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kpty-5.42.0.tar.xz";
-      sha256 = "07s16zxs03ixy7yxy9fda83yqhcgqzx42gnvwjwkyc8q05njmma6";
-      name = "kpty-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kpty-5.43.0.tar.xz";
+      sha256 = "09m02ramzk6jc9scnsvcm2sgnia2vmnnfgmjsddspc2kp1aj2km8";
+      name = "kpty-5.43.0.tar.xz";
     };
   };
   kross = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/portingAids/kross-5.42.0.tar.xz";
-      sha256 = "1aqqwby6jslimpvx42d4n6gjsjc8l82gmsq5ajpv9zkkk91dqfqi";
-      name = "kross-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/portingAids/kross-5.43.0.tar.xz";
+      sha256 = "05px64msss6as0pbrpl6l4y2n97kayphxqhwfilgsj9yjmyhm46h";
+      name = "kross-5.43.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/krunner-5.42.0.tar.xz";
-      sha256 = "0xh9kss67l09am1ilsr9zyx1yhlmaq3g9x60hw0sx7h7wrl6zsw6";
-      name = "krunner-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/krunner-5.43.0.tar.xz";
+      sha256 = "1wiaaz7wc2ls0gxyyws7cw6gmphkzayhdz1xxsyn4bzrc1h3z7dw";
+      name = "krunner-5.43.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kservice-5.42.0.tar.xz";
-      sha256 = "0z8zfpd00ndvkm1klp8l4mrcksshhyg280zgmg3gffz5rgh3gwri";
-      name = "kservice-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kservice-5.43.0.tar.xz";
+      sha256 = "1mdxd8kxawlhrsnd9lrx6cx9p8gvvsr9mx2d1s0bi90kapfqyqi3";
+      name = "kservice-5.43.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/ktexteditor-5.42.0.tar.xz";
-      sha256 = "020y3j6vm15sfpiwainr3qsx9i93j15mrvq523wmbmdj1z36yrh2";
-      name = "ktexteditor-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/ktexteditor-5.43.0.tar.xz";
+      sha256 = "1rhw1y0js2vjjp7c9f539lvqvci4nrgdicaypw3p5ndg8vsw2xag";
+      name = "ktexteditor-5.43.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/ktextwidgets-5.42.0.tar.xz";
-      sha256 = "088azbv95ycwxmxxw4l63i2l14fmn8l473pb4djh2mvz1ypfqayk";
-      name = "ktextwidgets-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/ktextwidgets-5.43.0.tar.xz";
+      sha256 = "0h5bxf1a9mik2p2xhnm7nnr0r54s6zf4cby4qd8nlwl292dyf8gy";
+      name = "ktextwidgets-5.43.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kunitconversion-5.42.0.tar.xz";
-      sha256 = "0219pna4l3vvhyf5acsc87n48jzdnws6kwyhaiy3hy1pzrilv32l";
-      name = "kunitconversion-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kunitconversion-5.43.0.tar.xz";
+      sha256 = "14syfc9vybmaais740xmb79g7ffpyanwkb2blar88zm810dpshqd";
+      name = "kunitconversion-5.43.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kwallet-5.42.0.tar.xz";
-      sha256 = "1kv3v7593srfn0wd7qp4rhvb30rxp7d2qmlwi0n4nc9s6v59pabn";
-      name = "kwallet-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kwallet-5.43.0.tar.xz";
+      sha256 = "01mxl06nbpgkp6dva1kvqcbhjahgjqkbql6rhwgdyhb4asabnsmj";
+      name = "kwallet-5.43.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kwayland-5.42.0.tar.xz";
-      sha256 = "0wr6ygppahxsx3dh71h2wmybv7z7iyqdv7wn80cxb0mp4zpyinh7";
-      name = "kwayland-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kwayland-5.43.0.tar.xz";
+      sha256 = "0glp9bnv53jjycwni0ywd7apr0jps3j0hpzs14y2v9bp4mwjgaji";
+      name = "kwayland-5.43.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.42.1";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kwidgetsaddons-5.42.1.tar.xz";
-      sha256 = "0h0vfrfl5zi01fpvmd825kazzlyawz3i66qrfkymdrnvqmfzcmlg";
-      name = "kwidgetsaddons-5.42.1.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kwidgetsaddons-5.43.0.tar.xz";
+      sha256 = "15x7k953jj6vqmb2bbw4wad2n10akkg4i5n0gmkj4fsaiag359sr";
+      name = "kwidgetsaddons-5.43.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kwindowsystem-5.42.0.tar.xz";
-      sha256 = "15k6x0f93qxka3mz7qfzak2ibdd88q77pz6akil8s3g41zsg2dqv";
-      name = "kwindowsystem-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kwindowsystem-5.43.0.tar.xz";
+      sha256 = "0zcrls3m9np2a9r5n7fry03ll6vrj36abjh2sajm531z657xmxjd";
+      name = "kwindowsystem-5.43.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kxmlgui-5.42.0.tar.xz";
-      sha256 = "0kfxjx8wrhkys5bydnv84nqxc2jqvv92zb2l6zpi0km5ggmia5y0";
-      name = "kxmlgui-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kxmlgui-5.43.0.tar.xz";
+      sha256 = "1jncpyfvanyl02zx8zi2mmwbx86yaq9k7k40vh716dswbh2idzd3";
+      name = "kxmlgui-5.43.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/kxmlrpcclient-5.42.0.tar.xz";
-      sha256 = "0ciip27ilsfk9s3gslpbi06v8i6ipdbmcig2jf43z3amsxpq0ncn";
-      name = "kxmlrpcclient-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/kxmlrpcclient-5.43.0.tar.xz";
+      sha256 = "0c99wq7kqaqvafppcai47q8w9n21ncfmrc562cvhyqnx9qr9n5vn";
+      name = "kxmlrpcclient-5.43.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/modemmanager-qt-5.42.0.tar.xz";
-      sha256 = "0q6qzn60z55h0gyc9xwdfaq45mjpk3zrr6d4qqjjfkqsr3866sfx";
-      name = "modemmanager-qt-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/modemmanager-qt-5.43.0.tar.xz";
+      sha256 = "16h8af046jlhn31dg1y3ajpniidkijf0wy0qa7z6bpqw01vj4l6w";
+      name = "modemmanager-qt-5.43.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/networkmanager-qt-5.42.0.tar.xz";
-      sha256 = "03hhvx8d52mfgbhd4gn0vhsk9k1fv1pvq24ixxdgs2mw44v884xq";
-      name = "networkmanager-qt-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/networkmanager-qt-5.43.0.tar.xz";
+      sha256 = "0pkm02bg201xcxyn2cbw1w3gag9ig4g5yz4wbd2db6qzvficmfqc";
+      name = "networkmanager-qt-5.43.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/oxygen-icons5-5.42.0.tar.xz";
-      sha256 = "0pnav9h0xmvbaamzpcyznjjv25slz8maszshx7sj7h07b5a23x46";
-      name = "oxygen-icons5-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/oxygen-icons5-5.43.0.tar.xz";
+      sha256 = "13c80jnc6h2z9bbwwzq1b8jsn80n4bs0zzr2xsbzsfbl5sw0hwpc";
+      name = "oxygen-icons5-5.43.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/plasma-framework-5.42.0.tar.xz";
-      sha256 = "079c8h0lmbkfr3srj5m8a40b50kyrxbgmy1n66329l8js9xrvaah";
-      name = "plasma-framework-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/plasma-framework-5.43.0.tar.xz";
+      sha256 = "1v7far0jz0b0rvx4jzqsq2pp1diny5c2qz67jyxnqlfgsba8y466";
+      name = "plasma-framework-5.43.0.tar.xz";
     };
   };
   prison = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/prison-5.42.0.tar.xz";
-      sha256 = "0bhg2fjdwsv7mk16jh1nc3miwggz1dl9l99l2f20xvi75hn7rryg";
-      name = "prison-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/prison-5.43.0.tar.xz";
+      sha256 = "018kj3xgl5wr3nhrasxmwvk6fh63fdwlz78z1rzyd78jx95wpaqc";
+      name = "prison-5.43.0.tar.xz";
+    };
+  };
+  purpose = {
+    version = "5.43.0";
+    src = fetchurl {
+      url = "${mirror}/stable/frameworks/5.43/purpose-5.43.0.tar.xz";
+      sha256 = "1vk796f3w2arqaql16yy012211vxgz6awa8kg0p1zrxbid43x757";
+      name = "purpose-5.43.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/qqc2-desktop-style-5.42.0.tar.xz";
-      sha256 = "1arlfhcshfs11pgf87jzjgln1p711zlx0v0q014740mbzb9g5wnk";
-      name = "qqc2-desktop-style-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/qqc2-desktop-style-5.43.0.tar.xz";
+      sha256 = "0q6v1si1c8dlvq5f303dd4n1qqrn9kw0r51dl37px6rvy2n16d0w";
+      name = "qqc2-desktop-style-5.43.0.tar.xz";
     };
   };
   solid = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/solid-5.42.0.tar.xz";
-      sha256 = "10lr8paaq6vaiqn833kzcdc3kkyv8j9fdchy7h8pvi9ajjjwq0lq";
-      name = "solid-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/solid-5.43.0.tar.xz";
+      sha256 = "0q62z23dml6rndgmkg6r09gsi0in8c4gbgv66dw47v02spsnp7v9";
+      name = "solid-5.43.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/sonnet-5.42.0.tar.xz";
-      sha256 = "1r3amddmy0nm8klw0jzvb8bl1l9hkrx50d8j0zq2lbjy36h3yliw";
-      name = "sonnet-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/sonnet-5.43.0.tar.xz";
+      sha256 = "0i5vxaw124093fi7fi8gjyi08xgxpkpb68lrpsxqdikadvx6nwaa";
+      name = "sonnet-5.43.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/syntax-highlighting-5.42.0.tar.xz";
-      sha256 = "1iwiym50859jki4x41rfdmbd14jiq5lr2hdg46pjkyw17njdjd60";
-      name = "syntax-highlighting-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/syntax-highlighting-5.43.0.tar.xz";
+      sha256 = "0a1xrpk3wavcq6d3cld33l05g5xlhz635vwcc6i1092gsgdns7k1";
+      name = "syntax-highlighting-5.43.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.42.0";
+    version = "5.43.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.42/threadweaver-5.42.0.tar.xz";
-      sha256 = "1isqlpnfxzxyz7mdm7yfrafgnx09mcndicdgdw3mi4r4misbrrbn";
-      name = "threadweaver-5.42.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.43/threadweaver-5.43.0.tar.xz";
+      sha256 = "0mmnf6lirvqwlrijpn5vqd8l9pk74dpsbr81y6kyfmx31mj36jjx";
+      name = "threadweaver-5.43.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

nox is still running.

@adisbladis @ttuegel @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

