### PR TITLE
hwinfo: 21.50 -> 21.52

### DIFF
--- a/pkgs/tools/system/hwinfo/default.nix
+++ b/pkgs/tools/system/hwinfo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "hwinfo-${version}";
-  version = "21.50";
+  version = "21.52";
 
   src = fetchFromGitHub {
     owner = "opensuse";
     repo = "hwinfo";
     rev = "${version}";
-    sha256 = "1kkq979qqdalxdm6f0gyl3l9nk5rm6i6rbms43rmy52jfda5f5bv";
+    sha256 = "1kva5bhylxbxgp2lv48av8mzcyybigj45rbwl9736l1kiv58i21r";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52/bin/hwinfo -h` got 0 exit code
- ran `/nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52/bin/hwinfo --help` got 0 exit code
- ran `/nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52/bin/hwinfo --version` and found version 21.52
- ran `/nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52/bin/check_hd help` got 0 exit code
- ran `/nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52/bin/getsysinfo -h` got 0 exit code
- ran `/nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52/bin/getsysinfo --help` got 0 exit code
- ran `/nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52/bin/getsysinfo help` got 0 exit code
- found 21.52 with grep in /nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52
- found 21.52 in filename of file in /nix/store/24ksvmssi2inha3nqbcdp1vdfl1pgkdn-hwinfo-21.52

cc "@bobvanderlinden @ndowens"