### PR TITLE
libisoburn: 1.4.4 -> 1.4.8

### DIFF
--- a/pkgs/development/libraries/libisoburn/default.nix
+++ b/pkgs/development/libraries/libisoburn/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libisoburn-${version}";
-  version = "1.4.4";
+  version = "1.4.8";
 
   src = fetchurl {
     url = "http://files.libburnia-project.org/releases/${name}.tar.gz";
-    sha256 = "1mn2dwkwdrdcjnd59czxali7r5nlxdx92clyxnsfpmw20f9s20kv";
+    sha256 = "19d53j17pn18vfxxqqlqwam5lm21ljyp8nai5434068g7x3m1kwi";
   };
 
   buildInputs = [ attr zlib libburn libisofs ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/wicrls5mhrpncr2012ly2l35iqrcxg19-libisoburn-1.4.8/bin/xorriso --help` got 0 exit code
- ran `/nix/store/wicrls5mhrpncr2012ly2l35iqrcxg19-libisoburn-1.4.8/bin/xorriso help` got 0 exit code
- ran `/nix/store/wicrls5mhrpncr2012ly2l35iqrcxg19-libisoburn-1.4.8/bin/xorriso --version` and found version 1.4.8
- ran `/nix/store/wicrls5mhrpncr2012ly2l35iqrcxg19-libisoburn-1.4.8/bin/xorriso version` and found version 1.4.8
- ran `/nix/store/wicrls5mhrpncr2012ly2l35iqrcxg19-libisoburn-1.4.8/bin/xorriso --help` and found version 1.4.8
- ran `/nix/store/wicrls5mhrpncr2012ly2l35iqrcxg19-libisoburn-1.4.8/bin/xorriso help` and found version 1.4.8
- found 1.4.8 with grep in /nix/store/wicrls5mhrpncr2012ly2l35iqrcxg19-libisoburn-1.4.8
- found 1.4.8 in filename of file in /nix/store/wicrls5mhrpncr2012ly2l35iqrcxg19-libisoburn-1.4.8

cc "@vrthra"