### PR TITLE
libbson: 1.8.0 -> 1.9.2

### DIFF
--- a/pkgs/development/libraries/libbson/default.nix
+++ b/pkgs/development/libraries/libbson/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libbson-${version}";
-  version = "1.8.0";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "mongodb";
     repo = "libbson";
     rev = version;
-    sha256 = "1bd9z07q3faq5k4521d9inv0j836w6hrsd0vj2sapjlq8jmqgslg";
+    sha256 = "1dlmcqsb43269z4pa3xmqb1gf1jsji82sk5yyibq0ndhk326iyck";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.9.2 with grep in /nix/store/5y9552xapnwpn686pmjgjkdsddrfppr8-libbson-1.9.2
- found 1.9.2 in filename of file in /nix/store/5y9552xapnwpn686pmjgjkdsddrfppr8-libbson-1.9.2