### PR TITLE
bindfs: 1.12.6 -> 1.13.9

### DIFF
--- a/pkgs/tools/filesystems/bindfs/default.nix
+++ b/pkgs/tools/filesystems/bindfs/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, fuse, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "1.12.6";
+  version = "1.13.9";
   name    = "bindfs-${version}";
 
   src = fetchurl {
     url    = "http://bindfs.org/downloads/${name}.tar.gz";
-    sha256 = "0s90n1n4rvpcg51ixr5wx8ixml1xnc7w28xlbnms34v19pzghm59";
+    sha256 = "1dgqjq2plpds442ygpv8czr5v199ljscp33m89y19x04ssljrymc";
   };
 
   dontStrip = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/56lvl3w77zgwsk1v618bklq10aq7fp17-bindfs-1.13.9/bin/bindfs -h` got 0 exit code
- ran `/nix/store/56lvl3w77zgwsk1v618bklq10aq7fp17-bindfs-1.13.9/bin/bindfs --help` got 0 exit code
- ran `/nix/store/56lvl3w77zgwsk1v618bklq10aq7fp17-bindfs-1.13.9/bin/bindfs -V` and found version 1.13.9
- ran `/nix/store/56lvl3w77zgwsk1v618bklq10aq7fp17-bindfs-1.13.9/bin/bindfs --version` and found version 1.13.9
- found 1.13.9 with grep in /nix/store/56lvl3w77zgwsk1v618bklq10aq7fp17-bindfs-1.13.9