### PR TITLE
libcue: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/libraries/libcue/default.nix
+++ b/pkgs/development/libraries/libcue/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libcue-${version}";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "lipnitsk";
     repo = "libcue";
     rev = "v${version}";
-    sha256 = "14a84d6sq3yp8s8i05lxvifjpkgpjwfpchrqf3bbpbwa8gvrc0rj";
+    sha256 = "0znn9scamy1nsz1dzvsamqg46zr7ldfvpxiyzi1ss9d6gbcm0frs";
   };
 
   nativeBuildInputs = [ cmake bison flex ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.2.0 with grep in /nix/store/w00chhmmp7hhlr5x1ysi3vclzx5jxc38-libcue-2.2.0
- found 2.2.0 in filename of file in /nix/store/w00chhmmp7hhlr5x1ysi3vclzx5jxc38-libcue-2.2.0

cc "@astsmtl"