### PR TITLE
llvmPackages_{4,5}: musl compat

### DIFF
--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -43,6 +43,8 @@ let
 
       # Patch for standalone doc building
       sed -i '1s,^,find_package(Sphinx REQUIRED)\n,' docs/CMakeLists.txt
+    '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+      sed -i -e 's/lgcc_s/lgcc_eh/' lib/Driver/Tools.cpp
     '';
 
     outputs = [ "out" "lib" "python" ];

--- a/pkgs/development/compilers/llvm/4/dynamiclibrary-musl.patch
+++ b/pkgs/development/compilers/llvm/4/dynamiclibrary-musl.patch
@@ -1,0 +1,33 @@
+From d12ecb83d01dcb580dd94f4d57828f33d3eb4c35 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Thu, 18 Feb 2016 15:33:21 +0100
+Subject: [PATCH 3/3] Fix DynamicLibrary to build with musl libc
+
+stdin/out/err is part of the libc and not the kernel so we check for the
+specific libc that does the unexpected instead of linux.
+
+This is needed for making it build with musl libc.
+---
+ lib/Support/DynamicLibrary.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/Support/DynamicLibrary.cpp b/lib/Support/DynamicLibrary.cpp
+index 9a7aeb5..0c1c8f8 100644
+--- a/lib/Support/DynamicLibrary.cpp
++++ b/lib/Support/DynamicLibrary.cpp
+@@ -140,10 +140,10 @@ void* DynamicLibrary::SearchForAddressOfSymbol(const char *symbolName) {
+ #define EXPLICIT_SYMBOL(SYM) \
+    if (!strcmp(symbolName, #SYM)) return &SYM
+ 
+-// On linux we have a weird situation. The stderr/out/in symbols are both
++// On GNU libc we have a weird situation. The stderr/out/in symbols are both
+ // macros and global variables because of standards requirements. So, we
+ // boldly use the EXPLICIT_SYMBOL macro without checking for a #define first.
+-#if defined(__linux__) and !defined(__ANDROID__)
++#if defined(__GLIBC__)
+   {
+     EXPLICIT_SYMBOL(stderr);
+     EXPLICIT_SYMBOL(stdout);
+-- 
+2.7.3
+

--- a/pkgs/development/compilers/llvm/4/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/4/libc++/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetch, cmake, llvm, libcxxabi, fixDarwinDylibNames, version }:
+{ lib, stdenv, fetch, cmake, python, llvm, libcxxabi, fixDarwinDylibNames, version }:
 
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
     ./pthread_mach_thread_np.patch
     # glibc 2.26 fix
     ./xlocale-glibc-2.26.patch
+  ] ++ stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+    ../../libcxx-0001-musl-hacks.patch
+    ./max_align_t.patch
   ];
 
   prePatch = ''
@@ -24,9 +27,10 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
     cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")
+  '' + lib.optionalString stdenv.hostPlatform.isMusl ''
+    patchShebangs utils/cat_files.py
   '';
-
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl python;
 
   buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
@@ -34,7 +38,7 @@ stdenv.mkDerivation rec {
     "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
     "-DLIBCXX_LIBCPPABI_VERSION=2"
     "-DLIBCXX_CXX_ABI=libcxxabi"
-  ];
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/4/libc++/max_align_t.patch
+++ b/pkgs/development/compilers/llvm/4/libc++/max_align_t.patch
@@ -1,0 +1,54 @@
+From 917331c88bd2afce0cf0fdbcab55a64541b5bcf0 Mon Sep 17 00:00:00 2001
+From: "David L. Jones" <dlj@google.com>
+Date: Fri, 10 Feb 2017 01:27:42 +0000
+Subject: [PATCH] Check for musl-libc's max_align_t in addition to other
+ variants.
+
+Summary:
+Libcxx will define its own max_align_t when it is not available. However, the
+availability checks today only check for Clang's definition and GCC's
+definition. In particular, it does not check for musl's definition, which is the
+same as GCC's but guarded with a different macro.
+
+Reviewers: mclow.lists, EricWF
+
+Reviewed By: EricWF
+
+Subscribers: chandlerc, cfe-commits
+
+Differential Revision: https://reviews.llvm.org/D28478
+
+git-svn-id: https://llvm.org/svn/llvm-project/libcxx/trunk@294683 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ include/cstddef  | 3 ++-
+ include/stddef.h | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/include/cstddef b/include/cstddef
+index edd106c00..103898b7d 100644
+--- a/include/cstddef
++++ b/include/cstddef
+@@ -48,7 +48,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
+ using ::ptrdiff_t;
+ using ::size_t;
+ 
+-#if defined(__CLANG_MAX_ALIGN_T_DEFINED) || defined(_GCC_MAX_ALIGN_T)
++#if defined(__CLANG_MAX_ALIGN_T_DEFINED) || defined(_GCC_MAX_ALIGN_T) || \
++    defined(__DEFINED_max_align_t)
+ // Re-use the compiler's <stddef.h> max_align_t where possible.
+ using ::max_align_t;
+ #else
+diff --git a/include/stddef.h b/include/stddef.h
+index 8841bbea2..faf8552d8 100644
+--- a/include/stddef.h
++++ b/include/stddef.h
+@@ -53,7 +53,8 @@ using std::nullptr_t;
+ }
+ 
+ // Re-use the compiler's <stddef.h> max_align_t where possible.
+-#if !defined(__CLANG_MAX_ALIGN_T_DEFINED) && !defined(_GCC_MAX_ALIGN_T)
++#if !defined(__CLANG_MAX_ALIGN_T_DEFINED) && !defined(_GCC_MAX_ALIGN_T) && \
++    !defined(__DEFINED_max_align_t)
+ typedef long double max_align_t;
+ #endif
+ 

