### PR TITLE
docker_compose : 1.18.0 -> 1.19.0

### DIFF
--- a/pkgs/development/python-modules/docker_compose/default.nix
+++ b/pkgs/development/python-modules/docker_compose/default.nix
@@ -6,12 +6,12 @@
 , enum34, functools32,
 }:
 buildPythonApplication rec {
-  version = "1.18.0";
+  version = "1.19.0";
   pname = "docker-compose";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2930cbfe2685018fbb75377600ab6288861d9955717b3f14212f63950351d379";
+    sha256 = "02zgbwf0ffiazswhyangdfhnxia2i43a40rbi67sz2nqnzjf09zj";
   };
 
   # lots of networking and other fails


### PR DESCRIPTION
Update Docker Compose to the latest version released. Various bugfixes and updates as specified at https://github.com/docker/compose/releases/tag/1.19.0

Tested locally and verify that bugs present in 1.18.0 (with some complex compose files) are fixed.

###### Use latest release with bugfixes and updates 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

