### PR TITLE
monkeysphere: wrap the monkeysphere executable with the necessary crypto libraries …

### DIFF
--- a/pkgs/tools/security/monkeysphere/default.nix
+++ b/pkgs/tools/security/monkeysphere/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
         CryptOpenSSLRSA
         CryptOpenSSLBignum
       ]}"
+    wrapProgram $out/bin/monkeysphere --prefix PERL5LIB :\
+      "${with perlPackages; stdenv.lib.makePerlPath [
+        CryptOpenSSLRSA
+        CryptOpenSSLBignum
+      ]}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
…for ssh-proxycommand

###### Motivation for this change
It was previously impossible to use this package to verify the public key of a host, since the perl program which printed the key fingerprint would crash due to these libraries being unavailable. This bug is fixed herein.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

