### PR TITLE
mackup: init at 0.8.16

### DIFF
--- a/pkgs/tools/backup/mackup/default.nix
+++ b/pkgs/tools/backup/mackup/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchurl
+, python2Packages
+, stdenv
+}:
+
+python2Packages.buildPythonApplication rec {
+    name = "mackup-0.8.16";
+
+    src = fetchurl {
+        url = "https://pypi.python.org/packages/e5/3a/e8a422e88dab6f734706a7612adc4715cc44512d48845295ceea7a9fc244/${name}.tar.gz";
+        sha256 = "0f5cb5srxa3bn7lbfs5rb4iqjs57blzvgypivndy756vsvm9ijrv";
+    };
+
+    "docopt" = python2Packages.buildPythonPackage {
+        name = "docopt-0.6.2";
+        doCheck = false;
+        src = fetchurl {
+            url = "https://pypi.python.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz";
+            sha256 = "14f4hn6d1j4b99svwbaji8n2zj58qicyz19mm0x6pmhb50jsics9";
+        };
+    };
+
+    propagatedBuildInputs = [ docopt ];
+
+    meta = with stdenv.lib; {
+        homepage = https://github.com/lra/mackup;
+        description = "Keep your application settings in sync (OS X/Linux)";
+        license = licenses.gpl3;
+        maintainers = with maintainers; [ joshuaks ];
+    };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3431,6 +3431,8 @@ with pkgs;
 
   macchanger = callPackage ../os-specific/linux/macchanger { };
 
+  mackup = callPackage ../tools/backup/mackup { };
+
   madlang = haskell.lib.justStaticExecutables haskellPackages.madlang;
 
   mailcheck = callPackage ../applications/networking/mailreaders/mailcheck { };


### PR DESCRIPTION
###### Motivation for this change

New application [mackup](https://github.com/lra/mackup) for handling dot files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

~~- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)~~ (I think this is broken on darwin at the moment)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
