### PR TITLE
biboumi: 6.1 -> 7.2

### DIFF
--- a/pkgs/servers/xmpp/biboumi/default.nix
+++ b/pkgs/servers/xmpp/biboumi/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "biboumi-${version}";
-  version = "6.1";
+  version = "7.2";
 
   src = fetchurl {
     url = "https://git.louiz.org/biboumi/snapshot/biboumi-${version}.tar.xz";
-    sha256 = "1la1n502v2wyfm0vl8v4m0hbigkkjchi21446n9mb203fz1cvr77";
+    sha256 = "0gyr2lp2imrjm5hvijcq0s7k9fzkirfl70cprjy9r4yvq6mg1jvd";
   };
 
   louiz_catch = fetchgit {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/d4rnh4qnwvfxx48nnjvgb928pjy600f5-biboumi-7.2/bin/biboumi --help` got 0 exit code
- found 7.2 with grep in /nix/store/d4rnh4qnwvfxx48nnjvgb928pjy600f5-biboumi-7.2
