### PR TITLE
busybox: 1.28.0 -> 1.28.1

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -33,14 +33,14 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "busybox-1.28.0";
+  name = "busybox-1.28.1";
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
   # still builds after the update.
   src = fetchurl {
     url = "http://busybox.net/downloads/${name}.tar.bz2";
-    sha256 = "1701carjf02y7r3djm1yvyd5kzrcxm4szinp7agfv7fmvfvm6ib0";
+    sha256 = "0bk52cxxlya5hg9va87snr9caz9ppdrpdyjwrnbwamhi64y1vzlq";
   };
 
   hardeningDisable = [ "format" ] ++ lib.optionals enableStatic [ "fortify" ];


### PR DESCRIPTION
Minor bump but one fix does impact our sandbox shell:
https://git.busybox.net/busybox/commit/?h=1_28_stable&id=59675c625d6500a9a0657481321954b0d1f63da9

You can try it with:

```console
$ nix run -f https://github.com/NixOS/nixpkgs/archive/master.tar.gz busybox-sandbox-shell -c busybox sh -c "shift 5 && echo eek"
eek
$
```

After this update:

```console
$ nix run -f .  busybox-sandbox-shell -c busybox sh -c "shift 5 && echo eek"
$ # no eek printed
```

bootstrap tools testing seems good.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---