### PR TITLE
kapacitor: 1.0.0 -> 1.4.0

### DIFF
--- a/pkgs/servers/monitoring/kapacitor/default.nix
+++ b/pkgs/servers/monitoring/kapacitor/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kapacitor-${version}";
-  version = "1.0.0";
+  version = "1.4.0";
 
   goPackagePath = "github.com/influxdata/kapacitor";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "influxdata";
     repo = "kapacitor";
     rev = "v${version}";
-    sha256 = "14l9bhj6qdif79s4dyqqbnjgj3m4iarvw0ckld1wdhpdgvl8w9qh";
+    sha256 = "1qanf7qljzqqkyw2cdazg0ll13q8a3fs3sqydcgfbgpdmf707sj2";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/zc5x872jh6g02y47rfa2giw7wjypnq12-kapacitor-1.4.0-bin/bin/kapacitord -h` got 0 exit code
- ran `/nix/store/zc5x872jh6g02y47rfa2giw7wjypnq12-kapacitor-1.4.0-bin/bin/kapacitord help` got 0 exit code
- ran `/nix/store/zc5x872jh6g02y47rfa2giw7wjypnq12-kapacitor-1.4.0-bin/bin/tickfmt help` got 0 exit code
- found 1.4.0 with grep in /nix/store/zc5x872jh6g02y47rfa2giw7wjypnq12-kapacitor-1.4.0-bin
- found 1.4.0 in filename of file in /nix/store/zc5x872jh6g02y47rfa2giw7wjypnq12-kapacitor-1.4.0-bin

cc "@offline @ehmry @lethalman"