### PR TITLE
libiconv: don't use deprecated crossAttrs, re-enabling cross-stripping

### DIFF
--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -22,12 +22,6 @@ stdenv.mkDerivation rec {
   configureFlags =
     lib.optional stdenv.isFreeBSD "--with-pic";
 
-  crossAttrs = {
-    # Disable stripping to avoid "libiconv.a: Archive has no index" (MinGW).
-    dontStrip = true;
-    dontCrossStrip = true;
-  };
-
   meta = {
     description = "An iconv(3) implementation";
 


### PR DESCRIPTION
Fixes retained references to bootstrap compiler in cross.

https://twitter.com/telent_net/status/967202831940964352


FWIW, this wa added in 2013 in e80ec28da17783cfe016f10f90ae53ca14907c8f,
and a lot of things have changed since then!

Removing as cruft and to fix closure sizes on platforms being used.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---