### PR TITLE
Pulseaudio by default, if sound is enabled

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -87,7 +87,7 @@ in {
     hardware.pulseaudio = {
       enable = mkOption {
         type = types.bool;
-        default = false;
+        default = true;
         description = ''
           Whether to enable the PulseAudio sound server.
         '';

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -87,7 +87,8 @@ in {
     hardware.pulseaudio = {
       enable = mkOption {
         type = types.bool;
-        default = true;
+        default = config.sound.enable;
+        defaultText = "config.sound.enable";
         description = ''
           Whether to enable the PulseAudio sound server.
         '';

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -87,7 +87,6 @@ in {
     hardware.pulseaudio = {
       enable = mkOption {
         type = types.bool;
-        default = config.sound.enable;
         defaultText = "config.sound.enable";
         description = ''
           Whether to enable the PulseAudio sound server.
@@ -208,6 +207,8 @@ in {
         target = "pulse/client.conf";
         source = clientConf;
       };
+
+      hardware.pulseaudio.enable = mkDefault config.sound.enable;
 
       hardware.pulseaudio.configFile = mkDefault "${getBin overriddenPackage}/etc/pulse/default.pa";
     }

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -23,7 +23,8 @@ in
         type = types.bool;
         default = true;
         description = ''
-          Whether to enable ALSA sound.
+          Whether to enable ALSA sound. Will also enable pulseaudio unless
+          <option>hardware.pulseaudio.enable</option> is set to false.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Major applications like Firefox no longer support a bare-alsa setup, the justification being that only a very small percentage of Linux users does not use pulseaudio.

This pull request still allows people who really want to to disable pulseaudio, but makes it the default on systems with sound enabled. I think it will make it easier for people to get started with NixOS if their sound works out of the box.

Minimal headless systems will also be unaffected, because they should already have sound disabled.

Previous discussion in  #29250, which was closed by me due to lack of consensus, but at the time, Firefox did not yet require PulseAudio.

EDIT: I misunderstood a bit, Firefox will still apparently run with Alsa, but it's not maintained and if there's bugs with the Alsa support, there's no guarantee anybody will fix it. The thing that triggered nixpkgs to build Firefox with Pulseaudio is that some playback quality is clipped in some scenarios.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

