### PR TITLE
sit: init at 0.1.2

### DIFF
--- a/pkgs/applications/version-management/sit/default.nix
+++ b/pkgs/applications/version-management/sit/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "sit-${version}";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "sit-it";
+    repo = "sit";
+    rev = "v${version}";
+    sha256 = "0fvxv9x971s5qvhw6gpbw9ggsxynkwfy1fn5rln50gn9yrjf7612";
+  };
+
+  cargoSha256 = "1y8a8a9jn9f374sy5fs1snmpiqyckqc0aw7idwnpfr912c1zzrxw";
+
+  meta = with stdenv.lib; {
+    description = "SCM-agnostic, file-based, offline-first, immutable issue tracker";
+    homepage = http://sit-it.org/;
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ dywedir ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4688,6 +4688,8 @@ with pkgs;
 
   sisco.lv2 = callPackage ../applications/audio/sisco.lv2 { };
 
+  sit = callPackage ../applications/version-management/sit { };
+
   skippy-xd = callPackage ../tools/X11/skippy-xd {};
 
   sks = callPackage ../servers/sks { inherit (ocamlPackages_4_02) ocaml camlp4; };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @yrashk :)