### PR TITLE
libzmf: 0.0.1 -> 0.0.2

### DIFF
--- a/pkgs/development/libraries/libzmf/default.nix
+++ b/pkgs/development/libraries/libzmf/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "libzmf";
-  version = "0.0.1";
+  version = "0.0.2";
   
   src = fetchurl {
     url = "http://dev-www.libreoffice.org/src/libzmf/${name}.tar.xz";
-    sha256 = "0yp5l1b90xim506zmr3ljkn3qkvbc7qk3dnwq1snxdpr57m37xga";
+    sha256 = "08mg5kmkjrmqrd8j5rkzw9vdqlvibhb1ynp6bmfxnzq5rcq1l197";
   };
 
   buildInputs = [boost icu libpng librevenge zlib cppunit];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qq22lnv1qj1qwxmnf1qikf5a76girca4-libzmf-0.0.2/bin/zmf2raw --version` and found version 0.0.2
- ran `/nix/store/qq22lnv1qj1qwxmnf1qikf5a76girca4-libzmf-0.0.2/bin/zmf2svg --version` and found version 0.0.2
- found 0.0.2 with grep in /nix/store/qq22lnv1qj1qwxmnf1qikf5a76girca4-libzmf-0.0.2
- found 0.0.2 in filename of file in /nix/store/qq22lnv1qj1qwxmnf1qikf5a76girca4-libzmf-0.0.2

cc "@raskin"