### PR TITLE
libgsf: 1.14.41 -> 1.14.42

### DIFF
--- a/pkgs/development/libraries/libgsf/default.nix
+++ b/pkgs/development/libraries/libgsf/default.nix
@@ -4,11 +4,11 @@
 let inherit (stdenv.lib) optionals; in
 
 stdenv.mkDerivation rec {
-  name = "libgsf-1.14.41";
+  name = "libgsf-1.14.42";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/libgsf/1.14/${name}.tar.xz";
-    sha256 = "1lq87wnrsjbjafpk3c8xwd56gqx319fhck9xkg2da88hd9c9h2qm";
+    sha256 = "1hhdz0ymda26q6bl5ygickkgrh998lxqq4z9i8dzpcvqna3zpzr9";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf -h` got 0 exit code
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf --help` got 0 exit code
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf help` got 0 exit code
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf -v` and found version 1.14.42
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf --version` and found version 1.14.42
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf -h` and found version 1.14.42
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf --help` and found version 1.14.42
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf-vba-dump -h` got 0 exit code
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf-vba-dump --help` got 0 exit code
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf-vba-dump help` got 0 exit code
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf-office-thumbnailer -h` got 0 exit code
- ran `/nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42/bin/gsf-office-thumbnailer --help` got 0 exit code
- found 1.14.42 with grep in /nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42
- found 1.14.42 in filename of file in /nix/store/r5m45cyq4pdbqf6a3fal3x7dgy69hqiv-libgsf-1.14.42

cc "@lovek323"