### PR TITLE
golint: 20160428 -> 20180208

### DIFF
--- a/pkgs/development/tools/golint/default.nix
+++ b/pkgs/development/tools/golint/default.nix
@@ -2,8 +2,8 @@
 
 buildGoPackage rec {
   name = "lint-${version}";
-  version = "20160428-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "c7bacac2b21ca01afa1dee0acf64df3ce047c28f";
+  version = "20180208-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "e14d9b0f1d332b1420c1ffa32562ad2dc84d645d";
   
   goPackagePath = "github.com/golang/lint";
   excludedPackages = "testdata";
@@ -11,7 +11,7 @@ buildGoPackage rec {
   src = fetchgit {
     inherit rev;
     url = "https://github.com/golang/lint";
-    sha256 = "024dllcmpg8lx78cqgq551i6f9w6qlykfcx8l7yazak9kjwhpwjg";
+    sha256 = "15ynf78v39n71aplrhbqvzfblhndp8cd6lnknm586sdl81wama6p";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/development/tools/golint/deps.nix
+++ b/pkgs/development/tools/golint/deps.nix
@@ -4,8 +4,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/tools";
-      rev = "9ae4729fba20b3533d829a9c6ba8195b068f2abc";
-      sha256 = "1j51aaskfqc953p5s9naqimr04hzfijm4yczdsiway1xnnvvpfr1";
+      rev = "66487607e2081c7c2af2281c62c14ee000d5024b";
+      sha256 = "03wiraqkms4jb5gi7vmp52mpmp4av08yw4gr2nk31c2rnhyd3jv4";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change
Golint is very out of date

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

