### PR TITLE
hubicfuse: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/tools/filesystems/hubicfuse/default.nix
+++ b/pkgs/tools/filesystems/hubicfuse/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "hubicfuse-${version}";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "TurboGit";
     repo = "hubicfuse";
     rev = "v${version}";
-    sha256 = "1y4n63bk9vd6n1l5psjb9xm9h042kw4yh2ni33z7agixkanajv1s";
+    sha256 = "1x988hfffxgvqxh083pv3lj5031fz03sbgiiwrjpaiywfbhm8ffr";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.0.1 in filename of file in /nix/store/lwcvnbi1i9w8y84zi6b2g3ayqzzyxd0p-hubicfuse-3.0.1

cc "@jpierre03"