### PR TITLE
libmng: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/development/libraries/libmng/default.nix
+++ b/pkgs/development/libraries/libmng/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, zlib, libpng, libjpeg, lcms2 }:
 
 stdenv.mkDerivation rec {
-  name = "libmng-2.0.2";
+  name = "libmng-2.0.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/libmng/${name}.tar.xz";
-    sha256 = "0l5wa3b9rr4zl49zbbjpapqyccqjwzkzw1ph3p4pk9p5h73h9317";
+    sha256 = "1lvxnpds0vcf0lil6ia2036ghqlbl740c4d2sz0q5g6l93fjyija";
   };
 
   outputs = [ "out" "dev" "devdoc" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.0.3 with grep in /nix/store/g7hv6hhrr23j1jcf0z03kz1jk19l8h32-libmng-2.0.3
- found 2.0.3 in filename of file in /nix/store/g7hv6hhrr23j1jcf0z03kz1jk19l8h32-libmng-2.0.3

cc "@marcweber"