### PR TITLE
virtualbox: fix extensionPack's hash, fixes #34846

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -19,7 +19,8 @@ let
   python = python2;
   buildType = "release";
   # Manually sha256sum the extensionPack file, must be hex!
-  extpack = "13n6d6wca3bnvqc1q0bapgwfjmfqm19nxn9c0vbzd28c4l88j991";
+  # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
+  extpack = "21258910250c89f6d7062cd96e53a8d855e9f8bb6a011c18de760dc5b869c68e";
   extpackRev = "120294";
   main = "0agjldjn01p4x54m53db50xwamrphl7iqcrika3wa04rvlb36f40";
   version = "5.1.32";


### PR DESCRIPTION
###### Motivation for this change

Fix #34846.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

