### PR TITLE
elvish: add shellPath passthru

### DIFF
--- a/pkgs/shells/elvish/default.nix
+++ b/pkgs/shells/elvish/default.nix
@@ -20,4 +20,8 @@ buildGoPackage rec {
     maintainers = with maintainers; [ vrthra ];
     platforms = with platforms; linux ++ darwin;
   };
+
+  passthru = {
+    shellPath = "/bin/elvish";
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
elvish is a shell package but is not recognized as such.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

