### PR TITLE
nginx/modules: use eustas' brotli module, google one is abandoned

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -2,13 +2,17 @@
 
 {
   brotli = {
-    src = fetchFromGitHub {
-      owner = "google";
+    src = let gitsrc = pkgs.fetchFromGitHub {
+      owner = "eustas";
       repo = "ngx_brotli";
-      rev = "bfd2885b2da4d763fed18f49216bb935223cd34b";
-      sha256 = "04yx1n0wi3l2x37jd1ynl9951qxkn8xp42yv0mfp1qz9svips81n";
-      fetchSubmodules = true;
-    };
+      rev = "47550a25d07363f8eb87ef901b2de5883c46352b";
+      sha256 = "0ap1kf51hzb8yvvxjkcj9hnmsmmd5drcay64hd4n7vybf9dqw6g6";
+    }; in pkgs.runCommandNoCC "ngx_brotli-src" {} ''
+      cp -a ${gitsrc} $out
+      substituteInPlace $out/config \
+        --replace /usr/local ${lib.getDev pkgs.brotli}
+    '';
+    inputs = [ pkgs.brotli ];
   };
 
   rtmp ={

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -5,7 +5,7 @@
     src = let gitsrc = pkgs.fetchFromGitHub {
       owner = "eustas";
       repo = "ngx_brotli";
-      rev = "47550a25d07363f8eb87ef901b2de5883c46352b";
+      rev = "8cd9dd5fc232d3a01644584921e52dae99034779";
       sha256 = "0ap1kf51hzb8yvvxjkcj9hnmsmmd5drcay64hd4n7vybf9dqw6g6";
     }; in pkgs.runCommandNoCC "ngx_brotli-src" {} ''
       cp -a ${gitsrc} $out


### PR DESCRIPTION
This version works with brotli newer than Dec 2016,
optionally using system brotli instead of vendored version
(which this PR puts to good use so there's only one brotli).

@eustas is primary contributor to brotli itself[1]
so this isn't some random fork.

As mentioned in the commit, FreeBSD switched to this fork
for similar reasons Dec 2017.

[1] https://github.com/google/brotli/graphs/contributors


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fork is also used by FreeBSD as of Dec 2017:
https://svnweb.freebsd.org/ports?view=revision&revision=455560

See also:
https://github.com/google/ngx_brotli/issues/62