### PR TITLE
pythonPackages.pypandoc: mark as broken

### DIFF
--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -4,7 +4,6 @@
 buildPythonPackage rec {
   pname = "pypandoc";
   version = "1.4";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
@@ -28,5 +27,7 @@ buildPythonPackage rec {
     homepage = https://github.com/bebraw/pypandoc;
     license = licenses.mit;
     maintainers = with maintainers; [ bennofs ];
+
+    broken = true; # incompatible with pandoc v2
   };
 }

--- a/pkgs/development/python-modules/pyrtlsdr/default.nix
+++ b/pkgs/development/python-modules/pyrtlsdr/default.nix
@@ -1,22 +1,34 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , rtl-sdr
-, pypandoc
-, pandoc
+, m2r
 }:
 
 buildPythonPackage rec {
   pname = "pyrtlsdr";
   version = "0.2.7";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "7942fe2e7821d09206002ea7e820e694094b3f964885123eb6eee1167f39b8da";
   };
 
-  buildInputs = [ pypandoc pandoc ];
+  # Replace pypandoc dependency by m2r
+  # See https://github.com/roger-/pyrtlsdr/pull/78
+  patches = [
+    (fetchpatch {
+      url = "${meta.homepage}/commit/2b7df0b.patch";
+      sha256 = "04h5z80969jgdgrf98b9ps56sybms09xacvmj6rwcfrmanli8rgf";
+    })
+    (fetchpatch {
+      url = "${meta.homepage}/commit/97dc3d0.patch";
+      sha256 = "1v1j0n91jwpsiam2j34yj71z4h39cvk4gi4565zgjrzsq6xr93i0";
+    })
+  ];
+
+  nativeBuildInputs = [ m2r ];
 
   postPatch = ''
     sed "s|driver_files =.*|driver_files = ['${rtl-sdr}/lib/librtlsdr.so']|" -i rtlsdr/librtlsdr.py
@@ -31,5 +43,5 @@ buildPythonPackage rec {
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ bjornfor ];
- };
+  };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @bennofs @bjornfor @kristoff3r 