### PR TITLE
z88dk : init at unstable-2018-02-20

### DIFF
--- a/pkgs/development/compilers/z88dk/Makefile.patch
+++ b/pkgs/development/compilers/z88dk/Makefile.patch
@@ -1,5 +1,5 @@
---- joachifm-rtfm/Makefile	1970-01-01 01:00:01.000000000 +0100
-+++ joachifm/Makefile	2018-02-16 13:28:44.979280387 +0100
+--- z88dk.orig/Makefile	1970-01-01 01:00:01.000000000 +0100
++++ z88dk/Makefile	2018-02-16 13:28:44.979280387 +0100
 @@ -8,32 +8,32 @@
  # ---> Configurable parameters are below his point
  prefix ?= /usr/local

--- a/pkgs/development/compilers/z88dk/Makefile.patch
+++ b/pkgs/development/compilers/z88dk/Makefile.patch
@@ -1,5 +1,5 @@
---- /nix/store/lqr8s3yi8gn98gf3xybrmxg2dj1d4li2-source/Makefile	1970-01-01 01:00:01.000000000 +0100
-+++ lqr8s3yi8gn98gf3xybrmxg2dj1d4li2-source/Makefile	2018-02-16 13:28:44.979280387 +0100
+--- joachifm-rtfm/Makefile	1970-01-01 01:00:01.000000000 +0100
++++ joachifm/Makefile	2018-02-16 13:28:44.979280387 +0100
 @@ -8,32 +8,32 @@
  # ---> Configurable parameters are below his point
  prefix ?= /usr/local

