### PR TITLE
deadbeefPlugins.opus: init at 0.8

### DIFF
--- a/pkgs/applications/audio/deadbeef/plugins/opus.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/opus.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromBitbucket, opusfile, libopus, libogg, openssl, deadbeef }:
+
+stdenv.mkDerivation rec {
+  name = "deadbeef-opus-plugin-${version}";
+  version = "0.8";
+
+  src = fetchFromBitbucket {
+    owner = "Lithopsian";
+    repo = "deadbeef-opus";
+    rev = "v${version}";
+    sha256 = "057rgsw4563gs63k05s7zsdc0n4djxwlbyqabf7c88f23z35ryyi";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-I${opusfile}/include/opus"
+  ];
+
+  buildInputs = [ deadbeef opusfile libopus libogg openssl ];
+
+  meta = with stdenv.lib; {
+    description = "Ogg Opus decoder plugin for the DeaDBeeF music player";
+    homepage = https://bitbucket.org/Lithopsian/deadbeef-opus;
+    license = licenses.gpl2; # There are three files, each licensed under different license: zlib, gpl2Plus and lgpl2
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -49,6 +49,7 @@ mapAliases (rec {
   cupsBjnp = cups-bjnp; # added 2016-01-02
   cups_filters = cups-filters; # added 2016-08
   cv = progress; # added 2015-09-06
+  deadbeef-mpris2-plugin = deadbeefPlugins.mpris2; # added 2018-02-23
   debian_devscripts = debian-devscripts; # added 2016-03-23
   digikam5 = digikam; # added 2017-02-18
   double_conversion = double-conversion; # 2017-11-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14872,7 +14872,10 @@ with pkgs;
     pulseSupport = config.pulseaudio or true;
   };
 
-  deadbeef-mpris2-plugin = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
+  deadbeefPlugins = {
+    mpris2 = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
+    opus = callPackage ../applications/audio/deadbeef/plugins/opus.nix { };
+  };
 
   deadbeef-with-plugins = callPackage ../applications/audio/deadbeef/wrapper.nix {
     plugins = [];


### PR DESCRIPTION
###### Motivation for this change
Adds opus support to deadbeef.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

