### PR TITLE
inboxer: 1.0.0 -> 1.0.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/inboxer/default.nix
+++ b/pkgs/applications/networking/mailreaders/inboxer/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "inboxer-${version}";
-  version = "1.0.0";
+  version = "1.0.2";
 
   meta = with stdenv.lib; {
     description = "Unofficial, free and open-source Google Inbox Desktop App";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/denysdovhan/inboxer/releases/download/v${version}/inboxer_${version}_amd64.deb";
-    sha256 = "01384fi5vrfqpznk9389nf3bwpi2zjbnkg84g6z1css8f3gp5i1c";
+    sha256 = "0nqgsqxsjnj46wsfb60p7fr631yx3fx7dfa4fpj6x2ml4i42kxid";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.0.2 with grep in /nix/store/r58bhh86hprpzb4fh5xk0snaqgbqa8vy-inboxer-1.0.2
- found 1.0.2 in filename of file in /nix/store/r58bhh86hprpzb4fh5xk0snaqgbqa8vy-inboxer-1.0.2

cc "@mgttlinger"