### PR TITLE
dhall: passthru dhall prelude

### DIFF
--- a/pkgs/development/interpreters/dhall/default.nix
+++ b/pkgs/development/interpreters/dhall/default.nix
@@ -1,0 +1,18 @@
+{ haskell, haskellPackages, stdenvNoCC }:
+
+let
+  static = haskell.lib.justStaticExecutables haskellPackages.dhall;
+
+in static.overrideAttrs (old: {
+  passthru = old.passthru or {} // {
+    prelude = stdenvNoCC.mkDerivation {
+      name = "dhall-prelude";
+      inherit (old) src;
+      phases = [ "unpackPhase" "installPhase" ];
+      installPhase = ''
+        mkdir $out
+        cp -r Prelude/* $out/
+      '';
+    };
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6817,7 +6817,7 @@ with pkgs;
 
   clooj = callPackage ../development/interpreters/clojure/clooj.nix { };
 
-  dhall = haskell.lib.justStaticExecutables haskellPackages.dhall;
+  dhall = callPackage ../development/interpreters/dhall { };
 
   dhall-nix = haskell.lib.justStaticExecutables haskellPackages.dhall-nix;
 


### PR DESCRIPTION
Makes it possible to reference `dhall.prelude`, the same version that comes with
the dhall exetutable’s source code.

cc @Gabriel439 @ocharles 