### PR TITLE
iperf3: remove upstreamed patches and workarounds (musl)

### DIFF
--- a/pkgs/tools/networking/iperf/3.nix
+++ b/pkgs/tools/networking/iperf/3.nix
@@ -10,22 +10,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
-  preConfigure = stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
-    NIX_CFLAGS_COMPILE+=" -D_GNU_SOURCE"
-  '';
-
   patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
-    (fetchpatch {
-      url = "http://git.alpinelinux.org/cgit/aports/plain/main/iperf3/build-fixes.patch";
-      name = "fix-musl-build.patch";
-      sha256 = "0zvfjnqdldh6rc6qggyb310swdnl9qk0m3z1kklnqzgjsh8dskvl";
-    })
     (fetchpatch {
       url = "http://git.alpinelinux.org/cgit/aports/plain/main/iperf3/remove-pg-flags.patch";
       name = "remove-pg-flags.patch";
       sha256 = "0lnczhass24kgq59drgdipnhjnw4l1cy6gqza7f2ah1qr4q104rm";
     })
-];
+  ];
 
   postInstall = ''
     ln -s iperf3 $out/bin/iperf


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---