### PR TITLE
restic: add completions and man page to package

### DIFF
--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -19,8 +19,16 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    mkdir -p $bin/bin/
+    mkdir -p \
+      $bin/bin \
+      $bin/etc/bash_completion.d \
+      $bin/share/zsh/vendor-completions \
+      $bin/share/man/man1
     cp restic $bin/bin/
+    $bin/bin/restic generate \
+      --bash-completion $bin/etc/bash_completion.d/restic.sh \
+      --zsh-completion $bin/share/zsh/vendor-completions/restic.sh \
+      --man $bin/share/man/man1
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Add bash/zsh completions for restic
Add manpage for restic

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

NOTE: I have not successfully tested the zsh completions! I am a bash user.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

