### PR TITLE
buildkite-agent: 2.6.6 -> 2.6.9

### DIFF
--- a/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
@@ -17,6 +17,10 @@ buildGoPackage {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  # on Linux, the TMPDIR is /build which is the same prefix as this package
+  # remove once #35068 is merged
+  noAuditTmpdir = stdenv.isLinux;
+
   postInstall = ''
     # Install bootstrap.sh
     mkdir -p $bin/libexec/buildkite-agent

--- a/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, coreutils, git, openssh, bash, gnused, gnugrep }:
 let
-  version = "2.6.6";
+  version = "2.6.9";
   goPackagePath = "github.com/buildkite/agent";
 in
 buildGoPackage {
@@ -12,7 +12,7 @@ buildGoPackage {
     owner = "buildkite";
     repo = "agent";
     rev = "v${version}";
-    sha256 = "0rpi63mfzlm39517l4xjcka3m4dnfjzwvpi0i1rpf1z2288cnkyx";
+    sha256 = "0rlinj7dcr8vzl1pb15nfny8jkvvj50i8czf4ahv26avnfycm4pz";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -44,6 +44,6 @@ buildGoPackage {
     homepage = https://buildkite.com/docs/agent;
     license = licenses.mit;
     maintainers = with maintainers; [ pawelpacana zimbatm ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Various upstream bug fixes.

https://github.com/buildkite/agent/releases/tag/v2.6.7
https://github.com/buildkite/agent/releases/tag/v2.6.8
https://github.com/buildkite/agent/releases/tag/v2.6.9


###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
