### PR TITLE
keepass: fix auto-type and clipboard features

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchurl, buildDotnetPackage, makeWrapper, unzip, makeDesktopItem, icoutils, gtk2, plugins ? [] }:
+{ stdenv, lib, fetchurl, buildDotnetPackage, substituteAll, makeWrapper, makeDesktopItem,
+  unzip, icoutils, gtk2, xorg, xdotool, xsel, plugins ? [] }:
 
 # KeePass looks for plugins in under directory in which KeePass.exe is
 # located. It follows symlinks where looking for that directory, so
@@ -18,6 +19,15 @@ with builtins; buildDotnetPackage rec {
   sourceRoot = ".";
 
   buildInputs = [ unzip makeWrapper icoutils ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      xsel = "${xsel}/bin/xsel";
+      xprop = "${xorg.xprop}/bin/xprop";
+      xdotool = "${xdotool}/bin/xdotool";
+    })
+  ];
 
   preConfigure = ''
     rm -rvf Build/*

--- a/pkgs/applications/misc/keepass/fix-paths.patch
+++ b/pkgs/applications/misc/keepass/fix-paths.patch
@@ -1,0 +1,87 @@
+diff --git a/KeePass/Native/NativeMethods.Unix.cs b/KeePass/Native/NativeMethods.Unix.cs
+index 7495a1c..4ef4727 100644
+--- a/KeePass/Native/NativeMethods.Unix.cs
++++ b/KeePass/Native/NativeMethods.Unix.cs
+@@ -128,7 +128,7 @@ namespace KeePass.Native
+ 			try
+ 			{
+ 				Application.DoEvents(); // E.g. for clipboard updates
+-				string strOutput = NativeLib.RunConsoleApp("xdotool", strParams);
++				string strOutput = NativeLib.RunConsoleApp("@xdotool@", strParams);
+ 				Application.DoEvents(); // E.g. for clipboard updates
+ 				return (strOutput ?? string.Empty);
+ 			}
+diff --git a/KeePass/Util/ClipboardUtil.Unix.cs b/KeePass/Util/ClipboardUtil.Unix.cs
+index e93a22a..3fd9a2b 100644
+--- a/KeePass/Util/ClipboardUtil.Unix.cs
++++ b/KeePass/Util/ClipboardUtil.Unix.cs
+@@ -62,7 +62,7 @@ namespace KeePass.Util
+ 			//	"-out -selection clipboard");
+ 			// if(str != null) return str;
+ 
+-			string str = NativeLib.RunConsoleApp("xsel",
++			string str = NativeLib.RunConsoleApp("@xsel@",
+ 				"--output --clipboard", null, XSelFlags);
+ 			if(str != null) return str;
+ 
+@@ -83,10 +83,10 @@ namespace KeePass.Util
+ 			if(string.IsNullOrEmpty(str))
+ 			{
+ 				// xsel with an empty input can hang, thus use --clear
+-				if(NativeLib.RunConsoleApp("xsel", "--clear --primary",
++				if(NativeLib.RunConsoleApp("@xsel@", "--clear --primary",
+ 					null, XSelFlags) != null)
+ 				{
+-					NativeLib.RunConsoleApp("xsel", "--clear --clipboard",
++					NativeLib.RunConsoleApp("@xsel@", "--clear --clipboard",
+ 						null, XSelFlags);
+ 					return;
+ 				}
+@@ -97,10 +97,10 @@ namespace KeePass.Util
+ 			}
+ 
+ 			// xsel does not support --primary and --clipboard together
+-			if(NativeLib.RunConsoleApp("xsel", "--input --primary",
++			if(NativeLib.RunConsoleApp("@xsel@", "--input --primary",
+ 				str, XSelFlags) != null)
+ 			{
+-				NativeLib.RunConsoleApp("xsel", "--input --clipboard",
++				NativeLib.RunConsoleApp("@xsel@", "--input --clipboard",
+ 					str, XSelFlags);
+ 				return;
+ 			}
+diff --git a/KeePassLib/Native/ClipboardU.cs b/KeePassLib/Native/ClipboardU.cs
+index ddd8f57..150eb82 100644
+--- a/KeePassLib/Native/ClipboardU.cs
++++ b/KeePassLib/Native/ClipboardU.cs
+@@ -27,7 +27,7 @@ namespace KeePassLib.Native
+ {
+ 	internal static class ClipboardU
+ 	{
+-		private const string XSel = "xsel";
++		private const string XSel = "@xsel@";
+ 		private const string XSelV = "--version";
+ 		private const string XSelR = "--output --clipboard";
+ 		private const string XSelC = "--clear --clipboard";
+diff --git a/KeePassLib/Utility/MonoWorkarounds.cs b/KeePassLib/Utility/MonoWorkarounds.cs
+index 0da7019..f6a1022 100644
+--- a/KeePassLib/Utility/MonoWorkarounds.cs
++++ b/KeePassLib/Utility/MonoWorkarounds.cs
+@@ -41,7 +41,7 @@ namespace KeePassLib.Utility
+ {
+ 	public static class MonoWorkarounds
+ 	{
+-		private const string AppXDoTool = "xdotool";
++		private const string AppXDoTool = "@xdotool@";
+ 
+ 		private static Dictionary<uint, bool> g_dForceReq = new Dictionary<uint, bool>();
+ 		private static Thread g_thFixClip = null;
+@@ -303,7 +303,7 @@ namespace KeePassLib.Utility
+ 				// }
+ 				// else { Debug.Assert(false); }
+ 
+-				string strWmClass = (NativeLib.RunConsoleApp("xprop",
++				string strWmClass = (NativeLib.RunConsoleApp("@xprop@",
+ 					"-id " + strHandle + " WM_CLASS") ?? string.Empty);
+ 
+ 				if(strWmClass.IndexOf("\"" + PwDefs.ResClass + "\"",


### PR DESCRIPTION
###### Motivation for this change
This fixes paths to `xdotool`, `xprop` and `xsel`. These are required tools for auto-type to work correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

