### PR TITLE
zathura: make compatible with darwin

### DIFF
--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig
 , gtk, girara, ncurses, gettext, docutils
-, file, sqlite, glib, texlive
-, synctexSupport ? true
+, file, sqlite, glib, texlive, libintlOrEmpty
+, gtk-mac-integration, synctexSupport ? true
 }:
 
 assert synctexSupport -> texlive != null;
@@ -19,12 +19,17 @@ stdenv.mkDerivation rec {
 
   icon = ./icon.xpm;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    pkgconfig
+  ] ++ optional stdenv.isDarwin [ libintlOrEmpty ];
+
   buildInputs = [
     file gtk girara
     gettext makeWrapper sqlite glib
-  ] ++ optional synctexSupport texlive.bin.core;
+  ] ++ optional synctexSupport texlive.bin.core
+    ++ optional stdenv.isDarwin [ gtk-mac-integration ];
 
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   makeFlags = [
@@ -50,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage    = http://pwmt.org/projects/zathura/;
     description = "A core component for zathura PDF viewer";
     license     = licenses.zlib;
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
     maintainers = with maintainers; [ garbas ];
   };
 }

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./gtkflags.patch ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
     string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
     makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
 
   patches = [ ./gtkflags.patch ];
 
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
+    string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
+    makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
+    echo "''${makefileC1/$string1/$string2}" > Makefile
+  '';
+
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
 
   meta = with stdenv.lib; {
@@ -23,7 +30,7 @@ stdenv.mkDerivation rec {
       djvulibre library.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ garbas ];
   };
 }

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -15,10 +15,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     zathura_core gtk girara openssl mupdf libjpeg jbig2dec openjpeg
+  ] ++ stdenv.lib.optional stdenv.isDarwin [
     gtk-mac-integration
   ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
     string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
     makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, lib, fetchurl, pkgconfig, zathura_core, gtk, girara, mupdf, openssl
-, libjpeg, jbig2dec, openjpeg, fetchpatch }:
+{ stdenv, lib, fetchurl, pkgconfig, zathura_core, gtk,
+gtk-mac-integration, girara, mupdf, openssl , libjpeg, jbig2dec,
+openjpeg, fetchpatch }:
 
 stdenv.mkDerivation rec {
   version = "0.3.2";
@@ -11,7 +12,18 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ zathura_core gtk girara openssl mupdf libjpeg jbig2dec openjpeg ];
+
+  buildInputs = [
+    zathura_core gtk girara openssl mupdf libjpeg jbig2dec openjpeg
+    gtk-mac-integration
+  ];
+
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
+    string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
+    makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
+    echo "''${makefileC1/$string1/$string2}" > Makefile
+  '';
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
 
@@ -23,7 +35,7 @@ stdenv.mkDerivation rec {
       using the mupdf rendering library.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan ];
   };
 }

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
     string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
     makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -9,10 +9,17 @@ stdenv.mkDerivation rec {
     sha256 = "1m55m7s7f8ng8a7lmcw9z4n5zv7xk4vp9n6fp9j84z6rk2imf7a2";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ poppler zathura_core girara ];
+  nativeBuildInputs = [ pkgconfig zathura_core ];
+  buildInputs = [ poppler girara ];
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
+
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
+    string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
+    makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
+    echo "''${makefileC1/$string1/$string2}" > Makefile
+  '';
 
   meta = with lib; {
     homepage = http://pwmt.org/projects/zathura/;
@@ -22,7 +29,7 @@ stdenv.mkDerivation rec {
       using the poppler rendering library.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan garbas ];
   };
 }

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./gtkflags.patch ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
     makefileC2=$(echo "$makefileC1" | sed 's|-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}|-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}|g' )
     echo "$makefileC2" > Makefile

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkgconfig, gtk, zathura_core, girara, libspectre, gettext }:
+{ stdenv, lib, fetchurl, pkgconfig, gtk2, zathura_core, girara, libspectre, gettext }:
 
 stdenv.mkDerivation rec {
   name = "zathura-ps-0.2.5";
@@ -9,9 +9,16 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libspectre gettext zathura_core gtk girara ];
+  buildInputs = [ libspectre gettext zathura_core gtk2 girara ];
 
   patches = [ ./gtkflags.patch ];
+
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
+    makefileC2=$(echo "$makefileC1" | sed 's|-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}|-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}|g' )
+    echo "$makefileC2" > Makefile
+    echo "$makefileC2"
+  '';
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
 
@@ -23,7 +30,7 @@ stdenv.mkDerivation rec {
       libspectre library.
       '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan garbas ];
   };
 }

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -11,8 +11,7 @@ in symlinkJoin {
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
-    wrapProgram $out/bin/zathura \
-      --add-flags --plugins-dir=${pluginsPath}
+    wrapProgram $out/bin/zathura --add-flags --plugins-dir=${pluginsPath}
   '';
 
   meta = with lib; {
@@ -25,7 +24,7 @@ in symlinkJoin {
       as well as an easy usage that mainly focuses on keyboard interaction.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers;[ garbas smironov ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I wanted to use zathura on Mac.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

