### PR TITLE
libofx: 0.9.10 -> 0.9.12

### DIFF
--- a/pkgs/development/libraries/libofx/default.nix
+++ b/pkgs/development/libraries/libofx/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, opensp, pkgconfig, libxml2, curl }:
         
 stdenv.mkDerivation rec {
-  name = "libofx-0.9.10";
+  name = "libofx-0.9.12";
 
   src = fetchurl {
     url = "mirror://sourceforge/libofx/${name}.tar.gz";
-    sha256 = "15gnbh4mszfxk70srdcjkdykk7dbhzqxi3pxgh48a9zg8i4nmqjl";
+    sha256 = "0wvkgffq9qjhjrggg8r1nbhmw65j3lcl4y4cdpmmkrqiz9ia0py1";
   };
 
   configureFlags = [ "--with-opensp-includes=${opensp}/include/OpenSP" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofx2qif -h` got 0 exit code
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofx2qif --help` got 0 exit code
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofx2qif help` got 0 exit code
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofxdump -h` got 0 exit code
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofxdump --help` got 0 exit code
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofxdump help` got 0 exit code
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofxdump -V` and found version 0.9.12
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofxdump --version` and found version 0.9.12
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofxdump -h` and found version 0.9.12
- ran `/nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12/bin/ofxdump --help` and found version 0.9.12
- found 0.9.12 with grep in /nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12
- found 0.9.12 in filename of file in /nix/store/i715fag3lnprgjw9nj4j1xkjc3vijwp1-libofx-0.9.12

cc ""