### PR TITLE
rubygems: 2.6.13 -> 2.7.6

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -136,6 +136,12 @@ let
           ++ op (stdenv.hostPlatform != stdenv.buildPlatform)
              "--with-baseruby=${buildRuby}";
 
+        preInstall = ''
+          # Ruby installs gems here itself now.
+          mkdir -pv "$out/${passthru.gemPath}"
+          export GEM_HOME="$out/${passthru.gemPath}"
+        '';
+
         installFlags = stdenv.lib.optionalString docSupport "install-doc";
         # Bundler tries to create this directory
         postInstall = ''
@@ -148,7 +154,6 @@ let
           sed -i '/NROFF/d' $out/lib/ruby/*/*/rbconfig.rb
 
           # Bundler tries to create this directory
-          mkdir -pv $out/${passthru.gemPath}
           mkdir -p $out/nix-support
           cat > $out/nix-support/setup-hook <<EOF
           addGemPath() {

--- a/pkgs/development/interpreters/ruby/rubygems-src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems-src.nix
@@ -1,6 +1,6 @@
 { fetchurl
-, version ? "2.6.13"
-, sha256 ? "1j98ww8cz9y4wwshg7p4i4acrmls3ywkyj1nlkh4k3bywwm50hfh"
+, version ? "2.7.6"
+, sha256 ? "1sqy6z1kngq91nxmv1hw4xhw1ycwx9s76hfbpcdlgkm9haji9xv7"
 }:
 fetchurl {
   url = "http://production.cf.rubygems.org/rubygems/rubygems-${version}.tgz";


### PR DESCRIPTION
###### Motivation for this change

https://www.ruby-lang.org/en/news/2018/02/17/multiple-vulnerabilities-in-rubygems/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

