### PR TITLE
libmodplug: 0.8.8.5 -> 0.8.9.0

### DIFF
--- a/pkgs/development/libraries/libmodplug/default.nix
+++ b/pkgs/development/libraries/libmodplug/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl }:
 
 let
-  version = "0.8.8.5";
+  version = "0.8.9.0";
 in stdenv.mkDerivation rec {
   name = "libmodplug-${version}";
 
@@ -15,6 +15,6 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/project/modplug-xmms/libmodplug/${version}/${name}.tar.gz";
-    sha256 = "1bfsladg7h6vnii47dd66f5vh1ir7qv12mfb8n36qiwrxq92sikp";
+    sha256 = "1pnri98a603xk47smnxr551svbmgbzcw018mq1k6srbrq6kaaz25";
   };
 }


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.8.9.0 with grep in /nix/store/vbfn9xivgfy294g5216r6jcy78dg9rf3-libmodplug-0.8.9.0
- found 0.8.9.0 in filename of file in /nix/store/vbfn9xivgfy294g5216r6jcy78dg9rf3-libmodplug-0.8.9.0

cc "@raskin"