### PR TITLE
certstrap: 1.0.1 -> 1.1.1

### DIFF
--- a/pkgs/tools/security/certstrap/default.nix
+++ b/pkgs/tools/security/certstrap/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "certstrap-${version}";
-  version = "1.0.1";
+  version = "1.1.1";
 
   goPackagePath = "github.com/square/certstrap";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "square";
     repo = "certstrap";
     rev = "v${version}";
-    sha256 = "0pw1g6nyb212ayic42rkm6i0cf4n2003f02qym6zp130m6aysb47";
+    sha256 = "0j7gi2nzykny7i0gjax9vixw72l9jcm4wnwxgm72hh1pji0ysa8n";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin/bin/certstrap -h` got 0 exit code
- ran `/nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin/bin/certstrap --help` got 0 exit code
- ran `/nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin/bin/certstrap help` got 0 exit code
- ran `/nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin/bin/certstrap -v` and found version 1.1.1
- ran `/nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin/bin/certstrap --version` and found version 1.1.1
- ran `/nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin/bin/certstrap -h` and found version 1.1.1
- ran `/nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin/bin/certstrap --help` and found version 1.1.1
- ran `/nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin/bin/certstrap help` and found version 1.1.1
- found 1.1.1 with grep in /nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin
- found 1.1.1 in filename of file in /nix/store/ysm8fw6liwvqvnwk4yds5xz5md7vi42y-certstrap-1.1.1-bin