### PR TITLE
iana-etc: 20180108 -> 20180131

### DIFF
--- a/pkgs/data/misc/iana-etc/default.nix
+++ b/pkgs/data/misc/iana-etc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "iana-etc-${version}";
-  version = "20180108";
+  version = "20180131";
 
   src = fetchurl {
     url = "https://github.com/Mic92/iana-etc/releases/download/${version}/iana-etc-${version}.tar.gz";
-    sha256 = "1x4jacrvjwcsan88rg2wf2a8bajsglg6w4396vbr18zh0sya84a2";
+    sha256 = "0p16anhppagfwaxk21v7pzrw34yqg0fd8rh7fvbi71yxx80c9d3w";
   };
 
   installPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 20180131 in filename of file in /nix/store/r3cyan1y936z2s0qvd7xgbx88zj58k3l-iana-etc-20180131