### PR TITLE
boolstuff: 0.1.15 -> 0.1.16

### DIFF
--- a/pkgs/development/libraries/boolstuff/default.nix
+++ b/pkgs/development/libraries/boolstuff/default.nix
@@ -3,11 +3,11 @@
 let baseurl = "https://perso.b2b2c.ca/~sarrazip/dev"; in
 
 stdenv.mkDerivation rec {
-  name = "boolstuff-0.1.15";
+  name = "boolstuff-0.1.16";
 
   src = fetchurl {
     url = "${baseurl}/${name}.tar.gz";
-    sha256 = "1mzw4368hqw0b6xr01yqcbs9jk9ma3qq9hk3iqxmkiwqqxgirgln";
+    sha256 = "10qynbyw723gz2vrvn4xk2var172kvhlz3l3l80qbdsfb3d12wn0";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ji68d52l18c35b8j96naan8ippmm4zqw-boolstuff-0.1.16/bin/booldnf --help` got 0 exit code
- ran `/nix/store/ji68d52l18c35b8j96naan8ippmm4zqw-boolstuff-0.1.16/bin/booldnf --help` and found version 0.1.16
- found 0.1.16 with grep in /nix/store/ji68d52l18c35b8j96naan8ippmm4zqw-boolstuff-0.1.16
- found 0.1.16 in filename of file in /nix/store/ji68d52l18c35b8j96naan8ippmm4zqw-boolstuff-0.1.16