### PR TITLE
mc: 4.8.19 -> 4.8.20

### DIFF
--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "mc-${version}";
-  version = "4.8.19";
+  version = "4.8.20";
 
   src = fetchurl {
     url = "http://www.midnight-commander.org/downloads/${name}.tar.xz";
-    sha256 = "1pzjq4nfxl2aakxipdjs5hq9n14374ly1l00s40kd2djnnxmd7pb";
+    sha256 = "072h7n9b3j79fqn48xaw0xhlcjavpsmfpz6nyh20lhmfz3sffzh1";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/1qjgxba6vrvnq70gjwfmhhj0blxlr5fy-mc-4.8.20/bin/mc -h` got 0 exit code
- ran `/nix/store/1qjgxba6vrvnq70gjwfmhhj0blxlr5fy-mc-4.8.20/bin/mc --help` got 0 exit code
- ran `/nix/store/1qjgxba6vrvnq70gjwfmhhj0blxlr5fy-mc-4.8.20/bin/mc -V` and found version 4.8.20
- ran `/nix/store/1qjgxba6vrvnq70gjwfmhhj0blxlr5fy-mc-4.8.20/bin/mc --version` and found version 4.8.20
- ran `/nix/store/1qjgxba6vrvnq70gjwfmhhj0blxlr5fy-mc-4.8.20/bin/mc -h` and found version 4.8.20
- ran `/nix/store/1qjgxba6vrvnq70gjwfmhhj0blxlr5fy-mc-4.8.20/bin/mc --help` and found version 4.8.20
- found 4.8.20 with grep in /nix/store/1qjgxba6vrvnq70gjwfmhhj0blxlr5fy-mc-4.8.20
- found 4.8.20 in filename of file in /nix/store/1qjgxba6vrvnq70gjwfmhhj0blxlr5fy-mc-4.8.20

cc "@sander"