### PR TITLE
pijul: 0.8.0 -> 0.8.3

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -4,12 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "pijul-${version}";
-  version = "0.8.0";
+  version = "0.8.3";
 
   src = fetchurl {
     url = "https://pijul.org/releases/${name}.tar.gz";
-    sha256 = "00pi03yp2bgnjpsz2hgaapxfw2i4idbjqc88cagpvn4yr1612wqx";
+    sha256 = "1xnl22gd9085q9a095z692pfz9zxg26bii5h64vraqlxmsirrvs5";
   };
+
+  preBuild = ''
+    cargo update
+  '';
 
   sourceRoot = "${name}/pijul";
 
@@ -18,7 +22,7 @@ buildRustPackage rec {
 
   doCheck = false;
 
-  cargoSha256 = "1cnr08qbpia3336l37k1jli20d7kwnrw2gys8s9mg271cb4vdx03";
+  cargoSha256 = "1h3p1f4v84kdwdjyslmijdxcbf1sdm58hllfssh4875ghws12g40";
 
   meta = with stdenv.lib; {
     description = "A distributed version control system";


### PR DESCRIPTION
The update was not straightforward. There was this failure after an update of the version:

```
error: the lock file needs to be updated but --locked was passed to prevent this
```

Adding a hook to the derivation helped with this, but I am not sure this is the best way
to handle this situation.

###### Motivation for this change

Pijul 0.8.3 is required to work with nest.pijul.com

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

