### PR TITLE
cups-zj-58: init at 2018-02-22

### DIFF
--- a/pkgs/misc/cups/drivers/zj-58/default.nix
+++ b/pkgs/misc/cups/drivers/zj-58/default.nix
@@ -1,0 +1,32 @@
+{stdenv, fetchFromGitHub, cups}:
+
+stdenv.mkDerivation rec {
+  pname = "cups-zj-58";
+  version = "2018-02-22";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "klirichek";
+    repo = "zj-58";
+    rev = "e4212cd";
+    sha256 = "1w2qkspm4qqg5h8n6gmakzhiww7gag64chvy9kf89xsl3wsyp6pi";
+  };
+
+  buildInputs = [cups];
+
+  installPhase = ''
+    mkdir -p $out/lib/cups/filter
+    cp rastertozj $out/lib/cups/filter
+
+    mkdir -p $out/share/cups/model/zjiang
+    cp ZJ-58.ppd $out/share/cups/model/zjiang/
+  '';
+
+  meta = {
+    description = "CUPS filter for thermal printer Zjiang ZJ-58";
+    homepage = https://github.com/klirichek/zj-58;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ makefu ];
+    license = stdenv.lib.licenses.bsd2;
+  };
+}

--- a/pkgs/misc/cups/drivers/zj-58/default.nix
+++ b/pkgs/misc/cups/drivers/zj-58/default.nix
@@ -12,21 +12,18 @@ stdenv.mkDerivation rec {
     sha256 = "1w2qkspm4qqg5h8n6gmakzhiww7gag64chvy9kf89xsl3wsyp6pi";
   };
 
-  buildInputs = [cups];
+  buildInputs = [ cups ];
 
   installPhase = ''
-    mkdir -p $out/lib/cups/filter
-    cp rastertozj $out/lib/cups/filter
-
-    mkdir -p $out/share/cups/model/zjiang
-    cp ZJ-58.ppd $out/share/cups/model/zjiang/
+    install -D rastertozj $out/lib/cups/filter/rastertozj
+    install -D ZJ-58.ppd $out/share/cups/model/zjiang/ZJ-58.ppd
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "CUPS filter for thermal printer Zjiang ZJ-58";
     homepage = https://github.com/klirichek/zj-58;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ makefu ];
-    license = stdenv.lib.licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ makefu ];
+    license = licenses.bsd2;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19937,6 +19937,8 @@ with pkgs;
 
   cups-toshiba-estudio = callPackage ../misc/cups/drivers/estudio {};
 
+  cups-zj-58 =  callPackage ../misc/cups/drivers/zj-58 { };
+
   crashplan = callPackage ../applications/backup/crashplan { };
   crashplansb = callPackage ../applications/backup/crashplan/crashplan-small-business.nix { inherit (gnome3) gconf; };
 


### PR DESCRIPTION
###### Motivation for this change

Adds cups drivers for Zjiang ZJ-58

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
