### PR TITLE
bro: 2.5.2 -> 2.5.3

### DIFF
--- a/pkgs/applications/networking/ids/bro/default.nix
+++ b/pkgs/applications/networking/ids/bro/default.nix
@@ -2,11 +2,11 @@
 , geoip, gperftools, python, swig }:
 
 stdenv.mkDerivation rec {
-  name = "bro-2.5.2";
+  name = "bro-2.5.3";
 
   src = fetchurl {
     url = "http://www.bro.org/downloads/${name}.tar.gz";
-    sha256 = "0w5rynw278nl6pdl5s7gsmxjwkl6z1g5pcm6byg930k26yyb35db";
+    sha256 = "09b227j1c0ggihbhbyphd7lnh26mpz07z1s0h148dg6fwqagm13k";
   };
 
   nativeBuildInputs = [ cmake flex bison file ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/l58hq30xhskjp4cvqpjjdxzjqi9q21wi-bro-2.5.3/bin/bro-config --version` and found version 2.5.3
- ran `/nix/store/l58hq30xhskjp4cvqpjjdxzjqi9q21wi-bro-2.5.3/bin/binpac -V` and found version 2.5.3
- ran `/nix/store/l58hq30xhskjp4cvqpjjdxzjqi9q21wi-bro-2.5.3/bin/binpac -v` and found version 2.5.3
- ran `/nix/store/l58hq30xhskjp4cvqpjjdxzjqi9q21wi-bro-2.5.3/bin/binpac --version` and found version 2.5.3
- ran `/nix/store/l58hq30xhskjp4cvqpjjdxzjqi9q21wi-bro-2.5.3/bin/bro -v` and found version 2.5.3
- ran `/nix/store/l58hq30xhskjp4cvqpjjdxzjqi9q21wi-bro-2.5.3/bin/bro --version` and found version 2.5.3
- found 2.5.3 with grep in /nix/store/l58hq30xhskjp4cvqpjjdxzjqi9q21wi-bro-2.5.3
- found 2.5.3 in filename of file in /nix/store/l58hq30xhskjp4cvqpjjdxzjqi9q21wi-bro-2.5.3