### PR TITLE
pamix: 1.5 -> 1.6

### DIFF
--- a/pkgs/applications/audio/pamix/default.nix
+++ b/pkgs/applications/audio/pamix/default.nix
@@ -1,19 +1,23 @@
 { stdenv, fetchFromGitHub
-, autoreconfHook, autoconf-archive, pkgconfig
+, pkgconfig, cmake
 , libpulseaudio, ncurses }:
 
 stdenv.mkDerivation rec {
   name = "pamix-${version}";
-  version = "1.5";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner  = "patroclos";
     repo   = "pamix";
     rev    = version;
-    sha256 = "1d6b0iv8p73bwq88kdaanm4igvmp9rkq082vyaxpc67mz398yjbp";
+    sha256 = "1d44ggnwkf2gff62959pj45v3a2k091q8v154wc5pmzamam458wp";
   };
 
-  nativeBuildInputs = [ autoreconfHook autoconf-archive pkgconfig ];
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt --replace "/etc" "$out/etc/xdg"
+  '';
+
+  nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ libpulseaudio ncurses ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

