### PR TITLE
rtl8192eu: init at 4.4.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -705,6 +705,7 @@
   treemo = "Matthieu Chevrier <matthieu.chevrier@treemo.fr>";
   trevorj = "Trevor Joynson <nix@trevor.joynson.io>";
   trino = "Hubert Mühlhans <muehlhans.hubert@ekodia.de>";
+  troydm = "Dmitry Geurkov <d.geurkov@gmail.com>";
   tstrobel = "Thomas Strobel <4ZKTUB6TEP74PYJOPWIR013S2AV29YUBW5F9ZH2F4D5UMJUJ6S@hash.domains>";
   ttuegel = "Thomas Tuegel <ttuegel@mailbox.org>";
   tv = "Tomislav Viljetić <tv@shackspace.de>";

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub, kernel }:
+
+with lib;
+
+let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/rtl8192eu";
+
+in stdenv.mkDerivation rec {
+  name = "rtl8192eu-${kernel.version}-${version}";
+  version = "4.4.1";
+
+  src = fetchFromGitHub {
+    owner = "Mange";
+    repo = "rtl8192eu-linux-driver";
+    rev = "4094004";
+    sha256 = "0rgcsp8bd5i5ik9b35qipdhq0xd8pva8kdijixxfaxm4vw6kbrvr";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p ${modDestDir}
+    find . -name '*.ko' -exec cp --parents {} ${modDestDir} \;
+    find ${modDestDir} -name '*.ko' -exec xz -f {} \;
+  '';
+
+  meta = {
+    description = "Realtek rtl8192eu driver";
+    homepage = https://github.com/Mange/rtl8192eu-linux-driver;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ troydm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13129,6 +13129,8 @@ with pkgs;
 
     ply = callPackage ../os-specific/linux/ply { };
 
+    rtl8192eu = callPackage ../os-specific/linux/rtl8192eu { };
+
     rtl8723bs = callPackage ../os-specific/linux/rtl8723bs { };
 
     rtl8812au = callPackage ../os-specific/linux/rtl8812au { };


### PR DESCRIPTION
###### Motivation for this change
lack of rtl8192eu package that is must have for all using that Realtek Wi-Fi chipset

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using nix-build and insmod, works fine with D-Link DWA-131 (which uses rtl8192eu), heck it's the only stable way to use wireless network on my laptop unfortunetly
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

