### PR TITLE
memcached: 1.5.4 -> 1.5.5

### DIFF
--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, cyrus_sasl, libevent}:
 
 stdenv.mkDerivation rec {
-  version = "1.5.4";
+  version = "1.5.5";
   name = "memcached-${version}";
 
   src = fetchurl {
     url = "http://memcached.org/files/${name}.tar.gz";
-    sha256 = "1m03fhzq1f9byk2agccsr0x458niqqjpips5mbcgzhm4kylczhz0";
+    sha256 = "1v87gvhxih5jav20cp9zdddna31s968xdm2iskc9mqzb5li6di72";
   };
 
   buildInputs = [cyrus_sasl libevent];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/6b8zx40j50ccjwn2z2s94zsgbzyghzxy-memcached-1.5.5/bin/memcached -h` got 0 exit code
- ran `/nix/store/6b8zx40j50ccjwn2z2s94zsgbzyghzxy-memcached-1.5.5/bin/memcached --help` got 0 exit code
- ran `/nix/store/6b8zx40j50ccjwn2z2s94zsgbzyghzxy-memcached-1.5.5/bin/memcached -V` and found version 1.5.5
- ran `/nix/store/6b8zx40j50ccjwn2z2s94zsgbzyghzxy-memcached-1.5.5/bin/memcached --version` and found version 1.5.5
- ran `/nix/store/6b8zx40j50ccjwn2z2s94zsgbzyghzxy-memcached-1.5.5/bin/memcached -h` and found version 1.5.5
- ran `/nix/store/6b8zx40j50ccjwn2z2s94zsgbzyghzxy-memcached-1.5.5/bin/memcached --help` and found version 1.5.5
- found 1.5.5 with grep in /nix/store/6b8zx40j50ccjwn2z2s94zsgbzyghzxy-memcached-1.5.5
- found 1.5.5 in filename of file in /nix/store/6b8zx40j50ccjwn2z2s94zsgbzyghzxy-memcached-1.5.5

cc "@coconnor"