### PR TITLE
bandwidth: 1.4.2 -> 1.5.1

### DIFF
--- a/pkgs/tools/misc/bandwidth/default.nix
+++ b/pkgs/tools/misc/bandwidth/default.nix
@@ -11,11 +11,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "bandwidth-${version}";
-  version = "1.4.2";
+  version = "1.5.1";
 
   src = fetchurl {
     url = "http://zsmith.co/archives/${name}.tar.gz";
-    sha256 = "1p1kp5s3fdgy667q7mc9ywnps0sbj4lpr42561yhi59m69n8c3kd";
+    sha256 = "1v9k1a2ilkbhc3viyacgq88c9if60kwsd1fy6rn84317qap4i7ib";
   };
 
   buildInputs = [ nasm ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/95n2hf0qk7qb85jav2mh395jxixb5145-bandwidth-1.5.1/bin/bandwidth64 -h` got 0 exit code
- ran `/nix/store/95n2hf0qk7qb85jav2mh395jxixb5145-bandwidth-1.5.1/bin/bandwidth64 --help` got 0 exit code
- found 1.5.1 with grep in /nix/store/95n2hf0qk7qb85jav2mh395jxixb5145-bandwidth-1.5.1