### PR TITLE
libtoxcore: add libconfig to buildInputs

### DIFF
--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libsodium libmsgpack ncurses
+    libsodium libmsgpack ncurses libconfig
   ] ++ stdenv.lib.optionals (!stdenv.isArm) [
     libopus
     libvpx


### PR DESCRIPTION
###### Motivation for this change

$out/bin/tox-bootstrapd is not built without it, silently

