### PR TITLE
lutris: init at 0.4.14

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -520,6 +520,7 @@
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";
   orivej = "Orivej Desh <orivej@gmx.fr>";
   osener = "Ozan Sener <ozan@ozansener.com>";
+  othercriteria = "Daniel Klein <othercriteria@gmail.com>";
   otwieracz = "Slawomir Gonet <slawek@otwiera.cz>";
   oxij = "Jan Malakhovski <oxij@oxij.org>";
   paholg = "Paho Lurie-Gregg <paho@paholg.com>";

--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl,
+  python36,
+  gtk3, gobjectIntrospection, wrapGAppsHook }:
+
+let
+  version = "0.4.14";
+  name = "lutris-${version}";
+
+  inherit (python36.pkgs) buildPythonApplication pygobject3 pyxdg pyyaml evdev;
+
+in buildPythonApplication rec {
+  inherit version name;
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  propagatedBuildInputs = [ gtk3 gobjectIntrospection pygobject3 pyxdg pyyaml evdev ];
+
+  # Fails otherwise, as it tries to write to $HOME.
+  doCheck = false;
+  
+  src = fetchurl {
+    url = "https://github.com/lutris/lutris/archive/v${version}.zip";
+    sha256 = "1yjd2nppv7m0sz8p0dpb731g6p7xvmya4zz0qpry82md1fljvwjg";
+  };
+
+  makeWrapperArgs = [
+    "--set GI_TYPELIB_PATH $GI_TYPELIB_PATH"
+    "--prefix XDG_DATA_DIRS : $out/share"
+    "--suffix XDG_DATA_DIRS : $XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+  ];
+
+  meta = {
+    description = "An open gaming platform for Linux.";
+    homepage = "https://lutris.net/";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.othercriteria ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16331,6 +16331,8 @@ with pkgs;
 
   lumail = callPackage ../applications/networking/mailreaders/lumail { };
 
+  lutris = callPackage ../applications/misc/lutris {};
+
   lv2bm = callPackage ../applications/audio/lv2bm { };
 
   lynx = callPackage ../applications/networking/browsers/lynx { };


### PR DESCRIPTION
Works well enough to launch Lutris GUI, and sync with Steam library,
although I can't get it to run external programs due to weird bash
issues.

###### Motivation for this change

No existing package existed for it and I wanted to try it out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

