### PR TITLE
gnome3.geary: 0.12.0 -> 0.12.1

### DIFF
--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -8,11 +8,11 @@ let
   majorVersion = "0.12";
 in
 stdenv.mkDerivation rec {
-  name = "geary-${majorVersion}.0";
+  name = "geary-${majorVersion}.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/geary/${majorVersion}/${name}.tar.xz";
-    sha256 = "0ii4qaqfqx90kvqwg0g9jahygkir4mb03ja55fa55yyx6cq0kwff";
+    sha256 = "12hbpd5j3rb122nrsqmgsg31x82xl0ksm0nmsl614v1dd7crqnh6";
   };
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];


### PR DESCRIPTION
###### Motivation for this change

Geary has a new release including several bug fixes and translations. See the [changelog](https://github.com/GNOME/geary/blob/187561447603654d91c1ca6e4526eb18decb9d17/debian/changelog#L1-L19) for the full list of improvements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

