### PR TITLE
lzip: 1.19 -> 1.20

### DIFF
--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "lzip-${version}";
-  version = "1.19";
+  version = "1.20";
 
   buildInputs = [ texinfo ];
 
   src = fetchurl {
     url = "mirror://savannah/lzip/${name}.tar.gz";
-    sha256 = "1abbch762gv8rjr579q3qyyk6c80plklbv2mw4x0vg71dgsw9bgz";
+    sha256 = "0319q59kb8g324wnj7xzbr7vvlx5bcs13lr34j0zb3kqlyjq2fy9";
   };
 
   configureFlags = "CPPFLAGS=-DNDEBUG CFLAGS=-O3 CXXFLAGS=-O3";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/y8gzi68gamcb4wjrhm075vg5xv3gjfam-lzip-1.20/bin/lzip -h` got 0 exit code
- ran `/nix/store/y8gzi68gamcb4wjrhm075vg5xv3gjfam-lzip-1.20/bin/lzip --help` got 0 exit code
- ran `/nix/store/y8gzi68gamcb4wjrhm075vg5xv3gjfam-lzip-1.20/bin/lzip -V` and found version 1.20
- ran `/nix/store/y8gzi68gamcb4wjrhm075vg5xv3gjfam-lzip-1.20/bin/lzip --version` and found version 1.20
- ran `/nix/store/y8gzi68gamcb4wjrhm075vg5xv3gjfam-lzip-1.20/bin/lzip -h` and found version 1.20
- ran `/nix/store/y8gzi68gamcb4wjrhm075vg5xv3gjfam-lzip-1.20/bin/lzip --help` and found version 1.20
- found 1.20 with grep in /nix/store/y8gzi68gamcb4wjrhm075vg5xv3gjfam-lzip-1.20
- found 1.20 in filename of file in /nix/store/y8gzi68gamcb4wjrhm075vg5xv3gjfam-lzip-1.20
