### PR TITLE
rdma-core: 16.1 -> 17

### DIFF
--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -3,7 +3,7 @@
 } :
 
 let
-  version = "16.1";
+  version = "17";
 
 in stdenv.mkDerivation {
   name = "rdma-core-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "linux-rdma";
     repo = "rdma-core";
     rev = "v${version}";
-    sha256 = "1fixw6hpf732vzlpczx0b2y84jrhgfjr3cljqxky7makzgh2s7ng";
+    sha256 = "1xql46favv8i4ni4zqkk9ra2kcqq2dyn7jyi940c869lndmjw9ni";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Update version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
->nixos/tests/rxe.nix still proceeds.
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

