### PR TITLE
fleet: 0.11.8 -> 1.0.0

### DIFF
--- a/pkgs/servers/fleet/default.nix
+++ b/pkgs/servers/fleet/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "fleet-${version}";
-  version = "0.11.8";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "coreos";
     repo = "fleet";
     rev = "v${version}";
-    sha256 = "13kwaa4hkiic602wnvnk13pflrxqhk2vxwpk1bn52ilwxkjyvkig";
+    sha256 = "0j48ajz19aqfzv9iyznnn39aw51y1nqcl270grmvi5cbqycmrfm0";
   };
 
   buildInputs = [ go ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.0.0 with grep in /nix/store/608n659blbbpf836scf4lnjdx1q25gra-fleet-1.0.0
- found 1.0.0 in filename of file in /nix/store/608n659blbbpf836scf4lnjdx1q25gra-fleet-1.0.0