### PR TITLE
Remove Xfce-specific display manager tip

### DIFF
--- a/nixos/doc/manual/configuration/xfce.xml
+++ b/nixos/doc/manual/configuration/xfce.xml
@@ -35,18 +35,7 @@ services.compton = {
         To install them manually (system wide), put them into your
         <literal>environment.systemPackages</literal>.
     </para>
-
-    <para>
-        NixOS’s default <emphasis>display manager</emphasis> is SLiM.
-        (DM is the program that provides a graphical login prompt
-         and manages the X server.)
-        You can, for example, select KDE’s
-        <command>sddm</command> instead:
-        <programlisting>
-services.xserver.displayManager.sddm.enable = true;
-        </programlisting>
-    </para>
-
+         
     <simplesect>
         <title>Thunar Volume Support</title>
 


### PR DESCRIPTION
###### Motivation for this change
This is already covered in the previous chapter https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/configuration/x-windows.xml#L38-L46 - Xfce also depends on X and it doesn't need a special section on display managers.
