### PR TITLE
snapraid: 11.1 -> 11.2

### DIFF
--- a/pkgs/tools/filesystems/snapraid/default.nix
+++ b/pkgs/tools/filesystems/snapraid/default.nix
@@ -2,14 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "snapraid-${version}";
-  version = "11.1";
+  version = "11.2";
 
   src = fetchFromGitHub {
     owner = "amadvance";
     repo = "snapraid";
     rev = "v${version}";
-    sha256 = "1vgyiagn6qvyyz4jkf8pzlg0w9apb6mzza97a9x03p82fav2afx0";
+    sha256 = "01z8fl3x2j5bnm0rybj7hhch18is6dkwqc43yzwc6418spr4imsd";
   };
+
+  VERSION = version;
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @makefu