### PR TITLE
buildah: 0.11 -> 0.12

### DIFF
--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -3,13 +3,13 @@
 , go-md2man }:
 
 let
-  version = "0.11";
+  version = "0.12";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "projectatomic";
     repo = "buildah";
-    sha256 = "0rq3dw6p9rcqc99jk93j0qwg1p8fh4pwqvzylcqlcyqhv46426zf";
+    sha256 = "0xyq7rv0lj6bxwh2rnf44w9gjcqbdkfcdff88023b9vlsc8h4k0m";
   };
   goPackagePath = "github.com/projectatomic/buildah";
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin/bin/buildah -h` got 0 exit code
- ran `/nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin/bin/buildah --help` got 0 exit code
- ran `/nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin/bin/buildah help` got 0 exit code
- ran `/nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin/bin/buildah -v` and found version 0.12
- ran `/nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin/bin/buildah --version` and found version 0.12
- ran `/nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin/bin/buildah -h` and found version 0.12
- ran `/nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin/bin/buildah --help` and found version 0.12
- ran `/nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin/bin/buildah help` and found version 0.12
- found 0.12 with grep in /nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin
- found 0.12 in filename of file in /nix/store/1by5s8x42fdb4xfz61h8a48dfw9vbdkp-buildah-0.12-bin