### PR TITLE
nnn: 1.6 -> 1.7

### DIFF
--- a/pkgs/applications/misc/nnn/default.nix
+++ b/pkgs/applications/misc/nnn/default.nix
@@ -4,13 +4,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "nnn-${version}";
-  version = "1.6";
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "nnn";
     rev = "v${version}";
-    sha256 = "1yl4k39wkh2ins7fz585kc4cg6fagiswgqkh5g36db1bka3v1kn0";
+    sha256 = "03cgsdj4l19gla5fx9d1ydqirpsah9d7gx9jaik73x38zqsabr89";
   };
 
   configFile = optionalString (conf!=null) (builtins.toFile "nnn.h" conf);


### PR DESCRIPTION
https://github.com/jarun/nnn/releases/tag/v1.7


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
 cc @jfrankenau 
