### PR TITLE
timewarrior: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "timewarrior-${version}";
-  version = "1.1.0";
+  version = "1.1.1";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
     url = "https://taskwarrior.org/download/timew-${version}.tar.gz";
-    sha256 = "0jnwj8lflr6nlch2j2hkmgpdqq3zbdd2sfpi5iwiabljk25v9iq9";
+    sha256 = "1jfcfzdwk5qqhxznj1bgy0sx3lnp3z5lqr9kch9a7iazwmi9lz8z";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "A command-line time tracker";
     homepage = https://tasktools.org/projects/timewarrior.html;
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ matthiasbeyer mrVanDalo ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
[Timewarrior 1.1.1 is released. This is a bug fix release and we recommend that everyoe upgrade to 1.1.1.](https://taskwarrior.org/news/news.20180203.2.html)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

