### PR TITLE
squashfuse : init at unstable-2018-02-20

### DIFF
--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, fetchpatch, automake, autoreconfHook, libtool, fuse,
+  pkgconfig, pcre, lz4, xz, zlib, lzo, zstd }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+
+  pname = "squashfuse";
+  version = "0.1.101";
+  rev = "371e4bee9caa254d842913df9bdbcc795c5b342c";
+  short_rev = "${builtins.substring 0 7 rev}";
+  name = "${pname}-${version}-${short_rev}";
+
+  meta = {
+    description = "FUSE filesystem to mount squashfs archives";
+    homepage = https://github.com/vasi/squashfuse;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+    license = "BSD-2-Clause";
+  };
+
+  # platforms.darwin should be supported : see PLATFORMS file in src.
+  # we could use a nix fuseProvider, and let the derivation choose the OS
+  # specific implementation.
+
+  src = fetchFromGitHub {
+    owner = "vasi";
+    repo  = "${pname}";
+    rev = "${rev}";
+    sha256 = "0i9p8r1c128hzy0cwmga1x7q8zk7kw68mh8li5ipfz8zba60d7vz";
+  };
+
+  patches = [
+	(fetchpatch {
+	  url = "https://github.com/vasi/squashfuse/commit/0c44cb2abe402d6e352dd47ac8b7e7495c7c2a6f.patch";
+	  sha256 = "0z53p7pi3ap05n0bxhmka4sz12cw2cjjvc7xn9jppbyynfzx32m0";
+	})
+  ];
+
+  nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];
+  buildInputs = [ lz4 xz zlib lzo zstd fuse ];
+}

--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -6,10 +6,8 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   pname = "squashfuse";
-  version = "0.1.101";
-  rev = "371e4bee9caa254d842913df9bdbcc795c5b342c";
-  short_rev = "${builtins.substring 0 7 rev}";
-  name = "${pname}-${version}-${short_rev}";
+  version = "unstable-2018-02-20";
+  name = "${pname}-${version}";
 
   meta = {
     description = "FUSE filesystem to mount squashfs archives";
@@ -26,16 +24,9 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "vasi";
     repo  = "${pname}";
-    rev = "${rev}";
-    sha256 = "0i9p8r1c128hzy0cwmga1x7q8zk7kw68mh8li5ipfz8zba60d7vz";
+    rev = "3f4a93f373796e88f7eee3a0c005ef60cb395d30";
+    sha256 = "07jv4qjjz9ky3mw3p5prgs19g1bna9dcd7jjdz8083s1wyipdgcq";
   };
-
-  patches = [
-	(fetchpatch {
-	  url = "https://github.com/vasi/squashfuse/commit/0c44cb2abe402d6e352dd47ac8b7e7495c7c2a6f.patch";
-	  sha256 = "0z53p7pi3ap05n0bxhmka4sz12cw2cjjvc7xn9jppbyynfzx32m0";
-	})
-  ];
 
   nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];
   buildInputs = [ lz4 xz zlib lzo zstd fuse ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4739,6 +4739,8 @@ with pkgs;
 
   squashfsTools = callPackage ../tools/filesystems/squashfs { };
 
+  squashfuse = callPackage ../tools/filesystems/squashfuse { };
+
   srcml = callPackage ../applications/version-management/srcml { };
 
   sshfs-fuse = callPackage ../tools/filesystems/sshfs-fuse { };


### PR DESCRIPTION
###### Motivation for this change

new PR with previous required changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

