### PR TITLE
geos: 3.6.1 -> 3.6.2

### DIFF
--- a/pkgs/development/libraries/geos/default.nix
+++ b/pkgs/development/libraries/geos/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, fetchpatch, python }:
 
 stdenv.mkDerivation rec {
-  name = "geos-3.6.1";
+  name = "geos-3.6.2";
 
   src = fetchurl {
     url = "http://download.osgeo.org/geos/${name}.tar.bz2";
-    sha256 = "1icz31kd5sml2kdxhjznvmv33zfr6nig9l0i6bdcz9q9g8x4wbja";
+    sha256 = "0ak5szby29l9l0vy43dm5z2g92xzdky20q1gc1kah1fnhkgi6nh4";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/1z3ldj647vpcdj0n4wdjnb3fl2ard1w2-geos-3.6.2/bin/geos-config --version` and found version 3.6.2
- found 3.6.2 with grep in /nix/store/1z3ldj647vpcdj0n4wdjnb3fl2ard1w2-geos-3.6.2
- found 3.6.2 in filename of file in /nix/store/1z3ldj647vpcdj0n4wdjnb3fl2ard1w2-geos-3.6.2
