### PR TITLE
caprice32 : init at unstable-2018-02-10

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -260,7 +260,7 @@
   gavin = "Gavin Rogers <gavin@praxeology.co.uk>";
   gebner = "Gabriel Ebner <gebner@gebner.org>";
   geistesk = "Alvar Penning <post@0x21.biz>";
-  genesis = "Ronan Bignaux <ronan@aimao.org>";
+  bignaux = "Ronan Bignaux <ronan@aimao.org>";
   georgewhewell = "George Whewell <georgerw@gmail.com>";
   gilligan = "Tobias Pflug <tobias.pflug@gmail.com>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -260,7 +260,7 @@
   gavin = "Gavin Rogers <gavin@praxeology.co.uk>";
   gebner = "Gabriel Ebner <gebner@gebner.org>";
   geistesk = "Alvar Penning <post@0x21.biz>";
-  bignaux = "Ronan Bignaux <ronan@aimao.org>";
+  genesis = "Ronan Bignaux <ronan@aimao.org>";
   georgewhewell = "George Whewell <georgerw@gmail.com>";
   gilligan = "Tobias Pflug <tobias.pflug@gmail.com>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";

--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, libpng, pkgconfig, SDL, freetype, zlib, mesa }:
+
+stdenv.mkDerivation rec {
+
+  pname = "caprice32";
+  version = "20170210";
+  rev = "53de69543300f81af85df32cbd21bb5c68cab61e";
+  short_rev = "${builtins.substring 0 7 rev}";
+  name = "${pname}-${version}-${short_rev}";
+
+  src = fetchFromGitHub {
+    owner = "ColinPitrat";
+    repo  = "${rev}";
+    rev = "53de69543300f81af85df32cbd21bb5c68cab61e";
+    sha256 = "12yv56blm49qmshpk4mgc802bs51wv2ra87hmcbf2wxma39c45fy";
+  };
+
+  postPatch = "substituteInPlace cap32.cfg --replace /usr/local $out";
+
+  meta = with stdenv.lib; {
+    description = "a complete emulation of CPC464, CPC664 and CPC6128";
+    homepage = https://github.com/ColinPitrat/caprice32 ;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libpng SDL freetype zlib ];
+  makeFlags = [ "GIT_HASH=$(src.rev)" "DESTDIR=$(out)" "prefix=/"];
+}

--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -3,29 +3,29 @@
 stdenv.mkDerivation rec {
 
   pname = "caprice32";
-  version = "20180210";
+  version = "2018-02-10";
   rev = "53de69543300f81af85df32cbd21bb5c68cab61e";
   short_rev = "${builtins.substring 0 7 rev}";
   name = "${pname}-${version}-${short_rev}";
 
   src = fetchFromGitHub {
+    inherit rev;
     owner = "ColinPitrat";
     repo  = "caprice32";
-    rev = "${rev}";
     sha256 = "12yv56blm49qmshpk4mgc802bs51wv2ra87hmcbf2wxma39c45fy";
   };
 
   postPatch = "substituteInPlace cap32.cfg --replace /usr/local $out";
 
   meta = with stdenv.lib; {
-    description = "a complete emulation of CPC464, CPC664 and CPC6128";
+    description = "A complete emulation of CPC464, CPC664 and CPC6128";
     homepage = https://github.com/ColinPitrat/caprice32 ;
     license = licenses.gpl2;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ maintainers.bignaux ];
     platforms = platforms.linux;
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libpng SDL freetype zlib ];
-  makeFlags = [ "GIT_HASH=$(src.rev)" "DESTDIR=$(out)" "prefix=/"];
+  makeFlags = [ "GIT_HASH=${src.rev}" "DESTDIR=$(out)" "prefix=/"];
 }

--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -3,15 +3,15 @@
 stdenv.mkDerivation rec {
 
   pname = "caprice32";
-  version = "20170210";
+  version = "20180210";
   rev = "53de69543300f81af85df32cbd21bb5c68cab61e";
   short_rev = "${builtins.substring 0 7 rev}";
   name = "${pname}-${version}-${short_rev}";
 
   src = fetchFromGitHub {
     owner = "ColinPitrat";
-    repo  = "${rev}";
-    rev = "53de69543300f81af85df32cbd21bb5c68cab61e";
+    repo  = "caprice32";
+    rev = "${rev}";
     sha256 = "12yv56blm49qmshpk4mgc802bs51wv2ra87hmcbf2wxma39c45fy";
   };
 

--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -2,16 +2,14 @@
 
 stdenv.mkDerivation rec {
 
-  pname = "caprice32";
-  version = "2018-02-10";
+  repo = "caprice32";
+  version = "unstable-2018-02-10";
   rev = "53de69543300f81af85df32cbd21bb5c68cab61e";
-  short_rev = "${builtins.substring 0 7 rev}";
-  name = "${pname}-${version}-${short_rev}";
+  name = "${repo}-${version}";
 
   src = fetchFromGitHub {
-    inherit rev;
+    inherit rev repo;
     owner = "ColinPitrat";
-    repo  = "caprice32";
     sha256 = "12yv56blm49qmshpk4mgc802bs51wv2ra87hmcbf2wxma39c45fy";
   };
 
@@ -21,7 +19,7 @@ stdenv.mkDerivation rec {
     description = "A complete emulation of CPC464, CPC664 and CPC6128";
     homepage = https://github.com/ColinPitrat/caprice32 ;
     license = licenses.gpl2;
-    maintainers = [ maintainers.bignaux ];
+    maintainers = [ maintainers.genesis ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19356,6 +19356,8 @@ with pkgs;
 
   cryptoverif = callPackage ../applications/science/logic/cryptoverif { };
 
+  caprice32 = callPackage ../misc/emulators/caprice32 { };
+
   cubicle = callPackage ../applications/science/logic/cubicle { };
 
   cvc3 = callPackage ../applications/science/logic/cvc3 {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

