### PR TITLE
nixos/opengl: unhide and document enable option

### DIFF
--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -34,10 +34,17 @@ in
 {
   options = {
     hardware.opengl.enable = mkOption {
-      description = "Whether this configuration requires OpenGL.";
+      description = ''
+        Whether to enable OpenGL drivers. This is needed to enable
+        OpenGL support in X11 systems, as well as for Wayland compositors
+        like sway, way-cooler and Weston. It is enabled by default
+        by the corresponding modules, so you do not usually have to
+        set it yourself, only if there is no module for your wayland
+        compositor of choice. See services.xserver.enable,
+        programs.sway.enable, and programs.way-cooler.enable.
+      '';
       type = types.bool;
       default = false;
-      internal = true;
     };
 
     hardware.opengl.driSupport = mkOption {


### PR DESCRIPTION
###### Motivation for this change
Some people may want to use compositors (like weston) for which no module exists. In this case, it's helpful to have this option exposed in the manual and options search.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

