### PR TITLE
fprintd: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "fprintd-${version}";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchurl {
     url = "http://people.freedesktop.org/~hadess/${name}.tar.xz";
-    sha256 = "05915i0bv7q62fqrs5diqwr8dz3pwqa1c1ivcgggkjyw0xk4ldp5";
+    sha256 = "00i21ycaya4x2qf94mys6s94xnbj5cfm8zhhd5sc91lvqjk4r99k";
   };
 
   buildInputs = [ libfprint glib dbus-glib polkit nss pam systemd ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/7rn5cnfv36fyzqfvw2b8gn17amav65im-fprintd-0.8.0/bin/fprintd-verify -h` got 0 exit code
- ran `/nix/store/7rn5cnfv36fyzqfvw2b8gn17amav65im-fprintd-0.8.0/bin/fprintd-verify --help` got 0 exit code
- ran `/nix/store/7rn5cnfv36fyzqfvw2b8gn17amav65im-fprintd-0.8.0/bin/fprintd-enroll -h` got 0 exit code
- ran `/nix/store/7rn5cnfv36fyzqfvw2b8gn17amav65im-fprintd-0.8.0/bin/fprintd-enroll --help` got 0 exit code
- found 0.8.0 with grep in /nix/store/7rn5cnfv36fyzqfvw2b8gn17amav65im-fprintd-0.8.0
- found 0.8.0 in filename of file in /nix/store/7rn5cnfv36fyzqfvw2b8gn17amav65im-fprintd-0.8.0

cc "@abbradar"