### PR TITLE
yarssr: init at git-2017-12-01

### DIFF
--- a/pkgs/applications/misc/yarssr/default.nix
+++ b/pkgs/applications/misc/yarssr/default.nix
@@ -1,0 +1,68 @@
+{
+fetchFromGitHub, stdenv, lib,
+autoreconfHook, intltool, pkgconfig, makeWrapper, pkgs,
+perl, perlPackages,
+gnome2 }:
+
+let
+  perlDeps = with perlPackages; [
+    Glib Gtk2 Gnome2 Pango Cairo Gnome2Canvas Gnome2VFS Gtk2GladeXML Gtk2TrayIcon
+    XMLLibXML XMLSAXBase XMLParser XMLRSS
+    HTMLParser
+    DateTime DateTimeFormatMail DateTimeFormatW3CDTF DateTimeLocale DateTimeTimeZone
+    ParamsValidate
+    ModuleImplementation ModuleRuntime
+    TryTiny
+    ClassSingleton
+    URI
+    AnyEvent AnyEventHTTP
+    CommonSense
+    FileSlurp
+    JSON
+    Guard
+    LocaleGettext
+  ];
+  libs = [
+    stdenv.cc.cc.lib
+    pkgs.gtk2
+  ];
+in
+stdenv.mkDerivation rec {
+  version = "git-2017-12-01";
+  name = "yarssr-${version}";
+
+  src = fetchFromGitHub {
+    owner = "JGRennison";
+    repo = "yarssr";
+    rev = "e70eb9fc6563599bfb91c6de6a79654de531c18d";
+    sha256 = "0x7hz8x8qyp3i1vb22zhcnvwxm3jhmmmlr22jqc5b09vpmbw1l45";
+  };
+
+  nativeBuildInputs = [ perl pkgs.gettext makeWrapper ];
+  buildInputs = perlDeps ++ [gnome2.libglade];
+  propagatedBuildInputs = libs ++ perlDeps;
+
+  installPhase = ''
+    DESTDIR=$out make install
+    mv $out/usr/* $out/
+    rm -R $out/usr
+    sed -i -r "s!use lib [^;]+;!use lib '$out/share/yarssr';!" $out/bin/yarssr
+    sed -i -r "s!$Yarssr::PREFIX = [^;]+;!$Yarssr::PREFIX = '$out';!" $out/bin/yarssr
+    sed -i -r "s!use Yarssr::Browser;!!" $out/share/yarssr/Yarssr/GUI.pm
+    chmod a+x $out/bin/yarssr
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/yarssr \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath libs} \
+      --set PERL5LIB "${lib.makePerlPath perlDeps}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/tsyrogit/zxcvbn-c;
+    description = "A fork of Yarssr (a RSS reader for the GNOME Tray) from http://yarssr.sf.net with various fixes.";
+    license = licenses.gpl1;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ xurei ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18310,6 +18310,8 @@ with pkgs;
 
   yarp = callPackage ../applications/science/robotics/yarp {};
 
+  yarssr = callPackage ../applications/misc/yarssr { };
+
   yate = callPackage ../applications/misc/yate { };
 
   yed = callPackage ../applications/graphics/yed {};


### PR DESCRIPTION
###### Motivation for this change

Add yarssr RSS notifier.

**WARNING** : currently depends on two other PR : #35183 & #35182. These should be merged before this one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

