### PR TITLE
libdvbpsi: 0.2.2 -> 1.3.2

### DIFF
--- a/pkgs/development/libraries/libdvbpsi/default.nix
+++ b/pkgs/development/libraries/libdvbpsi/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libdvbpsi-${version}";
-  version = "0.2.2";
+  version = "1.3.2";
 
   src = fetchurl {
     url = "http://get.videolan.org/libdvbpsi/${version}/${name}.tar.bz2";
-    sha256 = "1lry2swxqm8mhq0a4rjnc819ngsf2pxnfjajb57lml7yr12j79ls";
+    sha256 = "1zn5hfv4qbahmydbwh59a3b480s3m5ss27r6ml35gqdip7r3jkmc";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.3.2 with grep in /nix/store/s7iwmkbdw6lhkbiqb91r9j0crqqagc7v-libdvbpsi-1.3.2
- found 1.3.2 in filename of file in /nix/store/s7iwmkbdw6lhkbiqb91r9j0crqqagc7v-libdvbpsi-1.3.2
