### PR TITLE
fossil: 2.3 -> 2.5

### DIFF
--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   name = "fossil-${version}";
-  version = "2.3";
+  version = "2.5";
 
   src = fetchurl {
     urls =
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
         "https://www.fossil-scm.org/index.html/uv/fossil-src-${version}.tar.gz"
       ];
     name = "${name}.tar.gz";
-    sha256 = "0paalvb4rdyr79v6rwspaha5n4dqb92df9irijha13m3apsanwzh";
+    sha256 = "1lxawkhr1ki9fqw8076fxib2b1w673449yzb6vxjshqzh5h77c7r";
   };
 
   buildInputs = [ zlib openssl readline sqlite which ed ]


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/14r53ilafr0lhqc5czfifp4bwqk5rh1c-fossil-2.5/bin/fossil --help` got 0 exit code
- ran `/nix/store/14r53ilafr0lhqc5czfifp4bwqk5rh1c-fossil-2.5/bin/fossil help` got 0 exit code
- ran `/nix/store/14r53ilafr0lhqc5czfifp4bwqk5rh1c-fossil-2.5/bin/fossil version` and found version 2.5
- ran `/nix/store/14r53ilafr0lhqc5czfifp4bwqk5rh1c-fossil-2.5/bin/fossil --help` and found version 2.5
- ran `/nix/store/14r53ilafr0lhqc5czfifp4bwqk5rh1c-fossil-2.5/bin/fossil help` and found version 2.5
- found 2.5 with grep in /nix/store/14r53ilafr0lhqc5czfifp4bwqk5rh1c-fossil-2.5
- found 2.5 in filename of file in /nix/store/14r53ilafr0lhqc5czfifp4bwqk5rh1c-fossil-2.5