### PR TITLE
convmv: 1.15 -> 2.04

### DIFF
--- a/pkgs/tools/misc/convmv/default.nix
+++ b/pkgs/tools/misc/convmv/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
-  name = "convmv-1.15";
+  name = "convmv-2.04";
 
   src = fetchurl {
     url = "http://www.j3e.de/linux/convmv/${name}.tar.gz";
-    sha256 = "0daiiapsrca8zlbmlz2kw2fn4vmkh48cblb70h08idchhk3sw5f3";
+    sha256 = "075xn1ill26hbhg4nl54sp75b55db3ikl7lvhqb9ijvkpi67j6yy";
   };
 
   preBuild=''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.04 with grep in /nix/store/sfw526iv7av4agb4s2kbpy6882vk8h8x-convmv-2.04
- found 2.04 in filename of file in /nix/store/sfw526iv7av4agb4s2kbpy6882vk8h8x-convmv-2.04