### PR TITLE
postman : 5.5.2 -> 5.5.3

### DIFF
--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "postman-${version}";
-  version = "5.5.2";
+  version = "5.5.3";
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha1 = "68886197A8375E860AB880547838FEFC9E12FC64";
+    sha1 = "BC0C6117BEC6D1638FD18A0E2A580617669A9297";
     name = "${name}.tar.gz";
   };
 
@@ -16,10 +16,15 @@ stdenv.mkDerivation rec {
 
   buildPhase = ":";   # nothing to build
 
+  icon = fetchurl {
+    url = "https://www.getpostman.com/img-rebrand/logo.png";
+    sha256 = "0jdhl9c07b1723j2f172z3s5p5lh8sqa1rcvdzz3h6z5zwn21g7v";
+  };
+
   desktopItem = makeDesktopItem {
     name = "postman";
     exec = "postman";
-    icon = "$out/share/postman/resources/app/assets/icon.png";
+    icon = "${icon}";
     comment = "API Development Environment";
     desktopName = "Postman";
     genericName = "Postman";
@@ -28,10 +33,12 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/share/postman
-    mkdir -p $out/share/applications
     cp -R * $out/share/postman
+
     mkdir -p $out/bin
     ln -s $out/share/postman/Postman $out/bin/postman
+
+    mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Version update.
Also contains a fix for the desktop icon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

