### PR TITLE
 pythonPackages.magic-wormhole: 0.10.4 -> 0.10.5

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, twisted, mock }:
+
+buildPythonPackage rec {
+  pname = "magic-wormhole-transit-relay";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "faac36266c72745102a1a8b93abc5b25feed1be5bca7b29968a156966c312567";
+  };
+
+  propagatedBuildInputs = [ twisted ];
+
+  checkInputs = [ mock ];
+
+  checkPhase = ''
+    python -m twisted.trial wormhole_transit_relay
+  '';
+
+  meta = with lib; {
+    description = "Transit Relay server for Magic-Wormhole";
+    homepage = https://github.com/warner/magic-wormhole-transit-relay;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -2,37 +2,38 @@
 , buildPythonPackage
 , fetchPypi
 , pythonAtLeast
+, python
+, spake2
+, pynacl
+, six
+, attrs
+, twisted
+, autobahn
+, automat
+, hkdf
+, tqdm
+, click
+, humanize
+, ipaddress
+, txtorcon
 , nettools
 , glibcLocales
-, autobahn
-, cffi
-, click
-, hkdf
-, pynacl
-, spake2
-, tqdm
-, python
 , mock
-, ipaddress
-, humanize
-, pyopenssl
-, service-identity
-, txtorcon
+, magic-wormhole-transit-relay
 }:
 
 buildPythonPackage rec {
   pname = "magic-wormhole";
   version = "0.10.5";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "9558ea1f3551e535deec3462cd5c8391cb32ebb12ecd8b40b36861dbee4917ee";
   };
 
-  checkInputs = [ mock ];
+  checkInputs = [ mock magic-wormhole-transit-relay ];
   buildInputs = [ nettools glibcLocales ];
-  propagatedBuildInputs = [ autobahn cffi click hkdf pynacl spake2 tqdm ipaddress humanize pyopenssl service-identity txtorcon ];
+  propagatedBuildInputs = [ spake2 pynacl six attrs twisted autobahn automat hkdf tqdm click humanize ipaddress txtorcon ];
 
   postPatch = ''
     sed -i -e "s|'ifconfig'|'${nettools}/bin/ifconfig'|" src/wormhole/ipaddrs.py

--- a/pkgs/development/python-modules/spake2/default.nix
+++ b/pkgs/development/python-modules/spake2/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, hkdf, pytest }:
+
+buildPythonPackage rec {
+  pname = "spake2";
+  version = "0.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c17a614b29ee4126206e22181f70a406c618d3c6c62ca6d6779bce95e9c926f4";
+  };
+
+  checkInputs = [ pytest ];
+
+  propagatedBuildInputs = [ hkdf ];
+
+  checkPhase = ''
+    py.test $out
+  '';
+
+  meta = with lib; {
+    description = "SPAKE2 password-authenticated key exchange library";
+    homepage = "http://github.com/warner/python-spake2";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15889,29 +15889,7 @@ in {
     };
   };
 
-  spake2 = buildPythonPackage rec {
-    name = "spake2-${version}";
-    version = "0.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/spake2/${name}.tar.gz";
-      sha256 = "0rmplicbbid41qrvwc1ckyp211ban01ardms5yqqq16ixrc18a6j";
-    };
-
-    buildInputs = with self; [ pytest ];
-
-    propagatedBuildInputs = with self; [ hkdf ];
-
-    checkPhase = ''
-      py.test $out
-    '';
-
-    meta = {
-      description = "SPAKE2 password-authenticated key exchange library";
-      homepage = "http://github.com/warner/python-spake2";
-      license = licenses.mit;
-    };
-  };
+  spake2 = callPackage ../development/python-modules/spake2 { };
 
   sphfile = callPackage ../development/python-modules/sphfile { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18170,6 +18170,8 @@ EOF
 
   magic-wormhole = callPackage ../development/python-modules/magic-wormhole { };
 
+  magic-wormhole-transit-relay = callPackage ../development/python-modules/magic-wormhole-transit-relay { };
+
   wsgiproxy2 = buildPythonPackage rec {
     name = "WSGIProxy2-0.4.2";
 


### PR DESCRIPTION
###### Motivation for this change
magic-wormhole is broken on master

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @asymmetric 