### PR TITLE
Fix build of acl and attr from source with unstable Nix

### DIFF
--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -20,13 +20,14 @@ stdenv.mkDerivation rec {
     sed -e '/^\/\//d' -i include/acl.h
   '';
 
-  configureFlags = "MAKE=make MSGFMT=msgfmt MSGMERGE=msgmerge XGETTEXT=xgettext ZIP=gzip ECHO=echo SED=sed AWK=gawk";
+  configureFlags = [ "MAKE=make" "MSGFMT=msgfmt" "MSGMERGE=msgmerge" "XGETTEXT=xgettext" "ZIP=gzip" "ECHO=echo" "SED=sed" "AWK=gawk" ];
 
-  installTargets = "install install-lib install-dev";
+  installTargets = [ "install" "install-lib" "install-dev" ];
 
-  meta = {
-    homepage = http://savannah.nongnu.org/projects/acl;
+  meta = with stdenv.lib; {
+    homepage = "http://savannah.nongnu.org/projects/acl";
     description = "Library and tools for manipulating access control lists";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
   };
 }

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -12,13 +12,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gettext ];
 
-  configureFlags = "MAKE=make MSGFMT=msgfmt MSGMERGE=msgmerge XGETTEXT=xgettext ECHO=echo SED=sed AWK=gawk";
+  configureFlags = [ "MAKE=make" "MSGFMT=msgfmt" "MSGMERGE=msgmerge" "XGETTEXT=xgettext" "ECHO=echo" "SED=sed" "AWK=gawk" ];
 
-  installTargets = "install install-lib install-dev";
+  installTargets = [ "install" "install-lib" "install-dev" ];
 
-  meta = {
-    homepage = http://savannah.nongnu.org/projects/attr/;
+  meta = with stdenv.lib; {
+    homepage = "http://savannah.nongnu.org/projects/attr/";
     description = "Library and tools for manipulating extended attributes";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Because unstable Nix's `/bin/sh` is very barebones it doesn't include `getopts` shell builtin, so we need to use a proper shell for `install-sh` scripts instead.

See also https://github.com/NixOS/nixpkgs/issues/35014

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

