### PR TITLE
move python packages owned by makefu into separate folders in python-modules

### DIFF
--- a/pkgs/development/python-modules/d2to1/default.nix
+++ b/pkgs/development/python-modules/d2to1/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, nose
+}:
+buildPythonPackage rec {
+  pname = "d2to1";
+  version = "0.2.11";
+
+  checkInputs = [ nose ];
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "1a5z367b7dpd6dgi0w8pymb68aj2pblk8w04l2c8hibhj8dpl2b4";
+  };
+
+  meta = with lib;{
+    description = "Support for distutils2-like setup.cfg files as package metadata";
+    homepage = https://github.com/embray/d2to1;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/development/python-modules/d2to1/default.nix
+++ b/pkgs/development/python-modules/d2to1/default.nix
@@ -1,17 +1,19 @@
 { buildPythonPackage
 , lib
-, fetchPypi
+, fetchFromGitHub
 , nose
 }:
 buildPythonPackage rec {
   pname = "d2to1";
-  version = "0.2.11";
+  version = "0.2.12";
 
   checkInputs = [ nose ];
 
-  src = fetchPypi {
-    inherit version pname;
-    sha256 = "1a5z367b7dpd6dgi0w8pymb68aj2pblk8w04l2c8hibhj8dpl2b4";
+  src = fetchFromGitHub {
+    owner = "embray";
+    repo = pname;
+    rev = version;
+    sha256 = "1q04ab8vjvx7fmq9ckkl8r9hlwwbqiyjbzaa4v1mv5zicfssxwsi";
   };
 
   meta = with lib;{

--- a/pkgs/development/python-modules/xstatic-bootbox/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootbox/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "XStatic-Bootbox";
+  version = "4.3.0.1";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0wks1lsqngn3gvlhzrvaan1zj8w4wr58xi0pfqhrzckbghvvr0gj";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with lib;{
+    homepage = http://bootboxjs.com;
+    description = "Bootboxjs packaged static files for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+
+}

--- a/pkgs/development/python-modules/xstatic-bootstrap/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootstrap/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "XStatic-Bootstrap";
+  version = "3.3.5.1";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0jzjq3d4vp2shd2n20f9y53jnnk1cvphkj1v0awgrf18qsy2bmin";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with lib;{
+    homepage = http://getbootstrap.com;
+    description = "Bootstrap packaged static files for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+
+}

--- a/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, xstatic-jquery
+}:
+
+buildPythonPackage rec {
+  pname = "XStatic-jQuery-File-Upload";
+  version = "9.7.0.1";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0d5za18lhzhb54baxq8z73wazq801n3qfj5vgcz7ri3ngx7nb0cg";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  propagatedBuildInputs = [ xstatic-jquery ];
+
+  meta = with lib;{
+    homepage =  http://plugins.jquery.com/project/jQuery-File-Upload;
+    description = "jquery-file-upload packaged static files for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+
+}

--- a/pkgs/development/python-modules/xstatic-jquery-ui/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-ui/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, xstatic-jquery
+}:
+
+buildPythonPackage rec {
+  pname = "XStatic-jquery-ui";
+  version = "1.12.0.1";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0w7mabv6qflpd47g33j3ggp5rv17mqk0xz3bsdswcj97wqpga2l2";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  propagatedBuildInputs = [ xstatic-jquery ];
+
+  meta = with lib;{
+    homepage = http://jqueryui.com/;
+    description = "jquery-ui packaged static files for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+
+}

--- a/pkgs/development/python-modules/xstatic-jquery/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "XStatic-jQuery";
+  version = "1.10.2.1";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "018kx4zijflcq8081xx6kmiqf748bsjdq7adij2k91bfp1mnlhc3";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with lib;{
+    homepage =  http://jquery.org;
+    description = "jquery packaged static files for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+
+}

--- a/pkgs/development/python-modules/xstatic-pygments/default.nix
+++ b/pkgs/development/python-modules/xstatic-pygments/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "XStatic-Pygments";
+  version = "1.6.0.1";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0fjqgg433wfdnswn7fad1g6k2x6mf24wfnay2j82j0fwgkdxrr7m";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with lib;{
+    homepage = http://pygments.org;
+    description = "pygments packaged static files for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+
+}

--- a/pkgs/development/python-modules/xstatic/default.nix
+++ b/pkgs/development/python-modules/xstatic/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "XStatic";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "09npcsyf1ccygjs0qc8kdsv4qqy8gm1m6iv63g9y1fgbcry3vj8f";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with lib;{
+    homepage = https://bitbucket.org/thomaswaldmann/xstatic;
+    description = "Base packaged static files for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20473,21 +20473,7 @@ EOF
 
   xstatic-bootstrap = callPackage ../development/python-modules/xstatic-bootstrap {};
 
-  xstatic-jquery = buildPythonPackage rec {
-    name = "XStatic-jQuery-${version}";
-    version = "1.10.2.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/X/XStatic-jQuery/XStatic-jQuery-${version}.tar.gz";
-      sha256 = "018kx4zijflcq8081xx6kmiqf748bsjdq7adij2k91bfp1mnlhc3";
-    };
-
-    meta = {
-      homepage =  http://jquery.org;
-      description = "jquery packaged static files for python";
-      license = licenses.mit;
-      maintainers = [ maintainers.makefu ];
-    };
-  };
+  xstatic-jquery = callPackage ../development/python-modules/xstatic-jquery {};
 
   xstatic-jquery-file-upload = buildPythonPackage rec {
     name = "XStatic-jQuery-File-Upload-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20358,23 +20358,7 @@ EOF
     };
   };
 
