### PR TITLE
dante: 1.4.1 -> 1.4.2

### DIFF
--- a/pkgs/servers/dante/default.nix
+++ b/pkgs/servers/dante/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation (rec {
   name = "dante-${version}";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchurl {
     url = "https://www.inet.no/dante/files/${name}.tar.gz";
-    sha256 = "0lsg3hk8zd2h9f08s13bn4l4pvyyzkj4gr4ppwa7vj7gdyyk5lmn";
+    sha256 = "1bfafnm445afrmyxvvcl8ckq0p59yzykmr3y8qvryzrscd85g8ms";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3z75x46yp38ckpdvadhdk2mnvj1dz79s-dante-1.4.2/bin/sockd -h` got 0 exit code
- ran `/nix/store/3z75x46yp38ckpdvadhdk2mnvj1dz79s-dante-1.4.2/bin/sockd -v` and found version 1.4.2
- ran `/nix/store/3z75x46yp38ckpdvadhdk2mnvj1dz79s-dante-1.4.2/bin/sockd -h` and found version 1.4.2
- found 1.4.2 with grep in /nix/store/3z75x46yp38ckpdvadhdk2mnvj1dz79s-dante-1.4.2
- found 1.4.2 in filename of file in /nix/store/3z75x46yp38ckpdvadhdk2mnvj1dz79s-dante-1.4.2