### PR TITLE
build-support/rust: make use of abandoned cargoUpdateHook

### DIFF
--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation {
 
     export CARGO_HOME=$(mktemp -d cargo-home.XXX)
 
+    ${cargoUpdateHook}
+
     cargo vendor
 
     cp -ar vendor $out


### PR DESCRIPTION
Previously, cargoUpdateHook was meaningful as it was used
in
[`cargo-fetch-deps`](https://github.com/NixOS/nixpkgs/blob/19d3cf81d3436a6600f261579b55b9132a6ca8fb/pkgs/build-support/rust/fetch-cargo-deps#L71).

However, this entire file was removed in
5f8cf0048ea089fa73d17512fc4f9f0f0644e225. As far as I can
tell, nothing in the code is using it, but it is still
being passed around:
https://github.com/NixOS/nixpkgs/search?q=cargoUpdateHook&type=Code&utf8=%E2%9C%93

There are, however, legitimate use cases for it. For example,
in some software, some dependencies are not locked in Cargo.toml
and this causes Cargo to try fetching another version of them.
This doesn't work well with vendoring crates.

This hook allows to inject patching or whatever necessary workarounds
in the crate vendoring process. I suppose that's what it was for
in there in the first place.

This patch restores this hook and makes it usable again.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

