### PR TITLE
geckodriver: use devel version with slog fix

### DIFF
--- a/pkgs/development/tools/geckodriver/default.nix
+++ b/pkgs/development/tools/geckodriver/default.nix
@@ -1,20 +1,24 @@
 { lib
-, fetchurl
+, fetchFromGitHub
 , rustPlatform
 }:
 
 with rustPlatform; 
 
 buildRustPackage rec {
-  version = "0.19.1";
+  version = "unstable-2018-02-24";
   name = "geckodriver-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/mozilla/geckodriver/archive/v${version}.tar.gz";
-    sha256 = "04zpv4aiwbig466yj24hhazl5hrapkyvwlhvg0za5599ykzdv47m";
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "gecko-dev";
+    rev = "ecb86060b4c5a9808798b81a57e79e821bb47082";
+    sha256 = "1am84a60adw0bb12rlhdqbiwyywhza4qp5sf4f4fmssjl2qcr6nl";
   };
 
-  cargoSha256 = "1cny8caqcd9p98hra1k7y4d3lb8sxsyaplr0svbwam0d2qc1c257";
+  sourceRoot = "${src.name}/testing/geckodriver";
+
+  cargoSha256 = "0dvcvdb623jla29i93glx20nf8pbpfw6jj548ii6brzkcpafxxm8";
 
   meta = with lib; {
     description = "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers";


### PR DESCRIPTION
###### Motivation for this change

geckodriver does not compile. see #35301

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

