### PR TITLE
liburcu: 0.9.5 -> 0.10.1

### DIFF
--- a/pkgs/development/libraries/liburcu/default.nix
+++ b/pkgs/development/libraries/liburcu/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.5";
+  version = "0.10.1";
   name = "liburcu-${version}";
 
   src = fetchurl {
     url = "http://lttng.org/files/urcu/userspace-rcu-${version}.tar.bz2";
-    sha256 = "19iq7985rhvbrj99hlmbyq2wjrkhssvigh5454mhaprn3c7jaj6r";
+    sha256 = "01pbg67qy5hcssy2yi0ckqapzfclgdq93li2rmzw4pa3wh5j42cw";
   };
 
   nativeBuildInputs = stdenv.lib.optional doCheck perl;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.10.1 with grep in /nix/store/hfqs5amwgnhsmp0jbyw5fbg5vvx7n60w-liburcu-0.10.1
- found 0.10.1 in filename of file in /nix/store/hfqs5amwgnhsmp0jbyw5fbg5vvx7n60w-liburcu-0.10.1

cc "@bjornfor"