### PR TITLE
[WIP] stdenv: inherit `src.meta` to allow moving most of `meta` into `src.meta`

### DIFF
--- a/pkgs/applications/editors/ghostwriter/default.nix
+++ b/pkgs/applications/editors/ghostwriter/default.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A cross-platform, aesthetic, distraction-free Markdown editor";
-    homepage = src.meta.homepage;
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ dotlambda ];

--- a/pkgs/applications/misc/qdirstat/default.nix
+++ b/pkgs/applications/misc/qdirstat/default.nix
@@ -53,7 +53,6 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Graphical disk usage analyzer";
-    homepage = src.meta.homepage;
     license = licenses.gpl2;
     maintainers = with maintainers; [ gnidorah ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/speedread/default.nix
+++ b/pkgs/applications/misc/speedread/default.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
       reading points. This allows reading text at a much more rapid
       pace than usual as the eye can stay fixed on a single place.
     '';
-    homepage = src.meta.homepage;
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = [ maintainers.oxij ];

--- a/pkgs/applications/networking/instant-messengers/telegram/libqtelegram-aseman-edition/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/libqtelegram-aseman-edition/default.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     version = "6.1";
     description = "A fork of libqtelegram by Aseman, using qmake";
-    homepage = src.meta.homepage;
     license = licenses.gpl3;
     maintainers = [ maintainers.Profpatsch ];
     platforms = platforms.linux;

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-qml/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-qml/default.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     version = "0.9.2";
     description = "Telegram API tools for QtQml and Qml";
-    homepage = src.meta.homepage;
     license = licenses.gpl3;
     maintainers = [ maintainers.Profpatsch ];
     platforms = platforms.linux;

--- a/pkgs/applications/window-managers/orbment/bemenu.nix
+++ b/pkgs/applications/window-managers/orbment/bemenu.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A dynamic menu library and client program inspired by dmenu";
-    homepage = src.meta.homepage;
     license = with licenses; [ gpl3 lgpl3 ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/window-managers/velox/swc.nix
+++ b/pkgs/applications/window-managers/velox/swc.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A library for making a simple Wayland compositor";
-    homepage    = src.meta.homepage;
     license     = lib.licenses.mit;
     platforms   = lib.platforms.linux;
     maintainers = with lib.maintainers; [ ];

--- a/pkgs/applications/window-managers/velox/wld.nix
+++ b/pkgs/applications/window-managers/velox/wld.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A primitive drawing library targeted at Wayland";
-    homepage    = src.meta.homepage;
     license     = lib.licenses.mit;
     platforms   = lib.platforms.linux;
     maintainers = with lib.maintainers; [ ];

--- a/pkgs/build-support/emacs/generic.nix
+++ b/pkgs/build-support/emacs/generic.nix
@@ -20,8 +20,6 @@ let
   defaultMeta = {
     broken = false;
     platforms = emacs.meta.platforms;
-  } // optionalAttrs ((args.src.meta.homepage or "") != "") {
-    homepage = args.src.meta.homepage;
   };
 
 in

--- a/pkgs/development/interpreters/pixie/dust.nix
+++ b/pkgs/development/interpreters/pixie/dust.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Provides tooling around pixie, e.g. a nicer repl, running tests and fetching dependencies";
-    homepage = src.meta.homepage;
     license = stdenv.lib.licenses.lgpl3;
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };

--- a/pkgs/development/libraries/hotpatch/default.nix
+++ b/pkgs/development/libraries/hotpatch/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Hot patching executables on Linux using .so file injection";
-    homepage = src.meta.homepage;
     license = licenses.bsd3;
     maintainers = [ maintainers.gnidorah ];
     platforms = ["i686-linux" "x86_64-linux"];

--- a/pkgs/development/python-modules/bitcoinlib/default.nix
+++ b/pkgs/development/python-modules/bitcoinlib/default.nix
@@ -20,7 +20,6 @@ in buildPythonPackage rec {
   '';
 
   meta = {
-    homepage = src.meta.homepage;
     description = "Easy interface to the Bitcoin data structures and protocol";
     license = with lib.licenses; [ gpl3 ];
     maintainers = with lib.maintainers; [ jb55 ];

--- a/pkgs/games/quakespasm/vulkan.nix
+++ b/pkgs/games/quakespasm/vulkan.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   sourceRoot = "source/Quake";
-  
+
   buildInputs = [
     makeWrapper gzip SDL2 libvorbis libmad vulkan-loader.dev
   ];
@@ -28,10 +28,9 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
-  
+
   meta = {
     description = "Vulkan Quake port based on QuakeSpasm";
-    homepage = src.meta.homepage;
     longDescription = ''
       vkQuake is a Quake 1 port using Vulkan instead of OpenGL for rendering.
       It is based on the popular QuakeSpasm port and runs all mods compatible with it
@@ -40,7 +39,7 @@ stdenv.mkDerivation rec {
       passes & sub passes, pipeline barriers & synchronization, compute shaders, push &
       specialization constants, CPU/GPU parallelism and memory pooling.
     '';
-  
+
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.gnidorah ];
   };

--- a/pkgs/misc/themes/kde2/default.nix
+++ b/pkgs/misc/themes/kde2/default.nix
@@ -22,7 +22,6 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "KDE 2 window decoration ported to Plasma 5";
-    homepage = src.meta.homepage;
     license = licenses.bsd2;
     platforms = platforms.linux;
   };

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -232,6 +232,7 @@ rec {
               hasOutput = out: builtins.elem out outs;
             in [( lib.findFirst hasOutput null (["bin" "out"] ++ outs) )];
         }
+        // attrs.src.meta or {}
         // attrs.meta or {}
         # Fill `meta.position` to identify the source location of the package.
         // lib.optionalAttrs (pos != null) {

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -43,7 +43,6 @@ python2Packages.buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = src.meta.homepage;
     description = "ACME client that can obtain certs and extensibly update server configurations";
     platforms = platforms.unix;
     maintainers = [ maintainers.domenkozar ];

--- a/pkgs/tools/misc/zabbix-cli/default.nix
+++ b/pkgs/tools/misc/zabbix-cli/default.nix
@@ -22,7 +22,6 @@ in pythonPackages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Command-line interface for Zabbix";
-    homepage = src.meta.homepage;
     license = [ licenses.gpl3 ];
     maintainers = [ maintainers.womfoo ];
   };

--- a/pkgs/tools/security/eschalot/default.nix
+++ b/pkgs/tools/security/eschalot/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tor hidden service name generator";
-    homepage = src.meta.homepage;
     license = licenses.isc;
     platforms = platforms.unix;
     maintainers = with maintainers; [ dotlambda ];


### PR DESCRIPTION
###### Motivation for this change

You can now move `meta.license` or any other such thing to the `src` attribute of your derivation and by doing so ban the accidental downloading of the sources of softwares you blacklisted with check-meta.

In my opinion, moving most of `meta` into `src` makes sense. For instance, `homepage` is an attribute of a source, not an attribute of a derivation.

See commit messages for more info.

###### Things done

- [X] Nothing really changes (except `meta.evaluates` -> `meta.available`).
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

