### PR TITLE
rabbitmq-server: 3.6.10 -> 3.6.15 (and various improvements)

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -337,6 +337,7 @@ in rec {
   tests.pumpio = callTest tests/pump.io.nix {};
   # tests.quagga = callTest tests/quagga.nix {};
   tests.quake3 = callTest tests/quake3.nix {};
+  tests.rabbitmq = callTest tests/rabbitmq.nix {};
   tests.radicale = callTest tests/radicale.nix {};
   tests.rspamd = callSubTests tests/rspamd.nix {};
   tests.runInMachine = callTest tests/run-in-machine.nix {};

--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -1,40 +1,73 @@
-{ stdenv, fetchurl, erlang, python, libxml2, libxslt, xmlto
+{ stdenv, fetchurl, runCommand
+, erlang, python, libxml2, libxslt, xmlto
 , docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync
 
 , AppKit, Carbon, Cocoa
 }:
 
-stdenv.mkDerivation rec {
-  name = "rabbitmq-server-${version}";
+let
+  # we only need that one glibc binary (28k instead of 2.7M)
+  getconf = runCommand "getconf" {} ''
+    install -D ${stdenv.lib.getBin stdenv.cc.libc}/bin/getconf $out/bin/getconf
+  '';
 
-  version = "3.6.10";
+in stdenv.mkDerivation rec {
+  name = "rabbitmq-server-${version}";
+  version = "3.6.15";
 
   src = fetchurl {
     url = "https://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
-    sha256 = "0k1rhg1a51201b1hp6vaf4fk48hqz7m9hw55b8xnnyz2ld88jiqg";
+    sha256 = "1zdmil657mhjmd20jv47s5dfpj2liqwvyg0zv2ky3akanfpgj98y";
   };
 
   buildInputs =
     [ erlang python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip rsync ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit Carbon Cocoa ];
 
-  preBuild =
-    ''
-      # Fix the "/usr/bin/env" in "calculate-relative".
-      patchShebangs .
-    '';
+  outputs = [ "out" "man" "doc" ];
+
+  postPatch = with stdenv.lib; ''
+    # patch the path to getconf
+    substituteInPlace deps/rabbit_common/src/vm_memory_monitor.erl \
+      --replace "getconf PAGESIZE" "${getconf}/bin/getconf PAGESIZE"
+  '';
+
+  preBuild = ''
+    # Fix the "/usr/bin/env" in "calculate-relative".
+    patchShebangs .
+  '';
 
   installFlags = "PREFIX=$(out) RMQ_ERLAPP_DIR=$(out)";
   installTargets = "install install-man";
 
-  postInstall =
-    ''
-      echo 'PATH=${erlang}/bin:''${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
+  postInstall = ''
+    echo 'PATH=${erlang}/bin:''${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
+
+    # we know exactly where rabbitmq is gonna be,
+    # so we patch that into the env-script
+    substituteInPlace $out/sbin/rabbitmq-env \
+      --replace 'RABBITMQ_SCRIPTS_DIR=`dirname $SCRIPT_PATH`' \
+                "RABBITMQ_SCRIPTS_DIR=$out/sbin"
+
+    # there’s a few stray files that belong into share
+    mkdir -p $doc/share/doc/rabbitmq-server
+    mv $out/LICENSE* $doc/share/doc/rabbitmq-server
+
+    # and an unecessarily copied INSTALL file
+    rm $out/INSTALL
+
+    # patched into a source file above;
+    # needs to be explicitely passed to not be stripped by fixup
+    mkdir -p $out/nix-support
+    echo "${getconf}" > $out/nix-support/dont-strip-getconf
+
     '';
 
   meta = {
     homepage = http://www.rabbitmq.com/;
     description = "An implementation of the AMQP messaging protocol";
+    license = stdenv.lib.licenses.mpl11;
     platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ Profpatsch ];
   };
 }


### PR DESCRIPTION
- split outputs (doc, man, out)
- a new runtime dependency on getconf
- fix up SCRIPTS_DIR in wrapper
- clean output folder of stray doc files
- add license & maintainer

Tested with `nixos/tests/rabbitmq.nix`, inside a docker image and manually.

cc @binarin @phunehehe @nlewo @datakurre