### PR TITLE
libsass: 3.4.8 -> 3.4.9

### DIFF
--- a/pkgs/development/libraries/libsass/default.nix
+++ b/pkgs/development/libraries/libsass/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libsass-${version}";
-  version = "3.4.8";
+  version = "3.4.9";
 
   src = fetchurl {
     url = "https://github.com/sass/libsass/archive/${version}.tar.gz";
-    sha256 = "0gq0mg42sq2nxiv25fh37frlr0iyqamh7shv83qixnqklqpkfi13";
+    sha256 = "0f4mj91zzdzah7fxkdg3dnrimk9ip7czl4g26f32zgifz1nrqgjs";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.4.9 with grep in /nix/store/biismabsawadk87l7m83a62d8cj08iy1-libsass-3.4.9
- found 3.4.9 in filename of file in /nix/store/biismabsawadk87l7m83a62d8cj08iy1-libsass-3.4.9

cc "@codyopel @offline"