### PR TITLE
esptool: 2.1 -> 2.2.1

### DIFF
--- a/pkgs/tools/misc/esptool/default.nix
+++ b/pkgs/tools/misc/esptool/default.nix
@@ -2,13 +2,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   name = "esptool-${version}";
-  version = "2.1";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     rev = "v${version}";
-    sha256 = "137p0kcscly95qpjzgx1yxm8k2wf5y9v3srvlhp2ajniirgv8ijv";
+    sha256 = "0jnni4mgj5b0cng4cgg7x8p1ss73d59dfdgimsn2jxfld4h534x8";
   };
 
   buildInputs = with python3.pkgs; [ flake8 flake8-future-import ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/esptool.py -h` got 0 exit code
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/esptool.py --help` got 0 exit code
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/esptool.py version` and found version 2.2.1
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/esptool.py -h` and found version 2.2.1
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/esptool.py --help` and found version 2.2.1
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/.esptool.py-wrapped -h` got 0 exit code
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/.esptool.py-wrapped --help` got 0 exit code
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/.esptool.py-wrapped version` and found version 2.2.1
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/.esptool.py-wrapped -h` and found version 2.2.1
- ran `/nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1/bin/.esptool.py-wrapped --help` and found version 2.2.1
- found 2.2.1 with grep in /nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1
- found 2.2.1 in filename of file in /nix/store/ghmirxp7p1l379v908p8535fb16mqj6c-esptool-2.2.1
