### PR TITLE
utop: automatically populate the CAML_LD_LIBRARY_PATH env. variable

### DIFF
--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bash, ocaml, findlib, ocamlbuild, camlp4
+{ stdenv, fetchurl, writeText, bash, ocaml, findlib, ocamlbuild, camlp4
 , lambdaTerm, ocaml_lwt, camomile, zed, cppo, ppx_tools, makeWrapper
 }:
 
@@ -69,6 +69,16 @@ stdenv.mkDerivation rec {
       --add-flags "-I ${findlib}/lib/ocaml/${stdenv.lib.getVersion ocaml}/site-lib"
    done
    '';
+
+  setupHook = writeText "setupHook.sh" ''
+    addOCamlLDPath () {
+        if test -d "''$1/lib/ocaml/${ocaml.version}/site-lib/stubslibs"; then
+            export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/stubslibs"
+        fi
+    }
+
+    addEnvHooks "$targetOffset" addOCamlLDPath
+  '';
 
   meta = {
     description = "Universal toplevel for OCaml";


### PR DESCRIPTION
###### Motivation for this change

#34931: it is not convenient to use `utop`, as dynamically linked shared libraries cannot be found.

These libraries are searched in the directories listed in the `CAML_LD_LIBRARY_PATH` environment variable (see https://github.com/diml/utop#common-error for details).

This PR adds a setup-hook to the `utop` derivation; this hook automatically populates the `CAML_LD_LIBRARY_PATH` variable. Thus, in a shell with `utop`, `findlib` and some OCaml libraries with DLLs, that variable will be appropriately set, and dynamic loading (aka `#require "…";;`) will work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

