### PR TITLE
glm: fix gcc 7.3 support

### DIFF
--- a/pkgs/development/libraries/glm/default.nix
+++ b/pkgs/development/libraries/glm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, cmake }:
+{ stdenv, fetchurl, fetchzip, cmake }:
 
 stdenv.mkDerivation rec {
   version = "0.9.8.5";
@@ -15,9 +15,16 @@ stdenv.mkDerivation rec {
 
   cmakeConfigureFlags = [ "-DGLM_INSTALL_ENABLE=off" ];
 
+  # fetch newer version of platform.h which correctly supports gcc 7.3
+  gcc7PlatformPatch = fetchurl {
+    url = "https://raw.githubusercontent.com/g-truc/glm/dd48b56e44d699a022c69155c8672caacafd9e8a/glm/simd/platform.h";
+    sha256 = "0y91hlbgn5va7ijg5mz823gqkq9hqxl00lwmdwnf8q2g086rplzw";
+  };
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace '"''${CMAKE_CURRENT_BINARY_DIR}/''${GLM_INSTALL_CONFIGDIR}' '"''${GLM_INSTALL_CONFIGDIR}'
+    cp ${gcc7PlatformPatch} glm/simd/platform.h
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

`slop` fails to build after switching to gcc 7.3

The reason seems to be that `glm` did not correctly support gcc 7.3 . Although this issue have been fixed by upstream in https://github.com/g-truc/glm/commit/dd48b56e44d699a022c69155c8672caacafd9e8a , they haven't release any stable version contains the fix.
This PR fixes the issue by fetching new version of `platform.h`. (`patches` and `fetchpatch` cannot be used because that commit have some content which cannot be automatically merged)

cc maintainer @Fuuzetsu 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

