### PR TITLE
iio-sensor-proxy: 2.2 -> 2.4

### DIFF
--- a/pkgs/os-specific/linux/iio-sensor-proxy/default.nix
+++ b/pkgs/os-specific/linux/iio-sensor-proxy/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "iio-sensor-proxy-${version}";
-  version = "2.2";
+  version = "2.4";
 
   src = fetchFromGitHub {
     owner  = "hadess";
     repo   = "iio-sensor-proxy";
     rev    = version;
-    sha256 = "1x0whwm2r9g50hq5px0bgsrigy8naihqgi6qm0x5q87jz5lkhrnv";
+    sha256 = "1c8izq73c00gvv0jc6zby5hcircs4cb16a1d3ivp1i1iflknj46n";
   };
 
   configurePhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/w1kd60p20ps8v5pjicl3z9s6y4fmkgy0-iio-sensor-proxy-2.4/bin/iio-sensor-proxy -h` got 0 exit code
- ran `/nix/store/w1kd60p20ps8v5pjicl3z9s6y4fmkgy0-iio-sensor-proxy-2.4/bin/iio-sensor-proxy --help` got 0 exit code
- ran `/nix/store/w1kd60p20ps8v5pjicl3z9s6y4fmkgy0-iio-sensor-proxy-2.4/bin/iio-sensor-proxy help` got 0 exit code
- found 2.4 with grep in /nix/store/w1kd60p20ps8v5pjicl3z9s6y4fmkgy0-iio-sensor-proxy-2.4
- found 2.4 in filename of file in /nix/store/w1kd60p20ps8v5pjicl3z9s6y4fmkgy0-iio-sensor-proxy-2.4

cc "@peterhoeg"