### PR TITLE
epoxy:  1.3.1 -> 1.5.0, add mesa to libepoxy runpath as fallback

### DIFF
--- a/pkgs/development/libraries/epoxy/default.nix
+++ b/pkgs/development/libraries/epoxy/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "epoxy-${version}";
-  version = "1.3.1";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "anholt";
     repo = "libepoxy";
-    rev = "v${version}";
-    sha256 = "0dfkd4xbp7v5gwsf6qwaraz54yzizf3lj5ymyc0msjn0adq3j5yl";
+    rev = "${version}";
+    sha256 = "1ixpqb10pmdy3n9nxd5inflig9dal5502ggadcns5b58j6jr0yv0";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/epoxy/default.nix
+++ b/pkgs/development/libraries/epoxy/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, utilmacros, python
-, mesa, libX11
+, mesa_noglu, libX11
 }:
 
 stdenv.mkDerivation rec {
@@ -16,11 +16,16 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig utilmacros python ];
-  buildInputs = [ mesa libX11 ];
+  buildInputs = [ mesa_noglu libX11 ];
 
   preConfigure = stdenv.lib.optional stdenv.isDarwin ''
     substituteInPlace configure --replace build_glx=no build_glx=yes
     substituteInPlace src/dispatch_common.h --replace "PLATFORM_HAS_GLX 0" "PLATFORM_HAS_GLX 1"
+  '';
+
+  # add mesa_nonglu to rpath because libepoxy dlopen()s libEGL
+  postFixup = ''
+    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ mesa_noglu ]}:$(patchelf --print-rpath $out/lib/libepoxy.so.0.0.0)" $out/lib/libepoxy.so.0.0.0
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
1. Missing runtime dependency: libepoxy dlopen()s libEGL / libGL but didn't have mesa in its runpath
-> error unless lib is already open or in LD_LIBRARY_PATH

2. change expoxy dependency from mesa (should be avoided) to mesa_noglu

###### Motivation for this change

libepoxy dlopen()s libs from mesa, so mesa should be in its runpath as a fallback.
This change has no effect if the lib is already open or found in LD_LIBRARY_PATH, which is the case in most applications (or else this bug would have surfaced earlier...).
But it will retrigger a number of rebuilds.

I ran across this bug when trying to run qemu built with opengl/virglrenderer support.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

