### PR TITLE
release-cross: minor cleanup, add aarch64-musl

### DIFF
--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -50,6 +50,15 @@ let
     buildPackages.binutils = darwin;
   };
 
+  rpiCommon = linuxCommon // {
+    vim = nativePlatforms;
+    unzip = nativePlatforms;
+    ddrescue = nativePlatforms;
+    lynx = nativePlatforms;
+    patchelf = nativePlatforms;
+    buildPackages.binutils = nativePlatforms;
+    mpg123 = nativePlatforms;
+  };
 in
 
 {
@@ -111,30 +120,14 @@ in
   fuloongminipc = mapTestOnCross lib.systems.examples.fuloongminipc linuxCommon;
 
   /* Linux on Raspberrypi */
-  rpi = mapTestOnCross lib.systems.examples.raspberryPi (linuxCommon // {
-    vim = nativePlatforms;
-    unzip = nativePlatforms;
-    ddrescue = nativePlatforms;
-    lynx = nativePlatforms;
-    patchelf = nativePlatforms;
-    buildPackages.binutils = nativePlatforms;
-    mpg123 = nativePlatforms;
-  });
+  rpi = mapTestOnCross lib.systems.examples.raspberryPi rpiCommon;
+  rpi-musl = mapTestOnCross lib.systems.examples.muslpi rpiCommon;
 
   /* Linux on Aarch64 (TODO make android for real)  */
-  android = mapTestOnCross lib.systems.examples.aarch64-multiplatform (linuxCommon // {
-  });
+  android = mapTestOnCross lib.systems.examples.aarch64-multiplatform linuxCommon;
+  aarch64-musl = mapTestOnCross lib.systems.examples.aarch64-multiplatform-musl linuxCommon;
 
   x86_64-musl = mapTestOnCross lib.systems.examples.musl64 linuxCommon;
-  rpi-musl = mapTestOnCross lib.systems.examples.muslpi  (linuxCommon // {
-    vim = nativePlatforms;
-    unzip = nativePlatforms;
-    ddrescue = nativePlatforms;
-    lynx = nativePlatforms;
-    patchelf = nativePlatforms;
-    buildPackages.binutils = nativePlatforms;
-    mpg123 = nativePlatforms;
-  });
 
   /* Cross-built bootstrap tools for every supported platform */
   bootstrapTools = let


### PR DESCRIPTION
Only functional change is adding aarch64-musl.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---