### PR TITLE
pinentry: add option to enable pinentry-emacs

### DIFF
--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,5 +1,6 @@
 { fetchurl, fetchpatch, stdenv, lib, pkgconfig
-, libgpgerror, libassuan, libcap ? null, libsecret ? null, ncurses ? null, gtk2 ? null, gcr ? null, qt ? null
+, libgpgerror, libassuan, libcap ? null, libsecret ? null, ncurses ? null,  gtk2 ? null, gcr ? null, qt ? null
+, enableEmacs ? false
 }:
 
 let
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
     (mkEnable (libsecret != null) "libsecret")
     (mkEnable (ncurses != null)   "pinentry-curses")
     (mkEnable true                "pinentry-tty")
+    (mkEnable enableEmacs         "pinentry-emacs")
     (mkEnable (gtk2 != null)      "pinentry-gtk2")
     (mkEnable (gcr != null)       "pinentry-gnome3")
     (mkEnable (qt != null)        "pinentry-qt")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4145,6 +4145,10 @@ with pkgs;
     gtk2 = null;
   };
 
+  pinentry_emacs = pinentry_ncurses.override {
+    enableEmacs = true;
+  };
+
   pinentry_gnome = pinentry_ncurses.override {
     gcr = gnome3.gcr;
   };


### PR DESCRIPTION
###### Motivation for this change

I would like to easily build `pinentry-emacs` and use it as my preferred pinentry program for `gpg-agent`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: `nox` test failed due to an issue in `python-gnupg`:

```
======================================================================
ERROR: test_filenames_with_spaces (test_gnupg.GPGTestCase)
Test that filenames with spaces are correctly handled
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/nix-build-python2.7-python-gnupg-0.4.1.drv-0/python-gnupg-0.4.1/test_gnupg.py", line 758, in test_filenames_with_spaces
    self.do_file_encryption_and_decryption(encfname, decfname)
  File "/tmp/nix-build-python2.7-python-gnupg-0.4.1.drv-0/python-gnupg-0.4.1/test_gnupg.py", line 705, in do_file_encryption_and_decryption
    armor=False, output=encfname)
  File "/tmp/nix-build-python2.7-python-gnupg-0.4.1.drv-0/python-gnupg-0.4.1/gnupg.py", line 1372, in encrypt_file
    raise ValueError('No recipients specified with asymmetric '
ValueError: No recipients specified with asymmetric encryption

----------------------------------------------------------------------
Ran 21 tests in 63.728s
```

I don't believe the failure is related to this change.