### PR TITLE
suitesparse: 4.4.4 -> 5.3.0

### DIFF
--- a/pkgs/development/libraries/science/math/suitesparse/4.4.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/4.4.nix
@@ -1,32 +1,31 @@
-{ stdenv, fetchurl, gfortran, openblas, cmake
+{ stdenv, fetchurl, gfortran, openblas
 , enableCuda  ? false, cudatoolkit
 }:
 
 let
-  version = "5.3.0";
+  version = "4.4.4";
   name = "suitesparse-${version}";
 
+  int_t = if openblas.blas64 then "int64_t" else "int32_t";
   SHLIB_EXT = stdenv.hostPlatform.extensions.sharedLibrary;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
     url = "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-${version}.tar.gz";
-    sha256 = "0gcn1xj3z87wpp26gxn11k8073bxv6jswfd8jmddlm64v09rgrlh";
+    sha256 = "1zdn1y0ij6amj7smmcslkqgbqv9yy5cwmbyzqc9v6drzdzllgbpj";
   };
-
-  dontUseCmakeConfigure = true;
 
   preConfigure = ''
     mkdir -p $out/lib
     mkdir -p $out/include
-    mkdir -p $out/share/doc/${name}
 
     sed -i "SuiteSparse_config/SuiteSparse_config.mk" \
         -e 's/METIS .*$/METIS =/' \
         -e 's/METIS_PATH .*$/METIS_PATH =/' \
-        -e '/CHOLMOD_CONFIG/ s/$/-DNPARTITION/'
+        -e '/CHOLMOD_CONFIG/ s/$/-DNPARTITION -DLONGBLAS=${int_t}/' \
+        -e '/UMFPACK_CONFIG/ s/$/-DLONGBLAS=${int_t}/'
   ''
   + stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i "SuiteSparse_config/SuiteSparse_config.mk" \
@@ -48,56 +47,48 @@ stdenv.mkDerivation rec {
         -e 's|^[[:space:]]*\(NVCCFLAGS     =\)|NVCCFLAGS = $(NV20) -O3 -gencode=arch=compute_20,code=sm_20 -gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_60,code=sm_60|'
   '';
 
+  makeFlags = [
+    "PREFIX=\"$(out)\""
+    "INSTALL_LIB=$(out)/lib"
+    "INSTALL_INCLUDE=$(out)/include"
+    "BLAS=-lopenblas"
+    "LAPACK="
+  ];
+
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin " -DNTIMER";
 
-  buildPhase = ''
-    runHook preBuild
-
-    # Build individual shared libraries
-    make library        \
-        BLAS=-lopenblas \
-        LAPACK=""       \
-        ${stdenv.lib.optionalString openblas.blas64 "CFLAGS=-DBLAS64"}
-
-    # Build libsuitesparse.so which bundles all the individual libraries.
-    # Bundling is done by building the static libraries, extracting objects from
-    # them and combining the objects into one shared library.
-    mkdir -p static
-    make static AR_TARGET=$(pwd)/static/'$(LIBRARY).a'
+  postInstall = ''
+    # Build and install shared library
     (
-        cd static
-        for i in lib*.a; do
+        cd "$(mktemp -d)"
+        for i in "$out"/lib/lib*.a; do
           ar -x $i
         done
+        ${if enableCuda then cudatoolkit else stdenv.cc.outPath}/bin/${if enableCuda then "nvcc" else "cc"} *.o ${if stdenv.isDarwin then "-dynamiclib" else "--shared"} -o "$out/lib/libsuitesparse${SHLIB_EXT}" -lopenblas ${stdenv.lib.optionalString enableCuda "-lcublas"}
     )
-    ${if enableCuda then "${cudatoolkit}/bin/nvcc" else "${stdenv.cc.outPath}/bin/cc"} \
-        static/*.o                                                                     \
-        ${if stdenv.isDarwin then "-dynamiclib" else "--shared"}                       \
-        -o "lib/libsuitesparse${SHLIB_EXT}"                                            \
-        -lopenblas                                                                     \
-        ${stdenv.lib.optionalString enableCuda "-lcublas"}
+    for i in umfpack cholmod amd camd colamd spqr; do
+      ln -s libsuitesparse${SHLIB_EXT} "$out"/lib/lib$i${SHLIB_EXT}
+    done
 
-    runHook postBuild
+    # Install documentation
+    outdoc=$out/share/doc/${name}
+    mkdir -p $outdoc
+    cp -r AMD/Doc $outdoc/amd
+    cp -r BTF/Doc $outdoc/bft
+    cp -r CAMD/Doc $outdoc/camd
+    cp -r CCOLAMD/Doc $outdoc/ccolamd
+    cp -r CHOLMOD/Doc $outdoc/cholmod
+    cp -r COLAMD/Doc $outdoc/colamd
+    cp -r CXSparse/Doc $outdoc/cxsparse
+    cp -r KLU/Doc $outdoc/klu
+    cp -r LDL/Doc $outdoc/ldl
+    cp -r RBio/Doc $outdoc/rbio
+    cp -r SPQR/Doc $outdoc/spqr
+    cp -r UMFPACK/Doc $outdoc/umfpack
   '';
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out
-    cp -r lib $out/
-    cp -r include $out/
-    cp -r share $out/
-
-    # Fix rpaths
-    cd $out
-    find -name \*.so\* -type f -exec \
-      patchelf --set-rpath "$out/lib:${stdenv.lib.makeLibraryPath buildInputs}" {} \;
-
-    runHook postInstall
-  '';
-
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ openblas gfortran.cc.lib ] ++ stdenv.lib.optionals enableCuda [cudatoolkit];
+  nativeBuildInputs = [ gfortran ];
+  buildInputs = [ openblas ];
 
   meta = with stdenv.lib; {
     homepage = http://faculty.cse.tamu.edu/davis/suitesparse.html;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1537,7 +1537,7 @@ with pkgs;
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {
     conf = config.riot-web.conf or null;
   };
-  
+
   roundcube = callPackage ../servers/roundcube { };
 
   rsbep = callPackage ../tools/backup/rsbep { };
@@ -20953,8 +20953,9 @@ with pkgs;
   sageWithDoc = sage.override { withDoc = true; };
 
   suitesparse_4_2 = callPackage ../development/libraries/science/math/suitesparse/4.2.nix { };
-  suitesparse_4_4 = callPackage ../development/libraries/science/math/suitesparse {};
-  suitesparse = suitesparse_4_4;
+  suitesparse_4_4 = callPackage ../development/libraries/science/math/suitesparse/4.4.nix {};
+  suitesparse_5_3 = callPackage ../development/libraries/science/math/suitesparse {};
+  suitesparse = suitesparse_5_3;
 
   superlu = callPackage ../development/libraries/science/math/superlu {};
 


### PR DESCRIPTION
###### Motivation for this change

~~**This is work in progress, do not merge.**~~

**EDIT: Ready for review and merge now.**

Upgrading SuiteSparse to 5.3.0. ~~However, the build failed and I was a bit lost with all the complexity of the package. I thought I'd put it here if someone wants to help and/or that it's public so there wouldn't be overlapping efforts done.~~

~~[Error log](https://github.com/NixOS/nixpkgs/files/1739323/suitesparse.log)~~

~~cc: @ttuegel Perhaps you, as a maintainer, know better how to upgrade this package?~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

