### PR TITLE
kakoune: 2017-04-12 -> 2018-02-15

### DIFF
--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -4,15 +4,15 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "kakoune-unstable-${version}";
-  version = "2017-04-12";
+  version = "2018-02-15";
   src = fetchFromGitHub {
     repo = "kakoune";
     owner = "mawww";
-    rev = "7482d117cc85523e840dff595134dcb9cdc62207";
-    sha256 = "08j611y192n9vln9i94ldlvz3k0sg79dkmfc0b1vczrmaxhpgpfh";
+    rev = "f5e39972eb525166dc5b1d963067f79990991a75";
+    sha256 = "160a302xg6nfzx49dkis6ij20kyzr63kxvcv8ld3l07l8k69g80r";
   };
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ncurses boost asciidoc docbook_xsl libxslt ];
+  buildInputs = [ ncurses asciidoc docbook_xsl libxslt ];
 
   postPatch = ''
     export PREFIX=$out


### PR DESCRIPTION
###### Motivation for this change

It has been a while since the last version bump. I also removed the now unnecessary dependency on boost.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

