### PR TITLE
i2p: force openjdk

### DIFF
--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -1,6 +1,10 @@
-{ stdenv, procps, coreutils, fetchurl, jdk, jre, ant, gettext, which }:
+{ stdenv, procps, coreutils, fetchurl, openjdk8, ant, gettext, which }:
 
-let wrapper = stdenv.mkDerivation rec {
+let
+jdk = openjdk8;
+jre = openjdk8;
+
+wrapper = stdenv.mkDerivation rec {
   name = "wrapper-${version}";
   version = "3.5.32";
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

i2p requires openjdk only, not default system jdk

Fixes https://github.com/NixOS/nixpkgs/issues/30378
