### PR TITLE
arping: init at 2.19

### DIFF
--- a/pkgs/tools/networking/arping/default.nix
+++ b/pkgs/tools/networking/arping/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, libnet, libpcap }:
+
+stdenv.mkDerivation rec {
+  version = "2.19";
+  name = "arping-${version}";
+
+  buildInputs = [ libnet libpcap ];
+
+  src = fetchFromGitHub {
+    owner = "ThomasHabets";
+    repo = "arping";
+    rev = "arping-${version}";
+    sha256 = "10gpil6ic17x8v628vhz9s98rnw1k8ci2xs56i52pr103irirczw";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    description = "Broadcasts a who-has ARP packet on the network and prints answers";
+    homepage = https://github.com/ThomasHabets/arping;
+    license = with licenses; [ gpl2 ];
+    maintainers = [ maintainers.michalrus ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1366,6 +1366,8 @@ with pkgs;
 
   appdata-tools = callPackage ../tools/misc/appdata-tools { };
 
+  arping = callPackage ../tools/networking/arping { };
+
   asciidoc = callPackage ../tools/typesetting/asciidoc {
     inherit (python2Packages) matplotlib numpy aafigure recursivePthLoader;
     w3m = w3m-batch;


### PR DESCRIPTION
###### Motivation for this change

Very-very useful when debugging LANs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

