### PR TITLE
hamlib: 1.2.15.3 -> 3.1

### DIFF
--- a/pkgs/development/libraries/hamlib/default.nix
+++ b/pkgs/development/libraries/hamlib/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   pname = "hamlib";
-  version = "1.2.15.3";
+  version = "3.1";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${name}.tar.gz";
-    sha256 = "0ppp6fc2h9d8p30j2s9wlqd620kmnny4wd8fc3jxd6gxwi4lbjm2";
+    sha256 = "0klr1ibn5zqmy3z7669jah52spf9phrqphjzdbywrxlgx31h88v8";
   };
 
   buildInputs = [ perl perlPackages.ExtUtilsMakeMaker python2 swig gd libxml2


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctl -h` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctl --help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctl help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctl -V` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctl --version` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctld -h` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctld --help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctld -V` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigctld --version` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigmem -h` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigmem --help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigmem -V` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigmem --version` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigsmtr -h` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigsmtr --help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigsmtr -V` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigsmtr --version` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigswr -h` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigswr --help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigswr -V` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rigswr --version` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctl -h` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctl --help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctl help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctl -V` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctl --version` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctld -h` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctld --help` got 0 exit code
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctld -V` and found version 3.1
- ran `/nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1/bin/rotctld --version` and found version 3.1
- found 3.1 with grep in /nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1
- found 3.1 in filename of file in /nix/store/wv8sl7563h0n3z3qisdb19a8257d6q2w-hamlib-3.1

cc "@relrod"