### PR TITLE
lp_solve: 5.5.2.0 -> 5.5.2.5

### DIFF
--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   name = "lp_solve-${version}";
-  version = "5.5.2.0";
+  version = "5.5.2.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/lpsolve/lpsolve/${version}/lp_solve_${version}_source.tar.gz";
-    sha256 = "176c7f023mb6b8bfmv4rfqnrlw88lsg422ca74zjh19i2h5s69sq";
+    sha256 = "12pj1idjz31r7c2mb5w03vy1cmvycvbkx9z29s40qdmkp1i7q6i0";
   };
 
   patches = [ ./isnan.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/n5jgpvmzaqdfxdfawfi5rf8vav1qgi7w-lp_solve-5.5.2.5/bin/lp_solve -h` got 0 exit code
- ran `/nix/store/n5jgpvmzaqdfxdfawfi5rf8vav1qgi7w-lp_solve-5.5.2.5/bin/lp_solve -h` and found version 5.5.2.5
- found 5.5.2.5 with grep in /nix/store/n5jgpvmzaqdfxdfawfi5rf8vav1qgi7w-lp_solve-5.5.2.5
- found 5.5.2.5 in filename of file in /nix/store/n5jgpvmzaqdfxdfawfi5rf8vav1qgi7w-lp_solve-5.5.2.5

cc "@smironov"