### PR TITLE
dehydrated: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/tools/admin/dehydrated/default.nix
+++ b/pkgs/tools/admin/dehydrated/default.nix
@@ -1,7 +1,7 @@
 { stdenv, bash, coreutils, curl, diffutils, gawk, gnugrep, gnused, openssl, makeWrapper, fetchFromGitHub }:
 let
   pkgName = "dehydrated";
-  version = "0.4.0";
+  version = "0.5.0";
 in
 stdenv.mkDerivation rec {
   name = pkgName + "-" + version;
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "lukas2511";
     repo = "dehydrated";
     rev = "v${version}";
-    sha256 = "0nxs6l5i6409dzgiyjn8cnzjcblwj4rqcpxxb766vcvb8d4kqwby";
+    sha256 = "0ysfsz1ny3gcc4r9szrr09dg63zd7ppv6aih13wmai806yapwxrr";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0/bin/dehydrated -h` got 0 exit code
- ran `/nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0/bin/dehydrated --help` got 0 exit code
- ran `/nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0/bin/dehydrated -h` and found version 0.5.0
- ran `/nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0/bin/dehydrated --help` and found version 0.5.0
- ran `/nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0/bin/.dehydrated-wrapped -h` got 0 exit code
- ran `/nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0/bin/.dehydrated-wrapped --help` got 0 exit code
- ran `/nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0/bin/.dehydrated-wrapped -h` and found version 0.5.0
- ran `/nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0/bin/.dehydrated-wrapped --help` and found version 0.5.0
- found 0.5.0 with grep in /nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0
- found 0.5.0 in filename of file in /nix/store/khsw23siwrvmczmlcjdlp31ksqjxs902-dehydrated-0.5.0