### PR TITLE
nixUnstable: pre5943_52c777a7 -> pre5947_d26b71fd

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -151,12 +151,12 @@ in rec {
 
   nixUnstable = (lib.lowPrio (common rec {
     name = "nix-2.0${suffix}";
-    suffix = "pre5943_52c777a7";
+    suffix = "pre5947_d26b71fd";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "52c777a79318c85c8fbd8c02174a03511de278db";
-      sha256 = "0qwmyy7l16djrlksfpjfkfkh5v9s0cyg6ca2809m1qb6swfzqqdf";
+      rev = "d26b71fda61196033c27cbac0ffed2a94fd1fe4c";
+      sha256 = "0jxk5vbhnhwyzw934syaaiya0fpwpp7z03yli2d9j0jvx2igpgcj";
     };
     fromGit = true;
   })) // { perl-bindings = perl-bindings { nix = nixUnstable; }; };


### PR DESCRIPTION
###### Motivation for this change

Fixes the test failures on darwin.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

