### PR TITLE
msilbc: 2.0.3 -> 2.1.2

### DIFF
--- a/pkgs/development/libraries/msilbc/default.nix
+++ b/pkgs/development/libraries/msilbc/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, ilbc, mediastreamer, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "msilbc-2.0.3";
+  name = "msilbc-2.1.2";
 
   src = fetchurl {
     url = "mirror://savannah/linphone/plugins/sources/${name}.tar.gz";
-    sha256 = "125yadpc0w1q84839dadin3ahs0gxxfas0zmc4c18mjmf58dmm7d";
+    sha256 = "07j02y994ybh274fp7ydjvi76h34y2c34ndwjpjfcwwr03b48cfp";
   };
 
   propagatedBuildInputs = [ ilbc mediastreamer ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.1.2 with grep in /nix/store/382shdj4qs6hl916ycw7ai4c7xz1sd40-msilbc-2.1.2
- found 2.1.2 in filename of file in /nix/store/382shdj4qs6hl916ycw7ai4c7xz1sd40-msilbc-2.1.2
