### PR TITLE
buildkite-agent service: declarative hooks and extraConfig option

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -76,8 +76,10 @@ in
       meta-data = mkOption {
         type = types.str;
         default = "";
+        example = "queue=default,docker=true,ruby2=true";
         description = ''
-          Meta data for the agent.
+          Meta data for the agent. This is a comma-separated list of
+          <code>key=value</code> pairs.
         '';
       };
 

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -68,6 +68,7 @@ in
 
       name = mkOption {
         type = types.str;
+        default = "%hostname-%n";
         description = ''
           The name of the agent.
         '';

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -65,6 +65,15 @@ in
         '';
       };
 
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = "debug=true";
+        description = ''
+          Extra lines to be added verbatim to the configuration file.
+        '';
+      };
+
       openssh =
         { privateKeyPath = mkOption {
             type = types.path;
@@ -126,6 +135,7 @@ in
             build-path="${cfg.dataDir}/builds"
             hooks-path="${cfg.hooksPath}"
             bootstrap-script="${pkgs.buildkite-agent}/share/bootstrap.sh"
+            ${cfg.extraConfig}
             EOF
           '';
 

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -220,7 +220,6 @@ in
             meta-data="${cfg.meta-data}"
             build-path="${cfg.dataDir}/builds"
             hooks-path="${cfg.hooksPath}"
-            bootstrap-script="${pkgs.buildkite-agent}/share/bootstrap.sh"
             ${cfg.extraConfig}
             EOF
           '';


### PR DESCRIPTION
###### Motivation for this change

I thought it would be better to be able to set hook scripts as module options rather than manually creating a directory with script files.

There are other possible settings in the buildkite-agent config file which aren't covered by module options, so I have added an `extraConfig` option to handle those.

There are also other minor tweaks to the module.

The option changes are backwards compatible.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested NixOS module with Buildkite service.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @deepfire @zimbatm @domenkozar