### PR TITLE
latex2html: 2016 -> 2018

### DIFF
--- a/pkgs/tools/misc/latex2html/default.nix
+++ b/pkgs/tools/misc/latex2html/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   name = "latex2html-${version}";
-  version = "2016";
+  version = "2018";
 
   src = fetchurl {
     url = "http://mirrors.ctan.org/support/latex2html/latex2html-${version}.tar.gz";
-    sha256 = "028k0ypbq94mlhydf1sbqlphlfl2fhmlzhgqq5jjzihfmccbq7db";
+    sha256 = "1qnlg8ajh0amy9gy8rh8sp1l224ak54264i3dhk7rrv9s4k7bqq9";
   };
 
   buildInputs = [ ghostscript netpbm perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/texexpand -h` got 0 exit code
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/texexpand --help` got 0 exit code
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/texexpand --version` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/latex2html -h` got 0 exit code
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/latex2html --help` got 0 exit code
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/latex2html -V` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/latex2html -v` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/latex2html --version` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/latex2html -h` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/latex2html --help` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/.pstoimg-wrapped -h` got 0 exit code
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/.pstoimg-wrapped --help` got 0 exit code
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/.pstoimg-wrapped -V` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/.pstoimg-wrapped -v` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/.pstoimg-wrapped --version` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/.pstoimg-wrapped -h` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/.pstoimg-wrapped --help` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/pstoimg -h` got 0 exit code
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/pstoimg --help` got 0 exit code
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/pstoimg -V` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/pstoimg -v` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/pstoimg --version` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/pstoimg -h` and found version 2018
- ran `/nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018/bin/pstoimg --help` and found version 2018
- found 2018 with grep in /nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018
- found 2018 in filename of file in /nix/store/ca56d1xc80h2kjv0q7kz5bkj6j96kakg-latex2html-2018

cc "@yurrriq"