### PR TITLE
mpdas: 0.4.4 -> 0.4.5

### DIFF
--- a/pkgs/tools/audio/mpdas/default.nix
+++ b/pkgs/tools/audio/mpdas/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mpdas-${version}";
-  version = "0.4.4";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "hrkfdn";
     repo = "mpdas";
     rev = version;
-    sha256 = "1i6i36jd582y3nm5plcrswqljf528hd23whp8zw06hwqnsgca5b6";
+    sha256 = "0fcqc4w6iwbi1n3cllcgj0k61zffhqkbr8668myxap21m35x8y1r";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/57kxxdmzd8k758sj5fsc430cq54dzr4f-mpdas-0.4.5/bin/mpdas -h` got 0 exit code
- ran `/nix/store/57kxxdmzd8k758sj5fsc430cq54dzr4f-mpdas-0.4.5/bin/mpdas -v` and found version 0.4.5
- ran `/nix/store/57kxxdmzd8k758sj5fsc430cq54dzr4f-mpdas-0.4.5/bin/mpdas -h` and found version 0.4.5
- found 0.4.5 with grep in /nix/store/57kxxdmzd8k758sj5fsc430cq54dzr4f-mpdas-0.4.5
- found 0.4.5 in filename of file in /nix/store/57kxxdmzd8k758sj5fsc430cq54dzr4f-mpdas-0.4.5

cc "@taketwo"