### PR TITLE
ocamlPackages.ctypes: 0.11.5 -> 0.13.1

### DIFF
--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -1,19 +1,19 @@
-{stdenv, buildOcaml, fetchurl, libffi, pkgconfig, ncurses}:
+{ stdenv, buildOcaml, fetchzip, libffi, pkgconfig, ncurses, integers }:
 
 buildOcaml rec {
   name = "ctypes";
-  version = "0.11.5";
+  version = "0.13.1";
 
   minimumSupportedOcamlVersion = "4";
 
-  src = fetchurl {
-    url = "https://github.com/ocamllabs/ocaml-ctypes/archive/${version}.tar.gz";
-    sha256 = "164gyrs6zxr5pyljwpjgd4knwlrkcmamsq3gvkkkvgf9rmhrl3zf";
+  src = fetchzip {
+    url = "https://github.com/ocamllabs/ocaml-ctypes/archive/67e711ec891e087fbe1e0b4665aa525af4eaa409.tar.gz";
+    sha256 = "1z84s5znr3lj84rzv6m37xxj9h7fwx4qiiykx3djf52qgk1rb2xb";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses ];
-  propagatedBuildInputs = [ libffi ];
+  propagatedBuildInputs = [ integers libffi ];
 
   hasSharedObjects = true;
 

--- a/pkgs/development/ocaml-modules/janestreet/async_ssl.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async_ssl.nix
@@ -1,10 +1,12 @@
-{stdenv, buildOcamlJane, fetchurl, async, comparelib, core, ctypes, openssl,
- fieldslib, herelib, pipebang, sexplib, ocaml_oasis}:
+{ stdenv, ocaml, buildOcamlJane, fetchurl, async, comparelib, core, ctypes
+, openssl, fieldslib, herelib, pipebang, sexplib, ocaml_oasis, integers
+}:
 
 buildOcamlJane rec {
   name = "async_ssl";
   version = "113.33.07";
   hash = "0bhzpnmlx6dy4fli3i7ipjwqbsdi7fq171jrila5dr3ciy3841xs";
+  postPatch = "export CAML_LD_LIBRARY_PATH=${integers}/lib/ocaml/${ocaml.version}/site-lib/stubslibs:$CAML_LD_LIBRARY_PATH";
   propagatedBuildInputs = [ ctypes async comparelib core fieldslib
                             herelib pipebang sexplib openssl ocaml_oasis ];
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update.

This is not exactly the released version: it also includes a patch to fix the build with nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

