### PR TITLE
dico: 2.4 -> 2.5

### DIFF
--- a/pkgs/servers/dico/default.nix
+++ b/pkgs/servers/dico/default.nix
@@ -2,11 +2,11 @@
 , guile, python, pcre, libffi, groff }:
 
 stdenv.mkDerivation rec {
-  name = "dico-2.4";
+  name = "dico-2.5";
 
   src = fetchurl {
     url = "mirror://gnu/dico/${name}.tar.xz";
-    sha256 = "13m7vahfbdj7hb38bjgd4cmfswavvxrcpppj9n4m4rar3wyzg52g";
+    sha256 = "0szm3z4xvq0pjj8kxl4paq63byamf281kzn1la0cdm5ngavypxxq";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dicod -h` got 0 exit code
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dicod --help` got 0 exit code
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dicod -V` and found version 2.5
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dicod --version` and found version 2.5
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dico -h` got 0 exit code
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dico --help` got 0 exit code
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dico help` got 0 exit code
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dico -V` and found version 2.5
- ran `/nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5/bin/dico --version` and found version 2.5
- found 2.5 with grep in /nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5
- found 2.5 in filename of file in /nix/store/gd29d0p765hn7vy9772x64f9i3nfi3lw-dico-2.5