### PR TITLE
govc: init at 0.16.0

### DIFF
--- a/pkgs/tools/virtualization/govc/default.nix
+++ b/pkgs/tools/virtualization/govc/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildGoPackage }:
+  
+buildGoPackage rec {
+  name = "govc-${version}";
+  version = "0.16.0";
+
+  goPackagePath = "github.com/vmware/govmomi";
+
+  subPackages = [ "govc" ];
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "vmware";
+    repo = "govmomi";
+    sha256 = "09fllx7l2hsjrv1jl7g06xngjy0xwn5n5zng6x8dspgsl6kblyqp";
+  };
+
+  meta = {
+    description = "A vSphere CLI built on top of govmomi";
+    homepage = https://github.com/vmware/govmomi/tree/master/govc;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nicknovitski ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2511,6 +2511,8 @@ with pkgs;
 
   gource = callPackage ../applications/version-management/gource { };
 
+  govc = callPackage ../tools/virtualization/govc { };
+
   gpart = callPackage ../tools/filesystems/gpart { };
 
   gparted = callPackage ../tools/misc/gparted { };


### PR DESCRIPTION
###### Motivation for this change
I use govc to manage a vsphere cluster.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---