### PR TITLE
gpredict: 1.3 → 2.2.1

### DIFF
--- a/pkgs/applications/science/astronomy/gpredict/default.nix
+++ b/pkgs/applications/science/astronomy/gpredict/default.nix
@@ -1,20 +1,19 @@
-{ stdenv, fetchurl, pkgconfig
-, gtk2-x11, glib, curl, goocanvas, intltool
+{ stdenv, fetchurl, pkgconfig, intltool
+, gtk3, glib, curl, goocanvas2, gpsd
 }:
 
 let
-  version = "1.3";
-in
-stdenv.mkDerivation {
+  version = "2.2.1";
+in stdenv.mkDerivation {
   name = "gpredict-${version}";
 
   src = fetchurl {
-    url = "https://sourceforge.net/projects/gpredict/files/Gpredict/${version}/gpredict-${version}.tar.gz";
-    sha256 = "18ym71r2f5mwpnjcnrpwrk3py2f6jlqmj8hzp89wbcm1ipnvxxmh";
+    url = "https://github.com/csete/gpredict/releases/download/v${version}/gpredict-${version}.tar.bz2";
+    sha256 = "0hwf97kng1zy8rxyglw04x89p0bg07zq30hgghm20yxiw2xc8ng7";
   };
 
-  buildInputs = [ curl glib gtk2-x11 goocanvas ];
   nativeBuildInputs = [ pkgconfig intltool ];
+  buildInputs = [ curl glib gtk3 goocanvas2 gpsd ];
 
   meta = with stdenv.lib; {
     description = "Real time satellite tracking and orbit prediction";
@@ -27,7 +26,7 @@ stdenv.mkDerivation {
     '';
     license = licenses.gpl2;
     platforms = platforms.linux;
-    homepage = "https://sourceforge.net/projects/gpredict/";
+    homepage = http://gpredict.oz9aec.net/;
     maintainers = [ maintainers.markuskowa ];
   };
 }

--- a/pkgs/development/libraries/goocanvas/2.x.nix
+++ b/pkgs/development/libraries/goocanvas/2.x.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, pkgconfig, gettext, gtk-doc, gobjectIntrospection, python2, gtk3, cairo, glib }:
+
+let
+  version = "2.0.4";
+in stdenv.mkDerivation rec {
+  name = "goocanvas-${version}";
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/goocanvas/2.0/${name}.tar.xz";
+    sha256 = "141fm7mbqib0011zmkv3g8vxcjwa7hypmq71ahdyhnj2sjvy4a67";
+  };
+
+  nativeBuildInputs = [ pkgconfig gettext gtk-doc python2 ];
+  buildInputs = [ gtk3 cairo glib ];
+
+  configureFlags = [
+    "--disable-python"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Canvas widget for GTK+ based on the the Cairo 2D library";
+    homepage = https://wiki.gnome.org/Projects/GooCanvas;
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8940,6 +8940,7 @@ with pkgs;
   };
 
   goocanvas = callPackage ../development/libraries/goocanvas { };
+  goocanvas2 = callPackage ../development/libraries/goocanvas/2.x.nix { };
 
   google-gflags = callPackage ../development/libraries/google-gflags { };
 


### PR DESCRIPTION
###### Motivation for this change
Update.

cc @markuskowa 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

