### PR TITLE
fluidsynth: 1.1.8 -> 1.1.9

### DIFF
--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation  rec {
   name = "fluidsynth-${version}";
-  version = "1.1.8";
+  version = "1.1.9";
 
   src = fetchFromGitHub {
     owner = "FluidSynth";
     repo = "fluidsynth";
     rev = "v${version}";
-    sha256 = "12q7hv0zvgylsdj1ipssv5zr7ap2y410dxsd63dz22y05fa2hwwd";
+    sha256 = "0krvmb1idnf95l2ydzfcb08ayyx3n4m71hf9fgwv3srzaikvpf3q";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lahkxc281j7vxzivbp68c71k6jgjzmcj-fluidsynth-1.1.9/bin/fluidsynth -h` got 0 exit code
- ran `/nix/store/lahkxc281j7vxzivbp68c71k6jgjzmcj-fluidsynth-1.1.9/bin/fluidsynth --help` got 0 exit code
- ran `/nix/store/lahkxc281j7vxzivbp68c71k6jgjzmcj-fluidsynth-1.1.9/bin/fluidsynth -V` and found version 1.1.9
- ran `/nix/store/lahkxc281j7vxzivbp68c71k6jgjzmcj-fluidsynth-1.1.9/bin/fluidsynth --version` and found version 1.1.9
- ran `/nix/store/lahkxc281j7vxzivbp68c71k6jgjzmcj-fluidsynth-1.1.9/bin/fluidsynth -h` and found version 1.1.9
- ran `/nix/store/lahkxc281j7vxzivbp68c71k6jgjzmcj-fluidsynth-1.1.9/bin/fluidsynth --help` and found version 1.1.9
- found 1.1.9 with grep in /nix/store/lahkxc281j7vxzivbp68c71k6jgjzmcj-fluidsynth-1.1.9
- found 1.1.9 in filename of file in /nix/store/lahkxc281j7vxzivbp68c71k6jgjzmcj-fluidsynth-1.1.9