### PR TITLE
Update Mozilla sops to the latest version

### DIFF
--- a/pkgs/tools/security/sops/default.nix
+++ b/pkgs/tools/security/sops/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "sops-${version}";
-  version = "2.0.8";
+  version = "3.0.2";
 
   goPackagePath = "go.mozilla.org/sops";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev = version;
     owner = "mozilla";
     repo = "sops";
-    sha256 = "0kawnp24i3r981hz6apfwhgp71002vjq7ir54arq0zkssmykms1c";
+    sha256 = "0zszlb35cmw9j9dg1bpcbwxwh094wcfxhas4ns58jp5n79rqwv9i";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update Mozilla Sops to the latest release.

###### Things done

Only updated the tags as specified on the Mozilla Repo and tested locally

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

