### PR TITLE
dart: 1.16.1 -> 1.24.3

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -1,26 +1,51 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchurl, unzip, version }:
 
 let
-  version = "1.16.1";
+
+  sources = let
+
+    base = "https://storage.googleapis.com/dart-archive/channels";
+    stable = "${base}/stable/release";
+    dev = "${base}/dev/release";
+
+  in {
+    "1.16.1-x86_64-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "01cbnc8hd2wwprmivppmzvld9ps644k16wpgqv31h1596l5p82n2";
+    };
+    "1.16.1-i686-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "0jfwzc3jbk4n5j9ka59s9bkb25l5g85fl1nf676mvj36swcfykx3";
+    };
+    "1.24.3-x86_64-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "e323c97c35e6bc5d955babfe2e235a5484a82bb1e4870fa24562c8b9b800559b";
+    };
+    "1.24.3-i686-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "d67b8f8f9186e7d460320e6bce25ab343c014b6af4b2f61369ee83755d4da528";
+    };
+    "2.0.0-dev.26.0-x86_64-linux" = fetchurl {
+      url = "${dev}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "18360489a7914d5df09b34934393e16c7627ba673c1e9ab5cfd11cd1d58fd7df";
+    };
+    "2.0.0-dev.26.0-i686-linux" = fetchurl {
+      url = "${dev}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "83ba8b64c76f48d8de4e0eb887e49b7960053f570d27e7ea438cc0bac789955e";
+    };
+  };
+
 in
+
 stdenv.mkDerivation {
+
   name = "dart-${version}";
 
   nativeBuildInputs = [
     unzip
   ];
-  
-  src =
-    if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-linux-x64-release.zip";
-        sha256 = "01cbnc8hd2wwprmivppmzvld9ps644k16wpgqv31h1596l5p82n2";
-      }
-    else
-      fetchurl {
-        url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-linux-ia32-release.zip";
-        sha256 = "0jfwzc3jbk4n5j9ka59s9bkb25l5g85fl1nf676mvj36swcfykx3";
-      };
+
+  src = sources."${version}-${stdenv.system}" or (throw "unsupported version/system: ${version}/${stdenv.system}");
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20516,7 +20516,10 @@ with pkgs;
 
   spdlog = callPackage ../development/libraries/spdlog { };
 
-  dart = callPackage ../development/interpreters/dart { };
+  dart = dart_stable;
+  dart_old = callPackage ../development/interpreters/dart { version = "1.16.1"; };
+  dart_stable = callPackage ../development/interpreters/dart { version = "1.24.3"; };
+  dart_dev = callPackage ../development/interpreters/dart { version = "2.0.0-dev.26.0"; };
 
   httrack = callPackage ../tools/backup/httrack { };
 


### PR DESCRIPTION
Also, added support for the "dev" channel.

###### Motivation for this change

Trying to get flutter packaged, and it needs a particular version of dart (maybe?).

Also, just upgrading dart.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

