### PR TITLE
buildLuaPackage: propagate modules paths with a setupHook

### DIFF
--- a/pkgs/development/lua-modules/generic/default.nix
+++ b/pkgs/development/lua-modules/generic/default.nix
@@ -1,4 +1,4 @@
-lua:
+{ lua, writeText }:
 
 { buildInputs ? [], disabled ? false, ... } @ attrs:
 
@@ -19,5 +19,36 @@ else
     {
       name = "lua${lua.luaversion}-" + attrs.name;
       buildInputs = buildInputs ++ [ lua ];
+
+      setupHook = writeText "setup-hook.sh" ''
+        # check for lua/clua modules and don't add duplicates
+
+        addLuaLibPath() {
+          local package_path="$1/share/lua/${lua.luaversion}"
+          if [[ ! -d $package_path ]]; then return; fi
+          if [[ $LUA_PATH = *"$package_path"* ]]; then return; fi
+
+          if [[ -z $LUA_PATH ]]; then
+            export LUA_PATH="$package_path/?.lua"
+          else
+            export LUA_PATH="$LUA_PATH;$package_path/?.lua"
+          fi
+        }
+
+        addLuaLibCPath() {
+          local package_cpath="$1/lib/lua/${lua.luaversion}"
+          if [[ ! -d $package_cpath ]]; then return; fi
+          if [[ $LUA_CPATH = *"$package_cpath"* ]]; then return; fi
+
+          if [[ -z $LUA_CPATH ]]; then
+            export LUA_CPATH="$package_cpath/?.so"
+          else
+            export LUA_CPATH="$LUA_CPATH;$package_cpath/?.so"
+          fi
+        }
+
+        addEnvHooks "$hostOffset" addLuaLibPath
+        addEnvHooks "$hostOffset" addLuaLibCPath
+      '';
     }
   )

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -9,7 +9,7 @@
 , pcre, oniguruma, gnulib, tre, glibc, sqlite, openssl, expat, cairo
 , perl, gtk2, python, glib, gobjectIntrospection, libevent, zlib, autoreconfHook
 , mysql, postgresql, cyrus_sasl
-, fetchFromGitHub, libmpack, which, fetchpatch
+, fetchFromGitHub, libmpack, which, fetchpatch, writeText
 }:
 
 let
@@ -35,7 +35,9 @@ let
   getLuaCPath   = lib : getPath lib "so";
 
   #define build lua package function
-  buildLuaPackage = callPackage ../development/lua-modules/generic lua;
+  buildLuaPackage = callPackage ../development/lua-modules/generic {
+    inherit lua writeText;
+  };
 
   luarocks = callPackage ../development/tools/misc/luarocks {
     inherit lua;


### PR DESCRIPTION
Solves #25830, thanks @orbekk for inspiration with #25846

###### Motivation for this change

Tried to use few lua modules with my project with nix-shell, then I hit #25830. Modules are "useless" without proper export paths. 

This patch solves exporting properly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

