### PR TITLE
stdenv.mkDerivation: rename `meta.evaluates` -> `meta.available`

### DIFF
--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -36,7 +36,7 @@ let
           package = args.package or (lib.attrByPath path (throw "Invalid package attribute path `${toString path}'") pkgs);
         in "<listitem>"
         + "<para><literal>pkgs.${name} (${package.meta.name})</literal>"
-        + lib.optionalString (!package.meta.evaluates) " <emphasis>[UNAVAILABLE]</emphasis>"
+        + lib.optionalString (!package.meta.available) " <emphasis>[UNAVAILABLE]</emphasis>"
         + ": ${package.meta.description or "???"}.</para>"
         + lib.optionalString (args ? comment) "\n<para>${args.comment}</para>"
         # Lots of `longDescription's break DocBook, so we just wrap them into <programlisting>

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -159,7 +159,7 @@ let
     executables = listOf str;
     outputsToInstall = listOf str;
     position = str;
-    evaluates = bool;
+    available = bool;
     repositories = attrsOf str;
     isBuildPythonPackage = platforms;
     schedulingPriority = int;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -238,9 +238,9 @@ rec {
           position = pos.file + ":" + toString pos.line;
         # Expose the result of the checks for everyone to see.
         } // {
-          evaluates = validity.valid
+          available = validity.valid
                    && (if config.checkMetaRecursively or false
-                       then lib.all (d: d.meta.evaluates or true) references
+                       then lib.all (d: d.meta.available or true) references
                        else true);
         };
 


### PR DESCRIPTION
###### Motivation for this change

A much better name for this thing.

I just introduced it in #33057, so

- I don't think anyone outside nixpkgs uses it yet.
- There were no stable releases with this feature so I feel like its fine to change it without any grace period. Its master, after all.

###### Things done

- [X] No derivations change.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

