### PR TITLE
python: pytest-mock: fix Python 3 compatibility

### DIFF
--- a/pkgs/development/python-modules/pytest-mock/default.nix
+++ b/pkgs/development/python-modules/pytest-mock/default.nix
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "8ed6c9ac6b7565b226b4da2da48876c9198d76401ec8d9c5e4c69b45423e33f8";
   };
+  
+  # TODO: Remove when next version is released
+  patches = [ ./fix-python-3-compatibility.patch ];
 
   propagatedBuildInputs = [ pytest ] ++ lib.optional (!isPy3k) mock;
   nativeBuildInputs = [ setuptools_scm ];

--- a/pkgs/development/python-modules/pytest-mock/fix-python-3-compatibility.patch
+++ b/pkgs/development/python-modules/pytest-mock/fix-python-3-compatibility.patch
@@ -1,0 +1,29 @@
+From 9214b5eaf45bbe99c86700dc998fd6ad97406cc5 Mon Sep 17 00:00:00 2001
+From: Ghislain Antony Vaillant <ghisvail@users.noreply.github.com>
+Date: Mon, 19 Feb 2018 08:51:25 +0000
+Subject: [PATCH] Fix Python 3 compatibility
+
+---
+ setup.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 095629c..cc3e87b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,5 +1,6 @@
+ from setuptools import setup
+ 
++from io import open
+ 
+ setup(
+     name='pytest-mock',
+@@ -20,7 +21,7 @@
+     author='Bruno Oliveira',
+     author_email='nicoddemus@gmail.com',
+     description='Thin-wrapper around the mock package for easier use with py.test',
+-    long_description=open('README.rst').read(),
++    long_description=open('README.rst', encoding='utf-8').read(),
+     keywords="pytest mock",
+     classifiers=[
+         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
###### Motivation for this change

pytest-mock 1.7.0 fails to build with Python 3. This PR adds a patch that is already applied upstream (pytest-dev/pytest-mock/pull/107), but has not been released.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

