### PR TITLE
ddcutil: 0.8.5 -> 0.8.6

### DIFF
--- a/pkgs/tools/misc/ddcutil/default.nix
+++ b/pkgs/tools/misc/ddcutil/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "ddcutil-${version}";
-  version = "0.8.5";
+  version = "0.8.6";
 
   src = fetchFromGitHub {
     owner  = "rockowitz";
     repo   = "ddcutil";
     rev    = "v${version}";
-    sha256 = "127a5v545gvfgxqqjxqafsg1p8i4qd5wnpdwccr38jbsphl6yzl4";
+    sha256 = "1c4cl9cac90xf9rap6ss2d4yshcmhdq8pdfjz3g4cns789fs1vcf";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/kvyrlv9mdf4wxiw0nyygh1gz398lzbny-ddcutil-0.8.6/bin/ddcutil -h` got 0 exit code
- ran `/nix/store/kvyrlv9mdf4wxiw0nyygh1gz398lzbny-ddcutil-0.8.6/bin/ddcutil --help` got 0 exit code
- ran `/nix/store/kvyrlv9mdf4wxiw0nyygh1gz398lzbny-ddcutil-0.8.6/bin/ddcutil -V` and found version 0.8.6
- ran `/nix/store/kvyrlv9mdf4wxiw0nyygh1gz398lzbny-ddcutil-0.8.6/bin/ddcutil --version` and found version 0.8.6
- found 0.8.6 with grep in /nix/store/kvyrlv9mdf4wxiw0nyygh1gz398lzbny-ddcutil-0.8.6
- found 0.8.6 in filename of file in /nix/store/kvyrlv9mdf4wxiw0nyygh1gz398lzbny-ddcutil-0.8.6