### PR TITLE
libdap: 3.18.3 -> 3.19.1

### DIFF
--- a/pkgs/development/libraries/libdap/default.nix
+++ b/pkgs/development/libraries/libdap/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, bison, libuuid, curl, libxml2, flex }:
 
 stdenv.mkDerivation rec {
-  version = "3.18.3";
+  version = "3.19.1";
   name = "libdap-${version}";
 
   nativeBuildInputs = [ bison flex ];
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.opendap.org/pub/source/${name}.tar.gz";
-    sha256 = "0azjf4gjqvp1fdf1wb3s98x52zfy4viq1m3j9lggaidldfinmv8c";
+    sha256 = "0gnki93z3kkzp65x7n1kancy7bd503j4qja5fhzvm1gkmi5l65aj";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/getdap help` got 0 exit code
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/getdap -V` and found version 3.19.1
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/getdap4 help` got 0 exit code
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/getdap4 -V` and found version 3.19.1
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/dap-config -h` got 0 exit code
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/dap-config --help` got 0 exit code
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/dap-config help` got 0 exit code
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/dap-config --version` and found version 3.19.1
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/dap-config-pkgconfig -h` got 0 exit code
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/dap-config-pkgconfig --help` got 0 exit code
- ran `/nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1/bin/dap-config-pkgconfig help` got 0 exit code
- found 3.19.1 with grep in /nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1
- found 3.19.1 in filename of file in /nix/store/1lfj4rdq2h7v13y8qa6wwp1iwvchbzmf-libdap-3.19.1

cc "@bzizou"