### PR TITLE
kronometer: 2.1.3 -> 2.2.1

### DIFF
--- a/pkgs/tools/misc/kronometer/default.nix
+++ b/pkgs/tools/misc/kronometer/default.nix
@@ -6,14 +6,14 @@
 
 let
   pname = "kronometer";
-  version = "2.1.3";
+  version = "2.2.1";
 in
 mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "1z06gvaacm3d3a9smlmgg2vf0jdab5kqxx24r6v7iprqzgdpsn4i";
+    sha256 = "18b2qi5b9hn8jy3yhav72n14z5l9w3p5fv5kslhbxc7rfvjr4h3x";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.2.1 with grep in /nix/store/5164lzx4rdrck8h0xap2dx1ml02x8vzv-kronometer-2.2.1
- found 2.2.1 in filename of file in /nix/store/5164lzx4rdrck8h0xap2dx1ml02x8vzv-kronometer-2.2.1

cc "@peterhoeg"