### PR TITLE
otfcc: 0.8.6 -> 0.9.6

### DIFF
--- a/pkgs/tools/misc/otfcc/default.nix
+++ b/pkgs/tools/misc/otfcc/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "otfcc-${version}";
-  version = "0.8.6";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "caryll";
     repo = "otfcc";
     rev = "v${version}";
-    sha256 = "0yy9awffxxs0cdlf0akld73ndnwmylxvplac4k6j7641m3vk1g8p";
+    sha256 = "1rnjfqqyc6d9nhlh8if9k37wk94mcwz4wf3k239v6idg48nrk10b";
   };
 
   nativeBuildInputs = [ premake5 ninja ];


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

