### PR TITLE
Logkeys: Update and add `device` option to service

### DIFF
--- a/nixos/modules/services/misc/logkeys.nix
+++ b/nixos/modules/services/misc/logkeys.nix
@@ -7,6 +7,13 @@ let
 in {
   options.services.logkeys = {
     enable = mkEnableOption "logkeys service";
+
+    device = mkOption {
+      description = "Use the given device as keyboard input event device instead of /dev/input/eventX default.";
+      default = null;
+      type = types.nullOr types.string;
+      example = "/dev/input/event15";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -14,7 +21,7 @@ in {
       description = "LogKeys Keylogger Daemon";
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.logkeys}/bin/logkeys -s";
+        ExecStart = "${pkgs.logkeys}/bin/logkeys -s${lib.optionalString (cfg.device != null) " -d ${cfg.device}"}";
         ExecStop = "${pkgs.logkeys}/bin/logkeys -k";
         Type = "forking";
       };

--- a/pkgs/tools/security/logkeys/default.nix
+++ b/pkgs/tools/security/logkeys/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, autoconf, automake, which, procps, kbd }:
+{ stdenv, fetchFromGitHub, autoconf, automake, which, procps, kbd }:
 
 stdenv.mkDerivation rec {
   name = "logkeys-${version}";
-  version = "2017-10-10";
+  version = "2018-01-22";
 
-  src = fetchgit {
-    url = https://github.com/kernc/logkeys;
-    rev = "5c368327a2cd818efaed4794633c260b90b87abf";
-    sha256 = "0akj7j775y9c0p53zq5v12jk3fy030fpdvn5m1x9w4rdj47vxdpg";
+  src = fetchFromGitHub {
+    owner = "kernc";
+    repo = "logkeys";
+    rev = "7a9f19fb6b152d9f00a0b3fe29ab266ff1f88129";
+    sha256 = "1k6kj0913imwh53lh6hrhqmrpygqg2h462raafjsn7gbd3vkgx8n";
   };
 
   buildInputs = [ autoconf automake which procps kbd ];


### PR DESCRIPTION
###### Motivation for this change

Update the package and add the `device` option to specify it manually if needed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

