### PR TITLE
gdbm: 1.14 -> 1.14.1

### DIFF
--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -1,11 +1,11 @@
 { stdenv, lib, buildPlatform, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "gdbm-1.14";
+  name = "gdbm-1.14.1";
 
   src = fetchurl {
     url = "mirror://gnu/gdbm/${name}.tar.gz";
-    sha256 = "02dakgrq93xwgln8qfv3vs5jyz5yvds5nyzkx6rhg9v585x478dd";
+    sha256 = "0pxwz3jlwvglq2mrbxvrjgr8pa0aj73p3v9sxmdlj570zw0gzknd";
   };
 
   doCheck = true; # not cross;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbmtool -h` got 0 exit code
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbmtool --help` got 0 exit code
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbmtool -V` and found version 1.14.1
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbmtool --version` and found version 1.14.1
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbm_load -h` got 0 exit code
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbm_load --help` got 0 exit code
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbm_load -V` and found version 1.14.1
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbm_load --version` and found version 1.14.1
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbm_dump -h` got 0 exit code
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbm_dump --help` got 0 exit code
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbm_dump -V` and found version 1.14.1
- ran `/nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1/bin/gdbm_dump --version` and found version 1.14.1
- found 1.14.1 with grep in /nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1
- found 1.14.1 in filename of file in /nix/store/ww3vkzjgsrb48822wqxp0zx8c921z2k1-gdbm-1.14.1

cc "@vrthra"