### PR TITLE
pipewire: 0.1.8 → 0.1.9

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,10 +1,14 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig, doxygen, graphviz, valgrind
 , glib, dbus, gst_all_1, v4l_utils, alsaLib, ffmpeg, libjack2, libudev, libva, xlibs
-, sbc, SDL2
+, sbc, SDL2, makeFontsConf, freefont_ttf
 }:
 
 let
-  version = "0.1.8";
+  version = "0.1.9";
+
+  fontsConf = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
 in stdenv.mkDerivation rec {
   name = "pipewire-${version}";
 
@@ -12,7 +16,7 @@ in stdenv.mkDerivation rec {
     owner = "PipeWire";
     repo = "pipewire";
     rev = version;
-    sha256 = "1nim8d1lsf6yxk97piwmsz686w84b09lk6cagbyjr9m3k2hwybqn";
+    sha256 = "0r9mgwbggnnijhdz49fnv0qdka364xn1h8yml2jakyqpfrm3i2nm";
   };
 
   outputs = [ "out" "dev" "doc" ];
@@ -34,8 +38,9 @@ in stdenv.mkDerivation rec {
     "-Denable_gstreamer=true"
   ];
 
+  FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
+
   doCheck = true;
-  checkPhase = "meson test";
 
   meta = with stdenv.lib; {
     description = "Server and user space API to deal with multimedia pipelines";


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
    - [x] mutter
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

