### PR TITLE
herwig: 7.1.1 -> 7.1.2

### DIFF
--- a/pkgs/development/libraries/physics/herwig/default.nix
+++ b/pkgs/development/libraries/physics/herwig/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "herwig-${version}";
-  version = "7.1.1";
+  version = "7.1.2";
 
   src = fetchurl {
     url = "http://www.hepforge.org/archive/herwig/Herwig-${version}.tar.bz2";
-    sha256 = "13xaykwr7x6mp2bi22wz6dyzx3dxhcv6aw9cg8p29bh9l890g63j";
+    sha256 = "0wr2mmmf5rlvcc6xgdagafm6vb5g6ifvrjc7kd86gs9jip32p29i";
   };
 
   nativeBuildInputs = [ autoconf automake libtool ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/gosam2herwig -h` got 0 exit code
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/gosam2herwig --help` got 0 exit code
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/mg2herwig -h` got 0 exit code
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/mg2herwig --help` got 0 exit code
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/herwig-mergegrids -h` got 0 exit code
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/herwig-mergegrids --help` got 0 exit code
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/Herwig -h` got 0 exit code
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/Herwig --help` got 0 exit code
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/Herwig -V` and found version 7.1.2
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/Herwig --version` and found version 7.1.2
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/Herwig -h` and found version 7.1.2
- ran `/nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2/bin/Herwig --help` and found version 7.1.2
- found 7.1.2 with grep in /nix/store/wl85ali5l9g4naazpbkdlk3aqrlwi2g4-herwig-7.1.2

cc "@veprbl"