### PR TITLE
Fix Hydra build (gcc7)

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -15,13 +15,13 @@ let
         else throw "Unsupported system!";
 in stdenv.mkDerivation rec {
   name = "aws-sdk-cpp-${version}";
-  version = "1.3.22";
+  version = "1.4.4";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-sdk-cpp";
     rev = version;
-    sha256 = "0sdgy8kqhxnw7n0sw4m3p3ay7yic3rhad5ab8m5lbx61ad9bq3c2";
+    sha256 = "07wcxrb2ng31q8p3mbb6wd5sl704kyzgb0iwa5kr6a4n4c1g824k";
   };
 
   # FIXME: might be nice to put different APIs in different outputs

--- a/pkgs/development/libraries/libpqxx/default.nix
+++ b/pkgs/development/libraries/libpqxx/default.nix
@@ -1,14 +1,17 @@
-{ lib, stdenv, fetchurl, postgresql, python2, gnused }:
+{ lib, stdenv, fetchFromGitHub, postgresql, python2, gnused, doxygen, xmlto }:
 
 stdenv.mkDerivation rec {
-  name = "libpqxx-4.0.1";
+  name = "libpqxx-${version}";
+  version = "6.1.0";
 
-  src = fetchurl {
-    url = "http://pqxx.org/download/software/libpqxx/${name}.tar.gz";
-    sha256 = "0f6wxspp6rx12fkasanb0z2g2gc8dhcfwnxagx8wwqbpg6ifsz09";
+  src = fetchFromGitHub {
+    owner = "jtv";
+    repo = "libpqxx";
+    rev = version;
+    sha256 = "1dv96h10njg115216n2zm6fsvi4kb502hmhhn8cjhlfbxr9vc84q";
   };
 
-  buildInputs = [ postgresql python2 gnused ];
+  buildInputs = [ postgresql python2 gnused doxygen xmlto ];
 
   preConfigure = ''
     patchShebangs .

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -83,12 +83,10 @@ in releaseTools.nixBuild rec {
         apis = ["s3"];
         customMemoryManagement = false;
       }) (attrs: {
-        src = fetchFromGitHub {
-          owner = "edolstra";
-          repo = "aws-sdk-cpp";
-          rev = "local";
-          sha256 = "1vhgsxkhpai9a7dk38q4r239l6dsz2jvl8hii24c194lsga3g84h";
-        };
+        patchPhase = ''
+          substituteInPlace aws-cpp-sdk-core/source/utils/logging/ConsoleLogSystem.cpp \
+            --replace "std::cout" "std::cerr"
+        '';
       }))
     ];
 


### PR DESCRIPTION
###### Motivation for this change

Hydra dependencies were broken with gcc7. I've also fond aws-sdk-cpp override which pointed to some old @edolstra fork with patches that are mostly in upstream. So I updated aws-sdk-cpp to latest version and added hotpatch override for hydra (hope this is ok) also pqxx was too old.
  
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

