### PR TITLE
libuv: 1.19.1 -> 1.19.2

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -2,14 +2,14 @@
 , ApplicationServices, CoreServices }:
 
 stdenv.mkDerivation rec {
-  version = "1.19.1";
+  version = "1.19.2";
   name = "libuv-${version}";
 
   src = fetchFromGitHub {
     owner = "libuv";
     repo = "libuv";
     rev = "v${version}";
-    sha256 = "020jap4xvjns1rgb2kvpf1nib3f2d5fyqh04afgkk32hiag0kn66";
+    sha256 = "118r8wigm65107fm7kzfz7gc4awy8xxg0knvwnshx1j40ks08x9z";
   };
 
   postPatch = let


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.19.2 with grep in /nix/store/f45rl4z9a2rqd7hdhwnj9g831z1k4ilr-libuv-1.19.2
- found 1.19.2 in filename of file in /nix/store/f45rl4z9a2rqd7hdhwnj9g831z1k4ilr-libuv-1.19.2

cc "@cstrahan"