### PR TITLE
feh: 2.23 -> 2.23.2

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -6,11 +6,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "feh-${version}";
-  version = "2.23";
+  version = "2.23.2";
 
   src = fetchurl {
     url = "https://feh.finalrewind.org/${name}.tar.bz2";
-    sha256 = "18922zv8ckm82r1ap1yn7plbk6djpj02za2ahng58sjj2fw3rpqn";
+    sha256 = "1hw9xhhmm404ircmd7aw9n51n23wzjxzmav272ldk1pxb2jk3hcn";
   };
 
   outputs = [ "out" "man" "doc" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2/bin/feh -h` got 0 exit code
- ran `/nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2/bin/feh --help` got 0 exit code
- ran `/nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2/bin/feh -v` and found version 2.23.2
- ran `/nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2/bin/feh --version` and found version 2.23.2
- ran `/nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2/bin/.feh-wrapped -h` got 0 exit code
- ran `/nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2/bin/.feh-wrapped --help` got 0 exit code
- ran `/nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2/bin/.feh-wrapped -v` and found version 2.23.2
- ran `/nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2/bin/.feh-wrapped --version` and found version 2.23.2
- found 2.23.2 with grep in /nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2
- found 2.23.2 in filename of file in /nix/store/9r2xpmvwq8vslxz1p3kv7x0ia0j2ghkx-feh-2.23.2