### PR TITLE
[WIP] pkgs: pulseaudio -> pressureaudio; nixos: override when running a daemon

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -228,6 +228,9 @@ in {
           source = writeText "libao.conf" "default_driver=pulse"; }
       ];
 
+      environment.sessionVariables.LD_LIBRARY_PATH =
+        [ "${getLib overriddenPackage}/lib" ];
+
       # Allow PulseAudio to get realtime priority using rtkit.
       security.rtkit.enable = true;
 

--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, fetchpatch, jansson
+{ config, stdenv, fetchurl, intltool, pkgconfig, fetchpatch, jansson
 # deadbeef can use either gtk2 or gtk3
 , gtk2Support ? false, gtk2 ? null
 , gtk3Support ? true, gtk3 ? null, gsettings_desktop_schemas ? null, wrapGAppsHook ? null
@@ -20,7 +20,7 @@
 , osdSupport ? true, dbus ? null
 # output plugins
 , alsaSupport ? true, alsaLib ? null
-, pulseSupport ? true, libpulseaudio ? null
+, pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 # effect plugins
 , resamplerSupport ? true, libsamplerate ? null
 , overloadSupport ? true, zlib ? null

--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -1,7 +1,12 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake
-, alsaLib, glib, libjack2, libsndfile, libpulseaudio
+{ config, stdenv, lib, fetchFromGitHub, pkgconfig, cmake
+, alsaLib, glib, libsndfile
 , AudioUnit, CoreAudio, CoreMIDI, CoreServices
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
+, jackSupport ? stdenv.isLinux, libjack2 ? null
 }:
+
+assert pulseaudioSupport -> libpulseaudio != null;
+assert jackSupport -> libjack2 != null;
 
 stdenv.mkDerivation  rec {
   name = "fluidsynth-${version}";
@@ -17,7 +22,9 @@ stdenv.mkDerivation  rec {
   nativeBuildInputs = [ pkgconfig cmake ];
 
   buildInputs = [ glib libsndfile ]
-    ++ lib.optionals (!stdenv.isDarwin) [ alsaLib libpulseaudio libjack2 ]
+    ++ lib.optional  stdenv.isLinux alsaLib
+    ++ lib.optional  pulseaudioSupport libpulseaudio
+    ++ lib.optional  jackSupport libjack2
     ++ lib.optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreMIDI CoreServices ];
 
   cmakeFlags = lib.optional stdenv.isDarwin "-Denable-framework=off";

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -1,7 +1,15 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, alsaLib ? null, fftwFloat, fltk13
-, fluidsynth ? null, lame ? null, libgig ? null, libjack2 ? null, libpulseaudio ? null
+{ config, lib, stdenv, fetchFromGitHub, cmake, pkgconfig, alsaLib ? null, fftwFloat, fltk13
+, fluidsynth ? null, lame ? null, libgig ? null
 , libsamplerate, libsoundio ? null, libsndfile, libvorbis ? null, portaudio ? null
-, qtbase, qttools, SDL ? null }:
+, qtbase, qttools, SDL ? null
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
+, jackSupport ? stdenv.isLinux, libjack2 ? null
+}:
+
+with lib;
+
+assert pulseaudioSupport -> libpulseaudio != null;
+assert jackSupport -> libjack2 != null;
 
 stdenv.mkDerivation rec {
   name = "lmms-${version}";
@@ -23,8 +31,6 @@ stdenv.mkDerivation rec {
     fluidsynth
     lame
     libgig
-    libjack2
-    libpulseaudio
     libsamplerate
     libsndfile
     libsoundio
@@ -32,7 +38,9 @@ stdenv.mkDerivation rec {
     portaudio
     qtbase
     SDL # TODO: switch to SDL2 in the next version
-  ];
+  ]
+  ++ optional pulseaudioSupport libpulseaudio
+  ++ optional jackSupport libjack2;
 
   cmakeFlags = [ "-DWANT_QT5=ON" ];
   enableParallelBuilding = true;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -28,7 +28,7 @@
 , gnomeKeyringSupport ? false, libgnome_keyring3 ? null
 , proprietaryCodecs ? true
 , cupsSupport ? true
-, pulseSupport ? false, libpulseaudio ? null
+, pulseaudioSupport ? false, libpulseaudio ? null
 
 , upstream-info
 }:
@@ -131,7 +131,7 @@ let
     ] ++ optional gnomeKeyringSupport libgnome_keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]
