### PR TITLE
rss2email: add docs and code for running tests

### DIFF
--- a/pkgs/applications/networking/feedreaders/rss2email/default.nix
+++ b/pkgs/applications/networking/feedreaders/rss2email/default.nix
@@ -14,11 +14,23 @@ buildPythonApplication rec {
     sha256 = "02wj9zhmc2ym8ba1i0z9pm1c622z2fj7fxwagnxbvpr1402ahmr5";
   };
 
+  outputs = [ "out" "man" "doc" ];
+
   postInstall = ''
-    install -Dm 644 r2e.1 $out/share/man/man1/r2e.1
+    install -Dm 644 r2e.1 $man/share/man/man1/r2e.1
     # an alias for better finding the manpage
-    ln -s -T r2e.1 $out/share/man/man1/rss2email.1
+    ln -s -T r2e.1 $man/share/man/man1/rss2email.1
+
+    # copy documentation
+    mkdir -p $doc/share/doc/rss2email
+    cp AUTHORS COPYING CHANGELOG README $doc/share/doc/rss2email/
   '';
+
+  # The tests currently fail, see
+  # https://github.com/rss2email/rss2email/issues/14
+  # postCheck = ''
+  #   env PYTHONPATH=.:$PYTHONPATH python ./test/test.py
+  # '';
 
   meta = with lib; {
     description = "A tool that converts RSS/Atom newsfeeds to email.";

--- a/pkgs/applications/networking/feedreaders/rss2email/default.nix
+++ b/pkgs/applications/networking/feedreaders/rss2email/default.nix
@@ -16,6 +16,12 @@ buildPythonApplication rec {
 
   outputs = [ "out" "man" "doc" ];
 
+  postPatch = ''
+    # sendmail executable is called from PATH instead of sbin by default
+    sed -e 's|/usr/sbin/sendmail|sendmail|' \
+        -i rss2email/config.py
+  '';
+
   postInstall = ''
     install -Dm 644 r2e.1 $man/share/man/man1/r2e.1
     # an alias for better finding the manpage


### PR DESCRIPTION
The tests are not working yet (upstream bug).

Also patch one path in the default config.