### PR TITLE
avro-c: init at 1.8.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -373,6 +373,7 @@
   lasandell = "Luke Sandell <lasandell@gmail.com>";
   lassulus = "Lassulus <lassulus@gmail.com>";
   layus = "Guillaume Maudoux <layus.on@gmail.com>";
+  lblasc = "Luka Blaskovic <lblasc@znode.net>";
   ldesgoui = "Lucas Desgouilles <ldesgoui@gmail.com>";
   league = "Christopher League <league@contrapunctus.net>";
   lebastr = "Alexander Lebedev <lebastr@gmail.com>";

--- a/pkgs/development/libraries/avro-c/default.nix
+++ b/pkgs/development/libraries/avro-c/default.nix
@@ -1,35 +1,30 @@
 { stdenv, bash, cmake, fetchurl, pkgconfig, jansson, zlib }:
 
-let version = "1.8.2"; in
-
-stdenv.mkDerivation rec {
+let
+  version = "1.8.2";
+in stdenv.mkDerivation rec {
   name = "avro-c-${version}";
 
-  #
   src = fetchurl {
     url = "mirror://apache/avro/avro-${version}/c/avro-c-${version}.tar.gz";
     sha256 = "03pixl345kkpn1jds03rpdcwjabi41rgdzi8f7y93gcg5cmrhfa6";
   };
 
-  patchPhase = ''
-    substituteInPlace version.sh \
-      --replace /bin/bash "$bash/bin/bash"
+  postPatch = ''
+    patchShebangs .
   '';
 
-  buildInputs = [
-    pkgconfig
-    cmake
-    jansson
-    zlib
-  ];
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  buildInputs = [ jansson zlib ];
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A C library which implements parts of the Avro Specification";
     homepage = https://avro.apache.org/;
-    license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ lblasc ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lblasc ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/avro-c/default.nix
+++ b/pkgs/development/libraries/avro-c/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, bash, cmake, fetchurl, pkgconfig, jansson, zlib }:
+
+let version = "1.8.2"; in
+
+stdenv.mkDerivation rec {
+  name = "avro-c-${version}";
+
+  #
+  src = fetchurl {
+    url = "mirror://apache/avro/avro-${version}/c/avro-c-${version}.tar.gz";
+    sha256 = "03pixl345kkpn1jds03rpdcwjabi41rgdzi8f7y93gcg5cmrhfa6";
+  };
+
+  patchPhase = ''
+    substituteInPlace version.sh \
+      --replace /bin/bash "$bash/bin/bash"
+  '';
+
+  buildInputs = [
+    pkgconfig
+    cmake
+    jansson
+    zlib
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A C library which implements parts of the Avro Specification";
+    homepage = https://avro.apache.org/;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ lblasc ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -725,6 +725,8 @@ with pkgs;
     qt4Support = config.avahi.qt4Support or false;
   };
 
+  avro-c = callPackage ../development/libraries/avro-c { };
+
   avro-cpp = callPackage ../development/libraries/avro-c++ { boost = boost160; };
 
   aws = callPackage ../tools/virtualization/aws { };


### PR DESCRIPTION
###### Motivation for this change

Add C avro bindings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

