### PR TITLE
racket-minimal: build on darwin

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -4,6 +4,7 @@
 , libpng, libtool, mpfr, openssl, pango, poppler
 , readline, sqlite
 , disableDocs ? false
+, CoreFoundation
 }:
 
 let
@@ -47,9 +48,13 @@ stdenv.mkDerivation rec {
 
   FONTCONFIG_FILE = fontsConf;
   LD_LIBRARY_PATH = libPath;
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.cc.isGNU "-lgcc_s";
+  NIX_LDFLAGS = stdenv.lib.concatStringsSep " " [
+    (stdenv.lib.optionalString (stdenv.cc.isGNU && ! stdenv.isDarwin) "-lgcc_s")
+    (stdenv.lib.optionalString stdenv.isDarwin "-framework CoreFoundation")
+  ];
 
-  buildInputs = [ fontconfig libffi libtool makeWrapper sqlite ];
+  buildInputs = [ fontconfig libffi libtool makeWrapper sqlite ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation ];
 
   preConfigure = ''
     unset AR

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -14,6 +14,6 @@ racket.overrideAttrs (oldAttrs: rec {
       as well as libraries that live in collections. In particular, raco
       and the pkg library are still bundled.
     '';
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5822,6 +5822,8 @@ with pkgs;
     extraBuildInputs = lib.optional hostPlatform.isDarwin clang.cc;
   };
 
+  gcc7Stdenv = overrideCC gccStdenv gcc7;
+
   wrapCCMulti = cc:
     if system == "x86_64-linux" then let
       # Binutils with glibc multi
@@ -7102,7 +7104,8 @@ with pkgs;
     # racket 6.11 doesn't build with gcc6 + recent glibc:
     # https://github.com/racket/racket/pull/1886
     # https://github.com/NixOS/nixpkgs/pull/31017#issuecomment-343574769
-    stdenv = overrideCC stdenv gcc7;
+    stdenv = if stdenv.isDarwin then stdenv else gcc7Stdenv;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
   racket-minimal = callPackage ../development/interpreters/racket/minimal.nix { };
 


### PR DESCRIPTION
Technically, racket compiles and packages too, but it doesn't pass all
tests yet, so the build fails.

gcc7Stdenv is GCC 7 with the MacOS-specific adaptations retained.
Building on MacOS with that works, but we should be using clang.

I'm hoping that the next person wanting to override the compiler
version in some other derivation sees that attribute and doesn't
inadvertently break a MacOS build again.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [✓] macOS
   - [✓] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [✓] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [✓] Tested execution of all binary files (usually in `./result/bin/`)
- [✓] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

