### PR TITLE
Fix TZDIR paths in FHS environments

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -52,6 +52,7 @@ let
     export LOCALE_ARCHIVE='/usr/lib/locale/locale-archive'
     export LD_LIBRARY_PATH='/run/opengl-driver/lib:/run/opengl-driver-32/lib:/usr/lib:/usr/lib32'
     export PATH='/run/wrappers/bin:/usr/bin:/usr/sbin'
+    export TZDIR='/etc/zoneinfo'
 
     # Force compilers and other tools to look in default search paths
     export NIX_CC_WRAPPER_${stdenv.cc.infixSalt}_TARGET_HOST=1

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -9,16 +9,7 @@
 
 let
   commonTargetPkgs = pkgs: with pkgs;
-    let
-      tzdir = "${pkgs.tzdata}/share/zoneinfo";
-      # I'm not sure if this is the best way to add things like this
-      # to an FHSUserEnv
-      etc-zoneinfo = pkgs.runCommand "zoneinfo" {} ''
-        mkdir -p $out/etc
-        ln -s ${tzdir} $out/etc/zoneinfo
-        ln -s ${tzdir}/UTC $out/etc/localtime
-      '';
-    in [
+    [
       steamPackages.steam-fonts
       # Errors in output without those
       pciutils
@@ -30,8 +21,6 @@ let
       perl
       # Open URLs
       xdg_utils
-      # Zoneinfo
-      etc-zoneinfo
       iana-etc
     ] ++ lib.optional withJava jdk
       ++ lib.optional withPrimus primus
@@ -103,7 +92,6 @@ in buildFHSUserEnv rec {
 
   profile = ''
     export STEAM_RUNTIME=/steamrt
-    export TZDIR=/etc/zoneinfo
   '';
 
   runScript = writeScript "steam-wrapper.sh" ''


### PR DESCRIPTION
###### Motivation for this change

Move Steam fix to a more general place and clean up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@the-kenny @yegortimoshenko You seem to have games which may be affected by those changes -- can you test that they still work?