### PR TITLE
appstream: 0.10.6 -> 0.11.8 (and add appstream-qt)

### DIFF
--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -1,37 +1,55 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, gettext, intltool
-, xmlto, docbook_xsl, docbook_xml_dtd_45
-, glib, xapian, libxml2, libyaml, gobjectIntrospection
+{ stdenv, fetchpatch, fetchFromGitHub, meson, ninja, pkgconfig, gettext
+, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt
+, libstemmer, glib, xapian, libxml2, libyaml, gobjectIntrospection
 , pcre, itstool
 }:
 
 stdenv.mkDerivation rec {
   name = "appstream-${version}";
-  version = "0.10.6";
+  version = "0.11.8";
 
   src = fetchFromGitHub {
-    owner = "ximion";
-    repo = "appstream";
-    rev = "APPSTREAM_0_10_6";
-    sha256 = "1fg7zxx2qhkyj7fmcpwbf80b72d16kyi8dadi111kf00sgzfbiyy";
+    owner  = "ximion";
+    repo   = "appstream";
+    rev    = "APPSTREAM_${stdenv.lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "07vzz57g1p5byj2jfg17y5n3il0g07d9wkiynzwra71mcxar1p08";
   };
 
+  patches = [
+    # drop this in version 0.11.9 and above
+    (fetchpatch {
+      name   = "define-location-and-soname.patch";
+      url    = "https://github.com/ximion/appstream/commit/3e58f9c9.patch";
+      sha256 = "1ffgbdfg80yq5vahjrvdd4f8xsp32ksm9vyasfmc7hzhx294s78w";
+    })
+  ];
+
   nativeBuildInputs = [
-    cmake pkgconfig gettext intltool
-    xmlto docbook_xsl docbook_xml_dtd_45
+    meson ninja pkgconfig gettext
+    libxslt xmlto docbook_xsl docbook_xml_dtd_45
     gobjectIntrospection itstool
   ];
 
-  buildInputs = [ pcre glib xapian libxml2 libyaml ];
+  buildInputs = [ libstemmer pcre glib xapian libxml2 libyaml ];
 
-  cmakeFlags = ''
-    -DSTEMMING=off
-    '';
+  prePatch = ''
+    substituteInPlace meson.build \
+      --replace /usr/include ${libstemmer}/include
+
+    substituteInPlace data/meson.build \
+      --replace /etc $out/etc
+  '';
+
+  mesonFlags = [
+    "-Dapidocs=false"
+    "-Ddocs=false"
+    "-Dgir=false"
+  ];
 
   meta = with stdenv.lib; {
     description = "Software metadata handling library";
     homepage    = https://www.freedesktop.org/wiki/Distributions/AppStream/;
-    longDescription =
-    ''
+    longDescription = ''
       AppStream is a cross-distro effort for building Software-Center applications
       and enhancing metadata provided by software components.  It provides
       specifications for meta-information which is shipped by upstream projects and

--- a/pkgs/development/libraries/appstream/qt.nix
+++ b/pkgs/development/libraries/appstream/qt.nix
@@ -1,0 +1,25 @@
+{ stdenv, appstream, qtbase, qttools }:
+
+stdenv.mkDerivation rec {
+  name = "appstream-qt-${version}";
+  inherit (appstream) version src patches prePatch;
+
+  buildInputs = appstream.buildInputs ++ [ appstream qtbase ];
+
+  nativeBuildInputs = appstream.nativeBuildInputs ++ [ qttools ];
+
+  mesonFlags = appstream.mesonFlags ++ [ "-Dqt=true" ];
+
+  postInstall = ''
+    rm -rf $out/{bin,etc,include/appstream,lib/pkgconfig,lib/libappstream.so*,share}
+  '';
+
+  preFixup = ''
+    patchelf --add-needed ${appstream}/lib/libappstream.so.4 \
+      $out/lib/libAppStreamQt.so
+  '';
+
+  meta = appstream.meta // {
+    description = "Software metadata handling library - Qt";
+ };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5755,7 +5755,7 @@ with pkgs;
   compcert = callPackage ../development/compilers/compcert { };
 
   cpp-gsl = callPackage ../development/libraries/cpp-gsl { };
-  
+
   # Users installing via `nix-env` will likely be using the REPL,
   # which has a hard dependency on Z3, so make sure it is available.
   cryptol = haskellPackages.cryptol.overrideDerivation (oldAttrs: {
@@ -8184,6 +8184,8 @@ with pkgs;
   appstream = callPackage ../development/libraries/appstream { };
 
   appstream-glib = callPackage ../development/libraries/appstream-glib { };
+
+  appstream-qt = libsForQt5.callPackage ../development/libraries/appstream/qt.nix { };
 
   apr = callPackage ../development/libraries/apr { };
 


### PR DESCRIPTION
###### Motivation for this change

appstream-qt is needed for KDE discover and possibly others

The appstream upgrade causes a very large rebuild.

Another option is of course to use an override for the ```-qt``` version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

