### PR TITLE
double-conversion: 2.0.1 -> 3.0.0

### DIFF
--- a/pkgs/development/libraries/double-conversion/default.nix
+++ b/pkgs/development/libraries/double-conversion/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "double-conversion-${version}";
-  version = "2.0.1";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "double-conversion";
     rev = "v${version}";
-    sha256 = "05x5rdwndgp1vdq2z1bpvng0dd8pn93kw4vhl6nsvv9vsara2q4b";
+    sha256 = "05m78wlwrg310mxh1cl3d8d0ishzfvzh84x64xmvng252m0vc8yz";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.0.0 with grep in /nix/store/3401963nw3aw97ng939gk6viifymqzgx-double-conversion-3.0.0
- found 3.0.0 in filename of file in /nix/store/3401963nw3aw97ng939gk6viifymqzgx-double-conversion-3.0.0