### PR TITLE
fixedsys-excelsior: init at 3.00.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -494,6 +494,7 @@
   nicknovitski = "Nick Novitski <nixpkgs@nicknovitski.com>";
   nico202 = "Nicolò Balzarotti <anothersms@gmail.com>";
   NikolaMandic = "Ratko Mladic <nikola@mandic.email>";
+  ninjatrappeur = "Félix Baylac-Jacqué <felix@alternativebit.fr>";
   nipav = "Niko Pavlinek <niko.pavlinek@gmail.com>";
   nixy = "Andrew R. M. <nixy@nixy.moe>";
   nmattia = "Nicolas Mattia <nicolas@nmattia.com>";

--- a/pkgs/data/fonts/fixedsys-excelsior/default.nix
+++ b/pkgs/data/fonts/fixedsys-excelsior/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl } :
+
+let 
+  major = "3";
+  minor = "00";
+  version = "${major}.${minor}";
+
+in
+
+stdenv.mkDerivation rec {
+  name = "fixedsys-excelsior-${version}";
+
+  src = fetchurl {
+    url = http://www.fixedsysexcelsior.com/fonts/FSEX300.ttf;
+    sha256 = "6ee0f3573bc5e33e93b616ef6282f49bc0e227a31aa753ac76ed2e3f3d02056d";
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype/
+    cp $src $out/share/fonts/truetype/${name}.ttf
+  '';
+
+  outputHashMode = "recursive";
+
+  outputHashAlgo = "sha256";
+
+  outputHash = "32d6f07f1ff08c764357f8478892b2ba5ade23427af99759f34a0ba24bcd2e37";
+  
+  meta = {
+    description = "Pan-unicode version of Fixedsys, a classic DOS font.";
+    homepage = http://www.fixedsysexcelsior.com/;
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.publicDomain;
+    maintainers = [ stdenv.lib.maintainers.ninjatrappeur ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13842,6 +13842,8 @@ with pkgs;
 
   faba-mono-icons = callPackage ../data/icons/faba-mono-icons { };
 
+  fixedsys-excelsior = callPackage ../data/fonts/fixedsys-excelsior { };
+
   emacs-all-the-icons-fonts = callPackage ../data/fonts/emacs-all-the-icons-fonts { };
 
   emojione = callPackage ../data/fonts/emojione {


### PR DESCRIPTION
###### Motivation for this change
Fixedsys excelsior is a monospace true type font inspired by DOS's fixedsys.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

