### PR TITLE
nixos/tests: fix test failure due to preferTempAddress changes

### DIFF
--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -47,7 +47,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       # Detection).
       sub waitForAddress {
           my ($machine, $iface, $scope) = @_;
-          $machine->waitUntilSucceeds("[ `ip -o -6 addr show dev $iface scope $scope | grep -v tentative | wc -l` -eq 1 ]");
+          $machine->waitUntilSucceeds("[ `ip -o -6 addr show dev $iface scope $scope | grep -v tentative | wc -l` -ge 1 ]");
           my $ip = (split /[ \/]+/, $machine->succeed("ip -o -6 addr show dev $iface scope $scope"))[3];
           $machine->log("$scope address on $iface is $ip");
           return $ip;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/34492#issuecomment-366635668

###### Things done
- [x] builds nixos/tests/ipv6.nix
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @vcunat
