### PR TITLE
diod: 1.0.23 -> 1.0.24

### DIFF
--- a/pkgs/servers/diod/default.nix
+++ b/pkgs/servers/diod/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "diod-${version}";
-  version = "1.0.23";
+  version = "1.0.24";
 
   src = fetchurl {
     url = "https://github.com/chaos/diod/releases/download/${version}/${name}.tar.gz";
-    sha256 = "002vxc9fwdwshda4jydxagr63xd6nnhbc6fh73974gi2pvp6gid3";
+    sha256 = "17wckwfsqj61yixz53nwkc35z66arb1x3napahpi64m7q68jn7gl";
   };
 
   buildInputs = [ munge lua libcap perl ncurses ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/6cg1sba0szxb33hhk28qxbsw5hdlsrkd-diod-1.0.24/bin/diodload help` got 0 exit code
- found 1.0.24 with grep in /nix/store/6cg1sba0szxb33hhk28qxbsw5hdlsrkd-diod-1.0.24
- found 1.0.24 in filename of file in /nix/store/6cg1sba0szxb33hhk28qxbsw5hdlsrkd-diod-1.0.24