### PR TITLE
mbedtls: change extension .so -> .dylib on Darwin

### DIFF
--- a/pkgs/development/libraries/mbedtls/darwin_dylib.patch
+++ b/pkgs/development/libraries/mbedtls/darwin_dylib.patch
@@ -1,0 +1,28 @@
+diff --git a/library/Makefile b/library/Makefile
+index 28f9231..ad9cc32 100644
+--- a/library/Makefile
++++ b/library/Makefile
+@@ -103,9 +103,9 @@ libmbedtls.so: libmbedtls.$(SOEXT_TLS)
+ 	echo "  LN    $@ -> $<"
+ 	ln -sf $< $@
+ 
+-libmbedtls.dylib: $(OBJS_TLS)
++libmbedtls.dylib: $(OBJS_TLS) libmbedx509.dylib
+ 	echo "  LD    $@"
+-	$(CC) -dynamiclib $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_TLS)
++	$(CC) -dynamiclib -L. -lmbedcrypto -lmbedx509 $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_TLS)
+ 
+ libmbedtls.dll: $(OBJS_TLS) libmbedx509.dll
+ 	echo "  LD    $@"
+@@ -126,9 +126,9 @@ libmbedx509.so: libmbedx509.$(SOEXT_X509)
+ 	echo "  LN    $@ -> $<"
+ 	ln -sf $< $@
+ 
+-libmbedx509.dylib: $(OBJS_X509)
++libmbedx509.dylib: $(OBJS_X509) libmbedcrypto.dylib
+ 	echo "  LD    $@"
+-	$(CC) -dynamiclib $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_X509)
++	$(CC) -dynamiclib -L. -lmbedcrypto  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_X509)
+ 
+ libmbedx509.dll: $(OBJS_X509) libmbedcrypto.dll
+ 	echo "  LD    $@"

--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -12,19 +12,21 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  patches = stdenv.lib.optionals stdenv.isDarwin [ ./darwin_dylib.patch ];
+
+  postPatch = ''
+    patchShebangs .
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace library/Makefile --replace "-soname" "-install_name"
     substituteInPlace tests/scripts/run-test-suites.pl --replace "LD_LIBRARY_PATH" "DYLD_LIBRARY_PATH"
     # Necessary for install_name_tool below
     echo "LOCAL_LDFLAGS += -headerpad_max_install_names" >> programs/Makefile
   '';
 
-  postPatch = ''
-    patchShebangs .
-  '';
-
   makeFlags = [
     "SHARED=1"
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "DLEXT=dylib"
   ];
 
   installFlags = [
@@ -32,14 +34,14 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-      install_name_tool -change libmbedcrypto.so.0 $out/lib/libmbedcrypto.so.0 $out/lib/libmbedtls.so.10
-      install_name_tool -change libmbedcrypto.so.0 $out/lib/libmbedcrypto.so.0 $out/lib/libmbedx509.so.0
-      install_name_tool -change libmbedx509.so.0 $out/lib/libmbedx509.so.0 $out/lib/libmbedtls.so.10
+      install_name_tool -change libmbedcrypto.dylib $out/lib/libmbedcrypto.dylib $out/lib/libmbedtls.dylib
+      install_name_tool -change libmbedcrypto.dylib $out/lib/libmbedcrypto.dylib $out/lib/libmbedx509.dylib
+      install_name_tool -change libmbedx509.dylib $out/lib/libmbedx509.dylib $out/lib/libmbedtls.dylib
 
       for exe in $out/bin/*; do
-          install_name_tool -change libmbedtls.so.10 $out/lib/libmbedtls.so.10 $exe
-          install_name_tool -change libmbedx509.so.0 $out/lib/libmbedx509.so.0 $exe
-          install_name_tool -change libmbedcrypto.so.0 $out/lib/libmbedcrypto.so.0 $exe
+          install_name_tool -change libmbedtls.dylib $out/lib/libmbedtls.dylib $exe
+          install_name_tool -change libmbedx509.dylib $out/lib/libmbedx509.dylib $exe
+          install_name_tool -change libmbedcrypto.dylib $out/lib/libmbedcrypto.dylib $exe
       done
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Some programs fail to find libraries with extension `.so` on Darwin. If the extension is `.dylib`, they can.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

