### PR TITLE
btrfs-progs: 4.14.1 -> 4.15.1

### DIFF
--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -2,14 +2,14 @@
 , asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, libxslt, zstd
 }:
 
-let version = "4.14.1"; in
+let version = "4.15.1"; in
 
 stdenv.mkDerivation rec {
   name = "btrfs-progs-${version}";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v${version}.tar.xz";
-    sha256 = "1palnddw3d50kyflwk1j4xapbc6jniid6j5i9dsr8l8a7nkv7ich";
+    sha256 = "15izak6jg6pqr6ha9447cdrdj9k6kfiarvwlrj53cpvrsv02l437";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfs --help` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfs help` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfs --version` and found version 4.15.1
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfs version` and found version 4.15.1
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/mkfs.btrfs --help` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/mkfs.btrfs -V` and found version 4.15.1
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/mkfs.btrfs --version` and found version 4.15.1
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfs-debug-tree help` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfs-image --help` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfs-find-root --help` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfstune --help` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/btrfs-convert --help` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/fsck.btrfs -h` got 0 exit code
- ran `/nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1/bin/fsck.btrfs --help` got 0 exit code
- found 4.15.1 with grep in /nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1
- found 4.15.1 in filename of file in /nix/store/23glaba4yda3cyjixsxni52i2grvi799-btrfs-progs-4.15.1
