### PR TITLE
mcelog: 153 -> 154

### DIFF
--- a/pkgs/os-specific/linux/mcelog/default.nix
+++ b/pkgs/os-specific/linux/mcelog/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mcelog-${version}";
-  version = "153";
+  version = "154";
 
   src = fetchFromGitHub {
     owner  = "andikleen";
     repo   = "mcelog";
     rev    = "v${version}";
-    sha256 = "1wz55dzqdiam511d6p1958al6vzlhrhs73s7gly0mzm6kpji0gxa";
+    sha256 = "0vq7r3zknr62rmi9g0zd7mmxframm79vmrdw029pc7z6wrlv40cy";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/17fxzl242z1bjng82m4aqlbsjhdnxjb0-mcelog-154/bin/mcelog --help` got 0 exit code
- ran `/nix/store/17fxzl242z1bjng82m4aqlbsjhdnxjb0-mcelog-154/bin/mcelog --version` and found version 154
- ran `/nix/store/17fxzl242z1bjng82m4aqlbsjhdnxjb0-mcelog-154/bin/mcelog --help` and found version 154
- found 154 with grep in /nix/store/17fxzl242z1bjng82m4aqlbsjhdnxjb0-mcelog-154
- found 154 in filename of file in /nix/store/17fxzl242z1bjng82m4aqlbsjhdnxjb0-mcelog-154