-  d2to1 = buildPythonPackage rec {
-    name = "d2to1-${version}";
-    version = "0.2.11";
-
-    buildInputs = with self; [ nose ];
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/d2to1/d2to1-${version}.tar.gz";
-      sha256 = "1a5z367b7dpd6dgi0w8pymb68aj2pblk8w04l2c8hibhj8dpl2b4";
-    };
-
-    meta = {
-      description = "Support for distutils2-like setup.cfg files as package metadata";
-      homepage = https://pypi.python.org/pypi/d2to1;
-      license = licenses.bsd2;
-      maintainers = [ maintainers.makefu ];
-    };
-  };
+  d2to1 = callPackage ../development/python-modules/d2to1 { };
 
   ovh = callPackage ../development/python-modules/ovh { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20471,21 +20471,7 @@ EOF
 
   xstatic-bootbox = callPackage ../development/python-modules/xstatic-bootbox {};
 
-  xstatic-bootstrap = buildPythonPackage rec {
-    name = "XStatic-Bootstrap-${version}";
-    version = "3.3.5.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/X/XStatic-Bootstrap/XStatic-Bootstrap-${version}.tar.gz";
-      sha256 = "0jzjq3d4vp2shd2n20f9y53jnnk1cvphkj1v0awgrf18qsy2bmin";
-    };
-
-    meta = {
-      homepage =  http://getbootstrap.com;
-      description = "bootstrap packaged static files for python";
-      license = licenses.mit;
-      maintainers = [ maintainers.makefu ];
-    };
-  };
+  xstatic-bootstrap = callPackage ../development/python-modules/xstatic-bootstrap {};
 
   xstatic-jquery = buildPythonPackage rec {
     name = "XStatic-jQuery-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20469,21 +20469,7 @@ EOF
 
   xstatic = callPackage ../development/python-modules/xstatic {};
 
-  xstatic-bootbox = buildPythonPackage rec {
-    name = "XStatic-Bootbox-${version}";
-    version = "4.3.0.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/X/XStatic-Bootbox/XStatic-Bootbox-${version}.tar.gz";
-      sha256 = "0wks1lsqngn3gvlhzrvaan1zj8w4wr58xi0pfqhrzckbghvvr0gj";
-    };
-
-    meta = {
-      homepage =  http://bootboxjs.com;
-      description = "bootboxjs packaged static files for python";
-      license = licenses.mit;
-      maintainers = [ maintainers.makefu ];
-    };
-  };
+  xstatic-bootbox = callPackage ../development/python-modules/xstatic-bootbox {};
 
   xstatic-bootstrap = buildPythonPackage rec {
     name = "XStatic-Bootstrap-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20479,21 +20479,7 @@ EOF
 
   xstatic-jquery-ui = callPackage ../development/python-modules/xstatic-jquery-ui {};
 
-  xstatic-pygments = buildPythonPackage rec {
-    name = "XStatic-Pygments-${version}";
-    version = "1.6.0.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/X/XStatic-Pygments/XStatic-Pygments-${version}.tar.gz";
-      sha256 = "0fjqgg433wfdnswn7fad1g6k2x6mf24wfnay2j82j0fwgkdxrr7m";
-    };
-
-    meta = {
-      homepage = http://pygments.org;
-      description = "pygments packaged static files for python";
-      license = licenses.bsd2;
-      maintainers = [ maintainers.makefu ];
-    };
-  };
+  xstatic-pygments = callPackage ../development/python-modules/xstatic-pygments {};
 
   xvfbwrapper = callPackage ../development/python-modules/xvfbwrapper {
     inherit (pkgs.xorg) xorgserver;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20450,21 +20450,6 @@ EOF
     };
   };
 
