### PR TITLE
leatherman: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/libraries/leatherman/default.nix
+++ b/pkgs/development/libraries/leatherman/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "leatherman-${version}";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
-    sha256 = "1pcbfgq9khlcvxjsqpdshjskwljzawryzps0ickazwm7l3m7hrln";
+    sha256 = "0whlyzz0imv4lm69xkwhcd6jzh3s0rzlqjmwimbqz96p4771ivpd";
     rev = version;
     repo = "leatherman";
     owner = "puppetlabs";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.4.0 with grep in /nix/store/sxrvks9qfl857a5vgqw95dd9629l0p5q-leatherman-1.4.0
- found 1.4.0 in filename of file in /nix/store/sxrvks9qfl857a5vgqw95dd9629l0p5q-leatherman-1.4.0

cc "@womfoo"