### PR TITLE
gnupg: 2.2.4 -> 2.2.5

### DIFF
--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -15,11 +15,11 @@ assert guiSupport -> pinentry != null;
 stdenv.mkDerivation rec {
   name = "gnupg-${version}";
 
-  version = "2.2.4";
+  version = "2.2.5";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${name}.tar.bz2";
-    sha256 = "1v7j8v2ww1knknbrhw3svfrqkmf9ll58iq0dczbsdpqgg1j3w6j0";
+    sha256 = "0mzgibq4dpxh3i9anmwg12xdjry28y83icafhx3j3djg5niqk89z";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/security/gnupg/fix-libusb-include-path.patch
+++ b/pkgs/tools/security/gnupg/fix-libusb-include-path.patch
@@ -1,10 +1,11 @@
 --- a/configure
 +++ b/configure
-@@ -8872,7 +8872,7 @@
+@@ -8987,8 +8987,7 @@
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking libusb include dir" >&5
  $as_echo_n "checking libusb include dir... " >&6; }
     usb_incdir_found="no"
--   for _incdir in "" "/usr/include/libusb-1.0" "/usr/local/include/libusb-1.0"; do
+-   for _incdir in "" "/usr/include/libusb-1.0" \
+-       "/usr/local/include/libusb-1.0" "/usr/pkg/include/libusb-1.0"; do
 +   for _incdir in "$($PKG_CONFIG --variable=includedir libusb-1.0)/libusb-1.0"; do
       _libusb_save_cppflags=$CPPFLAGS
       if test -n "${_incdir}"; then


### PR DESCRIPTION
This is a maintenance release. Should probably be ported to stable.

See http://lists.gnu.org/archive/html/info-gnu/2018-02/msg00005.html
for release information

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

