### PR TITLE
libva: make `libva-full` the default

### DIFF
--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -14,7 +14,6 @@ let
     name = "mesa-drivers+txc-${p.mesa_drivers.version}";
     paths =
       [ p.mesa_drivers
-        p.mesa_drivers.out # mainly for libGL
         (if cfg.s3tcSupport then p.libtxc_dxtn else p.libtxc_dxtn_s2tc)
       ];
   };

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -33,89 +33,92 @@ in
 
 {
   options = {
-    hardware.opengl.enable = mkOption {
-      description = ''
-        Whether to enable OpenGL drivers. This is needed to enable
-        OpenGL support in X11 systems, as well as for Wayland compositors
-        like sway, way-cooler and Weston. It is enabled by default
-        by the corresponding modules, so you do not usually have to
-        set it yourself, only if there is no module for your wayland
-        compositor of choice. See services.xserver.enable,
-        programs.sway.enable, and programs.way-cooler.enable.
-      '';
-      type = types.bool;
-      default = false;
-    };
 
-    hardware.opengl.driSupport = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable accelerated OpenGL rendering through the
-        Direct Rendering Interface (DRI).
-      '';
-    };
+    hardware.opengl = {
+      enable = mkOption {
+        description = ''
+          Whether to enable OpenGL drivers. This is needed to enable
+          OpenGL support in X11 systems, as well as for Wayland compositors
+          like sway, way-cooler and Weston. It is enabled by default
+          by the corresponding modules, so you do not usually have to
+          set it yourself, only if there is no module for your wayland
+          compositor of choice. See services.xserver.enable,
+          programs.sway.enable, and programs.way-cooler.enable.
+        '';
+        type = types.bool;
+        default = false;
+      };
 
-    hardware.opengl.driSupport32Bit = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        On 64-bit systems, whether to support Direct Rendering for
-        32-bit applications (such as Wine).  This is currently only
-        supported for the <literal>nvidia</literal> and 
-        <literal>ati_unfree</literal> drivers, as well as
-        <literal>Mesa</literal>.
-      '';
-    };
+      driSupport = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable accelerated OpenGL rendering through the
+          Direct Rendering Interface (DRI).
+        '';
+      };
 
-    hardware.opengl.s3tcSupport = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Make S3TC(S3 Texture Compression) via libtxc_dxtn available
-        to OpenGL drivers instead of the patent-free S2TC replacement.
+      driSupport32Bit = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          On 64-bit systems, whether to support Direct Rendering for
+          32-bit applications (such as Wine).  This is currently only
+          supported for the <literal>nvidia</literal> and
+          <literal>ati_unfree</literal> drivers, as well as
+          <literal>Mesa</literal>.
+        '';
+      };
 
-        Using this library may require a patent license depending on your location.
-      '';
-    };
+      s3tcSupport = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Make S3TC(S3 Texture Compression) via libtxc_dxtn available
+          to OpenGL drivers instead of the patent-free S2TC replacement.
 
-    hardware.opengl.package = mkOption {
-      type = types.package;
-      internal = true;
-      description = ''
-        The package that provides the OpenGL implementation.
-      '';
-    };
+          Using this library may require a patent license depending on your location.
+        '';
+      };
 
-    hardware.opengl.package32 = mkOption {
-      type = types.package;
-      internal = true;
-      description = ''
-        The package that provides the 32-bit OpenGL implementation on
-        64-bit systems. Used when <option>driSupport32Bit</option> is
-        set.
-      '';
-    };
+      package = mkOption {
+        type = types.package;
+        internal = true;
+        description = ''
+          The package that provides the OpenGL implementation.
+        '';
+      };
 
-    hardware.opengl.extraPackages = mkOption {
-      type = types.listOf types.package;
-      default = [];
-      example = literalExample "with pkgs; [ vaapiIntel libvdpau-va-gl vaapiVdpau intel-ocl ]";
-      description = ''
-        Additional packages to add to OpenGL drivers. This can be used
-        to add OpenCL drivers, VA-API/VDPAU drivers etc.
-      '';
-    };
+      package32 = mkOption {
+        type = types.package;
+        internal = true;
+        description = ''
+          The package that provides the 32-bit OpenGL implementation on
+          64-bit systems. Used when <option>driSupport32Bit</option> is
+          set.
+        '';
+      };
 
-    hardware.opengl.extraPackages32 = mkOption {
-      type = types.listOf types.package;
-      default = [];
-      example = literalExample "with pkgs.pkgsi686Linux; [ vaapiIntel libvdpau-va-gl vaapiVdpau ]";
-      description = ''
-        Additional packages to add to 32-bit OpenGL drivers on
-        64-bit systems. Used when <option>driSupport32Bit</option> is
-        set. This can be used to add OpenCL drivers, VA-API/VDPAU drivers etc.
-      '';
+      extraPackages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        example = literalExample "with pkgs; [ vaapiIntel libvdpau-va-gl vaapiVdpau intel-ocl ]";
+        description = ''
+          Additional packages to add to OpenGL drivers. This can be used
+          to add OpenCL drivers, VA-API/VDPAU drivers etc.
+        '';
+      };
+
+      extraPackages32 = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        example = literalExample "with pkgs.pkgsi686Linux; [ vaapiIntel libvdpau-va-gl vaapiVdpau ]";
+        description = ''
+          Additional packages to add to 32-bit OpenGL drivers on
+          64-bit systems. Used when <option>driSupport32Bit</option> is
+          set. This can be used to add OpenCL drivers, VA-API/VDPAU drivers etc.
+        '';
+      };
     };
 
   };

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -27,13 +27,6 @@ let
   nvidia_x11 = nvidiaForKernel config.boot.kernelPackages;
   nvidia_libs32 = (nvidiaForKernel pkgs_i686.linuxPackages).override { libsOnly = true; kernel = null; };
 
-  nvidiaPackage = nvidia: pkgs:
-    if !nvidia.useGLVND then nvidia.out
-    else pkgs.buildEnv {
-      name = "nvidia-libs";
-      paths = [ pkgs.libglvnd nvidia.out ];
-    };
-
   enabled = nvidia_x11 != null;
 in
 
@@ -59,8 +52,8 @@ in
       source = "${nvidia_x11.bin}/share/nvidia/nvidia-application-profiles-rc";
     };
 
