### PR TITLE
libebur128: 1.0.2 -> 1.2.4

### DIFF
--- a/pkgs/development/libraries/libebur128/default.nix
+++ b/pkgs/development/libraries/libebur128/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, speexdsp, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.2";
+  version = "1.2.4";
   name = "libebur128-${version}";
 
   src = fetchFromGitHub {
     owner = "jiixyj";
     repo = "libebur128";
     rev = "v${version}";
-    sha256 = "19vy3ldbf931hjvn9jf9dvw1di3yx9ljxyk2yp5cnac1wqiza3jm";
+    sha256 = "0n81rnm8dm1zmibkr2v3q79rsd609y0dbbsrbay18njcjva88p0g";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.2.4 with grep in /nix/store/m2zvs6x1g15cz7gbf97wdn89gw7swwal-libebur128-1.2.4
- found 1.2.4 in filename of file in /nix/store/m2zvs6x1g15cz7gbf97wdn89gw7swwal-libebur128-1.2.4

cc "@andrewrk"