### PR TITLE
micawber: init at 0.3.5

### DIFF
--- a/pkgs/development/python-modules/micawber/default.nix
+++ b/pkgs/development/python-modules/micawber/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, beautifulsoup4 }:
+
+buildPythonPackage rec {
+  pname = "micawber";
+  version = "0.3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pnq6j8f144virhri0drgf0058x6qcxfd5yrb0ynbwr8djh326yn";
+  };
+
+  propagatedBuildInputs = [ beautifulsoup4 ];
+
+  meta = with stdenv.lib; {
+    homepage = http://micawber.readthedocs.io/en/latest/;
+    description = "A small library for extracting rich content from urls";
+    license = licenses.mit;
+    longDescription = ''
+      micawber supplies a few methods for retrieving rich metadata
+      about a variety of links, such as links to youtube videos.
+      micawber also provides functions for parsing blocks of text and html
+      and replacing links to videos with rich embedded content.
+    '';
+    maintainers = with maintainers; [ davidak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10111,6 +10111,8 @@ in {
     };
   };
 
+  micawber = callPackage ../development/python-modules/micawber { };
+
   minimock = buildPythonPackage rec {
     version = "1.2.8";
     name = "minimock-${version}";


### PR DESCRIPTION
###### Motivation for this change

Nikola needs it for the media shortcode. https://github.com/NixOS/nixpkgs/issues/33825

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

