### PR TITLE
gitless: 0.8.5 -> 0.8.6

### DIFF
--- a/pkgs/applications/version-management/gitless/default.nix
+++ b/pkgs/applications/version-management/gitless/default.nix
@@ -1,14 +1,15 @@
 { fetchFromGitHub, pythonPackages, stdenv }:
 
 pythonPackages.buildPythonApplication rec {
-  ver = "0.8.5";
-  name = "gitless-${ver}";
+  name = "${pname}-${version}";
+  version = "0.8.6";
+  pname = "gitless";
 
   src = fetchFromGitHub {
     owner = "sdg-mit";
     repo = "gitless";
-    rev = "v${ver}";
-    sha256 = "1v22i5lardswpqb6vxjgwra3ac8652qyajbijfj18vlkhajz78hq";
+    rev = "v${version}";
+    sha256 = "1q6y38f8ap6q1livvfy0pfnjr0l8b68hyhc9r5v87fmdyl7y7y8g";
   };
 
   propagatedBuildInputs = with pythonPackages; [ sh pygit2 clint ];


### PR DESCRIPTION
###### Motivation for this change
version bump.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

