### PR TITLE
consul: 0.9.3 -> 1.0.6

### DIFF
--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "consul-${version}";
-  version = "0.9.3";
+  version = "1.0.6";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/consul";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "hashicorp";
     repo = "consul";
     inherit rev;
-    sha256 = "1176frp7kimpycsmz9wrbizf46jgxr8jq7hz5w4q1x90lswvrxv3";
+    sha256 = "06isx7y6nc3305d9bw61738jfmyyh0czshgfdn8dvhdhvxjs5pp2";
   };
 
   # Keep consul.ui for backward compatability


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/xf97nh84m71qq46s1mqgra1gspszfamb-consul-1.0.6-bin/bin/consul -h` got 0 exit code
- ran `/nix/store/xf97nh84m71qq46s1mqgra1gspszfamb-consul-1.0.6-bin/bin/consul --help` got 0 exit code
- ran `/nix/store/xf97nh84m71qq46s1mqgra1gspszfamb-consul-1.0.6-bin/bin/consul -v` and found version 1.0.6
- ran `/nix/store/xf97nh84m71qq46s1mqgra1gspszfamb-consul-1.0.6-bin/bin/consul --version` and found version 1.0.6
- ran `/nix/store/xf97nh84m71qq46s1mqgra1gspszfamb-consul-1.0.6-bin/bin/consul version` and found version 1.0.6
- found 1.0.6 with grep in /nix/store/xf97nh84m71qq46s1mqgra1gspszfamb-consul-1.0.6-bin
- found 1.0.6 in filename of file in /nix/store/xf97nh84m71qq46s1mqgra1gspszfamb-consul-1.0.6-bin