### PR TITLE
pythonPackages.faulthandler: fix tests

### DIFF
--- a/pkgs/development/python-modules/faulthandler/default.nix
+++ b/pkgs/development/python-modules/faulthandler/default.nix
@@ -1,7 +1,6 @@
-{ stdenv, fetchPypi, buildPythonPackage }:
+{ stdenv, fetchPypi, buildPythonPackage, fetchpatch }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "faulthandler";
   version = "3.0";
 
@@ -9,6 +8,17 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "acc10e10909f0f956ba1b42b6c450ea0bdaaa27b3942899f65931396cfcdd36a";
   };
+
+  patches = [
+    (fetchpatch {
+      url = https://github.com/vstinner/faulthandler/commit/67b661e.patch;
+      sha256 = "1nn8c9nq5qypja949hzz0n4yprsyr63wihf5g3gwrinm2nkjnnv7";
+    })
+    (fetchpatch {
+      url = https://github.com/vstinner/faulthandler/commit/07cbb7b.patch;
+      sha256 = "0fh6rjyjw7z1hsiy3sgdc8j9mncg1vlv3y0h4bplqyw18vq3srb3";
+    })
+  ];
 
   meta = {
     description = "Dump the Python traceback";


### PR DESCRIPTION
The added patches accept "python2.7" as thread name in tests.

###### Motivation for this change
closes #34415

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

