### PR TITLE
fix zathura on stable 17.09

### DIFF
--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -6,11 +6,11 @@ assert withBuildColors -> ncurses != null;
 
 stdenv.mkDerivation rec {
   name = "girara-${version}";
-  version = "0.2.7";
+  version = "0.2.8";
 
   src = fetchurl {
     url    = "http://pwmt.org/projects/girara/download/${name}.tar.gz";
-    sha256 = "1r9jbhf9n40zj4ddqv1q5spijpjm683nxg4hr5lnir4a551s7rlq";
+    sha256 = "18wss3sak3djip090v2vdbvq1mvkwcspfswc87zbvv3magihan98";
   };
 
   preConfigure = ''

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -10,11 +10,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name    = "zathura-core-${version}";
-  version = "0.3.7";
+  version = "0.3.8";
 
   src = fetchurl {
     url    = "http://pwmt.org/projects/zathura/download/zathura-${version}.tar.gz";
-    sha256 = "1w0g74dq4z2vl3f99s2gkaqrb5pskgzig10qhbxj4gq9yj4zzbr2";
+    sha256 = "0dz5pky3vmf3s2cp2rv1c099gb1s49p9xlgm3ghyy4pzyxc8bgs6";
   };
 
   icon = ./icon.xpm;

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig
 , gtk, girara, ncurses, gettext, docutils
-, file, sqlite, glib, texlive
-, synctexSupport ? true
+, file, sqlite, glib, texlive, libintlOrEmpty
+, gtk-mac-integration, synctexSupport ? true
 }:
 
 assert synctexSupport -> texlive != null;
@@ -19,11 +19,17 @@ stdenv.mkDerivation rec {
 
   icon = ./icon.xpm;
 
+  nativeBuildInputs = [
+    pkgconfig
+  ] ++ optional stdenv.isDarwin [ libintlOrEmpty ];
+
   buildInputs = [
     pkgconfig file gtk girara
     gettext makeWrapper sqlite glib
-  ] ++ optional synctexSupport texlive.bin.core;
+  ] ++ optional synctexSupport texlive.bin.core
+    ++ optional stdenv.isDarwin [ gtk-mac-integration ];
 
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   makeFlags = [
@@ -48,7 +54,7 @@ stdenv.mkDerivation rec {
     homepage    = http://pwmt.org/projects/zathura/;
     description = "A core component for zathura PDF viewer";
     license     = licenses.zlib;
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
     maintainers = with maintainers; [ garbas ];
   };
 }

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-    "RSTTOMAN=${docutils}/bin/rst2man.py"
     "VERBOSE=1"
     "TPUT=${ncurses.out}/bin/tput"
     (optionalString synctexSupport "WITH_SYNCTEX=1")

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, gtk, zathura_core, girara, djvulibre, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "zathura-djvu-0.2.5";
+  name = "zathura-djvu-0.2.7";
 
   src = fetchurl {
     url = "http://pwmt.org/projects/zathura/plugins/download/${name}.tar.gz";
-    sha256 = "03cw54d2fipvbrnbqy0xccqkx6s77dyhyymx479aj5ryy4513dq8";
+    sha256 = "1sbfdsyp50qc85xc4458sn4w1rv1qbygdwmcr5kjlfpsmdq98vhd";
   };
 
   buildInputs = [ pkgconfig djvulibre gettext zathura_core gtk girara ];

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -12,6 +12,13 @@ stdenv.mkDerivation rec {
 
   patches = [ ./gtkflags.patch ];
 
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
+    string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
+    makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
+    echo "''${makefileC1/$string1/$string2}" > Makefile
+  '';
+
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
 
   meta = with stdenv.lib; {
@@ -22,7 +29,7 @@ stdenv.mkDerivation rec {
       djvulibre library.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ garbas ];
   };
 }

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./gtkflags.patch ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
     string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
     makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)

