### PR TITLE
electrum-ltc: 3.0.5.1 -> 3.0.6.2

### DIFF
--- a/pkgs/applications/misc/electrum-ltc/default.nix
+++ b/pkgs/applications/misc/electrum-ltc/default.nix
@@ -5,11 +5,11 @@
 
 python3Packages.buildPythonApplication rec {
   name = "electrum-ltc-${version}";
-  version = "3.0.5.1";
+  version = "3.0.6.2";
 
   src = fetchurl {
     url = "https://electrum-ltc.org/download/Electrum-LTC-${version}.tar.gz";
-    sha256 = "1acsgzmd83cz6ha5fw63mi7123fr6gbiq537p5lxxfs2i8zrl63r";
+    sha256 = "1bay4vfkanxsa8pj8n99sj55yc59s84nns97lbvagyp0p0lclia7";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2/bin/electrum-ltc -h` got 0 exit code
- ran `/nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2/bin/electrum-ltc --help` got 0 exit code
- ran `/nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2/bin/electrum-ltc help` got 0 exit code
- ran `/nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2/bin/electrum-ltc version` and found version 3.0.6.2
- ran `/nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2/bin/.electrum-ltc-wrapped -h` got 0 exit code
- ran `/nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2/bin/.electrum-ltc-wrapped --help` got 0 exit code
- ran `/nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2/bin/.electrum-ltc-wrapped help` got 0 exit code
- ran `/nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2/bin/.electrum-ltc-wrapped version` and found version 3.0.6.2
- found 3.0.6.2 with grep in /nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2
- found 3.0.6.2 in filename of file in /nix/store/7fpp297s6qy7r9m8j7pwkxgndp72lmzd-electrum-ltc-3.0.6.2