### PR TITLE
pythonPackages.jupyterhub-ldapauthenticator: init at 1.1

### DIFF
--- a/pkgs/development/python-modules/jupyterhub-ldapauthenticator/default.nix
+++ b/pkgs/development/python-modules/jupyterhub-ldapauthenticator/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, jupyterhub
+, ldap3
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "jupyterhub-ldapauthenticator";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19dz3a3122wln8lkixj5jbh9x3cqlrcb3p7a53825cj72cmpcxwz";
+  };
+
+  # No tests implemented
+  doCheck = false;
+   
+  propagatedBuildInputs = [ jupyterhub ldap3 ];
+
+  meta = with lib; {
+    description = "Simple LDAP Authenticator Plugin for JupyterHub";
+    homepage =  https://github.com/jupyterhub/ldapauthenticator;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ixxie ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9303,6 +9303,8 @@ in {
 
   jupyterhub = callPackage ../development/python-modules/jupyterhub { };
 
+  jupyterhub-ldapauthenticator = callPackage ../development/python-modules/jupyterhub-ldapauthenticator { };
+
   jsonpath_rw = buildPythonPackage rec {
     name = "jsonpath-rw-${version}";
     version = "1.4.0";


### PR DESCRIPTION


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

