### PR TITLE
sift: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/tools/text/sift/default.nix
+++ b/pkgs/tools/text/sift/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "sift-${version}";
-  version = "0.8.0";
+  version = "0.9.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/svent/sift";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "svent";
     repo = "sift";
-    sha256 = "1nb042k420xr6000ipwhqn41vg8jfp6ghq4z7y1sjnndkrhclzm1";
+    sha256 = "0bgy0jf84z1c3msvb60ffj4axayfchdkf0xjnsbx9kad1v10g7i1";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
###### Motivation for this change
Staying current.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

