### PR TITLE
ipset: 6.34 -> 6.35

### DIFF
--- a/pkgs/os-specific/linux/ipset/default.nix
+++ b/pkgs/os-specific/linux/ipset/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libmnl }:
 
 stdenv.mkDerivation rec {
-  name = "ipset-6.34";
+  name = "ipset-6.35";
 
   src = fetchurl {
     url = "http://ipset.netfilter.org/${name}.tar.bz2";
-    sha256 = "106nv1ngcvap0mqmb6jm07lc1q3w796rkzc1vrfs4yhbcwdq63np";
+    sha256 = "1p7l1fj3lbv6rr24zxjiwq7jk1yvazk8db6yyni0qbprw49i01rp";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset -h` got 0 exit code
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset --help` got 0 exit code
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset help` got 0 exit code
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset -V` and found version 6.35
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset -v` and found version 6.35
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset --version` and found version 6.35
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset version` and found version 6.35
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset -h` and found version 6.35
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset --help` and found version 6.35
- ran `/nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35/bin/ipset help` and found version 6.35
- found 6.35 with grep in /nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35
- found 6.35 in filename of file in /nix/store/paz6j5dhl2i8wd8r1hvf2i9w594fl52x-ipset-6.35

cc "@wkennington"