### PR TITLE
pythonPackages.magic-wormhole: patch the call to 'locale'

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -17,6 +17,7 @@
 , ipaddress
 , txtorcon
 , nettools
+, glibc
 , glibcLocales
 , mock
 , magic-wormhole-transit-relay
@@ -38,6 +39,12 @@ buildPythonPackage rec {
   postPatch = ''
     sed -i -e "s|'ifconfig'|'${nettools}/bin/ifconfig'|" src/wormhole/ipaddrs.py
     sed -i -e "s|if (os.path.dirname(os.path.abspath(wormhole))|if not os.path.abspath(wormhole).startswith('/nix/store') and (os.path.dirname(os.path.abspath(wormhole))|" src/wormhole/test/test_cli.py
+
+    # magic-wormhole will attempt to find all available locales by running
+    # 'locale -a'.  If we're building on Linux, then this may result in us
+    # running the system's locale binary instead of the one from Nix, so let's
+    # ensure we patch this.
+    sed -i -e 's|getProcessOutputAndValue("locale"|getProcessOutputAndValue("${glibc}/bin/locale"|' src/wormhole/test/test_cli.py
   '' + lib.optionalString (pythonAtLeast "3.3") ''
     sed -i -e 's|"ipaddress",||' setup.py
   '';


### PR DESCRIPTION
###### Motivation for this change
As it says in the comment, this ensures we can build `magic-wormhole` on Linux, where we already have a `locale` binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @asymmetric (maintainer)
cc @risicle (removed the previous comment)