### PR TITLE
nixos: disable sound by default, if stateVersion >= 18.03

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -210,6 +210,9 @@ following incompatible changes:</para>
     </para>
     <itemizedlist>
       <listitem>
+         <literal>sound.enable</literal> now defaults to false.
+      </listitem>
+      <listitem>
         <para>
           <literal>matrix-synapse</literal> uses postgresql by default instead of sqlite.
           Migration instructions can be found <link xlink:href="https://github.com/matrix-org/synapse/blob/master/docs/postgres.rst#porting-from-sqlite"> here </link>.

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -603,6 +603,10 @@ $bootLoaderConfig
   # Enable CUPS to print documents.
   # services.printing.enable = true;
 
+  # Enable sound.
+  # sound.enable = true;
+  # hardware.pulseaudio.enable = true;
+
   # Enable the X11 windowing system.
   # services.xserver.enable = true;
   # services.xserver.layout = "us";

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -21,7 +21,6 @@ in
 
       enable = mkOption {
         type = types.bool;
-        default = true;
         description = ''
           Whether to enable ALSA sound.
         '';
@@ -78,7 +77,9 @@ in
 
   ###### implementation
 
-  config = mkIf config.sound.enable {
+  config = {
+      sound.enable = mkDefault !(versionAtLeast config.system.stateVersion "18.03")
+    } // mkIf config.sound.enable {
 
     environment.systemPackages = [ alsaUtils ];
 

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -78,7 +78,7 @@ in
   ###### implementation
 
   config = {
-      sound.enable = mkDefault !(versionAtLeast config.system.stateVersion "18.03")
+      sound.enable = mkDefault !(versionAtLeast config.system.stateVersion "18.03");
     } // mkIf config.sound.enable {
 
     environment.systemPackages = [ alsaUtils ];

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -77,9 +77,11 @@ in
 
   ###### implementation
 
-  config = {
+  config = mkMerge [
+    ({
       sound.enable = mkDefault (!versionAtLeast config.system.stateVersion "18.03");
-    } // mkIf config.sound.enable {
+    })
+    (mkIf config.sound.enable {
 
     environment.systemPackages = [ alsaUtils ];
 
@@ -125,6 +127,6 @@ in
       ];
     };
 
-  };
+  })];
 
 }

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -78,7 +78,7 @@ in
   ###### implementation
 
   config = {
-      sound.enable = mkDefault !(versionAtLeast config.system.stateVersion "18.03");
+      sound.enable = mkDefault (!versionAtLeast config.system.stateVersion "18.03");
     } // mkIf config.sound.enable {
 
     environment.systemPackages = [ alsaUtils ];

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -21,6 +21,7 @@ in
 
       enable = mkOption {
         type = types.bool;
+        defaultText = "!versionAtLeast system.stateVersion \"18.03\"";
         description = ''
           Whether to enable ALSA sound.
         '';


### PR DESCRIPTION
###### Motivation for this change

This change was suggested by @fpletz in #35292. Sound is disabled by default (for stateVersion > 18.03), and nixos-generate-config now puts a helpful comment telling you how to enable it. This is consistent with X11 being disabled by default.

###### Things done

I'm still building the branch, so not ready yet with everything. I wanted to create the PR already to enable discussion.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

