### PR TITLE
gnome-shell-extension-remove-dropdown-arrows: init at v9

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/remove-dropdown-arrows/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/remove-dropdown-arrows/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-remove-dropdown-arrows-${version}";
+  version = "9";
+
+  src = fetchFromGitHub {
+    owner = "mpdeimos";
+    repo = "gnome-shell-remove-dropdown-arrows";
+    rev = "version/${version}";
+    sha256 = "1z9icxr75rd3cas28xjlmsbbd3j3sm1qvj6mp95jhfaqj821q665";
+  };
+
+  # This package has a Makefile, but it's used for publishing and linting, not
+  # for building. Disable the build phase so installing doesn't attempt to
+  # publish the extension.
+  dontBuild = true;
+
+  uuid = "remove-dropdown-arrows@mpdeimos.com";
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp extension.js $out/share/gnome-shell/extensions/${uuid}
+    cp metadata.json $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Remove dropdown arrows from GNOME Shell Menus";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jonafato ];
+    homepage = https://github.com/mpdeimos/gnome-shell-remove-dropdown-arrows;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19008,6 +19008,7 @@ with pkgs;
     mediaplayer = callPackage ../desktops/gnome-3/extensions/mediaplayer { };
     nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
     pixel-saver = callPackage ../desktops/gnome-3/extensions/pixel-saver { };
+    remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Add the Remove Dropdown Arrows GNOME Shell extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

