### PR TITLE
galen: 2.3.0 -> 2.3.6

### DIFF
--- a/pkgs/development/tools/galen/default.nix
+++ b/pkgs/development/tools/galen/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "galen";
-  version = "2.3.0";
+  version = "2.3.6";
   name = "${pname}-${version}";
 
   inherit jre8;
 
   src = fetchurl {
     url = "https://github.com/galenframework/galen/releases/download/galen-${version}/galen-bin-${version}.zip";
-    sha256 = "10z7vh3jiq7kbzzp3j0354swkr4xxz9qimi5c5bddbiy671k6cra";
+    sha256 = "0kndib3slj7mdvhd36fxin5q87cnsz4hs135yxgjx0nccxq4f2h5";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/sp59abnhzpg7zdn66207wizb57dy4fxx-galen-2.3.6/bin/galen -h` got 0 exit code
- ran `/nix/store/sp59abnhzpg7zdn66207wizb57dy4fxx-galen-2.3.6/bin/galen --help` got 0 exit code
- ran `/nix/store/sp59abnhzpg7zdn66207wizb57dy4fxx-galen-2.3.6/bin/galen help` got 0 exit code
- ran `/nix/store/sp59abnhzpg7zdn66207wizb57dy4fxx-galen-2.3.6/bin/galen -v` and found version 2.3.6
- ran `/nix/store/sp59abnhzpg7zdn66207wizb57dy4fxx-galen-2.3.6/bin/galen --version` and found version 2.3.6
- ran `/nix/store/sp59abnhzpg7zdn66207wizb57dy4fxx-galen-2.3.6/bin/galen version` and found version 2.3.6
- found 2.3.6 in filename of file in /nix/store/sp59abnhzpg7zdn66207wizb57dy4fxx-galen-2.3.6