### PR TITLE
 gnomeExtensions.no-title-bar: init at 8

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -671,6 +671,7 @@
   stumoss = "Stuart Moss <samoss@gmail.com>";
   SuprDewd = "Bjarki Ágúst Guðmundsson <suprdewd@gmail.com>";
   suvash = "Suvash Thapaliya <suvash+nixpkgs@gmail.com>";
+  svsdep = "Vasyl Solovei <svsdep@gmail.com>";
   swarren83 = "Shawn Warren <shawn.w.warren@gmail.com>";
   swflint = "Samuel W. Flint <swflint@flintfam.org>";
   swistak35 = "Rafał Łasocha <me@swistak35.com>";

--- a/pkgs/desktops/gnome-3/extensions/no-title-bar/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/no-title-bar/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, substituteAll, glib, gettext, xorg }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-no-title-bar-${version}";
+  version = "8";
+
+  src = fetchFromGitHub {
+    owner = "franglais125";
+    repo = "no-title-bar";
+    rev = "v${version}";
+    sha256 = "0n3ayf7k2icy913sjl1d6iwm21i8fivv0f7wj7gck8q7q2j7i3bz";
+  };
+
+  nativeBuildInputs = [
+    glib gettext
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      xprop = "${xorg.xprop}/bin/xprop";
+      xwininfo = "${xorg.xwininfo}/bin/xwininfo";
+    })
+  ];
+
+  makeFlags = [ "INSTALLBASE=$(out)/share/gnome-shell/extensions" ];
+
+  meta = with stdenv.lib; {
+    description = "Integrates maximized windows with the top panel";
+    homepage = https://github.com/franglais125/no-title-bar;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ jonafato svsdep ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/no-title-bar/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/extensions/no-title-bar/fix-paths.patch
@@ -1,0 +1,56 @@
+--- a/decoration.js
++++ b/decoration.js
+@@ -181,7 +181,7 @@
+         let act = win.get_compositor_private();
+         let xwindow = act && act['x-window'];
+         if (xwindow) {
+-            let xwininfo = GLib.spawn_command_line_sync('xwininfo -children -id 0x%x'.format(xwindow));
++            let xwininfo = GLib.spawn_command_line_sync('@xwininfo@ -children -id 0x%x'.format(xwindow));
+             if (xwininfo[0]) {
+                 let str = xwininfo[1].toString();
+ 
+@@ -207,7 +207,7 @@
+         // Try enumerating all available windows and match the title. Note that this
+         // may be necessary if the title contains special characters and `x-window`
+         // is not available.
+-        let result = GLib.spawn_command_line_sync('xprop -root _NET_CLIENT_LIST');
++        let result = GLib.spawn_command_line_sync('@xprop@ -root _NET_CLIENT_LIST');
+         if (result[0]) {
+             let str = result[1].toString();
+ 
+@@ -218,7 +218,7 @@
+ 
+             // For each window ID, check if the title matches the desired title.
+             for (var i = 0; i < windowList.length; ++i) {
+-                let cmd = 'xprop -id "' + windowList[i] + '" _NET_WM_NAME _NO_TITLE_BAR_ORIGINAL_STATE';
++                let cmd = '@xprop@ -id "' + windowList[i] + '" _NET_WM_NAME _NO_TITLE_BAR_ORIGINAL_STATE';
+                 let result = GLib.spawn_command_line_sync(cmd);
+ 
+                 if (result[0]) {
+@@ -258,7 +258,7 @@
+         }
+ 
+         let id = this._guessWindowXID(win);
+-        let cmd = 'xprop -id ' + id;
++        let cmd = '@xprop@ -id ' + id;
+ 
+         let xprops = GLib.spawn_command_line_sync(cmd);
+         if (!xprops[0]) {
+@@ -277,7 +277,7 @@
+         m = str.match(/^_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED(\(CARDINAL\))? = ([0-9]+)$/m);
+         if (m) {
+             let state = !!parseInt(m[2]);
+-            cmd = ['xprop', '-id', id,
++            cmd = ['@xprop@', '-id', id,
+                   '-f', '_NO_TITLE_BAR_ORIGINAL_STATE', '32c',
+                   '-set', '_NO_TITLE_BAR_ORIGINAL_STATE',
+                   (state ? '0x1' : '0x0')];
+@@ -358,7 +358,7 @@
+         let winXID = this._guessWindowXID(win);
+         if (winXID == null)
+             return;
+-        let cmd = ['xprop', '-id', winXID,
++        let cmd = ['@xprop@', '-id', winXID,
+                    '-f', '_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED', '32c',
+                    '-set', '_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED',
+                    (hide ? '0x1' : '0x0')];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19190,6 +19190,7 @@ with pkgs;
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     mediaplayer = callPackage ../desktops/gnome-3/extensions/mediaplayer { };
     nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
+    no-title-bar = callPackage ../desktops/gnome-3/extensions/no-title-bar { };
     pixel-saver = callPackage ../desktops/gnome-3/extensions/pixel-saver { };
     remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };
     taskwhisperer = callPackage ../desktops/gnome-3/extensions/taskwhisperer { };


### PR DESCRIPTION
###### Motivation for this change
I do need this extension for my Gnome Shell setup.
Tested locally.
The run-time dependencies are specified as it is required [here](https://github.com/franglais125/no-title-bar#dependencies).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

