### PR TITLE
libkate: 0.3.8 -> 0.4.1

### DIFF
--- a/pkgs/development/libraries/libkate/default.nix
+++ b/pkgs/development/libraries/libkate/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libogg, libpng }:
 
 stdenv.mkDerivation rec {
-  name = "libkate-0.3.8";
+  name = "libkate-0.4.1";
 
   src = fetchurl {
     url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libkate/${name}.tar.gz";
-    sha256 = "00d6561g31la9bb8q99b7l4rvi67yiwm50ky8dhlsjd88h7rks2n";
+    sha256 = "0s3vr2nxfxlf1k75iqpp4l78yf4gil3f0v778kvlngbchvaq23n4";
   };
 
   buildInputs = [ libogg libpng ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.4.1 with grep in /nix/store/mc5wm3bsmx9n4xxf54by4hck21yjzljx-libkate-0.4.1
- found 0.4.1 in filename of file in /nix/store/mc5wm3bsmx9n4xxf54by4hck21yjzljx-libkate-0.4.1