### PR TITLE
mattermost: add build number

### DIFF
--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,8 +1,13 @@
 { stdenv, fetchurl, fetchFromGitHub, buildGoPackage }:
 
+let
+  version = "4.7.2";
+  goPackagePath = "github.com/mattermost/mattermost-server";
+  buildFlags = "-ldflags \"-X '${goPackagePath}/model.BuildNumber=nixpkgs-${version}'\"";
+in
+
 buildGoPackage rec {
   name = "mattermost-${version}";
-  version = "4.7.2";
 
   src = fetchFromGitHub {
     owner = "mattermost";
@@ -16,12 +21,12 @@ buildGoPackage rec {
     sha256 = "14gr7zzx77q862qccjcdwrzd6n8g2z8yngw8aa4g3q6hypsqi4v3";
   };
 
-  goPackagePath = "github.com/mattermost/mattermost-server";
+  inherit goPackagePath;
 
   buildPhase = ''
     runHook preBuild
     cd go/src/${goPackagePath}/cmd/platform
-    go install
+    go install ${buildFlags}
     runHook postBuild
   '';
 
@@ -35,7 +40,7 @@ buildGoPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Open-Source, self-hosted Slack-alternative";
+    description = "Open-source, self-hosted Slack-alternative";
     homepage = https://www.mattermost.org;
     license = with licenses; [ agpl3 asl20 ];
     maintainers = with maintainers; [ fpletz ryantm ];


### PR DESCRIPTION
- [x] built and tested on NixOS
- [x] verified "nixpkgs-4.7.2" appears on the "About Mattermost" page

I'm generally not excited about the way Mattermost needs an external specification of the `BUILD_NUMBER` to get the version in there, but, if we are going to build the package from source, we need to get the version number in there. Since we have our own way of building this package (we don't use the provided Makefile) and to disambiguate our version from the official source release, I prefixed the build number with "nixpkgs-".