### PR TITLE
apulse: 0.1.10 -> 0.1.11, add pressureaudio

### DIFF
--- a/pkgs/misc/apulse/default.nix
+++ b/pkgs/misc/apulse/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "apulse-${version}";
-  version = "0.1.10";
+  version = "0.1.11";
 
   src = fetchFromGitHub {
     owner = "i-rinat";
     repo = "apulse";
     rev = "v${version}";
-    sha256 = "018gaxn647wz1vjbr49hfrch9svnv0d1nzijc8ckb4fsr8vv95a1";
+    sha256 = "16l278q0czca2794fj388ql6qn1zrw24a0p6k7bayrrf5h32fdzd";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/misc/apulse/pressureaudio.nix
+++ b/pkgs/misc/apulse/pressureaudio.nix
@@ -1,0 +1,82 @@
+{ stdenv, apulse, libpulseaudio, pkgconfig, intltool, autoreconfHook }:
+
+stdenv.mkDerivation {
+  name = "libpressureaudio-${apulse.version}";
+
+  src = libpulseaudio.src;
+
+  nativeBuildInputs = [ pkgconfig intltool autoreconfHook ];
+
+  configurePhase = ":";
+
+  buildPhase = ":";
+
+  installPhase = ''
+    echo "Copying libraries from apulse."
+    mkdir -p $out/lib
+    ls ${apulse}/lib/apulse $out/lib
+    cp -a ${apulse}/lib/apulse/* $out/lib/
+
+    echo "Copying headers from pulseaudio."
+    mkdir -p $out/include/pulse
+    cp -a src/pulse/*.h $out/include/pulse
+
+    echo "Generating custom pkgconfig definitions."
+    mkdir -p $out/lib/pkgconfig
+    for a in libpulse.pc libpulse-simple.pc libpulse-mainloop-glib.pc ; do
+        cat > $out/lib/pkgconfig/$a << EOF
+    prefix=$out
+    libdir=$out/lib
+    includedir=$out/include
+
+    EOF
+    done
+
+    cat >> $out/lib/pkgconfig/libpulse.pc << EOF
+    Name: libpulse
+    Description: PulseAudio Client Interface
+    Version: ${libpulseaudio.version}-rebootstrapped
+    Libs: -L$out/lib -lpulse 
+    Cflags: -I$out/include -D_REENTRANT
+    EOF
+
+    cat >> $out/lib/pkgconfig/libpulse-simple.pc << EOF
+    Name: libpulse-simple
+    Description: PulseAudio Simplified Synchronous Client Interface
+    Version: ${libpulseaudio.version}-rebootstrapped
+    Libs: -L$out/lib -lpulse-simple 
+    Cflags: -I$out/include -D_REENTRANT
+    Requires: libpulse
+    EOF
+
+    cat >> $out/lib/pkgconfig/libpulse-mainloop-glib.pc << EOF
+    Name: libpulse-mainloop-glib
+    Description: PulseAudio GLib 2.0 Main Loop Wrapper
+    Version: ${libpulseaudio.version}-rebootstrapped
+    Libs: -L$out/lib -lpulse-mainloop-glib 
+    Cflags: -I$out/include -D_REENTRANT
+    Requires: libpulse glib-2.0
+    EOF
+  '';
+
+  meta = apulse.meta // {
+    description = "libpulseaudio without any sound daemons over pure ALSA";
+    longDescription = ''
+      apulse (${apulse.meta.homepage}) implements most of libpulseaudio
+      API over pure ALSA in 5% LOC of the original PulseAudio.
+
+      But apulse is made to be used as a wrapper that substitutes its
+      replacement libs into LD_LIBRARY_PATH. The problem with that is
+      that you still have to link against the original libpulseaudio.
+
+      pressureaudio (http://git.r-36.net/pressureaudio/) wraps apulse
+      with everything you need to replace libpulseaudio completely.
+
+      This derivation is a reimplementation of pressureaudio in pure
+      nix.
+
+      You can simply override libpulseaudio with this and most
+      packages would just work.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -489,6 +489,8 @@ with pkgs;
 
   apulse = callPackage ../misc/apulse { };
 
+  libpressureaudio = callPackage ../misc/apulse/pressureaudio.nix { };
+
   archivemount = callPackage ../tools/filesystems/archivemount { };
 
   arandr = callPackage ../tools/X11/arandr { };


### PR DESCRIPTION
###### Motivation for this change

Living without PulseAudio.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

