### PR TITLE
libtermkey: 0.19 -> 0.20

### DIFF
--- a/pkgs/development/libraries/libtermkey/default.nix
+++ b/pkgs/development/libraries/libtermkey/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "libtermkey-${version}";
 
-  version = "0.19";
+  version = "0.20";
 
   src = fetchzip {
     url = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-${version}.tar.gz";
-    sha256 = "0v85h0zacd5lqwkykl2ms4009x8mfidzb6jr4dsq4gh7kwm54w56";
+    sha256 = "1i5a2zangq61ba1vdkag34ig5g4gzccldccdbcmqmk93saa6lkbx";
   };
 
   makeFlags = [ "PREFIX=$(out)" ]


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.20 with grep in /nix/store/4sswlqrcz5y3s241l0vgrbsyzcrl9gn5-libtermkey-0.20
- found 0.20 in filename of file in /nix/store/4sswlqrcz5y3s241l0vgrbsyzcrl9gn5-libtermkey-0.20