### PR TITLE
nixos/znapzend: fix when no previous zetup

### DIFF
--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -386,7 +386,7 @@ in
           echo Resetting znapzend zetups
           ${pkgs.znapzend}/bin/znapzendzetup list \
             | grep -oP '(?<=\*\*\* backup plan: ).*(?= \*\*\*)' \
-            | xargs ${pkgs.znapzend}/bin/znapzendzetup delete
+            | xargs -I{} ${pkgs.znapzend}/bin/znapzendzetup delete "{}"
         '' + concatStringsSep "\n" (mapAttrsToList (dataset: config: ''
           echo Importing znapzend zetup ${config} for dataset ${dataset}
           ${pkgs.znapzend}/bin/znapzendzetup import --write ${dataset} ${config}


### PR DESCRIPTION
When the znapzend module was enabled for the first time with pure =
true; then the list of previous entries is empty, but xargs still tried
to execute a znapzendzetup delete command with no arguments, which made
it fail

###### Motivation for this change
This was reported by ottidmes on IRC, who was trying to use the module and got an error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

