### PR TITLE
corosync: 2.4.2 -> 2.4.3

### DIFF
--- a/pkgs/servers/corosync/default.nix
+++ b/pkgs/servers/corosync/default.nix
@@ -9,11 +9,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "corosync-2.4.2";
+  name = "corosync-2.4.3";
 
   src = fetchurl {
     url = "http://build.clusterlabs.org/corosync/releases/${name}.tar.gz";
-    sha256 = "1aab380mv4ivy5icmwvk7941jbs6ikm21p5ijk7brr4z608k0vpj";
+    sha256 = "15y5la04qn2lh1gabyifygzpa4dx3ndk5yhmaf7azxyjx0if9rxi";
   };
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-blackbox -h` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-blackbox --help` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-blackbox help` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync -v` and found version 2.4.3
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-cfgtool -h` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-cfgtool --help` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-cfgtool help` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-cfgtool -V` and found version 2.4.3
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-cfgtool -v` and found version 2.4.3
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-cfgtool --help` and found version 2.4.3
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-cmapctl -h` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-cpgtool -h` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-keygen -h` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-keygen --help` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-qdevice-net-certutil -h` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-qdevice-net-certutil help` got 0 exit code
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-qdevice-net-certutil version` and found version 2.4.3
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-qdevice-net-certutil -h` and found version 2.4.3
- ran `/nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3/bin/corosync-qdevice-net-certutil help` and found version 2.4.3
- found 2.4.3 with grep in /nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3
- found 2.4.3 in filename of file in /nix/store/m08rvzr19g6c09xj6h6v073lxgyq0f53-corosync-2.4.3
