### PR TITLE
mlterm: 3.8.0 -> 3.8.4

### DIFF
--- a/pkgs/applications/misc/mlterm/default.nix
+++ b/pkgs/applications/misc/mlterm/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   name = "mlterm-${version}";
-  version = "3.8.0";
+  version = "3.8.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/mlterm/01release/${name}/${name}.tar.gz";
-    sha256 = "00dzx5rqsp73shgvn2jvgk85v3lirby06wxkqjcm1i1xwigidq3b";
+    sha256 = "07ih7953pr1jr99rayjn57ba5a0cr3niqkmvy9n59lcc1qwcrwf9";
   };
 
   nativeBuildInputs = [ pkgconfig autoconf ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlterm help` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlfc help` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlcc -h` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlcc --help` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlclient -h` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlclient --help` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlclient help` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlclientx -h` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlclientx --help` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlclientx help` got 0 exit code
- ran `/nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4/bin/mlterm-fb help` got 0 exit code
- found 3.8.4 with grep in /nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4
- found 3.8.4 in filename of file in /nix/store/hl028yiknrqbkp4i12nn0nibr41rwgvn-mlterm-3.8.4

cc "@vrthra @ramkromberg"