### PR TITLE
consul-template: 0.18.1 -> 0.19.4

### DIFF
--- a/pkgs/tools/system/consul-template/default.nix
+++ b/pkgs/tools/system/consul-template/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "consul-template-${version}";
-  version = "0.18.1";
+  version = "0.19.4";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/consul-template";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "hashicorp";
     repo = "consul-template";
-    sha256 = "0swyhc5smjbp5wql43qhpxrcbg47v89l5icb1s60gszhxizlkk7d";
+    sha256 = "06agjzpax45gw7s9b69cz9w523nx7ksikqcg0z0vipwrp7pwrydd";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3s9an36qfjcarbdz0vjbgj08la6p0wan-consul-template-0.19.4-bin/bin/consul-template -h` got 0 exit code
- ran `/nix/store/3s9an36qfjcarbdz0vjbgj08la6p0wan-consul-template-0.19.4-bin/bin/consul-template --help` got 0 exit code
- ran `/nix/store/3s9an36qfjcarbdz0vjbgj08la6p0wan-consul-template-0.19.4-bin/bin/consul-template -v` and found version 0.19.4
- ran `/nix/store/3s9an36qfjcarbdz0vjbgj08la6p0wan-consul-template-0.19.4-bin/bin/consul-template --version` and found version 0.19.4
- found 0.19.4 with grep in /nix/store/3s9an36qfjcarbdz0vjbgj08la6p0wan-consul-template-0.19.4-bin
- found 0.19.4 in filename of file in /nix/store/3s9an36qfjcarbdz0vjbgj08la6p0wan-consul-template-0.19.4-bin