### PR TITLE
python-notify2: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/notify2/default.nix
+++ b/pkgs/development/python-modules/notify2/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, pygobject3
+, dbus-python
+}:
+
+buildPythonPackage rec {
+  pname = "notify2";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0z8rrv9rsg1r2qgh2dxj3dfj5xnki98kgi3w839kqby4a26i1yik";
+  };
+
+
+  # Tests require Xorg and Dbus instance
+  doCheck = false;
+  propagatedBuildInputs = [ pygobject3
+                            dbus-python ]; 
+
+  meta = {
+    description = "Pure Python interface to DBus notifications";
+    homepage = https://bitbucket.org/takluyver/pynotify2;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ mog ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11319,6 +11319,8 @@ in {
     };
   });
 
+  notify2 = callPackage ../development/python-modules/notify2 {};
+
   notmuch = buildPythonPackage rec {
     name = "python-${pkgs.notmuch.name}";
 


### PR DESCRIPTION
###### Motivation for this change
i was requested to break this into two prs here https://github.com/NixOS/nixpkgs/pull/35245

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

