### PR TITLE
nixos: make systemd-nspawn work out of the box on a NixOS root filesystem

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -124,6 +124,15 @@
     </para>
    </listitem>
    <listitem>
+     <para>
+       The path of the init script in the docker image and the container tarballs changed from <filename>/init</filename> to <filename>/sbin/init</filename>.
+       This is one of the default search locations for <literal>lxc</literal> and <literal>systemd-nspawn</literal>
+       and removes the need for workarounds.
+       For docker, this should only affect you don't directly call another program
+       through <option>dockerTools.buildImage.config.Cmd</option>.
+     </para>
+   </listitem>
+   <listitem>
     <para>
      Buildbot now supports Python 3 and its packages have been moved to
      <literal>pythonPackages</literal>. The options
@@ -251,6 +260,17 @@
      In particular, this makes <filename>/etc/os-release</filename> adhere to
      <link xlink:href="https://www.freedesktop.org/software/systemd/man/os-release.html">the standard</link>.
     </para>
+   </listitem>
+   <listitem>
+     <para>
+      Running NixOS container tarballs via systemd-nspawn is now supported out of the box, even on non-NixOS hosts:
+      <screen language="commands"># nix-build nixos/release.nix -A containerTarball.x86_64-linux
+# sudo mkdir -p /var/lib/machines/mynixos
+# sudo tar -C /var/lib/machines/mynixos -xf result/tarball/nixos-system-x86_64-linux.tar.xz
+# sudo systemd-nspawn --boot --machine mynixos</screen>
+      Alternatively to building a <literal>containerTarball</literal> yourself, you can download them from
+      <link xlink:href="https://hydra.nixos.org/search?query=containerTarball">hydra</link>.
+     </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -244,6 +244,14 @@
       <option>services.kubernetes.addons.dns.replicas</option>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     Symlinks in <filename>/etc</filename> are now relative instead of absolute,
+     so that the links can be followed if the NixOS installation is not mounted as filesystem root.
+     In particular, this makes <filename>/etc/os-release</filename> adhere to
+     <link xlink:href="https://www.freedesktop.org/software/systemd/man/os-release.html">the standard</link>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/lib/make-system-tarball.sh
+++ b/nixos/lib/make-system-tarball.sh
@@ -43,7 +43,7 @@ for ((n = 0; n < ${#objects[*]}; n++)); do
     symlink=${symlinks[$n]}
     if test "$symlink" != "none"; then
         mkdir -p $(dirname ./$symlink)
-        ln -s $object ./$symlink
+        ln -s --relative ./$object ./$symlink
     fi
 done
 

--- a/nixos/modules/profiles/docker-container.nix
+++ b/nixos/modules/profiles/docker-container.nix
@@ -15,13 +15,22 @@ in {
 
   # Create the tarball
   system.build.tarball = pkgs.callPackage ../../lib/make-system-tarball.nix {
+
     contents = [];
+
     extraArgs = "--owner=0";
 
-    # Add init script to image
     storeContents = [
+      # Add init script to image
       { object = config.system.build.toplevel + "/init";
-        symlink = "/init";
+        # use /sbin/init instead of /init as it's the default location of lxc and systemd-nspawn
+        symlink = "/sbin/init";
+      }
+      # Add /etc/os-release from nix store upfront, so that it is there prior first boot.
+      # for docker, this is only informative and not required, but for lxc, which also
+      # imports this code, it is required when started with systemd-nspawn.
+      { object = config.environment.etc."os-release".source;
+        symlink = "/etc/os-release";
       }
     ] ++ (pkgs2storeContents [ pkgs.stdenv ]);
 
@@ -30,6 +39,9 @@ in {
   };
 
   boot.isContainer = true;
+  # TODO: /sbin/init handling could probably done through this,
+  # but this is not enough for /sbin/init to land in the image
+  # boot.loader.initScript.enable = true;
   boot.postBootCommands =
     ''
       # After booting, register the contents of the Nix store in the Nix
@@ -45,6 +57,6 @@ in {
 
   # Install new init script
   system.activationScripts.installInitScript = ''
-    ln -fs $systemConfig/init /init
+    ln -fs --relative $systemConfig/init /sbin/init
   '';
 }

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -10,6 +10,11 @@ users_=($users)
 groups_=($groups)
 set +f
 
+# Create relative symlinks, so that the links can be followed if
+# the NixOS installation is not mounted as filesystem root.
+# Absolute symlinks violate the os-release format
+# at https://www.freedesktop.org/software/systemd/man/os-release.html
+# and break e.g. systemd-nspawn and os-prober.
 for ((i = 0; i < ${#targets_[@]}; i++)); do
     source="${sources_[$i]}"
     target="${targets_[$i]}"
@@ -19,14 +24,14 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
         # If the source name contains '*', perform globbing.
         mkdir -p $out/etc/$target
         for fn in $source; do
-            ln -s "$fn" $out/etc/$target/
+            ln -s --relative "$fn" $out/etc/$target/
         done
 
     else
-        
+
         mkdir -p $out/etc/$(dirname $target)
         if ! [ -e $out/etc/$target ]; then
-            ln -s $source $out/etc/$target
+            ln -s --relative $source $out/etc/$target
         else
             echo "duplicate entry $target -> $source"
             if test "$(readlink $out/etc/$target)" != "$source"; then
@@ -34,13 +39,13 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
                 exit 1
             fi
         fi
-        
+
         if test "${modes_[$i]}" != symlink; then
             echo "${modes_[$i]}"  > $out/etc/$target.mode
             echo "${users_[$i]}"  > $out/etc/$target.uid
             echo "${groups_[$i]}" > $out/etc/$target.gid
         fi
-        
+
     fi
 done
 


### PR DESCRIPTION
instead of creating an absolute symlink, which violates the os-release format
at https://www.freedesktop.org/software/systemd/man/os-release.html and
breaks systemd-nspawn and os-prober.

###### Motivation for this change
Fixes #28833, related to #9884.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

