### PR TITLE
nixos/home-assistant: test MQTT configuration

### DIFF
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -2,17 +2,27 @@ import ./make-test.nix ({ pkgs, ... }:
 
 let
   configDir = "/var/lib/foobar";
+  apiPassword = "secret";
 
 in {
   name = "home-assistant";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = with maintainers; [ dotlambda ];
+  };
 
   nodes = {
     hass =
       { config, pkgs, ... }:
       {
+        environment.systemPackages = with pkgs; [
+          mosquitto
+        ];
         services.home-assistant = {
           inherit configDir;
           enable = true;
+          package = pkgs.home-assistant.override {
+            extraPackages = ps: with ps; [ hbmqtt ];
+          };
           config = {
             homeassistant = {
               name = "Home";
@@ -22,7 +32,16 @@ in {
               elevation = 0;
             };
             frontend = { };
-            http = { };
+            http.api_password = apiPassword;
+            mqtt = { }; # Use hbmqtt as broker
+            binary_sensor = [
+              {
+                platform = "mqtt";
+                state_topic = "home-assistant/test";
+                payload_on = "let_there_be_light";
+                payload_off = "off";
+              }
+            ];
           };
         };
       };
@@ -31,7 +50,7 @@ in {
   testScript = ''
     startAll;
     $hass->waitForUnit("home-assistant.service");
-    
+
     # Since config is specified using a Nix attribute set,
     # configuration.yaml is a link to the Nix store
     $hass->succeed("test -L ${configDir}/configuration.yaml");
@@ -39,8 +58,19 @@ in {
     # Check that Home Assistant's web interface and API can be reached
     $hass->waitForOpenPort(8123);
     $hass->succeed("curl --fail http://localhost:8123/states");
-    $hass->succeed("curl --fail http://localhost:8123/api/ | grep 'API running'");
+    $hass->succeed("curl --fail -H 'x-ha-access: ${apiPassword}' http://localhost:8123/api/ | grep -qF 'API running'");
 
+    # Toggle a binary sensor using MQTT
+    $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"off\"'");
+    $hass->waitUntilSucceeds("mosquitto_pub -V mqttv311 -t home-assistant/test -u homeassistant -P '${apiPassword}' -m let_there_be_light");
+    $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"on\"'");
+
+    # Check that no errors were logged
     $hass->fail("cat ${configDir}/home-assistant.log | grep -qF ERROR");
+
+    # Print log to ease debugging
+    my $log = $hass->succeed("cat ${configDir}/home-assistant.log");
+    print "\n### home-assistant.log ###\n";
+    print "$log\n";
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
I just set it up myself and because it's a common configuration, I thought why not add it to the test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @FRidh 