### PR TITLE
fceux: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/misc/emulators/fceux/default.nix
+++ b/pkgs/misc/emulators/fceux/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, scons, zlib, SDL, lua5_1, pkgconfig}:
 
 stdenv.mkDerivation {
-  name = "fceux-2.2.2";
+  name = "fceux-2.2.3";
 
   src = fetchurl {
-    url = mirror://sourceforge/fceultra/Source%20Code/2.2.2%20src/fceux-2.2.2.src.tar.gz;
-    sha256 = "1qg5bygla8ka30b7wqvq6dv84xc7pq0jspffh2jz75d1njyi2kc0";
+    url = mirror://sourceforge/fceultra/Source%20Code/2.2.3%20src/fceux-2.2.3.src.tar.gz;
+    sha256 = "0gl2i3qdmcm7v9m5kpfz98w05d8m33990jiwka043ya7lflxvrjb";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/27q1wf9bs3qp60l2q0b2pyzf6ykijarj-fceux-2.2.3/bin/fceux -h` got 0 exit code
- ran `/nix/store/27q1wf9bs3qp60l2q0b2pyzf6ykijarj-fceux-2.2.3/bin/fceux --help` got 0 exit code
- ran `/nix/store/27q1wf9bs3qp60l2q0b2pyzf6ykijarj-fceux-2.2.3/bin/fceux -h` and found version 2.2.3
- ran `/nix/store/27q1wf9bs3qp60l2q0b2pyzf6ykijarj-fceux-2.2.3/bin/fceux --help` and found version 2.2.3
- found 2.2.3 with grep in /nix/store/27q1wf9bs3qp60l2q0b2pyzf6ykijarj-fceux-2.2.3
- found 2.2.3 in filename of file in /nix/store/27q1wf9bs3qp60l2q0b2pyzf6ykijarj-fceux-2.2.3