### PR TITLE
openjdk: Clean up platform conditionals

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -14,9 +14,9 @@ let
    * The JRE libraries are in directories that depend on the CPU.
    */
   architecture =
-    if stdenv.system == "i686-linux" then
+    if stdenv.hostPlatform.system == "i686-linux" then
       "i386"
-    else if stdenv.system == "x86_64-linux" then
+    else if stdenv.hostPlatform.system == "x86_64-linux" then
       "amd64"
     else
       throw "openjdk requires i686-linux or x86_64 linux";

--- a/pkgs/development/compilers/openjdk/bootstrap.nix
+++ b/pkgs/development/compilers/openjdk/bootstrap.nix
@@ -1,11 +1,14 @@
-{ stdenv, runCommand, glibc, fetchurl, file
+{ stdenv
+, runCommand, fetchurl, file
 
 , version
 }:
 
+assert stdenv.hostPlatform.libc == "glibc";
+
 let
   # !!! These should be on nixos.org
-  src = if glibc.system == "x86_64-linux" then
+  src = if stdenv.hostPlatform.system == "x86_64-linux" then
     (if version == "8" then
       fetchurl {
         url = "https://www.dropbox.com/s/a0lsq2ig4uguky5/openjdk8-bootstrap-x86_64-linux.tar.xz?dl=1";
@@ -17,7 +20,7 @@ let
         sha256 = "024gg2sgg4labxbc1nhn8lxls2p7d9h3b82hnsahwaja2pm1hbra";
       }
     else throw "No bootstrap for version")
-  else if glibc.system == "i686-linux" then
+  else if stdenv.hostPlatform.system == "i686-linux" then
     (if version == "8" then
       fetchurl {
         url = "https://www.dropbox.com/s/rneqjhlerijsw74/openjdk8-bootstrap-i686-linux.tar.xz?dl=1";
@@ -39,22 +42,18 @@ let
 
     LIBDIRS="$(find $out -name \*.so\* -exec dirname {} \; | sort | uniq | tr '\n' ':')"
 
-    for i in $out/bin/*; do
-      patchelf --set-interpreter ${glibc.out}/lib/ld-linux*.so.2 $i || true
-      patchelf --set-rpath "${glibc.out}/lib:$LIBDIRS" $i || true
-    done
-
-    find $out -name \*.so\* | while read lib; do
-      patchelf --set-interpreter ${glibc.out}/lib/ld-linux*.so.2 $lib || true
-      patchelf --set-rpath "${glibc.out}/lib:${stdenv.cc.cc.lib}/lib:$LIBDIRS" $lib || true
+    find "$out" -type f -print0 | while IFS= read -r -d "" elf; do
+      isELF "$elf" || continue
+      patchelf --set-interpreter $(cat "${stdenv.cc}/nix-support/dynamic-linker") "$elf" || true
+      patchelf --set-rpath "${stdenv.cc.libc}/lib:$LIBDIRS" "$elf" || true
     done
 
     # Temporarily, while NixOS's OpenJDK bootstrap tarball doesn't have PaX markings:
-    exes=$(${file}/bin/file $out/bin/* 2> /dev/null | grep -E 'ELF.*(executable|shared object)' | sed -e 's/: .*$//')
-    for file in $exes; do
-      paxmark m "$file"
+    find "$out/bin" -type f -print0 | while IFS= read -r -d "" elf; do
+      isELF "$elf" || continue
+      paxmark m "$elf"
       # On x86 for heap sizes over 700MB disable SEGMEXEC and PAGEEXEC as well.
-      ${stdenv.lib.optionalString stdenv.isi686 ''paxmark msp "$file"''}
+      ${stdenv.lib.optionalString stdenv.isi686 ''paxmark msp "$elf"''}
     done
   '';
 in bootstrap


### PR DESCRIPTION
###### Motivation for this change

Better style, more robust with an eye towards cross compilation / portability.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

