### PR TITLE
Initial cross-compilation support for RISC-V

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -68,6 +68,14 @@ rec {
   musl64 = { config = "x86_64-unknown-linux-musl"; };
   musl32  = { config = "i686-unknown-linux-musl"; };
 
+  riscv = bits: {
+    config = "riscv${bits}-unknown-linux-gnu";
+    platform = platforms.riscv-multiplatform bits;
+  };
+  riscv64 = riscv "64";
+  riscv32 = riscv "32";
+
+
   #
   # Darwin
   #

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -541,6 +541,12 @@ rec {
     };
   };
 
+  riscv-multiplatform = bits: {
+    name = "riscv-multiplatform";
+    kernelArch = "riscv";
+    bfdEmulation = "elf${bits}lriscv";
+  };
+
   selectBySystem = system: {
       "i686-linux" = pc32;
       "x86_64-linux" = pc64;

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation rec {
   patches = [ (fetchpatch {
     url = "https://raw.githubusercontent.com/gentoo/musl/85b6a600996bdd71162b357e9ba93d8559342432/dev-libs/boehm-gc/files/boehm-gc-7.6.0-sys_select.patch";
     sha256 = "1gydwlklvci30f5dpp5ccw2p2qpph5y41r55wx9idamjlq66fbb3";
-  }) ];
+  }) ] ++
+    # https://github.com/ivmai/bdwgc/pull/208
+    lib.optional hostPlatform.isRiscV ./riscv.patch;
 
   configureFlags =
     [ "--enable-cplusplus" ]

--- a/pkgs/development/libraries/boehm-gc/riscv.patch
+++ b/pkgs/development/libraries/boehm-gc/riscv.patch
@@ -1,0 +1,53 @@
+diff --git a/include/private/gcconfig.h b/include/private/gcconfig.h
+index a8e55dd2..439cc88d 100644
+--- a/include/private/gcconfig.h
++++ b/include/private/gcconfig.h
+@@ -650,6 +650,15 @@
+ #   endif
+ #   define mach_type_known
+ # endif
++# if defined(__riscv) && defined(LINUX)
++#   if __riscv_xlen == 32
++#     define RISCV32
++#     define mach_type_known
++#   elif __riscv_xlen == 64
++#     define RISCV64
++#     define mach_type_known
++#   endif
++# endif
+ 
+ # if defined(SN_TARGET_PSP2)
+ #   define mach_type_known
+@@ -2970,6 +2979,32 @@
+ #   endif
+ # endif
+ 
++# ifdef RISCV32
++#   define CPP_WORDSZ 32
++#   define MACH_TYPE "RISC-V 32"
++#   define ALIGNMENT 4
++#   ifdef LINUX
++#     define OS_TYPE "LINUX"
++      extern int __data_start[];
++#     define DATASTART ((ptr_t)__data_start)
++#     define LINUX_STACKBOTTOM
++#     define DYNAMIC_LOADING
++#   endif
++# endif
++
++# ifdef RISCV64
++#   define CPP_WORDSZ 64
++#   define MACH_TYPE "RISC-V 64"
++#   define ALIGNMENT 8
++#   ifdef LINUX
++#     define OS_TYPE "LINUX"
++      extern int __data_start[];
++#     define DATASTART ((ptr_t)__data_start)
++#     define LINUX_STACKBOTTOM
++#     define DYNAMIC_LOADING
++#   endif
++# endif
++
+ #if defined(__GLIBC__) && !defined(DONT_USE_LIBC_PRIVATES)
+   /* Use glibc's stack-end marker. */
+ # define USE_LIBC_PRIVATES

--- a/pkgs/development/libraries/glibc/common-2.27.nix
+++ b/pkgs/development/libraries/glibc/common-2.27.nix
@@ -192,6 +192,8 @@ stdenv.mkDerivation ({
     maintainers = [ lib.maintainers.eelco ];
     platforms = lib.platforms.linux;
   } // meta;
+
+  passthru = { inherit version; };
 }
 
 // lib.optionalAttrs (cross != null) {

--- a/pkgs/development/libraries/libatomic_ops/default.nix
+++ b/pkgs/development/libraries/libatomic_ops/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, libtool }:
+{ stdenv, fetchurl, autoconf, automake, libtool, hostPlatform }:
 
 stdenv.mkDerivation rec {
   name = "libatomic_ops-${version}";
@@ -11,6 +11,9 @@ stdenv.mkDerivation rec {
     ];
     sha256 ="1rif2hjscq5mh639nsnjhb90c01gnmy1sbmj6x6hsn1xmpnj95r1";
   };
