### PR TITLE
Multiple modules in support of POE-1.367

### DIFF
--- a/pkgs/development/perl-modules/perl-POE-1.367-pod_linkcheck.patch
+++ b/pkgs/development/perl-modules/perl-POE-1.367-pod_linkcheck.patch
@@ -1,5 +1,5 @@
 commit 6d985026
-Author: Michael Brantley <brantley@deshaw.com>
+Author: Michael Brantley <limeytexan@gmail.com>
 Date:   Tue Feb 20 07:12:06 2018 -0500
 
     Update broken Pod links in lib/POE/Filter/HTTPD.pm

--- a/pkgs/development/perl-modules/perl-POE-1.367-pod_linkcheck.patch
+++ b/pkgs/development/perl-modules/perl-POE-1.367-pod_linkcheck.patch
@@ -1,0 +1,40 @@
+commit 6d985026
+Author: Michael Brantley <brantley@deshaw.com>
+Date:   Tue Feb 20 07:12:06 2018 -0500
+
+    Update broken Pod links in lib/POE/Filter/HTTPD.pm
+    
+    Update Pod links to refer only to the utf8 module and not its methods,
+    fix a mis-capitalized internal reference, and convert the dangling
+    "MaxContent" link into a code reference.
+    
+    Resolves bug: https://rt.cpan.org/Public/Bug/Display.html?id=124496
+
+diff --git a/lib/POE/Filter/HTTPD.pm b/lib/POE/Filter/HTTPD.pm
+index 9d4898e3..517be691 100644
+--- a/lib/POE/Filter/HTTPD.pm
++++ b/lib/POE/Filter/HTTPD.pm
+@@ -621,10 +621,10 @@ how to use these objects.
+ 
+ HTTP headers are not allowed to have UTF-8 characters; they must be
+ ISO-8859-1.  POE::Filter::HTTPD will convert all UTF-8 into the MIME encoded
+-equivalent.  It uses L<utf8::is_utf8> for detection-8 and
++equivalent.  It uses C<utf8::is_utf8> for detection-8 and
+ L<Email::MIME::RFC2047::Encoder> for convertion.  If L<utf8> is not
+ installed, no conversion happens.  If L<Email::MIME::RFC2047::Encoder> is
+-not installed, L<utf8::downgrade> is used instead.  In this last case, you will
++not installed, C<utf8::downgrade> is used instead.  In this last case, you will
+ see a warning if you try to send UTF-8 headers.
+ 
+ 
+@@ -651,8 +651,8 @@ streaming mode this filter will return either an HTTP::Request object or a
+ block of content.  The HTTP::Request object's content will return empty. 
+ The blocks of content will be parts of the request's body, up to
+ Content-Length in size.  You distinguish between request objects and content
+-blocks using C<Scalar::Util/bless> (See L</Streaming request> below).  This
+-option supersedes L</MaxContent>.
++blocks using C<Scalar::Util/bless> (See L</Streaming Request> below).  This
++option supersedes C<MaxContent>.
+ 
+ =head1 CAVEATS
+ 

--- a/pkgs/development/perl-modules/perl-POE-1.367-pod_no404s.patch
+++ b/pkgs/development/perl-modules/perl-POE-1.367-pod_no404s.patch
@@ -1,0 +1,46 @@
+commit 32571a21
+Author: Michael Brantley <brantley@deshaw.com>
+Date:   Tue Feb 20 07:07:22 2018 -0500
+
+    Update old URLs referenced in Pod
+    
+    Remove mention of old URLs, replace mention of canonical SVN repo with
+    the new git-based one at github.com.
+    
+    Resolves bug: https://rt.cpan.org/Public/Bug/Display.html?id=124495
+
+diff --git a/lib/POE.pm b/lib/POE.pm
+index 80e7feac..0554ff70 100644
+--- a/lib/POE.pm
++++ b/lib/POE.pm
+@@ -465,7 +465,7 @@ code snippets there as well.
+ The following command will fetch the most current version of POE into
+ the "poe" subdirectory:
+ 
+-  svn co https://poe.svn.sourceforge.net/svnroot/poe poe
++  git clone https://github.com/rcaputo/poe.git
+ 
+ =head2 SourceForge
+ 
+@@ -535,18 +535,9 @@ https://rt.cpan.org/Dist/Display.html?Status=Active&Queue=POE
+ 
+ =head2 Repositories and Changes
+ 
+-Thanks to the magic of distributed version control, POE is hosted at
+-three locations for redundancy.  You can browse the source at any one
+-of:
+-
+-https://github.com/rcaputo/poe
+-
+-https://gitorious.org/poe
+-
+-http://poe.git.sourceforge.net/git/gitweb-index.cgi
+-
+-Complete change logs can also be browsed at those sites.  They all
+-provide RSS news feeds for those who want to follow development in
++You can browse the POE source and complete change logs at
++https://github.com/rcaputo/poe. It also provides an RSS
++news feed for those who want to follow development in
+ near-realtime.
+ 
+ =head2 Other Resources

