### PR TITLE
cc-wrapper: Use response files for cc

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -202,9 +202,16 @@ if (( "${NIX_DEBUG:-0}" >= 1 )); then
     printf "  %q\n" ${extraAfter+"${extraAfter[@]}"} >&2
 fi
 
-PATH="$path_backup"
-# Old bash workaround, see above.
-exec @prog@ \
-    ${extraBefore+"${extraBefore[@]}"} \
-    ${params+"${params[@]}"} \
-    ${extraAfter+"${extraAfter[@]}"}
+params=(${extraBefore+"${extraBefore[@]}"} \
+        ${params+"${params[@]}"} \
+        ${extraAfter+"${extraAfter[@]}"})
+
+if [ "$(basename @prog@)" = "ld-reexport-delegate" ]; then
+    responseFile=$(mktemp)
+    printf " %q\n" "${params+"${params[@]}"}" >$responseFile
+    PATH="$path_backup"
+    exec @prog@ "@$responseFile"
+else
+    PATH="$path_backup"
+    exec @prog@ ${params+"${params[@]}"}
+fi

--- a/pkgs/build-support/bintools-wrapper/macos-sierra-reexport-hack.bash
+++ b/pkgs/build-support/bintools-wrapper/macos-sierra-reexport-hack.bash
@@ -7,11 +7,15 @@ if [ -n "@coreutils_bin@" ]; then
   PATH="@coreutils_bin@/bin"
 fi
 
+source @out@/nix-support/utils.sh
+
+expandResponseParams "$@"
+
 declare -r recurThreshold=300
 
 declare overflowCount=0
-for ((n=0; n < $#; ++n)); do
-    case "${!n}" in
+for p in "${params+"${params[@]}"}";  do
+    case "$p" in
         -l*) let overflowCount+=1 ;;
         -reexport-l*) let overflowCount+=1 ;;
         *) ;;
@@ -21,15 +25,15 @@ done
 declare -a allArgs=()
 
 if (( "$overflowCount" <= "$recurThreshold" )); then
-    allArgs=("$@")
+    allArgs=("${params+"${params[@]}"}")
 else
     declare -a childrenLookup=() childrenLink=()
 
-    while (( $# )); do
-        case "$1" in
+    for p in "${params+"${params[@]}"}"; do
+        case "$p" in
             -L/*)
-                childrenLookup+=("$1")
-                allArgs+=("$1")
+                childrenLookup+=("$p")
+                allArgs+=("$p")
                 ;;
             -L)
                 echo "cctools LD does not support '-L foo' or '-l foo'" >&2
@@ -41,18 +45,16 @@ else
                 ;;
             -lazy_library | -lazy_framework | -lto_library)
                 # We aren't linking any "azy_library", "to_library", etc.
-                allArgs+=("$1")
+                allArgs+=("$p")
                 ;;
-            -lazy-l | -weak-l)    allArgs+=("$1") ;;
+            -lazy-l | -weak-l)    allArgs+=("$p") ;;
                 # We can't so easily prevent header issues from these.
-            -lSystem)             allArgs+=("$1") ;;
+            -lSystem)             allArgs+=("$p") ;;
                 # Special case as indirection seems like a bad idea for something
                 # so fundamental. Can be removed for simplicity.
-            -l?* | -reexport-l?*) childrenLink+=("$1") ;;
-            *)                    allArgs+=("$1") ;;
+            -l?* | -reexport-l?*) childrenLink+=("$p") ;;
+            *)                    allArgs+=("$p") ;;
         esac
-
-        shift
     done
 
     declare n=0
@@ -87,22 +89,52 @@ else
             | @targetPrefix@as -Q -- -o $symbolBloatObject
     fi
 
+    responseFileBoth=$(mktemp)
+    printf " %q\n" "${childrenLookup[@]}" >$responseFileBoth
+    printf " %q\n" "$symbolBloatObject" >>$responseFileBoth    
     # first half of libs
+    responseFile1=$(mktemp)
+    printf " %q\n" "${childrenLink[@]:0:$((${#childrenLink[@]} / 2 ))}" >$responseFile1
     @targetPrefix@ld -macosx_version_min $MACOSX_DEPLOYMENT_TARGET -arch x86_64 -dylib \
       -o "$out/lib/lib${children[0]}.dylib" \
       -install_name "$out/lib/lib${children[0]}.dylib" \
-      "${childrenLookup[@]}" "$symbolBloatObject" \
-      "${childrenLink[@]:0:$((${#childrenLink[@]} / 2 ))}"
+      "@$responseFileBoth" "@$responseFile1"
 
     # second half of libs
+    responseFile2=$(mktemp)
+    printf " %q\n" "${childrenLink[@]:$((${#childrenLink[@]} / 2 ))}" >$responseFile2
     @targetPrefix@ld -macosx_version_min $MACOSX_DEPLOYMENT_TARGET -arch x86_64 -dylib \
       -o "$out/lib/lib${children[1]}.dylib" \
       -install_name "$out/lib/lib${children[1]}.dylib" \
-      "${childrenLookup[@]}" "$symbolBloatObject" \
-      "${childrenLink[@]:$((${#childrenLink[@]} / 2 ))}"
+      "@$responseFileBoth" "@$responseFile2"
 
     allArgs+=("-L$out/lib" "-l${children[0]}" "-l${children[1]}")
 fi
 
+templinks="$(mktemp -d "$PWD/XXXX")"
+prefix="$(basename $templinks)/"
+function finish {
+    rm "$prefix"*
+    rmdir "$templinks"
+}
+trap finish EXIT
+
+declare -i n=0
+shorterArgs=()
+nParams=${#allArgs[@]}
+while (( "$n" < "$nParams" )); do
+    p=${allArgs[n]}
+    case "$p" in
+        -L/*)
+            if [ -d "${p:2}" ]; then
+                ln -s "${p:2}" "$prefix$n"
+                shorterArgs+=("-L$prefix$n")
+            fi
+            ;;
+        *)
+            shorterArgs+=("$p") ;;
+    esac
+    n+=1
+done
 PATH="$path_backup"
-exec @prog@ "${allArgs[@]}"
+@prog@ "${shorterArgs[@]}"

--- a/pkgs/test/macos-sierra-shared/default.nix
+++ b/pkgs/test/macos-sierra-shared/default.nix
@@ -3,7 +3,7 @@
 let
   makeBigExe = stdenv: prefix: rec {
 
-    count = 320;
+    count = 500;
 
     sillyLibs = lib.genList (i: stdenv.mkDerivation rec {
       name = "${prefix}-fluff-${toString i}";


### PR DESCRIPTION
@Ericson2314, can you please take a look at this.  I have managed
to get webkitgtk building on macOS with the latest nixpkgs
but only if I use this change to work around the command line
argument limits.

###### Motivation for this change

This works around issues on OS that has a limited on the number of
arguments that can be passed to a process.

###### Things done

This change will passes all arguments in a temporary response file,
but only if we were able to expand response params with
expandResponseParams (that way we can safely assume there are
no unexpanded response params).

It also treats -L and -l linker options passed to cc-wrapper.sh
specially.  It puts these in a response file and adds that file to
the list of options with `-Wl,@...`.  This helps avoid issues when
the wrapped cc binary itself calls the linker.

Finally because ld cannot handle response files it shrinks the -L
options in macos-sierra-reexport-hack.bash using temporary local
symlinks with short names.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

