### PR TITLE
libqmi: 1.18.0 -> 1.20.0

### DIFF
--- a/pkgs/development/libraries/libqmi/default.nix
+++ b/pkgs/development/libraries/libqmi/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, python, libgudev, libmbim }:
 
 stdenv.mkDerivation rec {
-  name = "libqmi-1.18.0";
+  name = "libqmi-1.20.0";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/libqmi/${name}.tar.xz";
-    sha256 = "1v4cz3nsmh7nn3smhlhwzrb7yh6l1f270bwf40qacxayjdajr950";
+    sha256 = "1d3fca477sdwbv4bsq1cl98qc8sixrzp0gqjcmjj8mlwfk9qqhi1";
   };
 
   outputs = [ "out" "dev" "devdoc" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmi-network --help` got 0 exit code
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmi-network --version` and found version 1.20.0
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmicli -h` got 0 exit code
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmicli --help` got 0 exit code
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmicli -V` and found version 1.20.0
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmicli --version` and found version 1.20.0
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmi-firmware-update -h` got 0 exit code
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmi-firmware-update --help` got 0 exit code
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmi-firmware-update -V` and found version 1.20.0
- ran `/nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0/bin/qmi-firmware-update --version` and found version 1.20.0
- found 1.20.0 with grep in /nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0
- found 1.20.0 in filename of file in /nix/store/zv2yn5d1z16kcmi5p3766mh5v5imp8ky-libqmi-1.20.0

cc "@wkennington"