### PR TITLE
qt5: 5.10.0 -> 5.10.1

### DIFF
--- a/pkgs/development/libraries/qt-5/5.10/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.10/fetch.sh
@@ -1,2 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.10/5.10.0/submodules/ \
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.10/5.10.1/submodules/ \
             -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.10/qtbase.patch
+++ b/pkgs/development/libraries/qt-5/5.10/qtbase.patch
@@ -261,14 +261,13 @@ index 55c74aad66..0bbc8718eb 100644
          set_target_properties(Qt5::${Plugin} PROPERTIES
              \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
 diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
-index e645ba5803..a0e5c68b7e 100644
+index 50a1ec6764..d6368b769e 100644
 --- a/mkspecs/features/mac/default_post.prf
 +++ b/mkspecs/features/mac/default_post.prf
-@@ -24,166 +24,3 @@ qt {
-         }
+@@ -25,188 +25,3 @@ qt {
      }
  }
--
+ 
 -# Add the same default rpaths as Xcode does for new projects.
 -# This is especially important for iOS/tvOS/watchOS where no other option is possible.
 -!no_default_rpath {
@@ -291,6 +290,29 @@ index e645ba5803..a0e5c68b7e 100644
 -}
 -
 -macx-xcode {
+-    qmake_pkginfo_typeinfo.name = QMAKE_PKGINFO_TYPEINFO
+-    !isEmpty(QMAKE_PKGINFO_TYPEINFO): \
+-        qmake_pkginfo_typeinfo.value = $$QMAKE_PKGINFO_TYPEINFO
+-    else: \
+-        qmake_pkginfo_typeinfo.value = "????"
+-    QMAKE_MAC_XCODE_SETTINGS += qmake_pkginfo_typeinfo
+-
+-    !isEmpty(VERSION) {
+-        l = $$split(VERSION, '.') 0 0  # make sure there are at least three
+-        VER_MAJ = $$member(l, 0, 0)
+-        VER_MIN = $$member(l, 1, 1)
+-        VER_PAT = $$member(l, 2, 2)
+-        unset(l)
+-
+-        qmake_full_version.name = QMAKE_FULL_VERSION
+-        qmake_full_version.value = $${VER_MAJ}.$${VER_MIN}.$${VER_PAT}
+-        QMAKE_MAC_XCODE_SETTINGS += qmake_full_version
+-
+-        qmake_short_version.name = QMAKE_SHORT_VERSION
+-        qmake_short_version.value = $${VER_MAJ}.$${VER_MIN}
+-        QMAKE_MAC_XCODE_SETTINGS += qmake_short_version
+-    }
+-
 -    !isEmpty(QMAKE_XCODE_DEBUG_INFORMATION_FORMAT) {
 -        debug_information_format.name = DEBUG_INFORMATION_FORMAT
 -        debug_information_format.value = $$QMAKE_XCODE_DEBUG_INFORMATION_FORMAT
@@ -432,10 +454,10 @@ index e645ba5803..a0e5c68b7e 100644
 -
 -QMAKE_XCODE_LIBRARY_SUFFIX = $$qtPlatformTargetSuffix()
 diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
-index 44636f2288..3b01424e67 100644
+index f1a4ca77b2..3b01424e67 100644
 --- a/mkspecs/features/mac/default_pre.prf
 +++ b/mkspecs/features/mac/default_pre.prf
-@@ -1,56 +1,2 @@
+@@ -1,67 +1,2 @@
  CONFIG = asset_catalogs rez $$CONFIG
  load(default_pre)
 -
@@ -492,6 +514,17 @@ index 44636f2288..3b01424e67 100644
 -# feature, which allows Xcode to choose the Qt libraries to link to
 -# at build time, depending on the current Xcode SDK and configuration.
 -QMAKE_XCODE_LIBRARY_SUFFIX_SETTING = QT_LIBRARY_SUFFIX
+-
+-xcode_copy_phase_strip_setting.name = COPY_PHASE_STRIP
+-xcode_copy_phase_strip_setting.value = NO
+-QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
+-
+-xcode_product_bundle_identifier_setting.name = PRODUCT_BUNDLE_IDENTIFIER
+-xcode_product_bundle_identifier_setting.value = $$QMAKE_TARGET_BUNDLE_PREFIX
+-isEmpty(xcode_product_bundle_identifier_setting.value): \
+-    xcode_product_bundle_identifier_setting.value = "com.yourcompany"
+-xcode_product_bundle_identifier_setting.value = "$${xcode_product_bundle_identifier_setting.value}.${PRODUCT_NAME:rfc1034identifier}"
+-QMAKE_MAC_XCODE_SETTINGS += xcode_product_bundle_identifier_setting
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
 index 3f6dc076ca..e69de29bb2 100644
 --- a/mkspecs/features/mac/sdk.prf
@@ -676,10 +709,10 @@ index 72dde61a40..f891a2baed 100644
      INSTALLS += inst_qch_docs
  
 diff --git a/mkspecs/features/qt_example_installs.prf b/mkspecs/features/qt_example_installs.prf
-index 668669e4cd..eb4840a0aa 100644
+index c9ce926b1a..f00868a031 100644
 --- a/mkspecs/features/qt_example_installs.prf
 +++ b/mkspecs/features/qt_example_installs.prf
-@@ -82,7 +82,7 @@ sourcefiles += \
+@@ -88,7 +88,7 @@ sourcefiles += \
      $$SOURCES $$HEADERS $$FORMS $$RESOURCES $$TRANSLATIONS \
      $$DBUS_ADAPTORS $$DBUS_INTERFACES
  addInstallFiles(sources.files, $$sourcefiles)
@@ -765,7 +798,7 @@ index 90d84cc535..387481bfc6 100644
          INSTALLS += privpritarget
      }
 diff --git a/mkspecs/features/qt_plugin.prf b/mkspecs/features/qt_plugin.prf
-index 62e1b69fde..abd63123f9 100644
+index 14fc5f9a94..2a0f2cd27f 100644
 --- a/mkspecs/features/qt_plugin.prf
 +++ b/mkspecs/features/qt_plugin.prf
 @@ -88,7 +88,7 @@ CONFIG(static, static|shared)|prefix_build {
@@ -851,10 +884,10 @@ index 706304cf34..546420f6ad 100644
  set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
  !!ENDIF
 diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
-index 609e52d9d2..f0f29ce61f 100644
+index 3814894630..3c6468277c 100644
 --- a/src/corelib/kernel/qcoreapplication.cpp
 +++ b/src/corelib/kernel/qcoreapplication.cpp
-@@ -2580,6 +2580,15 @@ QStringList QCoreApplication::libraryPaths()
+@@ -2601,6 +2601,15 @@ QStringList QCoreApplication::libraryPaths()
          QStringList *app_libpaths = new QStringList;
          coreappdata()->app_libpaths.reset(app_libpaths);
  
@@ -871,7 +904,7 @@ index 609e52d9d2..f0f29ce61f 100644
          if (!libPathEnv.isEmpty()) {
              QStringList paths = QFile::decodeName(libPathEnv).split(QDir::listSeparator(), QString::SkipEmptyParts);
 diff --git a/src/corelib/tools/qtimezoneprivate_tz.cpp b/src/corelib/tools/qtimezoneprivate_tz.cpp
-index bcc1285472..a77eb472a3 100644
+index 6a5df6272a..a6136ca4cd 100644
 --- a/src/corelib/tools/qtimezoneprivate_tz.cpp
 +++ b/src/corelib/tools/qtimezoneprivate_tz.cpp
 @@ -70,7 +70,11 @@ typedef QHash<QByteArray, QTzTimeZone> QTzTimeZoneHash;
@@ -969,10 +1002,10 @@ index 07869efd7d..fb4183bada 100644
      set(imported_implib \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
  !!ENDIF
 diff --git a/src/network/kernel/qdnslookup_unix.cpp b/src/network/kernel/qdnslookup_unix.cpp
-index 1da00813ce..0bf877afcb 100644
+index ce1ec6442a..4f75655abe 100644
 --- a/src/network/kernel/qdnslookup_unix.cpp
 +++ b/src/network/kernel/qdnslookup_unix.cpp
-@@ -92,7 +92,7 @@ static bool resolveLibraryInternal()
+@@ -95,7 +95,7 @@ static bool resolveLibraryInternal()
      if (!lib.load())
  #endif
      {
@@ -1013,10 +1046,10 @@ index b5a0a5bbeb..6c20305f4d 100644
  
  QString TableGenerator::findComposeFile()
 diff --git a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
-index 3bc8590d36..2a78fde518 100644
+index a59dc15b0e..a13ee89b5a 100644
 --- a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
 +++ b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
-@@ -580,7 +580,14 @@ QFunctionPointer QGLXContext::getProcAddress(const char *procName)
+@@ -584,7 +584,14 @@ QFunctionPointer QGLXContext::getProcAddress(const char *procName)
  #if QT_CONFIG(library)
                  extern const QString qt_gl_library_name();
  //                QLibrary lib(qt_gl_library_name());

--- a/pkgs/development/libraries/qt-5/5.10/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.10/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   qt3d = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qt3d-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1arlplfpqdk0qki7bs1pp16y9cwa0awn071p551jg4y74xr7wi8j";
-      name = "qt3d-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qt3d-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0fvb346xhiyc0csxcvs5ifwkzs9wnza54vvsw6dvyax76qjv87q4";
+      name = "qt3d-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtactiveqt-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0x6nbi5hlbr1pncbd8zzkwmqi04gcy64q3bjy5w45rg6zws41mzr";
-      name = "qtactiveqt-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtactiveqt-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1r4i72i1pl9xnmcx8rr8g48fmym8mxs28pkg1nl302xi6izan8ch";
+      name = "qtactiveqt-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtandroidextras-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1ifb49px86abaf4znmlis9wyyxq132nlgj3fyqppbx1sranikygk";
-      name = "qtandroidextras-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtandroidextras-everywhere-src-5.10.1.tar.xz";
+      sha256 = "03jmf7gw4abn5gj92b1ns0k75bbi4wycbc4bbb7c9mngzkv3nzkn";
+      name = "qtandroidextras-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtbase = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtbase-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0qpp56cbw1sfz5ayhj2mskb07cl6jd1ijayg29y624qa6b6phmgx";
-      name = "qtbase-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtbase-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0sd9cn3ywkjfswddcxhbfplkwk8snqld752q5laaapdakhc0wrnq";
+      name = "qtbase-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtcanvas3d-everywhere-src-5.10.0.tar.xz";
-      sha256 = "11r98mdxy833kcnywlsjrfaqhax7m3b6yhb56072qvr30rpn52fj";
-      name = "qtcanvas3d-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtcanvas3d-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1h5hpjwdyp824r2ajmaqjcshra06yfzz7dp991h4kf54da79m0ny";
+      name = "qtcanvas3d-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtcharts-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1vri3f7wyg84w6j84452g8h2p7sk7k01r0xszpn4klv7hi52rkhj";
-      name = "qtcharts-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtcharts-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1j8y683ainri9ma44ky6q87pjs1d794znb2wfsrbplixyxxmf3ag";
+      name = "qtcharts-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtconnectivity-everywhere-src-5.10.0.tar.xz";
-      sha256 = "19k9n6gzrbg0sbgyhhcl5gv0d4b2gjwmz5966gn6b424fblf4grf";
-      name = "qtconnectivity-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtconnectivity-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1j9ydlkwz3039yslaizz923h0qbszm4z2sqspk28wr8rd3f22a35";
+      name = "qtconnectivity-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtdatavis3d-everywhere-src-5.10.0.tar.xz";
-      sha256 = "06363x449k7wkqrd7c0y6b5vqlpwssnkl0g5s1bhp8lkl3bw81lj";
-      name = "qtdatavis3d-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtdatavis3d-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0ny8j689jm2fghklzw894yc5hjqa23yf395yv17yvwi72kpiz0b3";
+      name = "qtdatavis3d-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtdeclarative-everywhere-src-5.10.0.tar.xz";
-      sha256 = "07kicxzbwiqwkg1x2k6447rwzvzn31cv1yyggc1m8r84lny4vjsw";
-      name = "qtdeclarative-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtdeclarative-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0lwmg1qan886czzkzi4px36mqxlqiw0acrsa9kqcddg5pi8yvy9s";
+      name = "qtdeclarative-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtdoc-everywhere-src-5.10.0.tar.xz";
-      sha256 = "01z4ikqrnnx9mzf5pvk4i2lqks4xai32fs9qqbqnsp0qrrcb1jfn";
-      name = "qtdoc-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtdoc-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1gl62acr346jrcfxla8vxlczf706a3md52zc0zaqbjw9rf2bgnqq";
+      name = "qtdoc-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtgamepad-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1rl77rsfgs69cdv75nfjp9w66mndwi211wix5cwl46d7i3wm0xak";
-      name = "qtgamepad-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtgamepad-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1xs6adpnv5ymdmb7kcbvcc0vx2lp6wqz53pzr9amyzbgyl0jiiw5";
+      name = "qtgamepad-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtgraphicaleffects-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0c2y0ixxncn5xslpxciigq1gfaxd3n7wkcf14k4iy5i15w8nkfcp";
-      name = "qtgraphicaleffects-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtgraphicaleffects-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0zw4n6s42w70r45gjg66ad0s9dpxil6wmwwrivshnqvrnlqhcfrz";
+      name = "qtgraphicaleffects-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtimageformats-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1z7lnw85apzf6ph3dgnbb6py17qzpgww92kz31n6vbv5z62bigwi";
-      name = "qtimageformats-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtimageformats-everywhere-src-5.10.1.tar.xz";
+      sha256 = "10x248s4a6ij18awkdskk3g7zfw6gwyj63l2jr803blyfyibl118";
+      name = "qtimageformats-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtlocation-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1iw5m9v5p6l6mivjvj7g1macpqf2n21mg4wg0hza36dwrz3wwkfq";
-      name = "qtlocation-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtlocation-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1jbjzl6gwxy4n43x6m55b86vkdpjvwyvw7xsxg4a40f72xaw0p2y";
+      name = "qtlocation-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtmacextras-everywhere-src-5.10.0.tar.xz";
-      sha256 = "08n8na36j9c15hvicqfs7h915m2av5xd5v0azf7660z0q9lk9zb3";
-      name = "qtmacextras-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtmacextras-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1jkzizsa8nr1dp5n9p81s6ylnqfh0vqwz8l72632fg68x229jfn7";
+      name = "qtmacextras-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtmultimedia-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0vw0i5jgn4q63g5ijwwrb6835qdaxcw7sfcjffbqfbdwqgyk70q0";
-      name = "qtmultimedia-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtmultimedia-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0j9nq8s2kzfc7zqs253pixqwd5xjv2cbqyik5lgvi9p5bq0riym1";
+      name = "qtmultimedia-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtnetworkauth-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1lnqi1qpy9j5pi2lcmdihf81lspxv6hgdg5jmbqqdqxwzblgpnpc";
-      name = "qtnetworkauth-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtnetworkauth-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1p6wnma2nygqbjhrbiijjgkc8jq6lkdmq6xaxcgdh8ynkcqiq8wp";
+      name = "qtnetworkauth-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtpurchasing-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0mkxslc8qc6sclpngllby3bb86qq5csrsz0xrc14nwmbkhwksxwc";
-      name = "qtpurchasing-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtpurchasing-everywhere-src-5.10.1.tar.xz";
+      sha256 = "090gmxy5bp44rirl5yrb1ryn97z37ri4fmmclh9z7c4dvnmr2d3j";
+      name = "qtpurchasing-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtquickcontrols-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0ab19raip9828br21qqaglr4y0kqmxix882r13sfxlnm4ivyycx1";
-      name = "qtquickcontrols-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtquickcontrols-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1dw22sk2x5bk2mix06w8dv1b05dyq0gx088aqvdz18y67ncs2cfj";
+      name = "qtquickcontrols-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtquickcontrols2-everywhere-src-5.10.0.tar.xz";
-      sha256 = "18d1b5aivaqgs1px61glkyclkky60xd7yzy1vwa1f89sg8j711w1";
-      name = "qtquickcontrols2-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtquickcontrols2-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0jk01vgzc78w45q8kys1hwri3jx0hzx5vxivzmv8nh8yj0dlmijx";
+      name = "qtquickcontrols2-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtremoteobjects-everywhere-src-5.10.0.tar.xz";
-      sha256 = "01bf1ykqxb4d8wz58vxy15yj4jsaqhi258k05dhy7ygdvfgscdnz";
-      name = "qtremoteobjects-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtremoteobjects-everywhere-src-5.10.1.tar.xz";
+      sha256 = "052fa27rv4b9h6qbldrq013zxb69ysgmqnxbyv9c48s2ra50pnp9";
+      name = "qtremoteobjects-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtscript = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtscript-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1z6a14x9yj0p2znc0vny8y4zkdvm5fp42rnisnf9rynakkqg5wkc";
-      name = "qtscript-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtscript-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0bakr5xcxc6j6l78fyazh7sgcz2hwf2g8k60jb9307qzrgvqlqg0";
+      name = "qtscript-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtscxml-everywhere-src-5.10.0.tar.xz";
-      sha256 = "142qysd5s706r62gap62s89xm7334i1ys29dqsp09av9n7b1kfsb";
-      name = "qtscxml-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtscxml-everywhere-src-5.10.1.tar.xz";
+      sha256 = "00v1n86pyw9cm320qa2fpazvkfi6czd027x60k2g2sprwh0x4hhb";
+      name = "qtscxml-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtsensors-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0w9rzqc0hva4521i5j298lrsvys3jqddmqd80cxj9nsvnapwb66d";
-      name = "qtsensors-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtsensors-everywhere-src-5.10.1.tar.xz";
+      sha256 = "15jw2r6snhwi26b4ajp7m89l89kaf1j0kgqds4wjpksk1rngf3dv";
+      name = "qtsensors-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtserialbus-everywhere-src-5.10.0.tar.xz";
-      sha256 = "06rr0191zy5yxqzxiv0c6dvshncjg8kdc33lszk41pajv624fn9z";
-      name = "qtserialbus-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtserialbus-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0mr2j86mk1fm9z5iba3kav651231j9jv0805q8716h7ia1ws2l06";
+      name = "qtserialbus-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtserialport-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0mqlhdp20jl6agv58mszznsikmi1dflhalkpfbgpiafjzzczx075";
-      name = "qtserialport-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtserialport-everywhere-src-5.10.1.tar.xz";
+      sha256 = "17ja368ggl9aak64r8sqzx34j2i8zv7z60bkhncynrgipc9wpr08";
+      name = "qtserialport-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtspeech-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1hashidb33f1215f0azjby1lh8iw7v2bvxp08mqvdk02jld9w5br";
-      name = "qtspeech-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtspeech-everywhere-src-5.10.1.tar.xz";
+      sha256 = "07clcy3bslq4fk7xb6cqlfsz5frhmy41hzpajdqjwj9h6dvmqxw5";
+      name = "qtspeech-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtsvg-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1c77wnpzjz4wwic5if876y5v1n44v2g2nhjmcs25cc8awz5afaja";
-      name = "qtsvg-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtsvg-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0nkz3kxclk7s95fnh8xgljahk131mwb8pjllgp7n70ycmc20rq00";
+      name = "qtsvg-everywhere-src-5.10.1.tar.xz";
     };
   };
   qttools = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qttools-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0cpybii2yznk6gwaa2cz83rk3cpzzm6l4wvn4n2xwdbrgdsdrx8z";
-      name = "qttools-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qttools-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0lwa0i6zspcrii0ak1dyxacif1fkv2vhmdp3dmp7af71bwg49spi";
+      name = "qttools-everywhere-src-5.10.1.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qttranslations-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1gmrisf08nsrni7fyjlz5ggfgfzzkjpq3g7l2hc6vq5g04vbskgc";
-      name = "qttranslations-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qttranslations-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1za34rvn3bhzi4mxqm9lghdhaqcxpsi6xa61dfbhpc047l788v8z";
+      name = "qttranslations-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtvirtualkeyboard-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0mqb9sgvq7djd2lz4q4p6p9f0c23cfhk447zx4axvv1mldjxsb9c";
-      name = "qtvirtualkeyboard-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtvirtualkeyboard-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0bnmhy0kibvyra0i15qzwc9195s8wpfhg5gk0d6rfwd5d07gj6a3";
+      name = "qtvirtualkeyboard-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtwayland-everywhere-src-5.10.0.tar.xz";
-      sha256 = "14sb0227rzqzf5z8dz8b9nzkk5rwq6hrfxifz603iy4mdijzjmsn";
-      name = "qtwayland-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtwayland-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0mk3p8pkfia3z7v7phk0qdyzd1zkfpk92c995g851p5wbqx699zm";
+      name = "qtwayland-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtwebchannel-everywhere-src-5.10.0.tar.xz";
-      sha256 = "18rml5xyb9chz8wrfamsgx4z32kkjbk1rc47ynvhn49mcbf2897j";
-      name = "qtwebchannel-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtwebchannel-everywhere-src-5.10.1.tar.xz";
+      sha256 = "0r1p1ar4xh7g7lzi564hgw1ng5xkim4mkpgq29ymjlmhxjgl8b62";
+      name = "qtwebchannel-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtwebengine-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1yb7jpydxg0dwdrx0iv7i5dq4wb9ld1iff8zpjdj8yl4xy4mkgx8";
-      name = "qtwebengine-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtwebengine-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1ph1pinxn0dp44zall9gihbgziira4zpynixacm4ldd85f6lyr0j";
+      name = "qtwebengine-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtwebglplugin = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtwebglplugin-everywhere-src-5.10.0.tar.xz";
-      sha256 = "0hgwb5lll3275knnj3ms04y1n0i6gph9kac2246ixmcq8sc7a2k7";
-      name = "qtwebglplugin-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtwebglplugin-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1hdzymwai5f6agkn4hz32aq5fjv2lqdac285fwrlk5gsff0j0yal";
+      name = "qtwebglplugin-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtwebsockets-everywhere-src-5.10.0.tar.xz";
-      sha256 = "00wlyhw7h2axyhinksfm912jfa3n73szxdccz5dlir8742i0zaqp";
-      name = "qtwebsockets-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtwebsockets-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1sjkml5kqigvyxrkv5b7x1cy69d69dzma40yfg72vr7zal4pkkvf";
+      name = "qtwebsockets-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtwebview-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1955fkc7a22d7a0y2n7kz7r1md56v2s5qvyb3h68szs60zjnk3xa";
-      name = "qtwebview-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtwebview-everywhere-src-5.10.1.tar.xz";
+      sha256 = "110mwc423cq1bwdz0vv78cjprzy03xawxnxhfcs4138gssfj0n0b";
+      name = "qtwebview-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtwinextras-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1mx5qihmh3awqcr9k3z2chxz8273bi5ha90v7f4fqr2vk3g6w4yd";
-      name = "qtwinextras-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtwinextras-everywhere-src-5.10.1.tar.xz";
+      sha256 = "05w9n8kry1mg3i14i4m98gm5hf20mlwxbagbk9xk11xykbm1wh0j";
+      name = "qtwinextras-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtx11extras-everywhere-src-5.10.0.tar.xz";
-      sha256 = "11jp0a40jqwcdq7isyip4f4mq2d58c9fx1kvg9g71m92n52ffyfb";
-      name = "qtx11extras-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtx11extras-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1d4pvisxbcyb7ljl1lh2zg72kw44h9kk14l0xmvajb8bslgkg2n3";
+      name = "qtx11extras-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.10.0";
+    version = "5.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.10/5.10.0/submodules/qtxmlpatterns-everywhere-src-5.10.0.tar.xz";
-      sha256 = "1hq3sbimbhaiw570d2cd84jhki0n2jw2x2s7iq92m53y4akbr2mh";
-      name = "qtxmlpatterns-everywhere-src-5.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.10/5.10.1/submodules/qtxmlpatterns-everywhere-src-5.10.1.tar.xz";
+      sha256 = "1zp9smsfdqyfiarxs7r8kfr7yq68cdn7biddwl36cybax6fgbpiw";
+      name = "qtxmlpatterns-everywhere-src-5.10.1.tar.xz";
     };
   };
   qtwebkit = {


### PR DESCRIPTION
###### Motivation for this change
Yeah, a bug fix release. 

It currently still compiles,  but it looks good.

@ttuegel @adisbladis @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

