### PR TITLE
bcftools: 1.6 -> 1.7

### DIFF
--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "bcftools";
-  version = "1.6";
+  version = "1.7";
 
   src = fetchurl {
     url = "https://github.com/samtools/bcftools/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "10prgmf09a13mk18840938ijqgfc9y92hfc7sa2gcv07ddri0c19";
+    sha256 = "1l82sgw86l1626b7kxv3h0696lbj7317bb48rvqb1zqd3gcn6kyx";
   };
 
   nativeBuildInputs = [ perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools -h` got 0 exit code
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools --help` got 0 exit code
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools help` got 0 exit code
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools -v` and found version 1.7
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools --version` and found version 1.7
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools version` and found version 1.7
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools -h` and found version 1.7
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools --help` and found version 1.7
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/bcftools help` and found version 1.7
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/plot-vcfstats -h` got 0 exit code
- ran `/nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7/bin/plot-vcfstats --help` got 0 exit code
- found 1.7 with grep in /nix/store/5yasri83ahcvhx06dv92fpzmxay9c833-bcftools-1.7