+
+  # https://github.com/ivmai/libatomic_ops/pull/32
+  patches = if hostPlatform.isRiscV then [ ./riscv.patch ] else null;
 
   nativeBuildInputs = stdenv.lib.optionals stdenv.isCygwin [ autoconf automake libtool ];
 

--- a/pkgs/development/libraries/libatomic_ops/riscv.patch
+++ b/pkgs/development/libraries/libatomic_ops/riscv.patch
@@ -1,0 +1,40 @@
+diff -Naur libatomic_ops-7.6.2-orig/src/atomic_ops/sysdeps/gcc/riscv.h libatomic_ops-7.6.2/src/atomic_ops/sysdeps/gcc/riscv.h
+--- libatomic_ops-7.6.2-orig/src/atomic_ops/sysdeps/gcc/riscv.h	1969-12-31 19:00:00.000000000 -0500
++++ libatomic_ops-7.6.2/src/atomic_ops/sysdeps/gcc/riscv.h	2018-02-18 00:48:53.581721375 -0500
+@@ -0,0 +1 @@
++#include "generic.h"
+diff -Naur libatomic_ops-7.6.2-orig/src/atomic_ops.h libatomic_ops-7.6.2/src/atomic_ops.h
+--- libatomic_ops-7.6.2-orig/src/atomic_ops.h	2017-12-24 03:31:12.000000000 -0500
++++ libatomic_ops-7.6.2/src/atomic_ops.h	2018-02-18 00:48:53.580721359 -0500
+@@ -352,6 +352,9 @@
+ # if defined(__tile__)
+ #   include "atomic_ops/sysdeps/gcc/tile.h"
+ # endif
++# if defined(__riscv)
++#   include "atomic_ops/sysdeps/gcc/riscv.h"
++# endif
+ #endif /* __GNUC__ && !AO_USE_PTHREAD_DEFS */
+ 
+ #if (defined(__IBMC__) || defined(__IBMCPP__)) && !defined(__GNUC__) \
+diff -Naur libatomic_ops-7.6.2-orig/src/Makefile.am libatomic_ops-7.6.2/src/Makefile.am
+--- libatomic_ops-7.6.2-orig/src/Makefile.am	2017-12-24 03:31:12.000000000 -0500
++++ libatomic_ops-7.6.2/src/Makefile.am	2018-02-18 00:48:53.579721342 -0500
+@@ -92,6 +92,7 @@
+           atomic_ops/sysdeps/gcc/mips.h \
+           atomic_ops/sysdeps/gcc/nios2.h \
+           atomic_ops/sysdeps/gcc/powerpc.h \
++          atomic_ops/sysdeps/gcc/riscv.h \
+           atomic_ops/sysdeps/gcc/s390.h \
+           atomic_ops/sysdeps/gcc/sh.h \
+           atomic_ops/sysdeps/gcc/sparc.h \
+diff -Naur libatomic_ops-7.6.2-orig/src/Makefile.in libatomic_ops-7.6.2/src/Makefile.in
+--- libatomic_ops-7.6.2-orig/src/Makefile.in	2017-12-24 03:32:23.000000000 -0500
++++ libatomic_ops-7.6.2/src/Makefile.in	2018-02-18 00:49:14.005062121 -0500
+@@ -446,6 +446,7 @@
+           atomic_ops/sysdeps/gcc/mips.h \
+           atomic_ops/sysdeps/gcc/nios2.h \
+           atomic_ops/sysdeps/gcc/powerpc.h \
++          atomic_ops/sysdeps/gcc/riscv.h \
+           atomic_ops/sysdeps/gcc/s390.h \
+           atomic_ops/sysdeps/gcc/sh.h \
+           atomic_ops/sysdeps/gcc/sparc.h \

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -24,8 +24,7 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "doc" "man" ];
 
