### PR TITLE
imgur-screenshot: 1.7.1 -> 1.7.4

### DIFF
--- a/pkgs/tools/graphics/imgur-screenshot/default.nix
+++ b/pkgs/tools/graphics/imgur-screenshot/default.nix
@@ -2,14 +2,14 @@
 
 let deps = stdenv.lib.makeBinPath [ curl gnugrep libnotify scrot which xclip ];
 in stdenv.mkDerivation rec {
-  version = "1.7.1";
+  version = "1.7.4";
   name = "imgur-screenshot-${version}";
 
   src = fetchFromGitHub {
     owner = "jomo";
     repo = "imgur-screenshot";
     rev = "v${version}";
-    sha256 = "01wiqrc7xxvk7kzgw756jahwa0szb200l8030iwfcgxb679k3v0j";
+    sha256 = "1bhi9sk8v7szh2fj13qwvdwzy5dw2w4kml86sy1ns1rn0xin0cgr";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/imgur-screenshot -h` got 0 exit code
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/imgur-screenshot --help` got 0 exit code
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/imgur-screenshot -v` and found version 1.7.4
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/imgur-screenshot --version` and found version 1.7.4
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/imgur-screenshot -h` and found version 1.7.4
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/imgur-screenshot --help` and found version 1.7.4
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/.imgur-screenshot-wrapped -h` got 0 exit code
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/.imgur-screenshot-wrapped --help` got 0 exit code
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/.imgur-screenshot-wrapped -v` and found version 1.7.4
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/.imgur-screenshot-wrapped --version` and found version 1.7.4
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/.imgur-screenshot-wrapped -h` and found version 1.7.4
- ran `/nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4/bin/.imgur-screenshot-wrapped --help` and found version 1.7.4
- found 1.7.4 with grep in /nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4
- found 1.7.4 in filename of file in /nix/store/qa21knqdq5iapkli5dhvmnj10wqrwpsi-imgur-screenshot-1.7.4

cc "@lw"