### PR TITLE
neomutt: fix smime_keys openssl path, closes #35654

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -38,6 +38,9 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postPatch = ''
+    substituteInPlace contrib/smime_keys \
+      --replace /usr/bin/openssl ${openssl}/bin/openssl
+
     for f in doc/*.{xml,xsl}*  ; do
       substituteInPlace $f \
         --replace http://docbook.sourceforge.net/release/xsl/current     ${docbook_xsl}/share/xml/docbook-xsl \


### PR DESCRIPTION
###### Motivation for this change

Fix #35654 as done in #20275.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

