### PR TITLE
tp_smapi: unstable-2017-12-04 -> 0.43

### DIFF
--- a/pkgs/os-specific/linux/tp_smapi/default.nix
+++ b/pkgs/os-specific/linux/tp_smapi/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "tp_smapi-${version}-${kernel.version}";
-  version = "unstable-2017-12-04";
+  version = "0.43";
 
   src = fetchFromGitHub {
     owner = "evgeni";
     repo = "tp_smapi";
-    rev = "76c5120f7be4880cf2c6801f872327e4e70c449f";
-    sha256 = "0g8l7rmylspl17qnqpa2h4yj7h3zvy6xlmj5nlnixds9avnbz2vy";
+    rev = "tp-smapi/${version}";
+    sha256 = "1rjb0njckczc2mj05cagvj0lkyvmyk6bw7wkiinv81lw8m90g77g";
     name = "tp-smapi-${version}";
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

