### PR TITLE
libre: 0.5.6 -> 0.5.7

### DIFF
--- a/pkgs/development/libraries/libre/default.nix
+++ b/pkgs/development/libraries/libre/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, zlib, openssl}:
 stdenv.mkDerivation rec {
-  version = "0.5.6";
+  version = "0.5.7";
   name = "libre-${version}";
   src = fetchurl {
     url = "http://www.creytiv.com/pub/re-${version}.tar.gz";
-    sha256 = "0sfz5c7b05crahblanrrvwca092qaqzhjkbkva58jbqnmlk9h4d3";
+    sha256 = "0f8h224xfzvnb2ngvhxz8gzxqjlkkfr6d0nj8zqivzr81ihibk2x";
   };
   buildInputs = [ zlib openssl ];
   makeFlags = [ "USE_ZLIB=1" "USE_OPENSSL=1" "PREFIX=$(out)" ]


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.5.7 with grep in /nix/store/flnmjxr20pwpgi7d35361gh6xwai8d07-libre-0.5.7
- found 0.5.7 in filename of file in /nix/store/flnmjxr20pwpgi7d35361gh6xwai8d07-libre-0.5.7

cc "@raskin"