### PR TITLE
icu: init at 60.2

### DIFF
--- a/pkgs/development/libraries/icu/60.nix
+++ b/pkgs/development/libraries/icu/60.nix
@@ -1,0 +1,4 @@
+import ./base.nix {
+  version = "60.2";
+  sha256 = "065l3n0q9wqaw8dz20x82srshhm6i987fr9ync5xf9mr6n7ylwzh";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9186,6 +9186,7 @@ with pkgs;
 
   icu58 = callPackage ../development/libraries/icu/58.nix { };
   icu59 = callPackage ../development/libraries/icu/59.nix { };
+  icu60 = callPackage ../development/libraries/icu/60.nix { };
 
   icu = icu59;
 


### PR DESCRIPTION
###### Motivation for this change

New version.
Should it be the default ```icu``` ?