### PR TITLE
flyway: 4.2.0 -> 5.0.7

### DIFF
--- a/pkgs/development/tools/flyway/default.nix
+++ b/pkgs/development/tools/flyway/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, jre_headless, makeWrapper }:
   let
-    version = "4.2.0";
+    version = "5.0.7";
   in
     stdenv.mkDerivation {
       name = "flyway-${version}";
       src = fetchurl {
-        url = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.2.0/flyway-commandline-${version}.tar.gz";
-        sha256 = "1fxj760qx6apsz50p60c9n79k6bqkjcv2zfgab0awvmdvdy4k661";
+        url = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/5.0.7/flyway-commandline-${version}.tar.gz";
+        sha256 = "1zmnzz7d5kb2wpmfizryxxhpjs16j5k9mich1hbb2qfkqvygk6sv";
       };
       buildInputs = [ makeWrapper ];
       dontBuild = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway -h` got 0 exit code
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway --help` got 0 exit code
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway help` got 0 exit code
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway -V` and found version 5.0.7
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway -v` and found version 5.0.7
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway --version` and found version 5.0.7
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway -h` and found version 5.0.7
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway --help` and found version 5.0.7
- ran `/nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7/bin/flyway help` and found version 5.0.7
- found 5.0.7 with grep in /nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7
- found 5.0.7 in filename of file in /nix/store/lzmkkf5v0xf3dxqn3gzcwww8a30gwgma-flyway-5.0.7