### PR TITLE
cc-wrapper: fix bool handling for empty and zero values

### DIFF
--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -25,7 +25,11 @@ mangleVarBool() {
     for infix in "${role_infixes[@]}"; do
         local inputVar="${var/+/${infix}}"
         if [ -v "$inputVar" ]; then
-            let "${outputVar} |= ${!inputVar}"
+            # "1" in the end makes `let` return success error code when
+            # expression itself evaluates to zero.
+            # We don't use `|| true` because that would silence actual
+            # syntax errors from bad variable values.
+            let "${outputVar} |= ${!inputVar:-0}" "1"
         fi
     done
 }


### PR DESCRIPTION
###### Motivation for this change

Before the code would fail silently for zero values and with some output for
empties. We now currently handle both via defaulting value to zero and making
`let` return success error code when there's no syntax error.

Test case:

1. `nix-shell -A hello`
2. `export NIX_ENFORCE_NO_NATIVE=""`
3. `gcc --version` (observe error)
4. `export NIX_ENFORCE_NO_NATIVE=0`
5. `gcc --version` (observe silent failure)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---