### PR TITLE
libmediainfo: 17.10 -> 17.12

### DIFF
--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "17.10";
+  version = "17.12";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "00m1b4m37c9lm16yhh63p5pidg2sr3qvsw36672lklmcv3y1ic30";
+    sha256 = "0lm4454ynp0msgqm3s0mnxqxql6i1ank35jvff5swnaxvwsbp0ml";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 17.12 with grep in /nix/store/8x38418jc8j511k8dk4jc2if6iizbz2b-libmediainfo-17.12
- found 17.12 in filename of file in /nix/store/8x38418jc8j511k8dk4jc2if6iizbz2b-libmediainfo-17.12

cc "@devhell"