### PR TITLE
nixos/dovecot: More sieve options and precompiling of scripts

### DIFF
--- a/nixos/tests/dovecot.nix
+++ b/nixos/tests/dovecot.nix
@@ -3,13 +3,42 @@ import ./make-test-python.nix {
 
   nodes.machine = { pkgs, ... }: {
     imports = [ common/user-account.nix ];
-    services.postfix.enable = true;
+    users.users.timmy = {
+      isNormalUser = true;
+      description = "Timmy Foobar";
+      password = "foobar";
+    };
+    services.postfix = {
+      enable = true;
+      rootAlias = "timmy";
+      extraConfig = "mailbox_transport = lmtp:unix:/var/run/dovecot2/lmtp";
+    };
     services.dovecot2 = {
       enable = true;
-      protocols = [ "imap" "pop3" ];
+      protocols = [ "imap" "pop3" "lmtp" "sieve" ];
       modules = [ pkgs.dovecot_pigeonhole ];
       mailUser = "vmail";
       mailGroup = "vmail";
+      mailboxes.Junk = {
+        specialUse = "Junk";
+        auto = "subscribe";
+      };
+      extraConfig = ''
+        mail_debug = yes
+
+        protocol lmtp {
+          postmaster_address = root@localhost
+          auth_username_format = %n
+          mail_plugins = $mail_plugins sieve
+        }
+      '';
+      sieveScripts.before = pkgs.writeText "before.sieve" ''
+        require "fileinto";
+        if header :is "X-Spam" "Yes" {
+          fileinto "Junk";
+          stop;
+        }
+      '';
     };
     environment.systemPackages = let
       sendTestMail = pkgs.writeScriptBin "send-testmail" ''
@@ -35,6 +64,19 @@ import ./make-test-python.nix {
         MAIL
       '';
 
+      sendTestMail2 = pkgs.writeScriptBin "send-testmail2" ''
+        #!${pkgs.runtimeShell}
+
+        exec sendmail -vt <<MAIL
+        From: root@localhost
+        To: alice@localhost
+        Subject: Very spammy!
+        X-Spam: Yes
+
+        This is spam!
+        MAIL
+      '';
+
       testImap = pkgs.writeScriptBin "test-imap" ''
         #!${pkgs.python3.interpreter}
         import imaplib
@@ -42,12 +84,32 @@ import ./make-test-python.nix {
         with imaplib.IMAP4('localhost') as imap:
           imap.login('alice', 'foobar')
           imap.select()
-          status, refs = imap.search(None, 'ALL')
+          status, data = imap.search(None, 'ALL')
           assert status == 'OK'
+          assert len(data) == 1
+          refs = data[0].split()
+          print(refs)
+          for num in refs:
+            status, msg = imap.fetch(num, 'BODY[TEXT]')
+            print(msg[0][1].decode("utf-8"))
           assert len(refs) == 1
           status, msg = imap.fetch(refs[0], 'BODY[TEXT]')
           assert status == 'OK'
           assert msg[0][1].strip() == b'Hello world!'
+
+          imap.select(mailbox='Junk')
+          status, data = imap.search(None, 'ALL')
+          assert status == 'OK'
+          assert len(data) == 1
+          refs = data[0].split()
+          print(refs)
+          for num in refs:
+            status, msg = imap.fetch(num, 'BODY[TEXT]')
+            print(msg[0][1].decode("utf-8"))
+          assert len(refs) == 1
+          status, msg = imap.fetch(refs[0], 'BODY[TEXT]')
+          assert status == 'OK'
+          assert msg[0][1].strip() == b'This is spam!'
       '';
 
       testPop = pkgs.writeScriptBin "test-pop" ''
@@ -66,15 +128,14 @@ import ./make-test-python.nix {
         finally:
           pop.quit()
       '';
-
-    in [ sendTestMail sendTestMailViaDeliveryAgent testImap testPop ];
+    in [ sendTestMail sendTestMailViaDeliveryAgent sendTestMail2 testImap testPop ];
   };
-
   testScript = ''
     machine.wait_for_unit("postfix.service")
     machine.wait_for_unit("dovecot2.service")
     machine.succeed("send-testmail")
     machine.succeed("send-lda")
+    machine.succeed("send-testmail2")
     machine.wait_until_fails('[ "$(postqueue -p)" != "Mail queue is empty" ]')
     machine.succeed("test-imap")
     machine.succeed("test-pop")

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/0001-binary-mtime.patch
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/0001-binary-mtime.patch
@@ -1,0 +1,39 @@
+From 31287bdc3487c3a710a27a3c1721bf88bfa23210 Mon Sep 17 00:00:00 2001
+From: Brian Olsen <brian@maven-group.org>
+Date: Sun, 4 Feb 2018 04:36:03 +0100
+Subject: [PATCH] When binary and script have same mtime count as up-to-date
+
+---
+ src/lib-sieve/storage/file/sieve-file-script.c | 2 +-
+ src/lib-sieve/storage/ldap/sieve-ldap-script.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib-sieve/storage/file/sieve-file-script.c b/src/lib-sieve/storage/file/sieve-file-script.c
+index 3c4ec606..27d1bd04 100644
+--- a/src/lib-sieve/storage/file/sieve-file-script.c
++++ b/src/lib-sieve/storage/file/sieve-file-script.c
+@@ -493,7 +493,7 @@ static int sieve_file_script_binary_read_metadata
+ 
+ 	if ( bstat->st_mtime < sstat->st_mtime ||
+ 		(bstat->st_mtime == sstat->st_mtime &&
+-			ST_MTIME_NSEC(*bstat) <= ST_MTIME_NSEC(*sstat)) ) {
++			ST_MTIME_NSEC(*bstat) < ST_MTIME_NSEC(*sstat)) ) {
+ 		if ( svinst->debug ) {
+ 			e_debug(script->event,
+ 				"Sieve binary `%s' is not newer "
+diff --git a/src/lib-sieve/storage/ldap/sieve-ldap-script.c b/src/lib-sieve/storage/ldap/sieve-ldap-script.c
+index 1c732db0..4a1f74ff 100644
+--- a/src/lib-sieve/storage/ldap/sieve-ldap-script.c
++++ b/src/lib-sieve/storage/ldap/sieve-ldap-script.c
+@@ -132,7 +132,7 @@ static int sieve_ldap_script_binary_read_metadata
+ 	string_t *dn, *modattr;
+ 
+ 	/* config file changed? */
+-	if ( bmtime <= lstorage->set_mtime ) {
++	if ( bmtime < lstorage->set_mtime ) {
+ 		if ( svinst->debug ) {
+ 			e_debug(script->event,
+ 				"Sieve binary `%s' is not newer "
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/compile.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/compile.nix
@@ -1,0 +1,38 @@
+{dovecot_pigeonhole, lib, writeText }:
+{ name, plugins ? [], extensions ? [], globalExtensions ? [], meta ? {}, nativeBuildInputs ? [], ... } @ args:
+with lib;
+let
+  config = writeText "buildSieveScripts-${name}-config" ''
+    plugin {
+      ${optionalString (plugins != [])
+        "sieve_plugins = ${concatStringsSep " " (map (e: "sieve_${e}") plugins)}"}
+      ${optionalString (extensions != [])
+        "sieve_extensions = ${concatStringsSep " " extensions}"}
+      ${optionalString (globalExtensions != [])
+        "sieve_global_extensions = ${concatStringsSep " " globalExtensions}"}
+    }
+  '';
+in
+
+dovecot_pigeonhole.stdenv.mkDerivation (args // {
+  inherit name;
+  nativeBuildInputs = nativeBuildInputs ++ [ dovecot_pigeonhole ];
+  installPhase = ''
+    mkdir -p "$out/sieve/"
+    for k in $(find * -name \*.sieve); do
+      mkdir -p "$out/sieve/$(dirname "$k")"
+      cp -a "$k" "$out/sieve/$k"
+      if [[ ! -L "$k" ]]; then
+        echo "Compiling $k"
+        touch -m --date=@0 "$out/sieve/$k"
+      else
+        echo "Compiling $k -> $(readlink -f "$k")"
+      fi
+      sievec -c "${config}" "$out/sieve/$k"
+    done
+  '' + (args.installPhase or "");
+
+  meta = {
+    platforms = dovecot_pigeonhole.meta.platforms or lib.platforms.all;
+  } // meta;
+})

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, dovecot, openssl }:
+{ lib, stdenv, fetchpatch, fetchurl, dovecot, openssl }:
 let
   dovecotMajorMinor = lib.versions.majorMinor dovecot.version;
 in stdenv.mkDerivation rec {
@@ -11,6 +11,11 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [ dovecot openssl ];
+
+  patches = [
+    # Fix mtime comparison so that scripts can be precompiled
+    ./0001-binary-mtime.patch
+  ];
 
   preConfigure = ''
     substituteInPlace src/managesieve/managesieve-settings.c --replace \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26343,6 +26343,7 @@ with pkgs;
   dovecot = callPackage ../servers/mail/dovecot { };
   dovecot_pigeonhole = callPackage ../servers/mail/dovecot/plugins/pigeonhole { };
   dovecot_fts_xapian = callPackage ../servers/mail/dovecot/plugins/fts_xapian { };
+  buildSieveScripts = callPackage ../servers/mail/dovecot/plugins/pigeonhole/compile.nix { };
 
   dspam = callPackage ../servers/mail/dspam { };
 


### PR DESCRIPTION
##### Motivation for this change

This PR does 4 different things in the 3 commit:

* Adds test of sieve scripts to `nixos/tests/dovecot.nix`
* Patches dovecot_pigeonhole with this change dovecot/pigeonhole#4
* Adds builder to precompile sieve scripts
* Adds more options relating to sieve scripts to dovecot2 module

###### test of sieve scripts

Before making changes to how sieve scripts were handled I thought it best that the dovecot test included some testing of the sieve script functionality.

######  Patching dovecot_pigeonhole and builder to precompile scripts

One of the changes I wanted to make was to precompile sieve scripts as part of a Nix derivation. But to do that dovecot_pigeonhole needs to be changed since when source and compiled script have same mtime it thinks that the compiled script is out of date. I have tried to upstream that change with dovecot/pigeonhole#4 but it is as of yet not merged.

The builder does its compilation in the install phase because the compiled `.svbin` files contain a reference to the full path of the source `.sieve` file and so the source needs to be in `$out` when doing the compile.

######  Sieve related options in the dovecot2 module

When precompiling sieve scripts the compiler needs a dovecot configuration that defines `sieve_plugins`, `sieve_extensions` and `sieve_global_extensions` to know which extensions and plugin functionality to allow but you can’t just use the dovecot2 config file directly because that would create a dependency cycle. So to better support precompilation I have added explicit options for these 3 things to the dovecot2 module so that I can reuse their values when precompiling.

The `sieveScripts` option followed very closely how dovecot configures global scripts and was a direct mapping from attribute name to `sieve_${attribute name}` which has some problems. E.g. if you defined `sieveScripts.after2` without defining `sieveScripts.after` your script would never be called. It also wasn’t totally clear without reading the dovecot documentation what scripts you could define.

So I have added explicit options `sieve.beforeScripts`, `sieve.defaultScript`, `sieve.afterScripts` and `sieve.discardScript` for each of the scripts you can define with `beforeScripts` and `afterScripts` being lists of paths that are automatically translated to the correct numbered dovecot configuration and with the added bonus that multiple definitions of the option are merged into one list. I have also included functionality so that existing configurations that use the `sieveScripts` option continue to work as before but now with a warning pointing to the new options.

The other place were you might use global sieve scripts and so would like to precompile the scripts is when using the `imapsieve` plugin. Before there were no options for this so I have added options for enabling and configuring `imapsieve` with support for automatic precompilation of scripts.


##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
