### PR TITLE
libmodbus: 3.0.6 -> 3.1.4

### DIFF
--- a/pkgs/development/libraries/libmodbus/default.nix
+++ b/pkgs/development/libraries/libmodbus/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libmodbus-3.0.6";
+  name = "libmodbus-3.1.4";
 
   src = fetchurl {
     url = "http://libmodbus.org/releases/${name}.tar.gz";
-    sha256 = "1dkijjv3dq0c5vc5z5f1awm8dlssbwg6ivsnvih22pkm1zqn6v84";
+    sha256 = "0drnil8bzd4n4qb0wv3ilm9zvypxvwmzd65w96d6kfm7x6q65j68";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.1.4 with grep in /nix/store/cllrhccg4a6va2ac33y7r50bz7ihiyf1-libmodbus-3.1.4
- found 3.1.4 in filename of file in /nix/store/cllrhccg4a6va2ac33y7r50bz7ihiyf1-libmodbus-3.1.4

cc "@bjornfor"