### PR TITLE
nixos/rspamd: Preserve runtime directory when using socket activation

### DIFF
--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -308,6 +308,7 @@ in
         ExecStart = "${pkgs.rspamd}/bin/rspamd ${optionalString cfg.debug "-d"} --user=${cfg.user} --group=${cfg.group} --pid=/run/rspamd.pid -c ${rspamdConfFile} -f";
         Restart = "always";
         RuntimeDirectory = "rspamd";
+        RuntimeDirectoryPreserve = mkIf cfg.socketActivation true;
         PrivateTmp = true;
         Sockets = mkIf cfg.socketActivation (concatStringsSep " " allSocketNames);
       };


### PR DESCRIPTION
###### Motivation for this change

When I added support for socket activation to rspamd module in #34562 I missed that systemd deletes the RuntimeDirectory when the service is stopped. Since the default worker socket is in that directory it means that if the service is stopped the socket is deleted which means the socket unit needs to be restarted for the socket to be recreated. 

Setting the `RuntimeDirectoryPreserve` option stops systemd from deleting the runtime directory so this change does that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
