### PR TITLE
trezor: Add pyblake2, click, libusb1 and ecdsa as propagatedBuildInput

### DIFF
--- a/pkgs/development/python-modules/trezor/default.nix
+++ b/pkgs/development/python-modules/trezor/default.nix
@@ -1,5 +1,5 @@
-{ lib, fetchPypi, buildPythonPackage, protobuf, hidapi, ecdsa, mnemonic
-, requests
+{ lib, fetchPypi, buildPythonPackage,
+  protobuf, hidapi, ecdsa, mnemonic, requests, pyblake2, click, libusb1
 }:
 
 buildPythonPackage rec {
@@ -12,9 +12,7 @@ buildPythonPackage rec {
     sha256 = "2dd01e11d669cb8f5e40fcf1748bcabc41fb5f41edb010fc807dc3088f9bd7de";
   };
 
-  propagatedBuildInputs = [ protobuf hidapi requests mnemonic ];
-
-  buildInputs = [ ecdsa ];
+  propagatedBuildInputs = [ protobuf hidapi ecdsa mnemonic requests pyblake2 click libusb1 ];
 
   # There are no actual tests: "ImportError: No module named tests"
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/trezor/python-trezor/commits/master/setup.py added lots of dependencies since 0.7.x, which didn't get included in the recent version bump https://github.com/NixOS/nixpkgs/commit/38116c692c748f9975333ca9f7d6754f81541475

###### Things done
Build and run bin/trezorctl successfully.
Note that electrum is still broken, and would require a new release after this commit https://github.com/spesmilo/electrum/pull/3621

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
