### PR TITLE
libmtp: 1.1.13 -> 1.1.14

### DIFF
--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libusb1 }:
 
 stdenv.mkDerivation rec {
-  name = "libmtp-1.1.13";
+  name = "libmtp-1.1.14";
 
   src = fetchurl {
     url = "mirror://sourceforge/libmtp/${name}.tar.gz";
-    sha256 = "0h3dv9py5mmvxhfxmkr8ky4s80hgq3d66cmrfnnnlcdwpwpy0kj9";
+    sha256 = "1s0jyhypxmj0j8s003ba1n74x63h1rw8am9q4z2ip3xyjvid65rq";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-connect help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-detect help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-tracks -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-tracks --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-tracks help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-files help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-folders -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-folders --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-folders help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-playlists help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-format help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albumart help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-albums help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-newplaylist help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-emptyfolders help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-thumb -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-thumb --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-thumb -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-thumb -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-thumb --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-thumb -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-thumb --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-reset help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-filetree -h` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-filetree --help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-filetree help` got 0 exit code
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-filetree -V` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-filetree -v` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-filetree --version` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-filetree -h` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-filetree --help` and found version 1.1.14
- ran `/nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin/bin/mtp-hotplug help` got 0 exit code
- found 1.1.14 with grep in /nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin
- found 1.1.14 in filename of file in /nix/store/iyb3412gsn2bv6zw2bc4yvv2hl85zc0c-libmtp-1.1.14-bin

cc ""