### PR TITLE
Parity: ethereum client

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -33,6 +33,7 @@
   ak = "Alexander Kjeldaas <ak@formalprivacy.com>";
   akaWolf = "Artjom Vejsel <akawolf0@gmail.com>";
   akc = "Anders Claesson <akc@akc.is>";
+  akru = "Alexander Krupenkin <mail@akru.me>";
   alexvorobiev = "Alex Vorobiev <alexander.vorobiev@gmail.com";
   algorith = "Dries Van Daele <dries_van_daele@telenet.be>";
   alibabzo = "Alistair Bill <alistair.bill@gmail.com>";

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -67,4 +67,6 @@ rec {
     withGui = false;
     openssl = openssl_1_1_0;
   };
+
+  parity = callPackage ./parity { };
 }

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -69,4 +69,5 @@ rec {
   };
 
   parity = callPackage ./parity { };
+  parity-beta = callPackage ./parity/beta.nix { };
 }

--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,7 +1,7 @@
 let
-  version     = "1.9.3";
-  sha256      = "19qyp6kafnnfhdnbq745v8zybnqizjzzc3k4701ly9hf0dvx53ka";
-  cargoSha256 = "1f2rq96ci1pm29wlaahp4vq6wmmywq33a7svdi9nw5wqvbr1l1nk";
+  version     = "1.9.4";
+  sha256      = "00b6wsyc2chmdkhfhi9h1i06hpcjj2abcx3qdc6k39clgha0081f";
+  cargoSha256 = "0pyb1mpykdp6i7c30lm5fprrxg3zanak44g28cygzli3l9l3xiy3";
   patches     = [ ./patches/vendored-sources-1.9.patch ];
 in
   import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,7 +1,7 @@
 let
   version     = "1.9.3";
   sha256      = "19qyp6kafnnfhdnbq745v8zybnqizjzzc3k4701ly9hf0dvx53ka";
-  cargoSha256 = "1vdvqs6ligp5fkw5s7v44vwqwz5dqa0ipilx0piz6swz0drilima";
+  cargoSha256 = "1f2rq96ci1pm29wlaahp4vq6wmmywq33a7svdi9nw5wqvbr1l1nk";
   patches     = [ ./patches/vendored-sources-1.9.patch ];
 in
   import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,0 +1,7 @@
+let
+  version     = "1.9.3";
+  sha256      = "19qyp6kafnnfhdnbq745v8zybnqizjzzc3k4701ly9hf0dvx53ka";
+  cargoSha256 = "1vdvqs6ligp5fkw5s7v44vwqwz5dqa0ipilx0piz6swz0drilima";
+  patches     = [ ./patches/vendored-sources-1.9.patch ];
+in
+  import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,0 +1,7 @@
+let
+  version     = "1.8.10";
+  sha256      = "0slqfzyz11s6wjf77npgw4q6bcgkqmfm53daj47slxm6axkd954r";
+  cargoSha256 = "0k0vqvmz2jr0lfzm8bfrshapgvxjr617shsg5m479m3r02p8l9l3";
+  patches     = [ ./patches/vendored-sources-1.8.patch ];
+in
+  import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,7 +1,7 @@
 let
-  version     = "1.8.10";
-  sha256      = "0slqfzyz11s6wjf77npgw4q6bcgkqmfm53daj47slxm6axkd954r";
-  cargoSha256 = "0k0vqvmz2jr0lfzm8bfrshapgvxjr617shsg5m479m3r02p8l9l3";
+  version     = "1.8.11";
+  sha256      = "1vabkglmmbx9jccwsqwvwck1brdjack3sw6iwsxy01wsc2jam56k";
+  cargoSha256 = "1l5hx77glclpwd9i35rr3lxfxshsf1bsxvs2chsp2vwjy06knjmi";
   patches     = [ ./patches/vendored-sources-1.8.patch ];
 in
   import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/parity.nix
