### PR TITLE
libcouchbase: 2.7.6 -> 2.8.4

### DIFF
--- a/pkgs/development/libraries/libcouchbase/default.nix
+++ b/pkgs/development/libraries/libcouchbase/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libcouchbase-${version}";
-  version = "2.7.6";
+  version = "2.8.4";
 
   src = fetchFromGitHub {
     owner = "couchbase";
     repo = "libcouchbase";
     rev = version;
-    sha256 = "13g7r0mcmrj37mihj6g1x1ckpaps659c4qwnw3ixrg7p5mb3p41f";
+    sha256 = "0i5kmv8grsnh2igvlkgjr8lz3h3yrxh82yxbbdsjfpslv61l0gpi";
   };
 
   cmakeFlags = "-DLCB_NO_MOCK=ON";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc help` got 0 exit code
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc version` and found version 2.8.4
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc-pillowfight --help` got 0 exit code
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc-n1qlback --help` got 0 exit code
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc-n1qlback --help` and found version 2.8.4
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc-subdoc --help` got 0 exit code
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc-subdoc --help` and found version 2.8.4
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc-proxy --help` got 0 exit code
- ran `/nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4/bin/cbc-proxy --help` and found version 2.8.4
- found 2.8.4 with grep in /nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4
- found 2.8.4 in filename of file in /nix/store/ag3ka0qv88321ih0gdn743p167vqmvdn-libcouchbase-2.8.4
