### PR TITLE
nixos/tests: fix random failures of privacy test

### DIFF
--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -530,7 +530,7 @@ let
           $client->waitUntilSucceeds("ping -c 1 fd00:1234:5678:1::1");
 
           # Test address used is temporary
-          $client->succeed("! ip route get fd00:1234:5678:1::1 | grep -q ':[a-f0-9]*ff:fe[a-f0-9]*:'");
+          $client->waitUntilSucceeds("! ip route get fd00:1234:5678:1::1 | grep -q ':[a-f0-9]*ff:fe[a-f0-9]*:'");
         '';
     };
   };


### PR DESCRIPTION
###### Motivation for this change
I was rebasing another PR and realized this test will randomly fail on the first try (when the kernel hasn't configured a temporary address yet).

###### Things done
- [x] Tested via nixos/tests/networking.nix
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @joachifm