-    hardware.opengl.package = nvidiaPackage nvidia_x11 pkgs;
-    hardware.opengl.package32 = nvidiaPackage nvidia_libs32 pkgs_i686;
+    hardware.opengl.package = nvidia_x11.out;
+    hardware.opengl.package32 = nvidia_libs32.out;
 
     environment.systemPackages = [ nvidia_x11.bin nvidia_x11.settings ]
       ++ lib.filter (p: p != null) [ nvidia_x11.persistenced ];

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -640,9 +640,7 @@ in
 
         environment =
           {
-            XORG_DRI_DRIVER_PATH = "/run/opengl-driver/lib/dri"; # !!! Depends on the driver selected at runtime.
-            LD_LIBRARY_PATH = concatStringsSep ":" (
-              [ "${xorg.libX11.out}/lib" "${xorg.libXext.out}/lib" "/run/opengl-driver/lib" ]
+            LD_LIBRARY_PATH = concatStringsSep ":" ([ "/run/opengl-driver/lib" ]
               ++ concatLists (catAttrs "libPath" cfg.drivers));
           } // cfg.displayManager.job.environment;
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -98,7 +98,7 @@ let
           ${qemuGraphics} \
           ${toString config.virtualisation.qemu.options} \
           $QEMU_OPTS \
-          $@
+          "$@"
     '';
 
 

--- a/pkgs/applications/graphics/fbida/default.nix
+++ b/pkgs/applications/graphics/fbida/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, libjpeg, libexif, libungif, libtiff, libpng, libwebp, libdrm
 , pkgconfig, freetype, fontconfig, which, imagemagick, curl, sane-backends, libXpm
-, epoxy, poppler, lirc }:
+, epoxy, poppler, mesa_noglu, lirc }:
 
 stdenv.mkDerivation rec {
   name = "fbida-2.13";
@@ -11,8 +11,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig which ];
-  buildInputs = [ libexif libjpeg libpng libungif freetype fontconfig libtiff
-   libwebp imagemagick curl sane-backends libdrm libXpm epoxy poppler lirc ];
+  buildInputs = [
+    libexif libjpeg libpng libungif freetype fontconfig libtiff libwebp
+    imagemagick curl sane-backends libdrm libXpm epoxy poppler lirc
+    mesa_noglu
+  ];
   
   makeFlags = [ "prefix=$(out)" "verbose=yes" "STRIP=" ];
 

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -13,7 +13,7 @@
 , libmpeg2, libsamplerate, libmad
 , libogg, libvorbis, flac, libxslt
 , lzo, libcdio, libmodplug, libass, libbluray
-, sqlite, mysql, nasm, gnutls, libva, wayland
+, sqlite, mysql, nasm, gnutls, libva, libdrm, wayland
 , curl, bzip2, zip, unzip, glxinfo, xdpyinfo
 , libcec, libcec_platform, dcadec, libuuid
 , libcrossguid, libmicrohttpd
@@ -121,7 +121,7 @@ in stdenv.mkDerivation rec {
       gnutls libidn libtasn1 nasm p11-kit
       libxml2 yasm python2
       boost libmicrohttpd
-      gettext pcre-cpp yajl fribidi libva
+      gettext pcre-cpp yajl fribidi libva libdrm
       openssl gperf tinyxml2 taglib libssh swig jre
       libX11 xproto inputproto libXt libXmu libXext xextproto
       libXinerama libXrandr randrproto libXtst libXfixes fixesproto

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -7,7 +7,7 @@
 , numaSupport ? stdenv.isLinux && !stdenv.isArm, numactl
 , seccompSupport ? stdenv.isLinux, libseccomp
 , pulseSupport ? !stdenv.isDarwin, libpulseaudio
-, sdlSupport ? !stdenv.isDarwin, SDL
+, sdlSupport ? !stdenv.isDarwin, SDL2
 , vncSupport ? true, libjpeg, libpng
 , spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
 , usbredirSupport ? spiceSupport, usbredir
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     ++ optionals seccompSupport [ libseccomp ]
     ++ optionals numaSupport [ numactl ]
     ++ optionals pulseSupport [ libpulseaudio ]
-    ++ optionals sdlSupport [ SDL ]
+    ++ optionals sdlSupport [ SDL2 ]
     ++ optionals vncSupport [ libjpeg libpng ]
     ++ optionals spiceSupport [ spice-protocol spice ]
     ++ optionals usbredirSupport [ usbredir ]

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -12,8 +12,8 @@
 , spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
-, openGLSupport ? true, mesa_noglu, epoxy, libdrm
-, virglSupport ? true, virglrenderer
+, openGLSupport ? sdlSupport, mesa_noglu, epoxy, libdrm
+, virglSupport ? openGLSupport, virglrenderer
 , hostCpuOnly ? false
 , nixosTestRunner ? false
 }:

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -12,6 +12,7 @@
 , spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
+, openGLSupport ? true, mesa_noglu, epoxy, libdrm
 , hostCpuOnly ? false
 , nixosTestRunner ? false
 }:
