### PR TITLE
mdbook: init at 0.1.3

### DIFF
--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, CoreServices ? null }:
+{ stdenv, fetchFromGitHub, rustPlatform, CoreServices }:
 
 rustPlatform.buildRustPackage rec {
   name = "mdbook-${version}";
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "19hpr78p9rzgirq6fjw8v11d5mgcglms6vbqgjyvg49xmkklsqzr";
   depsSha256 = "0q68qyl2h6i0qsz82z840myxlnjay8p1w5z7hfyr8fqp7wgwa9cx";
 
-  buildInputs = [] ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
 
   meta = with stdenv.lib; {
     description = "Create books from MarkDown";

--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, rustPlatform, CoreServices ? null }:
+
+rustPlatform.buildRustPackage rec {
+  name = "mdbook-${version}";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "rust-lang-nursery";
+    repo = "mdBook";
+    rev = "v${version}";
+    sha256 = "0m0vprjpd02z4nr3vd4qha2jka7l36k4liw8jcbf4xs09c584sjv";
+  };
+
+  cargoSha256 = "19hpr78p9rzgirq6fjw8v11d5mgcglms6vbqgjyvg49xmkklsqzr";
+  depsSha256 = "0q68qyl2h6i0qsz82z840myxlnjay8p1w5z7hfyr8fqp7wgwa9cx";
+
+  buildInputs = [] ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
+
+  meta = with stdenv.lib; {
+    description = "Create books from MarkDown";
+    homepage = https://github.com/rust-lang-nursery/mdbook;
+    license = [ licenses.asl20 licenses.mit ];
+    maintainers = [ maintainers.havvy ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -22,5 +22,9 @@ rustPlatform.buildRustPackage rec {
     license = [ licenses.asl20 licenses.mit ];
     maintainers = [ maintainers.havvy ];
     platforms = platforms.all;
+
+    # Because CoreServices needs to be updated,
+    # but Apple won't release the source.
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3169,7 +3169,9 @@ with pkgs;
 
   matrix-synapse = callPackage ../servers/matrix-synapse { };
 
-  mdbook = callPackage ../tools/text/mdbook { };
+  mdbook = callPackage ../tools/text/mdbook {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
 
   memtester = callPackage ../tools/system/memtester { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3169,6 +3169,8 @@ with pkgs;
 
   matrix-synapse = callPackage ../servers/matrix-synapse { };
 
+  mdbook = callPackage ../tools/text/mdbook { };
+
   memtester = callPackage ../tools/system/memtester { };
 
   minidlna = callPackage ../tools/networking/minidlna { };


### PR DESCRIPTION
###### Motivation for this change

I want to install mdbook for work on the Rust reference using nixpkgs instead of via `cargo install`.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

