### PR TITLE
catdocx: init at 20170102

### DIFF
--- a/pkgs/tools/text/catdocx/default.nix
+++ b/pkgs/tools/text/catdocx/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, unzip, catdoc }:
+
+stdenv.mkDerivation {
+  name = "catdocx-20170102";
+
+  src = fetchFromGitHub {
+    owner = "jncraton";
+    repo = "catdocx";
+    rev = "04fa0416ec1f116d4996685e219f0856d99767cb";
+    sha256 = "1sxiqhkvdqn300ygfgxdry2dj2cqzjhkzw13c6349gg5vxfypcjh";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/libexec $out/bin
+    cp catdocx.sh $out/libexec
+    chmod +x $out/libexec/catdocx.sh
+    wrapProgram $out/libexec/catdocx.sh --prefix PATH : "${lib.makeBinPath [ unzip catdoc ]}"
+    ln -s $out/libexec/catdocx.sh $out/bin/catdocx
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Extracts plain text from docx files";
+    homepage = https://github.com/jncraton/catdocx;
+    license = with licenses; [ bsd3 ];
+    maintainers = [ maintainers.michalrus ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -929,6 +929,8 @@ with pkgs;
 
   catdoc = callPackage ../tools/text/catdoc { };
 
+  catdocx = callPackage ../tools/text/catdocx { };
+
   catclock = callPackage ../applications/misc/catclock { };
 
   cde = callPackage ../tools/package-management/cde { };


### PR DESCRIPTION
###### Motivation for this change

`catdoc` is great, but it can’t do `*.docx`es.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Has no version, but upstream has no version either.