--- a/pkgs/applications/misc/zathura/djvu/gtkflags.patch
+++ b/pkgs/applications/misc/zathura/djvu/gtkflags.patch
@@ -1,7 +1,7 @@
---- a/config.mk	2012-05-14 01:13:09.009740082 +0400
-+++ b/config.mk	2012-05-14 01:13:50.400525700 +0400
-@@ -11,6 +11,9 @@
- LIBDIR ?= ${PREFIX}/lib
+--- zathura-djvu-0.2.7.orig/config.mk	2017-12-21 14:20:24.000000000 +0100
++++ zathura-djvu-0.2.7/config.mk	2017-12-31 00:41:02.580154770 +0100
+@@ -16,6 +16,9 @@
+ DESKTOPPREFIX ?= ${PREFIX}/share/applications
  
  # libs
 +GTK_INC ?= $(shell pkg-config --cflags gtk+-2.0)
@@ -10,14 +10,14 @@
  CAIRO_INC ?= $(shell pkg-config --cflags cairo)
  CAIRO_LIB ?= $(shell pkg-config --libs cairo)
  
-@@ -29,8 +32,8 @@
+@@ -34,8 +37,8 @@
  PLUGINDIR = ${LIBDIR}/zathura
  endif
  
--INCS = ${GIRARA_INC} ${GLIB_INC} ${DJVU_INC} ${ZATHURA_INC}
--LIBS = ${GIRARA_LIB} ${GLIB_LIB} ${DJVU_LIB}
-+INCS = ${GIRARA_INC} ${GLIB_INC} ${DJVU_INC} ${ZATHURA_INC} ${GTK_INC}
-+LIBS = ${GIRARA_LIB} ${GLIB_LIB} ${DJVU_LIB} ${GTK_LIB}
+-INCS = ${GIRARA_INC} ${GLIB_INC} ${DJVU_INC} ${CAIRO_INC} ${ZATHURA_INC}
+-LIBS = ${GIRARA_LIB} ${GLIB_LIB} ${DJVU_LIB} ${CAIRO_LIB}
++INCS = ${GIRARA_INC} ${GLIB_INC} ${DJVU_INC} ${CAIRO_INC} ${ZATHURA_INC} ${GTK_INC}
++LIBS = ${GIRARA_LIB} ${GLIB_LIB} ${DJVU_LIB} ${CAIRO_LIB} ${GTK_LIB}
  
