### PR TITLE
msitools: 0.94 -> 0.97

### DIFF
--- a/pkgs/development/tools/misc/msitools/default.nix
+++ b/pkgs/development/tools/misc/msitools/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, intltool, glib, pkgconfig, libgsf, libuuid, gcab, bzip2}:
 
 stdenv.mkDerivation rec {
-  version = "0.94";
+  version = "0.97";
   name = "msitools-${version}";
 
   src = fetchurl {
-    url = "http://ftp.gnome.org/pub/GNOME/sources/msitools/0.94/${name}.tar.xz";
-    sha256 = "0bndnm3mgcqkw5dhwy5l1zri4lqvjbhbn5rxz651fkxlkhab8bhm";
+    url = "http://ftp.gnome.org/pub/GNOME/sources/msitools/0.97/${name}.tar.xz";
+    sha256 = "0pn6izlgwi4ngpk9jk2n38gcjjpk29nm15aad89bg9z3k9n2hnrs";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiinfo -h` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiinfo --help` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiinfo help` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiinfo -v` and found version 0.97
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiinfo --version` and found version 0.97
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiextract -h` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiextract --help` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiextract help` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msiextract --version` and found version 0.97
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/wixl -h` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/wixl --help` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/wixl --version` and found version 0.97
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/wixl-heat -h` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/wixl-heat --help` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msidump -h` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msidump --help` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msidump -v` and found version 0.97
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msidump --version` and found version 0.97
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msidiff -h` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msidiff --help` got 0 exit code
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msidiff -v` and found version 0.97
- ran `/nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97/bin/msidiff --version` and found version 0.97
- found 0.97 with grep in /nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97
- found 0.97 in filename of file in /nix/store/xmsjbixyip29vcxgh0wkhlvvb9zpbhz2-msitools-0.97

cc "@vcunat"