### PR TITLE
pythonPackages.cairocffi: 0.7.2 → 0.8.0

### DIFF
--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python27Packages, glib, cairo, pango, pkgconfig, libxcb, xcbutilcursor }:
 
 let cairocffi-xcffib = python27Packages.cairocffi.override {
-    pythonPath = [ python27Packages.xcffib ];
+    withXcffib = true;
   };
 in
 

--- a/pkgs/development/python-modules/cairocffi/default.nix
+++ b/pkgs/development/python-modules/cairocffi/default.nix
@@ -1,0 +1,65 @@
+{ buildPythonPackage
+, fetchurl
+, makeFontsConf
+, freefont_ttf
+, pytest
+, glibcLocales
+, cairo
+, cffi
+, withXcffib ? false, xcffib
+, python
+, fetchpatch
+, glib
+, gdk_pixbuf }:
+
+buildPythonPackage rec {
+  name = "cairocffi-0.7.2";
+
+  src = fetchurl {
+    url = "mirror://pypi/c/cairocffi/${name}.tar.gz";
+    sha256 = "e42b4256d27bd960cbf3b91a6c55d602defcdbc2a73f7317849c80279feeb975";
+  };
+
+  LC_ALL = "en_US.UTF-8";
+
+  # checkPhase require at least one 'normal' font and one 'monospace',
+  # otherwise glyph tests fails
+  FONTCONFIG_FILE = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
+
+  checkInputs = [ pytest glibcLocales ];
+  propagatedBuildInputs = [ cairo cffi ] ++ lib.optional withXcffib xcffib;
+
+  checkPhase = ''
+    py.test $out/${python.sitePackages}
+  '';
+
+  # FIXME: make gdk_pixbuf dependency optional
+  # Happens with 0.7.1 and 0.7.2
+  # OSError: dlopen() failed to load a library: gdk_pixbuf-2.0 / gdk_pixbuf-2.0-0
+
+  patches = [
+    # This patch from PR substituted upstream
+    (fetchpatch {
+      url = "https://github.com/avnik/cairocffi/commit/2266882e263c5efc87350cf016d117b2ec6a1d59.patch";
+      sha256 = "0gb570z3ivf1b0ixsk526n3h29m8c5rhjsiyam7rr3x80dp65cdl";
+    })
+
+    ./dlopen-paths.patch
+    ./fix_test_scaled_font.patch
+  ];
+
+  postPatch = ''
+    # Hardcode cairo library path
+    substituteInPlace cairocffi/__init__.py --subst-var-by cairo ${cairo.out}
+    substituteInPlace cairocffi/__init__.py --subst-var-by glib ${glib.out}
+    substituteInPlace cairocffi/__init__.py --subst-var-by gdk_pixbuf ${gdk_pixbuf.out}
+  '';
+
+  meta = {
+    homepage = https://github.com/SimonSapin/cairocffi;
+    license = "bsd";
+    description = "cffi-based cairo bindings for Python";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2052,58 +2052,7 @@ in {
 
   canmatrix = callPackage ../development/python-modules/canmatrix {};
 
-  cairocffi = buildPythonPackage rec {
-    name = "cairocffi-0.7.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/cairocffi/${name}.tar.gz";
-      sha256 = "e42b4256d27bd960cbf3b91a6c55d602defcdbc2a73f7317849c80279feeb975";
-    };
-
-    LC_ALL = "en_US.UTF-8";
-
-    # checkPhase require at least one 'normal' font and one 'monospace',
-    # otherwise glyph tests fails
-    FONTCONFIG_FILE = pkgs.makeFontsConf {
-      fontDirectories = [ pkgs.freefont_ttf ];
-    };
-
-    buildInputs = with self; [ pytest pkgs.glibcLocales ];
-    propagatedBuildInputs = with self; [ pkgs.cairo cffi ];
-
-    checkPhase = ''
-      py.test $out/${python.sitePackages}
-    '';
-
-    # FIXME: make gdk_pixbuf dependency optional (as wel as xcfffi)
-    # Happens with 0.7.1 and 0.7.2
-    # OSError: dlopen() failed to load a library: gdk_pixbuf-2.0 / gdk_pixbuf-2.0-0
-
-    patches = [
-      # This patch from PR substituted upstream
-      (pkgs.fetchpatch {
-          url = "https://github.com/avnik/cairocffi/commit/2266882e263c5efc87350cf016d117b2ec6a1d59.patch";
-          sha256 = "0gb570z3ivf1b0ixsk526n3h29m8c5rhjsiyam7rr3x80dp65cdl";
-      })
-
-      ../development/python-modules/cairocffi/dlopen-paths.patch
-      ../development/python-modules/cairocffi/fix_test_scaled_font.patch
-    ];
-
-    postPatch = ''
-      # Hardcode cairo library path
-      substituteInPlace cairocffi/__init__.py --subst-var-by cairo ${pkgs.cairo.out}
-      substituteInPlace cairocffi/__init__.py --subst-var-by glib ${pkgs.glib.out}
-      substituteInPlace cairocffi/__init__.py --subst-var-by gdk_pixbuf ${pkgs.gdk_pixbuf.out}
-    '';
-
-    meta = {
-      homepage = https://github.com/SimonSapin/cairocffi;
-      license = "bsd";
-      description = "cffi-based cairo bindings for Python";
-    };
-  };
-
+  cairocffi = callPackage ../development/python-modules/cairocffi {};
 
   cairosvg = buildPythonPackage rec {
     version = "1.0.18";


### PR DESCRIPTION
###### Motivation for this change
Update and move out of `python-modules.nix`.

https://github.com/Kozea/cairocffi/blob/9cba2e6039869db6710a5fb6a1af0f139509fc00/CHANGES#L7-L19

###### Things done
I ran qtile (the only thing depending on this) in VM and it seemed to work fine.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

