### PR TITLE
opensm: init at 3.3.20

### DIFF
--- a/pkgs/tools/networking/opensm/default.nix
+++ b/pkgs/tools/networking/opensm/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit, autoconf, automake, libtool, bison, flex, rdma-core }:
+
+stdenv.mkDerivation rec {
+  name = "opensm-${version}";
+  version = "3.3.20";
+
+  src = fetchgit {
+    url = git://git.openfabrics.org/~halr/opensm.git;
+    rev = name;
+    sha256 = "1hlrn5z32yd4w8bj4z6bsfv84pk178s4rnppbabyjqv1rg3c58wl";
+  };
+
+  nativeBuildInputs = [ autoconf automake libtool bison flex ];
+
+  buildInputs = [ rdma-core ];
+
+  preConfigure = "bash ./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "Infiniband subnet manager";
+    homepage = https://www.openfabrics.org/;
+    license = licenses.gpl2; # dual licensed as 2-clause BSD
+    maintainers = [ maintainers.aij ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3960,6 +3960,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
+  opensm = callPackage ../tools/networking/opensm { };
+
   openssh =
     callPackage ../tools/networking/openssh {
       hpnSupport = false;


### PR DESCRIPTION
###### Motivation for this change

Need a subnet manager for an InfiniBand network.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] (N/A) Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] (N/A) Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

