### PR TITLE
ecm-tools: init at 1.0.3

### DIFF
--- a/pkgs/tools/cd-dvd/ecm-tools/default.nix
+++ b/pkgs/tools/cd-dvd/ecm-tools/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "ecm-tools-${version}";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "alucryd";
+    repo = "ecm-tools";
+    rev = "v${version}";
+    sha256 = "1rvyx5gcy8lfklgj80szlz3312x45wzx0d9jsgwyvy8f6m4nnb0c";
+  };
+
+  dontConfigure = true;
+
+  installPhase = ''
+    install --directory --mode=755 $out/bin
+    install --mode=755 bin2ecm $out/bin
+    (cd $out/bin; ln -s bin2ecm ecm2bin)
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A utility to uncompress ECM files to BIN CD format";
+    homepage = https://github.com/alucryd/ecm-tools;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1982,6 +1982,8 @@ with pkgs;
     # customConfig = builtins.readFile ./dvtm.config.h;
   };
 
+  ecmtools = callPackage ../tools/cd-dvd/ecm-tools { };
+
   e2tools = callPackage ../tools/filesystems/e2tools { };
 
   e2fsprogs = callPackage ../tools/filesystems/e2fsprogs { };


### PR DESCRIPTION
###### Motivation for this change

New package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

