### PR TITLE
gnulib: 0.1-357-gffe6467 -> 20180226

### DIFF
--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -1,17 +1,16 @@
 { stdenv, fetchgit }:
 
 stdenv.mkDerivation {
-  name = "gnulib-0.1-357-gffe6467";
-
-  phases = ["unpackPhase" "installPhase"];
+  name = "gnulib-20180226";
 
   src = fetchgit {
     url = "http://git.savannah.gnu.org/r/gnulib.git";
-    rev = "92b60e61666f008385d9b7f7443da17c7a44d1b1";
-    sha256 = "0sa1dndvaxhw0zyc19al5cmpgzlwnnznjz89lw1b4vj3xn7avjnr";
+    rev = "0bec5d56c6938c2f28417bb5fd1c4b05ea2e7d28";
+    sha256 = "0sifr3bkmhyr5s6ljgfyr0fw6w49ajf11rlp1r797f3r3r6j9w4k";
   };
 
   installPhase = "mkdir -p $out; mv * $out/";
+  dontFixup = true;
 
   meta = {
     homepage = http://www.gnu.org/software/gnulib/;


### PR DESCRIPTION
###### Motivation for this change

1. gnulib in ```nixpkgs``` [is 3.5 years old](http://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=92b60e61666f008385d9b7f7443da17c7a44d1b1)
2. a newer version is required to compile ```libvirt-4.x```
3. the present version schema (0.1-357-gffe6467) is vague and no other distro follows it, so I changed it to YYYYMMDD, for the reasons:
3.1. other distros use YYYYMMDD, so it would allow Repology to compare the versions.
3.2. a vague version scheme gives no hint how old is the package.
3.3. I have no idea what is the actual version number in (0.1-357-gffe6467)-like schema (UPD: I got it, it was ```git describe HEAD```)
