### PR TITLE
[RDY] pythonPackages.cmd2: 0.7.7 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   LC_ALL="en_US.UTF-8";
 
-  postPatch = stdenv.isDarwin ''
+  postPatch = stdenv.lib.optional stdenv.isDarwin ''
     # Fake the impure dependencies pbpaste and pbcopy
     mkdir bin
     echo '#/bin/sh' > bin/pbpaste

--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     mkdir bin
     echo '#/bin/sh' > bin/pbpaste
     echo '#/bin/sh' > bin/pbcopy
-    chmod +x bin/{pbpaste,bpcopy}
+    chmod +x bin/{pbcopy,pbpaste}
     export PATH=$(realpath bin):$PATH
   '';
 

--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
     # test_path_completion_user_expansion might be fixed in the next release
     py.test -k 'not test_path_completion_user_expansion'
   '';
+  doCheck = !stdenv.isDarwin;
 
   propagatedBuildInputs = [
     pyperclip

--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -16,6 +16,15 @@ buildPythonPackage rec {
 
   LC_ALL="en_US.UTF-8";
 
+  postPatch = stdenv.isDarwin ''
+    # Fake the impure dependencies pbpaste and pbcopy
+    mkdir bin
+    echo '#/bin/sh' > bin/pbpaste
+    echo '#/bin/sh' > bin/pbcopy
+    chmod +x bin/{pbpaste,bpcopy}
+    export PATH=$(realpath bin):$PATH
+  '';
+
   checkInputs= [ pytest mock which vim glibcLocales ];
   checkPhase = ''
     # test_path_completion_user_expansion might be fixed in the next release

--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -1,0 +1,36 @@
+{stdenv, fetchPypi, buildPythonPackage, pythonOlder
+, pyperclip, six, pyparsing
+, contextlib2 ? null, subprocess32 ? null
+, pytest, mock, which
+}:
+buildPythonPackage rec {
+  pname = "cmd2";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fmpn3dwc0pyhdi6q877mb8i4vw9p9a0lgmrvsaclfah62grsfjb";
+  };
+
+  # 25 out of 191 tests failed
+  doCheck=false;
+  checkInputs= [ pytest mock which ];
+  checkPhase = ''
+    py.test
+  '';
+
+  propagatedBuildInputs = [
+    pyperclip
+    six
+    pyparsing
+  ]
+  ++ stdenv.lib.optional (pythonOlder "3.5") contextlib2
+  ++ stdenv.lib.optional (pythonOlder "3.0") subprocess32
+  ;
+
+  meta = with stdenv.lib; {
+    description = "Enhancements for standard library's cmd module";
+    homepage = https://github.com/python-cmd2/cmd2;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -1,22 +1,25 @@
-{stdenv, fetchPypi, buildPythonPackage, pythonOlder
-, pyperclip, six, pyparsing
+{ stdenv, fetchPypi, buildPythonPackage, pythonOlder
+, pyperclip, six, pyparsing, vim
 , contextlib2 ? null, subprocess32 ? null
-, pytest, mock, which
+, pytest, mock, which, fetchFromGitHub, glibcLocales
 }:
 buildPythonPackage rec {
   pname = "cmd2";
   version = "0.8.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1fmpn3dwc0pyhdi6q877mb8i4vw9p9a0lgmrvsaclfah62grsfjb";
+  src = fetchFromGitHub {
+    owner = "python-cmd2";
+    repo = "cmd2";
+    rev = version;
+    sha256 = "0nw2b7n7zg51bc3glxw0l9fn91mwjnjshklhmxhyvjbsg7khf64z";
   };
 
-  # 25 out of 191 tests failed
-  doCheck=false;
-  checkInputs= [ pytest mock which ];
+  LC_ALL="en_US.UTF-8";
+
+  checkInputs= [ pytest mock which vim glibcLocales ];
   checkPhase = ''
-    py.test
+    # test_path_completion_user_expansion might be fixed in the next release
+    py.test -k 'not test_path_completion_user_expansion'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11829,29 +11829,7 @@ in {
    cachetools_1 = callPackage ../development/python-modules/cachetools/1.nix {};
    cachetools = callPackage ../development/python-modules/cachetools {};
 
-  cmd2 = buildPythonPackage rec {
-    name = "cmd2-${version}";
-    version = "0.7.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/cmd2/${name}.tar.gz";
-      sha256 = "0widbir8ay1fd4zm8l0rjq78j1cvbammbz8xs32crbanqsgzpqml";
-    };
-
-    # No tests included
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [
-      pyperclip
-      six
-      pyparsing
-    ];
-
-    meta = with stdenv.lib; {
-      description = "Enhancements for standard library's cmd module";
-      homepage = "http://packages.python.org/cmd2/";
-    };
-  };
+  cmd2 = callPackage ../development/python-modules/cmd2 {};
 
  warlock = buildPythonPackage rec {
    name = "warlock-${version}";


### PR DESCRIPTION
Some cool stuff like history saving to transcripts, support for argparse
based parsers etc:
https://github.com/python-cmd2/cmd2/blob/master/CHANGELOG.md

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

