### PR TITLE
logrotate: 3.12.3 -> 3.13.0

### DIFF
--- a/pkgs/tools/system/logrotate/default.nix
+++ b/pkgs/tools/system/logrotate/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "logrotate-${version}";
-  version = "3.12.3";
+  version = "3.13.0";
 
   src = fetchFromGitHub {
     owner = "logrotate";
     repo = "logrotate";
     rev = version;
-    sha256 = "04ygb709fj4ai8m2f1c6imzcmkdvr3ib5zf5qw2lif4fsb30jvyi";
+    sha256 = "0b7dnch74pddml3ysavizq26jgwdv0rjmwc8lf6zfvn9fjz19vvs";
   };
 
   # Logrotate wants to access the 'mail' program; to be done.


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qjpxc2hbnx8klaj6zxq9zxp29b4afqm1-logrotate-3.13.0/bin/logrotate --help` got 0 exit code
- found 3.13.0 in filename of file in /nix/store/qjpxc2hbnx8klaj6zxq9zxp29b4afqm1-logrotate-3.13.0

cc "@viric"