### PR TITLE
jgmenu: 0.8 -> 0.8.2

### DIFF
--- a/pkgs/applications/misc/jgmenu/default.nix
+++ b/pkgs/applications/misc/jgmenu/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "jgmenu-${version}";
-  version = "0.8";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "johanmalm";
     repo = "jgmenu";
     rev = "v${version}";
-    sha256 = "042nvix85a37aalc2rwg4yc2g3wyy6lym3c2ljj2xkl6c1b0c1r7";
+    sha256 = "0nflj4fcpz7rcd1s0zlyi5ikxjykkmz3p5w4gzica1fdbyn2l7x3";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/1ggjwr61hd0yd99gra484q1dfwzm4k8r-jgmenu-0.8.2/bin/jgmenu -h` got 0 exit code
- ran `/nix/store/1ggjwr61hd0yd99gra484q1dfwzm4k8r-jgmenu-0.8.2/bin/jgmenu --help` got 0 exit code
- ran `/nix/store/1ggjwr61hd0yd99gra484q1dfwzm4k8r-jgmenu-0.8.2/bin/jgmenu --version` and found version 0.8.2
- ran `/nix/store/1ggjwr61hd0yd99gra484q1dfwzm4k8r-jgmenu-0.8.2/bin/jgmenu_run --help` got 0 exit code
- found 0.8.2 with grep in /nix/store/1ggjwr61hd0yd99gra484q1dfwzm4k8r-jgmenu-0.8.2
- found 0.8.2 in filename of file in /nix/store/1ggjwr61hd0yd99gra484q1dfwzm4k8r-jgmenu-0.8.2

cc "@romildo"