### PR TITLE
envconsul: 0.6.2 -> 0.7.3

### DIFF
--- a/pkgs/tools/system/envconsul/default.nix
+++ b/pkgs/tools/system/envconsul/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "envconsul-${version}";
-  version = "0.6.2";
+  version = "0.7.3";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/envconsul";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "hashicorp";
     repo = "envconsul";
-    sha256 = "176jbicyg7vwd0kgawz859gq7ldrxyw1gx55wig7azakiidkl731";
+    sha256 = "03cgxkyyynr067dg5b0lhvaxn60318fj9fh55p1n43vj5nrzgnbc";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/djrl8w6b7ww5mk60grn239ahjmf5v0jb-envconsul-0.7.3-bin/bin/envconsul -h` got 0 exit code
- ran `/nix/store/djrl8w6b7ww5mk60grn239ahjmf5v0jb-envconsul-0.7.3-bin/bin/envconsul --help` got 0 exit code
- ran `/nix/store/djrl8w6b7ww5mk60grn239ahjmf5v0jb-envconsul-0.7.3-bin/bin/envconsul -v` and found version 0.7.3
- ran `/nix/store/djrl8w6b7ww5mk60grn239ahjmf5v0jb-envconsul-0.7.3-bin/bin/envconsul --version` and found version 0.7.3
- found 0.7.3 with grep in /nix/store/djrl8w6b7ww5mk60grn239ahjmf5v0jb-envconsul-0.7.3-bin
- found 0.7.3 in filename of file in /nix/store/djrl8w6b7ww5mk60grn239ahjmf5v0jb-envconsul-0.7.3-bin