### PR TITLE
mopidy-moped: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/applications/audio/mopidy-moped/default.nix
+++ b/pkgs/applications/audio/mopidy-moped/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "mopidy-moped-${version}";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchurl {
     url = "https://github.com/martijnboland/moped/archive/v${version}.tar.gz";
-    sha256 = "0xff8y1kc7rwwsd7ppgbvywf6i8lchjwbxjisfl1kmilwsb166yr";
+    sha256 = "1w71ing33hw2mlp8pw41w2sncp9lc3rgzn7nq6k90y6qk5q08xw6";
   };
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/applications/audio/mopidy-moped/default.nix
+++ b/pkgs/applications/audio/mopidy-moped/default.nix
@@ -1,18 +1,19 @@
-{ stdenv, fetchurl, pythonPackages, mopidy, glibcLocales }:
+{ stdenv, pythonPackages, mopidy, glibcLocales }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-moped-${version}";
-  version = "0.7.0";
+  pname = "Mopidy-Moped";
+  version = "0.7.1";
 
-  src = fetchurl {
-    url = "https://github.com/martijnboland/moped/archive/v${version}.tar.gz";
-    sha256 = "1w71ing33hw2mlp8pw41w2sncp9lc3rgzn7nq6k90y6qk5q08xw6";
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "15461174037d87af93dd59a236d4275c5abf71cea0670ffff24a7d0399a8a2e4";
   };
 
   LC_ALL = "en_US.UTF-8";
   buildInputs = [ glibcLocales ];
   propagatedBuildInputs = [ mopidy ];
 
+  # no tests implemented
   doCheck = false;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.7.0 with grep in /nix/store/snl5lx0r61cdy7q0csvwynbn6bbr6ynw-mopidy-moped-0.7.0
- found 0.7.0 in filename of file in /nix/store/snl5lx0r61cdy7q0csvwynbn6bbr6ynw-mopidy-moped-0.7.0

cc "@rickynils"