### PR TITLE
htop-vim: init at 70c91d6d598f15b0311ae6779810e036133e72d2

### DIFF
--- a/pkgs/misc/htop-vim/default.nix
+++ b/pkgs/misc/htop-vim/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, autoconf, automake, fetchFromGitHub, ncurses, pkgconfig }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "htop-vim";
+
+  src = fetchFromGitHub {
+    owner = "KoffeinFlummi";
+    repo = "htop-vim";
+    sha256 = "03mxh4zl1c6hf1sqvcmlzf48vzgp5nglfb80c38b99g9dqiphqyf";
+    rev = "70c91d6d598f15b0311ae6779810e036133e72d2";
+  };
+
+  buildPhase = ''
+    ./autogen.sh && ./configure --prefix=$out --program-suffix=-vim && make
+    '';
+
+  buildInputs = [ autoconf automake ncurses pkgconfig ];
+
+  installPhase = ''
+    make install 
+  '';
+
+  meta = {
+    homepage = https://github.com/KoffeinFlummi/htop-vim;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with maintainers; [ andsild ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2824,6 +2824,8 @@ with pkgs;
 
   hping = callPackage ../tools/networking/hping { };
 
+  htop-vim = callPackage ../misc/htop-vim { };
+
   htpdate = callPackage ../tools/networking/htpdate { };
 
   http-prompt = callPackage ../tools/networking/http-prompt { };


### PR DESCRIPTION
###### Motivation for this change
New package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

