### PR TITLE
jruby: 9.1.13.0 -> 9.1.16.0

### DIFF
--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -6,11 +6,11 @@ rubyVersion = callPackage ../ruby/ruby-version.nix {} "2" "3" "3" "";
 jruby = stdenv.mkDerivation rec {
   name = "jruby-${version}";
 
-  version = "9.1.13.0";
+  version = "9.1.16.0";
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/jruby.org/downloads/${version}/jruby-bin-${version}.tar.gz";
-    sha256 = "021rmm5c18js569i4z6vj1bb193j4nska43jfiqz5hisc936c5cx";
+    sha256 = "0nj8v4dcg4jj0z3fk661v6mzrgg4613xr0k9xzzsz81jkqsjnb6r";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0/bin/jruby -h` got 0 exit code
- ran `/nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0/bin/jruby --help` got 0 exit code
- ran `/nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0/bin/jruby -v` and found version 9.1.16.0
- ran `/nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0/bin/jruby --version` and found version 9.1.16.0
- ran `/nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0/bin/jruby.bash -h` got 0 exit code
- ran `/nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0/bin/jruby.bash --help` got 0 exit code
- ran `/nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0/bin/jruby.bash -v` and found version 9.1.16.0
- ran `/nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0/bin/jruby.bash --version` and found version 9.1.16.0
- found 9.1.16.0 with grep in /nix/store/yxs5d6pasfvp6000pm1sqhj89iirj3mv-jruby-9.1.16.0