### PR TITLE
getmail: 5.4 -> 5.5

### DIFF
--- a/pkgs/tools/networking/getmail/default.nix
+++ b/pkgs/tools/networking/getmail/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  version = "5.4";
+  version = "5.5";
   name = "getmail-${version}";
   namePrefix = "";
 
   src = fetchurl {
     url = "http://pyropus.ca/software/getmail/old-versions/${name}.tar.gz";
-    sha256 = "1iwss9z94p165gxr2yw7s9q12a0bn71fcdbikzkykr5s7xxnz2ds";
+    sha256 = "0l43lbnrnyyrq8mlnw37saq6v0mh3nkirdq1dwnsrihykzjjwf70";
   };
 
   doCheck = false;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail -h` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail --help` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail --version` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_fetch -h` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_fetch --help` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_fetch --version` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_maildir -h` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_maildir --help` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_maildir -h` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_maildir --help` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_mbox -h` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_mbox --help` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_mbox -h` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/getmail_mbox --help` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail-wrapped -h` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail-wrapped --help` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail-wrapped --version` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_fetch-wrapped -h` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_fetch-wrapped --help` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_fetch-wrapped --version` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_maildir-wrapped -h` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_maildir-wrapped --help` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_maildir-wrapped -h` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_maildir-wrapped --help` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_mbox-wrapped -h` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_mbox-wrapped --help` got 0 exit code
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_mbox-wrapped -h` and found version 5.5
- ran `/nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5/bin/.getmail_mbox-wrapped --help` and found version 5.5
- found 5.5 with grep in /nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5
- found 5.5 in filename of file in /nix/store/79s8fwglc4hz2di2kzc0nk9s77b9f7h2-getmail-5.5

cc "@raskin @domenkozar"