### PR TITLE
nix-buffer: make eshell-path-env be inherited

### DIFF
--- a/pkgs/build-support/emacs/buffer.nix
+++ b/pkgs/build-support/emacs/buffer.nix
@@ -45,6 +45,8 @@ rec {
       (setenv "PATH" (concat "${lib.makeSearchPath "bin" pkgs}:" (getenv "PATH")))
       (inherit-local-permanent exec-path (append '(${builtins.concatStringsSep " " (map (p: "\"${p}/bin\"") pkgs)}) exec-path))
 
+      (inherit-local-permanent eshell-path-env (concat "${lib.makeSearchPath "bin" pkgs}:" eshell-path-env))
+
       (setq nixpkgs--is-nixpkgs-buffer t)
       (inherit-local 'nixpkgs--is-nixpkgs-buffer)
 


### PR DESCRIPTION
@shlevy Does this seem like a good idea?

eshell-path-env won't be inherited otherwise leading to lots of 'command not found' errors.
