### PR TITLE
fpart: 0.9.3 -> 1.0.0

### DIFF
--- a/pkgs/tools/misc/fpart/default.nix
+++ b/pkgs/tools/misc/fpart/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "fpart-${version}";
-  version = "0.9.3";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "http://contribs.martymac.org/fpart/${name}.tar.gz";
-    sha256 = "0f1vm7c7v9nrd0mnz6qivpnngni6y53b11kvniclqfd25hhw6ggq";
+    sha256 = "1p0ajmry18lcg82znfp8nxs4w3izic775l7df08hywlq4vfa66pg";
   };
 
   postInstall = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0/bin/fpart -h` got 0 exit code
- ran `/nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0/bin/fpart --help` got 0 exit code
- ran `/nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0/bin/fpart -V` and found version 1.0.0
- ran `/nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0/bin/fpart --version` and found version 1.0.0
- ran `/nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0/bin/fpart --help` and found version 1.0.0
- ran `/nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0/bin/fpsync -h` got 0 exit code
- ran `/nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0/bin/fpsync -h` and found version 1.0.0
- found 1.0.0 with grep in /nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0
- found 1.0.0 in filename of file in /nix/store/f8lzzqnfr0byjrz4xv617j954f9nyqlv-fpart-1.0.0