### PR TITLE
hiawatha: 10.5 -> 10.7

### DIFF
--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -12,11 +12,11 @@ assert enableSSL -> openssl !=null;
 
 stdenv.mkDerivation rec {
   name = "hiawatha-${version}";
-  version = "10.5";
+  version = "10.7";
 
   src = fetchurl {
     url = "https://github.com/hsleisink/hiawatha/archive/v${version}.tar.gz";
-    sha256 = "11nqdmmhq1glgsiza8pfh69wmpgwl51vb3xijmpcxv63a7ywp4fj";
+    sha256 = "1k0vgpfkmdxmkimq4ab70cqwhj5qwr4pzq7nnv957ah8cw2ijy1z";
   };
 
   buildInputs =  [ cmake libxslt zlib libxml2 ] ++ stdenv.lib.optional enableSSL openssl ;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/ssi-cgi -h` got 0 exit code
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/ssi-cgi -v` and found version 10.7
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/ssi-cgi -h` and found version 10.7
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/hiawatha -h` got 0 exit code
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/hiawatha -v` and found version 10.7
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/hiawatha -h` and found version 10.7
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/wigwam -h` got 0 exit code
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/wigwam -v` and found version 10.7
- ran `/nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7/bin/wigwam -h` and found version 10.7
- found 10.7 with grep in /nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7
- found 10.7 in filename of file in /nix/store/5x2w4d0fm3m3wr5snf6c7qys9g2kia3h-hiawatha-10.7

cc "@ndowens"