### PR TITLE
lttng-tools: 2.10.1 -> 2.10.2

### DIFF
--- a/pkgs/development/tools/misc/lttng-tools/default.nix
+++ b/pkgs/development/tools/misc/lttng-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "lttng-tools-${version}";
-  version = "2.10.1";
+  version = "2.10.2";
 
   src = fetchurl {
     url = "https://lttng.org/files/lttng-tools/${name}.tar.bz2";
-    sha256 = "005axllajfbxh73vh1cacbapdvbxjsi3pkzq40giih4ps9x4pg10";
+    sha256 = "17wsdhkw8c8gb0d1bcgw4dfx2ljrq4rzgpi8sb9y9hs6pbwqy0xk";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng -V` and found version 2.10.2
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng --version` and found version 2.10.2
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng version` and found version 2.10.2
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng-crash -V` and found version 2.10.2
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng-crash --version` and found version 2.10.2
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng-relayd -V` and found version 2.10.2
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng-relayd --version` and found version 2.10.2
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng-sessiond -V` and found version 2.10.2
- ran `/nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2/bin/lttng-sessiond --version` and found version 2.10.2
- found 2.10.2 with grep in /nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2
- found 2.10.2 in filename of file in /nix/store/mxkd9dxy95rw5xg54h55nm0rdk5makvm-lttng-tools-2.10.2

cc "@bjornfor"