### PR TITLE
libspatialindex: 1.8.1 -> 1.8.5

### DIFF
--- a/pkgs/development/libraries/libspatialindex/default.nix
+++ b/pkgs/development/libraries/libspatialindex/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl }:
 
-let version = "1.8.1"; in
+let version = "1.8.5"; in
 
 stdenv.mkDerivation rec {
   name = "libspatialindex-${version}";
 
   src = fetchurl {
     url = "http://download.osgeo.org/libspatialindex/spatialindex-src-${version}.tar.gz";
-    sha256 = "1ay1kxn4baccd0cqx466v7fn8c8gcfbhlnd5mbdnd7s4aw0ix88j";
+    sha256 = "1vxzm7kczwnb6qdmc0hb00z8ykx11zk3sb68gc7rch4vrfi4dakw";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.8.5 with grep in /nix/store/37qfplsqfz7lq058pg2cvvm592yzvvf9-libspatialindex-1.8.5
- found 1.8.5 in filename of file in /nix/store/37qfplsqfz7lq058pg2cvvm592yzvvf9-libspatialindex-1.8.5
