### PR TITLE
containerd: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -5,13 +5,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "containerd-${version}";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "containerd";
     repo = "containerd";
     rev = "v${version}";
-    sha256 = "0kfafqi66yp4qy738pl11f050hfrx9m4kc670qpx7fmf9ii7q6p2";
+    sha256 = "1x6mmk69jksh4m9rjd8qwpp0qc7jmimpkq9pw9237p0v63p9yci0";
   };
 
   hardeningDisable = [ "fortify" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd -h` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd --help` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd help` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd -v` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd --version` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd -h` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd --help` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd help` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd-release -h` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd-release --help` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd-release help` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd-stress -h` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd-stress --help` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/containerd-stress help` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/ctr -h` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/ctr --help` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/ctr help` got 0 exit code
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/ctr -v` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/ctr --version` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/ctr -h` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/ctr --help` and found version 1.0.2
- ran `/nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2/bin/ctr help` and found version 1.0.2
- found 1.0.2 with grep in /nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2
- found 1.0.2 in filename of file in /nix/store/r3k13i9mxm9bsm21d3s0fd35adf53gxr-containerd-1.0.2