### PR TITLE
kid3: 3.4.2 -> 3.5.1

### DIFF
--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -10,11 +10,11 @@
 stdenv.mkDerivation rec {
 
   name = "kid3-${version}";
-  version = "3.4.2";
+  version = "3.5.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/kid3/kid3/${version}/${name}.tar.gz";
-    sha256 = "0gka4na583015jyqva18g85q7vnkjdk0iji2jp88di3kpvqhf1sw";
+    sha256 = "09iryxnhg8d9q36a4brb25bqkjprkx5kl0x7vyy82gxivqk0ihl8";
   };
 
   buildInputs = with stdenv.lib;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lnz0zqq75d7dpmaqj1g7i5yda4v12idl-kid3-3.5.1/bin/kid3-cli -h` got 0 exit code
- ran `/nix/store/lnz0zqq75d7dpmaqj1g7i5yda4v12idl-kid3-3.5.1/bin/kid3-cli --help` got 0 exit code
- ran `/nix/store/lnz0zqq75d7dpmaqj1g7i5yda4v12idl-kid3-3.5.1/bin/kid3-cli -h` and found version 3.5.1
- ran `/nix/store/lnz0zqq75d7dpmaqj1g7i5yda4v12idl-kid3-3.5.1/bin/kid3-cli --help` and found version 3.5.1
- found 3.5.1 with grep in /nix/store/lnz0zqq75d7dpmaqj1g7i5yda4v12idl-kid3-3.5.1
- found 3.5.1 in filename of file in /nix/store/lnz0zqq75d7dpmaqj1g7i5yda4v12idl-kid3-3.5.1

cc "@AndersonTorres"