### PR TITLE
expect: 5.45 -> 5.45.4

### DIFF
--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, tcl, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "5.45";
+  version = "5.45.4";
   name = "expect-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/expect/Expect/${version}/expect${version}.tar.gz";
-    sha256 = "0h60bifxj876afz4im35rmnbnxjx4lbdqp2ja3k30fwa8a8cm3dj";
+    sha256 = "0d1cp5hggjl93xwc8h1y6adbnrvpkk0ywkd00inz9ndxn21xm9s9";
   };
 
   buildInputs = [ tcl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/expect -v` and found version 5.45.4
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/timed-read -h` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/timed-read --help` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/timed-read help` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/weather help` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/kibitz help` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/rlogin-cwd -h` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/rlogin-cwd --help` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/rlogin-cwd help` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/mkpasswd -h` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/mkpasswd --help` got 0 exit code
- ran `/nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4/bin/.expect-wrapped -v` and found version 5.45.4
- found 5.45.4 with grep in /nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4
- found 5.45.4 in filename of file in /nix/store/3f5lmyfii8yzf3rw3ghpzcdj6f0v5l29-expect-5.45.4