### PR TITLE
slic3r-prusa3d: use system version for eigen and glew

### DIFF
--- a/pkgs/applications/misc/slic3r-prusa3d/default.nix
+++ b/pkgs/applications/misc/slic3r-prusa3d/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, makeWrapper, which, cmake, perl, perlPackages,
-  boost, tbb, wxGTK30, pkgconfig, gtk3, fetchurl, gtk2, bash, mesa_glu }:
+  boost, tbb, wxGTK30, pkgconfig, gtk3, fetchurl, gtk2, bash, mesa_glu,
+  glew, eigen }:
 let
   AlienWxWidgets = perlPackages.buildPerlPackage rec {
     name = "Alien-wxWidgets-0.69";
@@ -40,6 +41,8 @@ stdenv.mkDerivation rec {
     cmake
     perl
     makeWrapper
+    eigen
+    glew
     tbb
     which
     Wx

--- a/pkgs/applications/misc/slic3r-prusa3d/default.nix
+++ b/pkgs/applications/misc/slic3r-prusa3d/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
   name = "slic3r-prusa-edition-${version}";
   version = "1.38.7";
 
+  enableParallelBuilding = true;
+
   buildInputs = [
     cmake
     perl


### PR DESCRIPTION
###### Motivation for this change

If we don't provide eigen and glew, vendored versions are used.

Also enabling parallel building, cmake should be robust enough for that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

