### PR TITLE
mlmmj: 1.2.19.0 -> 1.3.0

### DIFF
--- a/pkgs/servers/mail/mlmmj/default.nix
+++ b/pkgs/servers/mail/mlmmj/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   name = "mlmmj-${version}";
-  version = "1.2.19.0";
+  version = "1.3.0";
 
   src = fetchurl {
     url = "http://mlmmj.org/releases/${name}.tar.gz";
-    sha256 = "18n7b41nfdj7acvmqzkkz984d26xvz14xk8kmrnzv23dkda364m0";
+    sha256 = "1sghqvwizvm1a9w56r34qy5njaq1c26bagj85r60h32gh3fx02bn";
   };
 
   postInstall = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-send -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-send --help` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-send -V` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-send -h` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-send --help` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-receive -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-receive --help` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-receive -V` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-receive -h` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-receive --help` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-process -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-process --help` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-process -V` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-process -h` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-process --help` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-sub -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-sub --help` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-sub -V` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-sub -h` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-sub --help` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-unsub -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-unsub --help` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-unsub -V` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-unsub -h` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-unsub --help` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-bounce -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-bounce --help` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-bounce -V` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-bounce -h` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-bounce --help` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-maintd -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-maintd --help` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-maintd -V` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-maintd -h` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-maintd --help` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-list -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-list --help` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-list -V` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-list -h` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-list --help` and found version 1.3.0
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-make-ml -h` got 0 exit code
- ran `/nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0/bin/mlmmj-make-ml -h` and found version 1.3.0
- found 1.3.0 with grep in /nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0
- found 1.3.0 in filename of file in /nix/store/a9ndyb3f81ssfkxhiyls76nqcba3rlnn-mlmmj-1.3.0

cc "@edwtjo"