### PR TITLE
babeltrace: 1.5.3 -> 1.5.4

### DIFF
--- a/pkgs/development/tools/misc/babeltrace/default.nix
+++ b/pkgs/development/tools/misc/babeltrace/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, libuuid, popt, elfutils }:
 
 stdenv.mkDerivation rec {
-  name = "babeltrace-1.5.3";
+  name = "babeltrace-1.5.4";
 
   src = fetchurl {
     url = "http://www.efficios.com/files/babeltrace/${name}.tar.bz2";
-    sha256 = "0z0k4qvz4ypxs4dmgrzv9da7ylf6jr94ra6nylqpfrdspvjzwj92";
+    sha256 = "1h8zi7afilbfx4jvdlhhgysj6x01w3799mdk4mdcgax04fch6hwn";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. The following tests were automatically performed:

- built on NixOS
- ran `/nix/store/kcq8gh0l8v2m71pyz5qqh8hiwnrfkwl6-babeltrace-1.5.4/bin/babeltrace -h` got 0 exit code
- ran `/nix/store/kcq8gh0l8v2m71pyz5qqh8hiwnrfkwl6-babeltrace-1.5.4/bin/babeltrace --help` got 0 exit code
- ran `/nix/store/kcq8gh0l8v2m71pyz5qqh8hiwnrfkwl6-babeltrace-1.5.4/bin/babeltrace -h` and found version 1.5.4
- ran `/nix/store/kcq8gh0l8v2m71pyz5qqh8hiwnrfkwl6-babeltrace-1.5.4/bin/babeltrace --help` and found version 1.5.4
- ran `/nix/store/kcq8gh0l8v2m71pyz5qqh8hiwnrfkwl6-babeltrace-1.5.4/bin/babeltrace-log -h` got 0 exit code
- ran `/nix/store/kcq8gh0l8v2m71pyz5qqh8hiwnrfkwl6-babeltrace-1.5.4/bin/babeltrace-log -h` and found version 1.5.4
- found 1.5.4 with grep in /nix/store/kcq8gh0l8v2m71pyz5qqh8hiwnrfkwl6-babeltrace-1.5.4