### PR TITLE
Add regextester

### DIFF
--- a/pkgs/applications/misc/regextester/default.nix
+++ b/pkgs/applications/misc/regextester/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, fetchFromGitHub
+, gettext
+, libxml2
+, pkgconfig
+, gtk3
+, granite
+, gnome3
+, cmake
+, ninja
+, vala
+, elementary-cmake-modules
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "regextester-${version}";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "artemanufrij";
+    repo = "regextester";
+    rev = version;
+    sha256 = "07shdm10dc7jz2hka5dc51yp81a0dgc47nmkrp6fs6r9wqx0j30n";
+  };
+
+  XDG_DATA_DIRS = stdenv.lib.concatStringsSep ":" [
+    "${granite}/share"
+    "${gnome3.libgee}/share"
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    wrapGAppsHook
+    vala
+    cmake
+    ninja
+    gettext
+    libxml2
+    elementary-cmake-modules
+  ];
+  buildInputs = [
+    gtk3
+    granite
+    gnome3.libgee
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A desktop application to test regular expressions interactively";
+    homepage = https://github.com/artemanufrij/regextester;
+    maintainers = with maintainers; [ samdroid-apps ];
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/development/libraries/elementary-cmake-modules/default.nix
+++ b/pkgs/development/libraries/elementary-cmake-modules/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig }:
+
+stdenv.mkDerivation {
+  name = "elementary-cmake-modules";
+
+  src = fetchFromGitHub {
+    owner = "elementary";
+    repo = "cmake-modules";
+    rev = "319ec5336e9f05f3f22b886cc2053ef3d4b6599e";
+    sha256 = "191hhvdxyqvh9axzndaqld7vrmv7xkn0czks908zhb2zpjhv9rby";
+  };
+
+  prePatch = ''
+    substituteInPlace CMakeLists.txt  \
+      --replace ' ''${CMAKE_ROOT}/Modules' " $out/lib/cmake"
+  '';
+
+  propagatedBuildInputs = [ cmake pkgconfig ];
+
+  setupHook = ./setup-hook.sh;
+
+  meta = with lib; {
+    platforms = platforms.linux ++ platforms.darwin;
+    homepage = https://github.com/elementary/cmake-modules;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.samdroid-apps ];
+  };
+}

--- a/pkgs/development/libraries/elementary-cmake-modules/setup-hook.sh
+++ b/pkgs/development/libraries/elementary-cmake-modules/setup-hook.sh
@@ -1,0 +1,4 @@
+_elementaryCMakeEnvHook() {
+  cmakeFlagsArray+=(-DCMAKE_MODULE_PATH=@out@/lib/cmake)
+}
+addEnvHooks "$targetOffset" _elementaryCMakeEnvHook

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9065,6 +9065,7 @@ with pkgs;
   gnome-sharp = callPackage ../development/libraries/gnome-sharp {};
 
   granite = callPackage ../development/libraries/granite { };
+  elementary-cmake-modules = callPackage ../development/libraries/elementary-cmake-modules { };
 
   gtk2 = callPackage ../development/libraries/gtk+/2.x.nix {
     cupsSupport = config.gtk2.cups or stdenv.isLinux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7117,6 +7117,8 @@ with pkgs;
 
   red = callPackage ../development/interpreters/red { };
 
+  regextester = callPackage ../applications/misc/regextester { };
+
   regina = callPackage ../development/interpreters/regina { };
 
   inherit (ocamlPackages) reason;


### PR DESCRIPTION
###### Motivation for this change

Add this cool application: https://github.com/artemanufrij/regextester

Also add some cmake modules that are used by many other elementary applications.  The cmake module package is based off kde's extra-cmake-modules package setup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

