### PR TITLE
rssguard: 3.5.5 -> 3.5.6

### DIFF
--- a/pkgs/applications/networking/feedreaders/rssguard/default.nix
+++ b/pkgs/applications/networking/feedreaders/rssguard/default.nix
@@ -3,24 +3,18 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "rssguard";
-  version = "3.5.5";
+  version = "3.5.6";
 
   src = fetchFromGitHub {
     owner = "martinrotter";
     repo = pname;
     rev = version;
-    sha256 = "0swjh664y1yqr1rn3ym2kicyx7r97ypr4qf7qrjl4a5q1spzsv48";
+    sha256 = "1pdas7hg3nzykm3qi951fk25c9s6gjb7my82b9xzjn2yd7ks71by";
   };
 
   buildInputs =  [ qtwebengine qttools ];
   nativeBuildInputs = [ qmake wrapGAppsHook ];
   qmakeFlags = [ "CONFIG+=release" ];
-
-  # FIXME: This shouldn't be needed after 3.5.5.
-  # See: https://github.com/martinrotter/rssguard/issues/175
-  preConfigure = ''
-    lrelease rssguard.pro
-  '';
 
   meta = with stdenv.lib; {
     description = "Simple RSS/Atom feed reader with online synchronization";


### PR DESCRIPTION
###### Motivation for this change

Upgrade RSS Guard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