@@ -57,7 +58,8 @@ stdenv.mkDerivation rec {
     ++ optionals spiceSupport [ spice-protocol spice ]
     ++ optionals usbredirSupport [ usbredir ]
     ++ optionals stdenv.isLinux [ alsaLib libaio libcap_ng libcap attr ]
-    ++ optionals xenSupport [ xen ];
+    ++ optionals xenSupport [ xen ]
+    ++ optionals openGLSupport [ mesa_noglu epoxy libdrm ];
 
   enableParallelBuilding = true;
 
@@ -88,7 +90,8 @@ stdenv.mkDerivation rec {
     ++ optional hostCpuOnly "--target-list=${hostCpuTargets}"
     ++ optional stdenv.isDarwin "--enable-cocoa"
     ++ optional stdenv.isLinux "--enable-linux-aio"
-    ++ optional xenSupport "--enable-xen";
+    ++ optional xenSupport "--enable-xen"
+    ++ optional openGLSupport "--enable-opengl";
 
   postFixup =
     ''

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -13,6 +13,7 @@
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
 , openGLSupport ? true, mesa_noglu, epoxy, libdrm
+, virglSupport ? true, virglrenderer
 , hostCpuOnly ? false
 , nixosTestRunner ? false
 }:
@@ -59,7 +60,8 @@ stdenv.mkDerivation rec {
     ++ optionals usbredirSupport [ usbredir ]
     ++ optionals stdenv.isLinux [ alsaLib libaio libcap_ng libcap attr ]
     ++ optionals xenSupport [ xen ]
-    ++ optionals openGLSupport [ mesa_noglu epoxy libdrm ];
+    ++ optionals openGLSupport [ mesa_noglu epoxy libdrm ]
+    ++ optionals virglSupport [ virglrenderer ];
 
   enableParallelBuilding = true;
 
@@ -91,7 +93,8 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin "--enable-cocoa"
     ++ optional stdenv.isLinux "--enable-linux-aio"
     ++ optional xenSupport "--enable-xen"
-    ++ optional openGLSupport "--enable-opengl";
+    ++ optional openGLSupport "--enable-opengl"
+    ++ optional virglSupport "--enable-virglrenderer";
 
   postFixup =
     ''

--- a/pkgs/development/libraries/cogl/default.nix
+++ b/pkgs/development/libraries/cogl/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchurl, pkgconfig, libGL, glib, gdk_pixbuf, xorg, libintl
-, pangoSupport ? true, pango, cairo, gobjectIntrospection, wayland, gnome3
+, pangoSupport ? true, pango, cairo, gobjectIntrospection, wayland
+, mesa_noglu, gnome3
 , gstreamerSupport ? true, gst_all_1 }:
 
 let
   pname = "cogl";
-  version = "1.22.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
@@ -24,7 +25,7 @@ in stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals (!stdenv.isDarwin) [ "--enable-gles1" "--enable-gles2" ];
 
   propagatedBuildInputs = with xorg; [
-      glib gdk_pixbuf gobjectIntrospection wayland
+      glib gdk_pixbuf gobjectIntrospection wayland mesa_noglu
       libGL libXrandr libXfixes libXcomposite libXdamage
     ]
     ++ stdenv.lib.optionals gstreamerSupport [ gst_all_1.gstreamer

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, libva-full }:
+{ callPackage }:
 
 rec {
   gstreamer = callPackage ./core { };
@@ -23,7 +23,6 @@ rec {
 
   gst-vaapi = callPackage ./vaapi {
     inherit gst-plugins-base gstreamer gst-plugins-bad;
-    libva = libva-full; # looks also for libva-{x11,wayland}
   };
 
   gst-validate = callPackage ./validate { inherit gst-plugins-base; };

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, gettext, perl, makeWrapper, shared-mime-info
 , expat, glib, cairo, pango, gdk_pixbuf, atk, at-spi2-atk, gobjectIntrospection
 , xorg, epoxy, json-glib, libxkbcommon, gmp
-, waylandSupport ? stdenv.isLinux, wayland, wayland-protocols
+, waylandSupport ? stdenv.isLinux, mesa_noglu, wayland, wayland-protocols
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? stdenv.isLinux, cups ? null
 , darwin, gnome3
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = with xorg; with stdenv.lib;
     [ expat glib cairo pango gdk_pixbuf atk at-spi2-atk gnome3.gsettings-desktop-schemas
       libXrandr libXrender libXcomposite libXi libXcursor libSM libICE ]
-    ++ optionals waylandSupport [ wayland wayland-protocols ]
+    ++ optionals waylandSupport [ mesa_noglu wayland wayland-protocols ]
     ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ AppKit Cocoa ])
     ++ optional xineramaSupport libXinerama
     ++ optional cupsSupport cups;

--- a/pkgs/development/libraries/libglvnd/default.nix
+++ b/pkgs/development/libraries/libglvnd/default.nix
@@ -1,15 +1,16 @@
-{stdenv, fetchFromGitHub, autoreconfHook, python2, pkgconfig, libGL_driver, libX11, libXext, glproto }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, python2, pkgconfig, libX11, libXext, glproto }:
 
-# Git version is needed for EGL and GLES handling.
-
-stdenv.mkDerivation rec {
-  name = "libglvnd-2016-12-22";
+let
+  driverLink = "/run/opengl-driver" + lib.optionalString stdenv.isi686 "-32";
+in stdenv.mkDerivation rec {
+  name = "libglvnd-${version}";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "libglvnd";
-    rev = "dc16f8c337703ad141f83583a4004fcf42e07766";
-    sha256 = "1dbwf1216np77xf1kx3ci3y7hfa1p4vgrrzg71gw36hqxf36vg5f";
+    rev = "v${version}";
+    sha256 = "1a126lzhd2f04zr3rvdl6814lfl0j077spi5dsf2alghgykn5iif";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig python2 ];
@@ -17,10 +18,13 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [
     "-UDEFAULT_EGL_VENDOR_CONFIG_DIRS"
-    "-DDEFAULT_EGL_VENDOR_CONFIG_DIRS=\"${libGL_driver.driverLink}/share/glvnd/egl_vendor.d\""
+    # FHS paths are added so that non-NixOS applications can find vendor files.
+    "-DDEFAULT_EGL_VENDOR_CONFIG_DIRS=\"${driverLink}/share/glvnd/egl_vendor.d:/etc/glvnd/egl_vendor.d:/usr/share/glvnd/egl_vendor.d\""
   ];
 
   outputs = [ "out" "dev" ];
+
+  passthru = { inherit driverLink; };
 
   meta = with stdenv.lib; {
     description = "The GL Vendor-Neutral Dispatch library";

--- a/pkgs/development/libraries/libva/1.0.0.nix
+++ b/pkgs/development/libraries/libva/1.0.0.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, libX11, pkgconfig, libXext, libdrm, libXfixes, wayland, libffi
-, mesa_noglu
+, libGL, libGL_driver
 , minimal ? true, libva
 }:
 
@@ -17,11 +17,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ libdrm ]
-    ++ lib.optionals (!minimal) [ libva libX11 libXext libXfixes wayland libffi mesa_noglu ];
+    ++ lib.optionals (!minimal) [ libva libX11 libXext libXfixes wayland libffi libGL ];
   # TODO: share libs between minimal and !minimal - perhaps just symlink them
 
   configureFlags =
-    [ "--with-drivers-path=${mesa_noglu.driverLink}/lib/dri" ] ++
+    # Add FHS paths for non-NixOS applications.
+    [ "--with-drivers-path=${libGL_driver.driverLink}/lib/dri:/usr/lib/dri:/usr/lib32/dri" ] ++
     lib.optionals (!minimal) [ "--enable-glx" ];
 
   installFlags = [ "dummy_drv_video_ladir=$(out)/lib/dri" ];

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig
 , libXext, libdrm, libXfixes, wayland, libffi, libX11
-, libGL
+, libGL, libGL_driver
 , minimal ? true, libva
 }:
 
