### PR TITLE
libspatialite: 4.2.0 -> 4.3.0a

### DIFF
--- a/pkgs/development/libraries/libspatialite/default.nix
+++ b/pkgs/development/libraries/libspatialite/default.nix
@@ -3,11 +3,11 @@
 with lib;
 
 stdenv.mkDerivation rec {
-  name = "libspatialite-4.2.0";
+  name = "libspatialite-4.3.0a";
 
   src = fetchurl {
     url = "http://www.gaia-gis.it/gaia-sins/libspatialite-sources/${name}.tar.gz";
-    sha256 = "0b9ipmp09y2ij7yajyjsh0zcwps8n5g88lzfzlkph33lail8l4wz";
+    sha256 = "16d4lpl7xrm9zy4gphy6nwanpjp8wn9g4wq2i2kh8abnlhq01448";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 4.3.0a with grep in /nix/store/m0xjxq9ca1fwhwzl6klfaz4kj7v21cnr-libspatialite-4.3.0a
- found 4.3.0a in filename of file in /nix/store/m0xjxq9ca1fwhwzl6klfaz4kj7v21cnr-libspatialite-4.3.0a
