### PR TITLE
browserpass: 2.0.10 -> 2.0.11

### DIFF
--- a/pkgs/tools/security/browserpass/default.nix
+++ b/pkgs/tools/security/browserpass/default.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "browserpass-${version}";
-  version = "2.0.10";
+  version = "2.0.11";
 
   goPackagePath = "github.com/dannyvankooten/browserpass";
 
@@ -13,7 +13,7 @@ buildGoPackage rec {
     repo = "browserpass";
     owner = "dannyvankooten";
     rev = version;
-    sha256 = "0clkalw2wz2zs0p5hsq57iqp2bdp7y17zf5l2d0y7xfddff9sd82";
+    sha256 = "0d6rpkka27a57nv69yiw71jj3m6axdj5hygsz36dznnn8w76vvyv";
   };
 
   postInstall = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.0.11 with grep in /nix/store/9kvlg1r91rvdqmvjlva1jwk2znsbj5l3-browserpass-2.0.11-bin
- found 2.0.11 in filename of file in /nix/store/9kvlg1r91rvdqmvjlva1jwk2znsbj5l3-browserpass-2.0.11-bin