### PR TITLE
libinput: 1.9.4 -> 1.10.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -373,6 +373,7 @@
   lasandell = "Luke Sandell <lasandell@gmail.com>";
   lassulus = "Lassulus <lassulus@gmail.com>";
   layus = "Guillaume Maudoux <layus.on@gmail.com>";
+  lblasc = "Luka Blaskovic <lblasc@znode.net>";
   ldesgoui = "Lucas Desgouilles <ldesgoui@gmail.com>";
   league = "Christopher League <league@contrapunctus.net>";
   lebastr = "Alexander Lebedev <lebastr@gmail.com>";

--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -6,11 +6,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "feh-${version}";
-  version = "2.23.2";
+  version = "2.24";
 
   src = fetchurl {
     url = "https://feh.finalrewind.org/${name}.tar.bz2";
-    sha256 = "1hw9xhhmm404ircmd7aw9n51n23wzjxzmav272ldk1pxb2jk3hcn";
+    sha256 = "148qbxkk5m7i3cxymnfwi7aikqjyfxr306dlqm9ndp6x932js5wq";
   };
 
   outputs = [ "out" "man" "doc" ];

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -5,9 +5,7 @@ with stdenv.lib;
 mkChromiumDerivation (base: rec {
   name = "chromium-browser";
   packageName = "chromium";
-  ## mojo_platform_bindings is built ahead of chrome, because of spurious
-  ## build errors, see https://github.com/NixOS/nixpkgs/issues/35296
-  buildTargets = [ "mksnapshot" "mojo_platform_bindings" "chrome_sandbox" "chrome" ];
+  buildTargets = [ "mksnapshot" "chrome_sandbox" "chrome" ];
 
   outputs = ["out" "sandbox"];
 

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,4 +1,4 @@
-{ stdenv, ninja, which, nodejs, fetchurl, gnutar
+{ stdenv, ninja, which, nodejs, fetchurl, fetchpatch, gnutar
 
 # default dependencies
 , bzip2, flac, speex, libopus
@@ -44,8 +44,12 @@ let
   # source tree.
   extraAttrs = buildFun base;
 
-  gentooPatch = name: sha256: fetchurl {
+  gentooPatch = name: sha256: fetchpatch {
     url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/www-client/chromium/files/${name}";
+    inherit sha256;
+  };
+  githubPatch = commit: sha256: fetchpatch {
+    url = "https://github.com/chromium/chromium/commit/${commit}.patch";
     inherit sha256;
   };
 
@@ -147,6 +151,8 @@ let
     ]  ++ optionals (versionRange "64" "65") [
       (gentooPatch "chromium-cups-r0.patch" "0hyjlfh062c8h54j4b27y4dq5yzd4w6mxzywk3s02yf6cj3cbkrl")
       (gentooPatch "chromium-angle-r0.patch" "0izdrqwsyr48117dhvwdsk8c6dkrnq2njida1q4mb1lagvwbz7gc")
+      # missing ninja dep https://github.com/NixOS/nixpkgs/issues/35296#issuecomment-368666833
+      (githubPatch "b1e3cfd4f9bfe43a1e08c5670b51c8c80d3e6372" "17vih86rpsy282r8ikrf2q5gfjdwqzvyn8859i75xzvl8agyhbaa")
     ]  ++ optionals (versionRange "65" "66") [
       #(gentooPatch "chromium-gcc-r0.patch" "127xdwabizn5gz8rf1qsw62i7m0b5bsfjqxv4kdbsnizmjanddf8")
       #(gentooPatch "chromium-memcpy-r0.patch" "1d3vra59wjg2lva7ddv55ff6l57mk9k50llsplr0b7vxk0lh0ps5")

--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -38,6 +38,9 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postPatch = ''
+    substituteInPlace contrib/smime_keys \
+      --replace /usr/bin/openssl ${openssl}/bin/openssl
+
     for f in doc/*.{xml,xsl}*  ; do
       substituteInPlace $f \
         --replace http://docbook.sourceforge.net/release/xsl/current     ${docbook_xsl}/share/xml/docbook-xsl \

--- a/pkgs/development/libraries/avro-c/default.nix
+++ b/pkgs/development/libraries/avro-c/default.nix
@@ -1,35 +1,30 @@
 { stdenv, bash, cmake, fetchurl, pkgconfig, jansson, zlib }:
 
-let version = "1.8.2"; in
-
-stdenv.mkDerivation rec {
+let
+  version = "1.8.2";
+in stdenv.mkDerivation rec {
   name = "avro-c-${version}";
 
-  #
   src = fetchurl {
     url = "mirror://apache/avro/avro-${version}/c/avro-c-${version}.tar.gz";
     sha256 = "03pixl345kkpn1jds03rpdcwjabi41rgdzi8f7y93gcg5cmrhfa6";
   };
 
-  patchPhase = ''
-    substituteInPlace version.sh \
-      --replace /bin/bash "$bash/bin/bash"
+  postPatch = ''
+    patchShebangs .
   '';
 
-  buildInputs = [
-    pkgconfig
-    cmake
-    jansson
-    zlib
-  ];
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  buildInputs = [ jansson zlib ];
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A C library which implements parts of the Avro Specification";
     homepage = https://avro.apache.org/;
-    license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ lblasc ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lblasc ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/avro-c/default.nix
+++ b/pkgs/development/libraries/avro-c/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, bash, cmake, fetchurl, pkgconfig, jansson, zlib }:
+
+let version = "1.8.2"; in
+
+stdenv.mkDerivation rec {
+  name = "avro-c-${version}";
+
+  #
+  src = fetchurl {
+    url = "mirror://apache/avro/avro-${version}/c/avro-c-${version}.tar.gz";
+    sha256 = "03pixl345kkpn1jds03rpdcwjabi41rgdzi8f7y93gcg5cmrhfa6";
+  };
+
+  patchPhase = ''
+    substituteInPlace version.sh \
+      --replace /bin/bash "$bash/bin/bash"
+  '';
+
+  buildInputs = [
+    pkgconfig
+    cmake
+    jansson
+    zlib
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A C library which implements parts of the Avro Specification";
+    homepage = https://avro.apache.org/;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ lblasc ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/libraries/glm/default.nix
+++ b/pkgs/development/libraries/glm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, cmake }:
+{ stdenv, fetchurl, fetchzip, cmake }:
 
 stdenv.mkDerivation rec {
   version = "0.9.8.5";
@@ -15,9 +15,16 @@ stdenv.mkDerivation rec {
 
   cmakeConfigureFlags = [ "-DGLM_INSTALL_ENABLE=off" ];
 
+  # fetch newer version of platform.h which correctly supports gcc 7.3
+  gcc7PlatformPatch = fetchurl {
+    url = "https://raw.githubusercontent.com/g-truc/glm/dd48b56e44d699a022c69155c8672caacafd9e8a/glm/simd/platform.h";
+    sha256 = "0y91hlbgn5va7ijg5mz823gqkq9hqxl00lwmdwnf8q2g086rplzw";
+  };
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace '"''${CMAKE_CURRENT_BINARY_DIR}/''${GLM_INSTALL_CONFIGDIR}' '"''${GLM_INSTALL_CONFIGDIR}'
+    cp ${gcc7PlatformPatch} glm/simd/platform.h
   '';
 
   postInstall = ''

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -16,11 +16,11 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libinput-${version}";
-  version = "1.9.4";
+  version = "1.10.0";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "142icwzpirwddl7ghfmynxpnsbjg53rjxpzv4arjsaiw9r6bvk8b";
+    sha256 = "0mrzsf0349d1g68lizkzxw7vaw459fl8xhl7v0s8njb31hp2riy2";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -3,8 +3,9 @@
 , which, swig, binutils, glibcLocales
 , python, jemalloc, openmpi
 , numpy, six, protobuf, tensorflow-tensorboard, backports_weakref, mock, enum34, absl-py
-, xlaSupport ? true
 , cudaSupport ? false, nvidia_x11 ? null, cudatoolkit ? null, cudnn ? null
+# XLA without CUDA is broken
+, xlaSupport ? cudaSupport
 # Default from ./configure script
 , cudaCapabilities ? [ "3.5" "5.2" ]
 , sse42Support ? false
@@ -145,9 +146,10 @@ in buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Computation using data flow graphs for scalable machine learning";
-    homepage = "http://tensorflow.org";
+    homepage = http://tensorflow.org;
     license = licenses.asl20;
     maintainers = with maintainers; [ jyp abbradar ];
     platforms = with platforms; if cudaSupport then linux else linux ++ darwin;
+    broken = !(xlaSupport -> cudaSupport);
   };
 }

--- a/pkgs/development/tools/delve/default.nix
+++ b/pkgs/development/tools/delve/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "delve-${version}";
-  version = "0.12.2";
+  version = "1.0.0";
 
   goPackagePath = "github.com/derekparker/delve";
   excludedPackages = "\\(_fixtures\\|scripts\\|service/test\\)";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "derekparker";
     repo = "delve";
     rev = "v${version}";
-    sha256 = "1241zqyimgqil4qd72f0yiw935lkdmfr88kvqbkn9n05k7xhdg30";
+    sha256 = "08hsairhrifh41d288jhc65zbhs9k0hs738dbdzsbcvlmycrhvgx";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -11,17 +11,17 @@ let
 
 in stdenv.mkDerivation rec {
   name = "displaylink-${version}";
-  version = "1.3.52";
+  version = "4.1.9";
 
   src = requireFile rec {
     name = "displaylink.zip";
-    sha256 = "0ridpsxcf761vym0nlpq702qa46ynddzci17bjmyax2pph7khr0k";
+    sha256 = "d762145014df7fea8ca7af12206a077d73d8e7f2259c8dc2ce7e5fb1e69ef9a3";
     message = ''
       In order to install the DisplayLink drivers, you must first
       comply with DisplayLink's EULA and download the binaries and
       sources from here:
 
-      http://www.displaylink.com/downloads/file?id=744
+      http://www.displaylink.com/downloads/file?id=1087
 
       Once you have downloaded the file, please use the following
       commands and re-run the installation:
@@ -56,6 +56,9 @@ in stdenv.mkDerivation rec {
 
     fixupPhase
   '';
+
+  dontStrip = true;
+  dontPatchELF = true;
 
   meta = with stdenv.lib; {
     description = "DisplayLink DL-5xxx, DL-41xx and DL-3x00 Driver for Linux";

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2;
     homepage = http://www.displaylink.com/;
-    broken = versionOlder kernel.version "4.9";
+    broken = versionOlder kernel.version "4.9" || versionAtLeast kernel.version "4.15";
   };
 }

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "evdi-${version}";
-  version = "unstable-2018-01-12";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = "evdi";
-    rev = "e7a08d08e3876efba8007e91df1b296f2447b8de";
+    rev = "v${version}";
     sha256 = "01z7bx5rgpb5lc4c6dxfiv52ni25564djxmvmgy3d7r1x1mqhxgs";
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "KVER=${kernel.modDirVersion}" "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
-  hardeningDisable = [ "pic" "format" ];
+  hardeningDisable = [ "format" "pic" "fortify" ];
 
   installPhase = ''
     install -Dm755 module/evdi.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gpu/drm/evdi/evdi.ko

--- a/pkgs/os-specific/linux/pipework/default.nix
+++ b/pkgs/os-specific/linux/pipework/default.nix
@@ -4,17 +4,16 @@
 
 stdenv.mkDerivation rec {
   name = "pipework-${version}";
-  version = "2015-07-30";
+  version = "2017-08-22";
   src = fetchFromGitHub {
     owner = "jpetazzo";
     repo = "pipework";
-    rev = "5a46ecb5f8f933fd268ef315f58a1eb1c46bd93d";
-    sha256 = "02znyg5ir37s8xqjcqqz6xnwyqxapn7c4scyqkcapxr932hf1frh";
+    rev = "ae42f1b5fef82b3bc23fe93c95c345e7af65fef3";
+    sha256 = "0c342m0bpq6ranr7dsxk9qi5mg3j5aw9wv85ql8gprdb2pz59qy8";
   };
   buildInputs = [ makeWrapper ];
   installPhase = ''
-    mkdir -p $out/bin
-    cp pipework $out/bin
+    install -D pipework $out/bin/pipework
     wrapProgram $out/bin/pipework --prefix PATH : \
       ${lib.makeBinPath [ bridge-utils iproute lxc openvswitch docker busybox dhcpcd dhcp ]};
   '';

--- a/pkgs/os-specific/linux/trinity/default.nix
+++ b/pkgs/os-specific/linux/trinity/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "trinity-${version}";
-  version = "1.8";
+  version = "1.8-git-2017-02-13";
 
   src = fetchFromGitHub {
     owner = "kernelslacker";
     repo = "trinity";
-    rev = "v${version}";
-    sha256 = "1ss6ir3ki2hnj4c8068v5bz8bpa43xqg9zlmzhgagi94g9l05qlf";
+    rev = "2989c11ce77bc7bec23da62987e2c3a0dd8a83c9";
+    sha256 = "19asyrypjhx2cgjdmwfvmgc0hk3xg00zvgkl89vwxngdb40bkwfq";
   };
 
   postPatch = ''

--- a/pkgs/servers/etcd/default.nix
+++ b/pkgs/servers/etcd/default.nix
@@ -4,7 +4,7 @@ with lib;
 
 buildGoPackage rec {
   name = "etcd-${version}";
-  version = "3.1.6"; # After updating check that nixos tests pass
+  version = "3.3.1"; # After updating check that nixos tests pass
   rev = "v${version}";
 
   goPackagePath = "github.com/coreos/etcd";
@@ -13,7 +13,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "coreos";
     repo = "etcd";
-    sha256 = "1qgi6zxnijzr644w2da2gbn3gw2qwk6a3z3qmdln0r2rjnm70sx0";
+    sha256 = "11gzmi05y4kpnzgqc737l0wk5svxai4z17nl92jazqga6zhyavyl";
   };
 
   subPackages = [

--- a/pkgs/tools/filesystems/ceph/0002-fix-absolute-include-path.patch
+++ b/pkgs/tools/filesystems/ceph/0002-fix-absolute-include-path.patch
@@ -1,0 +1,19 @@
+diff -ru ceph/src/key_value_store/kv_flat_btree_async.cc ceph-copy/src/key_value_store/kv_flat_btree_async.cc
+--- ceph/src/key_value_store/kv_flat_btree_async.cc	1980-01-02 00:00:00.000000000 +0100
++++ ceph-copy/src/key_value_store/kv_flat_btree_async.cc	2018-02-13 21:49:59.232860487 +0100
+@@ -15,13 +15,13 @@
+ #include "key_value_store/kv_flat_btree_async.h"
+ #include "key_value_store/kvs_arg_types.h"
+ #include "include/rados/librados.hpp"
+-#include "/usr/include/asm-generic/errno.h"
+-#include "/usr/include/asm-generic/errno-base.h"
+ #include "common/ceph_context.h"
+ #include "common/Clock.h"
+ #include "include/types.h"
+ 
+ 
++#include <asm-generic/errno.h>
++#include <asm-generic/errno-base.h>
+ #include <string>
+ #include <iostream>
+ #include <cassert>

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -86,12 +86,17 @@ let
   };
 
   ceph-python-env = python2Packages.python.withPackages (ps: [ 
-	ps.sphinx
-	ps.flask
-	ps.argparse
-	ps.cython 
-	ps.setuptools
-	ps.pip
+    ps.sphinx
+    ps.flask
+    ps.argparse
+    ps.cython 
+    ps.setuptools
+    ps.pip
+    # Libraries needed by the python tools
+    ps.Mako
+    ps.pecan
+    ps.prettytable
+    ps.webob
 	]);
 
 in
@@ -103,11 +108,13 @@ stdenv.mkDerivation {
   patches = [ 
  #	 ./ceph-patch-cmake-path.patch
     ./0001-kv-RocksDBStore-API-break-additional.patch   
+  ] ++ optionals stdenv.isLinux [
+    ./0002-fix-absolute-include-path.patch
   ];
 
   nativeBuildInputs = [
     cmake
-    pkgconfig which git
+    pkgconfig which git python2Packages.wrapPython
     (ensureNewerSourcesHook { year = "1980"; })
   ];
   
@@ -122,6 +129,7 @@ stdenv.mkDerivation {
   ] ++ optionals hasKinetic [
     optKinetic-cpp-client
   ];
+
   
   preConfigure =''
     # rip off submodule that interfer with system libs
@@ -148,6 +156,10 @@ stdenv.mkDerivation {
     "-DWITH_CEPHFS=OFF"
     "-DWITH_LIBCEPHFS=OFF"
   ];
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
 
   enableParallelBuilding = true;
   

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, udev }:
 
 stdenv.mkDerivation rec {
-  name = "dhcpcd-6.11.5";
+  name = "dhcpcd-7.0.1";
 
   src = fetchurl {
     url = "mirror://roy/dhcpcd/${name}.tar.xz";
-    sha256 = "17nnhxmbdcc7k2mh6sgvxisqcqbic5540xbig363ds97gvf795kg";
+    sha256 = "1j7kyg9gm5d1k6qjdscjz2rjgpqia0dxgk69lswp21y0pizm6dlb";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -725,6 +725,8 @@ with pkgs;
     qt4Support = config.avahi.qt4Support or false;
   };
 
+  avro-c = callPackage ../development/libraries/avro-c { };
+
   avro-cpp = callPackage ../development/libraries/avro-c++ { boost = boost160; };
 
   aws = callPackage ../tools/virtualization/aws { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8870,9 +8870,7 @@ with pkgs;
     glibc32 = pkgsi686Linux.glibc;
   };
 
-  glm = callPackage ../development/libraries/glm
-    (lib.optionalAttrs stdenv.cc.isGNU { stdenv = overrideCC stdenv gcc6;/*maybe a hack*/ });
-
+  glm = callPackage ../development/libraries/glm { };
   glm_0954 = callPackage ../development/libraries/glm/0954.nix { };
 
   globalplatform = callPackage ../development/libraries/globalplatform { };


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/zx5s9rsk3jh7n9vlx7824chzd54fw3nd-libinput-1.10.0/bin/libinput -h` got 0 exit code
- ran `/nix/store/zx5s9rsk3jh7n9vlx7824chzd54fw3nd-libinput-1.10.0/bin/libinput --help` got 0 exit code
- ran `/nix/store/zx5s9rsk3jh7n9vlx7824chzd54fw3nd-libinput-1.10.0/bin/libinput --version` and found version 1.10.0
- found 1.10.0 with grep in /nix/store/zx5s9rsk3jh7n9vlx7824chzd54fw3nd-libinput-1.10.0
- found 1.10.0 in filename of file in /nix/store/zx5s9rsk3jh7n9vlx7824chzd54fw3nd-libinput-1.10.0

cc "@codyopel @wkennington"