### PR TITLE
minizinc: 2.0.14 -> 2.1.7

### DIFF
--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, flex, bison }:
 let
-  version = "2.0.14";
+  version = "2.1.7";
 in
 stdenv.mkDerivation {
   name = "minizinc-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     rev = "${version}";
     owner = "MiniZinc";
     repo = "libminizinc";
-    sha256 = "02wy91nv79lrvvhhimcxp7sqz5wd457n1n68zl7qcsm5vfn1hm4q";
+    sha256 = "05rifsgzfaalv5ymv59sjcvhr6i1byzbmq5p36hj3hpi5f929kip";
   };
 
   # meta is all the information about the package..


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/mzn-fzn -h` got 0 exit code
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/mzn-fzn --help` got 0 exit code
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/mzn-fzn --version` and found version 2.1.7
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/mzn2fzn -h` got 0 exit code
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/mzn2fzn --help` got 0 exit code
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/mzn2fzn --version` and found version 2.1.7
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/mzn2fzn_test --version` and found version 2.1.7
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/solns2out -h` got 0 exit code
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/solns2out --help` got 0 exit code
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/solns2out --version` and found version 2.1.7
- ran `/nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7/bin/mzn2doc --version` and found version 2.1.7
- found 2.1.7 with grep in /nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7
- found 2.1.7 in filename of file in /nix/store/bjxi9sdz068kd74wjal05kmndgq51qdh-minizinc-2.1.7

cc "@sheenobu"