### PR TITLE
caddy: 0.10.10 -> 0.10.11

### DIFF
--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "caddy-${version}";
-  version = "0.10.10";
+  version = "0.10.11";
 
   goPackagePath = "github.com/mholt/caddy";
 
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "mholt";
     repo = "caddy";
     rev = "v${version}";
-    sha256 = "1x7f1yz5vnsy9n50ak0vjrm4w8fqc1qvhv8fmqnsc8cgbp7f3p8w";
+    sha256 = "04ls0s79dsyxnrpra55qvl0dk9nyvps59l034326r3bzk4jhb3q6";
   };
 
   buildFlagsArray = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/fak10szh33cyf8wf70m9wg4gp23jqzbq-caddy-0.10.11-bin/bin/caddy --version` and found version 0.10.11
- found 0.10.11 with grep in /nix/store/fak10szh33cyf8wf70m9wg4gp23jqzbq-caddy-0.10.11-bin
- found 0.10.11 in filename of file in /nix/store/fak10szh33cyf8wf70m9wg4gp23jqzbq-caddy-0.10.11-bin