### PR TITLE
monit: cross-compile, and make openssl optional

### DIFF
--- a/pkgs/tools/system/monit/default.nix
+++ b/pkgs/tools/system/monit/default.nix
@@ -1,5 +1,7 @@
-{stdenv, fetchurl, openssl, bison, flex, pam, zlib, usePAM ? stdenv.isLinux }:
-
+{stdenv, fetchurl, openssl, bison, flex, pam, zlib, usePAM ? stdenv.isLinux
+ , buildPlatform, hostPlatform }:
+let useSSL = (openssl != null);
+    isCross = ( buildPlatform != hostPlatform ) ; in
 stdenv.mkDerivation rec {
   name = "monit-5.23.0";
 
@@ -9,12 +11,19 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ bison flex ];
-  buildInputs = [ openssl zlib.dev ] ++ stdenv.lib.optionals usePAM [ pam ];
+  buildInputs = [ zlib.dev ] ++
+    stdenv.lib.optionals useSSL [ openssl ] ++
+    stdenv.lib.optionals usePAM [ pam ];
 
-  configureFlags = [
-    "--with-ssl-incl-dir=${openssl.dev}/include"
-    "--with-ssl-lib-dir=${openssl.out}/lib"
-  ] ++ stdenv.lib.optionals (! usePAM) [ "--without-pam" ];
+  configureFlags =
+    if useSSL then [
+      "--with-ssl-incl-dir=${openssl.dev}/include"
+      "--with-ssl-lib-dir=${openssl.out}/lib"
+    ] else [ "--without-ssl" ] ++
+    stdenv.lib.optionals (! usePAM) [ "--without-pam" ] ++
+    # will need to check both these are true for musl
+    stdenv.lib.optionals isCross [ "libmonit_cv_setjmp_available=yes"
+                                   "libmonit_cv_vsnprintf_c99_conformant=yes"];
 
   meta = {
     homepage = http://mmonit.com/monit/;


### PR DESCRIPTION
###### Motivation for this change

Upstream Monit optionally uses OpenSSL to provide HTTPS support in its builtin admin web server.  Being able to turn off SSL in Nixpkgs' monit derivation makes it much easier to build Monit on embedded systems - and the resulting package is smaller.

Security implication: if you choose not to build in openssl then you should probably configure Monit to allow HTTP access only from localhost (or over trusted networks only)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

