### PR TITLE
ddar: move out of pythonPackages and fix tests

### DIFF
--- a/pkgs/tools/backup/ddar/default.nix
+++ b/pkgs/tools/backup/ddar/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonApplication, fetchFromGitHub, python, protobuf, sqlite, roundup }:
+{ lib, buildPythonApplication, fetchFromGitHub, python, protobuf, roundup }:
 
 buildPythonApplication rec {
   pname = "ddar";
@@ -11,11 +11,25 @@ buildPythonApplication rec {
     sha256 = "158jdy5261k9yw540g48hddy5zyqrr81ir9fjlcy4jnrwfkg7ynm";
   };
 
+  prePatch = ''
+    substituteInPlace t/local-functions \
+      --replace 'PATH="$ddar_src:$PATH"' 'PATH="$out/bin:$PATH"'
+    # Test requires additional software and compilation of some C programs
+    substituteInPlace t/basic-test.sh \
+      --replace it_stores_and_extracts_corpus0 dont_test
+  '';
+
   preBuild = ''
     make -f Makefile.prep synctus/ddar_pb2.py
   '';
 
   propagatedBuildInputs = [ protobuf ];
+
+  checkInputs = [ roundup ];
+
+  checkPhase = ''
+    roundup t/basic-test.sh
+  '';
 
   meta = with lib; {
     description = "Unix de-duplicating archiver";

--- a/pkgs/tools/backup/ddar/default.nix
+++ b/pkgs/tools/backup/ddar/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonApplication, fetchFromGitHub, python, protobuf, sqlite, roundup }:
+
+buildPythonApplication rec {
+  pname = "ddar";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "basak";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "158jdy5261k9yw540g48hddy5zyqrr81ir9fjlcy4jnrwfkg7ynm";
+  };
+
+  preBuild = ''
+    make -f Makefile.prep synctus/ddar_pb2.py
+  '';
+
+  propagatedBuildInputs = [ protobuf ];
+
+  meta = with lib; {
+    description = "Unix de-duplicating archiver";
+    license = licenses.gpl3;
+    homepage = src.meta.homepage;
+  };
+}

--- a/pkgs/tools/misc/roundup/default.nix
+++ b/pkgs/tools/misc/roundup/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, ronn, shocco }:
+
+stdenv.mkDerivation rec {
+  name = "roundup-${version}";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "bmizerany";
+    repo = "roundup";
+    rev = "v${version}";
+    sha256 = "0nxaqmbv8mdvq9wcaqxk6k5mr31i68jzxf1wxa6pp7xp4prwdc9z";
+  };
+
+  prePatch = ''
+    # Don't change $PATH
+    substituteInPlace configure --replace PATH= NIRVANA=
+    # There are only man pages in sections 1 and 5 \
+    substituteInPlace Makefile --replace "{1..9}" "1 5"
+  '';
+
+  nativeBuildInputs = [ ronn shocco ];
+
+  installTargets = [ "install" "install-man" ];
+
+  preInstall = ''
+    for i in 1 5; do
+      mkdir -p $out/share/man/man$i
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A unit testing tool for running test plans which are written in any POSIX shell";
+    homepage = http://bmizerany.github.io/roundup/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/text/shocco/default.nix
+++ b/pkgs/tools/text/shocco/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, perlPackages, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  name = "shocco-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "rtomayko";
+    repo = "shocco";
+    rev = version;
+    sha256 = "1nkwcw9fqf4vyrwidqi6by7nrmainkjqkirkz3yxmzk6kzwr38mi";
+  };
+
+  prePatch = ''
+    # Don't change $PATH
+    substituteInPlace configure --replace PATH= NIRVANA=
+  '';
+
+  buildInputs = [ perlPackages.TextMarkdown pythonPackages.pygments ];
+
+  meta = with stdenv.lib; {
+    description = "A quick-and-dirty, literate-programming-style documentation generator for / in POSIX shell";
+    homepage = https://rtomayko.github.io/shocco/;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4628,6 +4628,8 @@ with pkgs;
 
   sharutils = callPackage ../tools/archivers/sharutils { };
 
+  shocco = callPackage ../tools/text/shocco { };
+
   shotwell = callPackage ../applications/graphics/shotwell { };
 
   shout = nodePackages.shout;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1031,6 +1031,8 @@ with pkgs;
 
   dateutils = callPackage ../tools/misc/dateutils { };
 
+  ddar = pythonPackages.callPackage ../tools/backup/ddar { };
+
   ddate = callPackage ../tools/misc/ddate { };
 
   dehydrated = callPackage ../tools/admin/dehydrated { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4498,6 +4498,8 @@ with pkgs;
 
   rnv = callPackage ../tools/text/xml/rnv { };
 
+  roundup = callPackage ../tools/misc/roundup { };
+
   routino = callPackage ../tools/misc/routino { };
 
   rq = callPackage ../development/tools/rq {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3836,27 +3836,6 @@ in {
     };
   });
 
-  ddar = buildPythonPackage {
-    name = "ddar-1.0";
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/basak/ddar/archive/v1.0.tar.gz";
-      sha256 = "08lv7hrbhcv6hbl01sx8fgx3l8s2nn8rvcicdidafwm87bvi2nmr";
-    };
-
-    preBuild = ''
-      make -f Makefile.prep synctus/ddar_pb2.py
-    '';
-
-    propagatedBuildInputs = with self; [ protobuf ];
-
-    meta = {
-      description = "Unix de-duplicating archiver";
-      license = licenses.gpl3;
-      homepage = https://github.com/basak/ddar;
-    };
-  };
-
   decorator = callPackage ../development/python-modules/decorator { };
 
   deform = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change
Even though probably not many people use ddar anymore, I think we have a responsibility towards the users and someone not being able to access their ddar backup seems like something to care about. Because ddar is broken on master, I've gone ahead and fixed the expression.
I don't know if it's okay to move it out of `pythonPackages`, but it doesn't belong there as its not a library and it doesn't work with Python 3 anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @viric 