### PR TITLE
dmtcp: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/os-specific/linux/dmtcp/default.nix
+++ b/pkgs/os-specific/linux/dmtcp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "dmtcp-${version}";
-  version = "2.5.1";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     owner = "dmtcp";
     repo = "dmtcp";
     rev = version;
-    sha256 = "1z6cc7avs2sj8csf7rapf7nbw0giva6xpj0cshv7p9s643y8yxmi";
+    sha256 = "1sq38in4wk855yhfnzbs9xpnps97fhja93w08xjmx7szzm33g5a8";
   };
 
   dontDisableStatic = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_discover_rm -h` got 0 exit code
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_discover_rm --help` got 0 exit code
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_discover_rm -V` and found version 2.5.2
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_discover_rm -v` and found version 2.5.2
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_discover_rm --version` and found version 2.5.2
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_discover_rm -h` and found version 2.5.2
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_discover_rm --help` and found version 2.5.2
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_rm_loclaunch -h` got 0 exit code
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_rm_loclaunch --help` got 0 exit code
- ran `/nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2/bin/dmtcp_rm_loclaunch help` got 0 exit code
- found 2.5.2 with grep in /nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2
- found 2.5.2 in filename of file in /nix/store/dpqcx4vr2nzam3c504xg5qc0rmmf1c4k-dmtcp-2.5.2