### PR TITLE
linuxPackages.broadcom-sta: fix build with Linux 4.15

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
     ./linux-4.11.patch
     # source: https://aur.archlinux.org/cgit/aur.git/tree/linux412.patch?h=broadcom-wl
     ./linux-4.12.patch
+    ./linux-4.15.patch
     ./null-pointer-fix.patch
     ./gcc.patch
   ];

--- a/pkgs/os-specific/linux/broadcom-sta/linux-4.15.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-4.15.patch
@@ -1,0 +1,47 @@
+See: https://lkml.org/lkml/2017/11/25/90
+
+diff -urNZ a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+--- a/src/wl/sys/wl_linux.c	2015-09-18 22:47:30.000000000 +0000
++++ b/src/wl/sys/wl_linux.c	2018-01-31 22:52:10.859856221 +0000
+@@ -93,7 +93,11 @@
+
+ #include <wlc_wowl.h>
+
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
++static void wl_timer(struct timer_list *tl);
++#else
+ static void wl_timer(ulong data);
++#endif
+ static void _wl_timer(wl_timer_t *t);
+ static struct net_device *wl_alloc_linux_if(wl_if_t *wlif);
+
+@@ -2298,9 +2302,15 @@
+ }
+
+ static void
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
++wl_timer(struct timer_list *tl)
++{
++	wl_timer_t *t = from_timer(t, tl, timer);
++#else
+ wl_timer(ulong data)
+ {
+ 	wl_timer_t *t = (wl_timer_t *)data;
++#endif
+
+ 	if (!WL_ALL_PASSIVE_ENAB(t->wl))
+ 		_wl_timer(t);
+@@ -2352,9 +2362,13 @@
+
+ 	bzero(t, sizeof(wl_timer_t));
+
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
++	timer_setup(&t->timer, wl_timer, 0);
++#else
+ 	init_timer(&t->timer);
+ 	t->timer.data = (ulong) t;
+ 	t->timer.function = wl_timer;
++#endif
+ 	t->wl = wl;
+ 	t->fn = fn;
+ 	t->arg = arg;


### PR DESCRIPTION
See: https://lkml.org/lkml/2017/11/25/90
(cherry picked from commit 65187722ec07fec21b2c8c53019255c6a9a5c4f8)

Fixes #35323

###### Motivation for this change

Backport from master, works fine on 17.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

