### PR TITLE
Fix haskellCompilerName version.

### DIFF
--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -138,7 +138,7 @@ stdenv.mkDerivation rec {
     targetPrefix = "";
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-7.0.4";
   };
 
   meta.license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/compilers/ghc/7.0.4.nix
+++ b/pkgs/development/compilers/ghc/7.0.4.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     targetPrefix = "";
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-7.0.4";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -171,7 +171,7 @@ stdenv.mkDerivation rec {
     inherit llvmPackages;
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-7.10.3";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation rec {
     targetPrefix = "";
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-7.4.2";
   };
 
   meta.license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     targetPrefix = "";
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-7.4.2";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -86,7 +86,7 @@ in stdenv.mkDerivation rec {
     targetPrefix = "";
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-7.6.3";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     targetPrefix = "";
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-7.8.4";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -172,7 +172,7 @@ stdenv.mkDerivation rec {
     inherit llvmPackages;
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-8.0.2";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -191,7 +191,7 @@ stdenv.mkDerivation rec {
     inherit llvmPackages;
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-8.2.2";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -190,7 +190,7 @@ stdenv.mkDerivation rec {
     inherit llvmPackages;
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-8.4.1";
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -180,7 +180,7 @@ stdenv.mkDerivation rec {
     inherit llvmPackages;
 
     # Our Cabal compiler name
-    haskellCompilerName = "ghc";
+    haskellCompilerName = "ghc-8.5";
   };
 
   meta = {


### PR DESCRIPTION
This matters for `callCabal2nix`, when the cabal file has something like `if impl(ghc >= 7.7)`

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