- # flags
- CFLAGS += -std=c99 -fPIC -pedantic -Wall -Wno-format-zero-length $(INCS)
+ # pre-processor flags
+ CPPFLAGS += -D_FILE_OFFSET_BITS=64

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -15,10 +15,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     zathura_core gtk girara openssl mupdf libjpeg jbig2dec openjpeg
+  ] ++ stdenv.lib.optional stdenv.isDarwin [
     gtk-mac-integration
   ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
     string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
     makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -2,12 +2,12 @@
 , libjpeg, jbig2dec, openjpeg, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.1";
+  version = "0.3.2";
   name = "zathura-pdf-mupdf-${version}";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura-pdf-mupdf/download/${name}.tar.gz";
-    sha256 = "06zqn8z6a0hfsx3s1kzqvqzb73afgcl6z5r062sxv7kv570fvffr";
+    sha256 = "0xkajc3is7ncmb2fmymbzfgrran2bz12i7zsm1vvxhxds728h7ck";
   };
 
   buildInputs = [ pkgconfig zathura_core gtk girara openssl mupdf libjpeg jbig2dec openjpeg ];

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, lib, fetchurl, pkgconfig, zathura_core, gtk, girara, mupdf, openssl
-, libjpeg, jbig2dec, openjpeg, fetchpatch }:
+{ stdenv, lib, fetchurl, pkgconfig, zathura_core, gtk,
+gtk-mac-integration, girara, mupdf, openssl , libjpeg, jbig2dec,
+openjpeg, fetchpatch }:
 
 stdenv.mkDerivation rec {
   version = "0.3.2";
@@ -10,7 +11,19 @@ stdenv.mkDerivation rec {
     sha256 = "0xkajc3is7ncmb2fmymbzfgrran2bz12i7zsm1vvxhxds728h7ck";
   };
 
-  buildInputs = [ pkgconfig zathura_core gtk girara openssl mupdf libjpeg jbig2dec openjpeg ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    zathura_core gtk girara openssl mupdf libjpeg jbig2dec openjpeg
+    gtk-mac-integration
+  ];
+
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
+    string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
+    makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
+    echo "''${makefileC1/$string1/$string2}" > Makefile
+  '';
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
 
@@ -22,7 +35,7 @@ stdenv.mkDerivation rec {
       using the mupdf rendering library.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan ];
   };
 }

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchurl, pkgconfig, zathura_core, girara, poppler }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.6";
+  version = "0.2.8";
   name = "zathura-pdf-poppler-${version}";
 
   src = fetchurl {
     url = "http://pwmt.org/projects/zathura/plugins/download/${name}.tar.gz";
-    sha256 = "1maqiv7yv8d8hymlffa688c5z71v85kbzmx2j88i8z349xx0rsyi";
+    sha256 = "1m55m7s7f8ng8a7lmcw9z4n5zv7xk4vp9n6fp9j84z6rk2imf7a2";
   };
 
   buildInputs = [ pkgconfig poppler zathura_core girara ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     homepage = http://pwmt.org/projects/zathura/;
     description = "A zathura PDF plugin (poppler)";
     longDescription = ''
-      The zathura-pdf-poppler plugin adds PDF support to zathura by 
+      The zathura-pdf-poppler plugin adds PDF support to zathura by
       using the poppler rendering library.
     '';
     license = licenses.zlib;

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
     string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
     makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -9,9 +9,17 @@ stdenv.mkDerivation rec {
     sha256 = "1m55m7s7f8ng8a7lmcw9z4n5zv7xk4vp9n6fp9j84z6rk2imf7a2";
   };
 
-  buildInputs = [ pkgconfig poppler zathura_core girara ];
+  nativeBuildInputs = [ pkgconfig zathura_core ];
+  buildInputs = [ poppler girara ];
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
+
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    string1='-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}'
+    string2='-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}'
+    makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
+    echo "''${makefileC1/$string1/$string2}" > Makefile
+  '';
 
   meta = with lib; {
     homepage = http://pwmt.org/projects/zathura/;
@@ -21,7 +29,7 @@ stdenv.mkDerivation rec {
       using the poppler rendering library.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan garbas ];
   };
 }

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./gtkflags.patch ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
     makefileC2=$(echo "$makefileC1" | sed 's|-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}|-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}|g' )
     echo "$makefileC2" > Makefile

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkgconfig, gtk, zathura_core, girara, libspectre, gettext }:
+{ stdenv, lib, fetchurl, pkgconfig, gtk2, zathura_core, girara, libspectre, gettext }:
 
 stdenv.mkDerivation rec {
   name = "zathura-ps-0.2.5";
@@ -8,9 +8,17 @@ stdenv.mkDerivation rec {
     sha256 = "1x4knqja8pw2a5cb3y2209nr3iddj1z8nwasy48v5nprj61fdxqj";
   };
 
-  buildInputs = [ pkgconfig libspectre gettext zathura_core gtk girara ];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libspectre gettext zathura_core gtk2 girara ];
 
   patches = [ ./gtkflags.patch ];
+
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    makefileC1=$(sed -r 's/\.so/.dylib/g' Makefile)
+    makefileC2=$(echo "$makefileC1" | sed 's|-shared ''${LDFLAGS} -o $@ ''$(OBJECTS) ''${LIBS}|-Wl,-dylib_install_name,''${PLUGIN}.dylib -Wl,-bundle_loader,${zathura_core}/bin/.zathura-wrapped -bundle ''${LDFLAGS} -o $@ ''${OBJECTS} ''${LIBS}|g' )
+    echo "$makefileC2" > Makefile
+    echo "$makefileC2"
+  '';
 
   makeFlags = [ "PREFIX=$(out)" "PLUGINDIR=$(out)/lib" ];
 
