### PR TITLE
hydra: fix build with gcc7, incl. libpqxx update

### DIFF
--- a/pkgs/development/libraries/libpqxx/default.nix
+++ b/pkgs/development/libraries/libpqxx/default.nix
@@ -1,14 +1,18 @@
-{ lib, stdenv, fetchurl, postgresql, python2, gnused }:
+{ lib, stdenv, fetchFromGitHub, postgresql, python2, gnused }:
 
 stdenv.mkDerivation rec {
-  name = "libpqxx-4.0.1";
+  name = "libpqxx-${version}";
+  version = "6.1.0";
 
-  src = fetchurl {
-    url = "http://pqxx.org/download/software/libpqxx/${name}.tar.gz";
-    sha256 = "0f6wxspp6rx12fkasanb0z2g2gc8dhcfwnxagx8wwqbpg6ifsz09";
+  src = fetchFromGitHub {
+    owner = "jtv";
+    repo = "libpqxx";
+    rev = version;
+    sha256 = "1dv96h10njg115216n2zm6fsvi4kb502hmhhn8cjhlfbxr9vc84q";
   };
 
-  buildInputs = [ postgresql python2 gnused ];
+  nativeBuildInputs = [ gnused python2 ];
+  buildInputs = [ postgresql ];
 
   preConfigure = ''
     patchShebangs .

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -79,17 +79,6 @@ in releaseTools.nixBuild rec {
       guile # optional, for Guile + Guix support
       perlDeps perl nixUnstable
       postgresql # for running the tests
-      (lib.overrideDerivation (aws-sdk-cpp.override {
-        apis = ["s3"];
-        customMemoryManagement = false;
-      }) (attrs: {
-        src = fetchFromGitHub {
-          owner = "edolstra";
-          repo = "aws-sdk-cpp";
-          rev = "local";
-          sha256 = "1vhgsxkhpai9a7dk38q4r239l6dsz2jvl8hii24c194lsga3g84h";
-        };
-      }))
     ];
 
   hydraPath = lib.makeBinPath (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10049,9 +10049,7 @@ with pkgs;
 
   libpfm = callPackage ../development/libraries/libpfm { };
 
-  libpqxx = callPackage ../development/libraries/libpqxx {
-    gnused = gnused_422;
-  };
+  libpqxx = callPackage ../development/libraries/libpqxx { };
 
   libproxy = callPackage ../development/libraries/libproxy {
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration CoreFoundation JavaScriptCore;


### PR DESCRIPTION
It builds, but it's otherwise untested.

I'm only concerned about the libpqxx update: it fixes the language issues rejected by gcc7, but it's a larger update, so there's some chance there was a semantic change that didn't break the build.  Therefore I'm not merging this until it gets some testing or someone knowing the Hydra's source verifies it's OK.  /cc maintainer @edolstra.