### PR TITLE
bwm-ng: fix build error with gcc7

### DIFF
--- a/pkgs/tools/networking/bwm-ng/default.nix
+++ b/pkgs/tools/networking/bwm-ng/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses }:
+{ writeText, stdenv, fetchurl, ncurses }:
 
 let
   version = "0.6.1";
@@ -12,6 +12,32 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ ncurses ];
+
+  # gcc7 has some issues with inline functions
+  patches = [
+    (writeText "gcc7.patch"
+    ''
+    --- a/src/bwm-ng.c
+    +++ b/src/bwm-ng.c
+    @@ -27,5 +27,5 @@
+     /* handle interrupt signal */
+     void sigint(int sig) FUNCATTR_NORETURN;
+    -inline void init(void);
+    +static inline void init(void);
+     
+     /* clear stuff and exit */
+    --- a/src/options.c
+    +++ b/src/options.c
+    @@ -35,5 +35,5 @@
+     inline int str2output_type(char *optarg);
+     #endif
+    -inline int str2out_method(char *optarg);
+    +static inline int str2out_method(char *optarg);
+     inline int str2in_method(char *optarg);
+
+    '')
+  ];
+
 
   # This code uses inline in the gnu89 sense: see http://clang.llvm.org/compatibility.html#inline
   NIX_CFLAGS_COMPILE = if stdenv.cc.isClang then "-std=gnu89" else null;


### PR DESCRIPTION
###### Motivation for this change

bwm_ng failed to build after switch to gcc7.
caused by some gcc7 issues with inline functions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

