### PR TITLE
gnujump: init at 1.0.8

### DIFF
--- a/pkgs/games/gnujump/default.nix
+++ b/pkgs/games/gnujump/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, SDL, SDL_image, SDL_mixer }:
+
+stdenv.mkDerivation rec {
+  name = "gnujump-${version}";
+  version = "1.0.8";
+  src = fetchurl {
+    url = "mirror://gnu/gnujump/${name}.tar.gz";
+    sha256 = "05syy9mzbyqcfnm0hrswlmhwlwx54f0l6zhcaq8c1c0f8dgzxhqk";
+  };
+  buildInputs = [ SDL SDL_image SDL_mixer ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://jump.gnu.sinusoid.es/";
+    description = "A clone of the simple yet addictive game Xjump";
+    longDescription = ''
+      The goal in this game is to jump to the next floor trying not to fall
+      down. As you go upper in the Falling Tower the floors will fall faster.
+      Try to survive longer get upper than anyone. It might seem too simple but
+      once you've tried you'll realize how addictive this is.
+    '';
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18677,6 +18677,8 @@ with pkgs;
 
   gnugo = callPackage ../games/gnugo { };
 
+  gnujump = callPackage ../games/gnujump { };
+
   gogui = callPackage ../games/gogui {};
 
   gtetrinet = callPackage ../games/gtetrinet {


### PR DESCRIPTION
###### Motivation for this change

A classic.

Can someone test if it works on darwin too? The website only mentions GNU/Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

