### PR TITLE
sayonara:  init at 1.0.0-git5-20180115

### DIFF
--- a/pkgs/applications/audio/sayonara/default.nix
+++ b/pkgs/applications/audio/sayonara/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, cmake, qt5, zlib, taglib, pkgconfig, pcre, gst_all_1 }:
+
+let
+  version = "1.0.0-git5-20180115";
+in
+stdenv.mkDerivation {
+  name = "sayonara-player-${version}";
+
+  src = fetchurl {
+    url = "https://sayonara-player.com/sw/sayonara-player-${version}.tar.gz";
+    sha256 = "1fl7zplnrrvbv1xm4g348bpd46jj39jvbm808hyjjq92i64wqg37";
+  };
+
+  buildInputs = [ cmake qt5.qtbase qt5.qttools zlib taglib pkgconfig pcre gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly ];
+
+  postUnpack = "sourceRoot=\${sourceRoot}/";
+
+  # CMake Error at src/GUI/Resources/Icons/cmake_install.cmake:49 (file):
+  #   file cannot create directory: /usr/share/icons.  Maybe need administrative
+  #   privileges.
+  # Call Stack (most recent call first):
+  #   src/GUI/Resources/cmake_install.cmake:50 (include)
+  #   src/GUI/cmake_install.cmake:50 (include)
+  #   src/cmake_install.cmake:59 (include)
+  #   cmake_install.cmake:42 (include)
+  postPatch = ''
+    substituteInPlace src/GUI/Resources/Icons/CMakeLists.txt \
+      --replace "/usr/share" "$out/share"
+  '';
+
+  # [ 65%] Building CXX object src/Components/Engine/CMakeFiles/say_comp_engine.dir/AbstractPipeline.cpp.o
+  # /tmp/nix-build-sayonara-player-1.0.0-git5-20180115.drv-0/sayonara-player/src/Components/Engine/AbstractPipeline.cpp:28:32: fatal error: gst/app/gstappsink.h: No such file or directory
+  #  #include <gst/app/gstappsink.h>
+  NIX_CFLAGS_COMPILE = "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0";
+
+  configurePhase = ''
+    mkdir build
+    cd build
+    runHook preConfigure
+    cmake .. \
+      -DCMAKE_INSTALL_PREFIX=$out \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DDESKTOPDIR=$out/share/applications \
+      -DICONDIR=$out/share/pixmaps
+    runHook postConfigure
+  '';
+
+  meta = with stdenv.lib;
+    { description = "Sayonara music player";
+      homepage = https://sayonara-player.com/;
+      license = licenses.gpl3;
+      platforms = qt5.qtbase.meta.platforms;
+      maintainers = [ maintainers.deepfire ];
+    };
+}

--- a/pkgs/applications/audio/sayonara/default.nix
+++ b/pkgs/applications/audio/sayonara/default.nix
@@ -11,9 +11,11 @@ stdenv.mkDerivation {
     sha256 = "1fl7zplnrrvbv1xm4g348bpd46jj39jvbm808hyjjq92i64wqg37";
   };
 
-  buildInputs = [ cmake qt5.qtbase qt5.qttools zlib taglib pkgconfig pcre gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-ugly ];
-
-  postUnpack = "sourceRoot=\${sourceRoot}/";
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = with qt5; with gst_all_1;
+      [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly
+        pcre qtbase qttools taglib zlib
+      ];
 
   # CMake Error at src/GUI/Resources/Icons/cmake_install.cmake:49 (file):
   #   file cannot create directory: /usr/share/icons.  Maybe need administrative
@@ -32,18 +34,6 @@ stdenv.mkDerivation {
   # /tmp/nix-build-sayonara-player-1.0.0-git5-20180115.drv-0/sayonara-player/src/Components/Engine/AbstractPipeline.cpp:28:32: fatal error: gst/app/gstappsink.h: No such file or directory
   #  #include <gst/app/gstappsink.h>
   NIX_CFLAGS_COMPILE = "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0";
-
-  configurePhase = ''
-    mkdir build
-    cd build
-    runHook preConfigure
-    cmake .. \
-      -DCMAKE_INSTALL_PREFIX=$out \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DDESKTOPDIR=$out/share/applications \
-      -DICONDIR=$out/share/pixmaps
-    runHook postConfigure
-  '';
 
   meta = with stdenv.lib;
     { description = "Sayonara music player";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17073,6 +17073,8 @@ with pkgs;
     vte = gnome3.vte;
   };
 
+  sayonara = callPackage ../applications/audio/sayonara { };
+
   sbagen = callPackage ../applications/misc/sbagen { };
 
   scantailor = callPackage ../applications/graphics/scantailor { };


### PR DESCRIPTION
###### Motivation for this change
Fix #34024 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

