### PR TITLE
kpcli: 3.1 -> 3.2

### DIFF
--- a/pkgs/tools/security/kpcli/default.nix
+++ b/pkgs/tools/security/kpcli/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, perl, perlPackages }:
 
 stdenv.mkDerivation rec {
-  version = "3.1";
+  version = "3.2";
   name = "kpcli-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/kpcli/${name}.pl";
-    sha256 = "06m276if13w6gd54wi8nqd1yvk2csbhdmm8pcw9aw3hdlc27gw7i";
+    sha256 = "11z6zbnsmqgjw73ai4nrq4idr83flrib22d8fqh1637d36p1nnk1";
   };
 
   buildInputs = [ makeWrapper perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/4x18w356x6ah895mfb17ascylzpp64py-kpcli-3.2/bin/kpcli -h` got 0 exit code
- ran `/nix/store/4x18w356x6ah895mfb17ascylzpp64py-kpcli-3.2/bin/kpcli --help` got 0 exit code
- found 3.2 with grep in /nix/store/4x18w356x6ah895mfb17ascylzpp64py-kpcli-3.2
- found 3.2 in filename of file in /nix/store/4x18w356x6ah895mfb17ascylzpp64py-kpcli-3.2

cc "@j-keck"