### PR TITLE
delve: 0.12.2 -> 1.0.0

### DIFF
--- a/pkgs/development/tools/delve/default.nix
+++ b/pkgs/development/tools/delve/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "delve-${version}";
-  version = "0.12.2";
+  version = "1.0.0";
 
   goPackagePath = "github.com/derekparker/delve";
   excludedPackages = "\\(_fixtures\\|scripts\\|service/test\\)";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "derekparker";
     repo = "delve";
     rev = "v${version}";
-    sha256 = "1241zqyimgqil4qd72f0yiw935lkdmfr88kvqbkn9n05k7xhdg30";
+    sha256 = "08hsairhrifh41d288jhc65zbhs9k0hs738dbdzsbcvlmycrhvgx";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lyxg9xfy3r2k5yzfdxy0qyskkanb702b-delve-1.0.0-bin/bin/dlv -h` got 0 exit code
- ran `/nix/store/lyxg9xfy3r2k5yzfdxy0qyskkanb702b-delve-1.0.0-bin/bin/dlv --help` got 0 exit code
- ran `/nix/store/lyxg9xfy3r2k5yzfdxy0qyskkanb702b-delve-1.0.0-bin/bin/dlv help` got 0 exit code
- ran `/nix/store/lyxg9xfy3r2k5yzfdxy0qyskkanb702b-delve-1.0.0-bin/bin/dlv version` and found version 1.0.0
- found 1.0.0 with grep in /nix/store/lyxg9xfy3r2k5yzfdxy0qyskkanb702b-delve-1.0.0-bin
- found 1.0.0 in filename of file in /nix/store/lyxg9xfy3r2k5yzfdxy0qyskkanb702b-delve-1.0.0-bin