### PR TITLE
jmeter: 3.3 -> 4.0

### DIFF
--- a/pkgs/applications/networking/jmeter/default.nix
+++ b/pkgs/applications/networking/jmeter/default.nix
@@ -1,10 +1,10 @@
 { fetchurl, stdenv, jre }:
 
 stdenv.mkDerivation rec {
-  name = "jmeter-3.3";
+  name = "jmeter-4.0";
   src = fetchurl {
     url = "http://archive.apache.org/dist/jmeter/binaries/apache-${name}.tgz";
-    sha256 = "190k6yrh5casadphkv4azp4nvf4wf2q85mrfysw67r9d96nb9kk5";
+    sha256 = "1dvngvi6j8qb6nmf5a3gpi5wxck4xisj41qkrj8sjwb1f8jq6nw4";
   };
 
   buildInputs = [ jre ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/create-rmi-keystore.sh -h` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/create-rmi-keystore.sh --help` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/create-rmi-keystore.sh help` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter -h` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter --help` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter -v` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter --version` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter -h` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter --help` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter-server -h` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter-server --help` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter-server -v` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter-server --version` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter-server -h` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter-server --help` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter.sh -h` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter.sh --help` got 0 exit code
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter.sh -v` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter.sh --version` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter.sh -h` and found version 4.0
- ran `/nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0/bin/jmeter.sh --help` and found version 4.0
- found 4.0 with grep in /nix/store/gbh1xvar82dcrjq2q8wy34bd3mzvvrsp-jmeter-4.0

cc "@garbas"