### PR TITLE
pkgs.plasma5.user-manager: init

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -135,6 +135,7 @@ let
       powerdevil = callPackage ./powerdevil.nix {};
       sddm-kcm = callPackage ./sddm-kcm.nix {};
       systemsettings = callPackage ./systemsettings.nix {};
+      user-manager = callPackage ./user-manager.nix {};
       xdg-desktop-portal-kde = callPackage ./xdg-desktop-portal-kde.nix {};
     };
 in

--- a/pkgs/desktops/plasma-5/user-manager.nix
+++ b/pkgs/desktops/plasma-5/user-manager.nix
@@ -1,0 +1,13 @@
+{
+  mkDerivation, extra-cmake-modules, kdoctools, kcmutils, kconfig, khtml,
+  ki18n, kiconthemes, kio, kwindowsystem, libpwquality
+}:
+
+mkDerivation {
+  name = "user-manager";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    kcmutils kconfig khtml ki18n kiconthemes kio kwindowsystem
+    libpwquality
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19274,7 +19274,7 @@ with pkgs;
     kwallet-pam kwayland-integration kwin kwrited milou oxygen plasma-desktop
     plasma-integration plasma-nm plasma-pa plasma-vault plasma-workspace
     plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm
-    systemsettings xdg-desktop-portal-kde;
+    systemsettings user-manager xdg-desktop-portal-kde;
 
   ### SCIENCE
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

