### PR TITLE
flatbuffers: 1.4.0 -> 1.8.0

### DIFF
--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "flatbuffers-${version}";
-  version = "1.4.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "flatbuffers";
     rev = "v${version}";
-    sha256 = "0jsqk49h521d5h4c9gk39a8968g6rcd6520a8knbfc7ssc4028y0";
+    sha256 = "1qq8qbv8wkiiizj8s984f17bsbjsrhbs9q1nw1yjgrw0grcxlsi9";
   };
 
   buildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/2zfi5j6wmfb6hbaqmmsbarbjz8r5f333-flatbuffers-1.8.0/bin/flatc --version` and found version 1.8.0
- found 1.8.0 with grep in /nix/store/2zfi5j6wmfb6hbaqmmsbarbjz8r5f333-flatbuffers-1.8.0
- found 1.8.0 in filename of file in /nix/store/2zfi5j6wmfb6hbaqmmsbarbjz8r5f333-flatbuffers-1.8.0