### PR TITLE
Pyarrow

### DIFF
--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "flatbuffers-${version}";
-  version = "1.4.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "flatbuffers";
     rev = "v${version}";
-    sha256 = "0jsqk49h521d5h4c9gk39a8968g6rcd6520a8knbfc7ssc4028y0";
+    sha256 = "1qq8qbv8wkiiizj8s984f17bsbjsrhbs9q1nw1yjgrw0grcxlsi9";
   };
 
   buildInputs = [ cmake ];

--- a/pkgs/development/libraries/rapidjson/default.nix
+++ b/pkgs/development/libraries/rapidjson/default.nix
@@ -1,15 +1,20 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake }:
+{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "rapidjson-${version}";
   version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "miloyip";
+    owner = "Tencent";
     repo = "rapidjson";
     rev = "v${version}";
     sha256 = "1jixgb8w97l9gdh3inihz7avz7i770gy2j2irvvlyrq3wi41f5ab";
   };
+
+  # Fix gcc 7 and later warnings until new release of rapidjson.
+  patches = [
+    ./disable-implicit-warnings.patch
+  ];
 
   nativeBuildInputs = [ pkgconfig cmake ];
 

--- a/pkgs/development/libraries/rapidjson/disable-implicit-warnings.patch
+++ b/pkgs/development/libraries/rapidjson/disable-implicit-warnings.patch
@@ -1,0 +1,22 @@
+commit e3c3cd3bd5b8feae804ae15d97744774ef301cbb
+Author: Tom Hunger <tehunger@gmail.com>
+Date:   Sun Feb 25 22:26:38 2018 +0000
+
+    bla
+
+diff --git a/include/rapidjson/internal/regex.h b/include/rapidjson/internal/regex.h
+index 422a5240..d24d513c 100644
+--- a/include/rapidjson/internal/regex.h
++++ b/include/rapidjson/internal/regex.h
+@@ -40,6 +40,11 @@ RAPIDJSON_DIAG_OFF(4512) // assignment operator could not be generated
+ #define RAPIDJSON_REGEX_VERBOSE 0
+ #endif
+ 
++#if __GNUC__ >= 7
++RAPIDJSON_DIAG_PUSH
++RAPIDJSON_DIAG_OFF(implicit-fallthrough)
++#endif
++
+ RAPIDJSON_NAMESPACE_BEGIN
+ namespace internal {
+ 

--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake, withStatic ? false }:
 
 stdenv.mkDerivation rec {
   name = "snappy-${version}";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" "-DCMAKE_SKIP_BUILD_RPATH=OFF" ] ++ (if withStatic then ["-DBUILD_SHARED_LIBS=OFF"] else []);
 
   checkTarget = "test";
 

--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, boost, zlib, libevent, openssl, python, pkgconfig, bison
-, flex, twisted
+, flex, twisted, cmake, withStatic ? false
 }:
 
 stdenv.mkDerivation rec {
   name = "thrift-${version}";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchurl {
     url = "http://archive.apache.org/dist/thrift/${version}/${name}.tar.gz";
-    sha256 = "02x1xw0l669idkn6xww39j60kqxzcbmim4mvpb5h9nz8wqnx1292";
+    sha256 = "1hk0zb9289gf920rdl0clmwqx6kvygz92nj01lqrhd2arfv3ibf4";
   };
 
   #enableParallelBuilding = true; problems on hydra
@@ -17,16 +17,22 @@ stdenv.mkDerivation rec {
   # pythonFull.buildEnv.override { extraLibs = [ thrift ]; }
   pythonPath = [];
 
+  cmakeFlags = [
+    "-DBUILD_TESTING=OFF"
+    "-DBUILD_EXAMPLES=OFF"
+    "-DBUILD_TUTORIALS=OFF"
+    "-DWITH_SHARED_LIB=ON"
+  ] ++ stdenv.lib.optional withStatic [ "-DWITH_STATIC_LIB=ON" ];
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    boost zlib libevent openssl python bison flex twisted
+    boost zlib libevent openssl python bison flex twisted cmake
   ];
 
   preConfigure = "export PY_PREFIX=$out";
 
   # TODO: package boost-test, so we can run the test suite. (Currently it fails
   # to find libboost_unit_test_framework.a.)
-  configureFlags = "--enable-tests=no";
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,0 +1,119 @@
+{ stdenv
+, pkgs
+, fetchFromGitHub
+, buildPythonPackage
+, numpy
+, cmake
+, boost
+, zlib
+, thrift
+, python
+, cython
+, setuptools_scm
+, pytest
+, pandas
+, six
+}:
+let
+pythonWithDeps = python.buildEnv.override {
+  extraLibs = [ numpy ];
+  ignoreCollisions = true;
+};
+staticSnappy = pkgs.snappy.override { withStatic = true; };
+staticLz4 = pkgs.lz4.override { withStatic = true; };
+arrow = stdenv.mkDerivation {
+  name = "arrow";
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "arrow";
+    rev = "apache-arrow-0.8.0";
+    sha256 = "0ggbbvmfwn1bqv8f4j4xsj4s22l9cnx94b2vj4ybr295w0d7ixp5";
+  };
+  preConfigure = ''
+    cd cpp
+  '';
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=release"
+    "-DARROW_PYTHON=ON"
+    # plasma has a compile error with flatbuffers
+    "-DARROW_PLASMA=OFF"
+
+    # TODO: The disabled compression codecs require static builds as
+    # well which is not generally supported in nixpkgs.
+    "-DARROW_WITH_BROTLI=OFF"
+    "-DARROW_WITH_ZSTD=OFF"
+    "-DARROW_WITH_ZLIB=OFF"
+    "-DARROW_BUILD_TESTS=OFF"
+    "-DSNAPPY_INCLUDE_DIR=${staticSnappy.dev}/include"
+    "-DSNAPPY_HOME=${staticSnappy}"
+    "-DLZ4_HOME=${staticLz4.dev}"
+    "-DLZ4_STATIC_LIB=${staticLz4}/lib/liblz4.a"
+    "-DFLATBUFFERS_HOME=${pkgs.flatbuffers}"
+    "-DRAPIDJSON_HOME=${pkgs.rapidjson}"
+  ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    boost
+    pythonWithDeps
+  ];
+};
+parquetCpp = stdenv.mkDerivation {
+  name = "parquet-cpp";
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "parquet-cpp";
+    rev = "f13c61fd4447bee82ffc5807a03b8ba01960430a";
+    sha256 = "13maczzhb8bkaws4rpyp1hvb92l1izb9cm95h2dzsvaf5p52z6bh";
+  };
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=release"
+    "-DPARQUET_BUILD_BENCHMARKS=off"
+    "-DPARQUET_BUILD_EXECUTABLES=off"
+    "-DPARQUET_BUILD_TESTS=off"
+    "-DTHRIFT_INCLUDE_DIR='${pkgs.thrift}/include'"
+    "-DTHRIFT_STATIC_LIB='${pkgs.thrift}/lib/libthrift.a'"
+    "-DTHRIFT_COMPILER='${pkgs.thrift}/bin/thrift'"
+    "-DARROW_HOME=${arrow}"
+  ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    boost
+    (pkgs.thrift.override { withStatic = true; })
+  ];
+};
+in buildPythonPackage rec {
+  # Loosely based on the instructions here: https://arrow.apache.org/docs/python/development.html
+  name = "${pname}-${version}";
+  pname = "pyarrow";
+  version = "0.8.0";
+
+  src = arrow.src;
+
+  preBuild = ''
+    pushd python
+    export ARROW_HOME=${arrow}
+    export PARQUET_HOME=${parquetCpp}
+    ${python.executable} setup.py build_ext --build-type=release --with-parquet --inplace
+  '';
+
+  propagatedBuildInputs = [ numpy six ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    cython
+    setuptools_scm
+    pytest
+    pandas
+  ];
+
+  checkPhase = ''
+    # test requires gzip which hasn't been enabled yet:
+    substituteInPlace pyarrow/tests/test_io.py --replace 'test_compress_decompress' '_test_disabled'
+    substituteInPlace pyarrow/tests/test_parquet.py --replace 'test_pandas_parquet_configuration_options' '_test_disabled'
+    py.test -v .
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Apache Arrow is a cross-language development platform for in-memory data.";
+    homepage = "https://arrow.apache.org/";
+  };
+}

