### PR TITLE
lcms2: 2.8 -> 2.9

### DIFF
--- a/pkgs/development/libraries/lcms2/default.nix
+++ b/pkgs/development/libraries/lcms2/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libtiff, libjpeg, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "lcms2-2.8";
+  name = "lcms2-2.9";
 
   src = fetchurl {
     url = "mirror://sourceforge/lcms/${name}.tar.gz";
-    sha256 = "08pvl289g0mbznzx5l6ibhaldsgx41kwvdn2c974ga9fkli2pl36";
+    sha256 = "083xisy6z01zhm7p7rgk4bx9d6zlr8l20qkfv1g29ylnhgwzvij8";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin/bin/tificc --help` got 0 exit code
- ran `/nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin/bin/tificc help` got 0 exit code
- ran `/nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin/bin/linkicc --help` got 0 exit code
- ran `/nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin/bin/linkicc help` got 0 exit code
- ran `/nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin/bin/jpgicc --help` got 0 exit code
- ran `/nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin/bin/jpgicc help` got 0 exit code
- ran `/nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin/bin/psicc --help` got 0 exit code
- ran `/nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin/bin/psicc help` got 0 exit code
- found 2.9 with grep in /nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin
- found 2.9 in filename of file in /nix/store/qra3h0k7sckb5kdmicg9j8privyaw56i-lcms2-2.9-bin
