### PR TITLE
gnomeExtensions.taskwhisperer: init at v11

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/taskwhisperer/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/taskwhisperer/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, substituteAll, fetchFromGitHub, taskwarrior }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-taskwhisperer-${version}";
+  version = "11";
+
+  src = fetchFromGitHub {
+    owner = "cinatic";
+    repo = "taskwhisperer";
+    rev = "v${version}";
+    sha256 = "1g1301rwnfg5jci78bjpmgxrn78ra80m1zp2inhfsm8jssr1i426";
+  };
+
+  buildInputs = [ taskwarrior ];
+
+  uuid = "taskwhisperer-extension@infinicode.de";
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp *.js $out/share/gnome-shell/extensions/${uuid}
+    cp -r extra $out/share/gnome-shell/extensions/${uuid}
+    cp -r icons $out/share/gnome-shell/extensions/${uuid}
+    cp -r locale $out/share/gnome-shell/extensions/${uuid}
+    cp -r schemas $out/share/gnome-shell/extensions/${uuid}
+    cp metadata.json $out/share/gnome-shell/extensions/${uuid}
+    cp settings.ui $out/share/gnome-shell/extensions/${uuid}
+    cp stylesheet.css $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      task = "${taskwarrior}/bin/task";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "GNOME Shell TaskWarrior GUI";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jonafato ];
+    homepage = https://github.com/cinatic/taskwhisperer;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/taskwhisperer/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/extensions/taskwhisperer/fix-paths.patch
@@ -1,0 +1,81 @@
+diff --git a/extra/create.sh b/extra/create.sh
+index a69e369..35d5ea1 100755
+--- a/extra/create.sh
++++ b/extra/create.sh
+@@ -1 +1 @@
+-bash -c "task add $1"
++bash -c "@task@ add $1"
+diff --git a/extra/modify.sh b/extra/modify.sh
+index 7964a26..8edd21b 100755
+--- a/extra/modify.sh
++++ b/extra/modify.sh
+@@ -1 +1 @@
+-bash -c "task $1 modify $2"
++bash -c "@task@ $1 modify $2"
+diff --git a/taskService.js b/taskService.js
+index dea40d8..ff35a80 100644
+--- a/taskService.js
++++ b/taskService.js
+@@ -186,7 +186,7 @@ const TaskService = new Lang.Class({
+ 
+         let project = projectName ? "project:" + projectName : "";
+ 
+-        let command = ['task', 'rc.json.array=on', status, project, 'export'];
++        let command = ['@task@', 'rc.json.array=on', status, project, 'export'];
+         let reader = new SpawnReader.SpawnReader();
+ 
+         let buffer = "";
+@@ -227,7 +227,7 @@ const TaskService = new Lang.Class({
+                 break;
+         }
+ 
+-        let shellProc = Gio.Subprocess.new(['task', status, 'projects'], Gio.SubprocessFlags.STDOUT_PIPE);
++        let shellProc = Gio.Subprocess.new(['@task@', status, 'projects'], Gio.SubprocessFlags.STDOUT_PIPE);
+ 
+         shellProc.wait_async(null, function(obj, result){
+             let shellProcExited = true;
+@@ -274,7 +274,7 @@ const TaskService = new Lang.Class({
+             return;
+         }
+ 
+-        let shellProc = Gio.Subprocess.new(['task', taskID.toString(), 'done'], Gio.SubprocessFlags.STDOUT_PIPE);
++        let shellProc = Gio.Subprocess.new(['@task@', taskID.toString(), 'done'], Gio.SubprocessFlags.STDOUT_PIPE);
+ 
+         shellProc.wait_async(null, function(obj, result){
+             let shellProcExited = true;
+@@ -307,7 +307,7 @@ const TaskService = new Lang.Class({
+             return;
+         }
+ 
+-        let shellProc = Gio.Subprocess.new(['task', 'modify', taskID.toString(), 'status:pending'], Gio.SubprocessFlags.STDOUT_PIPE);
++        let shellProc = Gio.Subprocess.new(['@task@', 'modify', taskID.toString(), 'status:pending'], Gio.SubprocessFlags.STDOUT_PIPE);
+ 
+         shellProc.wait_async(null, function(obj, result){
+             let shellProcExited = true;
+@@ -339,7 +339,7 @@ const TaskService = new Lang.Class({
+         {
+             return;
+         }
+-        let shellProc = Gio.Subprocess.new(['task', taskID.toString(), 'start'], Gio.SubprocessFlags.STDOUT_PIPE);
++        let shellProc = Gio.Subprocess.new(['@task@', taskID.toString(), 'start'], Gio.SubprocessFlags.STDOUT_PIPE);
+         shellProc.wait_async(null, function(obj, result){
+             let shellProcExited = true;
+             shellProc.wait_finish(result);
+@@ -369,7 +369,7 @@ const TaskService = new Lang.Class({
+         {
+             return;
+         }
+-        let shellProc = Gio.Subprocess.new(['task', taskID.toString(), 'stop'], Gio.SubprocessFlags.STDOUT_PIPE);
++        let shellProc = Gio.Subprocess.new(['@task@', taskID.toString(), 'stop'], Gio.SubprocessFlags.STDOUT_PIPE);
+         shellProc.wait_async(null, function(obj, result){
+             let shellProcExited = true;
+             shellProc.wait_finish(result);
+@@ -468,7 +468,7 @@ const TaskService = new Lang.Class({
+ 
+         try
+         {
+-            shellProc = Gio.Subprocess.new(['task', 'sync'], Gio.SubprocessFlags.STDOUT_PIPE);
++            shellProc = Gio.Subprocess.new(['@task@', 'sync'], Gio.SubprocessFlags.STDOUT_PIPE);
+         }
+         catch(err)
+         {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19099,6 +19099,7 @@ with pkgs;
     nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
     pixel-saver = callPackage ../desktops/gnome-3/extensions/pixel-saver { };
     remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };
+    taskwhisperer = callPackage ../desktops/gnome-3/extensions/taskwhisperer { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Add the TaskWhisperer GNOME Shell extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

