### PR TITLE
arpoison: init at 0.7

### DIFF
--- a/pkgs/tools/networking/arpoison/default.nix
+++ b/pkgs/tools/networking/arpoison/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchzip, libnet }:
+
+stdenv.mkDerivation rec {
+  name = "arpoison-0.7";
+
+  buildInputs = [ libnet ];
+
+  src = fetchzip {
+    url = "http://www.arpoison.net/${name}.tar.gz";
+    sha256 = "0krhszx3s0qwfg4rma5a51ak71nnd9xfs2ibggc3hwiz506s2x37";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man8
+    gzip arpoison.8
+    cp arpoison $out/bin
+    cp arpoison.8.gz $out/share/man/man8
+  '';
+
+  meta = with stdenv.lib; {
+    description = "UNIX arp cache update utility";
+    homepage = http://www.arpoison.net/;
+    license = with licenses; [ gpl2 ];
+    maintainers = [ maintainers.michalrus ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/networking/arpoison/default.nix
+++ b/pkgs/tools/networking/arpoison/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0krhszx3s0qwfg4rma5a51ak71nnd9xfs2ibggc3hwiz506s2x37";
   };
 
+  makeFlags = ["CC=cc"];
+
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man8
     gzip arpoison.8

--- a/pkgs/tools/networking/arpoison/default.nix
+++ b/pkgs/tools/networking/arpoison/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0krhszx3s0qwfg4rma5a51ak71nnd9xfs2ibggc3hwiz506s2x37";
   };
 
-  makeFlags = ["CC=cc"];
+  postPatch = "substituteInPlace Makefile --replace gcc cc";
 
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man8

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1372,6 +1372,8 @@ with pkgs;
 
   arping = callPackage ../tools/networking/arping { };
 
+  arpoison = callPackage ../tools/networking/arpoison { };
+
   asciidoc = callPackage ../tools/typesetting/asciidoc {
     inherit (python2Packages) matplotlib numpy aafigure recursivePthLoader;
     w3m = w3m-batch;


### PR DESCRIPTION
###### Motivation for this change

Useful for pentesting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

