### PR TITLE
libwebsockets: 2.3.0 -> 2.4.1

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libwebsockets-${version}";
-  version = "2.3.0";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "warmcat";
     repo = "libwebsockets";
     rev = "v${version}";
-    sha256 = "1hv2b5r6sg42xnqhm4ysjvyiz3cqpfmwaqm33vpbx0k7arj4ixvy";
+    sha256 = "0d3xqdq3hpk5l9cg4dqkba6jm6620y6knqqywya703662spmj2xw";
   };
 
   buildInputs = [ cmake openssl zlib libuv ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.4.1 with grep in /nix/store/lm20nl7bdr3fmnagp48b4a7pjagv5qdf-libwebsockets-2.4.1
- found 2.4.1 in filename of file in /nix/store/lm20nl7bdr3fmnagp48b4a7pjagv5qdf-libwebsockets-2.4.1
