### PR TITLE
e2fsprogs: 1.43.8 -> 1.43.9

### DIFF
--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,11 +1,11 @@
 { stdenv, buildPackages, fetchurl, pkgconfig, libuuid, gettext, texinfo }:
 
 stdenv.mkDerivation rec {
-  name = "e2fsprogs-1.43.8";
+  name = "e2fsprogs-1.43.9";
 
   src = fetchurl {
     url = "mirror://sourceforge/e2fsprogs/${name}.tar.gz";
-    sha256 = "1pn33rap3lcjm3gx07pmgyhx4j634gja63phmi4g5dq8yj0z8ciz";
+    sha256 = "15rqvkzylqqckshfy7vmk15k7wds2rh3k1pwrkrs684p3g0gzq2v";
   };
 
   outputs = [ "bin" "dev" "out" "man" "info" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/lsattr -V` and found version 1.43.9
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/lsattr -v` and found version 1.43.9
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/debugfs -V` and found version 1.43.9
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/dumpe2fs -V` and found version 1.43.9
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/e2fsck -V` and found version 1.43.9
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/e4crypt -h` got 0 exit code
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/e4crypt --help` got 0 exit code
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/e4crypt help` got 0 exit code
- ran `/nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin/bin/mke2fs -V` and found version 1.43.9
- found 1.43.9 with grep in /nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin
- found 1.43.9 in filename of file in /nix/store/fl7n7l6qww82jx6ldqb5j01s2gii5civ-e2fsprogs-1.43.9-bin
