### PR TITLE
keychain: 2.8.3 -> 2.8.5

### DIFF
--- a/pkgs/tools/misc/keychain/default.nix
+++ b/pkgs/tools/misc/keychain/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "keychain-${version}";
-  version = "2.8.3";
+  version = "2.8.5";
 
   src = fetchFromGitHub {
     owner = "funtoo";
     repo = "keychain";
     rev = "${version}";
-    sha256 = "0za2fi4g7ixzj3izgwlv71b3cviz3qhz43y4bhdkglg16x5cnzcb";
+    sha256 = "1bkjlg0a2bbdjhwp37ci1rwikvrl4s3xlbf2jq2z4azc96dr83mj";
   };
 
   buildInputs = [ makeWrapper perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain -h` got 0 exit code
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain --help` got 0 exit code
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain help` got 0 exit code
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain -V` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain --version` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain version` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain -h` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain --help` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/keychain help` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped -h` got 0 exit code
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped --help` got 0 exit code
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped help` got 0 exit code
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped -V` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped --version` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped version` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped -h` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped --help` and found version 2.8.5
- ran `/nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5/bin/.keychain-wrapped help` and found version 2.8.5
- found 2.8.5 with grep in /nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5
- found 2.8.5 in filename of file in /nix/store/455vx6ibapfgpy0n34j3y0qpd53v2zn2-keychain-2.8.5

cc "@sigma"