@@ -22,7 +30,7 @@ stdenv.mkDerivation rec {
       libspectre library.
       '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan garbas ];
   };
 }

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -1,11 +1,11 @@
 { stdenv, lib, fetchurl, pkgconfig, gtk, zathura_core, girara, libspectre, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "zathura-ps-0.2.3";
+  name = "zathura-ps-0.2.5";
 
   src = fetchurl {
     url = "http://pwmt.org/projects/zathura/plugins/download/${name}.tar.gz";
-    sha256 = "18wsfy8pqficdgj8wy2aws7j4fy8z78157rhqk17mj5f295zgvm9";
+    sha256 = "1x4knqja8pw2a5cb3y2209nr3iddj1z8nwasy48v5nprj61fdxqj";
   };
 
   buildInputs = [ pkgconfig libspectre gettext zathura_core gtk girara ];

--- a/pkgs/applications/misc/zathura/ps/gtkflags.patch
+++ b/pkgs/applications/misc/zathura/ps/gtkflags.patch
@@ -1,9 +1,7 @@
-diff --git a/config.mk b/config.mk.new
-index c3a7b37..0cbce67 100644
---- a/config.mk
-+++ b/config.mk
-@@ -10,6 +10,9 @@ ZATHURA_VERSION_CHECK ?= $(shell pkg-config --atleast-version=$(ZATHURA_MIN_VERS
- PREFIX ?= /usr
+--- zathura-ps-0.2.5.orig/config.mk	2017-12-21 14:21:17.000000000 +0100
++++ zathura-ps-0.2.5/config.mk	2017-12-31 01:05:17.507268817 +0100
+@@ -16,6 +16,9 @@
+ DESKTOPPREFIX ?= ${PREFIX}/share/applications
  
  # libs
 +GTK_INC ?= $(shell pkg-config --cflags gtk+-2.0)
@@ -12,14 +10,14 @@ index c3a7b37..0cbce67 100644
  CAIRO_INC ?= $(shell pkg-config --cflags cairo)
  CAIRO_LIB ?= $(shell pkg-config --libs cairo)
  
-@@ -26,8 +29,8 @@ ZATHURA_INC ?= $(shell pkg-config --cflags zathura)
- PLUGINDIR ?= $(shell pkg-config --variable=plugindir zathura)
- PLUGINDIR ?= ${PREFIX}/lib/zathura
+@@ -34,8 +37,8 @@
+ PLUGINDIR = ${LIBDIR}/zathura
+ endif
  
--INCS = ${GLIB_INC} ${SPECTRE_INC} ${GIRARA_INC} ${ZATHURA_INC}
--LIBS = ${GLIB_LIB} ${SPECTRE_LIB} ${GIRARA_LIB}
-+INCS = ${GLIB_INC} ${SPECTRE_INC} ${GIRARA_INC} ${ZATHURA_INC} ${GTK_INC}
-+LIBS = ${GLIB_LIB} ${SPECTRE_LIB} ${GIRARA_LIB} ${GTK_LIB}
+-INCS = ${GLIB_INC} ${SPECTRE_INC} ${GIRARA_INC} ${CAIRO_INC} ${ZATHURA_INC}
+-LIBS = ${GLIB_LIB} ${SPECTRE_LIB} ${GIRARA_LIB} ${CAIRO_LIB}
++INCS = ${GLIB_INC} ${SPECTRE_INC} ${GIRARA_INC} ${CAIRO_INC} ${ZATHURA_INC} ${GTK_INC}
++LIBS = ${GLIB_LIB} ${SPECTRE_LIB} ${GIRARA_LIB} ${CAIRO_LIB } ${GTK_LIB}
  
- # flags
- CFLAGS += -std=c99 -fPIC -pedantic -Wall -Wno-format-zero-length $(INCS)
+ # compiler flags
+ CFLAGS += -std=c11 -fPIC -pedantic -Wall -Wno-format-zero-length $(INCS)

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -11,8 +11,7 @@ in symlinkJoin {
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
-    wrapProgram $out/bin/zathura \
-      --add-flags --plugins-dir=${pluginsPath}
+    wrapProgram $out/bin/zathura --add-flags --plugins-dir=${pluginsPath}
   '';
 
   meta = with lib; {
@@ -25,7 +24,7 @@ in symlinkJoin {
       as well as an easy usage that mainly focuses on keyboard interaction.
     '';
     license = licenses.zlib;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers;[ garbas smironov ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

fixing zathura in 17.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (this seems to no longer work?)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

