### PR TITLE
spice-gtk: fix usb redirection

### DIFF
--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -61,7 +61,7 @@ in stdenv.mkDerivation rec {
 
     homepage = http://www.spice-space.org/;
     license = licenses.lgpl21;
-
+    maintainers = [ maintainers.xeji ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -25,12 +25,9 @@ in stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-fno-stack-protector";
 
   preAutoreconf = ''
-    substituteInPlace src/Makefile.am \
-          --replace '=codegendir pygtk-2.0' '=codegendir pygobject-2.0'
   '';
 
   configureFlags = [
-    "--disable-maintainer-mode"
     "--with-gtk3"
   ];
 

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, spice-protocol, gettext, celt_0_5_1
 , openssl, libpulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
 , cyrus_sasl, python2Packages, autoreconfHook, usbredir, libsoup
+, polkit, acl, usbutils, vala
 , gtk3, epoxy }:
 
 with stdenv.lib;
@@ -18,18 +19,32 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     spice-protocol celt_0_5_1 openssl libpulseaudio pixman gobjectIntrospection
     libjpeg_turbo zlib cyrus_sasl python pygtk usbredir gtk3 epoxy
+    polkit acl usbutils
   ];
 
-  nativeBuildInputs = [ pkgconfig gettext libsoup autoreconfHook ];
+  nativeBuildInputs = [ pkgconfig gettext libsoup autoreconfHook vala ];
 
   NIX_CFLAGS_COMPILE = "-fno-stack-protector";
 
+  # put polkit action in the $out/share/polkit-1/actions
   preAutoreconf = ''
+    substituteInPlace configure.ac \
+      --replace 'POLICYDIR=`''${PKG_CONFIG} polkit-gobject-1 --variable=policydir`' "POLICYDIR=$out/share/polkit-1/actions"
   '';
 
   configureFlags = [
     "--with-gtk3"
   ];
+
+  # usb redirection needs spice-client-glib-usb-acl-helper to run setuid root
+  # the helper then uses polkit to check access
+  # in nixos, enable this with
+  # security.wrappers.spice-client-glib-usb-acl-helper.source =
+  #   "${pkgs.spice_gtk}/bin/spice-client-glib-usb-acl-helper.real";
+  postFixup = ''
+    mv $out/bin/spice-client-glib-usb-acl-helper $out/bin/spice-client-glib-usb-acl-helper.real
+    ln -sf /run/wrappers/bin/spice-client-glib-usb-acl-helper $out/bin/spice-client-glib-usb-acl-helper
+  '';
 
   dontDisableStatic = true; # Needed by the coroutine test
 


### PR DESCRIPTION
###### Motivation for this change

Build spice-gtk with polkit and acl to enable usb redirection in virt-viewer and virt-manager. 
Fixes #27199.
usb redirection requires a setuid wrapper, see comment in code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

