### PR TITLE
libtomcrypt: 1.18.0 -> 1.18.1

### DIFF
--- a/pkgs/development/libraries/libtomcrypt/default.nix
+++ b/pkgs/development/libraries/libtomcrypt/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libtomcrypt-${version}";
-  version = "1.18.0";
+  version = "1.18.1";
 
   src = fetchurl {
     url = "https://github.com/libtom/libtomcrypt/releases/download/v${version}/crypt-${version}.tar.xz";
-    sha256 = "0ymqi0zf5gzn8pq4mnylwgg6pskml2v1p9rsjrqspyja65mgb7fs";
+    sha256 = "053z0jzyvf6c9929phlh2p0ybx289s34g7nii5hnjigxzcs3mhap";
   };
 
   nativeBuildInputs = [ libtool ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.18.1 with grep in /nix/store/iv3xsmfxm8i14mkkcc5cqqr7ixpq02i5-libtomcrypt-1.18.1
- found 1.18.1 in filename of file in /nix/store/iv3xsmfxm8i14mkkcc5cqqr7ixpq02i5-libtomcrypt-1.18.1