### PR TITLE
stride: init at 1.8.18

### DIFF
--- a/pkgs/applications/networking/instant-messengers/stride/default.nix
+++ b/pkgs/applications/networking/instant-messengers/stride/default.nix
@@ -1,0 +1,68 @@
+{ stdenv, fetchurl, dpkg, alsaLib, atk, cairo, cups, dbus, expat, fontconfig
+, freetype, gdk_pixbuf, glib, gnome2, nspr, nss, pango, udev, xorg }:
+let
+  fullPath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gnome2.gtk
+    nspr
+    nss
+    pango
+    udev
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxcb
+  ] + ":${stdenv.cc.cc.lib}/lib64";
+in
+stdenv.mkDerivation rec {
+  version = "1.8.18";
+  name = "stride-${version}";
+
+  src = fetchurl {
+    url = "https://packages.atlassian.com/stride-apt-client/pool/stride_${version}_amd64.deb";
+    sha256 = "0hpj3i3xbvckxm7fphqqb3scb31w2cg4riwp593y0gnbivpc0hym";
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+
+  buildInputs = [ dpkg ];
+
+  unpackPhase = ''
+    dpkg-deb -x ${src} ./
+  '';
+
+  installPhase =''
+    mkdir "$out"
+    mv usr/* "$out/"
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${fullPath}:\$ORIGIN" \
+      "$out/bin/stride"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Desktop client for Atlassian Stride";
+    homepage = https://www.stride.com/;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ puffnfresh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16475,6 +16475,8 @@ with pkgs;
 
   smtube = libsForQt5.callPackage ../applications/video/smtube {};
 
+  stride = callPackage ../applications/networking/instant-messengers/stride { };
+
   sudolikeaboss = callPackage ../tools/security/sudolikeaboss { };
 
   speedread = callPackage ../applications/misc/speedread { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

