### PR TITLE
lynis: 2.5.7 -> 2.6.2

### DIFF
--- a/pkgs/tools/security/lynis/default.nix
+++ b/pkgs/tools/security/lynis/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "lynis";
-  version = "2.5.7";
+  version = "2.6.2";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "CISOfy";
     repo = "${pname}";
     rev = "${version}";
-    sha256 = "19rfkiri73bi43i4yxpqrxjzpqn5rfrkq2picja5filjv14hbyly";
+    sha256 = "0jymp44dmc22cdrsd5hfyv9wc8a5sq92yh9p9c0rg22g53733910";
   };
 
   nativeBuildInputs = [ makeWrapper perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/xspm1nc8dznagjc1rnpg2rjxlf88ivkc-lynis-2.6.2/bin/lynis -V` and found version 2.6.2
- ran `/nix/store/xspm1nc8dznagjc1rnpg2rjxlf88ivkc-lynis-2.6.2/bin/lynis --version` and found version 2.6.2
- ran `/nix/store/xspm1nc8dznagjc1rnpg2rjxlf88ivkc-lynis-2.6.2/bin/.lynis-wrapped -V` and found version 2.6.2
- ran `/nix/store/xspm1nc8dznagjc1rnpg2rjxlf88ivkc-lynis-2.6.2/bin/.lynis-wrapped --version` and found version 2.6.2
- found 2.6.2 with grep in /nix/store/xspm1nc8dznagjc1rnpg2rjxlf88ivkc-lynis-2.6.2
- found 2.6.2 in filename of file in /nix/store/xspm1nc8dznagjc1rnpg2rjxlf88ivkc-lynis-2.6.2

cc "@ryneeverett"