### PR TITLE
Support mopidy on Darwin

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -22,8 +22,8 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with pythonPackages; [
-    gst-python pygobject3 pykka tornado requests dbus-python
-  ];
+    gst-python pygobject3 pykka tornado requests
+  ] ++ stdenv.lib.optional (!stdenv.isDarwin) dbus-python;
 
   # There are no tests
   doCheck = false;

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ]; # to deal with propagatedBuildInputs
 
-  configureFlags = "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt";
+  configureFlags = if stdenv.isDarwin then "--without-ca-certificates"
+    else "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt";
 
   LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt";
 
+  LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
+
   preBuild = ''
     sed -e "s@${glib.out}/lib/gio/modules@$out/lib/gio/modules@g" -i $(find . -name Makefile)
   '';

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -35,8 +35,12 @@ stdenv.mkDerivation rec {
       a real live maintainer, or some actual wide use.
     '';
     license     = licenses.lgpl2Plus;
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
   };
+
+  # TODO: Fix Cocoa build. The problem was ARC, which might be related to too
+  #       old version of Apple SDK's.
+  configureFlags = optional stdenv.isDarwin "--disable-cocoa";
 
   patchPhase = ''
     sed -i 's/openjpeg-2.2/openjpeg-${openJpegVersion}/' ext/openjpeg/*
@@ -58,7 +62,7 @@ stdenv.mkDerivation rec {
     openjpeg libopus librsvg
     fluidsynth libvdpau
     libwebp xvidcore gnutls mesa
-    mjpegtools libgme openssl x265 libxml2
+    libgme openssl x265 libxml2
   ]
     ++ libintlOrEmpty
     ++ optional faacSupport faac
@@ -67,7 +71,9 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isLinux wayland
     # wildmidi requires apple's OpenAL
     # TODO: package apple's OpenAL, fix wildmidi, include on Darwin
-    ++ optional (!stdenv.isDarwin) wildmidi;
+    ++ optional (!stdenv.isDarwin) wildmidi
+    # TODO: mjpegtools uint64_t is not compatible with guint64 on Darwin
+    ++ optional (!stdenv.isDarwin) mjpegtools;
 
   LDFLAGS = optionalString stdenv.isDarwin "-lintl";
 

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, python
 , gst-plugins-base, orc
 , a52dec, libcdio, libdvdread
-, lame, libmad, libmpeg2, x264, libintlOrEmpty
+, lame, libmad, libmpeg2, x264, libintlOrEmpty, mpg123
 }:
 
 stdenv.mkDerivation rec {
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gst-plugins-base orc
     a52dec libcdio libdvdread
-    lame libmad libmpeg2 x264
+    lame libmad libmpeg2 x264 mpg123
   ] ++ libintlOrEmpty;
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;


### PR DESCRIPTION
###### Motivation for this change

I wanted to try out mopidy on Darwin.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Had to modify a bunch of gstreamer related packages to get them to work on macOS. There were some hard parts in gst-plugins-bad, which resulted in me disabling Cocoa  and mjpegtools support in it.

As a side-note I added mpg123 to gst-plugins-ugly to enable MP3 playback in mopidy.

This PR is related to issue https://github.com/NixOS/nixpkgs/issues/35322

As a global change, I replaced hardcoded SSL cert path with cacert. Not sure if that is the way it should be done.