### PR TITLE
rpcs3: init at 2018-02-23

### DIFF
--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchgit, cmake, pkgconfig
+, qtbase, openal, glew, llvm_4, vulkan-loader, libpng, ffmpeg, libevdev
+, pulseaudioSupport ? true, libpulseaudio
+, waylandSupport ? true, wayland
+, alsaSupport ? true, alsaLib
+}:
+
+stdenv.mkDerivation rec {
+  name = "rpcs3-${version}";
+  version = "2018-02-23";
+
+  src = fetchgit {
+    url = "https://github.com/RPCS3/rpcs3";
+    rev = "41bd07274f15b8f1be2475d73c3c75ada913dabb";
+    sha256 = "1v28m64ahakzj4jzjkmdd7y8q75pn9wjs03vprbnl0z6wqavqn0x";
+  };
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_LIBPNG=ON"
+    "-DUSE_SYSTEM_FFMPEG=ON"
+    "-DUSE_NATIVE_INSTRUCTIONS=OFF"
+  ];
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [
+    qtbase openal glew llvm_4 vulkan-loader libpng ffmpeg libevdev
+  ] ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional alsaSupport alsaLib
+    ++ lib.optional waylandSupport wayland;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "PS3 emulator/debugger";
+    homepage = "https://rpcs3.net/";
+    maintainers = with maintainers; [ abbradar ];
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17199,6 +17199,8 @@ with pkgs;
 
   rofi-menugen = callPackage ../applications/misc/rofi-menugen { };
 
+  rpcs3 = libsForQt5.callPackage ../misc/emulators/rpcs3 { };
+
   rstudio = libsForQt5.callPackage ../applications/editors/rstudio { };
 
   rsync = callPackage ../applications/networking/sync/rsync {


### PR DESCRIPTION
###### Motivation for this change

Add a PlayStation 3 emulator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

