### PR TITLE
kops: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kops-${version}";
-  version = "1.8.0";
+  version = "1.8.1";
 
   goPackagePath = "k8s.io/kops";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev = version;
     owner = "kubernetes";
     repo = "kops";
-    sha256 = "0vaa18vhwk132fv7i896513isp66wnz9gn0b5613n3x28q0gvkmg";
+    sha256 = "12nyr0iw1xwp60apli3nlq2vyn4jk3qjrb404m2syx2mqbnn47my";
   };
 
   buildInputs = [go-bindata];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/hclwimgs404fz9k2lrx35xcxa16bgb9x-kops-1.8.1-bin/bin/kops -h` got 0 exit code
- ran `/nix/store/hclwimgs404fz9k2lrx35xcxa16bgb9x-kops-1.8.1-bin/bin/kops --help` got 0 exit code
- ran `/nix/store/hclwimgs404fz9k2lrx35xcxa16bgb9x-kops-1.8.1-bin/bin/kops help` got 0 exit code
- ran `/nix/store/hclwimgs404fz9k2lrx35xcxa16bgb9x-kops-1.8.1-bin/bin/kops version` and found version 1.8.1
- found 1.8.1 with grep in /nix/store/hclwimgs404fz9k2lrx35xcxa16bgb9x-kops-1.8.1-bin
- found 1.8.1 in filename of file in /nix/store/hclwimgs404fz9k2lrx35xcxa16bgb9x-kops-1.8.1-bin

cc "@offline @zimbatm @ehmry @lethalman"