### PR TITLE
Update minio client and server

### DIFF
--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -3,13 +3,13 @@
 buildGoPackage rec {
   name = "minio-${version}";
 
-  version = "2018-01-18T20-33-21Z";
+  version = "2018-02-09T22-40-05Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "102rilh1kjf9y6g6y83ikk42w7g1sbld11md3wm54hynyh956xrs";
+    sha256 = "0qxrzmkm5hza5xbx9dkrgadwjg3hykwf79hix3s0laqyksmpj9mk";
   };
 
   goPackagePath = "github.com/minio/minio";

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
     homepage = https://www.minio.io/;
     description = "An S3-compatible object storage server";
     maintainers = with maintainers; [ eelco bachp ];
-    platforms = platforms.x86_64 ++ ["aarch64-linux"];
+    platforms = platforms.unix;
     license = licenses.asl20;
   };
 }

--- a/pkgs/tools/networking/minio-client/default.nix
+++ b/pkgs/tools/networking/minio-client/default.nix
@@ -1,39 +1,28 @@
-{ lib, stdenv, fetchurl, go }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  name = "minio-client-${shortVersion}";
+buildGoPackage rec {
+  name = "minio-client-${version}";
 
-  shortVersion = "20170206";
-  longVersion = "2017-02-06T20-16-19Z";
+  version = "2018-02-09T23-07-36Z";
 
-  src = fetchurl {
-    url = "https://github.com/minio/mc/archive/RELEASE.${lib.replaceStrings [":"] ["-"] longVersion}.tar.gz";
-    sha256 = "0k66kr7x669jvydcxp3rpvg8p9knhmcihpnjiqynhqgrdy16mr1f";
+  src = fetchFromGitHub {
+    owner = "minio";
+    repo = "mc";
+    rev = "RELEASE.${version}";
+    sha256 = "1mzjqcvl8740jkkrsyycwqminnd0vdl1m2mvq8hnywj8hs816bfd";
   };
 
-  buildInputs = [ go ];
+  goPackagePath = "github.com/minio/mc";
 
-  unpackPhase = ''
-    d=$TMPDIR/src/github.com/minio/mc
-    mkdir -p $d
-    tar xf $src -C $d --strip-component 1
-    export GOPATH=$TMPDIR
-    cd $d
-  '';
+  buildFlagsArray = [''-ldflags=
+    -X github.com/minio/mc/cmd.Version=${version}
+  ''];
 
-  buildPhase = ''
-    mkdir -p $out/bin
-    go build -o $out/bin/minio-client \
-      --ldflags "-X github.com/minio/mc/cmd.Version=${longVersion}"
-  '';
-
-  installPhase = "ln -s minio-client $out/bin/mc";
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/minio/mc;
     description = "A replacement for ls, cp, mkdir, diff and rsync commands for filesystems and object storage";
-    maintainers = [ lib.maintainers.eelco ];
-    platforms = lib.platforms.linux;
-    license = lib.licenses.asl20;
+    maintainers = with maintainers; [ eelco bachp ];
+    platforms = platforms.linux;
+    license = licenses.asl20;
   };
 }

--- a/pkgs/tools/networking/minio-client/default.nix
+++ b/pkgs/tools/networking/minio-client/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
     homepage = https://github.com/minio/mc;
     description = "A replacement for ls, cp, mkdir, diff and rsync commands for filesystems and object storage";
     maintainers = with maintainers; [ eelco bachp ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.asl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update minio server and client to latest version.

I was not able to test the changes regarding `platforms.unix` support, maybe some build bot can do this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

