### PR TITLE
html-xml-utils: 7.1 -> 7.6

### DIFF
--- a/pkgs/tools/text/xml/html-xml-utils/default.nix
+++ b/pkgs/tools/text/xml/html-xml-utils/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "html-xml-utils-${version}";
-  version = "7.1";
+  version = "7.6";
 
   src = fetchurl {
     url = "http://www.w3.org/Tools/HTML-XML-utils/${name}.tar.gz";
-    sha256 = "0vnmcrbnc7irrszx5h71s3mqlp9wqh19zig519zbnr5qccigs3pc";
+    sha256 = "0l97ps089byy62838wf2jwvvc465iw29z9r5kwmwcq7f3bn11y3m";
   };
 
   buildInputs = [curl libiconv];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxaddid -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxcite -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxextract --help` got 0 exit code
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxextract help` got 0 exit code
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxextract -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxcopy -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxincl -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxnum -V` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxnum -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxnum --version` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxpipe -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxremove -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxselect -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxtabletrans -v` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxuncdata --help` got 0 exit code
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxuncdata --help` and found version 7.6
- ran `/nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6/bin/hxref -v` and found version 7.6
- found 7.6 with grep in /nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6
- found 7.6 in filename of file in /nix/store/zmpviib2f0h0qh15j4qnzqxxkx2734n8-html-xml-utils-7.6