### PR TITLE
dep: enable all platforms

### DIFF
--- a/pkgs/development/tools/dep/default.nix
+++ b/pkgs/development/tools/dep/default.nix
@@ -21,7 +21,7 @@ buildGoPackage rec {
     homepage = https://github.com/golang/dep;
     description = "Go dependency management tool";
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = [ maintainers.carlsverre ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
We use this tool on darwin and have noticed it builds perfectly fine.  According to the scripts and binary releases in its repo, it supports all the platforms nixpkgs does.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---