### PR TITLE
flacon: 2.1.1 -> 4.0.0

### DIFF
--- a/pkgs/applications/audio/flacon/default.nix
+++ b/pkgs/applications/audio/flacon/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "flacon-${version}";
-  version = "2.1.1";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "flacon";
     repo = "flacon";
     rev = "v${version}";
-    sha256 = "0jazv3d1xaydp2ws1pd5rmga76z5yk74v3a8yqfc8vbb2z6ahimz";
+    sha256 = "0l0xbzpy4nnr08z7gqvb4ngrjwzpspa382cbcrpkya3nd40987kr";
   };
 
   nativeBuildInputs = [ cmake pkgconfig makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0/bin/flacon -h` got 0 exit code
- ran `/nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0/bin/flacon --help` got 0 exit code
- ran `/nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0/bin/flacon help` got 0 exit code
- ran `/nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0/bin/flacon --version` and found version 4.0.0
- ran `/nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0/bin/.flacon-wrapped -h` got 0 exit code
- ran `/nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0/bin/.flacon-wrapped --help` got 0 exit code
- ran `/nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0/bin/.flacon-wrapped --version` and found version 4.0.0
- found 4.0.0 with grep in /nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0
- found 4.0.0 in filename of file in /nix/store/sfixg95yp8qsdhilwcf51g7380q33x7s-flacon-4.0.0