### PR TITLE
winetricks: 20171222 -> 20180217

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -58,8 +58,8 @@ in rec {
 
   winetricks = fetchFromGitHub rec {
     # https://github.com/Winetricks/winetricks/releases
-    version = "20171222";
-    sha256 = "04risg44kqq8z9nsflw7m7dqykw2aii8m8j495z6fgb7p0pi8ny9";
+    version = "20180217";
+    sha256 = "0k3vlsqjbzys5dfbxwgw76al8gh44jsjqkc06va103frkrgjxvc5";
     owner = "Winetricks";
     repo = "winetricks";
     rev = version;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

~~~~
$ nix-shell -I nixpkgs=/nix/nixpkgs -p winetricks --run 'winetricks --version'
20180217 - sha256sum: 54b9e96790d07b05dac265c35414bf89547829a49efe0c1ec9d3ddadf578d016
~~~~

Side note: Should `wineUnstable` be update to [3.2](https://dl.winehq.org/wine/source/3.x/) as well? The current [version](https://github.com/NixOS/nixpkgs/blob/a3c96fd4de3dc95a074919abce71620266d823b9/pkgs/misc/emulators/wine/sources.nix#L40) is 3.0 as same as `wineStable`.
