### PR TITLE
liblo: 0.26 -> 0.29

### DIFF
--- a/pkgs/development/libraries/liblo/default.nix
+++ b/pkgs/development/libraries/liblo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "liblo-0.26";
+  name = "liblo-0.29";
 
   src = fetchurl {
-    url = "mirror://sourceforge/liblo/liblo/0.26/${name}.tar.gz";
-    sha256 = "0n124fv9m8yjxs2yxnp3l1i30b8qgg1zx51y63ax12hpz04zndm6";
+    url = "mirror://sourceforge/liblo/liblo/0.29/${name}.tar.gz";
+    sha256 = "0sn0ckc1d0845mhsaa62wf7f9v0c0ykiq796a30ja5096kib9qdc";
   };
 
   meta = { 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ribwnr8bbvpnr54vwhhq6c4l7qvv3ibx-liblo-0.29/bin/oscdump -h` got 0 exit code
- ran `/nix/store/ribwnr8bbvpnr54vwhhq6c4l7qvv3ibx-liblo-0.29/bin/oscdump -h` and found version 0.29
- found 0.29 with grep in /nix/store/ribwnr8bbvpnr54vwhhq6c4l7qvv3ibx-liblo-0.29
- found 0.29 in filename of file in /nix/store/ribwnr8bbvpnr54vwhhq6c4l7qvv3ibx-liblo-0.29

cc "@marcweber"