### PR TITLE
tcl/tk: 8.6.6 -> 8.6.8 and create library symlink

### DIFF
--- a/pkgs/development/interpreters/tcl/8.6.nix
+++ b/pkgs/development/interpreters/tcl/8.6.nix
@@ -2,10 +2,10 @@
 
 callPackage ./generic.nix (args // rec {
   release = "8.6";
-  version = "${release}.6";
+  version = "${release}.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
-    sha256 = "01zypqhy57wvh1ikk28bg733sk5kf4q568pq9v6fvcz4h6bl0rd2";
+    sha256 = "0sprsg7wnraa4cbwgbcliylm6p0rspfymxn8ww02pr4ca70v0g64";
   };
 })

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     # Note: using $out instead of $man to prevent a runtime dependency on $man.
-    configureFlagsArray+=(--mandir=$out/share/man --enable-man-symlinks)
+    configureFlagsArray+=(--mandir=$out/share/man --enable-man-symlinks --enable-64bit)
 
     # Don't install tzdata because NixOS already has a more up-to-date copy.
     configureFlagsArray+=(--with-tzdata=no)
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     make install-private-headers
     ln -s $out/bin/tclsh${release} $out/bin/tclsh
+    ln -s $out/lib/libtcl${release}.so $out/lib/libtcl.so
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/tk/8.6.nix
+++ b/pkgs/development/libraries/tk/8.6.nix
@@ -4,7 +4,7 @@ callPackage ./generic.nix (args // rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/tcl/tk${tcl.version}-src.tar.gz";
-    sha256 = "17diivcfcwdhp4v5zi6j9nkxncccjqkivhp363c4wx5lf4d3fb6n";
+    sha256 = "0cvvznjwfn0i9vj9cw3wg8svx25ha34gg57m4xd1k5fyinhbrrs9";
   };
 
   patches = [ ./different-prefix-with-tcl.patch ] ++ stdenv.lib.optionals stdenv.isDarwin [ ./Fix-bad-install_name-for-libtk8.6.dylib.patch ];

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -10,13 +10,14 @@ stdenv.mkDerivation {
   setOutputFlags = false;
 
   preConfigure = ''
-    configureFlagsArray+=(--mandir=$man/share/man --enable-man-symlinks)
+    configureFlagsArray+=(--mandir=$man/share/man --enable-man-symlinks --enable-64bit)
     cd unix
   '';
 
   postInstall = ''
     ln -s $out/bin/wish* $out/bin/wish
     cp ../{unix,generic}/*.h $out/include
+    ln -s $out/lib/libtk${tcl.release}.so $out/lib/libtk.so
   '';
 
   configureFlags = [


### PR DESCRIPTION
tcl/tk were out of date. Also, I tried to compile something with `gcc -ltcl
-ltk` and it complained about not being able to find those libraries - turns
out, the symlinks for them are never made, so I had to use `gcc -ltcl8.6
-ltk8.6`. Most distros make these themselves, so I added another line.

There seems to be some oddness with the sha256 sum - the package built
successfully even when I forgot to update it (it's up to date in this commit); I
don't know what's going on here, but someone more experienced than me should
probably check it out.

I also enabled the `--enable-64bit` flag; this is probably not contentious, I
just saw that other distros were doing it too.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---