### PR TITLE
virglrenderer: init at 0.6.0

### DIFF
--- a/pkgs/development/libraries/virglrenderer/default.nix
+++ b/pkgs/development/libraries/virglrenderer/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pkgconfig, mesa_noglu, epoxy, libX11 }:
+
+
+stdenv.mkDerivation rec {
+
+  name = "virglrenderer-${version}";
+  version = "0.6.0";
+
+  src = fetchurl {
+    url = "https://www.freedesktop.org/software/virgl/${name}.tar.bz2";
+    sha256 = "a549e351e0eb2ad1df471386ddcf85f522e7202808d1616ee9ff894209066e1a";
+  };
+
+  buildInputs = [ mesa_noglu epoxy libX11 ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "A virtual 3D GPU library that allows a qemu guest to use the host GPU for accelerated 3D rendering";
+    homepage = https://virgil3d.github.io/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.xeji ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20559,6 +20559,8 @@ with pkgs;
   vips = callPackage ../tools/graphics/vips { };
   nip2 = callPackage ../tools/graphics/nip2 { };
 
+  virglrenderer = callPackage ../development/libraries/virglrenderer { };
+
   vokoscreen = libsForQt5.callPackage ../applications/video/vokoscreen { };
 
   wavegain = callPackage ../applications/audio/wavegain { };


### PR DESCRIPTION
###### Motivation for this change

needed to enable 3d accelerated virtio graphics for qemu guests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

