### PR TITLE
udisks2: add gobjectIntrospection to nativeBuildInputs

### DIFF
--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, gnused
 , expat, acl, systemd, glib, libatasmart, polkit
 , libxslt, docbook_xsl, utillinux, mdadm, libgudev
+, gobjectIntrospection
 }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0spl155k0g2l2hvqf8xyjv08i68gfyhzpjva6cwlzxx0bz4gbify";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "man" "dev" ];
 
   patches = [ ./force-path.patch ];
 
@@ -28,7 +29,7 @@ stdenv.mkDerivation rec {
         --replace " sed " " ${gnused}/bin/sed "
     '';
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ];
 
   buildInputs = [ libxslt docbook_xsl libgudev expat acl systemd glib libatasmart polkit ];
 
@@ -36,6 +37,11 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--with-udevdir=$(out)/lib/udev"
+  ];
+
+  makeFlags = [
+    "INTROSPECTION_GIRDIR=$(dev)/share/gir-1.0"
+    "INTROSPECTION_TYPELIBDIR=$(out)/lib/girepository-1.0"
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Same as in #35335.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

