### PR TITLE
bazel: 0.9 -> 0.10.1

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
 
-  version = "0.9.0";
+  version = "0.10.1";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "0aiifrp6g1d3ilhg8111wdhsrjy41x8gcmq67rjyxypw9znqzcpg";
+    sha256 = "0rz6zvkzyglf0mmc178avf52zynz487m4v0089ilsbrgv7v4i0kh";
   };
 
   sourceRoot = ".";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7284,8 +7284,7 @@ with pkgs;
   bam = callPackage ../development/tools/build-managers/bam {};
 
   bazel_0_4 = callPackage ../development/tools/build-managers/bazel/0.4.nix { };
-  bazel_0_9 = callPackage ../development/tools/build-managers/bazel { };
-  bazel = bazel_0_9;
+  bazel = callPackage ../development/tools/build-managers/bazel { };
 
   bear = callPackage ../development/tools/build-managers/bear { };
 


### PR DESCRIPTION
Also, remove the bazel_0_9 attribute that refers to `.../bazel/default.nix`.
It makes no sense to provide a versioned attribute to increment it on each update.
One could update `default.nix` without updating `all-packages.nix`.

This package builds an works on NixOS, and is not otherwise used in nixpkgs (only bazel_0_4 is used).

/cc @sigma, @mboes