### PR TITLE
jansson: 2.10 -> 2.11

### DIFF
--- a/pkgs/development/libraries/jansson/default.nix
+++ b/pkgs/development/libraries/jansson/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "jansson-2.10";
+  name = "jansson-2.11";
 
   src = fetchurl {
     url = "http://www.digip.org/jansson/releases/${name}.tar.gz";
-    sha256 = "0iv4rxsnamqm3ldpg7dyhjq0x9cp023nc7ac820jdd3pwb8ml8bq";
+    sha256 = "1x5jllzzqamq6kahx9d9a5mrarm9m3f30vfxvcqpi6p4mcnz91bf";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.11 with grep in /nix/store/pn90js1s03dg2jhpnc6sdyc2p4l0wagx-jansson-2.11
- found 2.11 in filename of file in /nix/store/pn90js1s03dg2jhpnc6sdyc2p4l0wagx-jansson-2.11

cc "@wkennington"