### PR TITLE
tmpdir audit: only fail with files referenced below

### DIFF
--- a/pkgs/build-support/setup-hooks/audit-tmpdir.sh
+++ b/pkgs/build-support/setup-hooks/audit-tmpdir.sh
@@ -13,23 +13,23 @@ auditTmpdir() {
     local dir="$1"
     [ -e "$dir" ] || return 0
 
-    header "checking for references to $TMPDIR in $dir..."
+    header "checking for references to $TMPDIR/ in $dir..."
 
     local i
     while IFS= read -r -d $'\0' i; do
         if [[ "$i" =~ .build-id ]]; then continue; fi
 
         if isELF "$i"; then
-            if patchelf --print-rpath "$i" | grep -q -F "$TMPDIR"; then
-                echo "RPATH of binary $i contains a forbidden reference to $TMPDIR"
+            if patchelf --print-rpath "$i" | grep -q -F "$TMPDIR/"; then
+                echo "RPATH of binary $i contains a forbidden reference to $TMPDIR/"
                 exit 1
             fi
         fi
 
         if  isScript "$i"; then
             if [ -e "$(dirname "$i")/.$(basename "$i")-wrapped" ]; then
-                if grep -q -F "$TMPDIR" "$i"; then
-                    echo "wrapper script $i contains a forbidden reference to $TMPDIR"
+                if grep -q -F "$TMPDIR/" "$i"; then
+                    echo "wrapper script $i contains a forbidden reference to $TMPDIR/"
                     exit 1
                 fi
             fi


### PR DESCRIPTION
###### Motivation for this change

On Linux the `$TMPDIR` is `/build`. The TMPDIR audit looks for `$TMPDIR`
in the build output, which will then fail with packages like
/buildkite-agent.

This fixes the heuristic to look for `$TMPDIR/` instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

