### PR TITLE
android-studio: Depend on ncurses5

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -106,6 +106,7 @@ let
   # environment is used as a work around for that.
   fhsEnv = buildFHSUserEnv {
     name = "${pname}-fhs-env";
+    multiPkgs = pkgs: [ pkgs.ncurses5 ];
   };
 
 in


### PR DESCRIPTION
AndroidStudio fails to compile the ndk test program because it could not find the `ncurses.so.5` library.

`ncurses5` is a dependency according to https://developer.android.com/studio/troubleshoot.html#linux_libraries

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

