### PR TITLE
mod_wsgi: 3.5 -> 4.5.24

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mod_wsgi-${version}";
-  version = "3.5";
+  version = "4.5.24";
 
   src = fetchurl {
     url = "https://github.com/GrahamDumpleton/mod_wsgi/archive/${version}.tar.gz";
-    sha256 = "14xz422jlakdhxzsl8xs9if86yf1fnkwdg0havjyqs7my0w4qrzh";
+    sha256 = "1anxml8i3q90x8n30xfydpmv41cxlwqrg3vr98ayzaak02maxr99";
   };
 
   buildInputs = [ apacheHttpd python2 ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 4.5.24 with grep in /nix/store/3a7nb1vrk4hfj3rarl1rfh319pab7j5i-mod_wsgi-4.5.24
- found 4.5.24 in filename of file in /nix/store/3a7nb1vrk4hfj3rarl1rfh319pab7j5i-mod_wsgi-4.5.24
