### PR TITLE
libchewing: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/development/libraries/libchewing/default.nix
+++ b/pkgs/development/libraries/libchewing/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec{
   name = "libchewing-${version}";
-  version = "0.4.0";
+  version = "0.5.1";
 
   src = fetchurl {
     url = "https://github.com/chewing/libchewing/releases/download/v${version}/libchewing-${version}.tar.bz2";
-    sha256 = "1j5g5j4w6yp73k03pmsq9n2r0p458hqriq0sd5kisj9xrssbynp5";
+    sha256 = "0aqp2vqgxczydpn7pxi7r6xf3l1hgl710f0gbi1k8q7s2lscc24p";
   };
 
   buildInputs = [ sqlite ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.5.1 with grep in /nix/store/j3cl2l9f1m6p14b5y8cf24p4hqhw9nsn-libchewing-0.5.1
- found 0.5.1 in filename of file in /nix/store/j3cl2l9f1m6p14b5y8cf24p4hqhw9nsn-libchewing-0.5.1

cc "@ericsagnes"