### PR TITLE
a52dec: add -fPIC to CFLAGS

### DIFF
--- a/pkgs/development/libraries/a52dec/default.nix
+++ b/pkgs/development/libraries/a52dec/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     ./A03-automake.patch
   ];
 
+  CFLAGS = "-fPIC";
+
   meta = {
     description = "ATSC A/52 stream decoder";
     homepage = http://liba52.sourceforge.net/;


### PR DESCRIPTION
Without -fPIC gst-plugins.ugly fails to compile. The problem
is that a52dec builds a static library. This library is then used
to create a gstreamer-plugin .so. The linking fails if a52dec is
compiled without -fPIC.

This problem manifests itself only when hardening is disabled.
As when hardening is enabled -fPIC is added automatically.

###### Things done

Tested on 17.09. I haven't built it on master.