### PR TITLE
cfdg: 3.0.2 -> 3.0.9

### DIFF
--- a/pkgs/tools/graphics/cfdg/default.nix
+++ b/pkgs/tools/graphics/cfdg/default.nix
@@ -2,9 +2,9 @@
 
 stdenv.mkDerivation rec {
   name = "cfdg-${version}";
-  version = "3.0.2";
+  version = "3.0.9";
   src = fetchurl {
-    sha256 = "1pd1hjippbhad8l4s4lsglykh22i24qfrgmnxrsx71bvcqbr356p";
+    sha256 = "1jqpinz6ri4a2l04mf2z1ljalkdk1m07hj47lqkh8gbf2slfs0jl";
     url = "http://www.contextfreeart.org/download/ContextFreeSource${version}.tgz";
   };
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.0.9 with grep in /nix/store/b7l7794afvg9xgymkd6c3lwk5r4qnahc-cfdg-3.0.9
- found 3.0.9 in filename of file in /nix/store/b7l7794afvg9xgymkd6c3lwk5r4qnahc-cfdg-3.0.9