### PR TITLE
coturn: 4.5.0.6 -> 4.5.0.7

### DIFF
--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -4,13 +4,13 @@ let inherit (stdenv.lib) optional; in
 
 stdenv.mkDerivation rec {
   name = "coturn-${version}";
-  version = "4.5.0.6";
+  version = "4.5.0.7";
 
   src = fetchFromGitHub {
     owner = "coturn";
     repo = "coturn";
     rev = "${version}";
-    sha256 = "084c3zgwmmz4s6211i5jbkzsn13703lsg7vhc2cpacazq4sgsrhb";
+    sha256 = "1781fx8lqgc54j973xzgq9d7k3g2j03va82jb4217gd3a93pa65l";
   };
 
   buildInputs = [ openssl libevent ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/70pa0xb505v9glp792ldfq66ifjbrk5i-coturn-4.5.0.7/bin/turnserver -h` got 0 exit code
- ran `/nix/store/70pa0xb505v9glp792ldfq66ifjbrk5i-coturn-4.5.0.7/bin/turnserver -h` and found version 4.5.0.7
- ran `/nix/store/70pa0xb505v9glp792ldfq66ifjbrk5i-coturn-4.5.0.7/bin/turnadmin -h` got 0 exit code
- ran `/nix/store/70pa0xb505v9glp792ldfq66ifjbrk5i-coturn-4.5.0.7/bin/turnadmin --help` got 0 exit code
- ran `/nix/store/70pa0xb505v9glp792ldfq66ifjbrk5i-coturn-4.5.0.7/bin/turnutils_natdiscovery help` got 0 exit code
- found 4.5.0.7 with grep in /nix/store/70pa0xb505v9glp792ldfq66ifjbrk5i-coturn-4.5.0.7
- found 4.5.0.7 in filename of file in /nix/store/70pa0xb505v9glp792ldfq66ifjbrk5i-coturn-4.5.0.7
