### PR TITLE
lightdm-gtk-greeter: 2.0.3 -> 2.0.4

### DIFF
--- a/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
@@ -9,14 +9,14 @@
 
 let
   ver_branch = "2.0";
-  version = "2.0.3";
+  version = "2.0.4";
 in
 stdenv.mkDerivation rec {
   name = "lightdm-gtk-greeter-${version}";
 
   src = fetchurl {
     url = "${meta.homepage}/${ver_branch}/${version}/+download/${name}.tar.gz";
-    sha256 = "0c6v2myzqj8nzpcqyvbab7c66kwgcshw2chn5r6dhm7xrx19bcrx";
+    sha256 = "1svbyq2l3l2d72k10nw79jz940rqsskryaim2viy6jfpv9k5jfv1";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

New upstream release is available, summary of the changes can be found at https://launchpad.net/lightdm-gtk-greeter/+download.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

