### PR TITLE
watchexec: init at 1.8.6

### DIFF
--- a/pkgs/tools/misc/watchexec/default.nix
+++ b/pkgs/tools/misc/watchexec/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "watchexec-${version}";
+  version = "1.8.6";
+
+  src = fetchFromGitHub {
+    owner = "mattgreen";
+    repo = "watchexec";
+    rev = "${version}";
+    sha256 = "1jib51dbr6s1iq21inm2xfsjnz1730nyd3af1x977iqivmwdisax";
+  };
+
+  cargoSha256 = "0sm1jvx1y18h7y66ilphsqmkbdxc76xly8y7kxmqwdi4lw54i9vl";
+
+  meta = with stdenv.lib; {
+    description = "Executes commands in response to file modifications";
+    homepage = https://github.com/mattgreen/watchexec;
+    license = with licenses; [ asl20 ];
+    maintainers = [ maintainers.michalrus ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5185,6 +5185,8 @@ with pkgs;
 
   wal_e = callPackage ../tools/backup/wal-e { };
 
+  watchexec = callPackage ../tools/misc/watchexec { };
+
   watchman = callPackage ../development/tools/watchman { };
 
   wavefunctioncollapse = callPackage ../tools/graphics/wavefunctioncollapse {};


### PR DESCRIPTION
###### Motivation for this change

One of the few tools of this sort that actually work reliably.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

