### PR TITLE
cbc: 2.9.5 -> 2.9.9

### DIFF
--- a/pkgs/applications/science/math/cbc/default.nix
+++ b/pkgs/applications/science/math/cbc/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, zlib, bzip2 }:
 
 stdenv.mkDerivation {
-  name = "cbc-2.9.5";
+  name = "cbc-2.9.9";
 
   src = fetchurl {
-    url = "http://www.coin-or.org/download/source/Cbc/Cbc-2.9.5.tgz";
-    sha256 = "0kmsg9qpajh5jhnql04m6akpdjzlppxfz99q320vw5bkzgl3i18w";
+    url = "http://www.coin-or.org/download/source/Cbc/Cbc-2.9.9.tgz";
+    sha256 = "1w8axdzm05xf5y13c31w7rc5z6ywxqxiwafnxcq3p195kgj0915a";
   };
 
   configureFlags = "-C";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/7q93md698w3bnl212mk38rq2l6k7wav6-cbc-2.9.9/bin/clp help` got 0 exit code
- ran `/nix/store/7q93md698w3bnl212mk38rq2l6k7wav6-cbc-2.9.9/bin/clp version` and found version 2.9.9
- ran `/nix/store/7q93md698w3bnl212mk38rq2l6k7wav6-cbc-2.9.9/bin/clp help` and found version 2.9.9
- ran `/nix/store/7q93md698w3bnl212mk38rq2l6k7wav6-cbc-2.9.9/bin/cbc help` got 0 exit code
- ran `/nix/store/7q93md698w3bnl212mk38rq2l6k7wav6-cbc-2.9.9/bin/cbc version` and found version 2.9.9
- ran `/nix/store/7q93md698w3bnl212mk38rq2l6k7wav6-cbc-2.9.9/bin/cbc help` and found version 2.9.9
- found 2.9.9 with grep in /nix/store/7q93md698w3bnl212mk38rq2l6k7wav6-cbc-2.9.9
- found 2.9.9 in filename of file in /nix/store/7q93md698w3bnl212mk38rq2l6k7wav6-cbc-2.9.9