### PR TITLE
tree-wide: spelling error s/propogatedBuildInputs/propagatedBuildInputs/

### DIFF
--- a/pkgs/applications/misc/calcurse/default.nix
+++ b/pkgs/applications/misc/calcurse/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   pythonEnv = python3Packages.python.buildEnv.override {
     extraLibs = [ python3Packages.httplib2 ];
   };
-  propogatedBuildInputs = [ pythonEnv ];
+  propagatedBuildInputs = [ pythonEnv ];
 
   postInstall = ''
     substituteInPlace $out/bin/calcurse-caldav --replace /usr/bin/python3 ${pythonEnv}/bin/python3

--- a/pkgs/development/python-modules/backports_csv/default.nix
+++ b/pkgs/development/python-modules/backports_csv/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "1imzbrradkfn8s2m1qcimyn74dn1mz2p3j381jljn166rf2i6hlc";
   };
 
-  propogatedBuildInputs = [ future ];
+  propagatedBuildInputs = [ future ];
 
   meta = with stdenv.lib; {
     description = "Backport of Python 3 csv module";


### PR DESCRIPTION
###### Motivation for this change
In working to get a different pr in I came across these mispellings of propagatedBuildInputs.. I haven't tested these just fixed the variable so it would be used correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

