### PR TITLE
minissdpd: 1.5.20160301 -> 1.5.20180203

### DIFF
--- a/pkgs/tools/networking/minissdpd/default.nix
+++ b/pkgs/tools/networking/minissdpd/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "minissdpd-${version}";
-  version = "1.5.20160301";
+  version = "1.5.20180203";
 
   src = fetchurl {
-    sha256 = "053icnb25jg2vvjxirkznks3ipbbdjxac278y19rk2w9cirgi9lv";
+    sha256 = "1yiri887s8wxh4zrjc5dw19gyypqg63962aimcgd19blvpbwnfcv";
     url = "http://miniupnp.free.fr/files/download.php?file=${name}.tar.gz";
     name = "${name}.tar.gz";
   };


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.5.20180203 in filename of file in /nix/store/2igp4fsygsvwysdjd5pnxmbq951n1lr3-minissdpd-1.5.20180203