### PR TITLE
upgrade and clean crashplan for small business

### DIFF
--- a/nixos/modules/services/backup/crashplan-small-business.nix
+++ b/nixos/modules/services/backup/crashplan-small-business.nix
@@ -23,7 +23,7 @@ with lib;
         example = "2G";
         type = types.str;
         description = ''
-          Maximum amount of that the crashplan engine should use.
+          Maximum amount of ram that the crashplan engine should use.
         '';
       };
       openPorts = mkOption {
@@ -52,28 +52,13 @@ with lib;
       after    = [ "network.target" "local-fs.target" ];
 
       preStart = ''
-        ensureDir() {
-          dir=$1
-          mode=$2
-
-          if ! test -e $dir; then
-            ${pkgs.coreutils}/bin/mkdir -m $mode -p $dir
-          elif [ "$(${pkgs.coreutils}/bin/stat -c %a $dir)" != "$mode" ]; then
-            ${pkgs.coreutils}/bin/chmod $mode $dir
-          fi
-        }
-
-        ensureDir ${crashplansb.vardir} 755
-        ensureDir ${crashplansb.vardir}/conf 700
-        ensureDir ${crashplansb.manifestdir} 700
-        ensureDir ${crashplansb.vardir}/cache 700
-        ensureDir ${crashplansb.vardir}/backupArchives 700
-        ensureDir ${crashplansb.vardir}/log 777
+        install -d -m 755 ${crashplansb.vardir}
+        install -d -m 700 ${crashplansb.vardir}/conf
+        install -d -m 700 ${crashplansb.manifestdir}
+        install -d -m 700 ${crashplansb.vardir}/cache
+        install -d -m 700 ${crashplansb.vardir}/backupArchives
+        install -d -m 777 ${crashplansb.vardir}/log
         cp -avn ${crashplansb}/conf.template/* ${crashplansb.vardir}/conf
-        #for x in bin install.vars lang lib libc42archive64.so libc42core.so libjniwrap64.so libjtux64.so libleveldb64.so libnetty-tcnative.so share upgrade; do
-        #  rm -f ${crashplansb.vardir}/$x;
-        #  ln -sf ${crashplansb}/$x ${crashplansb.vardir}/$x;
-        #done
       '';
 
       serviceConfig = {

--- a/pkgs/applications/backup/crashplan/crashplan-small-business.nix
+++ b/pkgs/applications/backup/crashplan/crashplan-small-business.nix
@@ -6,14 +6,14 @@
   maxRam ? "1024m" }:
 
 stdenv.mkDerivation rec {
-  version = "6.6.0";
-  rev = "1506661200660_4347";
+  version = "6.7.0";
+  rev = "1512021600670_4503";
   pname = "CrashPlanSmb";
   name = "${pname}_${version}_${rev}";
   
   src = fetchurl {
     url = "https://web-eam-msp.crashplanpro.com/client/installers/${name}_Linux.tgz";
-    sha256 = "1zzx60fpmi2nlzpq80x4hfgspsrgd7ycfcvc6w391wxr0qzf2i9k";
+    sha256 = "0f7ykfxaqjlvv4hv12yc5z8y1vjsysdblv53byml7i1fy1r0q26q";
   };
 
   nativeBuildInputs = [ makeWrapper cpio nodePackages.asar ];


### PR DESCRIPTION
###### Motivation for this change
The package for crashplan 6.6.0 has been removed from its location, breaking the package unless it's upgraded.

###### Things done

Removed unneeded code from the crashplan for small business service and upgraded the crashplan pkg from 6.6.0 to 6.7.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

