### PR TITLE
 salt: 2017.7.2 -> 2017.7.4, fix msgpack dependency

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -8,12 +8,11 @@
 
 python2Packages.buildPythonApplication rec {
   pname = "salt";
-  version = "2017.7.2";
-  name = "${pname}-${version}";
+  version = "2017.7.4";
 
   src = python2Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0h18zwp1w90rgxpmqgrmn9wp31h03f0vak8lpnnbh0dzbbgcffzz";
+    sha256 = "15xfvclk3ns8vk17j7bfy4alq7ab5x3y3jnpqzp5583bfyak0mqx";
   };
 
   propagatedBuildInputs = with python2Packages; [

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -20,7 +20,7 @@ python2Packages.buildPythonApplication rec {
     futures
     jinja2
     markupsafe
-    msgpack
+    msgpack-python
     pycrypto
     pyyaml
     pyzmq


### PR DESCRIPTION
###### Motivation for this change

Fix Salt build. Bump Salt to the latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

It looks like this package was missed in #34809; the latest (2017.7.3) still seems to require `msgpack-python`.
cc @danbst and @PierreR as Salt users: I won't be able to test this thoroughly for a bit, could you give this branch a spin and report how it goes?