### PR TITLE
freecell-solver: 4.8.0 -> 4.16.0

### DIFF
--- a/pkgs/games/freecell-solver/default.nix
+++ b/pkgs/games/freecell-solver/default.nix
@@ -6,11 +6,11 @@ with stdenv.lib;
 stdenv.mkDerivation rec{
 
   name = "freecell-solver-${version}";
-  version = "4.8.0";
+  version = "4.16.0";
 
   src = fetchurl {
     url = "http://fc-solve.shlomifish.org/downloads/fc-solve/${name}.tar.xz";
-    sha256 = "0274l1p71ps222i62whqfkg80fcc8m4w2hmpbrbbd5gh8kfpman3";
+    sha256 = "1ihrmxbsli7c1lm5gw9xgrakyn4nsmaj1zgk5gza2ywnfpgdb0ac";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/sfcaa32zc84ksyfdl2bkrwf8wvsfhmb5-freecell-solver-4.16.0/bin/fc-solve -h` got 0 exit code
- ran `/nix/store/sfcaa32zc84ksyfdl2bkrwf8wvsfhmb5-freecell-solver-4.16.0/bin/fc-solve --help` got 0 exit code
- ran `/nix/store/sfcaa32zc84ksyfdl2bkrwf8wvsfhmb5-freecell-solver-4.16.0/bin/fc-solve --version` and found version 4.16.0
- ran `/nix/store/sfcaa32zc84ksyfdl2bkrwf8wvsfhmb5-freecell-solver-4.16.0/bin/pi-make-microsoft-freecell-board -h` got 0 exit code
- ran `/nix/store/sfcaa32zc84ksyfdl2bkrwf8wvsfhmb5-freecell-solver-4.16.0/bin/pi-make-microsoft-freecell-board --help` got 0 exit code
- ran `/nix/store/sfcaa32zc84ksyfdl2bkrwf8wvsfhmb5-freecell-solver-4.16.0/bin/pi-make-microsoft-freecell-board help` got 0 exit code
- found 4.16.0 with grep in /nix/store/sfcaa32zc84ksyfdl2bkrwf8wvsfhmb5-freecell-solver-4.16.0
- found 4.16.0 in filename of file in /nix/store/sfcaa32zc84ksyfdl2bkrwf8wvsfhmb5-freecell-solver-4.16.0

cc "@AndersonTorres"