### PR TITLE
systemd-cryptsetup-generator: fix compilation with systemd 237

### DIFF
--- a/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
+++ b/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
@@ -10,21 +10,15 @@ stdenv.lib.overrideDerivation systemd (p: {
   outputs = [ "out" ];
 
   buildPhase = ''
-    make $makeFlags built-sources
-    make $makeFlags systemd-cryptsetup
-    make $makeFlags systemd-cryptsetup-generator
+    ninja systemd-cryptsetup systemd-cryptsetup-generator
   '';
 
-  # For some reason systemd-cryptsetup-generator is a wrapper-script
-  # with the current release of systemd. We want the real one.
-
-  # TODO: Remove `.libs` prefix when the wrapper-script is gone
   installPhase = ''
     mkdir -p $out/lib/systemd/
-    cp .libs/systemd-cryptsetup $out/lib/systemd/systemd-cryptsetup
-    cp .libs/*.so $out/lib/
+    cp systemd-cryptsetup $out/lib/systemd/systemd-cryptsetup
+    cp src/shared/*.so $out/lib/systemd/
 
     mkdir -p $out/lib/systemd/system-generators/
-    cp .libs/systemd-cryptsetup-generator $out/lib/systemd/system-generators/systemd-cryptsetup-generator
+    cp systemd-cryptsetup-generator $out/lib/systemd/system-generators/systemd-cryptsetup-generator
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Closes #35097

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

