### PR TITLE
diceware: init at 0.9.3

### DIFF
--- a/pkgs/tools/security/diceware/default.nix
+++ b/pkgs/tools/security/diceware/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, pythonPackages
+, fetchpatch
+}:
+
+with pythonPackages;
+
+buildPythonApplication rec {
+  pname = "diceware";
+  version = "0.9.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0p09q6945qvdmvckjl8rfqx0g8nf6igc3c6rab6v74k9bsmbf15p";
+  };
+
+  nativeBuildInputs = [ pytestrunner ];
+
+  checkInputs = [ pytest ];
+
+  # NOTE: remove once 0.9.4 is released
+  patches = [
+    (fetchpatch {
+      url = "${meta.homepage}/commit/86379bf49ade2b486071d6d330515f01ecb06ab4.patch";
+      sha256 = "0nxvxiqvxfsa9y6zwy9k7shsd0fk92psdzi4klqwd4wy3lbmw8di";
+    })
+    (fetchpatch {
+      url = "${meta.homepage}/commit/a7d844df76cd4b95a717f21ef5aa6167477b6733.patch";
+      sha256 = "0ab4fc2pbl2hcxqw5rr6awbhlnmdna6igqjijywwr1byzb7ga4iq";
+    })
+  ];
+
+  # see https://github.com/ulif/diceware/commit/a7d844df76cd4b95a717f21ef5aa6167477b6733
+  checkPhase = ''
+    py.test -m 'not packaging'
+  '';
+
+  meta = with lib; {
+    description = "Generates passphrases by concatenating words randomly picked from wordlists";
+    homepage = https://github.com/ulif/diceware;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ asymmetric ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20817,4 +20817,6 @@ with pkgs;
   safeDiscardStringContext = callPackage ../build-support/safe-discard-string-context.nix { };
 
   simplehttp2server = callPackage ../servers/simplehttp2server { };
+
+  diceware = callPackage ../tools/security/diceware { };
 }


### PR DESCRIPTION
###### Motivation for this change

Add package diceware

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

