### PR TITLE
packagekit: 1.1.7 -> 1.1.8 (packagekit-qt: init at 1.0.1)

### DIFF
--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   name = "packagekit-${version}";
-  version = "1.1.7";
+  version = "1.1.8";
 
   src = fetchFromGitHub {
     owner = "hughsie";
     repo = "PackageKit";
     rev = "PACKAGEKIT_${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "076rrczmyhapj87pxqldsar5pbz4mid6cm9l1n91zh2q403chdkb";
+    sha256 = "0bn9flsjbzlwmlbv2gphqwgzy9sx8ahch28z6dzgak4csbz5wcws";
   };
 
   buildInputs = [ glib polkit systemd python gobjectIntrospection vala_0_38 ]

--- a/pkgs/tools/package-management/packagekit/qt.nix
+++ b/pkgs/tools/package-management/packagekit/qt.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig
+, qtbase, qttools, packagekit }:
+
+stdenv.mkDerivation rec {
+  name = "packagekit-qt-${version}";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner  = "hughsie";
+    repo   = "PackageKit-Qt";
+    rev    = "v${version}";
+    sha256 = "1ls6mn9abpwzw5wjgmslc5h9happj3516y1q67imppczk8g9h2yk";
+  };
+
+  buildInputs = [ packagekit ];
+
+  nativeBuildInputs = [ cmake pkgconfig qttools ];
+
+  enableParallelBuilding = true;
+
+  meta = packagekit.meta // {
+    description = "System to facilitate installing and updating packages - Qt";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4017,6 +4017,8 @@ with pkgs;
     nix = nixUnstable;
   };
 
+  packagekit-qt = libsForQt5.callPackage ../tools/package-management/packagekit/qt.nix { };
+
   packetdrill = callPackage ../tools/networking/packetdrill { };
 
   padthv1 = callPackage ../applications/audio/padthv1 { };


### PR DESCRIPTION
###### Motivation for this change

General update + packagekit-qt

Cc: @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

