### PR TITLE
ppl: fix build

### DIFF
--- a/pkgs/development/libraries/ppl/default.nix
+++ b/pkgs/development/libraries/ppl/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, gmpxx, perl, gnum4 }:
+{ fetchurl, fetchpatch, stdenv, gmpxx, perl, gnum4 }:
 
 let version = "1.2"; in
 
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
     url = "http://bugseng.com/products/ppl/download/ftp/releases/${version}/ppl-${version}.tar.bz2";
     sha256 = "1wgxcbgmijgk11df43aiqfzv31r3bkxmgb4yl68g21194q60nird";
   };
+
+  patches = [(fetchpatch {
+    name = "ppl.patch";
+    url = "http://www.cs.unipr.it/git/gitweb.cgi?p=ppl/ppl.git;a=patch;h=c39f6a07b51f89e365b05ba4147aa2aa448febd7";
+    sha256 = "1zj90hm25pkgvk4jlkfzh18ak9b98217gbidl3731fdccbw6hr87";
+  })];
 
   nativeBuildInputs = [ perl gnum4 ];
   propagatedBuildInputs = [ gmpxx ];


### PR DESCRIPTION
###### Motivation for this change

`ppl` has been broken on darwin since 19d885016419ecc1c9045db0666f45d3e3f17953 (according to `git bisect`); it may thus affect other `clang`-based `stdenv`s:

```
In file included from Polyhedron_widenings.cc:28:
In file included from ./Rational_Box.hh:28:
In file included from ./Box_defs.hh:2286:
In file included from ./Box_templates.hh:38:
In file included from ./BD_Shape_defs.hh:2371:
In file included from ./BD_Shape_inlines.hh:31:
In file included from ./Octagonal_Shape_defs.hh:36:
In file included from ./OR_Matrix_defs.hh:607:
./OR_Matrix_inlines.hh:100:8: error: missing 'typename' prior to dependent type template name 'OR_Matrix<T>::Pseudo_Row'
inline OR_Matrix<T>::Pseudo_Row<U>&
       ^
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

