### PR TITLE
z88dk: init at unstable-2018-02-20

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -99,6 +99,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = ''BSD 4-clause "Original" or "Old" License'';
   };
 
+  clArtistic = spdx {
+    spdxId = "ClArtistic";
+    fullName = "Clarified Artistic License";
+  };
+
   cc0 = spdx {
     spdxId = "CC0-1.0";
     fullName = "Creative Commons Zero v1.0 Universal";

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -1,0 +1,50 @@
+{ fetchFromGitHub, fetchpatch, stdenv, makeWrapper, unzip, libxml2, m4, uthash }:
+
+stdenv.mkDerivation rec {
+  name = "z88dk-${version}";
+  version = "20180217";
+  rev = "49a7c6032b2675af742f5b0b3aa5bd5260bdd814";
+  short_rev = "${builtins.substring 0 7 rev}";
+
+  src = fetchFromGitHub {
+    owner = "z88dk";
+    repo  = "z88dk";
+    inherit rev;
+    sha256 = "00vbklh6lkq1gyd08ig2vcg6c1mghvlwfx3vq3wldf34hcs3k4pp";
+  };
+
+  # https://github.com/z88dk/z88dk/pull/612
+  patches = [(fetchpatch {
+    url = "https://github.com/Mic92/z88dk/commit/5b4ca132fa1f31c9ac48cf2220358715739ca0b2.patch";
+    sha256 = "1p2l31j68p7jzykhkhd9iagn2lr08hdclk3cl9l32p1q6ghdipfv";
+  })];
+
+  postPatch = ''
+    # we dont rely on build.sh :
+    export PATH="$PWD/bin:$PATH" # needed to have zcc in testsuite
+    export ZCCCFG=$PWD/lib/config/
+  '';
+
+  makeFlags = [
+    "prefix=$(out)"
+    "git_rev=${short_rev}"
+    "version=${version}"
+    "git_count=0"
+  ];
+  nativeBuildInputs = [ makeWrapper unzip ];
+  buildInputs = [ libxml2 m4 uthash ];
+
+  preInstall = ''
+    mkdir -p $out/{bin,share}
+  '';
+
+  installTargets = "libs install";
+
+  meta = with stdenv.lib; {
+    homepage    = https://www.z88dk.org;
+    description = "z80 Development Kit";
+    license     = licenses.clArtistic;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     description = "z80 Development Kit";
     license     = licenses.clArtistic;
     maintainers = [ maintainers.genesis ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6714,6 +6714,8 @@ with pkgs;
 
   yosys = callPackage ../development/compilers/yosys { };
 
+  z88dk = callPackage ../development/compilers/z88dk { };
+
   zulu8 = callPackage ../development/compilers/zulu/8.nix { };
   zulu9 = callPackage ../development/compilers/zulu { };
   zulu = zulu9;


### PR DESCRIPTION
fixes #35039

###### Motivation for this change

reworked #35039

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (compiled examples from repo)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