-      ++ optional pulseSupport libpulseaudio;
+      ++ optional pulseaudioSupport libpulseaudio;
 
     patches = [
       ./patches/nix_plugin_paths_52.patch
@@ -245,7 +245,7 @@ let
       proprietary_codecs = true;
       enable_hangout_services_extension = true;
       ffmpeg_branding = "Chrome";
-    } // optionalAttrs pulseSupport {
+    } // optionalAttrs pulseaudioSupport {
       use_pulseaudio = true;
       link_pulseaudio = true;
     } // (extraAttrs.gnFlags or {}));

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,4 +1,4 @@
-{ newScope, stdenv, makeWrapper, makeDesktopItem, ed
+{ config, newScope, stdenv, makeWrapper, makeDesktopItem, ed
 , glib, gtk3, gnome3, gsettings_desktop_schemas
 
 # package customization
@@ -11,7 +11,7 @@
 , enablePepperFlash ? false
 , enableWideVine ? false
 , cupsSupport ? true
-, pulseSupport ? false
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
 }:
 
@@ -23,7 +23,7 @@ let
 
     mkChromiumDerivation = callPackage ./common.nix {
       inherit enableNaCl enableHotwording gnomeSupport gnome
-              gnomeKeyringSupport proprietaryCodecs cupsSupport pulseSupport
+              gnomeKeyringSupport proprietaryCodecs cupsSupport pulseaudioSupport
               enableWideVine;
     };
 

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, config, wrapGAppsHook
+{ lib, stdenv, fetchurl, config, wrapGAppsHook
 , alsaLib
 , atk
 , cairo
@@ -87,7 +87,7 @@ stdenv.mkDerivation {
   libPath = stdenv.lib.makeLibraryPath
     [ stdenv.cc.cc
       alsaLib
-      alsaLib.dev
+      (lib.getDev alsaLib)
       atk
       cairo
       curl
@@ -124,7 +124,7 @@ stdenv.mkDerivation {
       pango
       libheimdal
       libpulseaudio
-      libpulseaudio.dev
+      (lib.getDev libpulseaudio)
       systemd
     ] + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [
       stdenv.cc.cc

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -71,7 +71,7 @@ let
             ++ lib.optionals (cfg.enableQuakeLive or false)
             (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib libudev ])
             ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash
-            ++ lib.optional (config.pulseaudio or true) libpulseaudio;
+            ++ lib.optional (config.pulseaudio or stdenv.isLinux) libpulseaudio;
       gst-plugins = with gst_all; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
       gtk_modules = [ libcanberra_gtk2 ];
 

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -4,6 +4,8 @@
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
 }:
 
+with lib;
+
 mkDerivation rec {
   name = "telegram-desktop-${version}";
   version = "1.2.6";
@@ -40,7 +42,7 @@ mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  GYP_DEFINES = lib.concatStringsSep "," [
+  GYP_DEFINES = concatStringsSep "," [
     "TDESKTOP_DISABLE_CRASH_REPORTS"
     "TDESKTOP_DISABLE_AUTOUPDATE"
     "TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME"
@@ -52,14 +54,14 @@ mkDerivation rec {
     "-DTDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME"
     "-I${minizip}/include/minizip"
     # See Telegram/gyp/qt.gypi
-    "-I${qtbase.dev}/mkspecs/linux-g++"
-  ] ++ lib.concatMap (x: [
-    "-I${qtbase.dev}/include/${x}"
-    "-I${qtbase.dev}/include/${x}/${qtbase.version}"
-    "-I${qtbase.dev}/include/${x}/${qtbase.version}/${x}"
-    "-I${libopus.dev}/include/opus"
-    "-I${alsaLib.dev}/include/alsa"
-    "-I${libpulseaudio.dev}/include/pulse"
+    "-I${getDev qtbase}/mkspecs/linux-g++"
+  ] ++ concatMap (x: [
+    "-I${getDev qtbase}/include/${x}"
+    "-I${getDev qtbase}/include/${x}/${qtbase.version}"
+    "-I${getDev qtbase}/include/${x}/${qtbase.version}/${x}"
+    "-I${getDev libopus}/include/opus"
+    "-I${getDev alsaLib}/include/alsa"
+    "-I${getDev libpulseaudio}/include/pulse"
   ]) [ "QtCore" "QtGui" "QtDBus" ];
   CPPFLAGS = NIX_CFLAGS_COMPILE;
 
@@ -116,7 +118,7 @@ mkDerivation rec {
       -e "s,'XDG-RUNTIME-DIR',\"\''${XDG_RUNTIME_DIR:-/run/user/\$(id --user)}\","
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Telegram Desktop messaging app";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/applications/video/bomi/default.nix
+++ b/pkgs/applications/video/bomi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, perl, python, which
+{ config, stdenv, fetchFromGitHub, fetchpatch, pkgconfig, perl, python, which
 , libX11, libxcb, mesa
 , qtbase, qtdeclarative, qtquickcontrols, qttools, qtx11extras, qmake, makeWrapper
 , libchardet
@@ -15,7 +15,7 @@
 , libbluray
 , jackSupport ? false, jack ? null
 , portaudioSupport ? false, portaudio ? null
-, pulseSupport ? true, libpulseaudio ? null
+, pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , cddaSupport ? false, libcdda ? null
 , youtubeSupport ? true, youtube-dl ? null
 }:

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ config
+, stdenv
 , fetchFromGitHub
 , cmake
 , fdk_aac
@@ -19,11 +20,14 @@
 , pkgconfig
 , vlc
 
-, alsaSupport ? false
-, alsaLib
-, pulseaudioSupport ? false
-, libpulseaudio
+, alsaSupport ? stdenv.isLinux
+, alsaLib ? null
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux
+, libpulseaudio ? null
 }:
+
+assert alsaSupport -> alsaLib != null;
+assert pulseaudioSupport -> libpulseaudio != null;
 
 let
   optional = stdenv.lib.optional;

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, iasl, dev86, pam, libxslt, libxml2, libX11, xproto, libXext
+{ config, stdenv, fetchurl, lib, iasl, dev86, pam, libxslt, libxml2, libX11, xproto, libXext
 , libXcursor, libXmu, qt5, libIDL, SDL, libcap, zlib, libpng, glib, lvm2
 , libXrandr, libXinerama
 , pkgconfig, which, docbook_xsl, docbook_xml_dtd_43
@@ -7,7 +7,7 @@
 , javaBindings ? false, jdk ? null
 , pythonBindings ? false, python2 ? null
 , enableExtensionPack ? false, requireFile ? null, patchelf ? null, fakeroot ? null
-, pulseSupport ? false, libpulseaudio ? null
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , enableHardening ? false
 , headless ? false
 , enable32bitGuests ? true
@@ -61,7 +61,7 @@ in stdenv.mkDerivation {
       libXmu libpng patchelfUnstable python ]
     ++ optional javaBindings jdk
     ++ optional pythonBindings python # Python is needed even when not building bindings
-    ++ optional pulseSupport libpulseaudio
+    ++ optional pulseaudioSupport libpulseaudio
     ++ optionals (headless) [ libXrandr ]
     ++ optionals (!headless) [ qt5.qtbase qt5.qtx11extras libXinerama SDL ];
 
@@ -79,7 +79,7 @@ in stdenv.mkDerivation {
     ls kBuild/bin/linux.amd64/k* tools/linux.amd64/bin/* | xargs -n 1 patchelf --set-interpreter ${stdenv.glibc.out}/lib/ld-linux-x86-64.so.2
 
     grep 'libpulse\.so\.0'      src include -rI --files-with-match | xargs sed -i -e '
-      ${optionalString pulseSupport
+      ${optionalString pulseaudioSupport
         ''s@"libpulse\.so\.0"@"${libpulseaudio.out}/lib/libpulse.so.0"@g''}'
 
     grep 'libdbus-1\.so\.3'     src include -rI --files-with-match | xargs sed -i -e '
@@ -137,7 +137,7 @@ in stdenv.mkDerivation {
       ${optionalString headless "--build-headless"} \
       ${optionalString (!javaBindings) "--disable-java"} \
       ${optionalString (!pythonBindings) "--disable-python"} \
-      ${optionalString (!pulseSupport) "--disable-pulse"} \
+      ${optionalString (!pulseaudioSupport) "--disable-pulse"} \
       ${optionalString (!enableHardening) "--disable-hardening"} \
       ${optionalString (!enable32bitGuests) "--disable-vmmraw"} \
       --disable-kmods --with-mkisofs=${xorriso}/bin/xorrisofs

--- a/pkgs/desktops/mate/libmatemixer/default.nix
+++ b/pkgs/desktops/mate/libmatemixer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, mate
 , alsaSupport ? stdenv.isLinux, alsaLib
-, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
+, pulseaudioSupport ? stdenv.config.pulseaudio or stdenv.isLinux, libpulseaudio
 , ossSupport ? false
  }:
 

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, dbus_glib, libxklavier, libcanberra_gtk3, libnotify, nss, polkit, gnome3, mate, wrapGAppsHook
-, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
+, pulseaudioSupport ? stdenv.config.pulseaudio or stdenv.isLinux, libpulseaudio
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix
@@ -30,8 +30,7 @@ stdenv.mkDerivation rec {
   # TODO : v4l, libvisual
   buildInputs =
     [ pkgconfig glib cairo orc ]
-    # can't build alsaLib on darwin
-    ++ stdenv.lib.optional (!stdenv.isDarwin) alsaLib
+    ++ stdenv.lib.optional stdenv.isLinux alsaLib
     ++ stdenv.lib.optionals (!minimalDeps)
       [ xorg.xlibsWrapper xorg.libXv libogg libtheora libvorbis freetype pango
         liboil ]

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
@@ -1,11 +1,14 @@
-{ fetchurl, stdenv, lib, pkgconfig, gst-plugins-base, aalib, cairo
+{ config, fetchurl, stdenv, lib, pkgconfig, gst-plugins-base, aalib, cairo
 , flac, libjpeg, zlib, speex, libpng, libdv, libcaca, libvpx
-, libiec61883, libavc1394, taglib, libpulseaudio, gdk_pixbuf, orc
+, libiec61883, libavc1394, taglib, gdk_pixbuf, orc
 , glib, gstreamer, bzip2, libsoup, libshout, ncurses, libintlOrEmpty
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , # Whether to build no plugins that have external dependencies
   # (except the PulseAudio plugin).
   minimalDeps ? false
 }:
+
+assert pulseaudioSupport -> libpulseaudio != null;
 
 stdenv.mkDerivation rec {
   name = "gst-plugins-good-0.10.31";
@@ -24,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ pkgconfig glib gstreamer gst-plugins-base ]
-    ++ lib.optional stdenv.isLinux libpulseaudio
+    ++ lib.optional pulseaudioSupport libpulseaudio
     ++ libintlOrEmpty
     ++ lib.optionals (!minimalDeps)
       [ aalib libcaca cairo libdv flac libjpeg libpng speex

--- a/pkgs/development/libraries/libmikmod/default.nix
+++ b/pkgs/development/libraries/libmikmod/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, texinfo, alsaLib, libpulseaudio, CoreAudio }:
+{ config, stdenv, fetchurl, texinfo, alsaLib, CoreAudio
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null }:
 
 let
   inherit (stdenv.lib) optional optionals optionalString;
@@ -11,10 +12,12 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [ texinfo ]
-    ++ optionals stdenv.isLinux [ alsaLib libpulseaudio ]
+    ++ optional stdenv.isLinux alsaLib
+    ++ optional pulseaudioSupport libpulseaudio
     ++ optional stdenv.isDarwin CoreAudio;
+
   propagatedBuildInputs =
-    optional stdenv.isLinux libpulseaudio;
+    optional pulseaudioSupport libpulseaudio;
 
   NIX_LDFLAGS = optionalString stdenv.isLinux "-lasound";
 

--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, cmake
+{ config, stdenv, fetchurl, cmake
 , alsaSupport ? !stdenv.isDarwin, alsaLib ? null
-, pulseSupport ? !stdenv.isDarwin, libpulseaudio ? null
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , CoreServices, AudioUnit, AudioToolbox
 }:
 
 with stdenv.lib;
 
 assert alsaSupport -> alsaLib != null;
-assert pulseSupport -> libpulseaudio != null;
+assert pulseaudioSupport -> libpulseaudio != null;
 
 stdenv.mkDerivation rec {
   version = "1.18.2";
@@ -22,12 +22,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = []
     ++ optional alsaSupport alsaLib
-    ++ optional pulseSupport libpulseaudio
+    ++ optional pulseaudioSupport libpulseaudio
     ++ optionals stdenv.isDarwin [ CoreServices AudioUnit AudioToolbox ];
 
   NIX_LDFLAGS = []
     ++ optional alsaSupport "-lasound"
-    ++ optional pulseSupport "-lpulse";
+    ++ optional pulseaudioSupport "-lpulse";
 
   meta = {
     description = "OpenAL alternative";

--- a/pkgs/development/libraries/pcaudiolib/default.nix
+++ b/pkgs/development/libraries/pcaudiolib/default.nix
@@ -1,6 +1,10 @@
-{ stdenv, lib, fetchFromGitHub, autoconf, automake, which, libtool, pkgconfig,
-  alsaLib, portaudio, 
-  pulseaudioSupport ? true, libpulseaudio }:
+{ config, stdenv, lib, fetchFromGitHub, autoconf, automake, which, libtool, pkgconfig
+, alsaLib, portaudio
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
+}:
+
+assert pulseaudioSupport -> libpulseaudio != null;
+
 
 stdenv.mkDerivation rec {
   name = "pcaudiolib-${version}";

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -1,15 +1,16 @@
-{ qtModule, stdenv, qtbase, qtdeclarative, pkgconfig
+{ qtModule, config, lib, stdenv, qtbase, qtdeclarative, pkgconfig
 , alsaLib, gstreamer, gst-plugins-base, libpulseaudio
 , darwin
 }:
 
-with stdenv.lib;
+with lib;
 
 qtModule {
   name = "qtmultimedia";
   qtInputs = [ qtbase qtdeclarative ];
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gstreamer gst-plugins-base libpulseaudio]
+  buildInputs = [ gstreamer gst-plugins-base ]
+    ++ optional (config.pulseaudio or stdenv.isLinux) libpulseaudio
     ++ optional (stdenv.isLinux) alsaLib;
   outputs = [ "bin" "dev" "out" ];
   qmakeFlags = [ "GST_VERSION=1.0" ];

--- a/pkgs/misc/apulse/default.nix
+++ b/pkgs/misc/apulse/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ alsaLib glib ];
 
+  cmakeFlags = [ "-DWITH_TRACE=1" ];
+
   meta = with stdenv.lib; {
     description = "PulseAudio emulation for ALSA";
     homepage = https://github.com/i-rinat/apulse;

--- a/pkgs/misc/apulse/default.nix
+++ b/pkgs/misc/apulse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, alsaLib, cmake, pkgconfig, glib }:
+{ stdenv, fetchFromGitHub, fetchpatch, alsaLib, cmake, pkgconfig, glib }:
 
 stdenv.mkDerivation rec {
   name = "apulse-${version}";
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "16l278q0czca2794fj388ql6qn1zrw24a0p6k7bayrrf5h32fdzd";
   };
+
+  patches = [(fetchpatch {
+    url = "https://github.com/oxij/apulse/commit/9060039d8518f39710f8afd6507a05dc8581d556.patch";
+    sha256 = "1z7f5lv25fjrgzvx61qliijmf0wigh29ddi4zhqz1f5mzsphy761";
+  })];
 
   enableParallelBuilding = true;
 

--- a/pkgs/misc/apulse/pressureaudio.nix
+++ b/pkgs/misc/apulse/pressureaudio.nix
@@ -1,9 +1,9 @@
-{ stdenv, apulse, libpulseaudio, pkgconfig, intltool, autoreconfHook }:
+{ stdenv, apulse, pulseaudioLib, pkgconfig, intltool, autoreconfHook }:
 
 stdenv.mkDerivation {
   name = "libpressureaudio-${apulse.version}";
 
-  src = libpulseaudio.src;
+  src = pulseaudioLib.src;
 
   nativeBuildInputs = [ pkgconfig intltool autoreconfHook ];
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
     cat >> $out/lib/pkgconfig/libpulse.pc << EOF
     Name: libpulse
     Description: PulseAudio Client Interface
-    Version: ${libpulseaudio.version}-rebootstrapped
+    Version: ${pulseaudioLib.version}-rebootstrapped
     Libs: -L$out/lib -lpulse 
     Cflags: -I$out/include -D_REENTRANT
     EOF
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
     cat >> $out/lib/pkgconfig/libpulse-simple.pc << EOF
     Name: libpulse-simple
     Description: PulseAudio Simplified Synchronous Client Interface
-    Version: ${libpulseaudio.version}-rebootstrapped
+    Version: ${pulseaudioLib.version}-rebootstrapped
     Libs: -L$out/lib -lpulse-simple 
     Cflags: -I$out/include -D_REENTRANT
     Requires: libpulse
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     cat >> $out/lib/pkgconfig/libpulse-mainloop-glib.pc << EOF
     Name: libpulse-mainloop-glib
     Description: PulseAudio GLib 2.0 Main Loop Wrapper
-    Version: ${libpulseaudio.version}-rebootstrapped
+    Version: ${pulseaudioLib.version}-rebootstrapped
     Libs: -L$out/lib -lpulse-mainloop-glib 
     Cflags: -I$out/include -D_REENTRANT
     Requires: libpulse glib-2.0
@@ -60,22 +60,22 @@ stdenv.mkDerivation {
   '';
 
   meta = apulse.meta // {
-    description = "libpulseaudio without any sound daemons over pure ALSA";
+    description = "libpulse without any sound daemons over pure ALSA";
     longDescription = ''
-      apulse (${apulse.meta.homepage}) implements most of libpulseaudio
+      apulse (${apulse.meta.homepage}) implements most of libpulse
       API over pure ALSA in 5% LOC of the original PulseAudio.
 
       But apulse is made to be used as a wrapper that substitutes its
       replacement libs into LD_LIBRARY_PATH. The problem with that is
-      that you still have to link against the original libpulseaudio.
+      that you still have to link against the original libpulse.
 
       pressureaudio (http://git.r-36.net/pressureaudio/) wraps apulse
-      with everything you need to replace libpulseaudio completely.
+      with everything you need to replace libpulse completely.
 
       This derivation is a reimplementation of pressureaudio in pure
       nix.
 
-      You can simply override libpulseaudio with this and most
+      You can simply override libpulse with this and most
       packages would just work.
     '';
   };

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, fetchFromGitHub, makeDesktopItem, coreutils, which, pkgconfig
+{ config, stdenv, fetchFromGitHub, makeDesktopItem, coreutils, which, pkgconfig
 , ffmpeg, mesa, freetype, libxml2, python34
 , enableNvidiaCgToolkit ? false, nvidia_cg_toolkit ? null
 , alsaLib ? null, libv4l ? null
 , udev ? null, libX11 ? null, libXext ? null, libXxf86vm ? null
-, libXdmcp ? null, SDL ? null, libpulseaudio ? null
+, libXdmcp ? null, SDL ? null
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 }:
 
 with stdenv.lib;
@@ -35,7 +36,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ffmpeg mesa freetype libxml2 coreutils python34 which SDL ]
                 ++ optional enableNvidiaCgToolkit nvidia_cg_toolkit
-                ++ optionals stdenv.isLinux [ udev alsaLib libX11 libXext libXxf86vm libXdmcp libv4l libpulseaudio ];
+                ++ optional pulseaudioSupport libpulseaudio
+                ++ optionals stdenv.isLinux [ udev alsaLib libX11 libXext libXxf86vm libXdmcp libv4l ];
 
   configureScript = "sh configure";
 

--- a/pkgs/os-specific/linux/alsa-plugins/default.nix
+++ b/pkgs/os-specific/linux/alsa-plugins/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, lib, pkgconfig, alsaLib, libogg, libpulseaudio ? null, libjack2 ? null }:
+{ config, stdenv, fetchurl, lib, pkgconfig, alsaLib, libogg
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
+, jackSupport ? stdenv.isLinux, libjack2 ? null }:
+
+assert pulseaudioSupport -> libpulseaudio != null;
+assert jackSupport -> libjack2 != null;
 
 stdenv.mkDerivation rec {
   name = "alsa-plugins-1.1.5";
@@ -14,8 +19,8 @@ stdenv.mkDerivation rec {
   # ToDo: a52, etc.?
   buildInputs =
     [ pkgconfig alsaLib libogg ]
-    ++ lib.optional (libpulseaudio != null) libpulseaudio
-    ++ lib.optional (libjack2 != null) libjack2;
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional jackSupport libjack2;
 
   meta = with lib; {
     description = "Various plugins for ALSA";

--- a/pkgs/os-specific/linux/alsa-plugins/default.nix
+++ b/pkgs/os-specific/linux/alsa-plugins/default.nix
@@ -1,8 +1,8 @@
 { config, stdenv, fetchurl, lib, pkgconfig, alsaLib, libogg
-, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, pulseaudioLib ? null
 , jackSupport ? stdenv.isLinux, libjack2 ? null }:
 
-assert pulseaudioSupport -> libpulseaudio != null;
+assert pulseaudioSupport -> pulseaudioLib != null;
 assert jackSupport -> libjack2 != null;
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   # ToDo: a52, etc.?
   buildInputs =
     [ pkgconfig alsaLib libogg ]
-    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional pulseaudioSupport pulseaudioLib
     ++ lib.optional jackSupport libjack2;
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/guvcview/default.nix
+++ b/pkgs/os-specific/linux/guvcview/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, intltool, gettext, pkgconfig
+{ config, stdenv, fetchurl, intltool, gettext, pkgconfig
 , gtk3, portaudio, libpng, SDL2, ffmpeg, udev, libusb1, libv4l, alsaLib, gsl
-, pulseaudioSupport ? true, libpulseaudio ? null }:
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null }:
 
 assert pulseaudioSupport -> libpulseaudio != null;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14652,7 +14652,6 @@ with pkgs;
 
   bomi = libsForQt5.callPackage ../applications/video/bomi {
     youtube-dl = pythonPackages.youtube-dl;
-    pulseSupport = config.pulseaudio or true;
     ffmpeg = ffmpeg_2;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10684,9 +10684,7 @@ with pkgs;
 
   pangoxsl = callPackage ../development/libraries/pangoxsl { };
 
-  pcaudiolib = callPackage ../development/libraries/pcaudiolib {
-    pulseaudioSupport = config.pulseaudio or true;
-  };
+  pcaudiolib = callPackage ../development/libraries/pcaudiolib { };
 
   pcg_c = callPackage ../development/libraries/pcg-c { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1446,9 +1446,7 @@ with pkgs;
       TestDifferences;
   };
 
-  blueman = callPackage ../tools/bluetooth/blueman {
-    withPulseAudio = config.pulseaudio or true;
-  };
+  blueman = callPackage ../tools/bluetooth/blueman { };
 
   bmrsa = callPackage ../tools/security/bmrsa/11.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17847,7 +17847,6 @@ with pkgs;
     stdenv = stdenv_32bit;
     inherit (gnome2) libIDL;
     enableExtensionPack = config.virtualbox.enableExtensionPack or false;
-    pulseSupport = config.pulseaudio or true;
   };
 
   virtualboxHardened = lowPrio (virtualbox.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14736,7 +14736,6 @@ with pkgs;
 
   chromium = callPackage ../applications/networking/browsers/chromium {
     channel = "stable";
-    pulseSupport = config.pulseaudio or true;
     enablePepperFlash = config.chromium.enablePepperFlash or false;
     enableWideVine = config.chromium.enableWideVine or false;
     gnome = gnome2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -423,7 +423,7 @@ with pkgs;
     automationSupport = config.aegisub.automationSupport or true;
     openalSupport     = config.aegisub.openalSupport or false;
     alsaSupport       = config.aegisub.alsaSupport or true;
-    pulseaudioSupport = config.aegisub.pulseaudioSupport or true;
+    pulseaudioSupport = config.aegisub.pulseaudioSupport or config.pulseaudio or stdenv.isLinux;
     portaudioSupport  = config.aegisub.portaudioSupport or false;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16735,10 +16735,7 @@ with pkgs;
 
   oblogout = callPackage ../tools/X11/oblogout { };
 
-  obs-studio = libsForQt5.callPackage ../applications/video/obs-studio {
-    alsaSupport = stdenv.isLinux;
-    pulseaudioSupport = config.pulseaudio or true;
-  };
+  obs-studio = libsForQt5.callPackage ../applications/video/obs-studio { };
 
   octoprint = callPackage ../applications/misc/octoprint { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14862,9 +14862,7 @@ with pkgs;
 
   ddgr = callPackage ../applications/misc/ddgr { };
 
-  deadbeef = callPackage ../applications/audio/deadbeef {
-    pulseSupport = config.pulseaudio or true;
-  };
+  deadbeef = callPackage ../applications/audio/deadbeef { };
 
   deadbeef-mpris2-plugin = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -489,10 +489,6 @@ with pkgs;
 
   aptly = callPackage ../tools/misc/aptly { };
 
-  apulse = callPackage ../misc/apulse { };
-
-  libpressureaudio = callPackage ../misc/apulse/pressureaudio.nix { };
-
   archivemount = callPackage ../tools/filesystems/archivemount { };
 
   arandr = callPackage ../tools/X11/arandr { };
@@ -12300,10 +12296,7 @@ with pkgs;
 
   pshs = callPackage ../servers/http/pshs { };
 
-  libpulseaudio = callPackage ../servers/pulseaudio {
-    libOnly = true;
-    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
-  };
+  # PulseAudio daemons
 
   # Name is changed to prevent use in packages;
   # please use libpulseaudio instead.
@@ -12322,6 +12315,32 @@ with pkgs;
     zeroconfSupport = true;
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };
+
+  # libpulse implementations
+
+  apulse = callPackage ../misc/apulse { };
+
+  pressureaudio = callPackage ../misc/apulse/pressureaudio.nix { };
+  libpressureaudio = pressureaudio;
+
+  pulseaudioLib = callPackage ../servers/pulseaudio {
+    libOnly = true;
+    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
+  };
+
+  # We link against pressureaudio by default to provide `libpulse` API
+  # over pure ALSA to apps that refuse to properly work over ALSA
+  # themselves (e.g. Firefox).
+  #
+  # NixOS then overrides this with `pulseaudioLib` via
+  # `LD_LIBRARY_PATH` when user enables the daemon service
+  # (`pressureaudio` and `pulseaudioLib` are link-time-compatible).
+  #
+  # This way users that don't run PulseAudio daemon and don't want to
+  # link against `pulseaudioLib` for ethical, religious, and/or
+  # security reasons don't need to make any overrides, while
+  # PulseAudio daemon users stay happy.
+  libpulseaudio = pressureaudio;
 
   tomcat_connectors = callPackage ../servers/http/apache-modules/tomcat-connectors { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15782,7 +15782,6 @@ with pkgs;
   gv = callPackage ../applications/misc/gv { };
 
   guvcview = callPackage ../os-specific/linux/guvcview {
-    pulseaudioSupport = config.pulseaudio or true;
     ffmpeg = ffmpeg_2;
   };
 


### PR DESCRIPTION
###### Motivation for this change

An idea that struck me when writing https://github.com/NixOS/nixpkgs/pull/35292#issuecomment-367564855 (see https://github.com/NixOS/nixpkgs/pull/35355#issuecomment-367864633 for in-depth explanation of the motivation behind every part of that comment).

With this we link against pressureaudio by default to provide `libpulse` API over pure ALSA to apps that refuse to properly work over ALSA themselves (e.g. Firefox).

NixOS then overrides this with `pulseaudioLib` via `LD_LIBRARY_PATH` when user enables the daemon service (`pressureaudio` and `pulseaudioLib` are link-time-compatible).

This way users that don't run PulseAudio daemon and don't want to link against `pulseaudioLib` for religious and/or security reasons don't need to make any overrides, while PulseAudio daemon users stay happy.

This also significantly reduces closure size when not running PulseAudio daemon since `pressureaudio` (`apulse`) is tiny in comparison to `pulseaudioLib` and requires only `alsaLib` and `glib`.

It is a mass rebuild, but none of my PRs to `staging` got merged this month, so.

###### Things not done

- [X] Not tested with `hardware.pulseaudio.enable` set. I refuse to set it for ethical reasons. But the change seems trivial enough that it should work.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of some pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` Seems to work.
- [X] Tested execution of many binary files of the changed packages. Seem to work.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

