### PR TITLE
lsyncd: 2.1.6 -> 2.2.2

### DIFF
--- a/pkgs/applications/networking/sync/lsyncd/default.nix
+++ b/pkgs/applications/networking/sync/lsyncd/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "lsyncd-${version}";
-  version = "2.1.6";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "axkibe";
     repo = "lsyncd";
     rev = "release-${version}";
-    sha256 = "1cab96h4qfyapk7lb682j1d8k0hpv7h9pl41vdgc0vr4bq4c3ij2";
+    sha256 = "1q2ixp52r96ckghgmxdbms6xrq8dbziimp8gmgzqfq4lk1v1w80y";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3f76mczmag2wnkww6la0hcdnf82jly92-lsyncd-2.2.2/bin/lsyncd --version` and found version 2.2.2
- found 2.2.2 with grep in /nix/store/3f76mczmag2wnkww6la0hcdnf82jly92-lsyncd-2.2.2
- found 2.2.2 in filename of file in /nix/store/3f76mczmag2wnkww6la0hcdnf82jly92-lsyncd-2.2.2

cc "@bobvanderlinden"