### PR TITLE
lxterminal: switch to using GTK3

### DIFF
--- a/pkgs/applications/misc/lxterminal/default.nix
+++ b/pkgs/applications/misc/lxterminal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, automake, autoconf, intltool, pkgconfig, gtk2, vte
+{ stdenv, fetchurl, automake, autoconf, intltool, pkgconfig, gtk3, vte
 , libxslt, docbook_xml_dtd_412, docbook_xml_xslt, libxml2, findXMLCatalogs
 }:
 
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-man"
+    "--enable-gtk3"
   ];
 
   nativeBuildInputs = [
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
     libxslt docbook_xml_dtd_412 docbook_xml_xslt libxml2 findXMLCatalogs
   ];
 
-  buildInputs = [ gtk2 vte ];
+  buildInputs = [ gtk3 vte ];
 
   patches = [
     ./respect-xml-catalog-files-var.patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17612,7 +17612,7 @@ with pkgs;
   };
 
   lxterminal = callPackage ../applications/misc/lxterminal {
-    vte = gnome2.vte;
+    vte = gnome3.vte;
   };
 
   deepin-terminal = callPackage ../applications/misc/deepin-terminal {


### PR DESCRIPTION
###### Motivation for this change

The version of VTE that uses GTK2 is not maintained, so using lxterminal with GTK2 means dealing with a lot of bugs that have already been fixed in newer VTE versions. I actually meant to set up lxterminal to use GTK3 in the first place, but didn't realize that wasn't the default until
now.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

