### PR TITLE
hugin: 2017.0.0 -> 2018.0.0

### DIFF
--- a/pkgs/applications/graphics/hugin/default.nix
+++ b/pkgs/applications/graphics/hugin/default.nix
@@ -5,11 +5,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "hugin-2017.0.0";
+  name = "hugin-2018.0.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/hugin/${name}.tar.bz2";
-    sha256 = "02a6rlwp20jdn5jdsyg3c7liljr10c3jfdkxiv9mkf9jgyi6wr46";
+    sha256 = "1jv5wpqbq49fhbl5g521g1qxhdm1rm7acxd18fr3n3n5d830vbyk";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/align_image_stack -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/align_image_stack --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/align_image_stack -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/align_image_stack --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/autooptimiser -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/autooptimiser --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/autooptimiser -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/autooptimiser --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/celeste_standalone help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/celeste_standalone version` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/celeste_standalone help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/checkpto -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/checkpto --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/checkpto -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/checkpto --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpclean -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpclean --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpclean -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpclean --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind -V` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind --version` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind version` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/cpfind help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/deghosting_mask -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/deghosting_mask --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/deghosting_mask -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/deghosting_mask --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/fulla -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/fulla --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/fulla -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/fulla --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/geocpset -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/geocpset --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/geocpset -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/geocpset --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_hdrmerge -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_hdrmerge --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_hdrmerge help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_hdrmerge -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_hdrmerge --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_lensdb -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_lensdb --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_lensdb help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_lensdb -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_lensdb --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_stacker -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_stacker --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_stacker -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/hugin_stacker --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/linefind -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/linefind --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/linefind -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/linefind --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/nona -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/nona --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/nona -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/nona --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pano_modify -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pano_modify --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pano_modify -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pano_modify --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pano_trafo -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pano_trafo --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pano_trafo -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pano_trafo --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_gen -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_gen --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_gen -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_gen --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_lensstack -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_lensstack --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_lensstack -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_lensstack --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_mask -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_mask --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_mask -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_mask --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_merge -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_merge --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_merge -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_merge --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_move -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_move --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_move -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_move --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_template -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_template --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_template -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_template --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_var -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_var --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_var -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/pto_var --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/tca_correct -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/tca_correct --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/tca_correct -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/tca_correct --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/verdandi -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/verdandi --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/verdandi -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/verdandi --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.align_image_stack-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.align_image_stack-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.align_image_stack-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.align_image_stack-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.autooptimiser-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.autooptimiser-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.autooptimiser-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.autooptimiser-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.celeste_standalone-wrapped help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.celeste_standalone-wrapped version` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.celeste_standalone-wrapped help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.checkpto-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.checkpto-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.checkpto-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.checkpto-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpclean-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpclean-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpclean-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpclean-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped -V` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped --version` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped version` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.cpfind-wrapped help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.deghosting_mask-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.deghosting_mask-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.deghosting_mask-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.deghosting_mask-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.fulla-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.fulla-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.fulla-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.fulla-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.geocpset-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.geocpset-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.geocpset-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.geocpset-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_hdrmerge-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_hdrmerge-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_hdrmerge-wrapped help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_hdrmerge-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_hdrmerge-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_lensdb-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_lensdb-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_lensdb-wrapped help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_lensdb-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_lensdb-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_stacker-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_stacker-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_stacker-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.hugin_stacker-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.linefind-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.linefind-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.linefind-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.linefind-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.nona-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.nona-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.nona-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.nona-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pano_modify-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pano_modify-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pano_modify-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pano_modify-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pano_trafo-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pano_trafo-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pano_trafo-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pano_trafo-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_gen-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_gen-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_gen-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_gen-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_lensstack-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_lensstack-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_lensstack-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_lensstack-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_mask-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_mask-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_mask-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_mask-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_merge-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_merge-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_merge-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_merge-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_move-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_move-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_move-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_move-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_template-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_template-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_template-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_template-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_var-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_var-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_var-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.pto_var-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.tca_correct-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.tca_correct-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.tca_correct-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.tca_correct-wrapped --help` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.verdandi-wrapped -h` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.verdandi-wrapped --help` got 0 exit code
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.verdandi-wrapped -h` and found version 2018.0.0
- ran `/nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0/bin/.verdandi-wrapped --help` and found version 2018.0.0
- found 2018.0.0 with grep in /nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0
- found 2018.0.0 in filename of file in /nix/store/6knfac5rmb7yigrf82az7yrb4y27lrfn-hugin-2018.0.0

cc "@viric @hrdinka"