### PR TITLE
fcron: 3.2.1 -> 3.3.0

### DIFF
--- a/pkgs/tools/system/fcron/default.nix
+++ b/pkgs/tools/system/fcron/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "fcron-${version}";
-  version = "3.2.1";
+  version = "3.3.0";
 
   src = fetchurl {
     url = "http://fcron.free.fr/archives/${name}.src.tar.gz";
-    sha256 = "0sjz7r050myj6zgixzx3pk5ff819v6b0zfn0q1lkd19jkaix0531";
+    sha256 = "0q5b1fdq1rpsd4lj7v717x47pmn62hhm13394g0yxqi614xd7sls";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0/bin/fcrontab -h` got 0 exit code
- ran `/nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0/bin/fcrontab --help` got 0 exit code
- ran `/nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0/bin/fcrontab help` got 0 exit code
- ran `/nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0/bin/fcronsighup -h` got 0 exit code
- ran `/nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0/bin/fcronsighup --help` got 0 exit code
- ran `/nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0/bin/fcronsighup help` got 0 exit code
- ran `/nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0/bin/fcrondyn -V` and found version 3.3.0
- found 3.3.0 with grep in /nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0
- found 3.3.0 in filename of file in /nix/store/dmh101f0pbqggvjywh5dfgmi1i8sh3ic-fcron-3.3.0