### PR TITLE
reflex: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/reflex/default.nix
+++ b/pkgs/development/tools/reflex/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildGoPackage }:
+
+
+buildGoPackage rec {
+  name = "reflex-${version}";
+  version = "0.2.0";
+
+  goPackagePath = "github.com/cespare/reflex";
+
+  src = fetchFromGitHub {
+    owner = "cespare";
+    repo = "reflex";
+    rev = "v${version}";
+    sha256 = "0ccwjmf8rjh03hpbmfiy70ai9dhgvb5vp7albffq0cmv2sl69dqr";
+  };
+
+  meta = with lib; {
+    description = "A small tool to watch a directory and rerun a command when certain files change";
+    homepage = https://github.com/cespare/reflex;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ nicknovitski ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4418,6 +4418,8 @@ with pkgs;
 
   recoll = callPackage ../applications/search/recoll { };
 
+  reflex = callPackage ../development/tools/reflex { };
+
   reiser4progs = callPackage ../tools/filesystems/reiser4progs { };
 
   reiserfsprogs = callPackage ../tools/filesystems/reiserfsprogs { };


### PR DESCRIPTION
###### Motivation for this change
A developer at my company prefers using this tool over similar ones.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

