### PR TITLE
geoip: fix regression

### DIFF
--- a/pkgs/development/libraries/geoip/default.nix
+++ b/pkgs/development/libraries/geoip/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  postPatch = ''
+  postConfigure = ''
     find . -name Makefile.in -exec sed -i -r 's#^pkgdatadir\s*=.+$#pkgdatadir = ${dataDir}#' {} \;
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/nixos/nixpkgs/commit/dfdb17d10d440e5ae704fcca7093d223730ec527 regression 

As geoip now is compiled from github instead of pre-./configure-d source tarball, there are no ```Makefile.in``` files yet on ```postPatch``` phase

@fpletz 