### PR TITLE
pythonPackages.py_stringmatching: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/py_stringmatching/default.nix
+++ b/pkgs/development/python-modules/py_stringmatching/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, numpy
+, six
+, nose
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "py_stringmatching";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rjsx7iipn6svki21lmsza7b0dz9vkgmix696zryiv7gkhblqyb4";
+  };
+
+  checkInputs = [ nose ];
+   
+  propagatedBuildInputs = [ numpy six ];
+
+  meta = with lib; {
+    description = "A Python string matching library including string tokenizers and string similarity measures";
+    homepage =  https://sites.google.com/site/anhaidgroup/projects/magellan/py_stringmatching;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ixxie ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -279,6 +279,8 @@ in {
 
   Pmw = callPackage ../development/python-modules/Pmw { };
 
+  py_stringmatching = callPackage ../development/python-modules/py_stringmatching { };
+
   pyaes = callPackage ../development/python-modules/pyaes { };
 
   pyamf = callPackage ../development/python-modules/pyamf { };


### PR DESCRIPTION


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

