### PR TITLE
 zsdcc: init at unstable-2018-02-24 

### DIFF
--- a/pkgs/development/compilers/sdcc/zsdcc.nix
+++ b/pkgs/development/compilers/sdcc/zsdcc.nix
@@ -1,0 +1,47 @@
+{ sdcc, fetchzip, ... }:
+# https://www.z88dk.org/wiki/doku.php?id=temp:front#sdcc1
+
+sdcc.overrideAttrs (oldAttrs: rec {
+  name = "zsdcc-${oldAttrs.version}";
+
+  patchrev = "a82f0ac5ed282038ba56ef490e6afcf1c3d38a63";
+
+  patches = [(fetchzip {
+    url = "https://github.com/z88dk/z88dk/raw/${patchrev}/libsrc/_DEVELOPMENT/sdcc_z88dk_patch.zip";
+    sha256 = "0hnf0cyr5cgrv0scr5r5qlj3icdbl55icy6nic9bpz4vmdjpdcx7";
+    # Removing Windows executables.
+    extraPostFetch = ''
+      rm $out/*.exe
+      mkdir -p $out/sdcc
+      mv $out/sdcc-z88dk.patch $out/sdcc'';
+    stripRoot = false;
+  })];
+
+  # we need only Z80
+  configureFlags = [
+      "--disable-mcs51-port"
+      "--disable-z180-port"
+      "--disable-r2k-port"
+      "--disable-r3ka-port"
+      "--disable-gbz80-port"
+      "--disable-tlcs90-port"
+      "--disable-ds390-port"
+      "--disable-ds400-port"
+      "--disable-pic14-port"
+      "--disable-pic16-port"
+      "--disable-hc08-port"
+      "--disable-s08-port"
+      "--disable-stm8-port"
+      "--disable-ucsim"
+      "--disable-device-lib"
+      "--disable-packihx"
+      "--disable-sdcdb"
+      "--disable-sdbinutils"
+      "--disable-non-free"
+    ];
+
+    meta = oldAttrs.meta // {
+      description = "SDCC with z88dk patches";
+      /* maintainers = [ maintainers.genesis ]; */
+  };
+})

--- a/pkgs/development/compilers/sdcc/zsdcc.nix
+++ b/pkgs/development/compilers/sdcc/zsdcc.nix
@@ -3,8 +3,8 @@
 # https://github.com/z88dk/z88dk/blob/master/src/zsdcc/readme.md
 
 sdcc.overrideAttrs (oldAttrs: rec {
-  version = "20180224";
-  name = "zsdcc-Unstable-${version}"; # ${oldAttrs.version}
+  version = "2018-02-24";
+  name = "zsdcc-unstable-${version}"; # ${oldAttrs.version}
 
   meta = oldAttrs.meta // {
     description = "SDCC with z88dk patches";

--- a/pkgs/development/compilers/sdcc/zsdcc.nix
+++ b/pkgs/development/compilers/sdcc/zsdcc.nix
@@ -24,9 +24,6 @@ sdcc.overrideAttrs (oldAttrs: rec {
   # we need only Z80
   configureFlags = [
       "--disable-mcs51-port"
-      "--disable-z180-port"
-      "--disable-r2k-port"
-      "--disable-r3ka-port"
       "--disable-gbz80-port"
       "--disable-tlcs90-port"
       "--disable-ds390-port"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6649,6 +6649,7 @@ with pkgs;
   scalafmt = callPackage ../development/tools/scalafmt { };
 
   sdcc = callPackage ../development/compilers/sdcc { };
+  zsdcc = callPackage ../development/compilers/sdcc/zsdcc.nix { };
 
   serpent = callPackage ../development/compilers/serpent { };
 


### PR DESCRIPTION
###### Motivation for this change

This provides only zsdcc   and  zsdcpp for z88dk. Not conflict with sdcc.
@bjornfor : can you have a look please since you are sdcc derivation maintainer ? 

###### Things done
tested with z88dk example.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

