### PR TITLE
closureInfo: Report the total closure size.

### DIFF
--- a/pkgs/build-support/closure-info.nix
+++ b/pkgs/build-support/closure-info.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
 
       mkdir $out
 
+      jq -r ".closure | map(.narSize) | add" < .attrs.json > $out/total-nar-size
       jq -r '.closure | map([.path, .narHash, .narSize, "", (.references | length)] + .references) | add | map("\(.)\n") | add' < .attrs.json | head -n -1 > $out/registration
       jq -r .closure[].path < .attrs.json > $out/store-paths
     '';


### PR DESCRIPTION
This can be useful for e.g. preallocating disk image sizes.