### PR TITLE
libsolv: 0.6.23 -> 0.6.32

### DIFF
--- a/pkgs/development/libraries/libsolv/default.nix
+++ b/pkgs/development/libraries/libsolv/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, zlib, expat, rpm, db }:
 
 stdenv.mkDerivation rec {
-  rev  = "0.6.23";
+  rev  = "0.6.32";
   name = "libsolv-${rev}";
 
   src = fetchFromGitHub {
     inherit rev;
     owner  = "openSUSE";
     repo   = "libsolv";
-    sha256 = "08ba7yx0br421lk6zf5mp0yl6nznkmc2vbka20qwm2lx5f0a25xg";
+    sha256 = "0gqvnnc1s5n0yj82ia6w2wjhhn8hpl6wm4lki2kzvjqjgla45fnq";
   };
 
   cmakeFlags = "-DENABLE_RPMMD=true -DENABLE_RPMDB=true -DENABLE_PUBKEY=true -DENABLE_RPMDB_BYRPMHEADER=true";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/mergesolv -h` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/mergesolv --help` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/mergesolv -V` and found version 0.6.32
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/mergesolv -v` and found version 0.6.32
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/mergesolv --version` and found version 0.6.32
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/mergesolv --help` and found version 0.6.32
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/dumpsolv -h` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/testsolv -h` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/testsolv help` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/rpmdb2solv -h` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/repomdxml2solv -h` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/rpmmd2solv -h` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/updateinfoxml2solv -h` got 0 exit code
- ran `/nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32/bin/deltainfoxml2solv -h` got 0 exit code
- found 0.6.32 with grep in /nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32
- found 0.6.32 in filename of file in /nix/store/z19rz030kl2vc1sgmcqmjblwmcb4n190-libsolv-0.6.32

cc "@copumpkin"