### PR TITLE
hatari: 1.8.0 -> 2.1.0

### DIFF
--- a/pkgs/misc/emulators/hatari/default.nix
+++ b/pkgs/misc/emulators/hatari/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, zlib, SDL, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "hatari-1.8.0";
+  name = "hatari-2.1.0";
 
   src = fetchurl {
-    url = "http://download.tuxfamily.org/hatari/1.8.0/${name}.tar.bz2";
-    sha256 = "1szznnndmbyc71751hir3dhybmbrx3rnxs6klgbv9qvqlmmlikvy";
+    url = "http://download.tuxfamily.org/hatari/2.1.0/${name}.tar.bz2";
+    sha256 = "0909l9fq20ninf8xgv5qf0a5y64cpk5ja1rsk2iaid1dx5h98agb";
   };
 
   # For pthread_cancel


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0/bin/hmsa -h` got 0 exit code
- ran `/nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0/bin/hmsa --help` got 0 exit code
- ran `/nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0/bin/hmsa -V` and found version 2.1.0
- ran `/nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0/bin/hmsa -v` and found version 2.1.0
- ran `/nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0/bin/hmsa --version` and found version 2.1.0
- ran `/nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0/bin/hmsa -h` and found version 2.1.0
- ran `/nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0/bin/hmsa --help` and found version 2.1.0
- found 2.1.0 with grep in /nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0
- found 2.1.0 in filename of file in /nix/store/9fnkx4rgnai6qvkqdwyhx9824xqdqawf-hatari-2.1.0

cc "@fuuzetsu"