### PR TITLE
dbus-broker: 9 -> 11

### DIFF
--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchgit, fetchFromGitHub, docutils, meson, ninja, pkgconfig
-, dbus, glib, systemd }:
+, dbus, glib, linuxHeaders, systemd }:
 
 stdenv.mkDerivation rec {
   name = "dbus-broker-${version}";
-  version = "9";
+  version = "11";
 
   src = fetchFromGitHub {
     owner           = "bus1";
     repo            = "dbus-broker";
     rev             = "v${version}";
-    sha256          = "0q0kbinkkia96bsy7jczlyjz8xgdrfkyx8v6gdr2zflgv0mgbsab";
+    sha256          = "19sszb6ac7md494i996ixqmz9b3gim8rrv2nbrmlgjd59gk6hf7b";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ docutils meson ninja pkgconfig ];
 
-  buildInputs = [ dbus glib systemd ];
+  buildInputs = [ dbus glib linuxHeaders systemd ];
 
   enableParallelBuilding = true;
 
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     install -Dm644 ../README $out/share/doc/dbus-broker/README
+
+    sed -i $out/lib/systemd/{system,user}/dbus-broker.service \
+      -e 's,^ExecReload.*busctl,ExecReload=${systemd}/bin/busctl,'
   '';
 
   checkPhase = "ninja test";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1047,7 +1047,7 @@ with pkgs;
 
   devmem2 = callPackage ../os-specific/linux/devmem2 { };
 
-  dbus-broker = callPackage ../os-specific/linux/dbus-broker {};
+  dbus-broker = callPackage ../os-specific/linux/dbus-broker { };
 
   ioport = callPackage ../os-specific/linux/ioport {};
 
@@ -5755,7 +5755,7 @@ with pkgs;
   compcert = callPackage ../development/compilers/compcert { };
 
   cpp-gsl = callPackage ../development/libraries/cpp-gsl { };
-  
+
   # Users installing via `nix-env` will likely be using the REPL,
   # which has a hard dependency on Z3, so make sure it is available.
   cryptol = haskellPackages.cryptol.overrideDerivation (oldAttrs: {


### PR DESCRIPTION
###### Motivation for this change

When this was merged directly to master, @GrahamcOfBorg failed evaluating it.

So let's try again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

