### PR TITLE
fix service.kresd fails due to kresd-cachedir hiatus

### DIFF
--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -89,6 +89,7 @@ in
     # Create the cacheDir; tmpfiles don't work on nixos-rebuild switch.
     systemd.services.kresd-cachedir = {
       serviceConfig.Type = "oneshot";
+      serviceConfig.RemainAfterExit = "yes";
       script = ''
         if [ ! -d '${cfg.cacheDir}' ]; then
           mkdir -p '${cfg.cacheDir}'


### PR DESCRIPTION
###### Motivation for this change

Without this change the kresd-cachedir enters an endless loop of restarts until systemd completely fails it after several retries. This in turn may cause kresd to be stopped by systemd, potentially leaving the system without a dns resolver.

Only relevant for 17.09, because master uses different services.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

