### PR TITLE
encfs: 1.9.2 -> 1.9.4

### DIFF
--- a/pkgs/tools/filesystems/encfs/default.nix
+++ b/pkgs/tools/filesystems/encfs/default.nix
@@ -5,10 +5,10 @@
 
 stdenv.mkDerivation rec {
   name = "encfs-${version}";
-  version = "1.9.2";
+  version = "1.9.4";
 
   src = fetchFromGitHub {
-    sha256 = "0isx7n4r8znk02464s0wvlzk6ry5mlnq3kgnd0rapnhjwdvwqr5y";
+    sha256 = "1hp2l4yk7fsimlrrd6a675vigmyikd323l1n3mybcdng58skj2ag";
     rev = "v${version}";
     repo = "encfs";
     owner = "vgough";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/cfhzvmll3rjhgrhl4ypv40ap726dlgh2-encfs-1.9.4/bin/encfs --version` and found version 1.9.4
- ran `/nix/store/cfhzvmll3rjhgrhl4ypv40ap726dlgh2-encfs-1.9.4/bin/encfsctl --version` and found version 1.9.4
- found 1.9.4 with grep in /nix/store/cfhzvmll3rjhgrhl4ypv40ap726dlgh2-encfs-1.9.4
- found 1.9.4 in filename of file in /nix/store/cfhzvmll3rjhgrhl4ypv40ap726dlgh2-encfs-1.9.4