### PR TITLE
gnomeExtensions.dash-to-dock: v61 -> v62

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-dash-to-dock-${version}";
-  version = "v61";
+  version = "v62";
 
   src = fetchFromGitHub {
     owner = "micheleg";
     repo = "dash-to-dock";
     rev = "extensions.gnome.org-" + version;
-    sha256 = "152xzhal3wr40j0pv03v0gg20054n5hqqy3s10bkj2a0x830pgjk";
+    sha256 = "1kmf7vxhd1c1zgaim1pwmcmsg0kffng7hcl5gfcy5qb5yvb4dy5d";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
A new version is out. Changelog [here](https://micheleg.github.io/dash-to-dock/release/2017/12/25/new-relsease-v62.html). Manually tested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

