### PR TITLE
drumkv1: 0.8.5 -> 0.8.6

### DIFF
--- a/pkgs/applications/audio/drumkv1/default.nix
+++ b/pkgs/applications/audio/drumkv1/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "drumkv1-${version}";
-  version = "0.8.5";
+  version = "0.8.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/drumkv1/${name}.tar.gz";
-    sha256 = "06xqqm1ylmpp2s7xk7xav325gc50kxlvh9vf1343b0n3i8xkgjfg";
+    sha256 = "0fwxrfyp15a4m77mzz4mwj36mhdrj646whlrkvcys33p2w75f8cq";
   };
 
   buildInputs = [ libjack2 alsaLib libsndfile liblo lv2 qt5.qtbase qt5.qttools ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.8.6 with grep in /nix/store/k2mm58aav72xhc9kf5a8ysb6yxrbnj6c-drumkv1-0.8.6
- found 0.8.6 in filename of file in /nix/store/k2mm58aav72xhc9kf5a8ysb6yxrbnj6c-drumkv1-0.8.6