### PR TITLE
mikmod: 3.2.6 -> 3.2.8

### DIFF
--- a/pkgs/applications/audio/mikmod/default.nix
+++ b/pkgs/applications/audio/mikmod/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libmikmod, ncurses, alsaLib }:
 
 stdenv.mkDerivation rec {
-  name = "mikmod-3.2.6";
+  name = "mikmod-3.2.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/mikmod/${name}.tar.gz";
-    sha256 = "0wr61raj10rpl64mk3x9g3rwys898fbzyg93c6mrz89nvc74wm04";
+    sha256 = "1k54p8pn3jinha0f2i23ad15pf1pamibzcxjrbzjbklpcz1ipc6v";
   };
 
   buildInputs = [ libmikmod ncurses ];


### PR DESCRIPTION
3.2.8 is what most distributions use: https://repology.org/metapackage/mikmod/information

Let's see how it works for us, changes seem mostly cleanup.

Changes in 3.2.8 and 3.2.7 are described here: https://github.com/sezero/mikmod/blob/16ec68822abc913377f0e93ba5462becedd087ae/mikmod/NEWS


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---