### PR TITLE
gammu: 1.38.2 -> 1.39.0

### DIFF
--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -8,13 +8,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "gammu-${version}";
-  version = "1.38.2";
+  version = "1.39.0";
 
   src = fetchFromGitHub {
     owner = "gammu";
     repo = "gammu";
     rev = version;
-    sha256 = "1rk3p3sjyy6n6mlqs4qgyxna4swrh1zm7b77npxv8j341wxj3khv";
+    sha256 = "1hr053z2l5mjgip83fsxnd1rqsp5gwywzagzrgdg243apn1nz0gs";
   };
 
   patches = [ ./bashcomp-dir.patch ./systemd.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd -h` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd --help` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd -v` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd --version` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd-inject -h` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd-inject --help` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd-inject -v` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd-inject --version` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd-monitor -h` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd-monitor --help` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd-monitor -v` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu-smsd-monitor --version` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu -h` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu --help` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu help` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu --version` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu version` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu -h` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu --help` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/gammu help` and found version 1.39.0
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/jadmaker -h` got 0 exit code
- ran `/nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0/bin/jadmaker --help` got 0 exit code
- found 1.39.0 with grep in /nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0
- found 1.39.0 in filename of file in /nix/store/bfy77lr5m9rqn8a6rmw31gjyrwzyyi4q-gammu-1.39.0

cc "@coroa"