### PR TITLE
buildGoPackage: disable cache creation

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -196,6 +196,9 @@ go.stdenv.mkDerivation (
     find $bin/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
   '';
 
+  # Disable go cache, which is not reused in nix anyway
+  GOCACHE = "off";
+
   shellHook = ''
     d=$(mktemp -d "--suffix=-$name")
   '' + toString (map (dep: ''


### PR DESCRIPTION
###### Motivation for this change

Since 1.10 go tries create a cache directory in the user's home, which fails since home does not exists for our nix builder. Therefore this pull request's disable go's attempt to cache builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

