### PR TITLE
meterbridge: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/applications/audio/meterbridge/default.nix
+++ b/pkgs/applications/audio/meterbridge/default.nix
@@ -2,12 +2,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.2";
+  version = "0.9.3";
   name = "meterbridge-${version}";
 
   src = fetchurl {
     url = "http://plugin.org.uk/meterbridge/${name}.tar.gz";
-    sha256 = "0jb6g3kbfyr5yf8mvblnciva2bmc01ijpr51m21r27rqmgi8gj5k";
+    sha256 = "0s7n3czfpil94vsd7iblv4xrck9c7zvsz4r3yfbkqcv85pjz1viz";
   };
 
   patches = [ ./buf_rect.patch ./fix_build_with_gcc-5.patch];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.9.3 with grep in /nix/store/647g97s9wbaysk2f7ch8wvk0ys3nv27h-meterbridge-0.9.3
- found 0.9.3 in filename of file in /nix/store/647g97s9wbaysk2f7ch8wvk0ys3nv27h-meterbridge-0.9.3

cc "@nico202"