### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+**/deps.nix linguist-generated
+**/node-packages.nix linguist-generated
+
+pkgs/applications/editors/emacs-modes/*-generated.nix linguist-generated
+pkgs/development/r-modules/*-packages.nix linguist-generated
+pkgs/development/haskell-modules/hackage-packages.nix linguist-generated
+pkgs/development/beam-modules/hex-packages.nix linguist-generated
+
+doc/** linguist-documentation
+doc/default.nix linguist-documentation=false
+
+nixos/doc/** linguist-documentation
+nixos/doc/default.nix linguist-documentation=false


### PR DESCRIPTION
This adds the .gitattributes file to the tree. I’ve added two
attributes: linguist-generated, and linguist-documentation.

GitHub’s Linguist will follow this when calculating our language stats
as well as in other cases like commit diffs.

Any additional attributes or other generated files are welcome to be added!
