### PR TITLE
lttng-ust: 2.10.0 -> 2.10.1

### DIFF
--- a/pkgs/development/tools/misc/lttng-ust/default.nix
+++ b/pkgs/development/tools/misc/lttng-ust/default.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   name = "lttng-ust-${version}";
-  version = "2.10.0";
+  version = "2.10.1";
 
   src = fetchurl {
     url = "https://lttng.org/files/lttng-ust/${name}.tar.bz2";
-    sha256 = "1avx4p71g9m3zvynhhhysxnpkqyhhlv42xiv9502bvp3nwfkgnqs";
+    sha256 = "17gfi1dn6bgg59qn4ihf8hag96lalx0g7dym2ccpzdz7f45krk07";
   };
 
   buildInputs = [ python ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lf189bg3wyp8bbiw6kqwlvhm3yc4wdgq-lttng-ust-2.10.1/bin/lttng-gen-tp -h` got 0 exit code
- ran `/nix/store/lf189bg3wyp8bbiw6kqwlvhm3yc4wdgq-lttng-ust-2.10.1/bin/lttng-gen-tp --help` got 0 exit code
- ran `/nix/store/lf189bg3wyp8bbiw6kqwlvhm3yc4wdgq-lttng-ust-2.10.1/bin/lttng-gen-tp help` got 0 exit code
- found 2.10.1 with grep in /nix/store/lf189bg3wyp8bbiw6kqwlvhm3yc4wdgq-lttng-ust-2.10.1
- found 2.10.1 in filename of file in /nix/store/lf189bg3wyp8bbiw6kqwlvhm3yc4wdgq-lttng-ust-2.10.1

cc "@bjornfor"