### PR TITLE
ocamlPackages.camlp5: 7.03 -> 7.05

### DIFF
--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -6,14 +6,21 @@ in
 
 stdenv.mkDerivation {
 
-  name = "camlp5${if transitional then "_transitional" else ""}-7.03";
+  name = "camlp5${if transitional then "_transitional" else ""}-7.05";
 
   src = fetchzip {
-    url = https://github.com/camlp5/camlp5/archive/rel703.tar.gz;
-    sha256 = "0bwzhp4qjypfa0x8drp8w434dfixm1nzrm6pcy9s5akpmqvb50a8";
+    url = https://github.com/camlp5/camlp5/archive/rel705.tar.gz;
+    sha256 = "16igfyjl2jja4f1mibjfzk0c2jr09nxsz6lb63x1jkccmy6430q2";
   };
 
   buildInputs = [ ocaml ];
+
+  postPatch = ''
+    for p in compile/compile.sh config/Makefile.tpl test/Makefile test/check_ocaml_versions.sh
+    do
+      substituteInPlace $p --replace '/bin/rm' rm
+    done
+  '';
 
   prefixKey = "-prefix ";
 


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

