### PR TITLE
monit: 5.23.0 -> 5.25.1

### DIFF
--- a/pkgs/tools/system/monit/default.nix
+++ b/pkgs/tools/system/monit/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, openssl, bison, flex, pam, zlib, usePAM ? stdenv.isLinux }:
 
 stdenv.mkDerivation rec {
-  name = "monit-5.23.0";
+  name = "monit-5.25.1";
 
   src = fetchurl {
     url = "${meta.homepage}dist/${name}.tar.gz";
-    sha256 = "04v7sp2vc1q6h8c5j8h4izffn9d97cdj0k64m4ml00lw6wxgwffx";
+    sha256 = "1g417cf6j0v6z233a3625fw1cxsh45xql7ag83jz2988n772ap2b";
   };
 
   nativeBuildInputs = [ bison flex ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qphnal7xszj71fmmy0l2kvz2d3bqpw1x-monit-5.25.1/bin/monit -h` got 0 exit code
- ran `/nix/store/qphnal7xszj71fmmy0l2kvz2d3bqpw1x-monit-5.25.1/bin/monit --help` got 0 exit code
- ran `/nix/store/qphnal7xszj71fmmy0l2kvz2d3bqpw1x-monit-5.25.1/bin/monit -V` and found version 5.25.1
- ran `/nix/store/qphnal7xszj71fmmy0l2kvz2d3bqpw1x-monit-5.25.1/bin/monit --version` and found version 5.25.1
- found 5.25.1 with grep in /nix/store/qphnal7xszj71fmmy0l2kvz2d3bqpw1x-monit-5.25.1
- found 5.25.1 in filename of file in /nix/store/qphnal7xszj71fmmy0l2kvz2d3bqpw1x-monit-5.25.1

cc "@raskin @wmertens"