### PR TITLE
nixos/networking: start dhcpcd even when defaultGateway6 is set

### DIFF
--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -155,8 +155,7 @@ in
 
     systemd.services.dhcpcd = let
       cfgN = config.networking;
-      hasDefaultGatewaySet = (cfgN.defaultGateway != null && cfgN.defaultGateway.address != "")
-                          || (cfgN.defaultGateway6 != null && cfgN.defaultGateway6.address != "");
+      hasDefaultGatewaySet = (cfgN.defaultGateway != null && cfgN.defaultGateway.address != "");
     in
       { description = "DHCP Client";
 

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -79,8 +79,7 @@ let
           then [ "${dev}-netdev.service" ]
           else optional (dev != null && dev != "lo" && !config.boot.isContainer) (subsystemDevice dev);
 
-        hasDefaultGatewaySet = (cfg.defaultGateway != null && cfg.defaultGateway.address != "")
-                            || (cfg.defaultGateway6 != null && cfg.defaultGateway6.address != "");
+        hasDefaultGatewaySet = (cfg.defaultGateway != null && cfg.defaultGateway.address != "");
 
         networkLocalCommands = {
           after = [ "network-setup.service" ];


### PR DESCRIPTION
###### Motivation for this change
Fix #34716

###### Things done

- [x] Tested via nixos/tests/networking.nix
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

