### PR TITLE
nixnote2: init at 2.0.2

### DIFF
--- a/pkgs/applications/misc/nixnote2/default.nix
+++ b/pkgs/applications/misc/nixnote2/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, mkDerivation, fetchFromGitHub, boost, qtbase, qtwebkit, poppler_qt5, qmake, hunspell, html-tidy}:
+
+mkDerivation rec {
+  name = "nixnote2-${version}";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "baumgarr";
+    repo = "nixnote2";
+    rev = "v${version}";
+    sha256 = "0cfq95mxvcgby66r61gclm1a2c6zck5aln04xmg2q8kg6p9d31fr";
+  };
+
+  buildInputs = [ boost qtbase qtwebkit poppler_qt5 hunspell ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ qmake ];
+
+  postPatch = ''
+    # Fix location of poppler-qt5.h
+    for f in threads/indexrunner.cpp html/noteformatter.cpp utilities/noteindexer.cpp gui/plugins/popplerviewer.h gui/plugins/pluginfactory.h gui/plugins/popplerviewer.cpp ; do
+      substituteInPlace $f \
+        --replace '#include <poppler-qt5.h>' '#include <poppler/qt5/poppler-qt5.h>'
+    done
+
+    substituteInPlace nixnote.cpp --replace 'tidyProcess.start("tidy' 'tidyProcess.start("${html-tidy}/bin/tidy'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An unofficial client of Evernote";
+    homepage = http://www.nixnote.org/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ htr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3236,6 +3236,8 @@ with pkgs;
 
   ninka = callPackage ../development/tools/misc/ninka { };
 
+  nixnote2 = libsForQt5.callPackage ../applications/misc/nixnote2 { };
+
   nodejs = hiPrio nodejs-6_x;
 
   nodejs-slim = nodejs-slim-6_x;
@@ -5755,7 +5757,7 @@ with pkgs;
   compcert = callPackage ../development/compilers/compcert { };
 
   cpp-gsl = callPackage ../development/libraries/cpp-gsl { };
-  
+
   # Users installing via `nix-env` will likely be using the REPL,
   # which has a hard dependency on Z3, so make sure it is available.
   cryptol = haskellPackages.cryptol.overrideDerivation (oldAttrs: {


### PR DESCRIPTION
###### Motivation for this change
Adds nixnote: an Evernote clone for linux

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

