### PR TITLE
frostwire: 6.4.5 -> 6.6.3-build-253

### DIFF
--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -1,24 +1,80 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, lib, fetchFromGitHub, gradle, perl, jre, makeWrapper, makeDesktopItem, mplayer }:
 
-with stdenv.lib;
+let
+  version = "6.6.3-build-253";
+  name = "frostwire-desktop-${version}";
 
-stdenv.mkDerivation rec {
-  version = "6.4.5";
-  name = "frostwire-${version}";
-
-  src = fetchurl {
-    url = "http://dl.frostwire.com/frostwire/${version}/frostwire-${version}.noarch.tar.gz";
-    sha256 = "01nq1vwkqdidmprlnz5d3c5412r6igv689barv64dmb9m6iqg53z";
+  src = fetchFromGitHub {
+    owner = "frostwire";
+    repo = "frostwire";
+    rev = name;
+    sha256 = "1bqv942hfz12i3b3nm1pfwdp7f58nzjxg44h31f3q47719hh8kd7";
   };
 
+  desktopItem = makeDesktopItem {
+    name = "frostwire";
+    desktopName = "FrostWire";
+    genericName = "P2P Bittorrent client";
+    exec = "frostwire";
+    icon = "frostwire";
+    comment = "Search and explore all kinds of files on the Bittorrent network";
+    categories = "Network;FileTransfer;P2P;";
+  };
+
+  # fake build to pre-download deps into fixed-output derivation
+  deps = stdenv.mkDerivation {
+    name = "${name}-deps";
+    inherit src;
+    buildInputs = [ gradle perl ];
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      ( cd desktop
+        gradle --no-daemon build
+      )
+    '';
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0p279i41q7pn6nss8vndv3g4qzrvj3pmhdxq50kymwkyp2kly3lc";
+  };
+
+in stdenv.mkDerivation {
+  inherit name src;
+
   nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ gradle ];
+
+  buildPhase = ''
+    export GRADLE_USER_HOME=$(mktemp -d)
+    ( cd desktop
+      substituteInPlace src/com/frostwire/gui/player/MediaPlayerLinux.java \
+        --replace /usr/bin/mplayer ${mplayer}/bin/mplayer
+      substituteInPlace build.gradle \
+        --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }'
+      gradle --offline --no-daemon build
+    )
+  '';
 
   installPhase = ''
-    mkdir -p $out/share/java
-    mv $(ls */*.jar) $out/share/java
+    mkdir -p $out/lib $out/share/java
 
-    makeWrapper $out/share/java/frostwire $out/bin/frostwire \
-      --prefix PATH : ${jre}/bin/
+    cp desktop/build/libs/frostwire.jar $out/share/java/frostwire.jar
+
+    cp ${ { x86_64-darwin = "desktop/lib/native/*.dylib";
+            x86_64-linux  = "desktop/lib/native/libjlibtorrent.so";
+            i686-linux    = "desktop/lib/native/libjlibtorrentx86.so";
+          }.${stdenv.system} or (throw "unsupported system ${stdenv.system}")
+        } $out/lib
+
+    cp -dpR ${desktopItem}/share $out
+
+    makeWrapper ${jre}/bin/java $out/bin/frostwire \
+      --add-flags "-Djava.library.path=$out/lib -jar $out/share/java/frostwire.jar"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -35,7 +35,7 @@ let
     # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
     installPhase = ''
       find $GRADLE_USER_HOME -type f -regex '.*\.\(jar\|pom\)' \
-        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
         | sh
     '';
     outputHashAlgo = "sha256";

--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -82,6 +82,6 @@ in stdenv.mkDerivation {
     description = "BitTorrent Client and Cloud File Downloader";
     license = licenses.gpl2;
     maintainers = with maintainers; [ gavin ];
-    platforms = platforms.all;
+    platforms = [ "x86_64-darwin" "x86_64-linux" "i686-linux" ];
   };
 }

--- a/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
+++ b/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "6.6.3";
+  name = "frostwire-${version}";
+
+  src = fetchurl {
+    url = "http://dl.frostwire.com/frostwire/${version}/frostwire-${version}.noarch.tar.gz";
+    sha256 = "0di1kfvdjglav5pm23gcggfn9qznk5viah55jggv4cb6h16vxc3p";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/share/java
+    mv $(ls */*.jar) $out/share/java
+
+    makeWrapper $out/share/java/frostwire $out/bin/frostwire \
+      --prefix PATH : ${jre}/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.frostwire.com/;
+    description = "BitTorrent Client and Cloud File Downloader";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ gavin ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
+++ b/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://dl.frostwire.com/frostwire/${version}/frostwire-${version}.noarch.tar.gz";
-    sha256 = "0di1kfvdjglav5pm23gcggfn9qznk5viah55jggv4cb6h16vxc3p";
+    sha256 = "0n1g0am3d2fxw4a4zzzyif1fal1x3xch9q7743jhkkm3mldl2grw";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2315,6 +2315,7 @@ with pkgs;
   frescobaldi = callPackage ../misc/frescobaldi {};
 
   frostwire = callPackage ../applications/networking/p2p/frostwire { };
+  frostwire-bin = callPackage ../applications/networking/p2p/frostwire/frostwire-bin.nix { };
 
   ftgl = callPackage ../development/libraries/ftgl { };
 


### PR DESCRIPTION
###### Motivation for this change

1. version update
2. build from sources
3. fixed hardcoded "/usr/bin/mplayer" in the sources
4. the first example in nixpkgs how to do a gradle build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

