### PR TITLE
Fix pkgs.biber on Darwin

### DIFF
--- a/pkgs/development/perl-modules/generic/builder_wrap.sh
+++ b/pkgs/development/perl-modules/generic/builder_wrap.sh
@@ -1,0 +1,46 @@
+source $stdenv/setup
+
+PERL5LIB="$PERL5LIB${PERL5LIB:+:}$out/lib/perl5/site_perl"
+
+perlFlags=
+for i in $(IFS=:; echo $PERL5LIB); do
+    perlFlags="$perlFlags -I$i"
+done
+
+oldPreConfigure="$preConfigure"
+preConfigure() {
+
+    eval "$oldPreConfigure"
+
+    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$perl/bin/perl\"
+}
+
+
+postFixup() {
+    if test -d "$out/bin"; then
+        fileList="$(find "$out/bin")"
+        echo "$fileList" | while read fn; do
+            if test -f "$fn"; then
+                wrapProgram "$fn" --prefix PERL5LIB : "$PERL5LIB"
+            fi
+        done
+    fi
+
+    # If a user installs a Perl package, she probably also wants its
+    # dependencies in the user environment (since Perl modules don't
+    # have something like an RPATH, so the only way to find the
+    # dependencies is to have them in the PERL5LIB variable).
+    if test -e $out/nix-support/propagated-build-inputs; then
+        ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages
+    fi
+}
+
+if test -n "$perlPreHook"; then
+    eval "$perlPreHook"
+fi
+
+genericBuild
+
+if test -n "$perlPostHook"; then
+    eval "$perlPostHook"
+fi

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,6 +1,14 @@
-{ lib, stdenv, perl, buildPackages, toPerlModule }:
+{ lib, stdenv, perl, buildPackages, toPerlModule, makeWrapper }:
 
-{ nativeBuildInputs ? [], name, ... } @ attrs:
+{ nativeBuildInputs ? [], doUseWrapper ? false, name, ... } @ attrs:
+# By default, executables produced by this function use the shebang as a way of injecting
+# dependent module paths. This can go over the shebang character limit which results
+# in the shebang being ignored. On Darwin, the limit appears to be 512 characters.
+#
+# See: https://github.com/boronine/shebang-test
+#
+# Use `doUseWrapper = true` to enable an alternative `makeWrapper` method of injecting
+# dependent module paths.
 
 toPerlModule(stdenv.mkDerivation (
   (
@@ -33,10 +41,20 @@ toPerlModule(stdenv.mkDerivation (
   attrs
   )
   //
-  {
-    name = "perl${perl.version}-${name}";
-    builder = ./builder.sh;
-    nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
-    perl = buildPackages.perl;
-  }
+  (
+  if doUseWrapper then
+    {
+      name = "perl${perl.version}-${name}";
+      builder = ./builder_wrap.sh;
+      nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) makeWrapper ];
+      perl = buildPackages.perl;
+    }
+  else
+    {
+      name = "perl${perl.version}-${name}";
+      builder = ./builder.sh;
+      nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
+      perl = buildPackages.perl;
+    }
+  )
 ))

--- a/pkgs/tools/typesetting/biber/default.nix
+++ b/pkgs/tools/typesetting/biber/default.nix
@@ -6,6 +6,7 @@ in
 
 perlPackages.buildPerlModule rec {
   name = "biber-${version}";
+  doUseWrapper = true;
   inherit (biberSource) version;
 
   src = "${biberSource}/source/bibtex/biber/biblatex-biber.tar.gz";


### PR DESCRIPTION
Fix for #35353

- As part of this PR, the fix is applied ONLY to `pkgs.biber` package
- The fix is can be enabled for other packages (ack, perlcritic, youtube-viewer etc.) using the flag `doUseWrapper` in the perl-modules builder

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

