### PR TITLE
welle-io: 1.0-rc1 -> 1.0-rc2

### DIFF
--- a/pkgs/applications/misc/welle-io/default.nix
+++ b/pkgs/applications/misc/welle-io/default.nix
@@ -3,7 +3,7 @@
 , faad2, rtl-sdr, libusb, fftwSinglePrec }:
 let
 
-  version = "1.0-rc1";
+  version = "1.0-rc2";
 
 in stdenv.mkDerivation {
 
@@ -13,7 +13,7 @@ in stdenv.mkDerivation {
     owner = "AlbrechtL";
     repo = "welle.io";
     rev = "V${version}";
-    sha256 = "1xi59rmk3rdqqxxxrm2pbllrlsql46vxs95l1pkfx7bp8f7n7rsv";
+    sha256 = "01x4ldq6lvmdrmxi857594nj9xpn2h7848vvf3f54sh1zrawn4k4";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

