### PR TITLE
kernel: fix cross compilation after switch to gcc 7

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -11,7 +11,7 @@
 
 , # Allow really overriding even our gcc7 default.
   # We want gcc >= 7.3 to enable the "retpoline" mitigation of security problems.
-  stdenvNoOverride ? overrideCC stdenv gcc7
+  stdenvNoOverride ? overrideCC stdenv buildPackages.gcc7
 
 , # The kernel source tarball.
   src


### PR DESCRIPTION
###### Motivation for this change

Kernel cross compilation no longer works after switching to gcc 7, because it uses the host's gcc7 package. This causes the derivation to attempt to cross-compile gcc, rather than building a cross compiler.

###### Things done

Switching to `buildPackages.gcc7` causes the build to use a compiler with the correct combination of platforms.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

