### PR TITLE
chkcrontab: init at 1.7

### DIFF
--- a/pkgs/tools/admin/chkcrontab/default.nix
+++ b/pkgs/tools/admin/chkcrontab/default.nix
@@ -1,0 +1,20 @@
+{ python, stdenv }:
+
+with python.pkgs;
+
+buildPythonApplication rec {
+  pname = "chkcrontab";
+  version = "1.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gmxavjkjkvjysgf9cf5fcpk589gb75n1mn20iki82wifi1pk1jn";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A tool to detect crontab errors";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ma27 ];
+    homepage = https://github.com/lyda/chkcrontab;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -608,6 +608,8 @@ with pkgs;
 
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };
 
+  chkcrontab = callPackage ../tools/admin/chkcrontab { };
+
   djmount = callPackage ../tools/filesystems/djmount { };
 
   dgsh = callPackage ../shells/dgsh { };


### PR DESCRIPTION
###### Motivation for this change

`chkcrontab` is a simple utility to check crontab for errors.
Fixes #34969

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

