### PR TITLE
libiodbc: 3.52.8 -> 3.52.12

### DIFF
--- a/pkgs/development/libraries/libiodbc/default.nix
+++ b/pkgs/development/libraries/libiodbc/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, gtk2, useGTK ? false }:
 
 stdenv.mkDerivation rec {
-  name = "libiodbc-3.52.8";
+  name = "libiodbc-3.52.12";
 
   src = fetchurl {
     url = "mirror://sourceforge/iodbc/${name}.tar.gz";
-    sha256 = "16hjb6fcval85gnkgkxfhw4c5h3pgf86awyh8p2bhnnvzc0ma5hq";
+    sha256 = "0qpvklgr1lcn5g8xbz7fbc9rldqf9r8s6xybhqj20m4sglxgziai";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctest -h` got 0 exit code
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctest --help` got 0 exit code
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctest help` got 0 exit code
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctest version` and found version 3.52.12
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctest help` and found version 3.52.12
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctestw -h` got 0 exit code
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctestw --help` got 0 exit code
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctestw help` got 0 exit code
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctestw version` and found version 3.52.12
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbctestw help` and found version 3.52.12
- ran `/nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12/bin/iodbc-config --version` and found version 3.52.12
- found 3.52.12 with grep in /nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12
- found 3.52.12 in filename of file in /nix/store/253wjz6c1fkj3af92qa1yrfwsr21agr3-libiodbc-3.52.12