### PR TITLE
mediainfo-gui: 17.10 -> 17.12

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -2,11 +2,11 @@
 , desktop-file-utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "17.10";
+  version = "17.12";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1yvh4r19kk3bzzgnr4ikrjxqldr6860s35sh4bqr51c7l77k048c";
+    sha256 = "1pxdf0ny3c38gl513zdiaagpvk4bqnsc2fn7476yjdpv2lxsw56f";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 17.12 with grep in /nix/store/2h8afaqw5li2fjj5kyvzbs8cw5a56hhp-mediainfo-gui-17.12
- found 17.12 in filename of file in /nix/store/2h8afaqw5li2fjj5kyvzbs8cw5a56hhp-mediainfo-gui-17.12

cc "@devhell"