### PR TITLE
gitAndTools.hubUnstable: init at 2.3.0-pre10

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -106,6 +106,10 @@ rec {
     inherit (darwin) Security;
   };
 
+  hubUnstable = callPackage ./hub/unstable.nix {
+    inherit (darwin) Security;
+  };
+
   qgit = qt5.callPackage ./qgit { };
 
   stgit = callPackage ./stgit {

--- a/pkgs/applications/version-management/git-and-tools/hub/unstable.nix
+++ b/pkgs/applications/version-management/git-and-tools/hub/unstable.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchgit, go, ronn, groff, utillinux, Security }:
+
+stdenv.mkDerivation rec {
+  name = "hub-${version}";
+  version = "2.3.0-pre10";
+
+  src = fetchgit {
+    url = https://github.com/github/hub.git;
+    rev = "refs/tags/v${version}";
+    sha256 = "07sz1i6zxx2g36ayhjp1vjw523ckk5b0cr8b80s1qhar2d2hkibd";
+  };
+
+  buildInputs = [ go ronn groff utillinux ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
+
+  buildPhase = ''
+    mkdir bin
+    ln -s ${ronn}/bin/ronn bin/ronn
+
+    patchShebangs .
+    make all man-pages
+  '';
+
+  installPhase = ''
+    prefix=$out sh -x < script/install.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command-line wrapper for git that makes you better at GitHub";
+
+    license = licenses.mit;
+    homepage = https://hub.github.com/;
+    maintainers = with maintainers; [ the-kenny ];
+    platforms = with platforms; unix;
+  };
+}


### PR DESCRIPTION
[Edit] The unstable version is now in a separate package. This should therefore not more be a problem to merge this PR as the changes are in a new, different package [/Edit]

I really wanted the ability to make pull-requests that follow `.github/PULL_REQUEST_TEMPLATE.md`. This feature is not released in a stable branch yet, so I updated to 2.3.0-pre10.

In the process, I refactored the build a bit to use the install script provided upstream.
This is why I decided to PR this change.

If there is strong apposition against comiting pre-release versions of hub, I will revert it to 2.2.9.

###### Motivation for this change 

Refactor the build instructions:
- do not skip the fixup phase
- use upstream install script
- generate man pages

/cc @the-kenny 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing
- Built on platform(s)
   - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