--- a/pkgs/development/perl-modules/perl-POE-1.367-pod_no404s.patch
+++ b/pkgs/development/perl-modules/perl-POE-1.367-pod_no404s.patch
@@ -1,5 +1,5 @@
 commit 32571a21
-Author: Michael Brantley <brantley@deshaw.com>
+Author: Michael Brantley <limeytexan@gmail.com>
 Date:   Tue Feb 20 07:07:22 2018 -0500
 
     Update old URLs referenced in Pod

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11297,6 +11297,47 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  POE = buildPerlPackage rec {
+    name = "POE-1.367";
+    patches = [
+      ../development/perl-modules/perl-POE-1.367-pod_linkcheck.patch
+      ../development/perl-modules/perl-POE-1.367-pod_no404s.patch
+    ];
+    src = fetchurl {
+      url = "http://search.cpan.org/CPAN/authors/id/R/RC/RCAPUTO/POE-1.367.tar.gz";
+      sha256 = "0b9s7yxaa2lgzyi56brgygycfjk7lz33d1ddvc1wvwwvm45p4wmp";
+    };
+    buildInputs = [
+      Curses EmailMIME HTTPMessage IOTty LWPProtocolHttps POETestLoops
+      TermReadKey TestPod TestPodCoverage TestPodLinkCheck TestPodNo404s
+    ];
+    propagatedBuildInputs = [ pkgs.cacert IOPipely ];
+    meta = {
+      maintainers = [ maintainers.limeytexan ];
+      description = "Portable multitasking and networking framework for any event loop";
+      license = stdenv.lib.licenses.artistic2;
+    };
+    preCheck = ''
+      export SSL_CERT_FILE=${pkgs.cacert.out}/etc/ssl/certs/ca-bundle.crt
+      export RELEASE_TESTING=1
+    '';
+  };
+
+  POETestLoops = buildPerlPackage rec {
+    name = "POE-Test-Loops-1.360";
+    src = fetchurl {
+      url = "http://search.cpan.org/CPAN/authors/id/R/RC/RCAPUTO/POE-Test-Loops-1.360.tar.gz";
+      sha256 = "0yx4wsljfmdzsiv0ni98x6lw975cm82ahngbwqvzv60wx5pwkl5y";
+    };
+    buildInputs = [ ];
+    propagatedBuildInputs = [ ];
+    meta = {
+      maintainers = [ maintainers.limeytexan ];
+      description = "Reusable tests for POE::Loop authors";
+      license = stdenv.lib.licenses.artistic2;
+    };
+  };
+
   PPI = buildPerlPackage rec {
     name = "PPI-1.236";
     src = fetchurl {
@@ -14077,6 +14118,20 @@ let self = _self // overrides; _self = with self; {
     meta = {
       homepage = http://search.cpan.org/dist/Test-Pod-LinkCheck/;
       description = "Tests POD for invalid links";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  TestPodNo404s = buildPerlPackage rec {
+    name = "Test-Pod-No404s-0.02";
+    src = fetchurl {
+      url = "http://search.cpan.org/CPAN/authors/id/A/AP/APOCAL/Test-Pod-No404s-0.02.tar.gz";
+      sha256 = "0ycfghsyl9f31kxdppjwx2g5iajrqh3fyywz0x7d8ayndw2hdihi";
+    };
+    propagatedBuildInputs = [ LWPUserAgent ModuleBuildTiny URIFind TestPod ];
+    meta = {
+      homepage = http://search.cpan.org/dist/Test-Pod-No404s/;
+      description = "Checks POD for any http 404 links";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };


### PR DESCRIPTION
POE: init at 1.367
POETestLoops: init at 1.360
TestPodNo404s: init at 0.02

Note that I encountered bugs as part of this effort as documented in the following CPAN bug tickets:

* https://rt.cpan.org/Ticket/Display.html?id=124495: POE-1.367 failed t/10_units/01_pod/03_pod_no404s.t
* https://rt.cpan.org/Ticket/Display.html?id=124496: POE-1.367 failed t/10_units/01_pod/04_pod_linkcheck.t

... and these bugs are addressed by the perl-POE-1.367-pod_no404s.patch and perl-POE-1.367-pod_linkcheck.patch files included with this patch, both of which have been submitted as PRs to https://github.com/rcaputo/poe.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

