### PR TITLE
emby: 3.2.60.0 -> 3.2.70.0

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.2.60.0";
+  version = "3.2.70.0";
 
   src = fetchurl {
     url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "0yrbwq5dzzq5047vdpar4vkwzcgd9dj2v9basaw413hzncf2q8gj";
+    sha256 = "051mbzh1igcbda43n14aijbvhhh98rqw8i13f06xqsm67afrjjcv";
   };
 
   buildInputs = with pkgs; [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.2.70.0 with grep in /nix/store/rrf5cqpbsmq42mwy2zsgab7r7pn44zim-emby-3.2.70.0