### PR TITLE
fix error handling and return code

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -208,11 +208,12 @@ clone(){
     init_remote "$url"
 
     # Download data from the repository.
-    checkout_ref "$hash" "$ref" ||
-    checkout_hash "$hash" "$ref" || (
-        echo 1>&2 "Unable to checkout $hash$ref from $url."
-        exit 1
-    )
+    exit_status=$(checkout_ref "$hash" "$ref" || checkout_hash "$hash" "$ref")
+
+    if [ $exit_status ]; then
+      echo 1>&2 "Unable to checkout $hash$ref from $url."
+      exit 1
+    fi
 
     # Checkout linked sources.
     if test -n "$fetchSubmodules"; then
@@ -314,11 +315,12 @@ clone_user_rev() {
         errfile="$(mktemp "${TMPDIR:-/tmp}/git-checkout-err-XXXXXXXX")"
         # shellcheck disable=SC2064
         trap "rm -rf \"$errfile\"" EXIT
-        _clone_user_rev "$@" 2> "$errfile" || (
-            status="$?"
-            cat "$errfile" >&2
-            exit "$status"
-        )
+        _clone_user_rev "$@" 2> "$errfile"
+        status=$?
+        if [ $status -ne 0 ]; then
+          cat "$errfile" >&2
+          exit $status
+        fi
     fi
 }
 


### PR DESCRIPTION
###### Motivation for this change

there is a bug in `nix-prefetch-git` which makes our implementation of `dep2nix` impossible, since the error handling is not working at all.

the cause for the problem is that `https://golang.org/x/net` is not a git repository at all and therefore `nix-prefetch-git` should fail with an exit code != 0 which is not the case.

###### the output before the change A

```
nix-prefetch-git https://golang.org/x/net --rev f5dfe339be1d06f81b22525fe34671ee7d2c8904
Leeres Git-Repository in /tmp/git-checkout-tmp-77RGm6hA/net-f5dfe33/.git/ initialisiert
fatal: https://golang.org/x/net/info/refs not valid: is this a git repository?
fatal: https://golang.org/x/net/info/refs not valid: is this a git repository?
Unable to checkout f5dfe339be1d06f81b22525fe34671ee7d2c8904 from https://golang.org/x/net.
joachim@lenovo-t530 /tmp> echo $status
1
```

###### the output before the change A (with --quiet)

```
nix-prefetch-git https://golang.org/x/net --rev f5dfe339be1d06f81b22525fe34671ee7d2c8904 --quiet
{
  "url": "https://golang.org/x/net",
  "rev": "f5dfe339be1d06f81b22525fe34671ee7d2c8904",
  "date": "",
  "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
  "fetchSubmodules": true
}
joachim@lenovo-t530 /tmp> echo $status
0
```

WARNING: exit code should still be 1 and not 0!

###### the output after the change B

```

[nix-shell:~/Desktop/projects/nixcloud/dep2nix/src/github.com/nixcloud/dep2nix]$ ./nix-prefetch-git https://golang.org/x/net --rev f5dfe339be1d06f81b22525fe34671ee7d2c8904 
Leeres Git-Repository in /run/user/1000/git-checkout-tmp-9SXKa8i0/net-f5dfe33/.git/ initialisiert
fatal: https://golang.org/x/net/info/refs not valid: is this a git repository?
fatal: https://golang.org/x/net/info/refs not valid: is this a git repository?

[nix-shell:~/Desktop/projects/nixcloud/dep2nix/src/github.com/nixcloud/dep2nix]$ echo $?
1
```

###### the output after the change B (with --quiet)

```
[nix-shell:~/Desktop/projects/nixcloud/dep2nix/src/github.com/nixcloud/dep2nix]$ ./nix-prefetch-git https://golang.org/x/net --rev f5dfe339be1d06f81b22525fe34671ee7d2c8904 --quiet

[nix-shell:~/Desktop/projects/nixcloud/dep2nix/src/github.com/nixcloud/dep2nix]$ echo $?
1

```

###### Things done
