### PR TITLE
nodejs: ship with development headers

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -26,6 +26,11 @@ let
      */
   ]) (builtins.attrNames sharedLibDeps);
 
+  copyLibHeaders =
+    map
+      (name: "${getDev sharedLibDeps.${name}}/include/*")
+      (builtins.attrNames sharedLibDeps);
+
   extraConfigFlags = optionals (!enableNpm) [ "--without-npm" ];
 in
 
@@ -74,6 +79,9 @@ in
         mkdir -p $out/share/bash-completion/completions/
         $out/bin/npm completion > $out/share/bash-completion/completions/npm
       ''}
+
+      # install the missing headers for node-gyp
+      cp -r ${concatStringsSep " " copyLibHeaders} $out/include/node
     '';
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

the headers are used by node-gyp to build C extensions and need to match
the exact node version that is going to be used at runtime.

This allows to install the headers in other node build environment like yarn2nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

