### PR TITLE
mkdocs: 0.16.3 -> 0.17.2

### DIFF
--- a/pkgs/development/tools/documentation/mkdocs/default.nix
+++ b/pkgs/development/tools/documentation/mkdocs/default.nix
@@ -4,14 +4,14 @@ with python.pkgs;
 
 buildPythonApplication rec {
   pname = "mkdocs";
-  version = "0.16.3";
+  version = "0.17.2";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "mkdocs";
     repo = "mkdocs";
     rev = version;
-    sha256 = "0gssa5gbd1y2v3azdhf2zh7ayx4ncfag4r2a6fi96jbic64r3qrs";
+    sha256 = "0hpjs9qj0nr57a249yv8xvl61d3d2rrdfqxp1fm28z77l2xjj772";
   };
 
   checkInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2/bin/.mkdocs-wrapped -h` got 0 exit code
- ran `/nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2/bin/.mkdocs-wrapped --help` got 0 exit code
- ran `/nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2/bin/.mkdocs-wrapped -V` and found version 0.17.2
- ran `/nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2/bin/.mkdocs-wrapped --version` and found version 0.17.2
- ran `/nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2/bin/mkdocs -h` got 0 exit code
- ran `/nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2/bin/mkdocs --help` got 0 exit code
- ran `/nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2/bin/mkdocs -V` and found version 0.17.2
- ran `/nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2/bin/mkdocs --version` and found version 0.17.2
- found 0.17.2 with grep in /nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2
- found 0.17.2 in filename of file in /nix/store/hndrgmyp176jgfgy4iyf0wdf21hhbdwv-mkdocs-0.17.2
