### PR TITLE
meson: fix rpath fixup

### DIFF
--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -47,11 +47,6 @@ stdenv.mkDerivation rec {
   postFixup = ''
     # Unwrap accidentally wrapped library
     mv $out/libexec/deja-dup/tools/.libduplicity.so-wrapped $out/libexec/deja-dup/tools/libduplicity.so
-
-    # Patched meson does not add internal libraries to rpath
-    for elf in "$out/bin/.deja-dup-wrapped" "$out/libexec/deja-dup/.deja-dup-monitor-wrapped" "$out/libexec/deja-dup/tools/libduplicity.so"; do
-      patchelf --set-rpath "$(patchelf --print-rpath "$elf"):$out/lib/deja-dup" "$elf"
-    done
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome-3/core/epiphany/default.nix
@@ -38,13 +38,6 @@ stdenv.mkDerivation rec {
     patchShebangs post_install.py
   '';
 
-  postFixup = ''
-    # Patched meson does not add internal libraries to rpath
-    for f in $out/bin/.*-wrapped $out/libexec/.*-wrapped $out/libexec/epiphany/.*-wrapped $out/lib/epiphany/*.so $out/lib/epiphany/web-extensions/*.so; do
-      patchelf --set-rpath "$out/lib/epiphany:$(patchelf --print-rpath $f)" "$f"
-    done
-  '';
-
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Epiphany;
     description = "WebKit based web browser for GNOME";

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -67,11 +67,6 @@ in stdenv.mkDerivation rec {
     glib-compile-schemas $out/share/glib-2.0/schemas
   '';
 
-  postFixup = ''
-    # Patched meson does not add internal libraries to rpath
-    patchelf --set-rpath "$out/lib/gnome-shell:$(patchelf --print-rpath $out/bin/.gnome-shell-wrapped)" $out/bin/.gnome-shell-wrapped
-  '';
-
   enableParallelBuilding = true;
 
   passthru = {

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, stdenv, targetPlatform, writeTextDir, m4 }: let
+{ lib, python3Packages, stdenv, targetPlatform, writeTextDir, substituteAll }: let
   targetPrefix = lib.optionalString stdenv.isCross
                    (targetPlatform.config + "-");
 in python3Packages.buildPythonApplication rec {
@@ -27,11 +27,17 @@ in python3Packages.buildPythonApplication rec {
     # We patch Meson to add a --fallback-library-path argument with
     # library install_dir to g-ir-scanner.
     ./gir-fallback-path.patch
-  ];
 
-  postPatch = ''
-    sed -i -e 's|e.fix_rpath(install_rpath)||' mesonbuild/scripts/meson_install.py
-  '';
+    # In common distributions, RPATH is only needed for internal libraries so
+    # meson removes everything else. With Nix, the locations of libraries
+    # are not as predictable, therefore we need to keep them in the RPATH.
+    # At the moment we are keeping the paths starting with /nix/store.
+    # https://github.com/NixOS/nixpkgs/issues/31222#issuecomment-365811634
+    (substituteAll {
+      src = ./fix-rpath.patch;
+      inherit (builtins) storeDir;
+    })
+  ];
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/development/tools/build-managers/meson/fix-rpath.patch
+++ b/pkgs/development/tools/build-managers/meson/fix-rpath.patch
@@ -1,0 +1,32 @@
+--- a/mesonbuild/compilers/compilers.py
++++ b/mesonbuild/compilers/compilers.py
+@@ -846,8 +848,10 @@
+             if paths != '':
+                 paths += ':'
+             paths += build_rpath
+-        if len(paths) < len(install_rpath):
+-            padding = 'X' * (len(install_rpath) - len(paths))
++        store_paths = ':'.join(filter(lambda path: path.startswith('@storeDir@'), paths.split(':')))
++        extra_space_needed = len(install_rpath + (':' if install_rpath and store_paths else '') + store_paths) - len(paths)
++        if extra_space_needed > 0:
++            padding = 'X' * extra_space_needed
+             if not paths:
+                 paths = padding
+             else:
+--- a/mesonbuild/scripts/depfixer.py
++++ b/mesonbuild/scripts/depfixer.py
+@@ -300,6 +300,14 @@
+             return
+         self.bf.seek(rp_off)
+         old_rpath = self.read_str()
++
++        if new_rpath:
++            new_rpath += b':'
++        else:
++            new_rpath = b''
++
++        new_rpath += b':'.join(filter(lambda path: path.startswith(b'@storeDir@'), old_rpath.split(b':')))
++
+         if len(old_rpath) < len(new_rpath):
+             sys.exit("New rpath must not be longer than the old one.")
+         # The linker does read-only string deduplication. If there is a

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -201,18 +201,6 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # The rpath to the shared systemd library is not added by meson. The
-  # functionality was removed by a nixpkgs patch because it would overwrite
-  # the existing rpath.
-  postFixup = ''
-    sharedLib=libsystemd-shared-${version}.so
-    for prog in `find $out -type f -executable`; do
-      (patchelf --print-needed $prog | grep $sharedLib > /dev/null) && (
-        patchelf --set-rpath `patchelf --print-rpath $prog`:"$out/lib/systemd" $prog
-      ) || true
-    done
-  '';
-
   # The interface version prevents NixOS from switching to an
   # incompatible systemd at runtime.  (Switching across reboots is
   # fine, of course.)  It should be increased whenever systemd changes


### PR DESCRIPTION
###### Motivation for this change
In common distributions, `RPATH` is only needed for internal libraries so meson removes everything else. With Nix, the locations of libraries are not as predictable, therefore we need to keep them in the `RPATH`. See https://github.com/NixOS/nixpkgs/issues/31222#issuecomment-365811634 for more details.

Previously we have just kept the `RPATH` produced by the linker, patching meson not to remove it. This deprived us of potentially replacing it with `install_rpath` provided by project so we had to re-add it manually, and also introduced a vulnerability of keeping build paths in `RPATH`.

This patch restores the clean-up but modifies it so the items starting with `/nix/store` are retained.

This should be relatively safe since the store is immutable, however, there might be some unwanted retainment of [`build_rpath`](http://mesonbuild.com/Release-notes-for-0-42-0.html#added-build_rpath-keyword-argument) if it contains paths from Nix store.

Closes: #31222

###### Things done

- Checked that built ELFs do not contain not found `DT_NEEDED` items.
   - [x] deja-dup (there are some but they were there before and they do not seem to affect function)
   - [x] epiphany (there is one but it does not seem to affect function)
   - [x] gnome3.gnome_shell
   - [x] systemd
   - [ ] ~~wlroots~~ they use a different fixup, let them (@primeos) clean it up themselves

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @brandonedens @rasendubi @yegortimoshenko 