### PR TITLE
mergerfs: 2.23.0 -> 2.23.1

### DIFF
--- a/pkgs/tools/filesystems/mergerfs/default.nix
+++ b/pkgs/tools/filesystems/mergerfs/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mergerfs-${version}";
-  version = "2.23.0";
+  version = "2.23.1";
 
   # not using fetchFromGitHub because of changelog being built with git log
   src = fetchgit {
     url = "https://github.com/trapexit/mergerfs";
     rev = "refs/tags/${version}";
-    sha256 = "0k4nn0f4c355q7hnni7iia8qi9m0khvyd04hx1hmlrnf0zsi9mfw";
+    sha256 = "0kbw64fkp3pjc7qm3y1q0ja20v3lhxi0nsq6gd19rq3m7ch9hcgl";
     deepClone = true;
     leaveDotGit = true;
   };


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @makefu