### PR TITLE
firehol: 3.1.5: fix errors when running firehol command

### DIFF
--- a/pkgs/applications/networking/firehol/default.nix
+++ b/pkgs/applications/networking/firehol/default.nix
@@ -2,8 +2,8 @@
 , autoconf, automake, curl, iprange, iproute, ipset, iptables, iputils
 , kmod, nettools, procps, tcpdump, traceroute, utillinux, whois
 
-# Just install FireQOS without FireHOL
-, onlyQOS ? true
+# If true, just install FireQOS without FireHOL
+, onlyQOS ? false
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/networking/firehol/default.nix
+++ b/pkgs/applications/networking/firehol/default.nix
@@ -52,6 +52,17 @@ stdenv.mkDerivation rec {
 
            AS_IF([test "x$ac_cv_ping_6_opt" = "xyes"],[
       '')
+
+    # put firehol config files in /etc/firehol (not $out/etc/firehol)
+    # to avoid error on startup, see #35114
+    (pkgs.writeText "firehol-sysconfdir.patch"
+      ''
+      --- a/sbin/install.config.in.in
+      +++ b/sbin/install.config.in.in
+      @@ -4 +4 @@
+      -SYSCONFDIR="@sysconfdir_POST@"
+      +SYSCONFDIR="/etc"
+      '')
   ];
   
   nativeBuildInputs = [ autoconf automake ];

--- a/pkgs/applications/networking/firehol/default.nix
+++ b/pkgs/applications/networking/firehol/default.nix
@@ -63,6 +63,24 @@ stdenv.mkDerivation rec {
       -SYSCONFDIR="@sysconfdir_POST@"
       +SYSCONFDIR="/etc"
       '')
+
+    # we must quote "$UNAME_CMD", or the dash in /nix/store/...-coreutils-.../bin/uname
+    # will be interpreted as IFS -> error. this might be considered an upstream bug
+    # but only appears when there are dashes in the command path
+    (pkgs.writeText "firehol-uname-command.patch"
+      ''
+      --- a/sbin/firehol
+      +++ b/sbin/firehol
+      @@ -10295,7 +10295,7 @@
+       	kmaj=$1
+       	kmin=$2
+       
+      -	set -- $($UNAME_CMD -r)
+      +	set -- $("$UNAME_CMD" -r)
+       	eval $kmaj=\$1 $kmin=\$2
+       }
+       kernel_maj_min KERNELMAJ KERNELMIN
+      '')
   ];
   
   nativeBuildInputs = [ autoconf automake ];


### PR DESCRIPTION
###### Motivation for this change

Fix two separate issues that made the firehol command unusable, see #35114 
 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

