### PR TITLE
imgpatchtools: init at 0.3

### DIFF
--- a/pkgs/development/mobile/imgpatchtools/default.nix
+++ b/pkgs/development/mobile/imgpatchtools/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchzip, bzip2, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "imgpatchtools-${version}";
+  version = "0.3";
+
+  src = fetchzip {
+    url = "https://github.com/erfanoabdi/imgpatchtools/archive/${version}.tar.gz";
+    sha256 = "1cwp1hfhip252dz0mbkhrsrkws6m15k359n4amw2vfnglnls8czd";
+  };
+
+  buildInputs = [ bzip2 openssl zlib ];
+
+  installPhase = "install -Dt $out/bin bin/*";
+
+  meta = with stdenv.lib; {
+    description = "Tools to manipulate Android OTA archives";
+    longDescription = ''
+      This package is useful for Android development. In particular, it can be
+      used to extract ext4 /system image from Android distribution ZIP archives
+      such as those distributed by LineageOS and Replicant, via BlockImageUpdate
+      utility. It also includes other, related, but arguably more advanced tools
+      for OTA manipulation.
+    '';
+    homepage = https://github.com/erfanoabdi/imgpatchtools;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ yegortimoshenko ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -644,6 +644,8 @@ with pkgs;
 
   glyr = callPackage ../tools/audio/glyr { };
 
+  imgpatchtools = callPackage ../development/mobile/imgpatchtools { };
+
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };
 
   pass = callPackage ../tools/security/pass { };


### PR DESCRIPTION
###### Motivation for this change

See: https://github.com/erfanoabdi/imgpatchtools

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

