### PR TITLE
logstalgia: 1.0.7 -> 1.1.1

### DIFF
--- a/pkgs/tools/graphics/logstalgia/default.nix
+++ b/pkgs/tools/graphics/logstalgia/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "logstalgia-${version}";
-  version = "1.0.7";
+  version = "1.1.1";
 
   src = fetchurl {
     url = "https://github.com/acaudwell/Logstalgia/releases/download/${name}/${name}.tar.gz";
-    sha256 = "1qghz1j3jmfj093br2hfyibayg3fmhg8fvp5ix9n9rbvzc1zslsm";
+    sha256 = "0nvnk8q9m2ignzwxak0vch88blywbx4znk70xf9fg38xa4rf94yn";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qj5igicvkqbsmy0zs5qxzkj91dx01cl1-logstalgia-1.1.1/bin/logstalgia -h` got 0 exit code
- ran `/nix/store/qj5igicvkqbsmy0zs5qxzkj91dx01cl1-logstalgia-1.1.1/bin/logstalgia --help` got 0 exit code
- ran `/nix/store/qj5igicvkqbsmy0zs5qxzkj91dx01cl1-logstalgia-1.1.1/bin/logstalgia -h` and found version 1.1.1
- ran `/nix/store/qj5igicvkqbsmy0zs5qxzkj91dx01cl1-logstalgia-1.1.1/bin/logstalgia --help` and found version 1.1.1
- found 1.1.1 with grep in /nix/store/qj5igicvkqbsmy0zs5qxzkj91dx01cl1-logstalgia-1.1.1
- found 1.1.1 in filename of file in /nix/store/qj5igicvkqbsmy0zs5qxzkj91dx01cl1-logstalgia-1.1.1

cc "@pSub"