### PR TITLE
libva: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "libva-${lib.optionalString (!minimal) "full-"}${version}";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner  = "01org";
     repo   = "libva";
     rev    = version;
-    sha256 = "1x8rlmv5wfqjz3j87byrxb4d9vp5b4lrrin2fx254nwl3aqy15hy";
+    sha256 = "1a60lrgr65hx9b2qp0gjky1298c4d4zp3ap6vnmmz850sxx5rm8w";
   };
 
   outputs = [ "dev" "out" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.1.0 with grep in /nix/store/0xbyhqx5jshrv4dhys1xcjpm6jj1sgln-libva-2.1.0-dev
- found 2.1.0 in filename of file in /nix/store/0xbyhqx5jshrv4dhys1xcjpm6jj1sgln-libva-2.1.0-dev

cc "@garbas"