### PR TITLE
qtox: remove opencv dependency

### DIFF
--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -3,7 +3,7 @@
   libpthreadstubs, libXdmcp, libXScrnSaver,
   qtbase, qtsvg, qttools, qttranslations,
   ffmpeg, filter-audio, libexif, libsodium, libopus,
-  libvpx, openal, opencv, pcre, qrencode, sqlcipher }:
+  libvpx, openal, pcre, qrencode, sqlcipher }:
 
 mkDerivation rec {
   name = "qtox-${version}";
@@ -21,7 +21,7 @@ mkDerivation rec {
     libpthreadstubs libXdmcp libXScrnSaver
     qtbase qtsvg qttranslations
     ffmpeg filter-audio libexif libopus libsodium
-    libvpx openal opencv pcre qrencode sqlcipher
+    libvpx openal pcre qrencode sqlcipher
   ];
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];


### PR DESCRIPTION
It doesn't depend on it for a long time.

###### Motivation for this change

Remove a dependency that is not needed anymore.

###### Things done

Tested on 17.09.
