### PR TITLE
mp3blaster: Build with support for ogg vorbis

### DIFF
--- a/pkgs/applications/audio/mp3blaster/default.nix
+++ b/pkgs/applications/audio/mp3blaster/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ncurses }:
+{ stdenv, fetchFromGitHub, ncurses, libvorbis }:
 stdenv.mkDerivation rec {
 
   version = "3.2.6";
@@ -12,7 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "0pzwml3yhysn8vyffw9q9p9rs8gixqkmg4n715vm23ib6wxbliqs";
   };
 
-  buildInputs = [ ncurses ];
+  buildInputs = [
+    ncurses
+    libvorbis
+  ];
 
   buildFlags = [ "CXXFLAGS=-Wno-narrowing" ];
 


### PR DESCRIPTION
###### Motivation for this change
This package usually supports OGG but was built with only support for MP3 and WAV.

Adding `libvorbis` means that mp3blaster can now play OGG files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

