### PR TITLE
mp3blaster: init at 3.2.6

### DIFF
--- a/pkgs/applications/audio/mp3blaster/default.nix
+++ b/pkgs/applications/audio/mp3blaster/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+stdenv.mkDerivation rec {
+
+  version = "3.2.6";
+
+  name = "mp3blaster-${version}";
+
+  src = fetchFromGitHub {
+    owner = "stragulus";
+    repo = "mp3blaster";
+    rev = "v${version}";
+    sha256 = "0pzwml3yhysn8vyffw9q9p9rs8gixqkmg4n715vm23ib6wxbliqs";
+  };
+
+  buildInputs = [ ncurses ];
+
+  buildFlags = [ "CXXFLAGS=-Wno-narrowing" ];
+
+  meta = with stdenv.lib; {
+    description = "An audio player for the text console";
+    homepage = http://www.mp3blaster.org/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ earldouglas ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1262,6 +1262,8 @@ with pkgs;
 
   meson = callPackage ../development/tools/build-managers/meson { };
 
+  mp3blaster = callPackage ../applications/audio/mp3blaster { };
+
   mp3fs = callPackage ../tools/filesystems/mp3fs { };
 
   mpdas = callPackage ../tools/audio/mpdas { };


### PR DESCRIPTION
###### Motivation for this change

Add a package for an excellent old-school mp3 player.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

