### PR TITLE
doclifter: 2.15 -> 2.17

### DIFF
--- a/pkgs/development/tools/misc/doclifter/default.nix
+++ b/pkgs/development/tools/misc/doclifter/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, python}:
 
 stdenv.mkDerivation {
-  name = "doclifter-2.15";
+  name = "doclifter-2.17";
   src = fetchurl {
-    url = http://www.catb.org/~esr/doclifter/doclifter-2.15.tar.gz;
-    sha256 = "14k750bxp0kpnm130pp22vx3vmppfnzwisc042din1416ka07yv0";
+    url = http://www.catb.org/~esr/doclifter/doclifter-2.17.tar.gz;
+    sha256 = "1m8yfjbl8wzcml9q4k7m1crwid0a14r07fqf33bmmgx1zpjk8kmv";
   };
   buildInputs = [ python ];
   


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/l2jl00f6gvvc17lsq27vvmw26md8nf4g-doclifter-2.17/bin/doclifter -V` and found version 2.17
- found 2.17 with grep in /nix/store/l2jl00f6gvvc17lsq27vvmw26md8nf4g-doclifter-2.17
- found 2.17 in filename of file in /nix/store/l2jl00f6gvvc17lsq27vvmw26md8nf4g-doclifter-2.17