-  xstatic = buildPythonPackage rec {
-    name = "XStatic-${version}";
-    version = "1.0.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/X/XStatic/XStatic-${version}.tar.gz";
-      sha256 = "09npcsyf1ccygjs0qc8kdsv4qqy8gm1m6iv63g9y1fgbcry3vj8f";
-    };
-    meta = {
-      homepage = https://bitbucket.org/thomaswaldmann/xstatic;
-      description = "Base packaged static files for python";
-      license = licenses.mit;
-      maintainers = [ maintainers.makefu ];
-    };
-  };
-
   xlsx2csv = buildPythonPackage rec {
     name = "xlsx2csv-${version}";
     version = "0.7.2";
@@ -20481,6 +20466,8 @@ EOF
   };
 
   xmpppy = callPackage ../development/python-modules/xmpppy {};
+
+  xstatic = callPackage ../development/python-modules/xstatic {};
 
   xstatic-bootbox = buildPythonPackage rec {
     name = "XStatic-Bootbox-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20475,22 +20475,7 @@ EOF
 
   xstatic-jquery = callPackage ../development/python-modules/xstatic-jquery {};
 
-  xstatic-jquery-file-upload = buildPythonPackage rec {
-    name = "XStatic-jQuery-File-Upload-${version}";
-    version = "9.7.0.1";
-    propagatedBuildInputs = with self;[ xstatic-jquery ];
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/X/XStatic-jQuery-File-Upload/XStatic-jQuery-File-Upload-${version}.tar.gz";
-      sha256 = "0d5za18lhzhb54baxq8z73wazq801n3qfj5vgcz7ri3ngx7nb0cg";
-    };
-
-    meta = {
-      homepage =  http://plugins.jquery.com/project/jQuery-File-Upload;
-      description = "jquery-file-upload packaged static files for python";
-      license = licenses.mit;
-      maintainers = [ maintainers.makefu ];
-    };
-  };
+  xstatic-jquery-file-upload = callPackage ../development/python-modules/xstatic-jquery-file-upload {};
 
   xstatic-jquery-ui = buildPythonPackage rec {
     name = "XStatic-jquery-ui-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20477,22 +20477,7 @@ EOF
 
   xstatic-jquery-file-upload = callPackage ../development/python-modules/xstatic-jquery-file-upload {};
 
-  xstatic-jquery-ui = buildPythonPackage rec {
-    name = "XStatic-jquery-ui-${version}";
-    version = "1.12.0.1";
-    propagatedBuildInputs = with self; [ xstatic-jquery ];
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/X/XStatic-jquery-ui/XStatic-jquery-ui-${version}.tar.gz";
-      sha256 = "0w7mabv6qflpd47g33j3ggp5rv17mqk0xz3bsdswcj97wqpga2l2";
-    };
-
-    meta = {
-      homepage = http://jqueryui.com/;
-      description = "jquery-ui packaged static files for python";
-      license = licenses.mit;
-      maintainers = [ maintainers.makefu ];
-    };
-  };
+  xstatic-jquery-ui = callPackage ../development/python-modules/xstatic-jquery-ui {};
 
   xstatic-pygments = buildPythonPackage rec {
     name = "XStatic-Pygments-${version}";


### PR DESCRIPTION
###### Motivation for this change

Move legacy python packages maintained by myself from `python-packages.nix` to `python-modules/`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @FRidh 