### PR TITLE
frostwire: 6.4.5 -> 6.6.3

### DIFF
--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -3,12 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "6.4.5";
+  version = "6.6.3";
   name = "frostwire-${version}";
 
   src = fetchurl {
     url = "http://dl.frostwire.com/frostwire/${version}/frostwire-${version}.noarch.tar.gz";
-    sha256 = "01nq1vwkqdidmprlnz5d3c5412r6igv689barv64dmb9m6iqg53z";
+    sha256 = "0di1kfvdjglav5pm23gcggfn9qznk5viah55jggv4cb6h16vxc3p";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 6.6.3 with grep in /nix/store/l6k2351xlmxbpp4mvwva4zr696hkrmid-frostwire-6.6.3
- found 6.6.3 in filename of file in /nix/store/l6k2351xlmxbpp4mvwva4zr696hkrmid-frostwire-6.6.3

cc "@gavin"
