### PR TITLE
sddm: minor refactoring, test both with and without plasma5

### DIFF
--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -5,18 +5,16 @@ with import ../lib/testing.nix { inherit system; };
 let
   inherit (pkgs) lib;
 
-  tests = {
-    default = {
-      name = "sddm";
+  mkLoginTest = suffix: extraMachineConfig: {
+      name = "sddm-${suffix}";
 
-      machine = { lib, ... }: {
+      machine = { lib, ... }: lib.recursiveUpdate {
         imports = [ ./common/user-account.nix ];
         services.xserver.enable = true;
         services.xserver.displayManager.sddm.enable = true;
         services.xserver.windowManager.default = "icewm";
         services.xserver.windowManager.icewm.enable = true;
-        services.xserver.desktopManager.default = "none";
-      };
+      } extraMachineConfig;
 
       enableOCR = true;
 
@@ -31,7 +29,11 @@ let
         $machine->succeed("xauth merge ~alice/.Xauthority");
         $machine->waitForWindow("^IceWM ");
       '';
-    };
+  };
+
+  tests = {
+    default = mkLoginTest "default" {};
+    plasma5 = mkLoginTest "with-plasma5" { services.xserver.desktopManager.plasma5.enable = true; };
 
     autoLogin = {
       name = "sddm-autologin";


### PR DESCRIPTION
Introduce test for SDDM+Plasma5, currently fails (locally, anyway?).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---