### PR TITLE
strace: disable mpers (multiple personality) support on aarch64 to fix

### DIFF
--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libunwind ]; # support -k
 
+  configureFlags = stdenv.lib.optional stdenv.hostPlatform.isAarch64 "--enable-mpers=no";
+
   meta = with stdenv.lib; {
     homepage = http://strace.sourceforge.net/;
     description = "A system call tracer for Linux";


### PR DESCRIPTION
This fixes the build on aarch64, but may limit functionality in the long-term
that would be hidden by avoiding an underlying problem.

Or maybe this is best.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---