### PR TITLE
Solving #30396

### DIFF
--- a/nixos/modules/services/editors/emacs.nix
+++ b/nixos/modules/services/editors/emacs.nix
@@ -15,6 +15,25 @@ let
     fi
   '';
 
+desktopApplicationFile = pkgs.writeTextFile {
+  name = "emacsclient.desktop";
+  destination = "/share/applications/emacsclient.desktop";
+  text = ''
+[Desktop Entry]
+Name=Emacsclient
+GenericName=Text Editor
+Comment=Edit text
+MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;
+Exec=emacseditor %F
+Icon=emacs
+Type=Application
+Terminal=false
+Categories=Development;TextEditor;
+StartupWMClass=Emacs
+Keywords=Text;Editor;
+'';
+};
+
 in {
 
   options.services.emacs = {
@@ -74,7 +93,7 @@ in {
       };
     } // optionalAttrs cfg.enable { wantedBy = [ "default.target" ]; };
 
-    environment.systemPackages = [ cfg.package editorScript ];
+    environment.systemPackages = [ cfg.package editorScript desktopApplicationFile ];
 
     environment.variables = {
       # This is required so that GTK applications launched from Emacs


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/30396
DR:
When setting `services.emacs.enable = true;`, a custom shell script to start `emacsclient`, namely `emacseditor` is build. This PR adds the generation of `.desktop` to `/share/applications/`, so that `emacseditor` can be run from an ordinary GUI program launcher.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

