### PR TITLE
autojump: 22.5.0 -> 22.5.1

### DIFF
--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, python, bash }:
 
 let
-  version = "22.5.0";
+  version = "22.5.1";
 in
   stdenv.mkDerivation rec {
     name = "autojump-${version}";
@@ -9,7 +9,7 @@ in
     src = fetchurl {
       url = "http://github.com/joelthelion/autojump/archive/release-v${version}.tar.gz";
       name = "autojump-${version}.tar.gz";
-      sha256 = "00ai0j37ka3557a8m7ig44dby7v01pckwi8gl479vz5b5pw1z8cd";
+      sha256 = "17z9j9936x0nizwrzf664bngh60x5qbvrrf1s5qdzd0f2gdanpvn";
     };
 
     buildInputs = [ python bash ];


### PR DESCRIPTION
Semi-automatic update

- [x] built on NixOS
- [x] ran binary on NixOS and verified version string is 22.5.1