### PR TITLE
html-tidy: 5.4.0 -> 5.6.0

### DIFF
--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "html-tidy-${version}";
-  version = "5.4.0";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "htacg";
     repo = "tidy-html5";
     rev = version;
-    sha256 = "1q9ag2dh2j636fw9vyz6gg0kiss8p6lvj22h25nqsw0daan57c32";
+    sha256 = "0w175c5d1babq0w1zzdzw9gl6iqbgyq58v8587s7srp05y3hwy9k";
   };
 
   nativeBuildInputs = [ cmake libxslt/*manpage*/ ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0/bin/tidy -h` got 0 exit code
- ran `/nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0/bin/tidy --help` got 0 exit code
- ran `/nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0/bin/tidy help` got 0 exit code
- ran `/nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0/bin/tidy -V` and found version 5.6.0
- ran `/nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0/bin/tidy -v` and found version 5.6.0
- ran `/nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0/bin/tidy --version` and found version 5.6.0
- ran `/nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0/bin/tidy -h` and found version 5.6.0
- ran `/nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0/bin/tidy --help` and found version 5.6.0
- found 5.6.0 with grep in /nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0
- found 5.6.0 in filename of file in /nix/store/9idavy2wphjqap2sw87ivczwq8wy7vjf-html-tidy-5.6.0

cc "@edwtjo"