### PR TITLE
libraw1394: 2.1.1 -> 2.1.2

### DIFF
--- a/pkgs/development/libraries/libraw1394/default.nix
+++ b/pkgs/development/libraries/libraw1394/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libraw1394-2.1.1";
+  name = "libraw1394-2.1.2";
 
   src = fetchurl {
     url = "mirror://kernel/linux/libs/ieee1394/${name}.tar.gz";
-    sha256 = "0x6az154wr7wv3945485grjvpk604khv34dbaph6vmc1zdasqq59";
+    sha256 = "0z5md84941ky5l7afayx2z6j0sk0mildxbjajq6niznd44ky7i6x";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2/bin/testlibraw -h` got 0 exit code
- ran `/nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2/bin/testlibraw --help` got 0 exit code
- ran `/nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2/bin/testlibraw help` got 0 exit code
- ran `/nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2/bin/sendiso -h` got 0 exit code
- ran `/nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2/bin/sendiso --help` got 0 exit code
- ran `/nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2/bin/dumpiso -h` got 0 exit code
- ran `/nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2/bin/dumpiso --help` got 0 exit code
- found 2.1.2 with grep in /nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2
- found 2.1.2 in filename of file in /nix/store/qxim1bskvnx2i91zlyblc62npb2m6yw1-libraw1394-2.1.2

cc "@wkennington"