### PR TITLE
cpp-gsl: init at unstable-2018-02-15

### DIFF
--- a/pkgs/development/libraries/cpp-gsl/default.nix
+++ b/pkgs/development/libraries/cpp-gsl/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
      use by the C++ Core Guidelines maintained by the Standard C++ Foundation.
      This package contains Microsoft's implementation of GSL.
     '';
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    platforms = stdenv.lib.platforms.unix;
     license = licenses.mit;
     maintainers = with maintainers; [ yuriaisaka ];
   };

--- a/pkgs/development/libraries/cpp-gsl/default.nix
+++ b/pkgs/development/libraries/cpp-gsl/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, catch }:
+
+stdenv.mkDerivation rec {
+  pname = "GSL-unstable";
+  version = "2017-02-15";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "Microsoft";
+    repo = "GSL";
+    rev = "c87c123d1b3e64ae2cf725584f0c004da4d90f1c";
+    sha256 = "0h8py468bvxnydkjs352d7a9s8hk0ihc7msjkcnzj2d7nzp5nsc1";
+  };
+
+  nativeBuildInputs = [ cmake catch ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Microsoft/GSL;
+    description = "C++ Core Guideline support library";
+    longDescription = ''
+     The Guideline Support Library (GSL) contains functions and types that are suggested for
+     use by the C++ Core Guidelines maintained by the Standard C++ Foundation.
+     This package contains Microsoft's implementation of GSL.
+    '';
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    license = licenses.mit;
+    maintainers = with maintainers; [ yuriaisaka ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5746,7 +5746,8 @@ with pkgs;
 
   compcert = callPackage ../development/compilers/compcert { };
 
-
+  cpp-gsl = callPackage ../development/libraries/cpp-gsl { };
+  
   # Users installing via `nix-env` will likely be using the REPL,
   # which has a hard dependency on Z3, so make sure it is available.
   cryptol = haskellPackages.cryptol.overrideDerivation (oldAttrs: {


### PR DESCRIPTION
###### Motivation for this change

The Guideline Support Library (GSL) contains functions and types that are suggested for use by the C++ Core Guidelines maintained by the Standard C++ Foundation.
This derivation packages Microsoft's implementation of GSL.

We package it under the name `cpp-gsl`, as `gsl` is already taken by GNU Scientific Library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

