### PR TITLE
brlaser: init from latest git

### DIFF
--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, cmake, zlib, cups, ghostscript }:
+
+stdenv.mkDerivation rec {
+
+  name = "brlaser";
+
+  src = fetchFromGitHub {
+    owner = "pdewacht";
+    repo = "brlaser";
+    rev = "a52149823373e11f918d9e6a56eda7242935c99b";
+    sha256 = "12d8g0aispdj2virf6vrvb0vx6d6ardjg3qyav75shsm1f94ids6";
+  };
+
+  buildInputs = [ cmake zlib cups ];
+
+  preConfigure = ''
+    cmakeFlags="$cmakeFlags -DCUPS_SERVER_BIN=$out/lib/cups/ -DCUPS_DATA_DIR=$out/share/cups/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A CUPS driver for Brother laser printers";
+    longDescription =
+      ''
+       Although most Brother printers support a standard printer language such as PCL or PostScript, not all do. If you have a monochrome Brother laser printer (or multi-function device) and the other open source drivers don't work, this one might help.
+
+       This driver is known to work with these printers:
+
+           Brother DCP-1510
+           Brother DCP-7030
+           Brother DCP-7040
+           Brother DCP-7055
+           Brother DCP-7055W
+           Brother DCP-7065DN
+           Brother HL-L2300D
+           Brother MFC-7360N
+      '';
+    homepage = https://github.com/pdewacht/brlaser;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ StijnDW ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20185,6 +20185,8 @@ with pkgs;
     snapscanFirmware = config.sane.snapscanFirmware or null;
   };
 
+  brlaser = callPackage ../misc/cups/drivers/brlaser { };
+
   brscan4 = callPackage ../applications/graphics/sane/backends/brscan4 { };
 
   mkSaneConfig = callPackage ../applications/graphics/sane/config.nix { };


### PR DESCRIPTION
###### Motivation for this change

brlaser is a CUPS driver for Brother laser printers.
I tested this with NixOS, nixpkgs from the master branch and a Brother DCP-7030 printer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

