### PR TITLE
libmaxminddb: 1.2.0 -> 1.3.2

### DIFF
--- a/pkgs/development/libraries/libmaxminddb/default.nix
+++ b/pkgs/development/libraries/libmaxminddb/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libmaxminddb-${version}";
-  version = "1.2.0";
+  version = "1.3.2";
 
   src = fetchurl {
     url = meta.homepage + "/releases/download/${version}/${name}.tar.gz";
-    sha256 = "0dxdyw6sxxmpzk2a96qp323r5kdmw7vm6m0l5a8gr52gf7nmks0z";
+    sha256 = "1w60yq26x3yr3abxk7fwqqaggw8dc98595jdliaa3kyqdfm83y76";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/391jqg25m136cs0fv99xixc5dfn4941a-libmaxminddb-1.3.2/bin/mmdblookup -h` got 0 exit code
- ran `/nix/store/391jqg25m136cs0fv99xixc5dfn4941a-libmaxminddb-1.3.2/bin/mmdblookup --help` got 0 exit code
- ran `/nix/store/391jqg25m136cs0fv99xixc5dfn4941a-libmaxminddb-1.3.2/bin/mmdblookup -V` and found version 1.3.2
- ran `/nix/store/391jqg25m136cs0fv99xixc5dfn4941a-libmaxminddb-1.3.2/bin/mmdblookup --version` and found version 1.3.2
- found 1.3.2 with grep in /nix/store/391jqg25m136cs0fv99xixc5dfn4941a-libmaxminddb-1.3.2
- found 1.3.2 in filename of file in /nix/store/391jqg25m136cs0fv99xixc5dfn4941a-libmaxminddb-1.3.2

cc "@vcunat"