### PR TITLE
nixos: properly disable sound by default, if stateVersion > 18.03

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -210,6 +210,9 @@ following incompatible changes:</para>
     </para>
     <itemizedlist>
       <listitem>
+         <literal>sound.enable</literal> now defaults to false.
+      </listitem>
+      <listitem>
         <para>
           <literal>matrix-synapse</literal> uses postgresql by default instead of sqlite.
           Migration instructions can be found <link xlink:href="https://github.com/matrix-org/synapse/blob/master/docs/postgres.rst#porting-from-sqlite"> here </link>.

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -603,6 +603,9 @@ $bootLoaderConfig
   # Enable CUPS to print documents.
   # services.printing.enable = true;
 
+  # Enable sound.
+  # sound.enable = true;
+
   # Enable the X11 windowing system.
   # services.xserver.enable = true;
   # services.xserver.layout = "us";

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ options, config, lib, pkgs, ... }:
 
 with lib;
 
@@ -77,6 +77,11 @@ in
   };
 
   config = {
+
+    warnings = lib.optional (options.system.stateVersion.highestPrio == 1001) ''
+      You don't have `system.stateVersion` explicitly set. Expect things to break.
+      See release notes and grep for "stateVersion" in `nixpkgs/nixos` tree.
+    '';
 
     system.nixos = {
       # These defaults are set here rather than up there so that

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -21,7 +21,8 @@ in
 
       enable = mkOption {
         type = types.bool;
-        default = true;
+        default = !versionAtLeast config.system.stateVersion "18.03";
+        defaultText = "!versionAtLeast system.stateVersion \"18.03\"";
         description = ''
           Whether to enable ALSA sound.
         '';


### PR DESCRIPTION
###### Motivation for this change

#35355 done properly:

- no breaking of existing configs,
- no sneaking in any PulseAudio-related changes.

The change to `lib` is somewhat ugly because the original impl is and other places in `nixos` depend on those functions and their semantics. I made a minimal possible change that doesn't break anything existing. Lets refactor (and break custom `.merge` for custom types) later if anyone cares.

Closes #35319 and closes #35355.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

