### PR TITLE
fwupd: 1.0.5 update & cleanups

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -8,12 +8,8 @@ let
   cfg = config.services.fwupd;
   originalEtc =
     let
-      isRegular = v: v == "regular";
-      listFiles = d: builtins.attrNames (filterAttrs (const isRegular) (builtins.readDir d));
-      copiedDirs = [ "fwupd/remotes.d" "pki/fwupd" "pki/fwupd-metadata" ];
-      originalFiles = concatMap (d: map (f: "${d}/${f}") (listFiles "${pkgs.fwupd}/etc/${d}")) copiedDirs;
       mkEtcFile = n: nameValuePair n { source = "${pkgs.fwupd}/etc/${n}"; };
-    in listToAttrs (map mkEtcFile originalFiles);
+    in listToAttrs (map mkEtcFile pkgs.fwupd.filesInstalledToEtc);
   extraTrustedKeys =
     let
       mkName = p: "pki/fwupd/${baseNameOf (toString p)}";

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -258,7 +258,7 @@ in rec {
   tests.firefox = callTest tests/firefox.nix {};
   tests.firewall = callTest tests/firewall.nix {};
   tests.fleet = callTestOnTheseSystems ["x86_64-linux"] tests/fleet.nix {};
-  #tests.fwupd = callTest tests/fwupd.nix {}; # build during evaluation
+  tests.fwupd = callTest tests/fwupd.nix {};
   #tests.gitlab = callTest tests/gitlab.nix {};
   tests.gitolite = callTest tests/gitolite.nix {};
   tests.gjs = callTest tests/gjs.nix {};

--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -1,25 +1,21 @@
-{ stdenv, fetchFromGitHub, autoreconfHook
-, pkgconfig, glib, systemd, libgudev, vala  }:
+{ stdenv, fetchFromGitHub, automake, autoconf, libtool, gtk_doc
+, pkgconfig, glib, systemd, libgudev, vala }:
 
 stdenv.mkDerivation rec {
-  name = "umockdev";
-  version = "0.8.13";
+  name = "umockdev-${version}";
+  version = "0.11";
 
   src = fetchFromGitHub {
     owner = "martinpitt";
     repo = "umockdev";
     rev = version;
-    sha256 ="0bw2dpshlgbdwg5mhq4j22z474llpqix8pxii63r2bk5nhjc537k";
+    sha256 ="1gpk2f03nad4qv084hx7549d68cqc1xibxm0ncanafm5xjz1hp55";
   };
 
-  buildInputs = [ glib systemd libgudev vala ];
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ glib systemd libgudev ];
+  nativeBuildInputs = [ automake autoconf libtool gtk_doc pkgconfig vala ];
 
-  ### docs/gtk-doc.make not found
-  prePatch = ''
-    sed -i 's|include $(top_srcdir)/docs/gtk-doc.make||g' docs/reference/Makefile.am
-   sed -i 's|+=|=|g' docs/reference/Makefile.am
-   '';
+  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
   meta = with stdenv.lib; {
     description = "Mock hardware devices for creating unit tests";

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -6,6 +6,7 @@
 , shared_mime_info, umockdev
 }:
 let
+  # Updating? Keep $out/etc synchronized with passthru.filesInstalledToEtc
   version = "1.0.5";
   python = python3.withPackages (p: with p; [ pygobject3 pycairo pillow ]);
   installedTestsPython = python3.withPackages (p: with p; [ pygobject3 requests ]);
@@ -65,6 +66,20 @@ in stdenv.mkDerivation {
     wrapProgram $installedTests/share/installed-tests/fwupd/hardware.py \
       --prefix GI_TYPELIB_PATH : "$out/lib/girepository-1.0:${libsoup}/lib/girepository-1.0"
   '';
+
+  passthru = {
+    filesInstalledToEtc = [
+      "fwupd/remotes.d/fwupd.conf"
+      "fwupd/remotes.d/lvfs-testing.conf"
+      "fwupd/remotes.d/lvfs.conf"
+      "fwupd/remotes.d/vendor.conf"
+      "pki/fwupd/GPG-KEY-Hughski-Limited"
+      "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
+      "pki/fwupd/LVFS-CA.pem"
+      "pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service"
+      "pki/fwupd-metadata/LVFS-CA.pem"
+    ];
+  };
 
   meta = with stdenv.lib; {
     homepage = https://fwupd.org/;

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -6,14 +6,14 @@
 , shared_mime_info, umockdev
 }:
 let
-  version = "1.0.4";
+  version = "1.0.5";
   python = python3.withPackages (p: with p; [ pygobject3 pycairo pillow ]);
   installedTestsPython = python3.withPackages (p: with p; [ pygobject3 requests ]);
 in stdenv.mkDerivation {
   name = "fwupd-${version}";
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-    sha256 = "1n4d6fw3ffg051072hbxn106s52x2wlh5dh2kxwdfjsb5kh03ra3";
+    sha256 = "0wm195vkf6x1kg1dz0sbfwpdcn9f6638l7vyzplcfrb3v07pqxpq";
   };
 
   outputs = [ "out" "devdoc" "man" "installedTests" ];
@@ -31,20 +31,9 @@ in stdenv.mkDerivation {
 
   patches = [
     ./fix-missing-deps.patch
-    # https://github.com/hughsie/fwupd/issues/403
     (fetchpatch {
-      url = https://github.com/hughsie/fwupd/commit/bd6082574989e4f48b66c7270bb408d439b77a06.patch;
-      sha256 = "17pixyizkmn6wlsjmr1wwya17ivn770hdv9mp769vifxinya8w9y";
-    })
-    # drop docbook2man
-    (fetchpatch {
-      url = https://github.com/hughsie/fwupd/commit/2c43d3e6e65868b66a9a64a76123697e259ec7c2.patch;
-      sha256 = "0vjv7jnai0g96frlipk2sc59pj3mhq9di01hajycjv7y5v6qqrmc";
-    })
-    # https://github.com/hughsie/fwupd/issues/405
-    (fetchpatch {
-      url = https://github.com/hughsie/fwupd/pull/407.patch;
-      sha256 = "1dxhqps12x7bz0s974xk5hfpk4nwn1gs29vl0dfi9j54wy18f688";
+      url = https://github.com/hughsie/fwupd/commit/767210e4b1401d5d5bb7ac1e7c052a60b6529d88.patch;
+      sha256 = "00adfabxpgdg74jx7i6jihhh8njjk2r7v3fxqs4scj3vn06k5fmw";
     })
   ];
 
@@ -77,7 +66,6 @@ in stdenv.mkDerivation {
       --prefix GI_TYPELIB_PATH : "$out/lib/girepository-1.0:${libsoup}/lib/girepository-1.0"
   '';
 
-  enableParallelBuilding = true;
   meta = with stdenv.lib; {
     homepage = https://fwupd.org/;
     maintainers = with maintainers; [];

--- a/pkgs/os-specific/linux/firmware/fwupdate/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupdate/default.nix
@@ -1,37 +1,62 @@
-{ stdenv, fetchurl, gnu-efi, efivar, libsmbios, popt, pkgconfig
-, gettext }:
-let version = "8"; in
-  stdenv.mkDerivation
-    { name = "fwupdate-${version}";
-      src = fetchurl
-        { url = "https://github.com/rhinstaller/fwupdate/releases/download/${version}/fwupdate-${version}.tar.bz2";
-          sha256 = "10q8k1kghvbcb5fwcl2smzp8vqdfzimx9dkk0c3hz39py1phy4n8";
-        };
-      makeFlags =
-        [ "EFIDIR=nixos"
-          "LIBDIR=$(out)/lib"
-          "GNUEFIDIR=${gnu-efi}/lib"
-          "TARGETDIR=$(out)/boot/efi/nixos/"
-          "prefix=$(out)/"
-        ];
-  nativeBuildInputs = [ pkgconfig ];
-      buildInputs = [ gnu-efi libsmbios popt gettext ];
-      propagatedBuildInputs = [ efivar ];
-      # TODO: Just apply the disable to the efi subdir
-      hardeningDisable = [ "all" ];
-      patchPhase = ''
-        sed -i 's|/usr/include/smbios_c/token.h|smbios_c/token.h|' \
-          linux/libfwup.c
-        sed -i 's|/usr/share|$(prefix)share|' linux/Makefile
-        sed -i "s|/usr/include|$out/include|" linux/fwup.pc.in
-        find . -type f -print0 | xargs -0 sed -i -e 's|/boot/efi|/boot|g' -e 's|/boot/efi/EFI|/boot/EFI|g'
-      '';
-      configurePhase = ''
-        arch=$(cc -dumpmachine | cut -f1 -d- | sed 's,i[3456789]86,ia32,' )
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gnu-efi}/include/efi -I${efivar}/include/efivar -I${gnu-efi}/include/efi/$arch"
-      '';
-      meta =
-        { license = [ stdenv.lib.licenses.gpl2 ];
-          platforms = stdenv.lib.platforms.linux;
-        };
-    }
+{ efivar, fetchurl, gettext, gnu-efi, libsmbios, pkgconfig, popt, stdenv }:
+let
+  version = "10";
+in stdenv.mkDerivation {
+  name = "fwupdate-${version}";
+  src = fetchurl {
+    url = "https://github.com/rhinstaller/fwupdate/releases/download/${version}/fwupdate-${version}.tar.bz2";
+    sha256 = "0fpk3q0msq2l0bs2mvk0cqp8jbwnmi17ggc81r4v96h4jxh2rx3k";
+  };
+
+  patches = [
+    # https://github.com/rhboot/fwupdate/pull/99
+    ./fix-paths.patch
+    ./do-not-create-sharedstatedir.patch
+  ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${gnu-efi}/include/efi" ];
+
+  # TODO: Just apply the disable to the efi subdir
+  hardeningDisable = [ "stackprotector" ];
+
+  makeFlags = [
+    "EFIDIR=nixos"
+    "prefix=$(out)"
+    "LIBDIR=$(out)/lib"
+    "GNUEFIDIR=${gnu-efi}/lib"
+    "ESPMOUNTPOINT=$(out)/boot"
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    gettext
+  ];
+
+  buildInputs = [
+    gnu-efi
+    libsmbios
+    popt
+  ];
+
+  propagatedBuildInputs = [
+    efivar
+  ];
+
+  # TODO: fix wrt cross-compilation
+  preConfigure = ''
+    arch=$(cc -dumpmachine | cut -f1 -d- | sed 's,i[3456789]86,ia32,' )
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gnu-efi}/include/efi/$arch"
+  '';
+
+  postInstall = ''
+    rm -rf $out/src
+    rm -rf $out/lib/debug
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tools for using the ESRT and UpdateCapsule() to apply firmware updates";
+    maintainers = with maintainers; [ ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/firmware/fwupdate/do-not-create-sharedstatedir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupdate/do-not-create-sharedstatedir.patch
@@ -1,0 +1,10 @@
+--- a/linux/Makefile
++++ b/linux/Makefile
+@@ -131,7 +131,6 @@
+ 		ln -fs $(x) $(patsubst %.so.1.$(VERSION),%.so.1,$(DESTDIR)$(libdir)/$(x)) ;\
+ 		ln -fs $(x) $(patsubst %.so.1.$(VERSION),%.so,$(DESTDIR)$(libdir)/$(x)) ;\
+ 		)
+-	$(INSTALL) -d -m 755 $(DESTDIR)$(sharedstatedir)/fwupdate/
+ 	$(INSTALL) -d -m 755 $(DESTDIR)$(libexecdir)/fwupdate/
+ 	$(INSTALL) -m 755 cleanup $(DESTDIR)$(libexecdir)/fwupdate/cleanup
+ 	$(INSTALL) -d -m 755 $(DESTDIR)$(libdatadir)/systemd/system

--- a/pkgs/os-specific/linux/firmware/fwupdate/fix-paths.patch
+++ b/pkgs/os-specific/linux/firmware/fwupdate/fix-paths.patch
@@ -1,0 +1,116 @@
+--- a/Make.defaults
++++ b/Make.defaults
+@@ -18,19 +18,20 @@
+ ABIDIFF		:= abidiff
+ ABIDW		:= abidw
+ prefix		?= /usr/
+-prefix		:= $(abspath $(prefix))/
++prefix		:= $(abspath $(prefix))
++exec_prefix		?= $(prefix)
+ ARCH		= $(shell $(CC) -dumpmachine | cut -f1 -d- | sed s,i[3456789]86,ia32,)
+ ifeq ($(ARCH),x86_64)
+-  LIBDIR	?= $(prefix)lib64
++  LIBDIR	?= $(exec_prefix)/lib64
+ endif
+ ifeq ($(ARCH),ia32)
+-  LIBDIR	?= $(prefix)lib
++  LIBDIR	?= $(exec_prefix)/lib
+ endif
+ ifeq ($(ARCH),aarch64)
+-  LIBDIR	?= $(prefix)lib64
++  LIBDIR	?= $(exec_prefix)/lib64
+ endif
+ ifeq ($(ARCH),arm)
+-  LIBDIR	?= $(prefix)lib
++  LIBDIR	?= $(exec_prefix)/lib
+ endif
+ LIBDIR		?= unknown
+ ifeq ($(LIBDIR),unknown)
+@@ -45,13 +46,13 @@
+ GNUEFIDIR	?= $(LIBDIR)/gnuefi
+ libdir		?= $(LIBDIR)
+ pcdir		?= $(libdir)/pkgconfig
+-mandir		?= $(prefix)share/man
+-includedir	?= $(prefix)include
+-bindir		?= $(prefix)bin
+-datadir 	?= $(prefix)share
++mandir		?= $(prefix)/share/man
++includedir	?= $(prefix)/include
++bindir		?= $(exec_prefix)/bin
++datadir 	?= $(prefix)/share
+ localedir	?= $(datadir)/locale
+-libexecdir	?= $(prefix)libexec
+-libdatadir	?= $(prefix)lib
++libexecdir	?= $(exec_prefix)/libexec
++libdatadir	?= $(exec_prefix)/lib
+ sharedstatedir	?= /var/lib
+ 
+ EFIDIR		?= $(shell x=$$(which --skip-alias --skip-functions git 2>/dev/null) ; [ -n "$$x" ] && git config --get fwupdate.efidir)
+@@ -63,8 +64,8 @@
+ 	ESPMOUNTPOINT = "/boot/efi"
+ endif
+ 
+-DEBUGINFO	?= $(prefix)lib/debug
+-DEBUGSOURCE	?= $(prefix)src/debug
++DEBUGINFO	?= $(exec_prefix)/lib/debug
++DEBUGSOURCE	?= $(prefix)/src/debug
+ TARGETDIR	?= $(ESPMOUNTPOINT)/EFI/$(EFIDIR)
+ 
+ .PHONY: check_efidir_error
+--- a/linux/Makefile
++++ b/linux/Makefile
+@@ -93,16 +93,19 @@
+ 	sed -e "s,@@VERSION@@,$(VERSION),g" \
+ 		-e "s,@@FWUP_MAJOR_VERSION@@,$(MAJOR_VERSION),g" \
+ 		-e "s,@@FWUP_MINOR_VERSION@@,$(MINOR_VERSION),g" \
++		-e "s,@@PREFIX@@,$(prefix),g" \
++		-e "s,@@EXEC_PREFIX@@,$(exec_prefix),g" \
+ 		-e "s,@@SHAREDSTATEDIR@@,$(sharedstatedir),g" \
+ 		-e "s,@@ESPMOUNTPOINT@@,$(ESPMOUNTPOINT),g" \
+ 		-e "s,@@EFIDIR@@,$(EFIDIR),g" \
+ 		-e "s,@@LIBDIR@@,$(libdir),g" \
+ 		-e "s,@@LIBEXECDIR@@,$(libexecdir),g" \
++		-e "s,@@INCLUDEDIR@@,$(includedir),g" \
+ 		$< > $@
+ 
+ tester : tester.c
+-	$(CC) -Wall -Werror -ggdb -L. -I./include -I/usr/include/efivar \
+-		-lefivar -lfwup -o $@ $^
++	$(CC) -Wall -Werror -ggdb -L. -I./include $(shell $(PKG_CONFIG) --cflags efivar) \
++		$(shell $(PKG_CONFIG) --libs efivar) -lfwup -o $@ $^
+ 
+ test : tester
+ 	LD_LIBRARY_PATH=$(shell pwd) ./tester
+@@ -134,6 +137,6 @@
+ 	$(INSTALL) -d -m 755 $(DESTDIR)$(libdatadir)/systemd/system
+ 	$(INSTALL) -m 644 cleanup.service \
+ 		$(DESTDIR)$(libdatadir)/systemd/system/fwupdate-cleanup.service
+-	$(INSTALL) -d -m 755 $(DESTDIR)/usr/share/bash-completion/completions/
++	$(INSTALL) -d -m 755 $(DESTDIR)$(datadir)/bash-completion/completions/
+ 	$(INSTALL) -m 755 $(VPATH)/bash-completion \
+-		$(DESTDIR)/usr/share/bash-completion/completions/fwupdate
++		$(DESTDIR)$(datadir)/bash-completion/completions/fwupdate
+--- a/linux/fwup.pc.in
++++ b/linux/fwup.pc.in
+@@ -1,7 +1,7 @@
+-prefix=/usr
+-exec_prefix=/usr
++prefix=@@PREFIX@@
++exec_prefix=@@EXEC_PREFIX@@
+ libdir=@@LIBDIR@@
+-includedir=/usr/include
++includedir=@@INCLUDEDIR@@
+ 
+ Name: fwup
+ Description: Library for deployment of UEFI firmware updates.
+--- a/linux/libfwup.c
++++ b/linux/libfwup.c
+@@ -35,7 +35,7 @@
+ 
+ #include <dell-wmi-smi.h>
+ #ifdef FWUPDATE_HAVE_LIBSMBIOS__
+-#include </usr/include/smbios_c/token.h>
++#include <smbios_c/token.h>
+ #include <smbios_c/smi.h>
+ #endif
+ 

--- a/pkgs/os-specific/linux/libsmbios/default.nix
+++ b/pkgs/os-specific/linux/libsmbios/default.nix
@@ -1,38 +1,37 @@
-{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, libtool, gettext
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, help2man, gettext
 , libxml2, perl, doxygen }:
 
 
 stdenv.mkDerivation rec {
   name = "libsmbios-${version}";
-  version = "2.3.3";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "dell";
     repo = "libsmbios";
     rev = "v${version}";
-    sha256 = "1cl5nb6qk8ki87hwqf9n1dd9nlhkjnlpdxlhzvm82za16gs7apkl";
+    sha256 = "158w5fz777is7nr5yhpr69b17nn6i1pavycxq1q9899frrpkzbsc";
   };
 
-  nativeBuildInputs = [ autoreconfHook doxygen gettext libtool perl pkgconfig ];
-  buildInputs = [ libxml2 ];
+  nativeBuildInputs = [ autoreconfHook doxygen gettext libxml2 help2man perl pkgconfig ];
 
   configureFlags = [ "--disable-python" "--disable-graphviz" ];
 
   enableParallelBuilding = true;
 
-  postInstall =
-    ''
-      mkdir -p $out/include
-      cp -a src/include/smbios_c $out/include/
-      cp -a out/public-include/smbios_c $out/include/
-    '';
+  postInstall = ''
+    mkdir -p $out/include
+    cp -a src/include/smbios_c $out/include/
+    cp -a out/public-include/smbios_c $out/include/
+  '';
 
   preFixup = ''rm -rf "$(pwd)" ''; # Hack to avoid TMPDIR in RPATHs
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/dell/libsmbios;
     description = "A library to obtain BIOS information";
-    license = with stdenv.lib.licenses; [ osl21 gpl2Plus ];
+    license = with licenses; [ osl21 gpl2Plus ];
+    maintainers = with maintainers; [ ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/tools/system/efibootmgr/default.nix
+++ b/pkgs/tools/system/efibootmgr/default.nix
@@ -5,17 +5,15 @@ stdenv.mkDerivation rec {
   version = "15";
 
   nativeBuildInputs = [ pkgconfig ];
-  
+
   buildInputs = [ efivar popt ];
 
   src = fetchFromGitHub {
-    owner = "rhinstaller";
+    owner = "rhboot";
     repo = "efibootmgr";
     rev = version;
     sha256 = "0z7h1dirp8za6lbbf4f3dzn7l1px891rdymhkbqc10yj6gi1jpqp";
   };
-
-  NIX_CFLAGS_COMPILE = "-I${efivar}/include/efivar";
 
   makeFlags = [ "EFIDIR=nixos" ];
 
@@ -23,8 +21,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A Linux user-space application to modify the Intel Extensible Firmware Interface (EFI) Boot Manager";
-    homepage = https://github.com/rhinstaller/efibootmgr;
+    homepage = https://github.com/rhboot/efibootmgr;
     license = licenses.gpl2;
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update fwupd, fwupdate, libsmbios and umockdev; clean up #35011, fix #32142, https://github.com/NixOS/nixpkgs/issues/35072, re-enable test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

