### PR TITLE
libwacom: 0.26 -> 0.28

### DIFF
--- a/pkgs/development/libraries/libwacom/default.nix
+++ b/pkgs/development/libraries/libwacom/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libwacom-${version}";
-  version = "0.26";
+  version = "0.28";
 
   src = fetchurl {
     url = "mirror://sourceforge/linuxwacom/libwacom/${name}.tar.bz2";
-    sha256 = "0xpvkjvzaj9blcmw8ha46616bzfivj99kwzvr91clxd6iaf11r63";
+    sha256 = "1vv768870597rvwxdb59v6pjn1pxaxg4r6znbb5j3cl828q35mp7";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/yi7myg1fay4my7dl64nbj0mlv2qdma6z-libwacom-0.28/bin/libwacom-list-local-devices -h` got 0 exit code
- ran `/nix/store/yi7myg1fay4my7dl64nbj0mlv2qdma6z-libwacom-0.28/bin/libwacom-list-local-devices --help` got 0 exit code
- ran `/nix/store/yi7myg1fay4my7dl64nbj0mlv2qdma6z-libwacom-0.28/bin/libwacom-list-local-devices help` got 0 exit code
- found 0.28 with grep in /nix/store/yi7myg1fay4my7dl64nbj0mlv2qdma6z-libwacom-0.28
- found 0.28 in filename of file in /nix/store/yi7myg1fay4my7dl64nbj0mlv2qdma6z-libwacom-0.28