### PR TITLE
ii: 1.7 -> 1.8

### DIFF
--- a/pkgs/applications/networking/irc/ii/default.nix
+++ b/pkgs/applications/networking/irc/ii/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "ii-1.7";
+  name = "ii-1.8";
   
   src = fetchurl {
     url = "http://dl.suckless.org/tools/${name}.tar.gz";
-    sha256 = "176cqwnn6h7w4kbfd66hzqa243l26pqp2b06bii0nmnm0rkaqwis";
+    sha256 = "1lk8vjl7i8dcjh4jkg8h8bkapcbs465sy8g9c0chfqsywbmf3ndr";
   };
 
   installPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.8 with grep in /nix/store/4ml6hcsv9k8gshqc461w2vvfpq3j9lh4-ii-1.8
- found 1.8 in filename of file in /nix/store/4ml6hcsv9k8gshqc461w2vvfpq3j9lh4-ii-1.8