### PR TITLE
libgap: 4.8.3 -> 4.8.6

### DIFF
--- a/pkgs/development/libraries/libgap/default.nix
+++ b/pkgs/development/libraries/libgap/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, gmp}:
 stdenv.mkDerivation rec {
   name = "libgap-${version}";
-  version = "4.8.3";
+  version = "4.8.6";
   # or fetchFromGitHub(owner,repo,rev) or fetchgit(rev)
   src = fetchurl {
     url = "http://mirrors.mit.edu/sage/spkg/upstream/libgap/libgap-${version}.tar.gz";
-    sha256 = "0ng4wlw7bj63spf4vkdp43v3ja1fp782lxzdsyf51x26z21idrsq";
+    sha256 = "1h5fx5a55857w583ql7ly2jl49qyx9mvs7j5abys00ra9gzrpn5v";
   };
   buildInputs = [gmp];
   meta = {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 4.8.6 with grep in /nix/store/05va3jfhvjfxri7311n92l8dgh3l0f0n-libgap-4.8.6
- found 4.8.6 in filename of file in /nix/store/05va3jfhvjfxri7311n92l8dgh3l0f0n-libgap-4.8.6

cc "@raskin"