### PR TITLE
Nginx formatter

### DIFF
--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -1,6 +1,8 @@
 # verifies:
 #   1. nginx generates config file with shared http context definitions above
 #      generated virtual hosts config.
+#
+#   2. nginx runs with a config file that contains non-ascii letters.
 
 import ./make-test.nix ({ pkgs, ...} : {
   name = "nginx";
@@ -28,6 +30,8 @@ import ./make-test.nix ({ pkgs, ...} : {
         services.nginx.virtualHosts."0.my.test" = {
           extraConfig = ''
             access_log syslog:server=unix:/dev/log,facility=user,tag=mytag,severity=info ceeformat;
+            # This comment is lifted from bug #22883:
+            # Statusseite für Monitoring freigeben
           '';
         };
       };

--- a/pkgs/tools/misc/nginx-config-formatter/default.nix
+++ b/pkgs/tools/misc/nginx-config-formatter/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python3 }:
 
 stdenv.mkDerivation rec {
-  version = "2016-06-16";
+  version = "2017-07-26";
   name = "nginx-config-formatter-${version}";
 
   src = fetchFromGitHub {
     owner = "1connect";
     repo = "nginx-config-formatter";
-    rev = "fe5c77d2a503644bebee2caaa8b222c201c0603d";
-    sha256 = "0akpkbq5136k1i1z1ls6yksis35hbr70k8vd10laqwvr1jj41bga";
+    rev = "f5a26225bd7ad5ea97fc6f681cc66fef2f43d5b6";
+    sha256 = "1wm6dfn797fdwjp6cpy70ngws6m9bh64xi1vinm43b3qms81cnb9";
   };
 
   buildInputs = [ python3 ];


### PR DESCRIPTION
###### Motivation for this change

This makes nginx.conf human-readable.

While nominally the file is not meant for human consumption, in practice I commonly need to manually inspect the output of complex nginx configurations to verify that it actually looks the way I want. Being able to read it is therefore useful.

Before formatting: http://ix.io/K9v
After formatting: http://ix.io/K9k

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Tested on a live system (https://madoka.brage.info), using cherry-pick against nixos-unstable release.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

