### PR TITLE
kompose: 1.5.0 -> 1.9.0

### DIFF
--- a/pkgs/applications/networking/cluster/kompose/default.nix
+++ b/pkgs/applications/networking/cluster/kompose/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kompose-${version}";
-  version = "1.5.0";
+  version = "1.9.0";
 
   goPackagePath = "github.com/kubernetes/kompose";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "kubernetes";
     repo = "kompose";
-    sha256 = "1r5f8jbr2c1xxb5fpfgy23w4m30zahhmrw23jlk1hpx2w1pi1iyh";
+    sha256 = "00yvih5gn67sw9v30a0rpaj1zag7k02i4biw1p37agxih0aphc86";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lbk05ajkfj5za1zgz0haz57sfipiv38y-kompose-1.9.0-bin/bin/kompose -h` got 0 exit code
- ran `/nix/store/lbk05ajkfj5za1zgz0haz57sfipiv38y-kompose-1.9.0-bin/bin/kompose --help` got 0 exit code
- ran `/nix/store/lbk05ajkfj5za1zgz0haz57sfipiv38y-kompose-1.9.0-bin/bin/kompose help` got 0 exit code
- ran `/nix/store/lbk05ajkfj5za1zgz0haz57sfipiv38y-kompose-1.9.0-bin/bin/kompose version` and found version 1.9.0
- found 1.9.0 with grep in /nix/store/lbk05ajkfj5za1zgz0haz57sfipiv38y-kompose-1.9.0-bin
- found 1.9.0 in filename of file in /nix/store/lbk05ajkfj5za1zgz0haz57sfipiv38y-kompose-1.9.0-bin

cc "@thpham @ehmry @lethalman"