### PR TITLE
cryptoverif: 1.22 -> 1.28

### DIFF
--- a/pkgs/applications/science/logic/cryptoverif/default.nix
+++ b/pkgs/applications/science/logic/cryptoverif/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cryptoverif-${version}";
-  version = "1.22";
+  version = "1.28";
 
   src = fetchurl {
     url    = "http://prosecco.gforge.inria.fr/personal/bblanche/cryptoverif/cryptoverif${version}.tar.gz";
-    sha256 = "17fbmv0askgfnhs5a0ilhizvrr93jkmq82ybm3cgyxhh2zrk0rq1";
+    sha256 = "0vssz751g1nn8wclkiwgghpm475jl00xkivc164vgbr9acxsr7n7";
   };
 
   buildInputs = [ ocaml ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/p13fvkr38qrak3ng6lpmj4z1palhr2in-cryptoverif-1.28/bin/cryptoverif --help` got 0 exit code
- found 1.28 with grep in /nix/store/p13fvkr38qrak3ng6lpmj4z1palhr2in-cryptoverif-1.28
- found 1.28 in filename of file in /nix/store/p13fvkr38qrak3ng6lpmj4z1palhr2in-cryptoverif-1.28