### PR TITLE
pybind11: init at 2.2.2

### DIFF
--- a/pkgs/development/libraries/pybind11/default.nix
+++ b/pkgs/development/libraries/pybind11/default.nix
@@ -1,7 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake
-# test deps
-, catch, python, pytest, numpy, eigen
-}:
+{ stdenv, fetchFromGitHub, cmake, python }:
 
 stdenv.mkDerivation rec {
   name = "pybind-${version}";
@@ -13,12 +10,12 @@ stdenv.mkDerivation rec {
     sha256 = "0x71i1n5d02hjbdcnkscrwxs9pb8kplmdpqddhsimabfp84fip48";
   };
 
-  nativeBuildInputs = [ cmake catch pytest eigen numpy ];
+  nativeBuildInputs = [ cmake ];
 
   # disable tests as some tests (test_embed/test_interpreter) are failing at the moment
   cmakeFlags = [
-    "-DPYTHON_EXECUTABLE=${python.interpreter}"
-    "-DPYBIND11_TEST=0"
+     "-DPYTHON_EXECUTABLE=${python.interpreter}"
+     "-DPYBIND11_TEST=0"
   ];
   doCheck = false;
 

--- a/pkgs/development/libraries/pybind11/default.nix
+++ b/pkgs/development/libraries/pybind11/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, cmake
+# test deps
+, catch, python, pytest, numpy, eigen
+}:
+
+stdenv.mkDerivation rec {
+  name = "pybind-${version}";
+  version = "2.2.2";
+  src = fetchFromGitHub {
+    owner = "pybind";
+    repo = "pybind11";
+    rev = "v${version}";
+    sha256 = "0x71i1n5d02hjbdcnkscrwxs9pb8kplmdpqddhsimabfp84fip48";
+  };
+
+  nativeBuildInputs = [ cmake catch pytest eigen numpy ];
+
+  # disable tests as some tests (test_embed/test_interpreter) are failing at the moment
+  cmakeFlags = [
+    "-DPYTHON_EXECUTABLE=${python.interpreter}"
+    "-DPYBIND11_TEST=0"
+  ];
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/pybind/pybind11;
+    description = "Seamless operability between C++11 and Python";
+    longDescription = ''
+      Pybind11 is a lightweight header-only library that exposes
+      C++ types in Python and vice versa, mainly to create Python
+      bindings of existing C++ code.
+    '';
+    platforms = with stdenv.lib.platforms; unix;
+    license = stdenv.lib.licenses.bsd;
+    maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
+  };
+
+}

--- a/pkgs/development/libraries/pybind11/default.nix
+++ b/pkgs/development/libraries/pybind11/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       bindings of existing C++ code.
     '';
     platforms = with stdenv.lib.platforms; unix;
-    license = stdenv.lib.licenses.bsd;
+    license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10697,9 +10697,7 @@ with pkgs;
 
   pugixml = callPackage ../development/libraries/pugixml { };
 
-  pybind11 = callPackage ../development/libraries/pybind11 {
-    inherit (python3Packages) python pytest numpy;
-  };
+  pybind11 = callPackage ../development/libraries/pybind11 { };
 
   re2 = callPackage ../development/libraries/re2 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10697,6 +10697,10 @@ with pkgs;
 
   pugixml = callPackage ../development/libraries/pugixml { };
 
+  pybind11 = callPackage ../development/libraries/pybind11 {
+    inherit (python3Packages) python pytest numpy;
+  };
+
   re2 = callPackage ../development/libraries/re2 { };
 
   qbs = callPackage ../development/tools/build-managers/qbs { };


### PR DESCRIPTION
###### Motivation for this change

`pybind11` ( https://github.com/pybind/pybind11 ) is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code.

This package is handy as well as is used at least in a couple of well-known deep learning frameworks (alas used often as git submodules).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

