### PR TITLE
libmbim: 1.14.2 -> 1.16.0

### DIFF
--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, python, udev, libgudev }:
 
 stdenv.mkDerivation rec {
-  name = "libmbim-1.14.2";
+  name = "libmbim-1.16.0";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/libmbim/${name}.tar.xz";
-    sha256 = "1krirl9881dnx7l29zhvagk2qlhi26vpvkzdifjklhrjhimzxji2";
+    sha256 = "1hpsjc7bzmakzvj8z9fffvqknc38fa8ridpmklq46jyxxnz51jn8";
   };
 
   outputs = [ "out" "dev" "man" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0/bin/mbim-network -h` got 0 exit code
- ran `/nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0/bin/mbim-network --help` got 0 exit code
- ran `/nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0/bin/mbim-network --version` and found version 1.16.0
- ran `/nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0/bin/mbimcli -h` got 0 exit code
- ran `/nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0/bin/mbimcli --help` got 0 exit code
- ran `/nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0/bin/mbimcli -V` and found version 1.16.0
- ran `/nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0/bin/mbimcli --version` and found version 1.16.0
- found 1.16.0 with grep in /nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0
- found 1.16.0 in filename of file in /nix/store/qp1xvvasv2abihckhlv8ygl6fgdgqdpw-libmbim-1.16.0

cc "@wkennington"