### PR TITLE
dnscrypt-wrapper: 0.3 -> 0.4.0

### DIFF
--- a/pkgs/tools/networking/dnscrypt-wrapper/default.nix
+++ b/pkgs/tools/networking/dnscrypt-wrapper/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "dnscrypt-wrapper-${version}";
-  version = "0.3";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "Cofyc";
     repo = "dnscrypt-wrapper";
     rev = "v${version}";
-    sha256 = "0wnkgn0ajx1qmfyb264jvpqxlbravdcq4m485iaa3wjp82g8xlca";
+    sha256 = "121y93sb06qc50fj7vv47r6dpzv77hh7ywl7sgrfp8i4jf4kaspa";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ylh6nyxzn765n9vc7byhsb4aryxcsvgd-dnscrypt-wrapper-0.4.0/bin/dnscrypt-wrapper -h` got 0 exit code
- ran `/nix/store/ylh6nyxzn765n9vc7byhsb4aryxcsvgd-dnscrypt-wrapper-0.4.0/bin/dnscrypt-wrapper --help` got 0 exit code
- ran `/nix/store/ylh6nyxzn765n9vc7byhsb4aryxcsvgd-dnscrypt-wrapper-0.4.0/bin/dnscrypt-wrapper -v` and found version 0.4.0
- ran `/nix/store/ylh6nyxzn765n9vc7byhsb4aryxcsvgd-dnscrypt-wrapper-0.4.0/bin/dnscrypt-wrapper --version` and found version 0.4.0
- found 0.4.0 with grep in /nix/store/ylh6nyxzn765n9vc7byhsb4aryxcsvgd-dnscrypt-wrapper-0.4.0
- found 0.4.0 in filename of file in /nix/store/ylh6nyxzn765n9vc7byhsb4aryxcsvgd-dnscrypt-wrapper-0.4.0