### PR TITLE
linux-common: Add CFS_BANDWIDTH

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -450,6 +450,7 @@ with stdenv.lib;
   RC_DEVICES? y # Enable IR devices
   RT2800USB_RT55XX y
   SCHED_AUTOGROUP y
+  CFS_BANDWIDTH y
   SCSI_LOGGING y # SCSI logging facility
   SERIAL_8250 y # 8250/16550 and compatible serial support
   SLIP_COMPRESSED y # CSLIP compressed headers


### PR DESCRIPTION
The option is needed to limit CPU usage of processes.
It seems to have no negative impact if left unused.

See https://lwn.net/Articles/428230/

###### Motivation for this change

I need this to limit Docker container resources:
https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler

Since there seems to be no negative impact to people not using the functionality, I propose this be added to the common configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

