### PR TITLE
mairix: 0.23 -> 0.24

### DIFF
--- a/pkgs/tools/text/mairix/default.nix
+++ b/pkgs/tools/text/mairix/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, zlib, bzip2, bison, flex }:
 
 stdenv.mkDerivation rec {
-  name = "mairix-0.23";
+  name = "mairix-0.24";
 
   src = fetchurl {
     url = "mirror://sourceforge/mairix/${name}.tar.gz";
-    sha256 = "1yzjpmsih6c60ks0d0ia153z9g35nj7dmk98383m0crw31dj6kl0";
+    sha256 = "0msaxz5c5hf7k1ci16i67m4ynrbrpsxbqzk84nz6z2vnkh3jww50";
   };
 
   buildInputs = [ zlib bzip2 bison flex ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/vibybpmnsw93gg4rlf04bms7qf5nc9c7-mairix-0.24/bin/mairix -h` got 0 exit code
- ran `/nix/store/vibybpmnsw93gg4rlf04bms7qf5nc9c7-mairix-0.24/bin/mairix --help` got 0 exit code
- ran `/nix/store/vibybpmnsw93gg4rlf04bms7qf5nc9c7-mairix-0.24/bin/mairix -V` and found version 0.24
- ran `/nix/store/vibybpmnsw93gg4rlf04bms7qf5nc9c7-mairix-0.24/bin/mairix --version` and found version 0.24
- ran `/nix/store/vibybpmnsw93gg4rlf04bms7qf5nc9c7-mairix-0.24/bin/mairix -h` and found version 0.24
- ran `/nix/store/vibybpmnsw93gg4rlf04bms7qf5nc9c7-mairix-0.24/bin/mairix --help` and found version 0.24
- found 0.24 with grep in /nix/store/vibybpmnsw93gg4rlf04bms7qf5nc9c7-mairix-0.24
- found 0.24 in filename of file in /nix/store/vibybpmnsw93gg4rlf04bms7qf5nc9c7-mairix-0.24

cc "@viric"