### PR TITLE
bcal: init at 1.7

### DIFF
--- a/pkgs/applications/science/math/bcal/default.nix
+++ b/pkgs/applications/science/math/bcal/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, python3Packages }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "bcal-${version}";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "jarun";
+    repo = "bcal";
+    rev = "v${version}";
+    sha256 = "08cqp2jysvy743gmwpzkbqhybsb49n65r63z3if53m3y59qg4aw8";
+  };
+
+  nativeBuildInputs = [ python3Packages.pytest ];
+
+  doCheck = true;
+  checkPhase = ''
+    python3 -m pytest test.py
+  '';
+
+  makeFlags = [ "CC=cc" ];
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  meta = {
+    description = "Storage conversion and expression calculator";
+    homepage = https://github.com/jarun/bcal;
+    license = licenses.gpl3;
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19708,6 +19708,8 @@ with pkgs;
 
   pcalc = callPackage ../applications/science/math/pcalc { };
 
+  bcal = callPackage ../applications/science/math/bcal { };
+
   pspp = callPackage ../applications/science/math/pspp {
     inherit (gnome3) gtksourceview;
   };


### PR DESCRIPTION
###### Motivation for this change

This is a nice and simple tool for calculating storage addresses and more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