@@ -27,7 +27,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configureFlags = [
-    "--with-drivers-path=${libGL.driverLink}/lib/dri"
+    # Add FHS paths for non-NixOS applications.
+    "--with-drivers-path=${libGL_driver.driverLink}/lib/dri:/usr/lib/dri:/usr/lib32/dri"
   ] ++ lib.optionals (!minimal) [ "--enable-glx" ];
 
   installFlags = [

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -1,11 +1,11 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig
 , libXext, libdrm, libXfixes, wayland, libffi, libX11
 , libGL, libGL_driver
-, minimal ? true, libva
+, minimal ? false, libva-minimal
 }:
 
 stdenv.mkDerivation rec {
-  name = "libva-${lib.optionalString (!minimal) "full-"}${version}";
+  name = "libva-${lib.optionalString minimal "minimal-"}${version}";
   version = "2.1.0";
 
   # update libva-utils and vaapiIntel as well
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [ libdrm ]
-    ++ lib.optionals (!minimal) [ libva libX11 libXext libXfixes wayland libffi libGL ];
+    ++ lib.optionals (!minimal) [ libva-minimal libX11 libXext libXfixes wayland libffi libGL ];
   # TODO: share libs between minimal and !minimal - perhaps just symlink them
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libvdpau/default.nix
+++ b/pkgs/development/libraries/libvdpau/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, xorg, libGL }:
+{ stdenv, fetchurl, pkgconfig, xorg, libGL_driver }:
 
 stdenv.mkDerivation rec {
-  name = "libvdpau-1.1.1";
+  name = "libvdpau-${version}";
+  version = "1.1.1";
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~aplattner/vdpau/${name}.tar.bz2";
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ xorg.libX11 ];
 
   configureFlags = stdenv.lib.optional stdenv.isLinux
-    "--with-module-dir=${libGL.driverLink}/lib/vdpau";
+    "--with-module-dir=${libGL_driver.driverLink}/lib/vdpau";
 
   installFlags = [ "moduledir=$(out)/lib/vdpau" ];
 

--- a/pkgs/development/libraries/mesa-glu/default.nix
+++ b/pkgs/development/libraries/mesa-glu/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, mesa_noglu }:
+{ stdenv, fetchurl, pkgconfig, libGL }:
 
 stdenv.mkDerivation rec {
-  name = "glu-9.0.0";
+  name = "glu-${version}";
+  version = "9.0.0";
 
   src = fetchurl {
     url = "ftp://ftp.freedesktop.org/pub/mesa/glu/${name}.tar.bz2";
@@ -12,7 +13,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ mesa_noglu ];
+  propagatedBuildInputs = [ libGL ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -55,7 +55,7 @@ let
     (if gallium_ == null
           then defaultGalliumDrivers
           else gallium_)
-    ++ ["swrast"];
+    ++ ["swrast" "virgl"];
   driDrivers =
     (if dri_ == null
       then defaultDriDrivers

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchpatch, lib
 , pkgconfig, intltool, autoreconfHook, substituteAll
 , file, expat, libdrm, xorg, wayland, wayland-protocols, openssl
-, llvmPackages, libffi, libomxil-bellagio, libva
+, llvmPackages, libffi, libomxil-bellagio, libva-minimal
 , libelf, libvdpau, valgrind-light, python2
 , libglvnd
 , grsecEnabled ? false
@@ -151,7 +151,7 @@ let self = stdenv.mkDerivation {
     glproto dri2proto dri3proto presentproto
     libX11 libXext libxcb libXt libXfixes libxshmfence
     libffi wayland wayland-protocols libvdpau libelf libXvMC
-    libomxil-bellagio libva libpthreadstubs openssl/*or another sha1 provider*/
+    libomxil-bellagio libva-minimal libpthreadstubs openssl/*or another sha1 provider*/
     valgrind-light python2
   ];
 

--- a/pkgs/development/libraries/ocl-icd/default.nix
+++ b/pkgs/development/libraries/ocl-icd/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ruby, opencl-headers, libGL }:
+{stdenv, fetchurl, ruby, opencl-headers, libGL_driver }:
 
 stdenv.mkDerivation rec {
   name = "ocl-icd-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ opencl-headers ];
 
   postPatch = ''
-    sed -i 's,"/etc/OpenCL/vendors","${libGL.driverLink}/etc/OpenCL/vendors",g' ocl_icd_loader.c
+    sed -i 's,"/etc/OpenCL/vendors","${libGL_driver.driverLink}/etc/OpenCL/vendors",g' ocl_icd_loader.c
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -76,7 +76,6 @@ stdenv.mkDerivation rec {
         icu = icu.out;
         libXfixes = libXfixes.out;
         glibc = stdenv.cc.libc.out;
-        openglDriver = if libGLSupported then libGL.driverLink else "/no-such-path";
       })
       (fetchpatch {
         name = "fix-medium-font.patch";

--- a/pkgs/development/libraries/qt-4.x/4.8/dlopen-absolute-paths.diff
+++ b/pkgs/development/libraries/qt-4.x/4.8/dlopen-absolute-paths.diff
@@ -59,32 +59,6 @@ index 6b42d1e..f88b628 100644
      lib.setLoadHints(QLibrary::ImprovedSearchHeuristics);
      if (!lib.load())
          return;
-diff --git a/src/plugins/platforms/xcb/qglxintegration.cpp b/src/plugins/platforms/xcb/qglxintegration.cpp
-index 229d6f9..c122bf3 100644
---- a/src/plugins/platforms/xcb/qglxintegration.cpp
-+++ b/src/plugins/platforms/xcb/qglxintegration.cpp
-@@ -136,7 +136,7 @@ void* QGLXContext::getProcAddress(const QString& procName)
-             {
-                 extern const QString qt_gl_library_name();
- //                QLibrary lib(qt_gl_library_name());
--                QLibrary lib(QLatin1String("GL"));
-+                QLibrary lib(QLatin1String("@openglDriver@/lib/libGL"));
-                 glXGetProcAddressARB = (qt_glXGetProcAddressARB) lib.resolve("glXGetProcAddressARB");
-             }
-         }
-diff --git a/src/plugins/platforms/xlib/qglxintegration.cpp b/src/plugins/platforms/xlib/qglxintegration.cpp
-index 2467247..a2441d4 100644
---- a/src/plugins/platforms/xlib/qglxintegration.cpp
-+++ b/src/plugins/platforms/xlib/qglxintegration.cpp
-@@ -137,7 +137,7 @@ void* QGLXContext::getProcAddress(const QString& procName)
-             {
-                 extern const QString qt_gl_library_name();
- //                QLibrary lib(qt_gl_library_name());
--                QLibrary lib(QLatin1String("GL"));
-+                QLibrary lib(QLatin1String("@openglDriver@/lib/libGL"));
-                 glXGetProcAddressARB = (qt_glXGetProcAddressARB) lib.resolve("glXGetProcAddressARB");
-             }
-         }
 diff --git a/src/plugins/platforms/xlib/qxlibstatic.cpp b/src/plugins/platforms/xlib/qxlibstatic.cpp
 index f8f3d69..d63c5bc 100644
 --- a/src/plugins/platforms/xlib/qxlibstatic.cpp

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -4,7 +4,7 @@
 , bison, coreutils, flex, git, gperf, ninja, pkgconfig, python2, which
 
 , xorg, libXcursor, libXScrnSaver, libXrandr, libXtst
-, fontconfig, freetype, harfbuzz, icu, dbus
+, fontconfig, freetype, harfbuzz, icu, dbus, libdrm
 , zlib, minizip, libjpeg, libpng, libtiff, libwebp, libopus
 , jsoncpp, protobuf, libvpx, srtp, snappy, nss, libevent
 , alsaLib
@@ -104,7 +104,7 @@ qtModule {
 
     # X11 libs
     xorg.xrandr libXScrnSaver libXcursor libXrandr xorg.libpciaccess libXtst
-    xorg.libXcomposite
+    xorg.libXcomposite xorg.libXdamage libdrm
   ];
 
   dontUseNinjaBuild = true;

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -2,7 +2,7 @@
 , openssl, libpulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
 , cyrus_sasl, python2Packages, autoreconfHook, usbredir, libsoup
 , polkit, acl, usbutils, vala
-, gtk3, epoxy }:
+, gtk3, epoxy, libdrm }:
 
 with stdenv.lib;
 
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     spice-protocol celt_0_5_1 openssl libpulseaudio pixman
-    libjpeg_turbo zlib cyrus_sasl python pygtk usbredir gtk3 epoxy
+    libjpeg_turbo zlib cyrus_sasl python pygtk usbredir gtk3 epoxy libdrm
     polkit acl usbutils
   ];
 

