### PR TITLE
eventstat: 0.03.04 -> 0.04.03

### DIFF
--- a/pkgs/os-specific/linux/eventstat/default.nix
+++ b/pkgs/os-specific/linux/eventstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "eventstat-${version}";
-  version = "0.03.04";
+  version = "0.04.03";
   src = fetchzip {
     url = "http://kernel.ubuntu.com/~cking/tarballs/eventstat/eventstat-${version}.tar.gz";
-    sha256 = "1sqf1mfafrw6402qx457gh8yxgsw80311qi0lp4cjl9dfz7vl2x1";
+    sha256 = "0yv7rpdg07rihw8iilvigib963nxf16mn26hzlb6qd1wv54k6dbr";
   };
   buildInputs = [ ncurses ];
   installFlags = [ "DESTDIR=$(out)" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/2zp45hxwi8mnlsaf2hwfdbd0hkzrfcvz-eventstat-0.04.03/bin/eventstat -h` got 0 exit code
- ran `/nix/store/2zp45hxwi8mnlsaf2hwfdbd0hkzrfcvz-eventstat-0.04.03/bin/eventstat -h` and found version 0.04.03
- found 0.04.03 with grep in /nix/store/2zp45hxwi8mnlsaf2hwfdbd0hkzrfcvz-eventstat-0.04.03
- found 0.04.03 in filename of file in /nix/store/2zp45hxwi8mnlsaf2hwfdbd0hkzrfcvz-eventstat-0.04.03
