### PR TITLE
xen_4_8: fix build

### DIFF
--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -49,15 +49,9 @@ callPackage (import ./generic.nix (rec {
       src = fetchgit {
         url = https://xenbits.xen.org/git-http/qemu-xen.git;
         rev = "refs/tags/qemu-xen-${version}";
-        sha256 = "1v19pp86kcgwvsbkrdrn4rlaj02i4054avw8k70w1m0rnwgcsdbs";
+        sha256 = "1l4sygd8p0mc13bskr4r1m31qh1kr58h195qn1s52869s58jyhvm";
       };
       buildInputs = qemuDeps;
-      patches = [
-        (xsaPatch {
-          name = "216-qemuu";
-          sha256 = "06w2iw1r5gip2bpbg19cziws965h9in0f6np74cr31f76yy30yxn";
-        })
-      ];
       meta.description = "Xen's fork of upstream Qemu";
     };
   } // optionalAttrs withInternalTraditionalQemu {

--- a/pkgs/applications/virtualization/xen/packages.nix
+++ b/pkgs/applications/virtualization/xen/packages.nix
@@ -58,10 +58,6 @@ rec {
   };
 
   xen_4_8-vanilla = callPackage ./4.8.nix {
-    # At the very least included seabios and etherboot need gcc49,
-    # so we have to build all of it with gcc49.
-    stdenv = overrideCC stdenv gcc49;
-
     meta = {
       description = "vanilla";
       longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

Was broken.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

