### PR TITLE
liblogging: 1.0.5 -> 1.0.6

### DIFF
--- a/pkgs/development/libraries/liblogging/default.nix
+++ b/pkgs/development/libraries/liblogging/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "liblogging-1.0.5";
+  name = "liblogging-1.0.6";
 
   src = fetchurl {
     url = "http://download.rsyslog.com/liblogging/${name}.tar.gz";
-    sha256 = "02w94j344q0ywlj4mdf9fnzwggdsn3j1yn43sdlsddvr29lw239i";
+    sha256 = "14xz00mq07qmcgprlj5b2r21ljgpa4sbwmpr6jm2wrf8wms6331k";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl -h` got 0 exit code
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl --help` got 0 exit code
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl help` got 0 exit code
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl -V` and found version 1.0.6
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl -v` and found version 1.0.6
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl --version` and found version 1.0.6
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl version` and found version 1.0.6
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl -h` and found version 1.0.6
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl --help` and found version 1.0.6
- ran `/nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6/bin/stdlogctl help` and found version 1.0.6
- found 1.0.6 with grep in /nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6
- found 1.0.6 in filename of file in /nix/store/1bqr2w33qs8prr9pf72abnljivy1jc86-liblogging-1.0.6

cc "@wkennington"