### PR TITLE
mattermost: 4.6.0 -> 4.7.0

### DIFF
--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -2,18 +2,18 @@
 
 buildGoPackage rec {
   name = "mattermost-${version}";
-  version = "4.6.0";
+  version = "4.7.0";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mattermost-server";
     rev = "v${version}";
-    sha256 = "158sfbg19sp165iavjwwfxx9s4y116yc5h3plsmvlxpdv674k7v3";
+    sha256 = "11rw2m26mf4x6xbxkf37c1j16kyxx059jv3cdajkpv31xn82s7iv";
   };
 
   webApp = fetchurl {
     url = "https://releases.mattermost.com/${version}/mattermost-team-${version}-linux-amd64.tar.gz";
-    sha256 = "1rbpl6zfmhfgzz2i1q2ym51ll6j54gk5p6ca99v9kjlm4ipcq9mv";
+    sha256 = "09dzkvrwj4ynk8yqrcbnhmv9hm3z3r3vyjrbzpvmznfrwcccc7lr";
   };
 
   goPackagePath = "github.com/mattermost/mattermost-server";


### PR DESCRIPTION
- [x] built and tested on NixOS
- [x] verified version number in client is 4.7.0