### PR TITLE
librep: 0.92.6 -> 0.92.7

### DIFF
--- a/pkgs/development/libraries/librep/default.nix
+++ b/pkgs/development/libraries/librep/default.nix
@@ -7,12 +7,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "librep-${version}";
-  version = "0.92.6";
+  version = "0.92.7";
   sourceName = "librep_${version}";
 
   src = fetchurl {
     url = "http://download.tuxfamily.org/librep/${sourceName}.tar.xz";
-    sha256 = "1k6c0hmyzxh8459r790slh9vv9vwy9d7w3nlmrqypbx9mk855hgy";
+    sha256 = "1bmcjl1x1rdh514q9z3hzyjmjmwwwkziipjpjsl301bwmiwrd8a8";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/n46m9li9xl794686xii90gh0hqgh2v7d-librep-0.92.7/bin/rep --help` got 0 exit code
- ran `/nix/store/n46m9li9xl794686xii90gh0hqgh2v7d-librep-0.92.7/bin/rep --version` and found version 0.92.7
- ran `/nix/store/n46m9li9xl794686xii90gh0hqgh2v7d-librep-0.92.7/bin/rep --help` and found version 0.92.7
- found 0.92.7 with grep in /nix/store/n46m9li9xl794686xii90gh0hqgh2v7d-librep-0.92.7
- found 0.92.7 in filename of file in /nix/store/n46m9li9xl794686xii90gh0hqgh2v7d-librep-0.92.7

cc "@AndersonTorres"