### PR TITLE
ipmiutil: 3.0.7 -> 3.0.8

### DIFF
--- a/pkgs/tools/system/ipmiutil/default.nix
+++ b/pkgs/tools/system/ipmiutil/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   baseName = "ipmiutil";
-  version = "3.0.7";
+  version = "3.0.8";
   name = "${baseName}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/${baseName}/${name}.tar.gz";
-    sha256 = "0bsl4czbwmz1f42b15y0fabys50bbfll4z73nm9xk161i2njzz6y";
+    sha256 = "0pqi63v9l95px1k0dh68gmbd4pbbpwy0pcg6nr5bi0zy898if135";
   };
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/baln3glisdn669gcqrpnbxin1i54wym8-ipmiutil-3.0.8/bin/idiscover help` got 0 exit code
- found 3.0.8 in filename of file in /nix/store/baln3glisdn669gcqrpnbxin1i54wym8-ipmiutil-3.0.8

cc "@raskin"