### PR TITLE
latte-dock: 0.7.1 -> 0.7.3

### DIFF
--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, cmake, xorg, plasma-framework, fetchFromGitHub
 , extra-cmake-modules, karchive, kwindowsystem, qtx11extras, kcrash }:
 
-let version = "0.7.1"; in
+let version = "0.7.3"; in
 
 mkDerivation {
   name = "latte-dock-${version}";
@@ -10,7 +10,7 @@ mkDerivation {
     owner = "psifidotos";
     repo = "Latte-Dock";
     rev = "v${version}";
-    sha256 = "0vdmsjj1qqlzz26mznb56znv5x7akbvw65ybbzakclp4q1xrsrm2";
+    sha256 = "110bal0dairsvgj624n5k0zabh2qfy9dk560a4wy7icxv0cjh7hg";
   };
 
   buildInputs = [ plasma-framework xorg.libpthreadstubs xorg.libXdmcp xorg.libSM ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.7.3 with grep in /nix/store/0ba5gi00dx85l1lvaf423gmsnxb3g60d-latte-dock-0.7.3
- found 0.7.3 in filename of file in /nix/store/0ba5gi00dx85l1lvaf423gmsnxb3g60d-latte-dock-0.7.3

cc "@benley"