### PR TITLE
libffcall: 2.0 -> 2.1

### DIFF
--- a/pkgs/development/libraries/libffcall/default.nix
+++ b/pkgs/development/libraries/libffcall/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libffcall-${version}";
-  version = "2.0";
+  version = "2.1";
 
   src = fetchurl {
     url = "mirror://gnu/libffcall/libffcall-${version}.tar.gz";
-    sha256 = "0v0rh3vawb8z5q40fs3kr2f9zp06n2fq4rr2ww4562nr96sd5aj1";
+    sha256 = "0iwcad6w78jp84vd6xaz5fwqm84n3cb42bdf5m5cj5xzpa5zp4d0";
   };
 
   enableParallelBuilding = false;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.1 with grep in /nix/store/3al1x63bcpba04rn27rxqwsic4jggqhw-libffcall-2.1-dev
- found 2.1 in filename of file in /nix/store/3al1x63bcpba04rn27rxqwsic4jggqhw-libffcall-2.1-dev