### PR TITLE
libxcomp: 3.5.0.32 -> 3.5.0.33

### DIFF
--- a/pkgs/development/libraries/libxcomp/default.nix
+++ b/pkgs/development/libraries/libxcomp/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "libxcomp-${version}";
-  version = "3.5.0.32";
+  version = "3.5.0.33";
 
   src = fetchurl {
-    sha256 = "02n5bdc1jsq999agb4w6dmdj5l2wlln2lka84qz6rpswwc59zaxm";
+    sha256 = "17qjsd6v2ldpfmyjrkdnlq4qk05hz5l6qs54g8h0glzq43w28f74";
     url = "http://code.x2go.org/releases/source/nx-libs/nx-libs-${version}-lite.tar.gz";
   };
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.5.0.33 with grep in /nix/store/mc3jmk1ka7ny9byjwxavx5mdcrxb4kdb-libxcomp-3.5.0.33
- found 3.5.0.33 in filename of file in /nix/store/mc3jmk1ka7ny9byjwxavx5mdcrxb4kdb-libxcomp-3.5.0.33