### PR TITLE
libwps: 0.4.3 -> 0.4.8

### DIFF
--- a/pkgs/development/libraries/libwps/default.nix
+++ b/pkgs/development/libraries/libwps/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libwps-${version}";
-  version = "0.4.3";
+  version = "0.4.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/libwps/${name}.tar.bz2";
-    sha256 = "0v1a0hj96i4jhb5833336s4zcslzb6md5cnmnrvgywx8cmw40c0c";
+    sha256 = "163gdqaanqfs767aj6zdzagqldngn8i7f0hbmhhxlxr0wmvx6c9q";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wps2html -v` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wps2html --version` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wps2raw -v` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wps2raw --version` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wps2text -v` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wps2text --version` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wks2csv -v` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wks2csv --version` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wks2raw -v` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wks2raw --version` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wks2text -v` and found version 0.4.8
- ran `/nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8/bin/wks2text --version` and found version 0.4.8
- found 0.4.8 with grep in /nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8
- found 0.4.8 in filename of file in /nix/store/xi4b6qg78waf3xxlls86paxz1xxfzh9x-libwps-0.4.8