### PR TITLE
gphoto2: 2.5.11 -> 2.5.15

### DIFF
--- a/pkgs/applications/misc/gphoto2/default.nix
+++ b/pkgs/applications/misc/gphoto2/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gphoto2-2.5.11";
+  name = "gphoto2-2.5.15";
 
   src = fetchurl {
     url = "mirror://sourceforge/gphoto/${name}.tar.bz2";
-    sha256 = "1sgr6rsvzzagcwhc8fxbnvz3k02wr2hab0vrbvcb04k5l3b48a1r";
+    sha256 = "0xsa12k5fz49v8y4h3zahzr427a3ylxaf0k7hybrkp43g4i1lmxf";
   };
 
   nativeBuildInputs = [ pkgconfig gettext libtool ];

--- a/pkgs/development/libraries/libgphoto2/default.nix
+++ b/pkgs/development/libraries/libgphoto2/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     owner = "gphoto";
     repo = "libgphoto2";
     rev = "${meta.tag}";
-    sha256 = "0chwnw3d2d1k8g4xidzkpy9f3ci30yz7yvxq1mipp2rbndl1y2am";
+    sha256 = "1svbpmxqm56pqkv0rxhlyk4vw7mjgjz8zz4p669qvmw630082yj9";
   };
 
   patches = [];
@@ -33,8 +33,8 @@ stdenv.mkDerivation rec {
       MTP, and other vendor specific protocols for controlling and transferring data
       from digital cameras.
     '';
-    version = "2.5.12";
-    tag = "libgphoto2-2_5_12-release";
+    version = "2.5.16";
+    tag = "libgphoto2-2_5_16-release";
     # XXX: the homepage claims LGPL, but several src files are lgpl21Plus
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = with stdenv.lib.platforms; unix;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

