### PR TITLE
firefox: enable pulseaudio by default

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -71,7 +71,7 @@ let
             ++ lib.optionals (cfg.enableQuakeLive or false)
             (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib libudev ])
             ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash
-            ++ lib.optional (config.pulseaudio or false) libpulseaudio;
+            ++ lib.optional (config.pulseaudio or true) libpulseaudio;
       gst-plugins = with gst_all; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
       gtk_modules = [ libcanberra_gtk2 ];
 


### PR DESCRIPTION
###### Motivation for this change
This fixes choppy audio in WebRTC. Firefox's closure already includes
libpulseaudio anyway, so this shouldn't affect closure size either.

Notes:

 - This does *not* disable ALSA support. Firefox will still use ALSA if pulseaudio is unavailable.
 - Previously suggested in #24012. This was to resolve a "no sound" issue which was caused by upstream disabling ALSA by default (!). This is to resolve a "choppy sound" issue which is caused by an upstream bug in the (unmaintained, ref https://bugzilla.mozilla.org/show_bug.cgi?id=1345661) ALSA code.

I think backporting to 17.09 is also appropriate?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

