### PR TITLE
cups: Add patch for bug where CUPS fails to save files to disk

### DIFF
--- a/pkgs/misc/cups/cups-clean-dirty.patch
+++ b/pkgs/misc/cups/cups-clean-dirty.patch
@@ -1,0 +1,13 @@
+diff --git a/scheduler/main.c b/scheduler/main.c
+index 8925c8373..acf031684 100644
+--- a/scheduler/main.c
++++ b/scheduler/main.c
+@@ -893,7 +893,7 @@ main(int  argc,				/* I - Number of command-line args */
+     * Write dirty config/state files...
+     */
+ 
+-    if (DirtyCleanTime && current_time >= DirtyCleanTime && cupsArrayCount(Clients) == 0)
++    if (DirtyCleanTime && current_time >= DirtyCleanTime)
+       cupsdCleanDirty();
+ 
+ #ifdef __APPLE__

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
       url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/cups-systemd-socket.patch?h=packages/cups";
       sha256 = "1ddgdlg9s0l2ph6l8lx1m1lx6k50gyxqi3qiwr44ppq1rxs80ny5";
     })
+    ./cups-clean-dirty.patch
   ];
 
   nativeBuildInputs = [ pkgconfig removeReferencesTo ];


### PR DESCRIPTION
Upstream report: https://github.com/apple/cups/issues/5118

In addition to not saving files, this results in spam messages in the log once per second (Expiring subscriptions...)
which is what led me to discover this bug. The patch was made by hand because the patch from the commit does not apply.

###### Motivation for this change

Spam log messages from cups every second.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

