### PR TITLE
insomnia: init at 5.14.7

### DIFF
--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -1,0 +1,66 @@
+{ stdenv, lib, makeWrapper, fetchurl, dpkg,
+
+  alsaLib, atk, cairo, cups, dbus_daemon, expat, fontconfig, freetype, gdk_pixbuf, glib, gnome2, gtk2-x11,
+  nspr, nss,
+
+  libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext, libXfixes, libXi, libXrandr,
+  libXrender, libXtst, libxcb,
+
+  libudev0-shim, glibc, curl
+}:
+
+let
+  libPath = lib.makeLibraryPath [
+    alsaLib atk cairo cups dbus_daemon.lib expat fontconfig freetype gdk_pixbuf glib gnome2.GConf gnome2.pango
+    gtk2-x11 nspr nss stdenv.cc.cc.lib libX11 libXScrnSaver libXcomposite libXcursor libXdamage libXext libXfixes
+    libXi libXrandr libXrender libXtst libxcb
+  ];
+  runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl ];
+in stdenv.mkDerivation rec {
+  name = "insomnia-${version}";
+  version = "5.14.7";
+
+  src = fetchurl {
+    url = "https://github.com/getinsomnia/insomnia/releases/download/v${version}/insomnia_${version}_amd64.deb";
+    sha256 = "1y6bn9kaxxplzyv7jjrcsfkrjnivjqdk5mbdp8vz32hv2bmdvzzy";
+  };
+
+  nativeBuildInputs = [ makeWrapper dpkg ];
+
+  buildPhase = ":";
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p $out/share/insomnia $out/lib $out/bin
+
+    mv usr/share/* $out/share/
+    mv opt/Insomnia/* $out/share/insomnia
+    mv $out/share/insomnia/*.so $out/lib/
+
+    ln -s $out/share/insomnia/insomnia $out/bin/insomnia
+  '';
+
+  preFixup = ''
+    for lib in $out/lib/*.so; do
+      patchelf --set-rpath "$out/lib:${libPath}" $lib
+    done
+
+    for bin in $out/bin/insomnia; do
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+               --set-rpath "$out/lib:${libPath}" \
+               $bin
+    done
+
+    wrapProgram "$out/bin/insomnia" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://insomnia.rest/;
+    description = "The most intuitive cross-platform REST API Client";
+    license = stdenv.lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ markus1189 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7792,7 +7792,9 @@ with pkgs;
 
   inotify-tools = callPackage ../development/tools/misc/inotify-tools { };
 
-  intel-gpu-tools = callPackage ../development/tools/misc/intel-gpu-tools {};
+  intel-gpu-tools = callPackage ../development/tools/misc/intel-gpu-tools { };
+
+  insomnia = callPackage ../development/web/insomnia { };
 
   iozone = callPackage ../development/tools/misc/iozone { };
 


### PR DESCRIPTION
###### Motivation for this change
Add the Insomnia REST client

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Some questions:

1) What about the desktop icons and the general layout in `$out/share`?  If somebody could give a look and feedback that would be great
2) Is `platforms` okay so?