### PR TITLE
stdenv, bash: fixing info pages and stuff

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -5,7 +5,8 @@
 # script that sets up the right environment variables so that the
 # compiler and the linker just "work".
 
-{ name ? "", stdenvNoCC, nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
+{ name ? ""
+, stdenvNoCC, nativeTools, propagateDoc ? !nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
 , bintools ? null, libc ? null
 , coreutils ? null, shell ? stdenvNoCC.shell, gnugrep ? null
 , extraPackages ? [], extraBuildCommands ? ""
@@ -15,7 +16,7 @@
 
 with stdenvNoCC.lib;
 
-assert nativeTools -> nativePrefix != "";
+assert nativeTools -> !propagateDoc && nativePrefix != "";
 assert !nativeTools ->
   bintools != null && coreutils != null && gnugrep != null;
 assert !(nativeLibc && noLibc);
@@ -83,7 +84,7 @@ stdenv.mkDerivation {
 
   inherit targetPrefix infixSalt;
 
-  outputs = [ "out" "info" "man" ];
+  outputs = [ "out" ] ++ optionals propagateDoc [ "man" "info" ];
 
   passthru = {
     inherit bintools libc nativeTools nativeLibc nativePrefix;
@@ -111,7 +112,7 @@ stdenv.mkDerivation {
     ''
       set -u
 
-      mkdir -p $out/bin {$out,$info,$man}/nix-support
+      mkdir -p $out/bin $out/nix-support
 
       wrap() {
         local dst="$1"
@@ -237,28 +238,27 @@ stdenv.mkDerivation {
     '')
 
     + optionalString (!nativeTools) ''
-
       ##
       ## User env support
       ##
 
       # Propagate the underling unwrapped bintools so that if you
-      # install the wrapper, you get tools like objdump, the manpages,
-      # etc. as well (same for any binaries of libc).
+      # install the wrapper, you get tools like objdump (same for any
+      # binaries of libc).
       printWords ${bintools_bin} ${if libc == null then "" else libc_bin} > $out/nix-support/propagated-user-env-packages
+    ''
 
+    + optionalString propagateDoc ''
       ##
       ## Man page and info support
       ##
 
-      printWords ${bintools.info or ""} \
-        >> $info/nix-support/propagated-build-inputs
-      printWords ${bintools.man or ""} \
-        >> $man/nix-support/propagated-build-inputs
+      mkdir -p $man/nix-support $info/nix-support
+      printWords ${bintools.man or ""} >> $man/nix-support/propagated-build-inputs
+      printWords ${bintools.info or ""} >> $info/nix-support/propagated-build-inputs
     ''
 
     + ''
-
       ##
       ## Hardening support
       ##
@@ -286,8 +286,8 @@ stdenv.mkDerivation {
       ##
       ## Extra custom steps
       ##
-
     ''
+
     + extraBuildCommands;
 
   inherit dynamicLinker expand-response-params;

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -36,9 +36,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  outputs = [ "out" "dev" "doc" "info" ]
-    # the man pages are small and useful enough, so include them in $out in interactive builds
-    ++ stdenv.lib.optional (!interactive) "man";
+  outputs = [ "out" "dev" "man" "doc" "info" ];
 
   NIX_CFLAGS_COMPILE = ''
     -DSYS_BASHRC="/etc/bashrc"

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -61,12 +61,14 @@ in rec {
                           libcxx,
                           allowedRequisites ? null}:
     let
+      name = "bootstrap-stage${toString step}";
+
       buildPackages = lib.optionalAttrs (last ? stdenv) {
         inherit (last) stdenv;
       };
 
-      coreutils = { name = "coreutils-9.9.9"; outPath = bootstrapTools; };
-      gnugrep   = { name = "gnugrep-9.9.9";   outPath = bootstrapTools; };
+      coreutils = { name = "${name}-coreutils"; outPath = bootstrapTools; };
+      gnugrep   = { name = "${name}-gnugrep";   outPath = bootstrapTools; };
 
       bintools = import ../../build-support/bintools-wrapper {
         inherit shell;
@@ -76,7 +78,7 @@ in rec {
         nativeLibc   = false;
         inherit buildPackages coreutils gnugrep;
         libc         = last.pkgs.darwin.Libsystem;
-        bintools     = { name = "binutils-9.9.9";  outPath = bootstrapTools; };
+        bintools     = { name = "${name}-binutils"; outPath = bootstrapTools; };
       };
 
       cc = if isNull last then "/dev/null" else import ../../build-support/cc-wrapper {
@@ -91,16 +93,16 @@ in rec {
         inherit buildPackages coreutils gnugrep bintools;
         libc         = last.pkgs.darwin.Libsystem;
         isClang      = true;
-        cc           = { name = "clang-9.9.9";     outPath = bootstrapTools; };
+        cc           = { name = "${name}-clang"; outPath = bootstrapTools; };
       };
 
       thisStdenv = import ../generic {
+        name = "${name}-stdenv-darwin";
+
         inherit config shell extraNativeBuildInputs extraBuildInputs;
         allowedRequisites = if allowedRequisites == null then null else allowedRequisites ++ [
           cc.expand-response-params cc.bintools
         ];
-
-        name = "stdenv-darwin-boot-${toString step}";
 
         buildPlatform = localSystem;
         hostPlatform = localSystem;
@@ -146,7 +148,7 @@ in rec {
     overrides = self: super: with stage0; rec {
       darwin = super.darwin // {
         Libsystem = stdenv.mkDerivation {
-          name = "bootstrap-Libsystem";
+          name = "bootstrap-stage0-Libsystem";
           buildCommand = ''
             mkdir -p $out
             ln -s ${bootstrapTools}/lib $out/lib
@@ -157,7 +159,7 @@ in rec {
       };
 
       libcxx = stdenv.mkDerivation {
-        name = "bootstrap-libcxx";
+        name = "bootstrap-stage0-libcxx";
         phases = [ "installPhase" "fixupPhase" ];
         installPhase = ''
           mkdir -p $out/lib $out/include
@@ -169,7 +171,7 @@ in rec {
       };
 
       libcxxabi = stdenv.mkDerivation {
-        name = "bootstrap-libcxxabi";
+        name = "bootstrap-stage0-libcxxabi";
         buildCommand = ''
           mkdir -p $out/lib
           ln -s ${bootstrapTools}/lib/libc++abi.dylib $out/lib/libc++abi.dylib
@@ -325,10 +327,10 @@ in rec {
       inherit binutils binutils-raw;
     };
   in import ../generic rec {
+    name = "stdenv-darwin";
+
     inherit config;
     inherit (pkgs.stdenv) fetchurlBoot;
-
-    name = "stdenv-darwin";
 
     buildPlatform = localSystem;
     hostPlatform = localSystem;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -86,6 +86,7 @@ in rec {
         extraPackages = lib.optional (libcxx != null) libcxx;
 
         nativeTools  = false;
+        propagateDoc = false;
         nativeLibc   = false;
         inherit buildPackages coreutils gnugrep bintools;
         libc         = last.pkgs.darwin.Libsystem;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -89,6 +89,7 @@ let
              then null
              else lib.makeOverridable (import ../../build-support/cc-wrapper) {
           nativeTools = false;
+          propagateDoc = false;
           nativeLibc = false;
           buildPackages = lib.optionalAttrs (prevStage ? stdenv) {
             inherit (prevStage) stdenv;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -66,7 +66,7 @@ let
     let
 
       thisStdenv = import ../generic {
-        name = "stdenv-linux-boot";
+        name = "${name}-stdenv-linux";
         buildPlatform = localSystem;
         hostPlatform = localSystem;
         targetPlatform = localSystem;
@@ -88,6 +88,7 @@ let
         cc = if isNull prevStage.gcc-unwrapped
              then null
              else lib.makeOverridable (import ../../build-support/cc-wrapper) {
+          name = "${name}-gcc-wrapper";
           nativeTools = false;
           propagateDoc = false;
           nativeLibc = false;
@@ -99,7 +100,6 @@ let
           isGNU = true;
           libc = getLibc prevStage;
           inherit (prevStage) coreutils gnugrep;
-          name = name;
           stdenvNoCC = prevStage.ccWrapperStdenv;
         };
 
@@ -139,7 +139,7 @@ in
   # Build a dummy stdenv with no GCC or working fetchurl.  This is
   # because we need a stdenv to build the GCC wrapper and fetchurl.
   (prevStage: stageFun prevStage {
-    name = null;
+    name = "bootstrap-stage0";
 
     overrides = self: super: {
       # We thread stage0's stdenv through under this name so downstream stages
@@ -153,7 +153,7 @@ in
       # create a dummy Glibc here, which will be used in the stdenv of
       # stage1.
       ${localSystem.libc} = self.stdenv.mkDerivation {
-        name = "bootstrap-${localSystem.libc}";
+        name = "bootstrap-stage0-${localSystem.libc}";
         buildCommand = ''
           mkdir -p $out
           ln -s ${bootstrapTools}/lib $out/lib
@@ -165,13 +165,13 @@ in
       };
       gcc-unwrapped = bootstrapTools;
       binutils = import ../../build-support/bintools-wrapper {
+        name = "bootstrap-stage0-binutils-wrapper";
         nativeTools = false;
         nativeLibc = false;
         buildPackages = { };
         libc = getLibc self;
         inherit (self) stdenvNoCC coreutils gnugrep;
         bintools = bootstrapTools;
-        name = "bootstrap-binutils-wrapper";
       };
       coreutils = bootstrapTools;
       gnugrep = bootstrapTools;
@@ -190,7 +190,7 @@ in
   # simply re-export those packages in the middle stage(s) using the
   # overrides attribute and the inherit syntax.
   (prevStage: stageFun prevStage {
-    name = "bootstrap-gcc-wrapper";
+    name = "bootstrap-stage1";
 
     # Rebuild binutils to use from stage2 onwards.
     overrides = self: super: {
@@ -214,7 +214,7 @@ in
   # 2nd stdenv that contains our own rebuilt binutils and is used for
   # compiling our own Glibc.
   (prevStage: stageFun prevStage {
-    name = "bootstrap-gcc-wrapper";
+    name = "bootstrap-stage2";
 
     overrides = self: super: {
       inherit (prevStage)
@@ -235,7 +235,7 @@ in
   # one uses the rebuilt Glibc from stage2.  It still uses the recent
   # binutils and rest of the bootstrap tools, including GCC.
   (prevStage: stageFun prevStage {
-    name = "bootstrap-gcc-wrapper";
+    name = "bootstrap-stage3";
 
     overrides = self: super: rec {
       inherit (prevStage)
@@ -263,7 +263,7 @@ in
   # Construct a fourth stdenv that uses the new GCC.  But coreutils is
   # still from the bootstrap tools.
   (prevStage: stageFun prevStage {
-    name = "";
+    name = "bootstrap-stage4";
 
     overrides = self: super: {
       # Zlib has to be inherited and not rebuilt in this stage,
@@ -292,7 +292,6 @@ in
         bintools = self.binutils;
         libc = getLibc self;
         inherit (self) stdenvNoCC coreutils gnugrep;
-        name = "";
         shell = self.bash + "/bin/bash";
       };
     };
@@ -311,6 +310,8 @@ in
   (prevStage: {
     inherit config overlays;
     stdenv = import ../generic rec {
+      name = "stdenv-linux";
+
       buildPlatform = localSystem;
       hostPlatform = localSystem;
       targetPlatform = localSystem;


### PR DESCRIPTION
###### Motivation for this change

Once upon a time I wanted to show the awesomeness of NixOS to a friend with "Look, we have all info pages installed!" Then I was like "Look! `$ info gcc`!" And it failed (because we now use separate outputs and I didn't check since before they were introduced). Then I was like "Well, shit. But look here! `$ info bash`". And failed again for the same reason. I became really unhappy about this and decided to fix it (and did fix it, just sayin').

In the process I made 0d887e928e1e2f636f25e728c2b03ece32670f03 which was very useful for debugging which stdenv stage broke things (all of them, just sayin'), so I left it in for future explorers.

Btw, with 0d887e928e1e2f636f25e728c2b03ece32670f03 applied you can now clearly see that stdenv stage4 is rebuilt twice for some reason. I have no idea why. Is this a bug? I confirmed it was the case even before this patchset, but it was hard to notice, because all stages were named "stdenv-boot" so you had to carefully count them.

###### Things done

- [X] Running on top of this for a couple of weeks without problems.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
