### PR TITLE
daq: 2.0.6 -> 2.2.2

### DIFF
--- a/pkgs/applications/networking/ids/daq/default.nix
+++ b/pkgs/applications/networking/ids/daq/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, flex, bison, libpcap, libdnet, libnfnetlink, libnetfilter_queue}:
 
 stdenv.mkDerivation rec {
-  name = "daq-2.0.6";
+  name = "daq-2.2.2";
 
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://snort.org/downloads/archive/snort/${name}.tar.gz";
-    sha256 = "1jz7gc9n6sr677ssv61qvcxybdrmsll4z7g6hsmax2p0fc91s3ml";
+    sha256 = "0yvzscy7vqj7s5rccza0f7p6awghfm3yaxihx1h57lqspg51in3w";
   };
 
   buildInputs = [ flex bison libpcap libdnet libnfnetlink libnetfilter_queue];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/k309zjlgh7pn9h1gpzf5rrmnxzmfifil-daq-2.2.2/bin/daq-modules-config -h` got 0 exit code
- ran `/nix/store/k309zjlgh7pn9h1gpzf5rrmnxzmfifil-daq-2.2.2/bin/daq-modules-config --help` got 0 exit code
- ran `/nix/store/k309zjlgh7pn9h1gpzf5rrmnxzmfifil-daq-2.2.2/bin/daq-modules-config help` got 0 exit code
- found 2.2.2 with grep in /nix/store/k309zjlgh7pn9h1gpzf5rrmnxzmfifil-daq-2.2.2
- found 2.2.2 in filename of file in /nix/store/k309zjlgh7pn9h1gpzf5rrmnxzmfifil-daq-2.2.2