### PR TITLE
libpst: 0.6.70 -> 0.6.71

### DIFF
--- a/pkgs/development/libraries/libpst/default.nix
+++ b/pkgs/development/libraries/libpst/default.nix
@@ -2,11 +2,11 @@
   pkgconfig, bzip2, xmlto, gettext, imagemagick, doxygen }:
 
 stdenv.mkDerivation rec {
-  name = "libpst-0.6.70";
+  name = "libpst-0.6.71";
 
   src = fetchurl {
       url = "http://www.five-ten-sg.com/libpst/packages/${name}.tar.gz";
-      sha256 = "1m378vxh1sf9ry8k11x773xpy5f6cab5gkzqglz0jp9hc431r60r";
+      sha256 = "130nksrwgi3ih32si5alvxwzd5kmlg8yi7p03w0h7w9r3b90i4pv";
     };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/lspst -h` got 0 exit code
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/lspst -V` and found version 0.6.71
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/lspst -h` and found version 0.6.71
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/readpst -h` got 0 exit code
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/readpst -V` and found version 0.6.71
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/readpst -h` and found version 0.6.71
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/pst2ldif -h` got 0 exit code
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/pst2ldif -V` and found version 0.6.71
- ran `/nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71/bin/pst2ldif -h` and found version 0.6.71
- found 0.6.71 with grep in /nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71
- found 0.6.71 in filename of file in /nix/store/xlx0625qp0sh74bp7h2g786an5kmhv75-libpst-0.6.71

cc "@tohl"