### PR TITLE
daemonize: 1.7.7 -> 1.7.8

### DIFF
--- a/pkgs/tools/system/daemonize/default.nix
+++ b/pkgs/tools/system/daemonize/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "daemonize-${version}";
-  version = "1.7.7";
+  version = "1.7.8";
 
   src = fetchurl {
     url    = "https://github.com/bmc/daemonize/archive/release-${version}.tar.gz";
-    sha256 = "01gabcc8m4jkymd31p6v5883ii3g7126cici6rd03maf4jizxjmk";
+    sha256 = "0q2c3i3si3k7wfhl6fyckkmkc81yp67pz52p3ggis79p4nczri10";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.7.8 with grep in /nix/store/5czx6iiyshzwx2as3m43hrwdb2cmvrm6-daemonize-1.7.8
- found 1.7.8 in filename of file in /nix/store/5czx6iiyshzwx2as3m43hrwdb2cmvrm6-daemonize-1.7.8