### PR TITLE
brltty: 5.5 -> 5.6

### DIFF
--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -4,11 +4,11 @@ assert alsaSupport -> alsaLib != null;
 assert systemdSupport -> systemd != null;
 
 stdenv.mkDerivation rec {
-  name = "brltty-5.5";
+  name = "brltty-5.6";
 
   src = fetchurl {
     url = "http://brltty.com/archive/${name}.tar.gz";
-    sha256 = "0slrqanwj9cm7ql0rpb296xq676zrc1sjyr13lh5lygp4b8qfpci";
+    sha256 = "06by51n35w0jq14w1vimxk3ssrlmiiw49wpxw29rasc106mpysfn";
   };
 
   nativeBuildInputs = [ pkgconfig python3.pkgs.cython ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-ctb -h` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-ctb --help` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty -h` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty --help` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty help` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty -V` and found version 5.6
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty -v` and found version 5.6
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty --version` and found version 5.6
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty version` and found version 5.6
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty -h` and found version 5.6
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty --help` and found version 5.6
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty help` and found version 5.6
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-trtxt -h` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-trtxt --help` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-ttb -h` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-ttb --help` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-atb -h` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-atb --help` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-ktb -h` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-ktb --help` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-tune -h` got 0 exit code
- ran `/nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6/bin/brltty-tune --help` got 0 exit code
- found 5.6 with grep in /nix/store/4zz86z1wi6k5nny7wiyqngpm8d94k9r7-brltty-5.6