### PR TITLE
libqrencode: 3.4.4 -> 4.0.0

### DIFF
--- a/pkgs/development/libraries/libqrencode/default.nix
+++ b/pkgs/development/libraries/libqrencode/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   name = "libqrencode-${version}";
-  version = "3.4.4";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "https://fukuchi.org/works/qrencode/qrencode-${version}.tar.gz";
     sha1 = "644054a76c8b593acb66a8c8b7dcf1b987c3d0b2";
-    sha256 = "0wiagx7i8p9zal53smf5abrnh9lr31mv0p36wg017401jrmf5577";
+    sha256 = "10da4q5pym7pzxcv21w2kc2rxmq7sp1rg58zdklwfr0jjci1nqjv";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/vfpi2hpblg4hrydn0ip56nq00n3px1sq-libqrencode-4.0.0/bin/qrencode -h` got 0 exit code
- ran `/nix/store/vfpi2hpblg4hrydn0ip56nq00n3px1sq-libqrencode-4.0.0/bin/qrencode --help` got 0 exit code
- ran `/nix/store/vfpi2hpblg4hrydn0ip56nq00n3px1sq-libqrencode-4.0.0/bin/qrencode -V` and found version 4.0.0
- ran `/nix/store/vfpi2hpblg4hrydn0ip56nq00n3px1sq-libqrencode-4.0.0/bin/qrencode --version` and found version 4.0.0
- ran `/nix/store/vfpi2hpblg4hrydn0ip56nq00n3px1sq-libqrencode-4.0.0/bin/qrencode -h` and found version 4.0.0
- ran `/nix/store/vfpi2hpblg4hrydn0ip56nq00n3px1sq-libqrencode-4.0.0/bin/qrencode --help` and found version 4.0.0
- found 4.0.0 with grep in /nix/store/vfpi2hpblg4hrydn0ip56nq00n3px1sq-libqrencode-4.0.0
- found 4.0.0 in filename of file in /nix/store/vfpi2hpblg4hrydn0ip56nq00n3px1sq-libqrencode-4.0.0

cc "@adolfogc"