### PR TITLE
libvirt: 3.10.0 -> 4.0.0

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -12,11 +12,11 @@ with stdenv.lib;
 # if you update, also bump <nixpkgs/pkgs/development/python-modules/libvirt/default.nix> or it will break
 stdenv.mkDerivation rec {
   name = "libvirt-${version}";
-  version = "3.10.0";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "http://libvirt.org/sources/${name}.tar.xz";
-    sha256 = "03kb37iv3dvvdlslznlc0njvjpmq082lczmsslz5p4fcwb50kwfz";
+    sha256 = "1j6zzajh4j3zzsaqn5f5mrchm0590xcf6rzkfajvqw3bd4dcms79";
   };
 
   patches = [ ./build-on-bsd.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-pki-validate -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-pki-validate --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-pki-validate -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-pki-validate --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-pki-validate -h` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-pki-validate --help` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virsh -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virsh --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virsh help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virsh -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virsh -v` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virsh --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-admin -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-admin --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-admin help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-admin -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-admin -v` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-admin --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-admin version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-login-shell -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-login-shell --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-login-shell -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-login-shell --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-login-shell -h` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-login-shell --help` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-host-validate -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-host-validate --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-host-validate -v` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-host-validate --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-host-validate -h` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-host-validate --help` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-xml-validate -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-xml-validate --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-xml-validate -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-xml-validate --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-xml-validate -h` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virt-xml-validate --help` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/.libvirtd-wrapped -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/.libvirtd-wrapped --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/.libvirtd-wrapped -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/.libvirtd-wrapped --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/.libvirtd-wrapped -h` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/.libvirtd-wrapped --help` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/libvirtd -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/libvirtd --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/libvirtd -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/libvirtd --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/libvirtd -h` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/libvirtd --help` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlockd -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlockd --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlockd -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlockd --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlockd -h` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlockd --help` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlogd -h` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlogd --help` got 0 exit code
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlogd -V` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlogd --version` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlogd -h` and found version 4.0.0
- ran `/nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0/bin/virtlogd --help` and found version 4.0.0
- found 4.0.0 with grep in /nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0
- found 4.0.0 in filename of file in /nix/store/640xi03pfzc488bg99b35xvicdqa60l5-libvirt-4.0.0

cc "@fpletz"