### PR TITLE
libinfinity: 0.6.5 -> 0.7.1

### DIFF
--- a/pkgs/development/libraries/libinfinity/default.nix
+++ b/pkgs/development/libraries/libinfinity/default.nix
@@ -12,10 +12,10 @@ let
 
 in stdenv.mkDerivation rec {
 
-  name = "libinfinity-0.6.5";
+  name = "libinfinity-0.7.1";
   src = fetchurl {
     url = "http://releases.0x539.de/libinfinity/${name}.tar.gz";
-    sha256 = "1idsxb6rz4i55g3vi2sv7hmm57psbccpb57yc4jgphaq6ydgqsr6";
+    sha256 = "1jw2fhrcbpyz99bij07iyhy9ffyqdn87vl8cb1qz897y3f2f0vk2";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.7.1 with grep in /nix/store/bl4k9m05mbhzwm8r2z6x2aqnqd2gdml0-libinfinity-0.7.1
- found 0.7.1 in filename of file in /nix/store/bl4k9m05mbhzwm8r2z6x2aqnqd2gdml0-libinfinity-0.7.1

cc "@phreedom"