### PR TITLE
ocamlPackages.curses: use default ncurses

### DIFF
--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -194,9 +194,7 @@ let
       then callPackage ../development/ocaml-modules/csv { }
       else callPackage ../development/ocaml-modules/csv/1.5.nix { };
 
-    curses = callPackage ../development/ocaml-modules/curses {
-      ncurses = pkgs.ncurses5;
-    };
+    curses = callPackage ../development/ocaml-modules/curses { };
 
     custom_printf = callPackage ../development/ocaml-modules/custom_printf { };
 


### PR DESCRIPTION
###### Motivation for this change

No need to downgrade to ncurses5 after @dezgeg fix https://github.com/NixOS/nixpkgs/commit/8afcfb2bb6681c56ecf21e056d91d6748d953997
