### PR TITLE
tmon: init

### DIFF
--- a/pkgs/os-specific/linux/tmon/default.nix
+++ b/pkgs/os-specific/linux/tmon/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, kernel, ncurses }:
+
+stdenv.mkDerivation {
+  name = "tmon-${kernel.version}";
+
+  inherit (kernel) src;
+
+  buildInputs = [ ncurses ];
+
+  configurePhase = ''
+    cd tools/thermal/tmon
+  '';
+
+  makeFlags = kernel.makeFlags ++ [ "INSTALL_ROOT=\"$(out)\"" "BINDIR=bin" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Monitoring and Testing Tool for Linux kernel thermal subsystem";
+    homepage = https://www.kernel.org/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13202,6 +13202,8 @@ with pkgs;
 
     systemtap = callPackage ../development/tools/profiling/systemtap { };
 
+    tmon = callPackage ../os-specific/linux/tmon { };
+
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };
 
     usbip = callPackage ../os-specific/linux/usbip { };


### PR DESCRIPTION
###### Motivation for this change

Adds a package for 'tmon', a thermal monitoring tool included in the Linux kernel.

I could add myself as a maintainer, but I don't think it is necessary since it doesn't require regular updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

