### PR TITLE
dvdstyler: 3.0.3 -> 3.0.4

### DIFF
--- a/pkgs/applications/video/dvdstyler/default.nix
+++ b/pkgs/applications/video/dvdstyler/default.nix
@@ -15,11 +15,11 @@ stdenv.mkDerivation rec {
 
   name = "dvdstyler-${version}";
   srcName = "DVDStyler-${version}";
-  version = "3.0.3";
+  version = "3.0.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/dvdstyler/dvdstyler/${version}/${srcName}.tar.bz2";
-    sha256 = "1j432kszmwmsd3nz398h5514dbm5vsrn4rr3iil72ckjj1h3i00q";
+    sha256 = "0lwc0hn94m9r8fi07sjqz3fr618l6lnw3zsakxw7nlgnxbjsk7pi";
   };
 
   nativeBuildInputs = 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4/bin/dvdstyler --help` got 0 exit code
- ran `/nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4/bin/dvdstyler --version` and found version 3.0.4
- ran `/nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4/bin/.dvdstyler-wrapped -h` got 0 exit code
- ran `/nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4/bin/.dvdstyler-wrapped --help` got 0 exit code
- ran `/nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4/bin/.dvdstyler-wrapped -v` and found version 3.0.4
- ran `/nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4/bin/.dvdstyler-wrapped --version` and found version 3.0.4
- ran `/nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4/bin/.dvdstyler-wrapped -h` and found version 3.0.4
- found 3.0.4 with grep in /nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4
- found 3.0.4 in filename of file in /nix/store/199jnnl507db7vsacx638sp3ql5m02av-dvdstyler-3.0.4