### PR TITLE
lgogdownloader: 3.2 -> 3.3

### DIFF
--- a/pkgs/games/lgogdownloader/default.nix
+++ b/pkgs/games/lgogdownloader/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "lgogdownloader-${version}";
-  version = "3.2";
+  version = "3.3";
 
   src = fetchFromGitHub {
     owner = "Sude-";
     repo = "lgogdownloader";
     rev = "v${version}";
-    sha256 = "0p1zh2l8g4y2z02xj0fndbfhcxgcpwhf5d9izwsdi3yljvqv23np";
+    sha256 = "056idwwxjcp2zjqk5h7l3py1h45sax4vbsm93bz9shnfx1s1h3gc";
   };
 
   nativeBuildInputs = [ cmake pkgconfig help2man ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/kxvhxpaxbcikm9gk2rz3pdmm35iwriqv-lgogdownloader-3.3/bin/lgogdownloader -h` got 0 exit code
- ran `/nix/store/kxvhxpaxbcikm9gk2rz3pdmm35iwriqv-lgogdownloader-3.3/bin/lgogdownloader --help` got 0 exit code
- ran `/nix/store/kxvhxpaxbcikm9gk2rz3pdmm35iwriqv-lgogdownloader-3.3/bin/lgogdownloader --version` and found version 3.3
- ran `/nix/store/kxvhxpaxbcikm9gk2rz3pdmm35iwriqv-lgogdownloader-3.3/bin/lgogdownloader -h` and found version 3.3
- ran `/nix/store/kxvhxpaxbcikm9gk2rz3pdmm35iwriqv-lgogdownloader-3.3/bin/lgogdownloader --help` and found version 3.3
- found 3.3 with grep in /nix/store/kxvhxpaxbcikm9gk2rz3pdmm35iwriqv-lgogdownloader-3.3
- found 3.3 in filename of file in /nix/store/kxvhxpaxbcikm9gk2rz3pdmm35iwriqv-lgogdownloader-3.3