### PR TITLE
jbuilder: 1.0+beta14 -> 1.0+beta18

### DIFF
--- a/pkgs/development/tools/ocaml/jbuilder/default.nix
+++ b/pkgs/development/tools/ocaml/jbuilder/default.nix
@@ -1,10 +1,13 @@
-{ stdenv, fetchzip, ocaml, opam }:
+{ stdenv, fetchFromGitHub, ocaml, opam }:
 
-stdenv.mkDerivation {
-  name = "jbuilder-1.0+beta14";
-  src = fetchzip {
-    url = http://github.com/janestreet/jbuilder/archive/1.0+beta14.tar.gz;
-    sha256 = "0vq4chqp7bm3rd5n6ry1j1ia6xqlz463059ljd1jmawa4dcyilvl";
+stdenv.mkDerivation rec {
+  name = "jbuilder-${version}";
+  version = "1.0+beta18";
+  src = fetchFromGitHub {
+    owner = "ocaml";
+    repo = "dune";
+    rev = "${version}";
+    sha256 = "1xw4i5qd2ndnddzb8b14fb52qxnjpr3lr9wx3mprv4f294kdg0l6";
   };
 
   buildInputs = [ ocaml ];


### PR DESCRIPTION
###### Motivation for this change

Bumps version and uses fetchFromGitHub instead of fetchzip.
Fixes bug that is blocking https://github.com/NixOS/nixpkgs/pull/25658#issuecomment-367382661.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

