### PR TITLE
nixos/programs.chromium: write policies for google-chrome too

### DIFF
--- a/nixos/modules/programs/chromium.nix
+++ b/nixos/modules/programs/chromium.nix
@@ -36,6 +36,7 @@ in
             "chlffgpmiacpedhhbkiomidkjlcfhogd" # pushbullet
             "mbniclmhobmnbdlbpiphghaielnnpgdp" # lightshot
             "gcbommkclmclpchllfjekcdonpmejbdp" # https everywhere
+            "cjpalhdlnbpafiamejdnhcphjbkeiagm" # ublock origin
           ]
         '';
       };
@@ -78,7 +79,11 @@ in
   ###### implementation
 
   config = lib.mkIf cfg.enable {
+    # for chromium
     environment.etc."chromium/policies/managed/default.json".text = builtins.toJSON defaultProfile;
     environment.etc."chromium/policies/managed/extra.json".text = builtins.toJSON cfg.extraOpts;
+    # for google-chrome https://www.chromium.org/administrators/linux-quick-start
+    environment.etc."opt/chrome/policies/managed/default.json".text = builtins.toJSON defaultProfile;
+    environment.etc."opt/chrome/policies/managed/extra.json".text = builtins.toJSON cfg.extraOpts;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

[Policy configuration files live under /etc/chromium for Chromium, and under /etc/opt/chrome for Google Chrome.
](https://www.chromium.org/administrators/linux-quick-start)

Fixes https://github.com/NixOS/nixpkgs/issues/26889
