### PR TITLE
texpretty: init at 0.02

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -391,6 +391,7 @@
   lluchs = "Lukas Werling <lukas.werling@gmail.com>";
   lnl7 = "Daiderd Jordan <daiderd@gmail.com>";
   lo1tuma = "Mathias Schreck <schreck.mathias@gmail.com>";
+  logarytm = "Olgierd Grzyb <kontakt@olgierd.me>";
   loskutov = "Ignat Loskutov <ignat.loskutov@gmail.com>";
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   lowfatcomputing = "Andreas Wagner <andreas.wagner@lowfatcomputing.org>";

--- a/pkgs/tools/text/texpretty/default.nix
+++ b/pkgs/tools/text/texpretty/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, perl, nettools, texinfo, bison, flex
+, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "texpretty-${version}";
+  version = "0.02";
+
+  src = fetchurl {
+    sha256 = "1ixnlwz0hzqx9mync630pd5gh26mdlz1ah9mr5qjz1b0gpl0p9sm";
+    url = http://ftp.math.utah.edu/pub/texpretty/texpretty-0.02.tar.gz;
+  };
+
+  buildInputs = [ nettools perl texinfo bison flex pkgconfig ];
+
+  postUnpack = ''
+    mkdir -p $out/bin $out/man/man1
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "TeX prettyprinter";
+    homepage = http://ftp.math.utah.edu/pub/texpretty/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ logarytm ];
+
+    longDescription = ''
+      texpretty filters its TeX input from stdin, or from one or more files
+      named on the command line, and prettyprints it to stdout.  Most
+      formatting systems based on TeX, including AmSTeX, AmSLaTeX, ETeX (K.
+      Berry's Extended plain TeX), LAmSTeX, LaTeX, and SliTeX, are handled
+      reasonably well.  texpretty also includes support for the Free Software
+      Foundation's GNU Project TeXinfo, whose markup syntax resembles that of
+      scribe(1) rather than that of TeX.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4947,6 +4947,8 @@ with pkgs;
 
   texmaker = callPackage ../applications/editors/texmaker { };
 
+  texpretty = callPackage ../tools/text/texpretty { };
+
   texstudio = callPackage ../applications/editors/texstudio { };
 
   textadept = callPackage ../applications/editors/textadept { };


### PR DESCRIPTION
###### Motivation for this change

A package for `texpretty`, a TeX prettyprinter.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---