### PR TITLE
jquery-ui: 1.11.4 -> 1.12.1

### DIFF
--- a/pkgs/development/libraries/javascript/jquery-ui/default.nix
+++ b/pkgs/development/libraries/javascript/jquery-ui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
-  name = "jquery-ui-1.11.4";
+  name = "jquery-ui-1.12.1";
 
   src = fetchurl {
     url = "http://jqueryui.com/resources/download/${name}.zip";
-    sha256 = "0ciyaj1acg08g8hpzqx6whayq206fvf4whksz2pjgxlv207lqgjh";
+    sha256 = "0kb21xf38diqgxcdi1z3s9ssq36pldvyqxy56hn6pcva6rs3c8zq";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.12.1 with grep in /nix/store/1f1qwba6p4kvjj4gfxcdn0hj60bc1p4w-jquery-ui-1.12.1
- found 1.12.1 in filename of file in /nix/store/1f1qwba6p4kvjj4gfxcdn0hj60bc1p4w-jquery-ui-1.12.1