### PR TITLE
confd: 0.9.0 -> 0.11.0

### DIFF
--- a/pkgs/tools/system/confd/default.nix
+++ b/pkgs/tools/system/confd/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "confd-${version}";
-  version = "0.9.0";
+  version = "0.11.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/kelseyhightower/confd";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "kelseyhightower";
     repo = "confd";
-    sha256 = "0rz533575hdcln8ciqaz79wbnga3czj243g7fz8869db6sa7jwlr";
+    sha256 = "0l8z688xs89bar4bifjxis4pa9z8c23z70bczw7y30nclp7m46z2";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.11.0 in filename of file in /nix/store/fy2xdlmav7xg0qqb4v8ck8qw0g2krfvv-confd-0.11.0-bin
