### PR TITLE
libwpg: 0.3.0 -> 0.3.2

### DIFF
--- a/pkgs/development/libraries/libwpg/default.nix
+++ b/pkgs/development/libraries/libwpg/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libwpd, zlib, librevenge }:
 
 stdenv.mkDerivation rec {
-  name = "libwpg-0.3.0";
+  name = "libwpg-0.3.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/libwpg/${name}.tar.xz";
-    sha256 = "097jx8a638fwwfrzf6v29r1yhc34rq9526py7wf0ck2z4fcr2w3g";
+    sha256 = "0cwc5zkp210c661l0bvk6q21jg9ak5g8gmy578w5fgfnjymz3yjp";
   };
 
   buildInputs = [ libwpd zlib librevenge ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/fy1rzjb6d204ca4063ymw4n5gcrnh7hp-libwpg-0.3.2/bin/wpg2raw --version` and found version 0.3.2
- ran `/nix/store/fy1rzjb6d204ca4063ymw4n5gcrnh7hp-libwpg-0.3.2/bin/wpg2svg --version` and found version 0.3.2
- found 0.3.2 with grep in /nix/store/fy1rzjb6d204ca4063ymw4n5gcrnh7hp-libwpg-0.3.2
- found 0.3.2 in filename of file in /nix/store/fy1rzjb6d204ca4063ymw4n5gcrnh7hp-libwpg-0.3.2

cc ""