### PR TITLE
skrooge: do not build designer library, switch to qtwebengine

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchurl,
-  cmake, extra-cmake-modules, qtwebkit, qtscript, grantlee,
+  cmake, extra-cmake-modules, qtwebengine, qtscript, grantlee,
   kxmlgui, kwallet, kparts, kdoctools, kjobwidgets, kdesignerplugin,
   kiconthemes, knewstuff, sqlcipher, qca-qt5, kactivities, karchive,
   kguiaddons, knotifyconfig, krunner, kwindowsystem, libofx, shared-mime-info
@@ -19,7 +19,7 @@ mkDerivation rec {
   ];
 
   buildInputs = [
-    qtwebkit qtscript grantlee kxmlgui kwallet kparts
+    qtwebengine qtscript grantlee kxmlgui kwallet kparts
     kjobwidgets kdesignerplugin kiconthemes knewstuff sqlcipher qca-qt5
     kactivities karchive kguiaddons knotifyconfig krunner kwindowsystem libofx
   ];
@@ -29,6 +29,7 @@ mkDerivation rec {
   # Source: https://forum.kde.org/viewtopic.php?f=210&t=143375#p393675
   cmakeFlags = [
     "-DSKG_DESIGNER=OFF"
+    "-DSKG_WEBENGINE=ON"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -24,6 +24,13 @@ mkDerivation rec {
     kactivities karchive kguiaddons knotifyconfig krunner kwindowsystem libofx
   ];
 
+  # SKG_DESIGNER must be used to generate the needed library for QtDesigner.
+  # This is needed ONLY for developers. So NOT NEEDED for end user.
+  # Source: https://forum.kde.org/viewtopic.php?f=210&t=143375#p393675
+  cmakeFlags = [
+    "-DSKG_DESIGNER=OFF"
+  ];
+
   meta = with lib; {
     description = "A personal finances manager, powered by KDE";
     license = with licenses; [ gpl3 ];


### PR DESCRIPTION
###### Motivation for this change

* Disable a designer's library
* Switch from qtwebkit to qtwebengine

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

