### PR TITLE
qmc2 : init at 0.195

### DIFF
--- a/pkgs/misc/emulators/qmc2/default.nix
+++ b/pkgs/misc/emulators/qmc2/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchurl, qmake, qttools, pkgconfig
+, minizip, zlib
+, qtbase, qtsvg, qtmultimedia, qtwebkit, qttranslations, qtxmlpatterns
+, rsync, SDL2, xwininfo
+, utillinux
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  name = "qmc2-${version}";
+  version = "0.195";
+
+  src = fetchurl {
+      url = "mirror://sourceforge/project/qmc2/qmc2/${version}/${name}.tar.gz";
+      sha256 = "1dzmjlfk8pdspns6zg1jmd5fqzg8igd4q38cz4a1vf39lx74svns";
+  };
+  
+  preBuild = ''
+    patchShebangs scripts
+  '';
+
+  nativeBuildInputs = [ qttools pkgconfig ];
+  buildInputs = [ minizip qtbase qtsvg qtmultimedia qtwebkit
+                  qttranslations qtxmlpatterns rsync SDL2
+                  xwininfo zlib utillinux xorg.libxcb ];
+
+  makeFlags = [ "DESTDIR=$(out)"
+                "PREFIX=/"
+                "DATADIR=/share/"
+                "SYSCONFDIR=/etc" ];
+
+  meta = with stdenv.lib; {
+    description = "A Qt frontend for MAME/MESS";
+    homepage = https://qmc2.batcom-it.net;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14300,6 +14300,8 @@ with pkgs;
 
   qgo = libsForQt5.callPackage ../games/qgo { };
 
+  qmc2 = libsForQt5.callPackage ../misc/emulators/qmc2 { };
+
   quattrocento = callPackage ../data/fonts/quattrocento {};
 
   quattrocento-sans = callPackage ../data/fonts/quattrocento-sans {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

