### PR TITLE
libcdio: 0.93 -> 2.0.0

### DIFF
--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, wrapGAppsHook, gettext, glib, gtk3
 , libmowgli, dbus_glib, libxml2, xorg, gnome3, alsaLib
 , libpulseaudio, libjack2, fluidsynth, libmad, libogg, libvorbis
-, libcdio082, libcddb, flac, ffmpeg, mpg123, libcue, libmms, libbs2b
+, libcdio, libcddb, flac, ffmpeg, mpg123, libcue, libmms, libbs2b
 , libsndfile, libmodplug, libsamplerate, soxr, lirc, curl, wavpack
 , neon, faad2, lame, libnotify, libsidplayfp
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gettext glib gtk3 libmowgli dbus_glib libxml2
     xorg.libXcomposite gnome3.defaultIconTheme alsaLib libjack2
-    libpulseaudio fluidsynth libmad libogg libvorbis libcdio082
+    libpulseaudio fluidsynth libmad libogg libvorbis libcdio
     libcddb flac ffmpeg mpg123 libcue libmms libbs2b libsndfile
     libmodplug libsamplerate soxr lirc curl wavpack neon faad2
     lame libnotify libsidplayfp

--- a/pkgs/applications/audio/audacious/qt-5.nix
+++ b/pkgs/applications/audio/audacious/qt-5.nix
@@ -3,7 +3,7 @@
   gettext, pkgconfig,
   qtbase,
   alsaLib, curl, faad2, ffmpeg, flac, fluidsynth, gdk_pixbuf, lame, libbs2b,
-  libcddb, libcdio082, libcue, libjack2, libmad, libmms, libmodplug,
+  libcddb, libcdio, libcue, libjack2, libmad, libmms, libmodplug,
   libmowgli, libnotify, libogg, libpulseaudio, libsamplerate, libsidplayfp,
   libsndfile, libvorbis, libxml2, lirc, mpg123, neon, qtmultimedia, soxr,
   wavpack
@@ -46,7 +46,7 @@ mkDerivation {
 
     # Plugin dependencies
     alsaLib curl faad2 ffmpeg flac fluidsynth gdk_pixbuf lame libbs2b libcddb
-    libcdio082 libcue libjack2 libmad libmms libmodplug libmowgli
+    libcdio libcue libjack2 libmad libmms libmodplug libmowgli
     libnotify libogg libpulseaudio libsamplerate libsidplayfp libsndfile
     libvorbis libxml2 lirc mpg123 neon qtmultimedia soxr wavpack
   ];

--- a/pkgs/development/libraries/libcdio/default.nix
+++ b/pkgs/development/libraries/libcdio/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchurl, libcddb, pkgconfig, ncurses, help2man, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "libcdio-0.93";
+  name = "libcdio-2.0.0";
 
   src = fetchurl {
     url = "mirror://gnu/libcdio/${name}.tar.bz2";
-    sha256 = "1a6x2c5bvpnkn7lhmxkjgz4axmh93m1clrlv41s1wzkc48lnc9zq";
+    sha256 = "0jr8ppdm80c533nzmrpz3iffnpc6nhvsria1di9f4jg1l19a03fd";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libcddb ncurses help2man ]
     ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
-  # Disabled because one test (check_paranoia.sh) fails.
-  #doCheck = true;
+  # Disabled due to several spurious test failures.
+  # doCheck = true;
 
   meta = with stdenv.lib; {
     description = "A library for OS-independent CD-ROM and CD image access";


### PR DESCRIPTION
This version bump also fixes a build failure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

