### PR TITLE
diskscan: 0.19 -> 0.20

### DIFF
--- a/pkgs/tools/misc/diskscan/default.nix
+++ b/pkgs/tools/misc/diskscan/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "diskscan-${version}";
-  version = "0.19";
+  version = "0.20";
 
   src = fetchFromGitHub {
     owner  = "baruch";
     repo   = "diskscan";
     rev    = "${version}";
-    sha256 = "0yqpaxfahbjr8hr9xw7nngncwigy7yncdwnyp5wy9s9wdp8mrjra";
+    sha256 = "1s2df082yrnr3gqnapdsqz0yd0ld75bin37g0rms83ymzkh4ysgv";
   };
 
   buildInputs = [ ncurses zlib ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.20 with grep in /nix/store/67w1bnhfjsv15cb68bjk3zppzhynw1ip-diskscan-0.20
- found 0.20 in filename of file in /nix/store/67w1bnhfjsv15cb68bjk3zppzhynw1ip-diskscan-0.20