### PR TITLE
cue2pops: init at git-2018-01-04

### DIFF
--- a/pkgs/tools/cd-dvd/cue2pops/default.nix
+++ b/pkgs/tools/cd-dvd/cue2pops/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   dontConfigure = true;
 
+  makeFlags = ["CC=cc"];
+
   installPhase = ''
     install --directory --mode=755 $out/bin
     install --mode=755 cue2pops $out/bin

--- a/pkgs/tools/cd-dvd/cue2pops/default.nix
+++ b/pkgs/tools/cd-dvd/cue2pops/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "cue2pops-${version}";
+  version = "git-2018-01-04";
+
+  src = fetchFromGitHub {
+    owner = "makefu";
+    repo = "cue2pops-linux";
+    rev = "541863adf23fdecde92eba5899f8d58586ca4551";
+    sha256 = "05w84726g3k33rz0wwb9v77g7xh4cnhy9sxlpilf775nli9bynrk";
+  };
+
+  dontConfigure = true;
+
+  installPhase = ''
+    install --directory --mode=755 $out/bin
+    install --mode=755 cue2pops $out/bin
+  '';
+
+  meta = {
+    description = "Convert CUE to ISO suitable to POPStarter";
+    homepage = https://github.com/makefu/cue2pops-linux;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -886,6 +886,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  cue2pops = callPackage ../tools/cd-dvd/cue2pops { };
+
   cabal2nix = haskell.lib.overrideCabal haskellPackages.cabal2nix (drv: {
     isLibrary = false;
     enableSharedExecutables = false;


### PR DESCRIPTION
###### Motivation for this change

New package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

