### PR TITLE
libHX: 3.21 -> 3.22

### DIFF
--- a/pkgs/development/libraries/libHX/default.nix
+++ b/pkgs/development/libraries/libHX/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoconf, automake, libtool }:
 
 stdenv.mkDerivation rec {
-  name = "libHX-3.21";
+  name = "libHX-3.22";
 
   src = fetchurl {
-    url = "mirror://sourceforge/libhx/libHX/3.21/${name}.tar.xz";
-    sha256 = "0wcr6kbhsw6v4js7q4p7fhli37c39dv1rryjf768rkwshl2z8f6v";
+    url = "mirror://sourceforge/libhx/libHX/3.22/${name}.tar.xz";
+    sha256 = "18w39j528lyg2026dr11f2xxxphy91cg870nx182wbd8cjlqf86c";
   };
 
   patches = [];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.22 with grep in /nix/store/4h5wjmczvxamiqhljh3iqbfmwx5zwz18-libHX-3.22
- found 3.22 in filename of file in /nix/store/4h5wjmczvxamiqhljh3iqbfmwx5zwz18-libHX-3.22

cc "@tstrobel"