### PR TITLE
impressive: 0.11.1 -> 0.12.0

### DIFF
--- a/pkgs/applications/office/impressive/default.nix
+++ b/pkgs/applications/office/impressive/default.nix
@@ -2,7 +2,7 @@
 , mesa, SDL, freeglut, ghostscript, pdftk, dejavu_fonts }:
 
 let
-  version = "0.11.1";
+  version = "0.12.0";
   pythonEnv = python2.withPackages (ps: with ps; [pyopengl pygame pillow]);
 in stdenv.mkDerivation {
     # This project was formerly known as KeyJNote.
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
 
     src = fetchurl {
       url = "mirror://sourceforge/impressive/Impressive-${version}.tar.gz";
-      sha256 = "0b3rmy6acp2vmf5nill3aknxvr9a5aawk1vnphkah61anxp62gsr";
+      sha256 = "0zaqq3yvd296mfr5bxpj2hqlk7vrb0rsbgd4dc1l5ag46giqvivx";
     };
 
     buildInputs = [ makeWrapper pythonEnv ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0/bin/impressive -h` got 0 exit code
- ran `/nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0/bin/impressive --help` got 0 exit code
- ran `/nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0/bin/impressive -h` and found version 0.12.0
- ran `/nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0/bin/impressive --help` and found version 0.12.0
- ran `/nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0/bin/.impressive-wrapped -h` got 0 exit code
- ran `/nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0/bin/.impressive-wrapped --help` got 0 exit code
- ran `/nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0/bin/.impressive-wrapped -h` and found version 0.12.0
- ran `/nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0/bin/.impressive-wrapped --help` and found version 0.12.0
- found 0.12.0 with grep in /nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0
- found 0.12.0 in filename of file in /nix/store/xrdylnbdlswc3xwsidpqc2vklkjbrn5h-impressive-0.12.0

cc "@lheckemann"