### PR TITLE
minisign: 0.7 -> 0.8

### DIFF
--- a/pkgs/tools/security/minisign/default.nix
+++ b/pkgs/tools/security/minisign/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "minisign-${version}";
-  version = "0.7";
+  version = "0.8";
 
   src = fetchFromGitHub {
     repo = "minisign";
     owner = "jedisct1";
     rev = version;
-    sha256 = "15w8fgplkxiw9757qahwmgnl4bwx9mm0rnwp1izs2jcy1wy35vp8";
+    sha256 = "0rgg9jb5108hd5psivlrfd8cxnjylawm0glcry8ba6zlmkv949r8";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3022qnvnd3j3zrz8qbyvv0izffbc17kj-minisign-0.8/bin/minisign -v` and found version 0.8
- ran `/nix/store/3022qnvnd3j3zrz8qbyvv0izffbc17kj-minisign-0.8/bin/minisign --version` and found version 0.8
- found 0.8 with grep in /nix/store/3022qnvnd3j3zrz8qbyvv0izffbc17kj-minisign-0.8
- found 0.8 in filename of file in /nix/store/3022qnvnd3j3zrz8qbyvv0izffbc17kj-minisign-0.8

cc "@joachifm"