### PR TITLE
libedit: 20160903-3.1 -> 20170329-3.1

### DIFF
--- a/pkgs/development/libraries/libedit/default.nix
+++ b/pkgs/development/libraries/libedit/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, ncurses, groff }:
 
 stdenv.mkDerivation rec {
-  name = "libedit-20160903-3.1";
+  name = "libedit-20170329-3.1";
 
   src = fetchurl {
     url = "http://thrysoee.dk/editline/${name}.tar.gz";
-    sha256 = "0rvmm8z6hal5bbp5pljp7yvkpqi4pkas1amizhvg35v0skkx5jqc";
+    sha256 = "1gnlgl0x8g9ky59s70nriy5gv47676d1s4ypvbv8y11apl7xkwli";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 20170329-3.1 with grep in /nix/store/r31p017kd7s11qnmivccnswvdd3c339g-libedit-20170329-3.1
- found 20170329-3.1 in filename of file in /nix/store/r31p017kd7s11qnmivccnswvdd3c339g-libedit-20170329-3.1