### PR TITLE
dhcpcd: 6.11.5 -> 7.0.1

### DIFF
--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, udev }:
 
 stdenv.mkDerivation rec {
-  name = "dhcpcd-6.11.5";
+  name = "dhcpcd-7.0.1";
 
   src = fetchurl {
     url = "mirror://roy/dhcpcd/${name}.tar.xz";
-    sha256 = "17nnhxmbdcc7k2mh6sgvxisqcqbic5540xbig363ds97gvf795kg";
+    sha256 = "1j7kyg9gm5d1k6qjdscjz2rjgpqia0dxgk69lswp21y0pizm6dlb";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/04mp6n1v5sgc62qwxpz1gfxv589cn76k-dhcpcd-7.0.1/bin/dhcpcd --help` got 0 exit code
- ran `/nix/store/04mp6n1v5sgc62qwxpz1gfxv589cn76k-dhcpcd-7.0.1/bin/dhcpcd --version` and found version 7.0.1
- found 7.0.1 with grep in /nix/store/04mp6n1v5sgc62qwxpz1gfxv589cn76k-dhcpcd-7.0.1
- found 7.0.1 in filename of file in /nix/store/04mp6n1v5sgc62qwxpz1gfxv589cn76k-dhcpcd-7.0.1