### PR TITLE
installer: Makes iso image compatible with *wrong* UEFI.

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -81,6 +81,10 @@ let
     cp -v ${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${targetArch}.efi $out/EFI/boot/boot${targetArch}.efi
     mkdir -p $out/loader/entries
 
+    # Compatibility with *bad UEFI*
+    mkdir -p $out/EFI/Microsoft/Boot
+    cp $out/EFI/boot/boot${targetArch}.efi $out/EFI/Microsoft/Boot/bootmgfw.efi
+
     cat << EOF > $out/loader/entries/nixos-iso.conf
     title NixOS ${config.system.nixos.label}${config.isoImage.appendToMenuLabel}
     linux /boot/${config.system.boot.loader.kernelFile}


### PR DESCRIPTION

###### Motivation for this change

This change will help users with arguably broken UEFI implementations.
It has been reported that at least one specific motherboard has this
problem, and that other motherboards can exhibit the same behaviour.

Those UEFI implementations are not following the spec with regard to the
autodetection:

> The format of the file path is defined as `<EFI_SYSTEM_PARTITION>/EFI/BOOT/BOOT<MACHINE_TYPE_SHORT_NAME>.EFI`;

Those boards will, instead, try to boot the default location of windows'
UEFI bootloader

> `/EFI/Microsoft/Boot/bootmgfw.efi`

This change *only affects the installation media*. It may be necessary
to document the caveat that some (older?) motherboards exhibit such
behaviour, possibly on the users' wiki; users of such computers may want
to install a secondary bootloader like rEFInd, or copy the bootloader
installed by NixOS to that location after their successful installation.

See:

  * https://wiki.archlinux.org/index.php/Unified_Extensible_Firmware_Interface#UEFI_boot_loader_does_not_show_up_in_firmware_menu
  * https://logs.nix.samueldr.com/nixos/2018-02-25#1519530841-1519530628;

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I couldn't verify whether the installer would boot on such hardware, but the file is at the expected location.
---

