### PR TITLE
binaryen: 42 -> 44

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -1,14 +1,14 @@
 { stdenv, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "42";
+  version = "44";
   rev = "version_${version}";
   name = "binaryen-${version}";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "binaryen";
-    sha256 = "0b8qc9cd7ncshgfjwv4hfapmwa81gmniaycnxmdkihq9bpm26x2k";
+    sha256 = "0zsqppc05fm62807w6vyccxkk2y2gar7kxbxxixq8zz3xsp6w84p";
     inherit rev;
   };
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-shell -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-shell --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-opt -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-opt --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-merge -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-merge --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-metadce -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-metadce --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/asm2wasm -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/asm2wasm --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm2asm -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm2asm --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/s2wasm -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/s2wasm --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-emscripten-finalize -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-emscripten-finalize --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-as -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-as --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-dis -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-dis --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-ctor-eval -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-ctor-eval --help` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-reduce -h` got 0 exit code
- ran `/nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44/bin/wasm-reduce --help` got 0 exit code
- found 44 with grep in /nix/store/1vkah592g2qsd97hnx0g9w7sgayf8zwv-binaryen-44
