### PR TITLE
go_1_10: init at 1.10 and set as default

### DIFF
--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -111,8 +111,6 @@ stdenv.mkDerivation rec {
     sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
 
     touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
-
-    sed -i '1 a\exit 0' misc/cgo/errors/test.bash
   '';
 
   patches = [

--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -179,7 +179,7 @@ stdenv.mkDerivation rec {
     homepage = http://golang.org/;
     description = "The Go Programming language";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ cstrahan orivej wkennington ];
+    maintainers = with maintainers; [ cstrahan orivej velovix mic92 ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.9.4";
+  version = "1.10";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "15d9lfiy1cjfz6nqnig5884ykqckx58cynd1bva1xna7bwcwwp2r";
+    sha256 = "1dzs1mz3zxgg1qyi2lrlxdz1lsvazxvmj9cb69pgqnwjlh3jpw0l";
   };
 
   # perl is used for testing go vet
@@ -115,14 +115,14 @@ stdenv.mkDerivation rec {
     sed -i '1 a\exit 0' misc/cgo/errors/test.bash
   '';
 
-  patches =
-    [ ./remove-tools-1.9.patch
-      ./ssl-cert-file-1.9.patch
-      ./creds-test-1.9.patch
-      ./remove-test-pie-1.9.patch
-      ./go-1.9-skip-flaky-19608.patch
-      ./go-1.9-skip-flaky-20072.patch
-    ];
+  patches = [
+    ./remove-tools-1.9.patch
+    ./ssl-cert-file-1.9.patch
+    ./remove-test-pie.patch
+    ./creds-test.patch
+    ./go-1.9-skip-flaky-19608.patch
+    ./go-1.9-skip-flaky-20072.patch
+  ];
 
   postPatch = optionalString stdenv.isDarwin ''
     echo "substitute hardcoded dsymutil with ${llvm}/bin/llvm-dsymutil"

--- a/pkgs/development/compilers/go/creds-test-1.9.patch
+++ b/pkgs/development/compilers/go/creds-test-1.9.patch
@@ -1,0 +1,14 @@
+diff -ru -x '*~' ./result/src/syscall/creds_test.go go-go1.7.4-src/src/syscall/creds_test.go
+--- ./result/src/syscall/creds_test.go	1970-01-01 01:00:01.000000000 +0100
++++ go-go1.7.4-src/src/syscall/creds_test.go	2016-12-21 14:06:39.559932164 +0100
+@@ -62,8 +62,8 @@
+ 		if sys, ok := err.(*os.SyscallError); ok {
+ 			err = sys.Err
+ 		}
+-		if err != syscall.EPERM {
+-			t.Fatalf("WriteMsgUnix failed with %v, want EPERM", err)
++		if err != syscall.EPERM && err != syscall.EINVAL {
++			t.Fatalf("WriteMsgUnix failed with %v, want EPERM or EINVAL", err)
+ 		}
+ 	}
+ 

--- a/pkgs/development/compilers/go/creds-test.patch
+++ b/pkgs/development/compilers/go/creds-test.patch
@@ -1,14 +1,13 @@
-diff -ru -x '*~' ./result/src/syscall/creds_test.go go-go1.7.4-src/src/syscall/creds_test.go
---- ./result/src/syscall/creds_test.go	1970-01-01 01:00:01.000000000 +0100
-+++ go-go1.7.4-src/src/syscall/creds_test.go	2016-12-21 14:06:39.559932164 +0100
-@@ -62,8 +62,8 @@
- 		if sys, ok := err.(*os.SyscallError); ok {
- 			err = sys.Err
+--- source.org/src/syscall/creds_test.go	1970-01-01 01:00:01.000000000 +0100
++++ source/src/syscall/creds_test.go	2018-02-22 10:43:47.223615358 +0000
+@@ -76,8 +76,8 @@
+ 			if sys, ok := err.(*os.SyscallError); ok {
+ 				err = sys.Err
+ 			}
+-			if err != syscall.EPERM {
+-				t.Fatalf("WriteMsgUnix failed with %v, want EPERM", err)
++			if err != syscall.EPERM && err != syscall.EINVAL {
++				t.Fatalf("WriteMsgUnix failed with %v, want EPERM or EINVAL", err)
+ 			}
  		}
--		if err != syscall.EPERM {
--			t.Fatalf("WriteMsgUnix failed with %v, want EPERM", err)
-+		if err != syscall.EPERM && err != syscall.EINVAL {
-+			t.Fatalf("WriteMsgUnix failed with %v, want EPERM or EINVAL", err)
- 		}
- 	}
  

--- a/pkgs/development/compilers/go/remove-test-pie.patch
+++ b/pkgs/development/compilers/go/remove-test-pie.patch
@@ -22,17 +22,3 @@
  	// sync tests
  	t.tests = append(t.tests, distTest{
  		name:    "sync_cpu",
-@@ -705,11 +690,11 @@
- 			heading: "API check",
- 			fn: func(dt *distTest) error {
- 				if t.compileOnly {
--return nil
-+					return nil
- 					t.addCmd(dt, "src", "go", "build", filepath.Join(goroot, "src/cmd/api/run.go"))
- 					return nil
- 				}
--return nil
-+				return nil
- 				t.addCmd(dt, "src", "go", "run", filepath.Join(goroot, "src/cmd/api/run.go"))
- 				return nil
- 			},

--- a/pkgs/development/compilers/go/remove-test-pie.patch
+++ b/pkgs/development/compilers/go/remove-test-pie.patch
@@ -1,0 +1,38 @@
+--- source.org/src/cmd/dist/test.go	2018-02-22 10:40:40.089632339 +0000
++++ source/src/cmd/dist/test.go	2018-02-22 10:56:53.075193788 +0000
+@@ -526,21 +526,6 @@
+ 		})
+ 	}
+ 
+-	// Test internal linking of PIE binaries where it is supported.
+-	if goos == "linux" && goarch == "amd64" && !isAlpineLinux() {
+-		// Issue 18243: We don't have a way to set the default
+-		// dynamic linker used in internal linking mode. So
+-		// this test is skipped on Alpine.
+-		t.tests = append(t.tests, distTest{
+-			name:    "pie_internal",
+-			heading: "internal linking of -buildmode=pie",
+-			fn: func(dt *distTest) error {
+-				t.addCmd(dt, "src", t.goTest(), "reflect", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60))
+-				return nil
+-			},
+-		})
+-	}
+-
+ 	// sync tests
+ 	t.tests = append(t.tests, distTest{
+ 		name:    "sync_cpu",
+@@ -705,11 +690,11 @@
+ 			heading: "API check",
+ 			fn: func(dt *distTest) error {
+ 				if t.compileOnly {
+-return nil
++					return nil
+ 					t.addCmd(dt, "src", "go", "build", filepath.Join(goroot, "src/cmd/api/run.go"))
+ 					return nil
+ 				}
+-return nil
++				return nil
+ 				t.addCmd(dt, "src", "go", "run", filepath.Join(goroot, "src/cmd/api/run.go"))
+ 				return nil
+ 			},

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6216,7 +6216,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   };
 
-  go = go_1_9;
+  go_1_10 = callPackage ../development/compilers/go/1.10.nix {
+    inherit (darwin.apple_sdk.frameworks) Security Foundation;
+  };
+
+  go = go_1_10;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
 


### PR DESCRIPTION
Changes are minor from 1.9, so let's just set it as default straight.

changelog: https://golang.org/doc/go1.10

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

