### PR TITLE
config.sound: Disable sound by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -373,6 +373,14 @@ following incompatible changes:</para>
       and <literal>stopJob</literal> provide an optional <literal>$user</literal> argument for that purpose.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      Sound is now disabled by default.
+
+      It can be enabled by setting <option>sound.enable</option> to <literal>true</literal>
+      It will be enabled for you if <option>services.xserver.enable</option> is set to <literal>true</literal>
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -21,7 +21,8 @@ in
 
       enable = mkOption {
         type = types.bool;
-        default = true;
+        default = config.services.xserver.enable;
+        defaultText = "config.services.xserver.enable";
         description = ''
           Whether to enable ALSA sound.
         '';


### PR DESCRIPTION
###### Motivation for this change
In https://github.com/NixOS/nixpkgs/pull/35292 @fpletz brought up the imo very good idea to disable sound by default.

Per my proposal here: https://github.com/NixOS/nixpkgs/pull/35292#issuecomment-367549108 I enable sound if `services.xserver.enable` is `true`.
This gives most users the desired effect, desktop users get working sound and server users will not get `alsaUtils` or any ALSA services.

If you feel like you dont belong in either category it's simple enough to enable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

