### PR TITLE
libgme: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/development/libraries/audio/libgme/default.nix
+++ b/pkgs/development/libraries/audio/libgme/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromBitbucket, cmake }:
 let
-  version = "0.6.1";
+  version = "0.6.2";
 in stdenv.mkDerivation {
   name = "libgme-${version}";
 
@@ -16,7 +16,7 @@ in stdenv.mkDerivation {
     owner = "mpyne";
     repo = "game-music-emu";
     rev = version;
-    sha256 = "04vwpv3pmjcil1jw5vcnlg45nch5awqs06y3xqdlp3ibx5i4k199";
+    sha256 = "00vlbfk5h99dq5rbwxk20dv72dig6wdwpgf83q451avsscky0jvk";
   };
 
   buildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.6.2 with grep in /nix/store/md3caddisps4xfvxh7ywmb2gdcpmcv4z-libgme-0.6.2
- found 0.6.2 in filename of file in /nix/store/md3caddisps4xfvxh7ywmb2gdcpmcv4z-libgme-0.6.2

cc "@lheckemann"