### PR TITLE
caffe2: init at 0.8.1

### DIFF
--- a/pkgs/development/libraries/science/math/caffe2/default.nix
+++ b/pkgs/development/libraries/science/math/caffe2/default.nix
@@ -84,6 +84,8 @@ stdenv.mkDerivation rec {
   ;
   propagatedBuildInputs = [ numpy future six python-protobuf pydot ];
 
+  patches = if stdenv.cc.isClang then [ ./update_clang_cvtsh_bugfix.patch ] else [ ];
+
   cmakeFlags = [ ''-DBUILD_TEST=OFF''
                  ''-DBUILD_PYTHON=ON''
                  ''-DUSE_CUDA=${if useCuda then ''ON''else ''OFF''}''

--- a/pkgs/development/libraries/science/math/caffe2/default.nix
+++ b/pkgs/development/libraries/science/math/caffe2/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   ;
   propagatedBuildInputs = [ numpy future six python-protobuf pydot ];
 
-  patches = if stdenv.cc.isClang then [ ./update_clang_cvtsh_bugfix.patch ] else [ ];
+  patches = lib.optional stdenv.cc.isClang [ ./update_clang_cvtsh_bugfix.patch ];
 
   cmakeFlags = [ ''-DBUILD_TEST=OFF''
                  ''-DBUILD_PYTHON=ON''

--- a/pkgs/development/libraries/science/math/caffe2/default.nix
+++ b/pkgs/development/libraries/science/math/caffe2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, config, fetchurl, fetchFromGitHub
+{ stdenv, lib, config, fetchFromGitHub
 , cmake
 , glog, google-gflags, gtest
 , protobuf, snappy
@@ -61,10 +61,11 @@ in
 stdenv.mkDerivation rec {
   name = "caffe2-${version}";
   version = "0.8.1";
-  src = fetchurl {
-    name = "caffe2-0.8.1.tar.gz";
-    url = "https://github.com/caffe2/caffe2/archive/v0.8.1.tar.gz";
-    sha256 = "1a798nlh69hjw55grl4nwk5n7j5df63yhlfyzninsqmg9i8khy9b";
+  src = fetchFromGitHub {
+    owner = "caffe2";
+    repo = "caffe2";
+    rev = "v${version}";
+    sha256 = "18y7zjc69j6n5642l9caddl641b0djf3pjn4wacdsc1wk1jiyqk8";
   };
 
   nativeBuildInputs = [ cmake doxygen gtest ];

--- a/pkgs/development/libraries/science/math/caffe2/default.nix
+++ b/pkgs/development/libraries/science/math/caffe2/default.nix
@@ -131,6 +131,7 @@ stdenv.mkDerivation rec {
       algorithms. You can bring your creations to scale using the power of GPUs in the
       cloud or to the masses on mobile with Caffe2's cross-platform libraries.
     '';
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     license = stdenv.lib.licenses.asl20;
     maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
   };

--- a/pkgs/development/libraries/science/math/caffe2/default.nix
+++ b/pkgs/development/libraries/science/math/caffe2/default.nix
@@ -1,0 +1,136 @@
+{ stdenv, lib, config, fetchurl, fetchFromGitHub
+, cmake
+, glog, google-gflags, gtest
+, protobuf, snappy
+, python, future, six, python-protobuf, numpy, pydot
+, eigen3
+, doxygen
+, useCuda ? (config.cudaSupport or false), cudatoolkit ? null
+, useCudnn ? (config.cudnnSupport or false), cudnn ? null
+, useOpenmp ? false, openmp ? null
+, useOpencv3 ? true, opencv3 ? null
+, useLeveldb ? false, leveldb ? null
+, useLmdb ? true, lmdb ? null
+, useRocksdb ? false, rocksdb ? null
+, useZeromq ? false, zeromq ? null
+, useMpi ? false, mpi ? null
+# TODO: distributed computations
+#, useGloo ? false
+#, useNccl ? false
+#, useNnpack ? false
+}:
+
+assert useCuda -> cudatoolkit != null;
+assert useCudnn -> (useCuda && cudnn != null);
+assert useOpencv3 -> opencv3 != null;
+assert useLeveldb -> leveldb != null;
+assert useLmdb -> lmdb != null;
+assert useRocksdb -> rocksdb != null;
+assert useZeromq -> zeromq != null;
+assert useMpi -> mpi != null;
+
+let
+  # Third party modules that caffe2 holds as git submodules.
+  # Download them and create symlinks from caffe2/third_party.
+  installExtraSrc = extra: ''
+    rmdir "third_party/${extra.dst}"
+    ln -s "${extra.src}" "third_party/${extra.dst}"
+  '';
+
+  cub = {
+    src = fetchFromGitHub rec {
+      owner  = "NVlabs";
+      repo   = "cub";
+      rev    = "v1.7.4";
+      sha256 = "0ksd5n1lxqhm5l5cd2lps4cszhjkf6gmzahaycs7nxb06qci8c66";
+    };
+    dst = "cub";
+  };
+
+  pybind11 = {
+    src = fetchFromGitHub {
+      owner  = "pybind";
+      repo   = "pybind11";
+      rev    = "86e2ad4f77442c3350f9a2476650da6bee253c52";
+      sha256 = "05gi58dirvc8fgm0avpydvidzsbh2zrzgfaq671ym09f6dz0bcgz";
+    };
+    dst = "pybind11";
+  };
+in
+
+stdenv.mkDerivation rec {
+  name = "caffe2-${version}";
+  version = "0.8.1";
+  src = fetchurl {
+    name = "caffe2-0.8.1.tar.gz";
+    url = "https://github.com/caffe2/caffe2/archive/v0.8.1.tar.gz";
+    sha256 = "1a798nlh69hjw55grl4nwk5n7j5df63yhlfyzninsqmg9i8khy9b";
+  };
+
+  nativeBuildInputs = [ cmake doxygen gtest ];
+  outputs = [ "bin" "out" ];
+  propagatedBuildOutputs = [ ]; # otherwise propagates out -> bin cycle
+
+  buildInputs = [ glog google-gflags protobuf snappy eigen3 ]
+    ++ lib.optional useCuda cudatoolkit
+    ++ lib.optional useCudnn cudnn
+    ++ lib.optional useOpenmp openmp
+    ++ lib.optional useOpencv3 opencv3
+    ++ lib.optional useLeveldb leveldb
+    ++ lib.optional useLmdb lmdb
+    ++ lib.optional useRocksdb rocksdb
+    ++ lib.optional useZeromq zeromq
+  ;
+  propagatedBuildInputs = [ numpy future six python-protobuf pydot ];
+
+  cmakeFlags = [ ''-DBUILD_TEST=OFF''
+                 ''-DBUILD_PYTHON=ON''
+                 ''-DUSE_CUDA=${if useCuda then ''ON''else ''OFF''}''
+                 ''-DUSE_OPENMP=${if useOpenmp then ''ON''else ''OFF''}''
+                 ''-DUSE_OPENCV=${if useOpencv3 then ''ON''else ''OFF''}''
+                 ''-DUSE_MPI=${if useMpi then ''ON''else ''OFF''}''
+                 ''-DUSE_LEVELDB=${if useLeveldb then ''ON''else ''OFF''}''
+                 ''-DUSE_LMDB=${if useLmdb then ''ON''else ''OFF''}''
+                 ''-DUSE_ROCKSDB=${if useRocksdb then ''ON''else ''OFF''}''
+                 ''-DUSE_ZMQ=${if useZeromq  then ''ON''else ''OFF''}''
+                 ''-DUSE_GLOO=OFF''
+                 ''-DUSE_NNPACK=OFF''
+                 ''-DUSE_NCCL=OFF''
+                 ''-DUSE_REDIS=OFF''
+                 ''-DUSE_FFMPEG=OFF''
+               ]
+               ++ lib.optional useCuda [
+                 ''-DCUDA_TOOLKIT_ROOT_DIR=${cudatoolkit}''
+                 ''-DCUDA_FAST_MATH=ON''
+                 ''-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/gcc''
+               ];
+
+  preConfigure = ''
+    ${installExtraSrc cub}
+    ${installExtraSrc pybind11}
+    # XXX hack
+    export NIX_CFLAGS_COMPILE="-I ${eigen3}/include/eigen3/ $NIX_CFLAGS_COMPILE"
+  '';
+
+  postInstall = ''
+    moveToOutput "bin" "$bin"
+    mkdir -p $out/lib/${python.libPrefix}
+    ln -s $out/ $out/${python.sitePackages}
+  '';
+
+  doCheck = false;
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = https://caffe2.ai/;
+    description = "A new lightweight, modular, and scalable deep learning framework";
+    longDescription = ''
+      Caffe2 aims to provide an easy and straightforward way for you to experiment
+      with deep learning and leverage community contributions of new models and
+      algorithms. You can bring your creations to scale using the power of GPUs in the
+      cloud or to the masses on mobile with Caffe2's cross-platform libraries.
+    '';
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
+  };
+}

--- a/pkgs/development/libraries/science/math/caffe2/update_clang_cvtsh_bugfix.patch
+++ b/pkgs/development/libraries/science/math/caffe2/update_clang_cvtsh_bugfix.patch
@@ -1,0 +1,55 @@
+diff --git a/caffe2/perfkernels/cvtsh_ss_bugfix.h b/caffe2/perfkernels/cvtsh_ss_bugfix.h
+index bd06681..00172b7 100644
+--- a/caffe2/perfkernels/cvtsh_ss_bugfix.h
++++ b/caffe2/perfkernels/cvtsh_ss_bugfix.h
+@@ -1,10 +1,36 @@
++/**
++ * Copyright (c) 2016-present, Facebook, Inc.
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
+ #pragma once
+ 
+-#if defined(__APPLE__) && (__clang_major__ < 8)
++// Apple clang was fixed in 8.1
++#if defined(__apple_build_version__) && ((__clang_major__ < 8) || ((__clang_major__ == 8) && (__clang_minor__ < 1)))
++#define __APPLE_NEED_FIX 1
++#endif
++
++// Regular clang was fixed in 3.9
++#if defined(__clang__) && (__clang_major__ < 4) && (__clang_minor__ < 9)
++#define __CLANG_NEED_FIX 1
++#endif
++
++#if __APPLE_NEED_FIX || __CLANG_NEED_FIX
+ 
+ #include <emmintrin.h>
+ 
+-// This version of apple clang has a bug that _cvtsh_ss is not defined, see
++// This version of clang has a bug that _cvtsh_ss is not defined, see
+ // https://reviews.llvm.org/D16177
+ static __inline float
+     __attribute__((__always_inline__, __nodebug__, __target__("f16c")))
+@@ -15,7 +41,10 @@ _cvtsh_ss(unsigned short a)
+   return r[0];
+ }
+ 
+-#endif // defined(__APPLE__) && (__clang_major__ < 8)
++#endif // __APPLE_NEED_FIX || __CLANG_NEED_FIX
++
++#undef __APPLE_NEED_FIX
++#undef __CLANG_NEED_FIX
+ 
+ #ifdef _MSC_VER
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19540,6 +19540,13 @@ with pkgs;
     cudnnSupport = cudaSupport;
   };
 
+  caffe2 = callPackage ../development/libraries/science/math/caffe2 {
+    eigen3 = eigen3_3;
+    inherit (python3Packages) python future six numpy pydot;
+    protobuf = protobuf3_1;
+    python-protobuf = python3Packages.protobuf3_1;
+  };
+
   cntk = callPackage ../applications/science/math/cntk rec {
     cudaSupport = pkgs.config.cudaSupport or false;
     cudnnSupport = cudaSupport;


### PR DESCRIPTION
###### Motivation for this change

Caffe2 is a lightweight, modular, and scalable deep learning framework developed at Facebook.
It is a successor to the widely used Caffe framework, and provides both C++ and Python APIs.

Requests for review:

(1) package location

I've tentatively put the package to `pkgs/development/library/science/math`,
although it might fit nicer to `pkgs/development/library/science/machine-learning`
if there's such a directory.

Notes:
- There's a directory named `pkgs/applications/science/machine-learning/`
- `caffe` resides in: `pkgs/applications/science/math/`
- Other major deep learning frameworks (notably `tensorflow` & `pytorch`) are registered as python packages.

(2) CUDA issues

- Caffe2 v0.8.1 (the version packaged in this PR) does not officially support Cuda Toolkit9
- Cuda Toolkit8 does not officially support gcc6
- Caffe2/CPU v0.8.1 compiles and seems to work fine both with gcc5 and gcc6.
- I haven't been able to compile Caffe2/GPU v0.8.1 with Cuda Toolkit8 and gcc5.5 from `18.03pre` (`overrideCC stdenv pkgs.gcc5`). It compiles (and seems to work fine) with Cuda Toolkit8 and gcc5.4 from `release-17.09`.
- The errors from Caffe2/GPU v0.8.1 with Cuda Toolkit8 and gcc5.5 seems to be arising from AVX intrinsics, e.g.:
  ```
  Building NVCC (Device) object caffe2/CMakeFiles/Caffe2_GPU.dir/utils/Caffe2_GPU_generated_math_gpu.cu.o
  /nix/store/0l7rjsr59d7l8pr0gxvf37jx8gnva5fi-gcc-5.5.0/lib/gcc/x86_64-unknown-linux-gnu/5.5.0/include/avx512fintrin.h(9220): error: argument of type "const void *" is incompatible with parameter of type "const float *"
  ``` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

