### PR TITLE
luatex: patch to fix crash w/gcc7

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -168,6 +168,8 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
         # http://tex.stackexchange.com/questions/97999/when-to-use-luajittex-in-favour-of-luatex
       ];
 
+  patches = [ ./luatex-gcc7.patch ];
+
   configureScript = ":";
 
   # we use static libtexlua, because it's only used by a single binary

--- a/pkgs/tools/typesetting/tex/texlive/luatex-gcc7.patch
+++ b/pkgs/tools/typesetting/tex/texlive/luatex-gcc7.patch
@@ -4,8 +4,8 @@ https://www.tug.org/pipermail/tex-live/2017-June/040192.html
  texk/web2c/luatexdir/luaffi/ffi.h   |    2 +-
  2 files changed, 5 insertions(+), 1 deletion(-)
 
---- texk/web2c/luatexdir/luaffi/ctype.c
-+++ texk/web2c/luatexdir/luaffi/ctype.c	2017-05-31 13:08:25.421741873 +0000
+--- a/texk/web2c/luatexdir/luaffi/ctype.c
++++ b/texk/web2c/luatexdir/luaffi/ctype.c       2017-05-31 13:08:25.421741873 +0000
 @@ -245,6 +245,10 @@ void* to_cdata(lua_State* L, int idx, st
  
      lua_pop(L, 1); /* mt */
@@ -17,8 +17,8 @@ https://www.tug.org/pipermail/tex-live/2017-June/040192.html
      *ct = cd->type;
      lua_getuservalue(L, idx);
  
---- texk/web2c/luatexdir/luaffi/ffi.h
-+++ texk/web2c/luatexdir/luaffi/ffi.h	2017-06-01 09:12:45.128442092 +0000
+--- a/texk/web2c/luatexdir/luaffi/ffi.h
++++ b/texk/web2c/luatexdir/luaffi/ffi.h 2017-06-01 09:12:45.128442092 +0000
 @@ -370,7 +370,7 @@ __declspec(align(16))
  #endif
  struct cdata {

--- a/pkgs/tools/typesetting/tex/texlive/luatex-gcc7.patch
+++ b/pkgs/tools/typesetting/tex/texlive/luatex-gcc7.patch
@@ -1,0 +1,30 @@
+https://www.tug.org/pipermail/tex-live/2017-June/040192.html
+---
+ texk/web2c/luatexdir/luaffi/ctype.c |    4 ++++
+ texk/web2c/luatexdir/luaffi/ffi.h   |    2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+--- texk/web2c/luatexdir/luaffi/ctype.c
++++ texk/web2c/luatexdir/luaffi/ctype.c	2017-05-31 13:08:25.421741873 +0000
+@@ -245,6 +245,10 @@ void* to_cdata(lua_State* L, int idx, st
+ 
+     lua_pop(L, 1); /* mt */
+     cd = (struct cdata*) lua_touserdata(L, idx);
++    if (!cd) {
++        lua_pushnil(L);
++        return NULL;
++    }
+     *ct = cd->type;
+     lua_getuservalue(L, idx);
+ 
+--- texk/web2c/luatexdir/luaffi/ffi.h
++++ texk/web2c/luatexdir/luaffi/ffi.h	2017-06-01 09:12:45.128442092 +0000
+@@ -370,7 +370,7 @@ __declspec(align(16))
+ #endif
+ struct cdata {
+     const struct ctype type
+-#ifdef __GNUC__
++#if 0 /* def __GNUC__ */
+       __attribute__ ((aligned(16)))
+ #endif
+       ;


### PR DESCRIPTION
Fixes #35839



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Tested to fix crash with luatex as reported in linked issue.