--- a/pkgs/development/compilers/llvm/4/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/4/libc++abi.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation {
     export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
+  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
+    patch -p1 -d $(ls -d libcxx-*) -i ${./libc++/max_align_t.patch}
   '';
 
   installPhase = if stdenv.isDarwin

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -80,6 +80,9 @@ in stdenv.mkDerivation (rec {
     )
   '' + stdenv.lib.optionalString stdenv.isAarch64 ''
     patch -p0 < ${../aarch64.patch}
+  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    patch -p1 -i ${../TLI-musl.patch}
+    patch -p1 -i ${./dynamiclibrary-musl.patch}
   '';
 
   # hacky fix: created binaries need to be run before installation
@@ -110,6 +113,14 @@ in stdenv.mkDerivation (rec {
   ++ stdenv.lib.optionals (isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"
+  ]
+  ++ stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+    "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+
+    "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
+    "-DCOMPILER_RT_BUILD_XRAY=OFF"
   ];
 
   postBuild = ''

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -44,6 +44,8 @@ let
 
       # Patch for standalone doc building
       sed -i '1s,^,find_package(Sphinx REQUIRED)\n,' docs/CMakeLists.txt
+    '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+      sed -i -e 's/lgcc_s/lgcc_eh/' lib/Driver/ToolChains/*.cpp
     '';
 
     outputs = [ "out" "lib" "python" ];

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -9,9 +9,13 @@ stdenv.mkDerivation rec {
     unpackFile ${libcxxabi.src}
     export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
   '';
-  patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+
+  # on next rebuild, this can be replaced with optionals; for now set to null to avoid
+  # patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+  patches = if stdenv.hostPlatform.isMusl then [
     ../../libcxx-0001-musl-hacks.patch
-  ];
+  ] else null;
+
   prePatch = ''
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
   '';

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetch, cmake, llvm, libcxxabi, fixDarwinDylibNames, version }:
+{ lib, stdenv, fetch, cmake, python, llvm, libcxxabi, fixDarwinDylibNames, version }:
 
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     unpackFile ${libcxxabi.src}
     export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
   '';
-
+  patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+    ../../libcxx-0001-musl-hacks.patch
+  ];
   prePatch = ''
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"
   '';
@@ -17,9 +19,10 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
     cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$LIBCXXABI_INCLUDE_DIR")
+  '' + lib.optionalString stdenv.hostPlatform.isMusl ''
+    patchShebangs utils/cat_files.py
   '';
-
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl python;
 
   buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
@@ -27,7 +30,7 @@ stdenv.mkDerivation rec {
     "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
     "-DLIBCXX_LIBCPPABI_VERSION=2"
     "-DLIBCXX_CXX_ABI=libcxxabi"
-  ];
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/5/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/5/libc++abi.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
     export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
