### PR TITLE
virtmanager: 1.4.3 -> 1.5.0, cleanup dependencies

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -61,6 +61,8 @@ python2Packages.buildPythonApplication rec {
       manages Xen and LXC (linux containers).
     '';
     license = licenses.gpl2;
+    # exclude Darwin since libvirt-glib currently doesn't build there
+    platforms = platforms.linux;
     maintainers = with maintainers; [ qknight offline fpletz ];
   };
 }

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, python2Packages, intltool, file
 , wrapGAppsHook, gtkvnc, vte, avahi, dconf
 , gobjectIntrospection, libvirt-glib, system-libvirt
-, gsettings_desktop_schemas, glib, libosinfo, gnome3
+, gsettings_desktop_schemas, glib, libosinfo, gnome3, gtk3
 , spiceSupport ? true, spice_gtk ? null
 }:
 
@@ -24,7 +24,7 @@ python2Packages.buildPythonApplication rec {
 
   buildInputs =
     [ libvirt-glib vte dconf gtkvnc gnome3.defaultIconTheme avahi
-      gsettings_desktop_schemas libosinfo
+      gsettings_desktop_schemas libosinfo gtk3
     ] ++ optional spiceSupport spice_gtk;
 
   propagatedBuildInputs = with python2Packages;

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python2Packages, intltool, file
-, wrapGAppsHook, virtinst, gtkvnc, vte, avahi, dconf
+, wrapGAppsHook, gtkvnc, vte, avahi, dconf
 , gobjectIntrospection, libvirt-glib, system-libvirt
 , gsettings_desktop_schemas, glib, libosinfo, gnome3
 , spiceSupport ? true, spice_gtk ? null
@@ -9,12 +9,12 @@ with stdenv.lib;
 
 python2Packages.buildPythonApplication rec {
   name = "virt-manager-${version}";
-  version = "1.4.3";
+  version = "1.5.0";
   namePrefix = "";
 
   src = fetchurl {
     url = "http://virt-manager.org/download/sources/virt-manager/${name}.tar.gz";
-    sha256 = "093azs8p4p7y4nf5j25xpsvdxww7gky1g0hs8mkcvmpxl2wjd0jj";
+    sha512 = "b375927776b9132fbd9dacd8223b6c94b89c32d6812394ec7e18df7c66f7e6dec853885e85e2b4b4ffd283e8afe0dd2526bafeac4b55511a4a115ef5798f97da";
   };
 
   nativeBuildInputs = [
@@ -23,15 +23,13 @@ python2Packages.buildPythonApplication rec {
   ];
 
   buildInputs =
-    [ libvirt-glib vte virtinst dconf gtkvnc gnome3.defaultIconTheme avahi
+    [ libvirt-glib vte dconf gtkvnc gnome3.defaultIconTheme avahi
       gsettings_desktop_schemas libosinfo
     ] ++ optional spiceSupport spice_gtk;
 
   propagatedBuildInputs = with python2Packages;
-    [ eventlet greenlet gflags netaddr carrot routes PasteDeploy
-      m2crypto ipy twisted distutils_extra simplejson
-      cheetah lockfile httplib2 urlgrabber pyGtkGlade dbus-python
-      pygobject3 ipaddr mox libvirt libxml2 requests
+    [
+      pygobject3 ipaddr libvirt libxml2 requests
     ];
 
   patchPhase = ''

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -14,7 +14,7 @@ python2Packages.buildPythonApplication rec {
 
   src = fetchurl {
     url = "http://virt-manager.org/download/sources/virt-manager/${name}.tar.gz";
-    sha512 = "b375927776b9132fbd9dacd8223b6c94b89c32d6812394ec7e18df7c66f7e6dec853885e85e2b4b4ffd283e8afe0dd2526bafeac4b55511a4a115ef5798f97da";
+    sha256 = "d43a7b99d40acdcb8e9455e7874beee132cfcfce9eed0d6252e8f254a82cadc6";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -35,6 +35,6 @@ in stdenv.mkDerivation rec {
     '';
     homepage = http://libvirt.org/;
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -35,6 +35,6 @@ in stdenv.mkDerivation rec {
     '';
     homepage = http://libvirt.org/;
     license = licenses.lgpl2Plus;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
remove unneeded dependencies.
closes issue #34043 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc maintainers:  @qknight @offlinehacker  @fpletz 