-  configureFlags = [
-    "--enable-jit"
+  configureFlags = optional (!hostPlatform.isRiscV) "--enable-jit" ++ [
     "--enable-unicode-properties"
     "--disable-cpp"
   ]

--- a/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
@@ -4,6 +4,8 @@ assert guileSupport -> ( pkgconfig != null && guile != null );
 
 let
   version = "4.2.1";
+
+  needGlibcPatch = (stdenv.cc.libc.version or "") == "2.27";
 in
 stdenv.mkDerivation {
   name = "gnumake-${version}";
@@ -20,7 +22,7 @@ stdenv.mkDerivation {
     # included Makefiles, don't look in /usr/include and friends.
     ./impure-dirs.patch
     ./pselect.patch
-  ];
+  ] ++ stdenv.lib.optional needGlibcPatch ./glibc-2.27.patch;
 
   nativeBuildInputs = stdenv.lib.optionals guileSupport [ pkgconfig ];
   buildInputs = stdenv.lib.optionals guileSupport [ guile ];

--- a/pkgs/development/tools/build-managers/gnumake/4.2/glibc-2.27.patch
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/glibc-2.27.patch
@@ -1,0 +1,24 @@
+From 48c8a116a914a325a0497721f5d8b58d5bba34d4 Mon Sep 17 00:00:00 2001
+From: Paul Smith <psmith@gnu.org>
+Date: Sun, 19 Nov 2017 15:09:16 -0500
+Subject: * configure.ac: Support GLIBC glob interface version 2
+
+---
+ configure.ac | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff -Naur a/configure b/configure
+--- configure	2016-06-10 19:03:21.000000000 -0400
++++ configure	2018-02-18 04:40:32.971371555 -0500
+@@ -11481,10 +11481,9 @@
+ #include <glob.h>
+ #include <fnmatch.h>
+ 
+-#define GLOB_INTERFACE_VERSION 1
+ #if !defined _LIBC && defined __GNU_LIBRARY__ && __GNU_LIBRARY__ > 1
+ # include <gnu-versions.h>
+-# if _GNU_GLOB_INTERFACE_VERSION == GLOB_INTERFACE_VERSION
++# if _GNU_GLOB_INTERFACE_VERSION == 1 || _GNU_GLOB_INTERFACE_VERSION == 2
+    gnu glob
+ # endif
+ #endif

--- a/pkgs/os-specific/linux/busybox/sandbox-shell.nix
+++ b/pkgs/os-specific/linux/busybox/sandbox-shell.nix
@@ -1,8 +1,9 @@
-{ busybox }:
+{ busybox, hostPlatform }:
 
 # Minimal shell for use as basic /bin/sh in sandbox builds
 busybox.override {
-  useMusl = true;
+  # musl roadmap has RISC-V support projected for 1.1.20
+  useMusl = !hostPlatform.isRiscV;
   enableStatic = true;
   enableMinimal = true;
   extraConfig = ''

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -17,4 +17,5 @@ in with (import ../../../lib).systems.examples; {
   i686-musl    = make musl32;
   armv6l-musl  = make muslpi;
   aarch64-musl = make aarch64-multiplatform-musl;
+  riscv64 = make riscv64;
 }

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -5,6 +5,7 @@
 let
   pkgs = import ../../.. { inherit localSystem crossSystem; };
   libc = pkgs.stdenv.cc.libc;
+  isl = with pkgs; if targetPlatform.isRiscV then isl_0_17 else isl_0_14;
 in with pkgs; rec {
 
 
@@ -19,7 +20,7 @@ in with pkgs; rec {
   tarMinimal = gnutar.override { acl = null; };
 
   busyboxMinimal = busybox.override {
-    useMusl = true;
+    useMusl = !targetPlatform.isRiscV;
     enableStatic = true;
     enableMinimal = true;
     extraConfig = ''
@@ -143,7 +144,7 @@ in with pkgs; rec {
         # These needed for cross but not native tools because the stdenv
         # GCC has certain things built in statically. See
         # pkgs/stdenv/linux/default.nix for the details.
-        cp -d ${isl_0_14.out}/lib/libisl*.so* $out/lib
+        cp -d ${isl.out}/lib/libisl*.so* $out/lib
 
       '' + ''
         cp -d ${bzip2.out}/lib/libbz2.so* $out/lib

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -30,7 +30,7 @@ let
     buildInputs = [ curl openssl sqlite xz bzip2 ]
       ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
       ++ lib.optionals fromGit [ brotli ] # Since 1.12
-      ++ lib.optional stdenv.isLinux libseccomp
+      ++ lib.optional (stdenv.isLinux && !hostPlatform.isRiscV) libseccomp
       ++ lib.optional ((stdenv.isLinux || stdenv.isDarwin) && is20)
           (aws-sdk-cpp.override {
             apis = ["s3"];
@@ -55,7 +55,9 @@ let
       ]
       ++ lib.optional (
           hostPlatform != buildPlatform && hostPlatform ? nix && hostPlatform.nix ? system
-      ) ''--with-system=${hostPlatform.nix.system}'';
+      ) ''--with-system=${hostPlatform.nix.system}''
+         # RISC-V support in progress https://github.com/seccomp/libseccomp/pull/50
+      ++ lib.optional hostPlatform.isRiscV "--disable-seccomp-sandboxing";
 
     makeFlags = "profiledir=$(out)/etc/profile.d";
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -124,12 +124,12 @@ in rec {
 
   nixUnstable = (lib.lowPrio (common rec {
     name = "nix-2.0${suffix}";
-    suffix = "pre5950_3a5a241b";
+    suffix = "pre5951_690ac7c9";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "3a5a241b3209f14f8801b902ba20b5cb0666c9df";
-      sha256 = "0cwjyhgyfzi2dz561nj897zhkbyx6lzi49avcyia2pr4498jcl6k";
+      rev = "690ac7c90b5bf3c599e210c53365c7d229c8b0ff";
+      sha256 = "1yn2p38kp1i67makbawr1rhdiwihgnvk2zwrz0gvf6q65mj2k89c";
     };
     fromGit = true;
   })) // { perl-bindings = perl-bindings { nix = nixUnstable; }; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12942,7 +12942,7 @@ with pkgs;
 
   inherit (callPackages ../os-specific/linux/kernel-headers { })
     linuxHeaders_4_4 linuxHeaders_4_15;
-  linuxHeaders = if hostPlatform.isMusl then linuxHeaders_4_15 else linuxHeaders_4_4;
+  linuxHeaders = if hostPlatform.isMusl || hostPlatform.isRiscV then linuxHeaders_4_15 else linuxHeaders_4_4;
 
   kernelPatches = callPackage ../os-specific/linux/kernel/patches.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5784,8 +5784,12 @@ with pkgs;
   gambit = callPackage ../development/compilers/gambit { };
   gerbil = callPackage ../development/compilers/gerbil { };
 
-  gccFun = callPackage ../development/compilers/gcc/6;
-  gcc = gcc6;
+  # !!! When updating to gcc7 everywhere we can get rid of the
+  # isRiscV overrides here and in gccCrossStageStatic
+  gccFun6 = callPackage ../development/compilers/gcc/6;
+  gccFun7 = callPackage ../development/compilers/gcc/7;
+  gccFun = if targetPlatform.isRiscV then gccFun7 else gccFun6;
+  gcc = if targetPlatform.isRiscV then gcc7 else gcc6;
   gcc-unwrapped = gcc.cc;
 
   gccStdenv = if stdenv.cc.isGNU then stdenv else stdenv.override {
@@ -5865,6 +5869,7 @@ with pkgs;
       bintools = binutils-unwrapped;
       libc = libcCross1;
     };
+    isl = if targetPlatform.isRiscV then isl_0_17 else isl_0_14;
     in wrapCCWith {
       name = "gcc-cross-wrapper";
       cc = gccFun {
@@ -5872,7 +5877,7 @@ with pkgs;
         inherit noSysDirs;
         # PGO seems to speed up compilation by gcc by ~10%, see #445 discussion
         profiledCompiler = with stdenv; (!isDarwin && (isi686 || isx86_64));
-        isl = if !stdenv.isDarwin then isl_0_14 else null;
+        isl = if !stdenv.isDarwin then isl else null;
 
         # just for stage static
         crossStageStatic = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8763,7 +8763,11 @@ with pkgs;
   };
 
   # Being redundant to avoid cycles on boot. TODO: find a better way
-  glibcCross = callPackage ../development/libraries/glibc {
+  glibcCross = let
+    expr = if hostPlatform.isRiscV
+             then ../development/libraries/glibc/2.27.nix
+           else ../development/libraries/glibc;
+  in callPackage expr {
     installLocales = config.glibc.locales or false;
     stdenv = crossLibcStdenv;
   };


### PR DESCRIPTION
Tested up to building `nixUnstable` which ran a repl successfully under `qemu-riscv`.

Part of #35089