### PR TITLE
libabw: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/development/libraries/libabw/default.nix
+++ b/pkgs/development/libraries/libabw/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libabw-${version}";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchurl {
     url = "http://dev-www.libreoffice.org/src/libabw/${name}.tar.xz";
-    sha256 = "0zi1zj4fpxgpglbbb5n1kg3dmhqq5rpf46lli89r5daavp19iing";
+    sha256 = "11949iscdb99f2jplxjd39282jxcrf2fw0sqbh5dl7gqb96r8whb";
   };
 
   # Boost 1.59 compatability fix


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/dnqszp481y82724zpmcgag2glhs8n18s-libabw-0.1.2/bin/abw2raw --version` and found version 0.1.2
- ran `/nix/store/dnqszp481y82724zpmcgag2glhs8n18s-libabw-0.1.2/bin/abw2html --version` and found version 0.1.2
- ran `/nix/store/dnqszp481y82724zpmcgag2glhs8n18s-libabw-0.1.2/bin/abw2text --version` and found version 0.1.2
- found 0.1.2 with grep in /nix/store/dnqszp481y82724zpmcgag2glhs8n18s-libabw-0.1.2
- found 0.1.2 in filename of file in /nix/store/dnqszp481y82724zpmcgag2glhs8n18s-libabw-0.1.2