### PR TITLE
lib, treewide: Add missing MIPS arches, and fix existing usage

### DIFF
--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -53,7 +53,7 @@ $ nix-env -qa hello --json
                 "x86_64-linux",
                 "armv5tel-linux",
                 "armv7l-linux",
-                "mips64el-linux",
+                "mips32-linux",
                 "x86_64-darwin",
                 "i686-cygwin",
                 "i686-freebsd",

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -9,7 +9,7 @@ let
     "aarch64-linux"
     "armv5tel-linux" "armv6l-linux" "armv7l-linux"
 
-    "mips64el-linux"
+    "mipsel-linux"
 
     "i686-cygwin" "i686-freebsd" "i686-linux" "i686-netbsd" "i686-openbsd"
 

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -51,7 +51,7 @@ rec {
   };
 
   fuloongminipc = rec {
-    config = "mips64el-unknown-linux-gnu";
+    config = "mipsel-unknown-linux-gnu";
     arch = "mips";
     float = "hard";
     platform = platforms.fuloong2f_n32;

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -75,7 +75,10 @@ rec {
     aarch64  = { bits = 64; significantByte = littleEndian; family = "aarch64"; };
     i686     = { bits = 32; significantByte = littleEndian; family = "x86"; };
     x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; };
-    mips64el = { bits = 32; significantByte = littleEndian; family = "mips"; };
+    mips     = { bits = 32; significantByte = bigEndian;    family = "mips"; };
+    mipsel   = { bits = 32; significantByte = littleEndian; family = "mips"; };
+    mips64   = { bits = 64; significantByte = bigEndian;    family = "mips"; };
+    mips64el = { bits = 64; significantByte = littleEndian; family = "mips"; };
     powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; };
     riscv32  = { bits = 32; significantByte = littleEndian; family = "riscv"; };
     riscv64  = { bits = 64; significantByte = littleEndian; family = "riscv"; };

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -561,6 +561,6 @@ rec {
       "armv6l-linux" = raspberrypi;
       "armv7l-linux" = armv7l-hf-multiplatform;
       "aarch64-linux" = aarch64-multiplatform;
-      "mips64el-linux" = fuloong2f_n32;
+      "mipsel-linux" = fuloong2f_n32;
     }.${system} or pcBase;
 }

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -16,7 +16,7 @@ in with lib.systems.doubles; lib.runTests {
 
   arm = assertTrue (mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv7l-linux" ]);
   i686 = assertTrue (mseteq i686 [ "i686-linux" "i686-freebsd" "i686-netbsd" "i686-openbsd" "i686-cygwin" ]);
-  mips = assertTrue (mseteq mips [ "mips64el-linux" ]);
+  mips = assertTrue (mseteq mips [ "mipsel-linux" ]);
   x86_64 = assertTrue (mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" ]);
 
   cygwin = assertTrue (mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ]);
@@ -24,7 +24,7 @@ in with lib.systems.doubles; lib.runTests {
   freebsd = assertTrue (mseteq freebsd [ "i686-freebsd" "x86_64-freebsd" ]);
   gnu = assertTrue (mseteq gnu (linux /* ++ hurd ++ kfreebsd ++ ... */));
   illumos = assertTrue (mseteq illumos [ "x86_64-solaris" ]);
-  linux = assertTrue (mseteq linux [ "i686-linux" "x86_64-linux" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" "mips64el-linux" ]);
+  linux = assertTrue (mseteq linux [ "i686-linux" "x86_64-linux" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" "mipsel-linux" ]);
   netbsd = assertTrue (mseteq netbsd [ "i686-netbsd" "x86_64-netbsd" ]);
   openbsd = assertTrue (mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ]);
   unix = assertTrue (mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos));

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -58,7 +58,7 @@ let
     else if (with targetPlatform; isArm && isLinux)   then "${libc_lib}/lib/ld-linux*.so.3"
     else if targetPlatform.system == "aarch64-linux"  then "${libc_lib}/lib/ld-linux-aarch64.so.1"
     else if targetPlatform.system == "powerpc-linux"  then "${libc_lib}/lib/ld.so.1"
-    else if targetPlatform.system == "mips64el-linux" then "${libc_lib}/lib/ld.so.1"
+    else if targetPlatform.isMips                     then "${libc_lib}/lib/ld.so.1"
     else if targetPlatform.isDarwin                   then "/usr/lib/dyld"
     else if stdenv.lib.hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1"
     else null;
@@ -171,13 +171,20 @@ stdenv.mkDerivation {
       else if targetPlatform.isWindows then "pe"
       else "elf" + toString targetPlatform.parsed.cpu.bits;
     endianPrefix = if targetPlatform.isBigEndian then "big" else "little";
+    sep = optionalString (targetPlatform.isx86 || targetPlatform.isArm) "-";
     arch =
       /**/ if targetPlatform.isAarch64 then endianPrefix + "aarch64"
       else if targetPlatform.isArm     then endianPrefix + "arm"
       else if targetPlatform.isx86_64  then "x86-64"
       else if targetPlatform.isi686    then "i386"
+      else if targetPlatform.isMips    then {
+          "mips"     = "btsmipn32"; # n32 variant
+          "mipsel"   = "ltsmipn32"; # n32 variant
+          "mips64"   = "btsmip";
+          "mips64el" = "ltsmip";
+        }.${targetPlatform.parsed.cpu.name}
       else throw "unknown emulation for platform: " + targetPlatform.config;
-    in targetPlatform.platform.bfdEmulation or (fmt + "-" + arch);
+    in targetPlatform.platform.bfdEmulation or (fmt + sep + arch);
 
   depsTargetTargetPropagated = extraPackages;
 

--- a/pkgs/development/compilers/gcc/4.5/default.nix
+++ b/pkgs/development/compilers/gcc/4.5/default.nix
@@ -317,8 +317,8 @@ stdenv.mkDerivation ({
 
     # Platform-specific flags
     optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
-    # Trick that should be taken out once we have a mips64el-linux not loongson2f
-    optional (targetPlatform == hostPlatform && stdenv.system == "mips64el-linux") "--with-arch=loongson2f"
+    # Trick that should be taken out once we have a mipsel-linux not loongson2f
+    optional (targetPlatform == hostPlatform && stdenv.system == "mipsel-linux") "--with-arch=loongson2f"
   ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;

--- a/pkgs/development/tools/misc/pkgconfig/default.nix
+++ b/pkgs/development/tools/misc/pkgconfig/default.nix
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
   patches = optional (!vanilla) ./requires-private.patch
     ++ optional stdenv.isCygwin ./2.36.3-not-win32.patch;
 
-  preConfigure = optionalString (stdenv.system == "mips64el-linux")
-    ''cp -v ${automake}/share/automake*/config.{sub,guess} .'';
+  preConfigure = ""; # TODO(@Ericson2314): Remove next mass rebuild
   buildInputs = optional (stdenv.isCygwin || stdenv.isDarwin || stdenv.isSunOS) libiconv;
 
   configureFlags = [ "--with-internal-glib" ]

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
       # We get a warning in armv5tel-linux and the fuloong2f, so we
       # disable -Werror in it.
-      ${stdenv.lib.optionalString (stdenv.isArm || stdenv.system == "mips64el-linux") ''
+      ${stdenv.lib.optionalString (stdenv.isArm || stdenv.hostPlatform.isMips) ''
         sed -i s/-Werror// src/Makefile.am
       ''}
     '';

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -94,7 +94,9 @@ rec {
               # without proper `file` command, libtool sometimes fails
               # to recognize 64-bit DLLs
             ++ stdenv.lib.optional (hostPlatform.config == "x86_64-w64-mingw32") pkgs.file
-            ++ stdenv.lib.optional (hostPlatform.isAarch64 || hostPlatform.libc == "musl") pkgs.updateAutotoolsGnuConfigScriptsHook
+            ++ stdenv.lib.optional
+                 (hostPlatform.isAarch64 || hostPlatform.isMips || hostPlatform.libc == "musl")
+                 pkgs.updateAutotoolsGnuConfigScriptsHook
             ;
 
           crossConfig = hostPlatform.config;

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -45,7 +45,7 @@ in
     "armv6l-linux" = stagesLinux;
     "armv7l-linux" = stagesLinux;
     "aarch64-linux" = stagesLinux;
-    "mips64el-linux" = stagesLinux;
+    "mipsel-linux" = stagesLinux;
     "powerpc-linux" = /* stagesLinux */ stagesNative;
     "x86_64-darwin" = stagesDarwin;
     "x86_64-solaris" = stagesNix;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -15,7 +15,7 @@
       "armv6l-linux" = import ./bootstrap-files/armv6l.nix;
       "armv7l-linux" = import ./bootstrap-files/armv7l.nix;
       "aarch64-linux" = import ./bootstrap-files/aarch64.nix;
-      "mips64el-linux" = import ./bootstrap-files/loongson2f.nix;
+      "mipsel-linux" = import ./bootstrap-files/loongson2f.nix;
     };
     "musl" = {
       "aarch64-linux" = import ./bootstrap-files/aarch64-musl.nix;
@@ -40,7 +40,7 @@ let
       export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
       export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
       ${if system == "x86_64-linux" then "NIX_LIB64_IN_SELF_RPATH=1" else ""}
-      ${if system == "mips64el-linux" then "NIX_LIB32_IN_SELF_RPATH=1" else ""}
+      ${if system == "mipsel-linux" then "NIX_LIB32_IN_SELF_RPATH=1" else ""}
     '';
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5442,7 +5442,7 @@ with pkgs;
   xbursttools = assert stdenv ? glibc; callPackage ../tools/misc/xburst-tools rec {
     # It needs a cross compiler for mipsel to build the firmware it will
     # load into the Ben Nanonote
-    crossPrefix = "mips64el-unknown-linux-gnu";
+    crossPrefix = "mipsel-unknown-linux-gnu";
     gccCross =
       let
         pkgsCross = nixpkgsFun {


### PR DESCRIPTION
This is just the barest minimum so that nixpkgs can recognize mips/mipsel as systems - although required for building individual derivations for MIPS boards, it is not sufficient if you want to actually build NixOS or even the majority of the nixpkgs collection on those targets.

###### Motivation for this change

For me this is necessary so that I can build MIPS binaries for NixWRT.  I don't expect it to have any other effect.

(I note in passing that there is an existing system `mips64el` which has `bits = 32` set, which seems ... odd. Perhaps it's for a  system with a 64 bit kernel and 32 bit userland, but I haven't touched it)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

