### PR TITLE
babl: 0.1.42 -> 0.1.44

### DIFF
--- a/pkgs/development/libraries/babl/default.nix
+++ b/pkgs/development/libraries/babl/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "babl-0.1.42";
+  name = "babl-0.1.44";
 
   src = fetchurl {
     url = "http://ftp.gtk.org/pub/babl/0.1/${name}.tar.bz2";
-    sha256 = "1wc7fyj9bfqfiwf1w33g3vv3wcl18pd9cxr9fc0iy391szrsynb8";
+    sha256 = "0zfy1jrwdp4ja2f1rqa2m46vx6nilm73f72d4d1c8d65vshgsqzl";
   };
 
   doCheck = true;


### PR DESCRIPTION
Semi-automatic update. The following tests were automatically performed:

- built on NixOS
- found 0.1.44 with grep in /nix/store/wm1yfyjhfmx2030cvmvx1k5wnizdgcfc-babl-0.1.44