### PR TITLE
blktrace: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/os-specific/linux/blktrace/default.nix
+++ b/pkgs/os-specific/linux/blktrace/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, libaio }:
 
 stdenv.mkDerivation {
-  name = "blktrace-1.1.0";
+  name = "blktrace-1.2.0";
 
   # Official source
   # "git://git.kernel.org/pub/scm/linux/kernel/git/axboe/blktrace.git"
   src = fetchurl {
-    url = "http://brick.kernel.dk/snaps/blktrace-1.1.0.tar.bz2";
-    sha256 = "15cj9aki7z5i5y6bnchqry6yp40r4lmgmam6ar5gslnx0smgm8jl";
+    url = "http://brick.kernel.dk/snaps/blktrace-1.2.0.tar.bz2";
+    sha256 = "0i9z7ayh9qx4wi0ihyz15bhr1c9aknjl8v5i8c9mx3rhyy41i5i6";
   };
 
   buildInputs = [ libaio ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/blkparse -V` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/blkparse --version` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/blktrace -V` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/blktrace -v` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/blktrace --version` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/blkiomon -V` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/blkiomon --version` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btrace help` got 0 exit code
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btt -h` got 0 exit code
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btt --help` got 0 exit code
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btt -V` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btt --version` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btt -h` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btt --help` and found version 1.2.0
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btrecord -h` got 0 exit code
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btrecord --help` got 0 exit code
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btreplay -h` got 0 exit code
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/btreplay --help` got 0 exit code
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/bno_plot.py -h` got 0 exit code
- ran `/nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0/bin/bno_plot.py --help` got 0 exit code
- found 1.2.0 with grep in /nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0
- found 1.2.0 in filename of file in /nix/store/11v1yxf5d2xiw62d99bbbsv5qhwyjair-blktrace-1.2.0