### PR TITLE
gpodder: 3.10.0 -> 3.10.1

### DIFF
--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -5,7 +5,7 @@
 
 python3Packages.buildPythonApplication rec {
   name = "gpodder-${version}";
-  version = "3.10.0";
+  version = "3.10.1";
 
   format = "other";
 
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
     owner = "gpodder";
     repo = "gpodder";
     rev = version;
-    sha256 = "0f3m1kcj641xiwsxan66k81lvslkl3aziakn5z17y4mmdci79jv0";
+    sha256 = "1cqhm5h0kkdb2m691dbj8i3bixl7bw0iww2pl6k1jkz8mgafyd9d";
   };
 
   postPatch = with stdenv.lib; ''
@@ -26,7 +26,11 @@ python3Packages.buildPythonApplication rec {
     glibcLocales
   ];
 
-  buildInputs = [ python3 gobjectIntrospection ];
+  buildInputs = [
+    python3
+    gobjectIntrospection
+    gnome3.defaultIconTheme
+  ];
 
   checkInputs = with python3Packages; [
     coverage minimock


### PR DESCRIPTION
also add defaultIconTheme back

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

