### PR TITLE
idsk : init at unstable-2018-02-11

### DIFF
--- a/pkgs/tools/filesystems/idsk/default.nix
+++ b/pkgs/tools/filesystems/idsk/default.nix
@@ -2,29 +2,29 @@
 
 stdenv.mkDerivation rec {
 
-	repo = "idsk";
-	version = "unstable-2018-02-11";
-	rev = "1846729ac3432aa8c2c0525be45cfff8a513e007";
-	name = "${repo}-${version}";
+  repo = "idsk";
+  version = "unstable-2018-02-11";
+  rev = "1846729ac3432aa8c2c0525be45cfff8a513e007";
+  name = "${repo}-${version}";
 
-	meta = with stdenv.lib; {
-		description = "Manipulating CPC dsk images and files";
-		homepage = https://github.com/cpcsdk/idsk ;
-		license = "unknown";
-		maintainers = [ maintainers.bignaux ];
-		platforms = platforms.linux;
-	};
+  meta = with stdenv.lib; {
+    description = "Manipulating CPC dsk images and files";
+    homepage = https://github.com/cpcsdk/idsk ;
+    license = "unknown";
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
 
-	src = fetchFromGitHub {
-		inherit rev repo;
-		owner = "cpcsdk";
-		sha256 = "0d891lvf2nc8bys8kyf69k54rf3jlwqrcczbff8xi0w4wsiy5ckv";
-	};
+  src = fetchFromGitHub {
+    inherit rev repo;
+    owner = "cpcsdk";
+    sha256 = "0d891lvf2nc8bys8kyf69k54rf3jlwqrcczbff8xi0w4wsiy5ckv";
+  };
 
-	nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
-	installPhase = ''
-		mkdir -p $out/bin
-		cp iDSK $out/bin
-		'';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp iDSK $out/bin
+  '';
 }

--- a/pkgs/tools/filesystems/idsk/default.nix
+++ b/pkgs/tools/filesystems/idsk/default.nix
@@ -26,5 +26,5 @@ stdenv.mkDerivation rec {
 	installPhase = ''
 		mkdir -p $out/bin
 		cp iDSK $out/bin
-	'';
+		'';
 }

--- a/pkgs/tools/filesystems/idsk/default.nix
+++ b/pkgs/tools/filesystems/idsk/default.nix
@@ -1,0 +1,33 @@
+
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+
+	pname = "idsk";
+  version = "0.16";
+  rev = "1846729ac3432aa8c2c0525be45cfff8a513e007";
+  short_rev = "${builtins.substring 0 7 rev}";
+	name = "${pname}-${version}-${short_rev}";
+
+  meta = with stdenv.lib; {
+    description = "manipulating cpc dsk images and files";
+    homepage = https://github.com/cpcsdk/idsk ;
+    license = "unknown";
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+
+	src = fetchFromGitHub {
+		owner = "cpcsdk";
+		repo  = "${pname}";
+		rev = "${rev}";
+		sha256 = "0d891lvf2nc8bys8kyf69k54rf3jlwqrcczbff8xi0w4wsiy5ckv";
+	};
+
+	nativeBuildInputs = [ cmake ];
+
+	installPhase = ''
+		mkdir -p $out/bin
+		cp iDSK $out/bin
+	'';
+}

--- a/pkgs/tools/filesystems/idsk/default.nix
+++ b/pkgs/tools/filesystems/idsk/default.nix
@@ -1,26 +1,23 @@
-
 { stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
 
-	pname = "idsk";
-  version = "0.16";
-  rev = "1846729ac3432aa8c2c0525be45cfff8a513e007";
-  short_rev = "${builtins.substring 0 7 rev}";
-	name = "${pname}-${version}-${short_rev}";
+	repo = "idsk";
+	version = "unstable-2018-02-11";
+	rev = "1846729ac3432aa8c2c0525be45cfff8a513e007";
+	name = "${repo}-${version}";
 
-  meta = with stdenv.lib; {
-    description = "manipulating cpc dsk images and files";
-    homepage = https://github.com/cpcsdk/idsk ;
-    license = "unknown";
-    maintainers = [ maintainers.genesis ];
-    platforms = platforms.linux;
-  };
+	meta = with stdenv.lib; {
+		description = "Manipulating CPC dsk images and files";
+		homepage = https://github.com/cpcsdk/idsk ;
+		license = "unknown";
+		maintainers = [ maintainers.bignaux ];
+		platforms = platforms.linux;
+	};
 
 	src = fetchFromGitHub {
+		inherit rev repo;
 		owner = "cpcsdk";
-		repo  = "${pname}";
-		rev = "${rev}";
 		sha256 = "0d891lvf2nc8bys8kyf69k54rf3jlwqrcczbff8xi0w4wsiy5ckv";
 	};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19928,6 +19928,8 @@ with pkgs;
 
   epkowa = callPackage ../misc/drivers/epkowa { };
 
+  idsk = callPackage ../tools/filesystems/idsk { };
+
   illum = callPackage ../tools/system/illum { };
 
   # using the new configuration style proposal which is unstable


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

