### PR TITLE
etcd: 3.1.6 -> 3.3.1

### DIFF
--- a/pkgs/servers/etcd/default.nix
+++ b/pkgs/servers/etcd/default.nix
@@ -4,7 +4,7 @@ with lib;
 
 buildGoPackage rec {
   name = "etcd-${version}";
-  version = "3.1.6"; # After updating check that nixos tests pass
+  version = "3.3.1"; # After updating check that nixos tests pass
   rev = "v${version}";
 
   goPackagePath = "github.com/coreos/etcd";
@@ -13,7 +13,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "coreos";
     repo = "etcd";
-    sha256 = "1qgi6zxnijzr644w2da2gbn3gw2qwk6a3z3qmdln0r2rjnm70sx0";
+    sha256 = "11gzmi05y4kpnzgqc737l0wk5svxai4z17nl92jazqga6zhyavyl";
   };
 
   subPackages = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/benchmark -h` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/benchmark --help` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/benchmark help` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcd-dump-db -h` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcd-dump-db --help` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcd-dump-db help` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcdctl -h` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcdctl --help` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcdctl help` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcdctl -v` and found version 3.3.1
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcdctl --version` and found version 3.3.1
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcdctl -h` and found version 3.3.1
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcdctl --help` and found version 3.3.1
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcdctl help` and found version 3.3.1
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcd -h` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcd --help` got 0 exit code
- ran `/nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin/bin/etcd --version` and found version 3.3.1
- found 3.3.1 with grep in /nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin
- found 3.3.1 in filename of file in /nix/store/bv1hwms0avpnxymgsvwyw9j3n8578k24-etcd-3.3.1-bin