### PR TITLE
gnomeExtensions.appindicator: init at v22

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/appindicator/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/appindicator/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-appindicator-${version}";
+  version = "22";
+
+  src = fetchFromGitHub {
+    owner = "Ubuntu";
+    repo = "gnome-shell-extension-appindicator";
+    rev = "v${version}";
+    sha256 = "1gqw54d55hxjj2hh04p0dx2j40bhi4ck9hgwlz8f7j4v7r37z0qw";
+  };
+
+  # This package has a Makefile, but it's used for building a zip for
+  # publication to extensions.gnome.org. Disable the build phase so
+  # installing doesn't build an unnecessary release.
+  dontBuild = true;
+
+  uuid = "appindicatorsupport@rgcjonas.gmail.com";
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp *.js $out/share/gnome-shell/extensions/${uuid}
+    cp -r interfaces-xml $out/share/gnome-shell/extensions/${uuid}
+    cp metadata.json $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "AppIndicator/KStatusNotifierItem support for GNOME Shell";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ jonafato ];
+    homepage = https://github.com/Ubuntu/gnome-shell-extension-appindicator;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19017,6 +19017,7 @@ with pkgs;
   gnome3 = recurseIntoAttrs (callPackage ../desktops/gnome-3 { });
 
   gnomeExtensions = {
+    appindicator = callPackage ../desktops/gnome-3/extensions/appindicator { };
     caffeine = callPackage ../desktops/gnome-3/extensions/caffeine { };
     clipboard-indicator = callPackage ../desktops/gnome-3/extensions/clipboard-indicator { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };


### PR DESCRIPTION
###### Motivation for this change

Add the AppIndicator Support GNOME Shell extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

