### PR TITLE
pythonPackages.pynacl: use system libsodium

### DIFF
--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -11,14 +11,14 @@ buildPythonPackage rec {
     sha256 = "0z9i1z4hjzmp23igyhvg131gikbrr947506lwfb3fayf0agwfv8f";
   };
 
-  #set timeout to unlimited, remove deadline from tests, see https://github.com/pyca/pynacl/issues/370
+  # set timeout to unlimited, remove deadline from tests, see https://github.com/pyca/pynacl/issues/370
   patches = [ ./pynacl-no-timeout-and-deadline.patch ];
 
-  checkInputs = [ pytest coverage hypothesis ];
+  checkInputs = [ pytest hypothesis ];
   propagatedBuildInputs = [ libsodium cffi six ];
 
   checkPhase = ''
-    coverage run --source nacl --branch -m pytest
+    py.test
   '';
   
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -17,6 +17,8 @@ buildPythonPackage rec {
   checkInputs = [ pytest hypothesis ];
   propagatedBuildInputs = [ libsodium cffi six ];
 
+  SODIUM_INSTALL = "system";
+
   checkPhase = ''
     py.test
   '';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @va1entin 