### PR TITLE
llvm_4: fix cosmetic issue in help output

### DIFF
--- a/pkgs/development/compilers/llvm/4/cmdline-help.patch
+++ b/pkgs/development/compilers/llvm/4/cmdline-help.patch
@@ -1,0 +1,39 @@
+From c7a9aa3a697c81432786a5583bf973771c7be15e Mon Sep 17 00:00:00 2001
+From: Don Hinton <hintonda@gmail.com>
+Date: Wed, 12 Jul 2017 01:15:46 +0000
+Subject: [PATCH] Fix minor typo introduced in r276404
+
+Summary:
+A space was added between '-' and 'help' when emitting help output.
+
+See https://reviews.llvm.org/D22621 for details.
+
+Reviewers: MaggieYi, vsk
+
+Reviewed By: vsk
+
+Subscribers: llvm-commits
+
+Differential Revision: https://reviews.llvm.org/D35283
+
+git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@307745 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ lib/Support/CommandLine.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/Support/CommandLine.cpp b/lib/Support/CommandLine.cpp
+index 3889902eea5..79defa5c36c 100644
+--- a/lib/Support/CommandLine.cpp
++++ b/lib/Support/CommandLine.cpp
+@@ -1236,7 +1236,7 @@ bool CommandLineParser::ParseCommandLineOptions(int argc,
+              << ": Not enough positional command line arguments specified!\n"
+              << "Must specify at least " << NumPositionalRequired
+              << " positional argument" << (NumPositionalRequired > 1 ? "s" : "")
+-             << ": See: " << argv[0] << " - help\n";
++             << ": See: " << argv[0] << " -help\n";
+     }
+ 
+     ErrorParsing = true;
+-- 
+2.14.0
+

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -78,6 +78,9 @@ in stdenv.mkDerivation (rec {
       substituteInPlace lib/esan/esan_sideline_linux.cpp \
         --replace 'struct sigaltstack' 'stack_t'
     )
+  '' + # Fix extra space printed in commandline help sometimes, "- help"
+  ''
+    patch -p1 -i ${./cmdline-help.patch}
   '' + stdenv.lib.optionalString stdenv.isAarch64 ''
     patch -p0 < ${../aarch64.patch}
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''


### PR DESCRIPTION
Fix bug in help output.

Can be observed in programs like "llvm-link".


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---