### PR TITLE
pythonPackages.curtsies: fix build

### DIFF
--- a/pkgs/development/python-modules/curtsies/default.nix
+++ b/pkgs/development/python-modules/curtsies/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, buildPythonPackage, fetchPypi, blessings, mock, nose, pyte, pytest, wcwidth }:
+{ stdenv, buildPythonPackage, fetchPypi
+, blessings, mock, nose, pyte, pytest
+, wcwidth, typing
+}:
 
 buildPythonPackage rec {
   pname = "curtsies";
   version = "0.3.0";
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "89c802ec051d01dec6fc983e9856a3706e4ea8265d2940b1f6d504a9e26ed3a9";
   };
 
-  propagatedBuildInputs = [ blessings wcwidth pyte ];
+  propagatedBuildInputs = [ blessings wcwidth pyte typing ];
 
   checkInputs = [ nose mock pytest ];
 
-  checkPhase = ''
-    py.test
-  '';
+  checkPhase = "py.test";
 
   meta = with stdenv.lib; {
     description = "Curses-like terminal wrapper, with colored strings!";
-    homepage = https://pypi.python.org/pypi/curtsies;
-    license = licenses.mit;
+    homepage    = https://pypi.python.org/pypi/curtsies;
+    license     = licenses.mit;
     maintainers = with maintainers; [ flokli ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
It's missing a dependency apparently.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (none, library)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---