--- a/pkgs/development/compilers/z88dk/Makefile.patch
+++ b/pkgs/development/compilers/z88dk/Makefile.patch
@@ -1,0 +1,60 @@
+--- /nix/store/lqr8s3yi8gn98gf3xybrmxg2dj1d4li2-source/Makefile	1970-01-01 01:00:01.000000000 +0100
++++ lqr8s3yi8gn98gf3xybrmxg2dj1d4li2-source/Makefile	2018-02-16 13:28:44.979280387 +0100
+@@ -8,32 +8,32 @@
+ # ---> Configurable parameters are below his point
+ prefix ?= /usr/local
+ prefix_share = $(prefix)/share/z88dk
+-git_rev = $(shell git rev-parse --short HEAD)
+-git_count = $(shell git rev-list --count HEAD)
+-version := $(shell date +%Y%m%d)
++git_rev ?= $(shell git rev-parse --short HEAD)
++git_count ?= $(shell git rev-list --count HEAD)
++version ?= $(shell date +%Y%m%d)
+ 
+ INSTALL ?= install
+ CFLAGS ?= -O2
+ CC ?= gcc
+ # Prefix for executables (eg z88dk-, hence z88dk-z80asm, z88dk-copt etc)
+-EXEC_PREFIX ?= 
++EXEC_PREFIX ?=
+ CROSS ?= 0
+ 
+ # --> End of Configurable Options
+ 
+-export CC INSTALL CFLAGS EXEC_PREFIX CROSS 
++export CC INSTALL CFLAGS EXEC_PREFIX CROSS
+ 
+ all: setup appmake copt zcpp ucpp sccz80 z80asm zcc zpragma zx7 z80nm lstmanip ticks z80svg testsuite z88dk-lib
+ 
+ setup:
+ 	$(shell if [ "${git_count}" != "" ]; then \
+-	    echo '#define PREFIX "${prefix_share}"' > src/config.h; \
++	    echo '#define PREFIX "${DESTDIR}${prefix_share}"' > src/config.h; \
+ 	    echo '#define UNIX 1' >> src/config.h; \
+ 	    echo '#define EXEC_PREFIX "${EXEC_PREFIX}"' >> src/config.h; \
+ 	    echo '#define Z88DK_VERSION "${git_count}-${git_rev}-${version}"' >> src/config.h; \
+ 	fi)
+ 	$(shell if [ ! -f src/config.h ]; then \
+-	    echo '#define PREFIX "${prefix_share}"' > src/config.h; \
++	    echo '#define PREFIX "${DESTDIR}${prefix_share}"' > src/config.h; \
+ 	    echo '#define UNIX 1' >> src/config.h; \
+ 	    echo '#define EXEC_PREFIX "${EXEC_PREFIX}"' >> src/config.h; \
+ 	    echo '#define Z88DK_VERSION "unknown-unknown-${version}"' >> src/config.h; \
+@@ -103,7 +103,7 @@
+ 	cd libsrc ; $(MAKE) install
+ 
+ install: install-clean
+-	install -d $(DESTDIR)/$(prefix) $(DESTDIR)/$(prefix_share)/lib 
++	install -d $(DESTDIR)/$(prefix) $(DESTDIR)/$(prefix_share)/lib
+ 	$(MAKE) -C src/appmake PREFIX=$(DESTDIR)/$(prefix) install
+ 	$(MAKE) -C src/copt PREFIX=$(DESTDIR)/$(prefix) install
+ 	$(MAKE) -C src/ucpp PREFIX=$(DESTDIR)/$(prefix) install
+@@ -131,7 +131,7 @@
+ test:
+ 	$(MAKE) -C test
+ 
+-testsuite: 
++testsuite:
+ 	$(MAKE) -C testsuite
+ 
+ install-clean:

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -3,15 +3,15 @@
 stdenv.mkDerivation rec {
 
   repo = "z88dk";
-  version = "unstable-2018-02-20";
-  rev = "da4648333983e4b6755a343ba917a7e4af23de7c";
+  version = "unstable-2018-02-21";
+  rev = "57623766828abb0a9a75b7b6f0ffe3191dbf390c";
   short_rev = "${builtins.substring 0 7 rev}";
   name = "${repo}-${version}";
 
   src = fetchFromGitHub {
     inherit rev repo;
     owner = "z88dk";
-    sha256 = "1iq9m9sjbsmwb39fdzii8lwjk3d8zq92jhh8dd7nmcdggqg81sy9";
+    sha256 = "0q64k5rjk32asny8aw9afjsr2dc975m9bks2l6vsslsv2saxsf1v";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -1,0 +1,46 @@
+{ fetchFromGitHub, stdenv, makeWrapper, unzip, libxml2, m4, uthash }:
+
+stdenv.mkDerivation rec {
+
+  pname = "z88dk";
+  version = "20180217";
+  rev = "49a7c6032b2675af742f5b0b3aa5bd5260bdd814";
+  short_rev = "${builtins.substring 0 7 rev}";
+  name = "${pname}-${version}-${short_rev}";
+
+  src = fetchFromGitHub {
+    owner = "z88dk";
+    repo  = "${pname}";
+    rev = "${rev}";
+    sha256 = "0jd312jcl0rqn15c2nbllpqz2x67hwvkhlz2smbqjyv8mrbhqbcc";
+  };
+
+  meta = with stdenv.lib; {
+    homepage    = https://www.z88dk.org;
+    description = "z80 Development Kit";
+    license     = "Clarified-Artistic";
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+
+  patches = [ ./Makefile.patch ];
+
+  postPatch =
+  ''
+    # we dont rely on build.sh :
+    make clean
+    export PATH="$PWD/bin:$PATH" # needed to have zcc in testsuite
+    export ZCCCFG=$PWD/lib/config/
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" "prefix=/" "git_rev=${short_rev}"
+                "version=${version}" "git_count=0"];
+  nativeBuildInputs = [ makeWrapper unzip ];
+  buildInputs = [ libxml2 m4 uthash ];
+
+  preInstall = ''
+    mkdir -p $out/{bin,share}
+  '';
+
+  installTargets = "libs install";
+}

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     homepage    = https://www.z88dk.org;
     description = "z80 Development Kit";
     license     = "Clarified-Artistic";
-    maintainers = [ maintainers.bignaux ];
+    maintainers = [ maintainers.genesis ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -2,16 +2,15 @@
 
 stdenv.mkDerivation rec {
 
-  pname = "z88dk";
-  version = "20180217";
+  repo = "z88dk";
+  version = "unstable-2018-02-17";
   rev = "49a7c6032b2675af742f5b0b3aa5bd5260bdd814";
   short_rev = "${builtins.substring 0 7 rev}";
-  name = "${pname}-${version}-${short_rev}";
+  name = "${repo}-${version}";
 
   src = fetchFromGitHub {
+    inherit rev repo;
     owner = "z88dk";
-    repo  = "${pname}";
-    rev = "${rev}";
     sha256 = "0jd312jcl0rqn15c2nbllpqz2x67hwvkhlz2smbqjyv8mrbhqbcc";
   };
 
@@ -19,7 +18,7 @@ stdenv.mkDerivation rec {
     homepage    = https://www.z88dk.org;
     description = "z80 Development Kit";
     license     = "Clarified-Artistic";
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ maintainers.bignaux ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -3,15 +3,15 @@
 stdenv.mkDerivation rec {
 
   repo = "z88dk";
-  version = "unstable-2018-02-17";
-  rev = "49a7c6032b2675af742f5b0b3aa5bd5260bdd814";
+  version = "unstable-2018-02-20";
+  rev = "da4648333983e4b6755a343ba917a7e4af23de7c";
   short_rev = "${builtins.substring 0 7 rev}";
   name = "${repo}-${version}";
 
   src = fetchFromGitHub {
     inherit rev repo;
     owner = "z88dk";
-    sha256 = "0jd312jcl0rqn15c2nbllpqz2x67hwvkhlz2smbqjyv8mrbhqbcc";
+    sha256 = "1iq9m9sjbsmwb39fdzii8lwjk3d8zq92jhh8dd7nmcdggqg81sy9";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6714,6 +6714,8 @@ with pkgs;
 
   yosys = callPackage ../development/compilers/yosys { };
 
+  z88dk = callPackage ../development/compilers/z88dk { };
+
   zulu8 = callPackage ../development/compilers/zulu/8.nix { };
   zulu9 = callPackage ../development/compilers/zulu { };
   zulu = zulu9;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

