### PR TITLE
syncthing-gtk: 0.9.2.7 → 0.9.3

### DIFF
--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchFromGitHub, libnotify, librsvg, psmisc, gtk3, substituteAll, syncthing, wrapGAppsHook, gnome3, buildPythonApplication, dateutil, pyinotify, pygobject3, bcrypt, gobjectIntrospection }:
+{ stdenv, fetchFromGitHub, libnotify, librsvg, darwin, psmisc, gtk3, libappindicator-gtk3, substituteAll, syncthing, wrapGAppsHook, gnome3, buildPythonApplication, dateutil, pyinotify, pygobject3, bcrypt, gobjectIntrospection }:
 
 buildPythonApplication rec {
-  version = "0.9.2.7";
+  version = "0.9.3.1";
   name = "syncthing-gtk-${version}";
 
   src = fetchFromGitHub {
     owner = "syncthing";
     repo = "syncthing-gtk";
     rev = "v${version}";
-    sha256 = "08k7vkibia85klwjxbnzk67h4pphrizka5v9zxwvvv3cisjiclc2";
+    sha256 = "15bh9i0j0g7hrqsz22px8g2bg0xj4lsn81rziznh9fxxx5b9v9bb";
   };
 
   nativeBuildInputs = [
@@ -18,8 +18,8 @@ buildPythonApplication rec {
   ];
 
   buildInputs = [
-    gtk3 librsvg
-    libnotify
+    gtk3 librsvg libappindicator-gtk3
+    libnotify gnome3.adwaita-icon-theme
     # Schemas with proxy configuration
     gnome3.gsettings-desktop-schemas
   ];
@@ -32,7 +32,7 @@ buildPythonApplication rec {
     ./disable-syncthing-binary-configuration.patch
     (substituteAll {
       src = ./paths.patch;
-      killall = "${psmisc}/bin/killall";
+      killall = "${if stdenv.isDarwin then darwin.shell_cmds else psmisc}/bin/killall";
       syncthing = "${syncthing}/bin/syncthing";
     })
   ];

--- a/pkgs/applications/networking/syncthing-gtk/disable-syncthing-binary-configuration.patch
+++ b/pkgs/applications/networking/syncthing-gtk/disable-syncthing-binary-configuration.patch
@@ -1,5 +1,5 @@
---- a/find-daemon.glade
-+++ b/find-daemon.glade
+--- a/glade/find-daemon.glade
++++ b/glade/find-daemon.glade
 @@ -112,6 +112,7 @@
                    <object class="GtkEntry" id="vsyncthing_binary">
                      <property name="visible">True</property>
@@ -16,6 +16,24 @@
                      <property name="receives_default">True</property>
                      <property name="use_underline">True</property>
                      <property name="yalign">0.51999998092651367</property>
+--- a/glade/ui-settings.glade
++++ b/glade/ui-settings.glade
+@@ -943,6 +943,7 @@
+                     <property name="label" translatable="yes">_Browse...</property>
+                     <property name="visible">True</property>
+                     <property name="can_focus">True</property>
++                    <property name="sensitive">False</property>
+                     <property name="receives_default">True</property>
+                     <property name="use_underline">True</property>
+                     <property name="yalign">0.51999998092651367</property>
+@@ -974,6 +975,7 @@
+                   <object class="GtkEntry" id="vsyncthing_binary">
+                     <property name="visible">True</property>
+                     <property name="can_focus">True</property>
++                    <property name="sensitive">False</property>
+                     <property name="hexpand">True</property>
+                     <signal name="changed" handler="cb_check_value" swapped="no"/>
+                   </object>
 --- a/syncthing_gtk/configuration.py
 +++ b/syncthing_gtk/configuration.py
 @@ -168,6 +168,8 @@
@@ -57,21 +75,3 @@
  		self.add_page(GenerateKeysPage())
  		self.add_page(HttpSettingsPage())
  		self.add_page(SaveSettingsPage())
---- a/ui-settings.glade
-+++ b/ui-settings.glade
-@@ -943,6 +943,7 @@
-                     <property name="label" translatable="yes">_Browse...</property>
-                     <property name="visible">True</property>
-                     <property name="can_focus">True</property>
-+                    <property name="sensitive">False</property>
-                     <property name="receives_default">True</property>
-                     <property name="use_underline">True</property>
-                     <property name="yalign">0.51999998092651367</property>
-@@ -974,6 +975,7 @@
-                   <object class="GtkEntry" id="vsyncthing_binary">
-                     <property name="visible">True</property>
-                     <property name="can_focus">True</property>
-+                    <property name="sensitive">False</property>
-                     <property name="hexpand">True</property>
-                     <signal name="changed" handler="cb_check_value" swapped="no"/>
-                   </object>


### PR DESCRIPTION
###### Motivation for this change
https://github.com/syncthing/syncthing-gtk/releases/tag/v0.9.3

It is supposed to fix the UI freezes, though it certainly does not for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

