### PR TITLE
mono: add 5.8.108 (current stable)

### DIFF
--- a/pkgs/development/compilers/mono/5.8.nix
+++ b/pkgs/development/compilers/mono/5.8.nix
@@ -1,0 +1,8 @@
+{ stdenv, callPackage, Foundation, libobjc }:
+
+callPackage ./generic-cmake.nix (rec {
+  inherit Foundation libobjc;
+  version = "5.8.0.108";
+  sha256 = "177khb06dfll0pcncr84vvibni7f8m5fgb30ndgsdjk25xfcbmzc";
+  enableParallelBuilding = false;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6511,6 +6511,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   });
 
+  mono58 = lowPrio (callPackage ../development/compilers/mono/5.8.nix {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  });
+
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
   mozart-binary = callPackage ../development/compilers/mozart/binary.nix { };


### PR DESCRIPTION
###### Motivation for this change

Duh.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (there are none)
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

