### PR TITLE
qemu: add optional virglrenderer and opengl support

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -10,6 +10,8 @@
 , sdlSupport ? !stdenv.isDarwin, SDL
 , vncSupport ? true, libjpeg, libpng
 , spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
+, virglrendererSupport ? false, virglrenderer
+, openglSupport ? virglrendererSupport, mesa_noglu, libdrm, epoxy
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
 , hostCpuOnly ? false
@@ -55,6 +57,8 @@ stdenv.mkDerivation rec {
     ++ optionals sdlSupport [ SDL ]
     ++ optionals vncSupport [ libjpeg libpng ]
     ++ optionals spiceSupport [ spice-protocol spice ]
+    ++ optionals virglrendererSupport [ virglrenderer ]
+    ++ optionals openglSupport [ mesa_noglu libdrm epoxy ]
     ++ optionals usbredirSupport [ usbredir ]
     ++ optionals stdenv.isLinux [ alsaLib libaio libcap_ng libcap attr ]
     ++ optionals xenSupport [ xen ];
@@ -80,6 +84,8 @@ stdenv.mkDerivation rec {
     ++ optional numaSupport "--enable-numa"
     ++ optional seccompSupport "--enable-seccomp"
     ++ optional spiceSupport "--enable-spice"
+    ++ optional virglrendererSupport "--enable-virglrenderer"
+    ++ optional openglSupport "--enable-opengl"
     ++ optional usbredirSupport "--enable-usb-redir"
     ++ optional hostCpuOnly "--target-list=${hostCpuTargets}"
     ++ optional stdenv.isDarwin "--enable-cocoa"

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -10,7 +10,7 @@
 , sdlSupport ? !stdenv.isDarwin, SDL
 , vncSupport ? true, libjpeg, libpng
 , spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
-, virglrendererSupport ? false, virglrenderer
+, virglrendererSupport ? false, virglrenderer ? null
 , openglSupport ? virglrendererSupport, mesa_noglu, libdrm, epoxy
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen


### PR DESCRIPTION
###### Motivation for this change

new build options `virglrendererSupport` and `openglSupport` to enable 3d accelerated virtio graphics for qemu guests. Both options are disabled by default for now (closure size).

virglrendererSupport depends on #35226 to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

