### PR TITLE
webtorrent_desktop: init at 0.19.0

### DIFF
--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -1,0 +1,88 @@
+{
+  alsaLib, atk, cairo, cups, dbus, dpkg, expat, fetchurl, fontconfig, freetype,
+  gdk_pixbuf, glib, gnome2, libX11, libXScrnSaver, libXcomposite, libXcursor,
+  libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst,
+  libxcb, nspr, nss, stdenv, udev
+}:
+
+  let
+    rpath = stdenv.lib.makeLibraryPath ([
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gnome2.gtk
+    gnome2.pango
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libxcb
+    nspr
+    nss
+    stdenv.cc.cc
+    udev
+    ]);
+  in stdenv.mkDerivation rec {
+    name = "webtorrent-desktop-${version}";
+    version = "0.19.0";
+
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = "https://github.com/webtorrent/webtorrent-desktop/releases/download/v0.19.0/webtorrent-desktop_${version}-1_amd64.deb";
+          sha256 = "0v4fgvf8qgxjwg5kz30pcxl71pi9rri0l3cy20pid07rdd6r4sgd";
+        }
+        else
+          throw "Webtorrent is not currently supported on ${stdenv.system}";
+    phases = [ "unpackPhase" "installPhase" ];
+    nativeBuildInputs = [ dpkg ];
+    unpackPhase = "dpkg-deb -x $src .";
+    installPhase = ''
+      mkdir -p $out
+      cp -R opt $out
+
+      mv ./usr/share $out/share
+      mv $out/opt/webtorrent-desktop $out/libexec
+      chmod +x $out/libexec/WebTorrent
+      rmdir $out/opt
+
+      chmod -R g-w $out
+
+      # Patch WebTorrent
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+               --set-rpath ${rpath}:$out/libexec $out/libexec/WebTorrent
+
+      # Symlink to bin
+      mkdir -p $out/bin
+      ln -s $out/libexec/WebTorrent $out/bin/WebTorrent
+
+      # Fix the desktop link
+      substituteInPlace $out/share/applications/webtorrent-desktop.desktop \
+        --replace /opt/webtorrent-desktop/WebTorrent $out/bin/WebTorrent
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Streaming torrent app for Mac, Windows, and Linux.";
+      homepage = https://webtorrent.io/desktop;
+      licenses = licenses.mit;
+      maintainers = [ maintainers.flokli ];
+      platforms = [
+        "x86_64-linux"
+      ];
+    };
+  }

--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -79,7 +79,7 @@
     meta = with stdenv.lib; {
       description = "Streaming torrent app for Mac, Windows, and Linux.";
       homepage = https://webtorrent.io/desktop;
-      licenses = licenses.mit;
+      license = licenses.mit;
       maintainers = [ maintainers.flokli ];
       platforms = [
         "x86_64-linux"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17970,6 +17970,8 @@ with pkgs;
 
   wayv = callPackage ../tools/X11/wayv {};
 
+  webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {};
+
   weechat = callPackage ../applications/networking/irc/weechat {
     inherit (darwin) libobjc;
     inherit (darwin) libresolv;


### PR DESCRIPTION
###### Motivation for this change
This adds [WebTorrent Desktop](https://webtorrent.io/desktop/).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

