### PR TITLE
Some QuantStack libraries

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -470,6 +470,7 @@
   mpickering = "Matthew Pickering <matthewtpickering@gmail.com>";
   mpscholten = "Marc Scholten <marc@mpscholten.de>";
   mpsyco = "Francis St-Amour <fr.st-amour@gmail.com>";
+  mredaelli = "Massimo Redaelli <m.redaelli@gmail.com>";
   mrVanDalo = "Ingolf Wanger <contact@ingolf-wagner.de>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";
   mschristiansen = "Mikkel Christiansen <mikkel@rheosystems.com>";

--- a/pkgs/development/libraries/xsimd/default.nix
+++ b/pkgs/development/libraries/xsimd/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake, buildTests ? false, gmock ? null }:
+
+assert buildTests -> gmock != null; 
+
+let version = "4.0.0"
+; in
+stdenv.mkDerivation {
+  name = "xsimd-${version}";
+
+  src = fetchFromGitHub {
+    owner = "QuantStack";
+    repo = "xsimd";
+    rev = version;
+    sha256 = "08fv1ri62rq75k86mwcpxcg4dwz7gxbk189n1c8gav1yiy3m47rm";
+  };
+
+  nativeBuildInputs = [ cmake (if buildTests then gmock else null) ];
+  cmakeFlags = if !buildTests then [ "-DBUILD_TESTS=OFF" ] else null;
+  
+  meta = with stdenv.lib; {
+    description = "C++ wrappers for SIMD intrinsics";
+    homepage = https://github.com/QuantStack/xsimd;
+    license = licenses.bsd3;
+    maintainers =  with stdenv.lib.maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/development/libraries/xtensor/default.nix
+++ b/pkgs/development/libraries/xtensor/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, xtl }:
+let version = "0.15.4";
+in
+stdenv.mkDerivation rec {
+  name = "xtensor-${version}";
+
+  src = fetchFromGitHub {
+    owner = "QuantStack";
+    repo = "xtensor";
+    rev = version;
+    sha256 = "0q1flbz3h6dsjfqm9avf7f73l0lxjij0md6w161k1qs6lk3sks49";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ xtl ];
+
+  meta = with stdenv.lib; {
+    description = "Multi-dimensional arrays with broadcasting and lazy computing";
+    homepage = http://quantstack.net/xtensor;
+    license = licenses.bsd3;
+    maintainers =  with stdenv.lib.maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/development/libraries/xtl/default.nix
+++ b/pkgs/development/libraries/xtl/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+let version = "0.4.0";
+in stdenv.mkDerivation rec {
+  name = "xtl-${version}";
+
+  src = fetchFromGitHub {
+    owner = "QuantStack";
+    repo = "xtl";
+    rev = version;
+    sha256 = "1qd1ij78bp62702gpp4bfjvk8j01kxs5pv5ivqfhrj7xmqy88hxf";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "C++ QuantStack tools library";
+    homepage = https://github.com/QuantStack/xtl;
+    license = licenses.bsd3;
+    maintainers =  with stdenv.lib.maintainers; [ mredaelli ];    
+  };
+}

--- a/pkgs/development/python-modules/gast/default.nix
+++ b/pkgs/development/python-modules/gast/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, fetchFromGitHub, lib }:
+
+buildPythonPackage rec {
+  pname = "gast";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    rev = "1de043272fdcb8e01c20bfc3ec53bc00d2d6fe8e";
+    owner = "serge-sans-paille";
+    repo = "gast";
+    sha256 = "0f0f1q5l0j1cgmrfhgax5wzdjadkympf306y259gf6z1wik3nbbz";
+  };
+
+  meta = {
+    description = "Python AST that abstracts the underlying Python version";
+    homepage = https://github.com/serge-sans-paille/gast;
+    license = lib.licenses.bsd3;
+    maintainers =  with lib.maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/development/python-modules/networkx/2.nix
+++ b/pkgs/development/python-modules/networkx/2.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, decorator
+}:
+
+buildPythonPackage rec {
+  pname = "networkx";
+  version = "2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "64272ca418972b70a196cb15d9c85a5a6041f09a2f32e0d30c0255f25d458bb1";
+    extension = "zip";
+  };
+
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ decorator ];
+
+  meta = {
+    homepage = "https://networkx.github.io/";
+    description = "Library for the creation, manipulation, and study of the structure, dynamics, and functions of complex networks";
+    license = lib.licenses.bsd3;
+    maintainers =  with lib.maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, ply, networkx2, decorator, gast, six }:
+
+buildPythonPackage rec {
+  pname = "pythran";
+  version = "0.8.4.post0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1df5496298ae31dfe237f5069e6e5689157647f590cd8f304ace55285b771b5c";
+  };
+
+  propagatedBuildInputs = [ ply networkx2 decorator gast six ];
+
+  meta = {
+    description = "A claimless python to c++ converter";
+    homepage = https://github.com/serge-sans-paille/gast;
+    license = lib.licenses.bsd3;
+    maintainers =  with lib.maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20655,4 +20655,10 @@ with pkgs;
   safeDiscardStringContext = callPackage ../build-support/safe-discard-string-context.nix { };
 
   simplehttp2server = callPackage ../servers/simplehttp2server { };
+
+  xtl = callPackage ../development/libraries/xtl { };
+
+  xsimd = callPackage ../development/libraries/xsimd { buildTests = true; };
+
+  xtensor = callPackage ../development/libraries/xtensor { };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15644,6 +15644,10 @@ in {
 
   scipy = callPackage ../development/python-modules/scipy { };
 
+  gast = callPackage ../development/python-modules/gast { };
+
+  pythran = callPackage ../development/python-modules/pythran { };
+
   scikitimage = buildPythonPackage rec {
     name = "scikit-image-${version}";
     version = "0.12.3";
@@ -20179,6 +20183,7 @@ EOF
   };
 
   networkx = callPackage ../development/python-modules/networkx { };
+  networkx2 = callPackage ../development/python-modules/networkx/2.nix { };
 
   ofxclient = callPackage ../development/python-modules/ofxclient {};
 


### PR DESCRIPTION
###### Motivation for this change
Missing libraries from the QuantStack ecosystem

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).