--- a/pkgs/development/libraries/virglrenderer/default.nix
+++ b/pkgs/development/libraries/virglrenderer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libGLU, epoxy, libX11 }:
+{ stdenv, fetchurl, pkgconfig, libGLU, epoxy, libX11, libdrm, mesa_noglu }:
 
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "a549e351e0eb2ad1df471386ddcf85f522e7202808d1616ee9ff894209066e1a";
   };
 
-  buildInputs = [ libGLU epoxy libX11 ];
+  buildInputs = [ libGLU epoxy libX11 libdrm mesa_noglu ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, fetchFromGitHub, cmake, pkgconfig, git, python3,
   python3Packages, glslang, spirv-tools, x11, libxcb, libXrandr,
-  libXext, wayland, libGL, makeWrapper }:
+  libXext, wayland, libGL_driver, makeWrapper }:
 
 let
   version = "1.0.61.1";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_WSI_MIR_SUPPORT=OFF"
-    "-DFALLBACK_DATA_DIRS=${libGL.driverLink}/share:/usr/local/share:/usr/share"
+    "-DFALLBACK_DATA_DIRS=${libGL_driver.driverLink}/share:/usr/local/share:/usr/share"
   ];
 
   outputs = [ "out" "dev" "demos" ];

--- a/pkgs/development/libraries/webkitgtk/2.20.nix
+++ b/pkgs/development/libraries/webkitgtk/2.20.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     sqlite gst-plugins-base gst-plugins-bad libxkbcommon epoxy at-spi2-core
   ] ++ optional enableGeoLocation geoclue2
     ++ optional enableGtk2Plugins gtk2
-    ++ (with xorg; [ libXdmcp libXt libXtst ])
+    ++ (with xorg; [ libXdmcp libXt libXtst libXdamage ])
     ++ optionals stdenv.isDarwin [ libedit readline libGLU_combined ]
     ++ optional stdenv.isLinux wayland;
 

--- a/pkgs/development/mobile/genymotion/default.nix
+++ b/pkgs/development/mobile/genymotion/default.nix
@@ -5,9 +5,9 @@
 
 let
   packages = [
-    stdenv.cc.cc zlib glib xorg.libX11 libxkbcommon libXmu libXi libXext
+    stdenv.cc.cc zlib glib xorg.libX11 libxkbcommon libXmu libXi libXext libGL
   ];
