### PR TITLE
libevdev: 1.5.7 -> 1.5.8

### DIFF
--- a/pkgs/development/libraries/libevdev/default.nix
+++ b/pkgs/development/libraries/libevdev/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, python }:
 
 stdenv.mkDerivation rec {
-  name = "libevdev-1.5.7";
+  name = "libevdev-1.5.8";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/libevdev/${name}.tar.xz";
-    sha256 = "08nl3p6226k51zph52fhilxvi3b31spp6fz8szzrglzhl8vrxrd1";
+    sha256 = "0vac7n1miqdprikq4g63vsk681q8v416r0nbh2xai7b08qgdi0v0";
   };
 
   buildInputs = [ python ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/s03fn5nf1d4bxiwnjngz4fa8qbxxak2d-libevdev-1.5.8/bin/libevdev-tweak-device -h` got 0 exit code
- ran `/nix/store/s03fn5nf1d4bxiwnjngz4fa8qbxxak2d-libevdev-1.5.8/bin/libevdev-tweak-device --help` got 0 exit code
- found 1.5.8 with grep in /nix/store/s03fn5nf1d4bxiwnjngz4fa8qbxxak2d-libevdev-1.5.8
- found 1.5.8 in filename of file in /nix/store/s03fn5nf1d4bxiwnjngz4fa8qbxxak2d-libevdev-1.5.8

cc "@amorsillo"