### PR TITLE
[RDY] allow override of Kernel printk

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -170,7 +170,7 @@ in
       [ "loglevel=${toString config.boot.consoleLogLevel}" ] ++
       optionals config.boot.vesa [ "vga=0x317" ];
 
-    boot.kernel.sysctl."kernel.printk" = config.boot.consoleLogLevel;
+    boot.kernel.sysctl."kernel.printk" = mkDefault config.boot.consoleLogLevel;
 
     boot.kernelModules = [ "loop" "atkbd" ];
 


### PR DESCRIPTION
At one point in my configuration I had:
```nix
boot.kernel.sysctl = {
      # https://unix.stackexchange.com/questions/13019/description-of-kernel-printk-values
      "kernel.printk" = "4	4	1	7";
};
```
which triggered:

```
error: The unique option `boot.kernel.sysctl.kernel.printk' is defined multiple times, in `/home/teto/dotfiles/nixpkgs/mptcp-unstable.nix' and `/home/teto/nixpkgs/nixos/modules/system/boot/kernel.nix'.
(use ‘--show-trace’ to show detailed location information)
Traceback (most recent call last):
  File "/home/teto/nixops/scripts/nixops", line 984, in <module>
    args.op()
  File "/home/teto/nixops/scripts/nixops", line 406, in op_deploy
    max_concurrent_activate=args.max_concurrent_activate)
  File "/home/teto/nixops/nixops/deployment.py", line 1045, in deploy
    self.run_with_notify('deploy', lambda: self._deploy(**kwargs))
  File "/home/teto/nixops/nixops/deployment.py", line 1034, in run_with_notify
    f()
  File "/home/teto/nixops/nixops/deployment.py", line 1045, in <lambda>
    self.run_with_notify('deploy', lambda: self._deploy(**kwargs))
  File "/home/teto/nixops/nixops/deployment.py", line 985, in _deploy
    self.configs_path = self.build_configs(dry_run=dry_run, repair=repair, include=include, exclude=exclude)
  File "/home/teto/nixops/nixops/deployment.py", line 653, in build_configs
    raise Exception("unable to build all machine configurations")
Exception: unable to build all machine configurations
```

This simple addition allows to override it.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