+++ b/pkgs/applications/altcoins/parity/parity.nix
@@ -33,5 +33,6 @@ rustPlatform.buildRustPackage rec {
     homepage = http://parity.io;
     license = licenses.gpl3;
     maintainers = [ maintainers.akru ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/altcoins/parity/parity.nix
+++ b/pkgs/applications/altcoins/parity/parity.nix
@@ -1,0 +1,37 @@
+{ version
+, sha256
+, cargoSha256
+, patches
+}:
+
+{ stdenv
+, fetchFromGitHub
+, rustPlatform 
+, pkgconfig
+, openssl
+, systemd
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "parity-${version}";
+  inherit cargoSha256 patches;
+
+  src = fetchFromGitHub {
+    owner = "paritytech";
+    repo = "parity";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  buildInputs = [ pkgconfig systemd.lib systemd.dev openssl openssl.dev ]; 
+
+  # Some checks failed
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Fast, light, robust Ethereum implementation";
+    homepage = http://parity.io;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.akru ];
+  };
+}

--- a/pkgs/applications/altcoins/parity/patches/vendored-sources-1.8.patch
+++ b/pkgs/applications/altcoins/parity/patches/vendored-sources-1.8.patch
@@ -1,0 +1,100 @@
+diff --git a/.cargo/config b/.cargo/config
+new file mode 100644
+index 000000000..8dddda426
+--- /dev/null
++++ b/.cargo/config
+@@ -0,0 +1,94 @@
++[source."https://github.com/alexcrichton/mio-named-pipes"]
++git = "https://github.com/alexcrichton/mio-named-pipes"
++branch = "master" 
++replace-with = "vendored-sources"
++
++[source."https://github.com/nikvolf/parity-tokio-ipc"]
++git = "https://github.com/nikvolf/parity-tokio-ipc"
++branch = "master" 
++replace-with = "vendored-sources"
++
++[source."https://github.com/nikvolf/tokio-named-pipes"]
++git = "https://github.com/nikvolf/tokio-named-pipes"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/bn"]
++git = "https://github.com/paritytech/bn"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/hidapi-rs"]
++git = "https://github.com/paritytech/hidapi-rs"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/hyper"]
++git = "https://github.com/paritytech/hyper"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/js-precompiled.git"]
++git = "https://github.com/paritytech/js-precompiled.git"
++branch = "stable"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/jsonrpc.git"]
++git = "https://github.com/paritytech/jsonrpc.git"
++branch = "parity-1.8"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/libusb-rs"]
++git = "https://github.com/paritytech/libusb-rs"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/libusb-sys"]
++git = "https://github.com/paritytech/libusb-sys"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/nanomsg.rs.git"]
++git = "https://github.com/paritytech/nanomsg.rs.git"
++branch = "parity-1.7"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/rust-ctrlc.git"]
++git = "https://github.com/paritytech/rust-ctrlc.git"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/rust-rocksdb"]
++git = "https://github.com/paritytech/rust-rocksdb"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/rust-secp256k1"]
++git = "https://github.com/paritytech/rust-secp256k1"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/rust-snappy"]
++git = "https://github.com/paritytech/rust-snappy"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/trezor-sys"]
++git = "https://github.com/paritytech/trezor-sys"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/wasm-utils"]
++git = "https://github.com/paritytech/wasm-utils"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/tailhook/rotor"]
++git = "https://github.com/tailhook/rotor"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/tomusdrw/ws-rs"]
++git = "https://github.com/tomusdrw/ws-rs"
++branch = "master"
++replace-with = "vendored-sources"

--- a/pkgs/applications/altcoins/parity/patches/vendored-sources-1.9.patch
+++ b/pkgs/applications/altcoins/parity/patches/vendored-sources-1.9.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 000000000..0efb69724
 --- /dev/null
 +++ b/.cargo/config
-@@ -0,0 +1,96 @@
+@@ -0,0 +1,100 @@
 +
 +[source."https://github.com/alexcrichton/mio-named-pipes"]
 +git = "https://github.com/alexcrichton/mio-named-pipes"
@@ -87,6 +87,11 @@ index 000000000..0efb69724
 +
 +[source."https://github.com/paritytech/wasm-utils"]
 +git = "https://github.com/paritytech/wasm-utils"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/pepyakin/wasmi"]
++git = "https://github.com/pepyakin/wasmi"
 +branch = "master"
 +replace-with = "vendored-sources"
 +

--- a/pkgs/applications/altcoins/parity/patches/vendored-sources-1.9.patch
+++ b/pkgs/applications/altcoins/parity/patches/vendored-sources-1.9.patch
@@ -1,0 +1,102 @@
+diff --git a/.cargo/config b/.cargo/config
+new file mode 100644
+index 000000000..0efb69724
+--- /dev/null
++++ b/.cargo/config
+@@ -0,0 +1,96 @@
++
++[source."https://github.com/alexcrichton/mio-named-pipes"]
++git = "https://github.com/alexcrichton/mio-named-pipes"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/js-dist-paritytech/parity-beta-1-9-shell.git"]
++git = "https://github.com/js-dist-paritytech/parity-beta-1-9-shell.git"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/js-dist-paritytech/parity-beta-1-9-v1.git"]
++git = "https://github.com/js-dist-paritytech/parity-beta-1-9-v1.git"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/nikvolf/parity-tokio-ipc"]
++git = "https://github.com/nikvolf/parity-tokio-ipc"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/nikvolf/tokio-named-pipes"]
++git = "https://github.com/nikvolf/tokio-named-pipes"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/bn"]
++git = "https://github.com/paritytech/bn"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/hidapi-rs"]
++git = "https://github.com/paritytech/hidapi-rs"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/hyper"]
++git = "https://github.com/paritytech/hyper"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/jsonrpc.git"]
++git = "https://github.com/paritytech/jsonrpc.git"
++branch = "parity-1.9"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/libusb-rs"]
++git = "https://github.com/paritytech/libusb-rs"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/libusb-sys"]
++git = "https://github.com/paritytech/libusb-sys"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/rust-ctrlc.git"]
++git = "https://github.com/paritytech/rust-ctrlc.git"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/rust-rocksdb"]
++git = "https://github.com/paritytech/rust-rocksdb"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/rust-secp256k1"]
++git = "https://github.com/paritytech/rust-secp256k1"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/rust-snappy"]
++git = "https://github.com/paritytech/rust-snappy"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/trezor-sys"]
++git = "https://github.com/paritytech/trezor-sys"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/paritytech/wasm-utils"]
++git = "https://github.com/paritytech/wasm-utils"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/tailhook/rotor"]
++git = "https://github.com/tailhook/rotor"
++branch = "master"
++replace-with = "vendored-sources"
++
++[source."https://github.com/tomusdrw/ws-rs"]
++git = "https://github.com/tomusdrw/ws-rs"
++branch = "master"
++replace-with = "vendored-sources"
++

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14494,6 +14494,7 @@ with pkgs;
   hevm = self.altcoins.hevm;
 
   parity = self.altcoins.parity;
+  parity-beta = self.altcoins.parity-beta;
 
   stellar-core = self.altcoins.stellar-core;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14493,6 +14493,8 @@ with pkgs;
   dapp = self.altcoins.dapp;
   hevm = self.altcoins.hevm;
 
+  parity = self.altcoins.parity;
+
   stellar-core = self.altcoins.stellar-core;
 
   aumix = callPackage ../applications/audio/aumix {


### PR DESCRIPTION
###### Motivation for this change

> This is clean version of #34441.

Added two versions of Parity ethereum client (https://parity.io):

* parity v1.8.11
* parity-beta v1.9.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

