### PR TITLE
leaps: 0.5.1 -> 0.9.0

### DIFF
--- a/pkgs/development/tools/leaps/default.nix
+++ b/pkgs/development/tools/leaps/default.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   name = "leaps-${version}";
-  version = "0.5.1";
+  version = "0.9.0";
 
-  goPackagePath = "github.com/jeffail/leaps";
+  goPackagePath = "github.com/Jeffail/leaps";
 
   src = fetchFromGitHub {
-    owner = "jeffail";
+    owner = "Jeffail";
     repo = "leaps";
-    sha256 = "0w63y777h5qc8fwnkrbawn3an9px0l1zz3649x0n8lhk125fvchj";
+    sha256 = "1bzas7ixyfsfh81lnvplhx59yghkmnmy5p7jv9rnwp219dwbylpz";
     rev = "v${version}";
   };
 

--- a/pkgs/development/tools/leaps/deps.nix
+++ b/pkgs/development/tools/leaps/deps.nix
@@ -1,94 +1,185 @@
-[
-  {
-    goPackagePath  = "github.com/amir/raidman";
-    fetch = {
-      type = "git";
-      url = "https://github.com/amir/raidman";
-      rev =  "91c20f3f475cab75bb40ad7951d9bbdde357ade7";
-      sha256 = "0pkqy5hzjkk04wj1ljq8jsyla358ilxi4lkmvkk73b3dh2wcqvpp";
-    };
-  }
-  {
-    goPackagePath = "github.com/elazarl/go-bindata-assetfs";
-    fetch = {
-      type = "git";
-      url = "https://github.com/elazarl/go-bindata-assetfs";
-      rev = "57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2";
-      sha256 = "1za29pa15y2xsa1lza97jlkax9qj93ks4a2j58xzmay6rczfkb9i";
-    };
-  }
-  {
-   goPackagePath =  "github.com/garyburd/redigo";
-    fetch =  {
-      type =  "git";
-       url =  "https://github.com/garyburd/redigo";
-       rev =  "8873b2f1995f59d4bcdd2b0dc9858e2cb9bf0c13";
-       sha256 =  "1lzhb99pcwwf5ddcs0bw00fwf9m1d0k7b92fqz2a01jlij4pm5l2";
-    };
-  }
-  {
-   goPackagePath =  "github.com/go-sql-driver/mysql";
-    fetch =  {
-      type =  "git";
-       url =  "https://github.com/go-sql-driver/mysql";
-       rev =  "7ebe0a500653eeb1859664bed5e48dec1e164e73";
-       sha256 =  "1gyan3lyn2j00di9haq7zm3zcwckn922iigx3fvml6s2bsp6ljas";
-    };
-  }
-  {
-   goPackagePath =  "github.com/golang/protobuf";
-    fetch =  {
-      type =  "git";
-       url =  "https://github.com/golang/protobuf";
-       rev =  "bf531ff1a004f24ee53329dfd5ce0b41bfdc17df";
-       sha256 =  "10lnvmq28jp2wk1xc32mdk4745lal2bmdvbjirckb9wlv07zzzf0";
-    };
-  }
-  {
-   goPackagePath =  "github.com/jeffail/gabs";
-    fetch =  {
-      type =  "git";
-       url =  "https://github.com/jeffail/gabs";
-       rev =  "ee1575a53249b51d636e62464ca43a13030afdb5";
-       sha256 =  "0svv57193n8m86r7v7n0y9lny0p6nzr7xvz98va87h00mg146351";
-    };
-  }
-  {
-   goPackagePath =  "github.com/jeffail/util";
-    fetch =  {
-      type =  "git";
-       url =  "https://github.com/jeffail/util";
-       rev =  "48ada8ff9fcae546b5986f066720daa9033ad523";
-       sha256 =  "0k8zz7gdv4hb691fdyb5mhlixppcq8x4ny84fanflypnv258a3i0";
-    };
-  }
-  {
-   goPackagePath =  "github.com/lib/pq";
-    fetch =  {
-      type =  "git";
-       url =  "https://github.com/lib/pq";
-       rev =  "3cd0097429be7d611bb644ef85b42bfb102ceea4";
-       sha256 =  "1q7qfzyfgjk6rvid548r43fi4jhvsh4dhfvfjbp2pz4xqsvpsm7a";
-    };
-  }
-  {
-   goPackagePath =  "github.com/satori/go.uuid";
-    fetch =  {
-      type =  "git";
-       url =  "https://github.com/satori/go.uuid";
-       rev =  "f9ab0dce87d815821e221626b772e3475a0d2749";
-       sha256 =  "0z18j6zxq9kw4lgcpmhh3k7jrb9gy1lx252xz5qhs4ywi9w77xwi";
-    };
-  }
 
-  {
-   goPackagePath =  "golang.org/x/net";
-    fetch =  {
-      type =  "git";
-       url =  "https://go.googlesource.com/net";
-       rev =  "07b51741c1d6423d4a6abab1c49940ec09cb1aaf";
-       sha256 =  "12lvdj0k2gww4hw5f79qb9yswqpy4i3bgv1likmf3mllgdxfm20w";
-    };
-  }
+  # file automatically generated from Gopkg.lock with https://github.com/nixcloud/dep2nix (golang dep)
+  [
+  
+    {
+      goPackagePath  = "github.com/Azure/go-autorest";
+      fetch = {
+        type = "git";
+        url = "https://github.com/Azure/go-autorest";
+        rev =  "fc3b03a2d2d1f43fad3007038bd16f044f870722";
+        sha256 = "1j6aqbizlpiqcywdsj4dy4i76g8fbqc7d61c22ppc9knw0968h4r";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/Jeffail/gabs";
+      fetch = {
+        type = "git";
+        url = "https://github.com/Jeffail/gabs";
+        rev =  "2a3aa15961d5fee6047b8151b67ac2f08ba2c48c";
+        sha256 = "1fx6fyl5x037viwlj319f3gsq749an17q5l6n2zvf3ny5wq0iqxr";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/amir/raidman";
+      fetch = {
+        type = "git";
+        url = "https://github.com/amir/raidman";
+        rev =  "1ccc43bfb9c93cb401a4025e49c64ba71e5e668b";
+        sha256 = "074ckbyslrwn23q4x01hn3j7c3xngagn36lbli2g51n9j3x14jxr";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/azure/azure-sdk-for-go";
+      fetch = {
+        type = "git";
+        url = "https://github.com/azure/azure-sdk-for-go";
+        rev =  "21b68149ccf7c16b3f028bb4c7fd0ab458fe308f";
+        sha256 = "0zlhrh3n9mc5w7r0sdaqmpqfm2d290b50an0k1bvrr892m4cnxaq";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/cenkalti/backoff";
+      fetch = {
+        type = "git";
+        url = "https://github.com/cenkalti/backoff";
+        rev =  "61153c768f31ee5f130071d08fc82b85208528de";
+        sha256 = "08x77mgb9zsj047n74rx6c16jjx985lmy4s6fl58mdgxgxjv54y5";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/dgrijalva/jwt-go";
+      fetch = {
+        type = "git";
+        url = "https://github.com/dgrijalva/jwt-go";
+        rev =  "dbeaa9332f19a944acb5736b4456cfcc02140e29";
+        sha256 = "0zk6l6kzsjdijfn7c4h0aywdjx5j2hjwi67vy1k6wr46hc8ks2hs";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/elazarl/go-bindata-assetfs";
+      fetch = {
+        type = "git";
+        url = "https://github.com/elazarl/go-bindata-assetfs";
+        rev =  "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43";
+        sha256 = "1swfb37g6sga3awvcmxf49ngbpvjv7ih5an9f8ixjqcfcwnb7nzp";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/garyburd/redigo";
+      fetch = {
+        type = "git";
+        url = "https://github.com/garyburd/redigo";
+        rev =  "d1ed5c67e5794de818ea85e6b522fda02623a484";
+        sha256 = "0gw18k9kg93hvdks93hckrdqppg1bav82sp2c98q6z36dkvaih24";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/go-sql-driver/mysql";
+      fetch = {
+        type = "git";
+        url = "https://github.com/go-sql-driver/mysql";
+        rev =  "a0583e0143b1624142adab07e0e97fe106d99561";
+        sha256 = "1rw1m91dpm23s6nn6jc4zi6rq2mgl7zx07gyadrdn0sh7cj8c89d";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/golang/protobuf";
+      fetch = {
+        type = "git";
+        url = "https://github.com/golang/protobuf";
+        rev =  "925541529c1fa6821df4e44ce2723319eb2be768";
+        sha256 = "1d3zjvhl115l23xakj0014qpjchivlg098h10v5nfirkk1i9f9sa";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/gorilla/websocket";
+      fetch = {
+        type = "git";
+        url = "https://github.com/gorilla/websocket";
+        rev =  "ea4d1f681babbce9545c9c5f3d5194a789c89f5b";
+        sha256 = "1bhgs2542qs49p1dafybqxfs2qc072xv41w5nswyrknwyjxxs2a1";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/kardianos/osext";
+      fetch = {
+        type = "git";
+        url = "https://github.com/kardianos/osext";
+        rev =  "ae77be60afb1dcacde03767a8c37337fad28ac14";
+        sha256 = "056dkgxrqjj5r18bnc3knlpgdz5p3yvp12y4y978hnsfhwaqvbjz";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/lib/pq";
+      fetch = {
+        type = "git";
+        url = "https://github.com/lib/pq";
+        rev =  "88edab0803230a3898347e77b474f8c1820a1f20";
+        sha256 = "02y7c8xy33x5q4167x2drzrys41nfi7wxxp9hy4vpazfws88al9p";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/marstr/guid";
+      fetch = {
+        type = "git";
+        url = "https://github.com/marstr/guid";
+        rev =  "8bdf7d1a087ccc975cf37dd6507da50698fd19ca";
+        sha256 = "1mxcigzfc1bbh5b616hm89bp06allhwcsas9v9lks235h0acgn4x";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/satori/go.uuid";
+      fetch = {
+        type = "git";
+        url = "https://github.com/satori/go.uuid";
+        rev =  "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3";
+        sha256 = "1j4s5pfg2ldm35y8ls8jah4dya2grfnx2drb4jcbjsyrp4cm5yfb";
+      };
+    }
+    
+    {
+      goPackagePath  = "golang.org/x/net";
+      fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/net";
+        rev =  "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb";
+        sha256 = "1hmpqkxh97ayyy0xcdvf1bwirwja4wyin3sh0fzjlh93aqmqgylf";
+      };
+    }
+    
+    {
+      goPackagePath  = "gopkg.in/alexcesaro/statsd.v2";
+      fetch = {
+        type = "git";
+        url = "https://gopkg.in/alexcesaro/statsd.v2";
+        rev =  "7fea3f0d2fab1ad973e641e51dba45443a311a90";
+        sha256 = "02jdx68vicwsgabrnwgg1rvc45rinyh8ikinqgbqc56c5hkx3brj";
+      };
+    }
+    
+    {
+      goPackagePath  = "gopkg.in/yaml.v2";
+      fetch = {
+        type = "git";
+        url = "https://gopkg.in/yaml.v2";
+        rev =  "d670f9405373e636a5a2765eea47fac0c9bc91a4";
+        sha256 = "1w1xid51n8v1mydn2m3vgggw8qgpd5a5sr62snsc77d99fpjsrs0";
+      };
+    }
+    
 ]
-


### PR DESCRIPTION
###### Motivation for this change

Significant update of the leaps software.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

