### PR TITLE
mfcl2720dwlpr / mfcl2720dwcupswrapper: init at 3.2.0-1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -763,6 +763,7 @@
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
   xaverdh = "Dominik Xaver Hörl <hoe.dom@gmx.de>";
+  xeji = "xeji <xeji@cat3.de>";
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
   xurei = "Olivier Bourdoux <olivier.bourdoux@gmail.com>";
   xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";

--- a/pkgs/misc/cups/drivers/mfcl2720dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2720dwcupswrapper/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, dpkg, makeWrapper, coreutils, gnugrep, gnused, perl, mfcl2720dwlpr }:
+
+stdenv.mkDerivation rec {
+  name = "mfcl2720dwcupswrapper-${version}";
+  version = "3.2.0-1";
+
+  src = fetchurl {
+    url = "http://download.brother.com/welcome/dlf101802/${name}.i386.deb";
+    sha256 = "6d131926ce22c51b1854d2b91e426cc7ecbf5d6dabd698ef51a417090e35c598";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    basedir=${mfcl2720dwlpr}/opt/brother/Printers/MFCL2720DW
+    dir=$out/opt/brother/Printers/MFCL2720DW
+
+    substituteInPlace $dir/cupswrapper/brother_lpdwrapper_MFCL2720DW \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "basedir =~" "basedir = \"$basedir\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"MFCL2720DW\"; #"
+
+    substituteInPlace $dir/cupswrapper/paperconfigml1 \
+      --replace /usr/bin/perl ${perl}/bin/perl
+
+    wrapProgram $dir/cupswrapper/brother_lpdwrapper_MFCL2720DW \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gnugrep gnused ]}
+
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    ln $dir/cupswrapper/brother_lpdwrapper_MFCL2720DW $out/lib/cups/filter
+    ln $dir/cupswrapper/brother-MFCL2720DW-cups-en.ppd $out/share/cups/model
+  '';
+
+  meta = {
+    description = "Brother MFC-L2720DW CUPS wrapper driver";
+    homepage = http://www.brother.com/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ stdenv.lib.maintainers.xeji ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcl2720dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2720dwlpr/default.nix
@@ -1,0 +1,45 @@
+{ pkgs, stdenv, fetchurl, dpkg, makeWrapper, coreutils, ghostscript, gnugrep, gnused, which, perl }:
+
+stdenv.mkDerivation rec {
+  name = "mfcl2720dwlpr-${version}";
+  version = "3.2.0-1";
+
+  src = fetchurl {
+    url = "http://download.brother.com/welcome/dlf101801/${name}.i386.deb";
+    sha256 = "088217e9ad118ec1e7f3d3f8f60f3bd839fe2c7d7c1136b249e9ac648dc742af";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    dir=$out/opt/brother/Printers/MFCL2720DW
+
+    substituteInPlace $dir/lpd/filter_MFCL2720DW \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"MFCL2720DW\"; #"
+
+    wrapProgram $dir/lpd/filter_MFCL2720DW \
+      --prefix PATH : ${stdenv.lib.makeBinPath [
+        coreutils ghostscript gnugrep gnused which
+      ]}
+
+    # need to use i686 glibc here, these are 32bit proprietary binaries
+    interpreter=${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2
+    patchelf --set-interpreter "$interpreter" $dir/inf/braddprinter
+    patchelf --set-interpreter "$interpreter" $dir/lpd/brprintconflsr3
+    patchelf --set-interpreter "$interpreter" $dir/lpd/rawtobr3
+  '';
+
+  meta = {
+    description = "Brother MFC-L2720DW lpr driver";
+    homepage = http://www.brother.com/;
+    license = stdenv.lib.licenses.unfree;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ stdenv.lib.maintainers.xeji ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20205,6 +20205,7 @@ with pkgs;
   mfcl2700dncupswrapper = callPackage ../misc/cups/drivers/mfcl2700dncupswrapper { };
   mfcl2700dnlpr = callPackage_i686 ../misc/cups/drivers/mfcl2700dnlpr { };
 
+  mfcl2720dwcupswrapper = callPackage ../misc/cups/drivers/mfcl2720dwcupswrapper { };
   mfcl2720dwlpr = callPackage ../misc/cups/drivers/mfcl2720dwlpr { };
 
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20205,6 +20205,8 @@ with pkgs;
   mfcl2700dncupswrapper = callPackage ../misc/cups/drivers/mfcl2700dncupswrapper { };
   mfcl2700dnlpr = callPackage_i686 ../misc/cups/drivers/mfcl2700dnlpr { };
 
+  mfcl2720dwlpr = callPackage ../misc/cups/drivers/mfcl2720dwlpr { };
+
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung { };
   samsung-unified-linux-driver_4_01_17 = callPackage ../misc/cups/drivers/samsung/4.01.17.nix { };
   samsung-unified-linux-driver = callPackage ../misc/cups/drivers/samsung/4.00.39 { };


### PR DESCRIPTION
###### Motivation for this change

Brother MFC-L2720DW printer drivers. Contains two packages, mfcl2720dwlpr and mfcl2720dwcupswrapper. Put them in one PR since the second package depends on the first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

