### PR TITLE
oath-toolkit: Switch over to git branch (GCC7 fix)

### DIFF
--- a/pkgs/tools/security/oath-toolkit/default.nix
+++ b/pkgs/tools/security/oath-toolkit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pam, xmlsec }:
+{ stdenv, fetchgit, pam, xmlsec, autoconf, automake, libtool, pkgconfig, libxml2, gtkdoc, perl, gengetopt, bison, help2man }:
 
 let
   securityDependency =
@@ -8,13 +8,23 @@ in
 stdenv.mkDerivation rec {
   name = "oath-toolkit-2.6.2";
 
-  src = fetchurl {
-    url = "mirror://savannah/oath-toolkit/${name}.tar.gz";
-    sha256 = "182ah8vfbg0yhv6mh1b6ap944d0na6x7lpfkwkmzb6jl9gx4cd5h";
+  src = fetchgit {
+    url = "https://gitlab.com/oath-toolkit/oath-toolkit.git";
+    sha256 = "0n2sl444723f1k0sjmc0mzdwslx51yxac39c2cx2bl3ykacgfv74";
+    rev = "0dffdec9c5af5c89a5af43add29d8275eefe7414";
   };
 
+  buildInputs = [ securityDependency automake autoconf libtool pkgconfig libxml2 gtkdoc perl gengetopt bison help2man ];
 
-  buildInputs = [ securityDependency ];
+  configureFlags = [ "--disable-pskc" ];
+
+  preConfigure = ''
+     # Replicate the steps from cfg.mk
+     printf "gdoc_MANS =\ngdoc_TEXINFOS =\n" > liboath/man/Makefile.gdoc
+     printf "gdoc_MANS =\ngdoc_TEXINFOS =\n" > libpskc/man/Makefile.gdoc
+     touch ChangeLog
+     autoreconf --force --install
+  '';
 
   meta = {
     homepage = http://www.nongnu.org/oath-toolkit/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3887,7 +3887,7 @@ with pkgs;
 
   nzbget = callPackage ../tools/networking/nzbget { };
 
-  oathToolkit = callPackage ../tools/security/oath-toolkit { };
+  oathToolkit = callPackage ../tools/security/oath-toolkit { inherit (gnome2) gtkdoc;  };
 
   obex_data_server = callPackage ../tools/bluetooth/obex-data-server { };
 


### PR DESCRIPTION
The git repo doesn't contain a configure script which adds a lot of
build dependencies.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/35326

Approaches rejected:
* Rejected pulling just the GL fix patch from upstream (https://gitlab.com/oath-toolkit/oath-toolkit/commit/a7a989a9e33474aca941fe037259b0289177748e) because this triggers an autoconf rerun, which requires aclocal-1.14, and we don't have automake-1.14 packaged to support this.
* Rejected rerunning autoconf/autoreconf/automake for the above. That would fail on GL_INIT m4 macros not being there.
* Rejected not pulling any patches but running "make -f cfg.mk glimport", which runs gnulib-tool import, which presumably updates gnulib's source. This fails with "/nix/store/[..]-gnulib-0.1-357-gffe6467/gnulib-tool: line 4718: ./build-aux/git-version-gen.tmp: Permission denied"

As much as I dislike pulling this from a git repo directly, I haven't found any other way to fix this reasonably easy.

###### Things done
Test my local TOTP logins. They work as expected.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

