### PR TITLE
eprover: fix build in non-GCC environments

### DIFF
--- a/pkgs/applications/science/logic/eprover/default.nix
+++ b/pkgs/applications/science/logic/eprover/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, which }:
+
 stdenv.mkDerivation rec {
   name = "eprover-${version}";
   version = "2.0";
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ which ];
 
   preConfigure = ''
-    sed -e 's/ *CC *= gcc$//' -i Makefile.vars
+    sed -e 's/ *CC *= *gcc$//' -i Makefile.vars
   '';
   configureFlags = "--exec-prefix=$(out) --man-prefix=$(out)/share/man";
 


### PR DESCRIPTION
###### Motivation for this change

`eprover` does not build on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

