### PR TITLE
entr: 3.9 -> 4.0

### DIFF
--- a/pkgs/tools/misc/entr/default.nix
+++ b/pkgs/tools/misc/entr/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "entr-${version}";
-  version = "3.9";
+  version = "4.0";
 
   src = fetchurl {
     url = "http://entrproject.org/code/${name}.tar.gz";
-    sha256 = "0xk8y8asy0wxi5jx03c521p9919gjr8053lxpfzn83jkmqc8zmq2";
+    sha256 = "12vc3xp0z0abmsy5kbix0wmn0sca39c8miyga6cijydi128zxm2a";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 4.0 with grep in /nix/store/c0571y53r1krsbg57vn8pwg9sfm7wcxq-entr-4.0
- found 4.0 in filename of file in /nix/store/c0571y53r1krsbg57vn8pwg9sfm7wcxq-entr-4.0