### PR TITLE
librelp: 1.2.12 -> 1.2.14

### DIFF
--- a/pkgs/development/libraries/librelp/default.nix
+++ b/pkgs/development/libraries/librelp/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, gnutls, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "librelp-1.2.12";
+  name = "librelp-1.2.14";
 
   src = fetchurl {
     url = "http://download.rsyslog.com/librelp/${name}.tar.gz";
-    sha256 = "1mvvxqfsfg96rb6xv3fw7mcsqmyfnsb74sc53gnhpcpp4h2p6m83";
+    sha256 = "0marms2np729ck0x0hsj1bdmi0ly57pl7pfspwrqld9n8cd29xhi";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.2.14 with grep in /nix/store/8h9pj41013zl5mvi0k69zvl7wrc13bz5-librelp-1.2.14
- found 1.2.14 in filename of file in /nix/store/8h9pj41013zl5mvi0k69zvl7wrc13bz5-librelp-1.2.14

cc "@wkennington"