### PR TITLE
xcpc: init at version 20070122

### DIFF
--- a/pkgs/misc/emulators/libdsk/default.nix
+++ b/pkgs/misc/emulators/libdsk/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libdsk-${version}";
+  version = "1.5.8";
+
+  src = fetchurl {
+    url = "http://www.seasip.info/Unix/LibDsk/${name}.tar.gz";
+    sha256 = "1fdypk6gjkb4i2ghnbn3va50y69pdym51jx3iz9jns4636z4sfqd";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A library for accessing discs and disc image files";
+    homepage = http://www.seasip.info/Unix/LibDsk/;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/misc/emulators/xcpc/default.nix
+++ b/pkgs/misc/emulators/xcpc/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, libdsk, pkgconfig, glib, libXaw, libX11, libXext, lesstif }:
+
+stdenv.mkDerivation rec {
+  version = "20070122";
+  name = "xcpc-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/xcpc/${name}.tar.gz";
+    sha256 = "0hxsbhmyzyyrlidgg0q8izw55q0z40xrynw5a1c3frdnihj9jf7n";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ glib libdsk libXaw libX11 libXext lesstif ];
+
+  meta = with stdenv.lib; {
+    description = "A portable Amstrad CPC 464/664/6128 emulator written in C";
+    homepage = https://www.xcpc-emulator.net;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16288,6 +16288,8 @@ with pkgs;
 
   lighttable = callPackage ../applications/editors/lighttable {};
 
+  libdsk = callPackage ../misc/emulators/libdsk { };
+
   links2 = callPackage ../applications/networking/browsers/links2 { };
 
   linphone = callPackage ../applications/networking/instant-messengers/linphone rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20692,6 +20692,8 @@ with pkgs;
 
   zsnes = callPackage_i686 ../misc/emulators/zsnes { };
 
+  xcpc = callPackage ../misc/emulators/xcpc { };
+
   zxcvbn-c = callPackage ../development/libraries/zxcvbn-c { };
 
   snes9x-gtk = callPackage ../misc/emulators/snes9x-gtk { };


### PR DESCRIPTION
###### Motivation for this change

libdsk : new , dep for xcpc
xcpc + caprice32 , small derivations, i put all this in same commit, should be easy to review.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

