### PR TITLE
qt5: install pkg_config files on darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/5.10/default.nix
+++ b/pkgs/development/libraries/qt-5/5.10/default.nix
@@ -37,7 +37,9 @@ let
   srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
 
   patches = {
-    qtbase = [ ./qtbase.patch ] ++ optional stdenv.isDarwin ./qtbase-darwin.patch;
+    qtbase = [ ./qtbase.patch ] ++
+      optionals stdenv.isDarwin [ ./qtbase-darwin.patch
+                                  ./restore-pc-files.patch ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];

--- a/pkgs/development/libraries/qt-5/5.10/restore-pc-files.patch
+++ b/pkgs/development/libraries/qt-5/5.10/restore-pc-files.patch
@@ -1,0 +1,15 @@
+Partially reverts <https://codereview.qt-project.org/#/c/140954/>.
+
+diff --git i/mkspecs/features/qt_module.prf w/mkspecs/features/qt_module.prf
+index bb28af97..36bb6483 100644
+--- i/mkspecs/features/qt_module.prf
++++ w/mkspecs/features/qt_module.prf
+@@ -245,7 +245,7 @@ load(qt_installs)
+ load(qt_targets)
+
+ # this builds on top of qt_common
+-!internal_module:!lib_bundle:if(unix|mingw) {
++!internal_module:if(unix|mingw) {
+     CONFIG += create_pc
+     QMAKE_PKGCONFIG_DESTDIR = pkgconfig
+     host_build: \


### PR DESCRIPTION
Fixes #31685

This patch is applied in Homebrew here and looks to have worked for
them:

https://github.com/Homebrew/homebrew-core/blob/fafbdbd237ee87fb49b1080821e2597b38ff521c/Formula/qt.rb#L33-L44

I rewrote the patch to work in our src tree (got rid of qtbase/ prefix
in files).

Right now I am just applying the patch in 5.10 because I don’t have
time to try these out on 5.6 or 5.9. Anyone who wants to can try it on
those if they have time.

This should be based off of staging and need to test in Hydra before
we don’t have extra issues introduced.
