### PR TITLE
hack-font: 2.020 -> 3.002

### DIFF
--- a/pkgs/data/fonts/hack/default.nix
+++ b/pkgs/data/fonts/hack/default.nix
@@ -1,20 +1,18 @@
 { stdenv, fetchzip }:
 
 let
-  version = "2.020";
+  version = "3.002";
 in fetchzip rec {
   name = "hack-font-${version}";
 
-  url = let
-    version_ = with stdenv.lib; concatStringsSep "_" (splitString "." version);
-  in "https://github.com/chrissimpkins/Hack/releases/download/v${version}/Hack-v${version_}-ttf.zip";
+  url = "https://github.com/chrissimpkins/Hack/releases/download/v${version}/Hack-v${version}-ttf.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/hack
   '';
 
-  sha256 = "0cpsglb9vnhmpsn496aqisfvmq3yxvjnj7c361dspy0fn6z8x60c";
+  sha256 = "11f3hl4nvxq6pvsmwr1c1r5wrxhrp7ixr5bshrz2dmqn7l8bxa63";
 
   meta = with stdenv.lib; {
     description = "A typeface designed for source code";
@@ -25,7 +23,7 @@ in fetchzip rec {
       The face has been re-designed with a larger glyph set, modifications of
       the original glyph shapes, and meticulous attention to metrics.
     '';
-    homepage = http://sourcefoundry.org/hack/;
+    homepage = https://sourcefoundry.org/hack/;
 
     /*
      "The font binaries are released under a license that permits unlimited
@@ -36,6 +34,7 @@ in fetchzip rec {
       the license is available in LICENSE.md" (From the GitHub page)
     */
     license = licenses.free;
+    maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

