### PR TITLE
Adding @0x4A6F to maintainers.nix

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -7,7 +7,6 @@
   to ping a package @<handle>), and <Real Name> is your real name, not
   a pseudonym. Please keep the list alphabetically sorted. */
 {
-  0x4A6F = "Joachim Ernst <0x4A6F@shackspace.de>";
   a1russell = "Adam Russell <adamlr6+pub@gmail.com>";
   aaronschif = "Aaron Schif <aaronschif@gmail.com>";
   abaldeau = "Andreas Baldeau <andreas@baldeau.net>";
@@ -757,6 +756,7 @@
   womfoo = "Kranium Gikos Mendoza <kranium@gikos.net>";
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
+  x4A6F = "Joachim Ernst <0x4A6F@shackspace.de>";
   xaverdh = "Dominik Xaver Hörl <hoe.dom@gmx.de>";
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
   xurei = "Olivier Bourdoux <olivier.bourdoux@gmail.com>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -7,6 +7,7 @@
   to ping a package @<handle>), and <Real Name> is your real name, not
   a pseudonym. Please keep the list alphabetically sorted. */
 {
+  0x4A6F = "Joachim Ernst <0x4A6F@shackspace.de>";
   a1russell = "Adam Russell <adamlr6+pub@gmail.com>";
   aaronschif = "Aaron Schif <aaronschif@gmail.com>";
   abaldeau = "Andreas Baldeau <andreas@baldeau.net>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -327,6 +327,7 @@
   jirkamarsik = "Jirka Marsik <jiri.marsik89@gmail.com>";
   jlesquembre = "José Luis Lafuente <jl@lafuente.me>";
   jluttine = "Jaakko Luttinen <jaakko.luttinen@iki.fi>";
+  Jo = "Joachim Ernst <0x4A6F@shackspace.de>";
   joachifm = "Joachim Fasting <joachifm@fastmail.fm>";
   joamaki = "Jussi Maki <joamaki@gmail.com>";
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
@@ -756,7 +757,6 @@
   womfoo = "Kranium Gikos Mendoza <kranium@gikos.net>";
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
-  x4A6F = "Joachim Ernst <0x4A6F@shackspace.de>";
   xaverdh = "Dominik Xaver Hörl <hoe.dom@gmx.de>";
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
   xurei = "Olivier Bourdoux <olivier.bourdoux@gmail.com>";


### PR DESCRIPTION
###### Motivation for this change

Trying to add my handle @0x4A6F to maintainers, to contribute to nixpkgs.

Looking forward for inclusion of #34842.

###### Things done

Adding github handle starting with decimal to maintainers.nix, but this will break nix expression.
nix-repl lib/maintainers.nix 
```
Welcome to Nix version 1.11.16. Type :? for help.

Loading ‘lib/maintainers.nix’...
error: syntax error, unexpected INT, at /home/user/repositories/github.com/0x4A6F/nixpkgs-origin/lib/maintainers.nix:10:3
```

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

