### PR TITLE
joker: 0.8.7 -> 0.8.9

### DIFF
--- a/pkgs/development/interpreters/joker/default.nix
+++ b/pkgs/development/interpreters/joker/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "joker-${version}";
-  version = "0.8.7";
+  version = "0.8.9";
 
   goPackagePath = "github.com/candid82/joker";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "candid82";
     repo = "joker";
-    sha256 = "1cmvja8qdrrzacdfn944f22mdg8177qkxfrb10ykq59c2yp1xn01";
+    sha256 = "0ph5f3vc6x1qfh3zn3va2xqx3axv1i2ywbhxayk58p55fxblj5c9";
   };
 
   preBuild = "go generate ./...";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/16sl6aacbf5yg39jy7k5851ixs26hsnh-joker-0.8.9-bin/bin/joker -h` got 0 exit code
- ran `/nix/store/16sl6aacbf5yg39jy7k5851ixs26hsnh-joker-0.8.9-bin/bin/joker --help` got 0 exit code
- ran `/nix/store/16sl6aacbf5yg39jy7k5851ixs26hsnh-joker-0.8.9-bin/bin/joker help` got 0 exit code
- ran `/nix/store/16sl6aacbf5yg39jy7k5851ixs26hsnh-joker-0.8.9-bin/bin/joker -v` and found version 0.8.9
- ran `/nix/store/16sl6aacbf5yg39jy7k5851ixs26hsnh-joker-0.8.9-bin/bin/joker --version` and found version 0.8.9
- found 0.8.9 with grep in /nix/store/16sl6aacbf5yg39jy7k5851ixs26hsnh-joker-0.8.9-bin
- found 0.8.9 in filename of file in /nix/store/16sl6aacbf5yg39jy7k5851ixs26hsnh-joker-0.8.9-bin

cc "@andrestylianos @ehmry @lethalman"