### PR TITLE
exempi: 2.4.2 -> 2.4.4

### DIFF
--- a/pkgs/development/libraries/exempi/default.nix
+++ b/pkgs/development/libraries/exempi/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, expat, zlib, boost, libiconv, darwin }:
 
 stdenv.mkDerivation rec {
-  name = "exempi-2.4.2";
+  name = "exempi-2.4.4";
 
   src = fetchurl {
     url = "http://libopenraw.freedesktop.org/download/${name}.tar.bz2";
-    sha256 = "1v665fc7x0yi7x6lzskvd8bd2anf7951svn2vd5384dblmgv43av";
+    sha256 = "1c1xxiw9lazdaz4zvrnvcy9pif9l1wib7zy91m48i7a4bnf9mmd2";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.4.4 with grep in /nix/store/9039bglagidwg2w8qskvi9l6mbmvwdvh-exempi-2.4.4
- found 2.4.4 in filename of file in /nix/store/9039bglagidwg2w8qskvi9l6mbmvwdvh-exempi-2.4.4