### PR TITLE
blas: 3.7.1 -> 3.8.0

### DIFF
--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "blas-${version}";
-  version = "3.7.1";
+  version = "3.8.0";
 
   src = fetchurl {
     url = "http://www.netlib.org/blas/${name}.tgz";
-    sha256 = "1hvmwp488hd6sdxdbmhjhmyrrd4s1ds1cjzh5d86l10b3wsm99n5";
+    sha256 = "1s24iry5197pskml4iygasw196bdhplj0jmbsb9jhabcjqj2mpsm";
   };
 
   buildInputs = [ gfortran ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.8.0 in filename of file in /nix/store/6j28cb5b114fxj7x7wpwv8mdbiqxq1fj-blas-3.8.0