### PR TITLE
keepass: bring back and update plugins load patches

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -1,12 +1,6 @@
 { stdenv, lib, fetchurl, buildDotnetPackage, substituteAll, makeWrapper, makeDesktopItem,
   unzip, icoutils, gtk2, xorg, xdotool, xsel, plugins ? [] }:
 
-# KeePass looks for plugins in under directory in which KeePass.exe is
-# located. It follows symlinks where looking for that directory, so
-# buildEnv is not enough to bring KeePass and plugins together.
-#
-# This derivation patches KeePass to search for plugins in specified
-# plugin derivations in the Nix store and nowhere else.
 with builtins; buildDotnetPackage rec {
   baseName = "keepass";
   version = "2.38";
@@ -28,6 +22,29 @@ with builtins; buildDotnetPackage rec {
       xdotool = "${xdotool}/bin/xdotool";
     })
   ];
+
+  # KeePass looks for plugins in under directory in which KeePass.exe is
+  # located. It follows symlinks where looking for that directory, so
+  # buildEnv is not enough to bring KeePass and plugins together.
+  #
+  # This derivation patches KeePass to search for plugins in specified
+  # plugin derivations in the Nix store and nowhere else.
+  pluginLoadPathsPatch =
+    let outputLc = toString (add 7 (length plugins));
+        patchTemplate = readFile ./keepass-plugins.patch;
+        loadTemplate  = readFile ./keepass-plugins-load.patch;
+        loads =
+          lib.concatStrings
+            (map
+              (p: replaceStrings ["$PATH$"] [ (unsafeDiscardStringContext (toString p)) ] loadTemplate)
+              plugins);
+    in replaceStrings ["$OUTPUT_LC$" "$DO_LOADS$"] [outputLc loads] patchTemplate;
+
+  passAsFile = [ "pluginLoadPathsPatch" ];
+  postPatch = ''
+    sed -i 's/\r*$//' KeePass/Forms/MainForm.cs
+    patch -p1 <$pluginLoadPathsPatchPath
+  '';
 
   preConfigure = ''
     rm -rvf Build/*

--- a/pkgs/applications/misc/keepass/keepass-plugins-load.patch
+++ b/pkgs/applications/misc/keepass/keepass-plugins-load.patch
@@ -1,0 +1,1 @@
++			m_pluginManager.LoadAllPlugins("$PATH$/lib/dotnet/keepass", SearchOption.TopDirectoryOnly, new string[] {});

--- a/pkgs/applications/misc/keepass/keepass-plugins.patch
+++ b/pkgs/applications/misc/keepass/keepass-plugins.patch
@@ -1,0 +1,13 @@
+diff --git a/KeePass/Forms/MainForm.cs b/KeePass/Forms/MainForm.cs
+index 3d5fca0..4c3f3d4 100644
+--- a/KeePass/Forms/MainForm.cs
++++ b/KeePass/Forms/MainForm.cs
+@@ -406,7 +406,$OUTPUT_LC$ @@ namespace KeePass.Forms
+ 			m_pluginManager.Initialize(m_pluginDefaultHost);
+ 
+ 			m_pluginManager.UnloadAllPlugins();
+-			if(AppPolicy.Current.Plugins) m_pluginManager.LoadAllPlugins();
+$DO_LOADS$+
+ 
+ 			// Delete old files *after* loading plugins (when timestamps
+ 			// of loaded plugins have been updated already)


### PR DESCRIPTION
###### Motivation for this change
Plugins loading was broken as those patches were removed
in latest release. I brought patches back and updated them
onto 2.38 release code base.

This closes #35446.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

