### PR TITLE
zziplib: 0.13.67 -> 0.13.68

### DIFF
--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -2,20 +2,25 @@
 
 stdenv.mkDerivation rec {
   name = "zziplib-${version}";
-  version = "0.13.67";
+  version = "0.13.68";
 
   src = fetchurl {
     url = "https://github.com/gdraheim/zziplib/archive/v${version}.tar.gz";
-    sha256 = "0802kdxwxx9zanpwb4w4wfi3blwhv0ri05mzdgd35j5sva5ify0j";
+    sha256 = "0chhl6m02562z6c4hjy568mh11pbq2qngw6g2x924ajr8sdr2q4l";
   };
 
   postPatch = ''
     sed -i -e s,--export-dynamic,, configure
   '';
 
+  # TODO: still an issue: https://github.com/gdraheim/zziplib/issues/27
+
   buildInputs = [ docbook_xml_dtd_412 perl python2 zip xmlto zlib ];
 
-  doCheck = true;
+  # tests are broken (https://github.com/gdraheim/zziplib/issues/20),
+  # and test/zziptests.py requires network access
+  # (https://github.com/gdraheim/zziplib/issues/24)
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Library to extract data from files archived in a zip file";

--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, perl, python2, zip, xmlto, zlib }:
+{ docbook_xml_dtd_412, fetchurl, stdenv, perl, python2, zip, xmlto, zlib }:
 
 stdenv.mkDerivation rec {
   name = "zziplib-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sed -i -e s,--export-dynamic,, configure
   '';
 
-  buildInputs = [ perl python2 zip xmlto zlib ];
+  buildInputs = [ docbook_xml_dtd_412 perl python2 zip xmlto zlib ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0802kdxwxx9zanpwb4w4wfi3blwhv0ri05mzdgd35j5sva5ify0j";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s,--export-dynamic,, configure
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Bump zziplib to 0.13.68 to fix multiple CVE issues:

 - CVE-2018-6381
 (https://github.com/gdraheim/zziplib/commit/a803559fa9194be895422ba3684cf6309b6bb598)
 - CVE-2018-6484
 (https://github.com/gdraheim/zziplib/issues/14#issuecomment-363198084)
 - CVE-2018-6540
 (https://github.com/gdraheim/zziplib/commit/72ec933663f738d8e166979aa7fd5590b2104a07)
 - CVE-2018-6541
 (https://github.com/gdraheim/zziplib/issues/16#issuecomment-363197718)
 - CVE-2018-6542
 (https://github.com/gdraheim/zziplib/commit/931f962ddfec0e00d6f486df2c56d9857b55944e)

Unfortunately, getting only those patches is hard, as they're not well referenced to linked issues.
The testsuite is currently broken, and the newer python testsuite checking for vulns requires network access.

https://github.com/gdraheim/zziplib/issues/20 might still be an issue, so keeping this as a TODO here.
Vulnerability roundup 37 (master) #35408

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

