### PR TITLE
buildkite-agent: 2.1.13 -> 2.6.9

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -109,7 +109,6 @@ in
             meta-data="${cfg.meta-data}"
             hooks-path="${toString cfg.hooksPath}"
             build-path="/var/lib/buildkite-agent/builds"
-            bootstrap-script="${pkgs.buildkite-agent}/share/bootstrap.sh"
             EOF
           '';
 

--- a/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
@@ -1,32 +1,38 @@
-{ stdenv, fetchurl, makeWrapper, coreutils, git, openssh, bash, gnused, gnugrep }:
-
-stdenv.mkDerivation rec {
-  version = "2.1.13";
+{ stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, coreutils, git, openssh, bash, gnused, gnugrep }:
+let
+  version = "2.6.9";
+  goPackagePath = "github.com/buildkite/agent";
+in
+buildGoPackage {
   name = "buildkite-agent-${version}";
-  dontBuild = true;
 
-  src = fetchurl {
-    url = "https://github.com/buildkite/agent/releases/download/v${version}/buildkite-agent-linux-386-${version}.tar.gz";
-    sha256 = "bd40c2ba37b3b54b875241a32b62190a4cf4c15e2513c573f1626a3ca35c8657";
+  inherit goPackagePath;
+
+  src = fetchFromGitHub {
+    owner = "buildkite";
+    repo = "agent";
+    rev = "v${version}";
+    sha256 = "0rlinj7dcr8vzl1pb15nfny8jkvvj50i8czf4ahv26avnfycm4pz";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  sourceRoot = ".";
-  installPhase = ''
-    install -Dt "$out/bin/" buildkite-agent
 
-    mkdir -p $out/share
-    mv hooks bootstrap.sh $out/share/
+  postInstall = ''
+    # Install bootstrap.sh
+    mkdir -p $bin/libexec/buildkite-agent
+    cp $NIX_BUILD_TOP/go/src/${goPackagePath}/templates/bootstrap.sh $bin/libexec/buildkite-agent
+    sed -e "s|#!/bin/bash|#!${bash}/bin/bash|g" -i $bin/libexec/buildkite-agent/bootstrap.sh
+
+    # Fix binary name
+    mv $bin/bin/{agent,buildkite-agent}
+
+    # These are runtime dependencies
+    wrapProgram $bin/bin/buildkite-agent \
+      --prefix PATH : '${stdenv.lib.makeBinPath [ openssh git coreutils gnused gnugrep ]}' \
+      --set BUILDKITE_BOOTSTRAP_SCRIPT_PATH $bin/libexec/buildkite-agent/bootstrap.sh
   '';
 
-  postFixup = ''
-    substituteInPlace $out/share/bootstrap.sh \
-      --replace "#!/bin/bash" "#!$(type -P bash)"
-    wrapProgram $out/bin/buildkite-agent \
-      --set PATH '"${stdenv.lib.makeBinPath [ openssh git coreutils gnused gnugrep ]}:$PATH"'
-  '';
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "Build runner for buildkite.com";
     longDescription = ''
       The buildkite-agent is a small, reliable, and cross-platform build runner
@@ -36,8 +42,8 @@ stdenv.mkDerivation rec {
       and uploading the job's artifacts.
     '';
     homepage = https://buildkite.com/docs/agent;
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.pawelpacana ];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ pawelpacana zimbatm ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = https://buildkite.com/docs/agent;
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.pawelpacana ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Newer upstream version which fixes bugs.

See also: #35033

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
