### PR TITLE
ceph: Modify ceph package so that it compiles and runs fine on nixos

### DIFF
--- a/pkgs/tools/filesystems/ceph/0002-fix-absolute-include-path.patch
+++ b/pkgs/tools/filesystems/ceph/0002-fix-absolute-include-path.patch
@@ -1,0 +1,19 @@
+diff -ru ceph/src/key_value_store/kv_flat_btree_async.cc ceph-copy/src/key_value_store/kv_flat_btree_async.cc
+--- ceph/src/key_value_store/kv_flat_btree_async.cc	1980-01-02 00:00:00.000000000 +0100
++++ ceph-copy/src/key_value_store/kv_flat_btree_async.cc	2018-02-13 21:49:59.232860487 +0100
+@@ -15,13 +15,13 @@
+ #include "key_value_store/kv_flat_btree_async.h"
+ #include "key_value_store/kvs_arg_types.h"
+ #include "include/rados/librados.hpp"
+-#include "/usr/include/asm-generic/errno.h"
+-#include "/usr/include/asm-generic/errno-base.h"
+ #include "common/ceph_context.h"
+ #include "common/Clock.h"
+ #include "include/types.h"
+ 
+ 
++#include <asm-generic/errno.h>
++#include <asm-generic/errno-base.h>
+ #include <string>
+ #include <iostream>
+ #include <cassert>

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -86,12 +86,17 @@ let
   };
 
   ceph-python-env = python2Packages.python.withPackages (ps: [ 
-	ps.sphinx
-	ps.flask
-	ps.argparse
-	ps.cython 
-	ps.setuptools
-	ps.pip
+    ps.sphinx
+    ps.flask
+    ps.argparse
+    ps.cython 
+    ps.setuptools
+    ps.pip
+    # Libraries needed by the python tools
+    ps.Mako
+    ps.pecan
+    ps.prettytable
+    ps.webob
 	]);
 
 in
@@ -103,11 +108,13 @@ stdenv.mkDerivation {
   patches = [ 
  #	 ./ceph-patch-cmake-path.patch
     ./0001-kv-RocksDBStore-API-break-additional.patch   
+  ] ++ optionals stdenv.isLinux [
+    ./0002-fix-absolute-include-path.patch
   ];
 
   nativeBuildInputs = [
     cmake
-    pkgconfig which git
+    pkgconfig which git python2Packages.wrapPython
     (ensureNewerSourcesHook { year = "1980"; })
   ];
   
@@ -122,6 +129,7 @@ stdenv.mkDerivation {
   ] ++ optionals hasKinetic [
     optKinetic-cpp-client
   ];
+
   
   preConfigure =''
     # rip off submodule that interfer with system libs
@@ -148,6 +156,10 @@ stdenv.mkDerivation {
     "-DWITH_CEPHFS=OFF"
     "-DWITH_LIBCEPHFS=OFF"
   ];
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
 
   enableParallelBuilding = true;
   


### PR DESCRIPTION
With adding a patch that makes 2 absolute paths into 2 relative paths, ensuring the third-party libraries are available
in the python environment used and wrapping the python tools with wrapPrograms does so that the fixed ceph pkg can
compile and run as intended on NixOS.

###### Motivation for this change

The fixed package for ceph was made to be compiled and run on non-nixos systems, this PR fixes so that the fixed package can compile and run successfully on NixOS too.
The git dependency could also be removed, its not needed unless you want to run tests defined in the source tree or generate release notes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

