### PR TITLE
buildbot: 0.9.15.post1 -> 1.0.0

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -228,6 +228,7 @@ in rec {
   tests.boot = callSubTests tests/boot.nix {};
   tests.boot-stage1 = callTest tests/boot-stage1.nix {};
   tests.borgbackup = callTest tests/borgbackup.nix {};
+  tests.buildbot = callTest tests/buildbot.nix {};
   tests.cadvisor = callTestOnTheseSystems ["x86_64-linux"] tests/cadvisor.nix {};
   tests.chromium = (callSubTestsOnTheseSystems ["x86_64-linux"] tests/chromium.nix {}).stable;
   tests.cjdns = callTest tests/cjdns.nix {};

--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -14,11 +14,11 @@ let
   package = pythonPackages.buildPythonApplication rec {
     name = "${pname}-${version}";
     pname = "buildbot";
-    version = "0.9.15.post1";
+    version = "1.0.0";
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "01m5x4lpz90lqf8j0s2c26gqb5yzan6x9d1ffgmrklwf0bljkwni";
+      sha256 = "0y7gpymxl09gd9dyqj7zqhaihpl9da1v8ppxi4r161ywd8jv9b1g";
     };
 
     buildInputs = with pythonPackages; [

--- a/pkgs/development/tools/build-managers/buildbot/pkg.nix
+++ b/pkgs/development/tools/build-managers/buildbot/pkg.nix
@@ -3,11 +3,11 @@
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "buildbot-pkg";
-  version = "0.9.15.post1";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0gsa5fi1gkwnz8dsrl2s5kzcfawnj3nl8g8h6z1winz627l9n8sh";
+    sha256 = "1rs2x0b2v92xfsfk0f2nr9x8lz5baawf768s58brj4jiab6mq312";
   };
 
   propagatedBuildInputs = [ setuptools ];

--- a/pkgs/development/tools/build-managers/buildbot/plugins.nix
+++ b/pkgs/development/tools/build-managers/buildbot/plugins.nix
@@ -11,7 +11,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version format;
-      sha256 = "19cnzp5prima3jrk525xspw7vqc5pjln2nihj4kc3w90dhzllj8x";
+      sha256 = "0nmrq50c5ib185rpb8ai1mm7gjq2mjvxik1kqrjfa62i1ia9ikyj";
     };
 
     meta = with stdenv.lib; {
@@ -29,7 +29,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "1j6aw2j2sl7ix8rb67pbs6nfvv8v3smgkvqzsjsyh5sdfr2663cg";
+      sha256 = "1laz7l7cbbz0czb6skxw314bd2qk2f63qw3n2rs7m7v11gd9cdll";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -49,7 +49,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "0k0wd4rq034bij2flfjv60h8czkfn836bnaa7hwsrl58gxds39m4";
+      sha256 = "0mmri8c4n1zwxc1dx2a11yllrmnwqqxjvvil9224lbs98mpchppi";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -69,7 +69,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "08ng56jmy50s3zyn6wxizji1zhgzhi65z7w3wljg02qrbd5688gj";
+      sha256 = "0nwlw2m3qfifia6gy3d4lrnycra50k98ax071p2zjqknanh563vr";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -89,7 +89,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "15fm72yymv873n3vsw9kprypcf6jzln18v4lb062n8lqw9pykwb1";
+      sha256 = "1zml9bd910zwcby4vr3lmzap2grinha2w5zgb2cmixmz7hfrqswp";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];

--- a/pkgs/development/tools/build-managers/buildbot/worker.nix
+++ b/pkgs/development/tools/build-managers/buildbot/worker.nix
@@ -3,11 +3,11 @@
 pythonPackages.buildPythonApplication (rec {
   name = "${pname}-${version}";
   pname = "buildbot-worker";
-  version = "0.9.15.post1";
+  version = "1.0.0";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "12zscqb218w88y9fd1jwfn4cr2sw35j998d0jlgd22bch020sy65";
+    sha256 = "0ws31ypmksah1c83h4npwg560p8v7n9j6l94p79y5pispjsgzqzl";
   };
 
   buildInputs = with pythonPackages; [ setuptoolsTrial mock ];


### PR DESCRIPTION
###### Motivation for this change

Updates buildbot to version 1.0.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

