### PR TITLE
libivykis: 0.41 -> 0.42.1

### DIFF
--- a/pkgs/development/libraries/libivykis/default.nix
+++ b/pkgs/development/libraries/libivykis/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "libivykis-${version}";
 
-  version = "0.41";
+  version = "0.42.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/libivykis/${version}/ivykis-${version}.tar.gz";
-    sha256 = "1igk3svf36i5xgb6ipc507xpj6zjm4xi9j1j2cdqaachllwlb4rc";
+    sha256 = "0c90cfpxipw2m8i3ajr7vy7lb8gvcz2kh5n8sd542zphr4na8whq";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.42.1 with grep in /nix/store/npgsv4dlpgkbm8r2rz1wqns7ispcq4na-libivykis-0.42.1
- found 0.42.1 in filename of file in /nix/store/npgsv4dlpgkbm8r2rz1wqns7ispcq4na-libivykis-0.42.1

cc "@rickynils"