### PR TITLE
lnav: 0.8.2 -> 0.8.3

### DIFF
--- a/pkgs/tools/misc/lnav/default.nix
+++ b/pkgs/tools/misc/lnav/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "tstack";
     repo = "lnav";
     rev = "v${meta.version}";
-    sha256 = "1jdjn64cxgbhhyg73cisrfrk7vjg1hr9nvkmfdk8gxc4g82y3xxc";
+    sha256 = "0hq9ri6a18z682gihxlbh1rndka0v6brkdqsyfsgh4c2fgib4fb7";
     inherit name;
   };
 
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     '';
     downloadPage = "https://github.com/tstack/lnav/releases";
     license = licenses.bsd2;
-    version = "0.8.2";
+    version = "0.8.3";
     maintainers = [ maintainers.dochang ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/14wbn5qpd1jxqwwbcjdr7jg9fq9qs659-lnav-0.8.3/bin/lnav -h` got 0 exit code
- ran `/nix/store/14wbn5qpd1jxqwwbcjdr7jg9fq9qs659-lnav-0.8.3/bin/lnav -V` and found version 0.8.3
- ran `/nix/store/14wbn5qpd1jxqwwbcjdr7jg9fq9qs659-lnav-0.8.3/bin/lnav -h` and found version 0.8.3
- found 0.8.3 with grep in /nix/store/14wbn5qpd1jxqwwbcjdr7jg9fq9qs659-lnav-0.8.3
- found 0.8.3 in filename of file in /nix/store/14wbn5qpd1jxqwwbcjdr7jg9fq9qs659-lnav-0.8.3

cc "@dochang"