--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, valgrind }:
+{ stdenv, fetchFromGitHub, valgrind, withStatic ? false }:
 
 stdenv.mkDerivation rec {
   name = "lz4-${version}";
@@ -17,14 +17,16 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  makeFlags = [ "PREFIX=$(out)" "INCLUDEDIR=$(dev)/include" ];
+  makeFlags = let static = if withStatic then "yes" else "no"; in [
+    "PREFIX=$(out)"
+    "INCLUDEDIR=$(dev)/include"
+    "BUILD_STATIC=${static}"
+  ];
 
   doCheck = false; # tests take a very long time
   checkTarget = "test";
 
   patches = [ ./install-on-freebsd.patch ] ;
-
-  postInstall = "rm $out/lib/*.a";
 
   meta = with stdenv.lib; {
     description = "Extremely fast compression algorithm";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -623,6 +623,8 @@ in {
 
   arrow = callPackage ../development/python-modules/arrow { };
 
+  pyarrow = callPackage ../development/python-modules/pyarrow { };
+
   async = buildPythonPackage rec {
     name = "async-0.6.1";
     disabled = isPy3k;


### PR DESCRIPTION
###### Motivation for this change

This is probably one for @FRidh. I've been meaning to package pyarrow for a while, but it turned out to be a bit fiddly, mainly because its reliance on static libraries.

This PR is a suggestion for how we could package pyarrow, though I understand that some changes might be a bit controversial (new static flags for snappy, thrift & lz4 e.g.).

I still need to run this through `nox-review pr` & test the plasma binary 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

