### PR TITLE
libdvdcss: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/development/libraries/libdvdcss/default.nix
+++ b/pkgs/development/libraries/libdvdcss/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libdvdcss-${version}";
-  version = "1.4.0";
+  version = "1.4.1";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin IOKit;
 
   src = fetchurl {
     url = "http://get.videolan.org/libdvdcss/${version}/${name}.tar.bz2";
-    sha256 = "0nl45ifc4xcb196snv9d6hinfw614cqpzcqp92dg43c0hickg290";
+    sha256 = "1b7awvyahivglp7qmgx2g5005kc5npv257gw7wxdprjsnx93f1zb";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.4.1 with grep in /nix/store/vc0dcpqiashz0c0ihd4n2bj7jhawnpf3-libdvdcss-1.4.1
- found 1.4.1 in filename of file in /nix/store/vc0dcpqiashz0c0ihd4n2bj7jhawnpf3-libdvdcss-1.4.1
