### PR TITLE
tree-wide: no pulseaudio by default

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -232,6 +232,8 @@ in {
       security.rtkit.enable = true;
 
       systemd.packages = [ overriddenPackage ];
+
+      nixpkgs.config.pulseaudio = true;
     })
 
     (mkIf hasZeroconf {

--- a/pkgs/desktops/mate/libmatemixer/default.nix
+++ b/pkgs/desktops/mate/libmatemixer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib
 , alsaSupport ? stdenv.isLinux, alsaLib
-, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
+, pulseaudioSupport ? stdenv.config.pulseaudio or false, libpulseaudio
 , ossSupport ? false
  }:
 

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, dbus_glib, libxklavier, libcanberra_gtk3, libnotify, nss, polkit, gnome3, mate, wrapGAppsHook
-, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
+, pulseaudioSupport ? stdenv.config.pulseaudio or false, libpulseaudio
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -415,7 +415,7 @@ with pkgs;
     automationSupport = config.aegisub.automationSupport or true;
     openalSupport     = config.aegisub.openalSupport or false;
     alsaSupport       = config.aegisub.alsaSupport or true;
-    pulseaudioSupport = config.aegisub.pulseaudioSupport or true;
+    pulseaudioSupport = config.aegisub.pulseaudioSupport or false;
     portaudioSupport  = config.aegisub.portaudioSupport or false;
   };
 
@@ -1418,7 +1418,7 @@ with pkgs;
   };
 
   blueman = callPackage ../tools/bluetooth/blueman {
-    withPulseAudio = config.pulseaudio or true;
+    withPulseAudio = config.pulseaudio or false;
   };
 
   bmrsa = callPackage ../tools/security/bmrsa/11.nix { };
@@ -8538,7 +8538,7 @@ with pkgs;
     libmodplug = if stdenv.isDarwin then null else libmodplug;
     libvpx = if stdenv.isDarwin then null else libvpx;
     openal = if stdenv.isDarwin then null else openal;
-    libpulseaudio = if stdenv.isDarwin then null else libpulseaudio;
+    libpulseaudio = if config.pulseaudio or false then libpulseaudio else null;
     samba = if stdenv.isDarwin then null else samba;
     vid-stab = if stdenv.isDarwin then null else vid-stab;
     x265 = if stdenv.isDarwin then null else x265;
@@ -9254,7 +9254,7 @@ with pkgs;
   libagar_test = callPackage ../development/libraries/libagar/libagar_test.nix { };
 
   libao = callPackage ../development/libraries/libao {
-    usePulseAudio = config.pulseaudio or stdenv.isLinux;
+    usePulseAudio = config.pulseaudio or false;
     inherit (darwin.apple_sdk.frameworks) CoreAudio CoreServices AudioUnit;
   };
 
@@ -10578,7 +10578,7 @@ with pkgs;
   pangoxsl = callPackage ../development/libraries/pangoxsl { };
 
   pcaudiolib = callPackage ../development/libraries/pcaudiolib {
-    pulseaudioSupport = config.pulseaudio or true;
+    pulseaudioSupport = config.pulseaudio or false;
   };
 
   pcg_c = callPackage ../development/libraries/pcg-c { };
@@ -11037,7 +11037,7 @@ with pkgs;
     openglSupport = mesaSupported;
     alsaSupport = stdenv.isLinux;
     x11Support = !stdenv.isCygwin;
-    pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
+    pulseaudioSupport = config.pulseaudio or false;
     inherit (darwin.apple_sdk.frameworks) OpenGL CoreAudio CoreServices AudioUnit Kernel Cocoa;
   };
 
@@ -11063,7 +11063,7 @@ with pkgs;
     x11Support = !stdenv.isCygwin;
     waylandSupport = stdenv.isLinux;
     udevSupport = stdenv.isLinux;
-    pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
+    pulseaudioSupport = config.pulseaudio or false;
     inherit (darwin.apple_sdk.frameworks) AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL;
   };
 
@@ -14503,7 +14503,7 @@ with pkgs;
 
   bomi = libsForQt5.callPackage ../applications/video/bomi {
     youtube-dl = pythonPackages.youtube-dl;
-    pulseSupport = config.pulseaudio or true;
+    pulseSupport = config.pulseaudio or false;
     ffmpeg = ffmpeg_2;
   };
 
@@ -14716,7 +14716,7 @@ with pkgs;
   ddgr = callPackage ../applications/misc/ddgr { };
 
   deadbeef = callPackage ../applications/audio/deadbeef {
-    pulseSupport = config.pulseaudio or true;
+    pulseSupport = config.pulseaudio or false;
   };
 
   deadbeef-mpris2-plugin = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
@@ -15632,7 +15632,7 @@ with pkgs;
   gv = callPackage ../applications/misc/gv { };
 
   guvcview = callPackage ../os-specific/linux/guvcview {
-    pulseaudioSupport = config.pulseaudio or true;
+    pulseaudioSupport = config.pulseaudio or false;
     ffmpeg = ffmpeg_2;
   };
 
@@ -16584,7 +16584,7 @@ with pkgs;
 
   obs-studio = libsForQt5.callPackage ../applications/video/obs-studio {
     alsaSupport = stdenv.isLinux;
-    pulseaudioSupport = config.pulseaudio or true;
+    pulseaudioSupport = config.pulseaudio or false;
   };
 
   octoprint = callPackage ../applications/misc/octoprint { };
@@ -17686,7 +17686,7 @@ with pkgs;
     stdenv = stdenv_32bit;
     inherit (gnome2) libIDL;
     enableExtensionPack = config.virtualbox.enableExtensionPack or false;
-    pulseSupport = config.pulseaudio or true;
+    pulseSupport = config.pulseaudio or false;
   };
 
   virtualboxHardened = lowPrio (virtualbox.override {
@@ -20317,7 +20317,7 @@ with pkgs;
       cairoSupport = true;
       cursesSupport = true;
       saneSupport = true;
-      pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
+      pulseaudioSupport = config.pulseaudio or false;
       udevSupport = true;
       xineramaSupport = true;
       xmlSupport = true;


### PR DESCRIPTION
###### Motivation for this change

I run with `config.pulseaudio = false` for years, it works perfectly.
But having it enabled by default in some packages and disabled in others in nixpkgs sends a mixed message: many people think that you need this broken piece of insecure bloatware to have sound, which is as far from being true as humanly possible (see #29250).

Lets just disable it by default so that "its already in the closure, so lets add it proper" (see #24012, #35005) motivation goes away.
Also lets just disable it by default to minimize the attack surface it provides.

If you think you need it by default go read #29250. If you think its ok to have it by default go read #29250.

If you do use it, the second patch to nixos now enables it.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Tested execution of many binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

