### PR TITLE
homesick: 1.1.3 -> 1.1.6

### DIFF
--- a/pkgs/tools/misc/homesick/Gemfile.lock
+++ b/pkgs/tools/misc/homesick/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    homesick (1.1.3)
+    homesick (1.1.6)
       thor (>= 0.14.0)
-    thor (0.19.1)
+    thor (0.20.0)
 
 PLATFORMS
   ruby
@@ -12,4 +12,4 @@ DEPENDENCIES
   homesick
 
 BUNDLED WITH
-   1.10.6
+   1.14.6

--- a/pkgs/tools/misc/homesick/default.nix
+++ b/pkgs/tools/misc/homesick/default.nix
@@ -1,6 +1,6 @@
 { lib, bundlerEnv, git}:
 bundlerEnv {
-  name = "homesick-1.1.3";
+  name = "homesick-1.1.6";
 
   gemdir = ./.;
 

--- a/pkgs/tools/misc/homesick/gemset.nix
+++ b/pkgs/tools/misc/homesick/gemset.nix
@@ -1,16 +1,19 @@
 {
   homesick = {
-    version = "1.1.3";
+    dependencies = ["thor"];
     source = {
-        type = "gem";
-        sha256 = "1pqsnbykisc6qamkz1gcbgis4az95sggxfdkq9v5hjr1a46q0s91";
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lxvnp4ncbx0irlblfxbd1f8h4hl11hgmyiy35q79w137r3prxml";
+      type = "gem";
     };
+    version = "1.1.6";
   };
   thor = {
-      version = "0.19.1";
-      source = {
-          type = "gem";
-          sha256 = "08p5gx18yrbnwc6xc0mxvsfaxzgy2y9i78xq7ds0qmdm67q39y4z";
-      };
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nmqpyj642sk4g16nkbq6pj856adpv91lp4krwhqkh2iw63aszdl";
+      type = "gem";
+    };
+    version = "0.20.0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Outdated project

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

