### PR TITLE
gthumb: fixed mime types

### DIFF
--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -1,7 +1,7 @@
 { stdenv,  fetchurl, gnome3, itstool, libxml2, pkgconfig, intltool,
   exiv2, libjpeg, libtiff, gstreamer, libraw, libsoup, libsecret,
   libchamplain, librsvg, libwebp, json_glib, webkit, lcms2, bison,
-  flex, hicolor_icon_theme, wrapGAppsHook }:
+  flex, hicolor_icon_theme, wrapGAppsHook, shared_mime_info }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
       librsvg libwebp json_glib webkit lcms2 bison flex hicolor_icon_theme defaultIconTheme ];
 
   enableParallelBuilding = true;
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared_mime_info}/share")
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/gthumb;


### PR DESCRIPTION
Fixed #35216
Related to #12280


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---