### PR TITLE
mbpfan: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/os-specific/linux/mbpfan/default.nix
+++ b/pkgs/os-specific/linux/mbpfan/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "mbpfan-${version}";
-  version = "2.0.1";
+  version = "2.0.2";
   src = fetchFromGitHub {
     owner = "dgraziotin";
     repo = "mbpfan";
     rev = "v${version}";
-    sha256 = "1iri1py9ym0zz7fcacbf0d9y3i3ay77jmajckchagamkfha16zyp";
+    sha256 = "1l8fj92jxfp0sldvznsdsm3pn675b35clq3371h6d5wk4jx67fvg";
   };
   installPhase = ''
     mkdir -p $out/bin $out/etc


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/pn2g5kbmbjdi9z60cn2fwzpbcidvz7ks-mbpfan-2.0.2/bin/mbpfan -h` got 0 exit code
- ran `/nix/store/pn2g5kbmbjdi9z60cn2fwzpbcidvz7ks-mbpfan-2.0.2/bin/mbpfan --help` got 0 exit code
- ran `/nix/store/pn2g5kbmbjdi9z60cn2fwzpbcidvz7ks-mbpfan-2.0.2/bin/mbpfan -V` and found version 2.0.2
- ran `/nix/store/pn2g5kbmbjdi9z60cn2fwzpbcidvz7ks-mbpfan-2.0.2/bin/mbpfan --version` and found version 2.0.2
- ran `/nix/store/pn2g5kbmbjdi9z60cn2fwzpbcidvz7ks-mbpfan-2.0.2/bin/mbpfan -h` and found version 2.0.2
- ran `/nix/store/pn2g5kbmbjdi9z60cn2fwzpbcidvz7ks-mbpfan-2.0.2/bin/mbpfan --help` and found version 2.0.2
- found 2.0.2 in filename of file in /nix/store/pn2g5kbmbjdi9z60cn2fwzpbcidvz7ks-mbpfan-2.0.2

cc "@cstrahan"