### PR TITLE
libpipeline: 1.4.1 -> 1.5.0

### DIFF
--- a/pkgs/development/libraries/libpipeline/default.nix
+++ b/pkgs/development/libraries/libpipeline/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
  
 stdenv.mkDerivation rec {
-  name = "libpipeline-1.4.1";
+  name = "libpipeline-1.5.0";
   
   src = fetchurl {
     url = "mirror://savannah/libpipeline/${name}.tar.gz";
-    sha256 = "1vmrs4nvdsmb550bk10cankrd42ffczlibpsnafxpak306rdfins";
+    sha256 = "0avg525wvifcvjrwa6i1r6kvahmsswj0mpxrsxzzdzra9wpf2whd";
   };
 
   patches = stdenv.lib.optionals stdenv.isDarwin [ ./fix-on-osx.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.5.0 with grep in /nix/store/cd9sjdxaa1d5yrws4rrwr5sfmsbimmai-libpipeline-1.5.0
- found 1.5.0 in filename of file in /nix/store/cd9sjdxaa1d5yrws4rrwr5sfmsbimmai-libpipeline-1.5.0
