### PR TITLE
nixos/doc: document password-promptless installation

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -275,11 +275,6 @@ Enter new UNIX password: ***
 Retype new UNIX password: ***
 </screen>
 
-    </para>
-
-  </listitem>
-
-  <listitem>
     <note>
       <para>
         To prevent the password prompt, set <code>users.mutableUsers = false;</code> in
@@ -287,6 +282,12 @@ Retype new UNIX password: ***
         necessary in automation.
       </para>
     </note>
+
+    </para>
+
+  </listitem>
+
+  <listitem>
     <para>If everything went well:
 
 <screen>

--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -279,7 +279,15 @@ Retype new UNIX password: ***
 
   </listitem>
 
-  <listitem><para>If everything went well:
+  <listitem>
+    <note>
+      <para>
+        To prevent the password prompt, set <code>users.mutableUsers = false;</code> in
+        <filename>configuration.nix</filename>, which allows unattended installation
+        necessary in automation.
+      </para>
+    </note>
+    <para>If everything went well:
 
 <screen>
 # reboot</screen>


### PR DESCRIPTION
###### Motivation for this change
I would have liked to have read this line in the manual instead of digging up an issue.

Potentially closes the issue ["nix-install cannot run unattended because interactive passwd"](https://github.com/NixOS/nixpkgs/issues/14312) - see that discussion for more details.

Not too sure about formatting line breaks in the manual - I can fix that up if it's important.