### PR TITLE
media-player-info: 22 -> 23

### DIFF
--- a/pkgs/data/misc/media-player-info/default.nix
+++ b/pkgs/data/misc/media-player-info/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, pkgconfig, python3, udev, systemd }:
 
 let
-  name = "media-player-info-22";
+  name = "media-player-info-23";
 in
 
   stdenv.mkDerivation {
     inherit name;
 
     src = fetchurl {
-      url = "http://www.freedesktop.org/software/media-player-info/${name}.tar.gz";
-      sha256 = "0di3gfx5z8c34yspzyllydr5snzg71r985kbqhrhb1il51qxgrvy";
+      url = "https://www.freedesktop.org/software/media-player-info/${name}.tar.gz";
+      sha256 = "1jy8xh4xjgjc4wj4qrw6sx2j3606zsj4bgiczhzf3xlpnkh6vax9";
     };
 
     buildInputs = [ udev systemd ];
@@ -25,7 +25,7 @@ in
 
     meta = with stdenv.lib; {
       description = "A repository of data files describing media player capabilities";
-      homepage = http://www.freedesktop.org/wiki/Software/media-player-info/;
+      homepage = https://www.freedesktop.org/wiki/Software/media-player-info/;
       license = licenses.bsd3;
       maintainers = with maintainers; [ ttuegel ];
       platforms = with platforms; linux;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 23 with grep in /nix/store/fwi1kp97s2smbwf5ir9jrykf6427i4n6-media-player-info-23
- found 23 in filename of file in /nix/store/fwi1kp97s2smbwf5ir9jrykf6427i4n6-media-player-info-23

cc "@ttuegel"