-  libPath = "${stdenv.lib.makeLibraryPath packages}:${libGL.driverLink}/lib";
+  libPath = "${stdenv.lib.makeLibraryPath packages}";
 in
 stdenv.mkDerivation rec {
   name = "genymotion-${version}";

--- a/pkgs/development/tools/misc/intel-gpu-tools/default.nix
+++ b/pkgs/development/tools/misc/intel-gpu-tools/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     substituteInPlace tests/Makefile.am --replace '$(CAIRO_CFLAGS)' '$(CAIRO_CFLAGS) $(GLIB_CFLAGS)'
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     homepage = https://01.org/linuxgraphics/;
     description = "Tools for development and testing of the Intel DRM driver";

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -57,6 +57,7 @@ in buildFHSUserEnv rec {
     xorg.libXext
     xorg.libX11
     xorg.libXfixes
+    libGL
 
     # Not formally in runtime but needed by some games
     gst_all_1.gstreamer
@@ -144,7 +145,6 @@ in buildFHSUserEnv rec {
     SDL2_mixer
     gstreamer
     gst-plugins-base
-    libGLU
     libappindicator-gtk2
     libcaca
     libcanberra

--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libpng, pkgconfig, SDL, freetype, zlib, mesa }:
+{ stdenv, fetchFromGitHub, libpng, pkgconfig, SDL, freetype, zlib }:
 
 stdenv.mkDerivation rec {
 

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   ++ lib.optionals openclSupport [ pkgs.opencl-headers pkgs.ocl-icd ]
   ++ lib.optionals xmlSupport    [ pkgs.libxml2 pkgs.libxslt ]
   ++ lib.optionals tlsSupport    [ pkgs.openssl pkgs.gnutls ]
-  ++ lib.optionals openglSupport [ pkgs.libGLU_combined pkgs.libGL.osmesa pkgs.libdrm ]
+  ++ lib.optionals openglSupport [ pkgs.libGLU_combined pkgs.mesa_noglu.osmesa pkgs.libdrm ]
   ++ (with pkgs.xorg; [
     libX11  libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext
   ])));

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   ++ lib.optional odbcSupport            pkgs.unixODBC
   ++ lib.optional netapiSupport          pkgs.samba4
   ++ lib.optional cursesSupport          pkgs.ncurses
-  ++ lib.optional vaSupport              pkgs.libva-full
+  ++ lib.optional vaSupport              pkgs.libva
   ++ lib.optional pcapSupport            pkgs.libpcap
   ++ lib.optional v4lSupport             pkgs.libv4l
   ++ lib.optional saneSupport            pkgs.sane-backends

--- a/pkgs/os-specific/linux/amdgpu-pro/default.nix
+++ b/pkgs/os-specific/linux/amdgpu-pro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, elfutils, libGL
+{ stdenv, fetchurl, elfutils
 , xorg, patchelf, openssl, libdrm, libudev
 , libxcb, libxshmfence, epoxy, perl, zlib
 , fetchFromGitHub, ncurses
@@ -12,8 +12,6 @@ with stdenv.lib;
 let
 
   kernelDir = if libsOnly then null else kernel.dev;
-
-  inherit (libGL) driverLink;
 
   bitness = if stdenv.is64bit then "64" else "32";
 

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -1,6 +1,6 @@
 nvidia_x11: sha256:
 
-{ stdenv, lib, fetchurl, pkgconfig, m4, jansson, gtk2, dbus, gtk3, libXv, libXrandr, libvdpau, libXext
+{ stdenv, lib, fetchurl, pkgconfig, m4, jansson, gtk2, dbus, gtk3, libXv, libXrandr, libXext, libXxf86vm, libvdpau
 , librsvg, wrapGAppsHook
 , withGtk2 ? false, withGtk3 ? true
 }:
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig m4 ];
 
-  buildInputs = [ jansson libXv libXrandr libvdpau nvidia_x11 gtk2 dbus libXv ]
+  buildInputs = [ jansson libXv libXrandr libXext libXxf86vm libvdpau nvidia_x11 gtk2 dbus ]
              ++ lib.optionals withGtk3 [ gtk3 librsvg wrapGAppsHook ];
 
   makeFlags = [ "NV_USE_BUNDLED_LIBJANSSON=0" ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1,6 +1,6 @@
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 args @ { clangStdenv, fetchurl, fetchgit, fetchpatch, stdenv, pkgconfig, intltool, freetype, fontconfig
-, libxslt, expat, libpng, zlib, perl, mesa_drivers, spice-protocol
+, libxslt, expat, libpng, zlib, perl, mesa_noglu, mesa_drivers, spice-protocol
 , dbus, libuuid, openssl, gperf, m4, libevdev, tradcpp, libinput, mcpp, makeWrapper, autoreconfHook
 , autoconf, automake, libtool, xmlto, asciidoc, flex, bison, python, mtdev, pixman, ... }: with args;
 
@@ -1839,9 +1839,9 @@ let
       sha256 = "0z56ifw3xiq9dychv8chg1cny0hq4v3c1r9pqcybk5fp7nzw9jpq";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ fontsproto mesa libdrm udev randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
+    buildInputs = [ fontsproto libGL libdrm udev randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
     meta.platforms = stdenv.lib.platforms.unix;
-  }) // {inherit fontsproto mesa libdrm udev randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+  }) // {inherit fontsproto libGL libdrm udev randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
 
   xf86videoark = (mkDerivation "xf86videoark" {
     name = "xf86-video-ark-0.7.5";

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl -w
+#! /usr/bin/env perl
 
 # Typical command to generate the list of tarballs:
 
@@ -11,6 +11,7 @@
 
 
 use strict;
+use warnings;
 
 my $tmpDir = "/tmp/xorg-unpack";
 
@@ -25,7 +26,7 @@ my %pcMap;
 my %extraAttrs;
 
 
-my @missingPCs = ("fontconfig", "libdrm", "libXaw", "zlib", "perl", "python", "mesa", "mkfontscale", "mkfontdir", "bdftopcf", "libxslt", "openssl", "gperf", "m4");
+my @missingPCs = ("fontconfig", "libdrm", "libXaw", "zlib", "perl", "python", "mkfontscale", "mkfontdir", "bdftopcf", "libxslt", "openssl", "gperf", "m4");
 $pcMap{$_} = $_ foreach @missingPCs;
 $pcMap{"freetype2"} = "freetype";
 $pcMap{"libpng12"} = "libpng";
@@ -33,7 +34,7 @@ $pcMap{"libpng"} = "libpng";
 $pcMap{"dbus-1"} = "dbus";
 $pcMap{"uuid"} = "libuuid";
 $pcMap{"libudev"} = "udev";
-$pcMap{"gl"} = "mesa";
+$pcMap{"gl"} = "libGL";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "renderproto";
 $pcMap{"\$DRI3PROTO"} = "dri3proto";
@@ -230,7 +231,7 @@ print OUT "";
 print OUT <<EOF;
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 args @ { clangStdenv, fetchurl, fetchgit, fetchpatch, stdenv, pkgconfig, intltool, freetype, fontconfig
-, libxslt, expat, libpng, zlib, perl, mesa_drivers, spice-protocol
+, libxslt, expat, libpng, zlib, perl, mesa_noglu, mesa_drivers, spice-protocol
 , dbus, libuuid, openssl, gperf, m4, libevdev, tradcpp, libinput, mcpp, makeWrapper, autoreconfHook
 , autoconf, automake, libtool, xmlto, asciidoc, flex, bison, python, mtdev, pixman, ... }: with args;
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -405,7 +405,7 @@ in
   };
 
   xdriinfo = attrs: attrs // {
-    buildInputs = attrs.buildInputs ++ [args.mesa];
+    buildInputs = attrs.buildInputs ++ [args.libGL];
   };
 
   xvinfo = attrs: attrs // {
@@ -465,7 +465,7 @@ in
       version = (builtins.parseDrvName attrs.name).version;
       commonBuildInputs = attrs.buildInputs ++ [ xtrans ];
       commonPropagatedBuildInputs = [
-        args.zlib args.mesa args.dbus
+        args.zlib args.libGL args.mesa_noglu args.dbus
         xf86bigfontproto glproto xf86driproto
         compositeproto scrnsaverproto resourceproto
         xf86dgaproto
@@ -494,7 +494,7 @@ in
       if (!isDarwin)
       then {
         outputs = [ "out" "dev" ];
-        buildInputs = [ makeWrapper ] ++ commonBuildInputs;
+        buildInputs = [ makeWrapper args.libdrm ] ++ commonBuildInputs;
         propagatedBuildInputs = [ libpciaccess args.epoxy ] ++ commonPropagatedBuildInputs ++ lib.optionals stdenv.isLinux [
           args.udev
         ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -515,8 +515,6 @@ in
         ];
         postInstall = ''
           rm -fr $out/share/X11/xkb/compiled # otherwise X will try to write in it
-          wrapProgram $out/bin/Xvfb \
-            --set XORG_DRI_DRIVER_PATH ${args.mesa}/lib/dri
           ( # assert() keeps runtime reference xorgserver-dev in xf86-video-intel and others
             cd "$dev"
             for f in include/xorg/*.h; do

--- a/pkgs/tools/X11/bumblebee/default.nix
+++ b/pkgs/tools/X11/bumblebee/default.nix
@@ -39,7 +39,7 @@ let
   primus = if useNvidia then primusLib else primusLib.override { nvidia_x11 = null; };
   primus_i686 = if useNvidia then primusLib_i686 else primusLib_i686.override { nvidia_x11 = null; };
 
-  primusLibs = lib.makeLibraryPath ([primus] ++ lib.optional (primusLib_i686 != null) primus_i686);
+  primusLibs = lib.makeLibraryPath ([ primus ] ++ lib.optional (primusLib_i686 != null) primus_i686);
 
   nvidia_x11s = [ nvidia_x11 ]
                 ++ lib.optional nvidia_x11.useGLVND libglvnd
@@ -49,7 +49,6 @@ let
   nvidiaLibs = lib.makeLibraryPath nvidia_x11s;
 
   bbdPath = lib.makeBinPath [ kmod xorgserver ];
-  bbdLibs = lib.makeLibraryPath [ libX11 libXext ];
 
   xmodules = lib.concatStringsSep "," (map (x: "${x.out or x}/lib/xorg/modules") ([ xorgserver ] ++ lib.optional (!useNvidia) xf86videonouveau));
 
@@ -133,8 +132,7 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram "$out/sbin/bumblebeed" \
-      --prefix PATH : "${bbdPath}" \
-      --prefix LD_LIBRARY_PATH : "${bbdLibs}"
+      --prefix PATH : "${bbdPath}"
 
     wrapProgram "$out/bin/optirun" \
       --prefix PATH : "${virtualgl}/bin"

--- a/pkgs/tools/X11/primus/lib.nix
+++ b/pkgs/tools/X11/primus/lib.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch
-, libX11, libGL
+, libX11, libGL, mesa_noglu
 , nvidia_x11 ? null
 , libglvnd
 }:
@@ -33,7 +33,7 @@ in stdenv.mkDerivation {
   makeFlags = [ "LIBDIR=$(out)/lib"
                 "PRIMUS_libGLa=${aPackage}/lib/libGL.so"
                 "PRIMUS_libGLd=${libGL}/lib/libGL.so"
-                "PRIMUS_LOAD_GLOBAL=${libGL}/lib/libglapi.so"
+                "PRIMUS_LOAD_GLOBAL=${mesa_noglu}/lib/libglapi.so"
               ];
 
   installPhase = ''

--- a/pkgs/tools/graphics/glxinfo/default.nix
+++ b/pkgs/tools/graphics/glxinfo/default.nix
@@ -1,23 +1,22 @@
-{ stdenv, fetchurl, xlibsWrapper, libGL }:
+{ stdenv, fetchurl, libGL, libX11 }:
 
-let version = "8.3.0"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "glxinfo-${version}";
+  version = "8.3.0";
 
   src = fetchurl {
-    url = "ftp://ftp.freedesktop.org/pub/libGLU_combined/demos/${version}/mesa-demos-${version}.tar.bz2";
+    url = "ftp://ftp.freedesktop.org/pub/mesa/demos/${version}/mesa-demos-${version}.tar.bz2";
     sha256 = "1vqb7s5m3fcg2csbiz45mha1pys2xx6rhw94fcyvapqdpm5iawy1";
   };
 
-  buildInputs = [ xlibsWrapper libGL ];
+  buildInputs = [ libX11 libGL ];
 
   configurePhase = "true";
 
   buildPhase = "
     cd src/xdemos
-    gcc glxinfo.c glinfo_common.c -o glxinfo -lGL -lX11
-    gcc glxgears.c -o glxgears -lGL -lX11
+    $CC glxinfo.c glinfo_common.c -o glxinfo -lGL -lX11
+    $CC glxgears.c -o glxgears -lGL -lX11 -lm
   ";
 
   installPhase = "
@@ -25,7 +24,11 @@ stdenv.mkDerivation {
     cp glxinfo glxgears $out/bin/
   ";
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    description = "Test utilities for OpenGL";
+    homepage = https://www.mesa3d.org/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10498,60 +10498,47 @@ with pkgs;
   ## libGL/libGLU/Mesa stuff
 
   # Default libGL implementation, should provide headers and libGL.so/libEGL.so/... to link agains them
-  # Default implementation is `mesa`, but can be eventually replaced with `libglvnd`,
-  # or other runtime dispatcher
-  libGL = mesa_noglu;
+  libGL = libGLDarwinOr mesa_noglu.stubs;
 
   # Default libGLU
-  libGLU = mesa_glu;
+  libGLU = libGLDarwinOr mesa_glu;
 
   # Combined derivation, contains both libGL and libGLU
   # Please, avoid using this attribute.  It was meant as transitional hack
   # for packages that assume that libGLU and libGL live in the same prefix.
   # libGLU_combined propagates both libGL and libGLU
-  libGLU_combined = mesa;
+  libGLU_combined = libGLDarwinOr (buildEnv {
+    name = "libGLU-combined";
+    paths = [ libGL libGLU ];
+    extraOutputsToInstall = [ "dev" ];
+  });
 
   # Default derivation with libGL.so.1 to link into /run/opengl-drivers (if need)
-  libGL_driver = mesa_drivers;
+  libGL_driver = libGLDarwinOr mesa_drivers;
 
   libGLSupported = lib.elem system lib.platforms.mesaPlatforms;
 
-  libGLDarwinOr = alternative: if stdenv.isDarwin
-    then callPackage ../development/libraries/mesa-darwin {
-      inherit (darwin.apple_sdk.frameworks) OpenGL;
-      inherit (darwin.apple_sdk.libs) Xplugin;
-      inherit (darwin) apple_sdk;
-    }
-    else alternative;
+  libGLDarwin = callPackage ../development/libraries/mesa-darwin {
+    inherit (darwin.apple_sdk.frameworks) OpenGL;
+    inherit (darwin.apple_sdk.libs) Xplugin;
+    inherit (darwin) apple_sdk;
+  };
 
-  # FIXME: should be `libGL = libGLDarwinOr mesa_nonglu` but this change cause mass rebuild,
-  # until all packages will refer to libGL/GLU/GLU combined
-  mesa_noglu = libGLDarwinOr (callPackage ../development/libraries/mesa {
+  libGLDarwinOr = alternative: if stdenv.isDarwin then libGLDarwin else alternative;
+
+  mesa_noglu = callPackage ../development/libraries/mesa {
     # makes it slower, but during runtime we link against just mesa_drivers
     # through /run/opengl-driver*, which is overriden according to config.grsecurity
     # grsecEnabled = true; # no more support in nixpkgs ATM
-  });
+  };
 
-  mesa_glu =  libGLDarwinOr (callPackage ../development/libraries/mesa-glu { });
-  mesa_drivers = libGLDarwinOr (
+  mesa_glu =  callPackage ../development/libraries/mesa-glu { };
+  mesa_drivers =
     let mo = mesa_noglu.override {
       grsecEnabled = config.grsecurity or false;
       enableTextureFloats = true;
     };
-    in mo.drivers
-  );
-
-  # Please, avoid using this attribute.  It was meant as transitional hack
-  # for packages that assume that libGLU and libGL live in the same prefix.
-  # Otherwise it's better to use mesa_glu or mesa_noglu, depending on whether
-  # you need libGLU or not (_glu propagates _noglu).
-  mesa = libGLDarwinOr (buildEnv {
-    name = "mesa-${mesa_noglu.version}";
-    paths = [ mesa_noglu.dev mesa_noglu.out mesa_glu mesa_glu.dev ];
-    meta = {
-      platforms = lib.platforms.unix;
-    };
-  });
+    in mo.drivers;
 
   ## End libGL/libGLU/Mesa stuff
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10328,7 +10328,8 @@ with pkgs;
   });
 
   libva = callPackage ../development/libraries/libva { };
-  libva-full = libva.override { minimal = false; };
+  libva-minimal = libva.override { minimal = true; };
+  libva-full = libva;
   libva-utils = callPackage ../development/libraries/libva-utils { };
 
   libva1 = callPackage ../development/libraries/libva/1.0.0.nix { };
@@ -10336,9 +10337,7 @@ with pkgs;
 
   libvdpau = callPackage ../development/libraries/libvdpau { };
 
-  libvdpau-va-gl = callPackage ../development/libraries/libvdpau-va-gl {
-    libva = libva-full; # also wants libva-{x11}
-  };
+  libvdpau-va-gl = callPackage ../development/libraries/libvdpau-va-gl { };
 
   libvirt = callPackage ../development/libraries/libvirt { };
 
@@ -11109,9 +11108,7 @@ with pkgs;
 
     libopenshot-audio = callPackage ../applications/video/openshot-qt/libopenshot-audio.nix { };
 
-    libqtav = callPackage ../development/libraries/libqtav {
-      libva = libva-full; # also wants libva-x11
-    };
+    libqtav = callPackage ../development/libraries/libqtav { };
 
     kpmcore = callPackage ../development/libraries/kpmcore { };
 
@@ -11644,13 +11641,9 @@ with pkgs;
 
   v8_static = lowPrio (self.v8.override { static = true; });
 
-  vaapiIntel = callPackage ../development/libraries/vaapi-intel {
-    libva = libva-full; # also wants libva-{x11,drm,wayland}
-  };
+  vaapiIntel = callPackage ../development/libraries/vaapi-intel { };
 
-  vaapiVdpau = callPackage ../development/libraries/vaapi-vdpau {
-    libva = libva-full; # needs libva-{x11,glx}
-  };
+  vaapiVdpau = callPackage ../development/libraries/vaapi-vdpau { };
 
   vale = callPackage ../tools/text/vale { };
 
@@ -14706,9 +14699,7 @@ with pkgs;
 
   autopanosiftc = callPackage ../applications/graphics/autopanosiftc { };
 
-  avidemux = libsForQt5.callPackage ../applications/video/avidemux {
-    libva = libva-full;
-  };
+  avidemux = libsForQt5.callPackage ../applications/video/avidemux { };
 
   avogadro = callPackage ../applications/science/chemistry/avogadro {
     eigen = eigen2;
@@ -16732,7 +16723,6 @@ with pkgs;
   mpv = callPackage ../applications/video/mpv rec {
     inherit (luaPackages) luasocket;
     youtube-dl = pythonPackages.youtube-dl;
-    libva      = libva-full;
     waylandSupport     = stdenv.isLinux;
     alsaSupport        = !stdenv.isDarwin;
     pulseSupport       = !stdenv.isDarwin;
@@ -18142,7 +18132,6 @@ with pkgs;
 
   vlc = callPackage ../applications/video/vlc {
     ffmpeg = ffmpeg_2;
-    libva = libva-full; # also wants libva-x11
   };
 
   vlc_npapi = callPackage ../applications/video/vlc/plugin.nix {
@@ -18399,9 +18388,7 @@ with pkgs;
     gtk = gtk2;
   };
 
-  kodiPlain = callPackage ../applications/video/kodi {
-    libva = libva-full;
-  };
+  kodiPlain = callPackage ../applications/video/kodi { };
   xbmcPlain = kodiPlain;
 
   kodiPlugins = recurseIntoAttrs (callPackage ../applications/video/kodi/plugins.nix {});

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12844,12 +12844,11 @@ with pkgs;
     inherit clangStdenv fetchurl fetchgit fetchpatch stdenv intltool freetype fontconfig
       libxslt expat libpng zlib perl mesa_drivers spice-protocol libunwind
       dbus libuuid openssl gperf m4 libevdev tradcpp libinput mcpp makeWrapper autoreconfHook
-      autoconf automake libtool mtdev pixman
+      autoconf automake libtool mtdev pixman libGL
       cairo epoxy;
     inherit (buildPackages) pkgconfig xmlto asciidoc flex bison;
     inherit (darwin) apple_sdk cf-private libobjc;
     bootstrap_cmds = if stdenv.isDarwin then darwin.bootstrap_cmds else null;
-    mesa = libGL;
     python = python2; # Incompatible with Python 3x
     udev = if stdenv.isLinux then udev else null;
     libdrm = if stdenv.isLinux then libdrm else null;


### PR DESCRIPTION
###### Motivation for this change

Side-effect of me making kodi play torrent streams (will PR when this gets merged and staging gets merged into master).

It seems that all uses of `libva` it in nixpkgs except `mesa` and itself actually
either will gain from using `libva-full` instead of `libva-minimal` by default
or simply won't care.

They way it was recursively defined with overrides before was also very
confusing.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Tested compilation of most pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

