### PR TITLE
hy: 0.13.1 -> 0.14.0

### DIFF
--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -2,14 +2,20 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "hy-${version}";
-  version = "0.13.1";
+  version = "0.14.0";
 
   src = fetchurl {
     url = "mirror://pypi/h/hy/${name}.tar.gz";
-    sha256 = "1fjip998k336r26i1gpri18syvfjg7z46wng1n58dmc238wm53sx";
+    sha256 = "0cbdh1q0zm00p4h7i44kir4qhw0p6sid78xf6llrx2p21llsnv98";
   };
 
   propagatedBuildInputs = with pythonPackages; [ appdirs clint astor rply ];
+
+  # The build generates a .json parser file in the home directory under .cache.
+  # This is needed to get it to not try and open files in /homeless-shelter
+  preConfigure = ''
+    export HOME=$TMP
+  '';
 
   meta = {
     description = "A LISP dialect embedded in Python";


### PR DESCRIPTION
###### Motivation for this change

Updating hy for the new release.

The preConfigure hook is pretty gross and I'd like some input on a better way to do this if it's possible. To be specific the build process uses `rply` to generate a parser and output it at `~/.cache/rply/hy_parser-$hash_of_something.json`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

