### PR TITLE
mopidy-mopify: 1.5.17 -> 1.6.0

### DIFF
--- a/pkgs/applications/audio/mopidy-mopify/default.nix
+++ b/pkgs/applications/audio/mopidy-mopify/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchurl, pythonPackages, mopidy }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-mopify-${version}";
+  pname = "Mopidy-Mopify";
+  version = "1.6.1";
 
-  version = "1.6.0";
-
-  src = fetchurl {
-    url = "https://github.com/dirkgroenen/mopidy-mopify/archive/${version}.tar.gz";
-    sha256 = "1qjl40izb11jx939hh9ibxf1747j1fxbc1qv0lmjpsq5mri7jpim";
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "93ad2b3d38b1450c8f2698bb908b0b077a96b3f64cdd6486519e518132e23a5c";
   };
 
   propagatedBuildInputs = with pythonPackages; [ mopidy configobj ];
 
+  # no tests implemented
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/mopidy-mopify/default.nix
+++ b/pkgs/applications/audio/mopidy-mopify/default.nix
@@ -3,11 +3,11 @@
 pythonPackages.buildPythonApplication rec {
   name = "mopidy-mopify-${version}";
 
-  version = "1.5.17";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://github.com/dirkgroenen/mopidy-mopify/archive/${version}.tar.gz";
-    sha256 = "1qi7f5i87ygn486gxc84njl22y84xrwabpz58y5a1hw7z1lp7l8s";
+    sha256 = "1qjl40izb11jx939hh9ibxf1747j1fxbc1qv0lmjpsq5mri7jpim";
   };
 
   propagatedBuildInputs = with pythonPackages; [ mopidy configobj ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.6.0 with grep in /nix/store/k988x3a5gm4ff987yynn97gzcxh16hbl-mopidy-mopify-1.6.0
- found 1.6.0 in filename of file in /nix/store/k988x3a5gm4ff987yynn97gzcxh16hbl-mopidy-mopify-1.6.0

cc "@Gonzih"