### PR TITLE
libexttextcat: 3.4.1 -> 3.4.5

### DIFF
--- a/pkgs/development/libraries/libexttextcat/default.nix
+++ b/pkgs/development/libraries/libexttextcat/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libexttextcat-3.4.1";
+  name = "libexttextcat-3.4.5";
 
   src = fetchurl {
     url = "http://dev-www.libreoffice.org/src/libexttextcat/${name}.tar.xz";
-    sha256 = "0g1spzpsfbv3y8k9m1v53imz18437q93iq101hind7m4x00j6wpl";
+    sha256 = "1j6sjwkyhqvsgyw938bxxfwkzzi1mahk66g5342lv6j89jfvrz8k";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.4.5 with grep in /nix/store/z24cwnyn0qhdxr11d6bh5cjakagdj3n3-libexttextcat-3.4.5
- found 3.4.5 in filename of file in /nix/store/z24cwnyn0qhdxr11d6bh5cjakagdj3n3-libexttextcat-3.4.5