+  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
   '';
 
   installPhase = if stdenv.isDarwin

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -74,6 +74,11 @@ in stdenv.mkDerivation (rec {
     patch -p1 -i ${./compiler-rt-codesign.patch} -d projects/compiler-rt
   '' + stdenv.lib.optionalString stdenv.isAarch64 ''
     patch -p0 < ${../aarch64.patch}
+  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    patch -p1 -i ${../TLI-musl.patch}
+    substituteInPlace unittests/Support/CMakeLists.txt \
+      --replace "add_subdirectory(DynamicLibrary)" ""
+    rm unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
   '';
 
   # hacky fix: created binaries need to be run before installation
@@ -104,6 +109,14 @@ in stdenv.mkDerivation (rec {
   ++ stdenv.lib.optionals (isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"
     "-DCAN_TARGET_i386=false"
+  ]
+  ++ stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+    "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+
+    "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
+    "-DCOMPILER_RT_BUILD_XRAY=OFF"
   ];
 
   postBuild = ''

--- a/pkgs/development/compilers/llvm/TLI-musl.patch
+++ b/pkgs/development/compilers/llvm/TLI-musl.patch
@@ -1,0 +1,35 @@
+From 5c571082fdaf61f6df19d9b7137dc26d71334058 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Thu, 18 Feb 2016 10:33:04 +0100
+Subject: [PATCH 2/3] Fix build with musl libc
+
+On musl libc the fopen64 and fopen are the same thing, but for
+compatibility they have a `#define fopen64 fopen`. Same applies for
+fseek64, fstat64, fstatvfs64, ftello64, lstat64, stat64 and tmpfile64.
+---
+ include/llvm/Analysis/TargetLibraryInfo.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/include/llvm/Analysis/TargetLibraryInfo.h b/include/llvm/Analysis/TargetLibraryInfo.h
+index 7becdf0..7f14427 100644
+--- a/include/llvm/Analysis/TargetLibraryInfo.h
++++ b/include/llvm/Analysis/TargetLibraryInfo.h
+@@ -18,6 +18,15 @@
+ #include "llvm/IR/Module.h"
+ #include "llvm/Pass.h"
+ 
++#undef fopen64
++#undef fseeko64
++#undef fstat64
++#undef fstatvfs64
++#undef ftello64
++#undef lstat64
++#undef stat64
++#undef tmpfile64
++
+ namespace llvm {
+ /// VecDesc - Describes a possible vectorization of a function.
+ /// Function 'VectorFnName' is equivalent to 'ScalarFnName' vectorized
+-- 
+2.7.3
+

--- a/pkgs/development/compilers/llvm/libcxx-0001-musl-hacks.patch
+++ b/pkgs/development/compilers/llvm/libcxx-0001-musl-hacks.patch
@@ -1,0 +1,39 @@
+From 1c936d7fda3275265e37f93697232a1ed652390f Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Sat, 9 Jul 2016 19:22:54 -0500
+Subject: [PATCH] musl fixes/hacks
+
+Conflicts:
+
+	include/__config
+	include/locale
+	src/locale.cpp
+---
+ include/locale |    4 ++--
+ 1 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/locale b/include/locale
+index 3d804e8..9b01f5b 100644
+--- a/include/locale
++++ b/include/locale
+@@ -695,7 +695,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        long long __ll = strtoll(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;
+@@ -735,7 +735,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
+         typename remove_reference<decltype(errno)>::type __save_errno = errno;
+         errno = 0;
+         char *__p2;
+-        unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
++        unsigned long long __ll = strtoull(__a, &__p2, __base);
+         typename remove_reference<decltype(errno)>::type __current_errno = errno;
+         if (__current_errno == 0)
+             errno = __save_errno;
+-- 
+1.7.1
+


### PR DESCRIPTION
Fix llvm, clang, libcxxClang.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Setting triples is part of one approach for enabling cross-compilation,
but for now only address native compilation and avoid rebuilds.

-----

Prebuilt versions of these are available via cache.allvm.org if that's  useful, details here: https://github.com/NixOS/nixpkgs/pull/34645 ("Quickstart with Binary Cache").

On Nix 2.0 you can probably use a temporary store or something to do this quickly without trusting the ALLVM cache system-wide...