### PR TITLE
opencv3: Fix pkg-config lib path

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -152,6 +152,8 @@ stdenv.mkDerivation rec {
   inherit version src;
 
   patches = [
+    ./pkg-config-lib-path.patch
+
     # Fix for: https://github.com/opencv/opencv/issues/10474
     (fetchpatch {
       url = "https://github.com/opencv/opencv/commit/ea5a3e557f93844fdb5e54e3e8acfc5f61c6fd9f.patch";

--- a/pkgs/development/libraries/opencv/pkg-config-lib-path.patch
+++ b/pkgs/development/libraries/opencv/pkg-config-lib-path.patch
@@ -1,0 +1,29 @@
+diff -ruN a/cmake/OpenCVGenPkgconfig.cmake b/cmake/OpenCVGenPkgconfig.cmake
+--- a/cmake/OpenCVGenPkgconfig.cmake	2018-02-27 15:39:00.000000000 -0500
++++ b/cmake/OpenCVGenPkgconfig.cmake	2018-02-27 17:31:56.000000000 -0500
+@@ -124,14 +124,14 @@
+ ocv_list_unique(_3rdparty)
+ 
+ set(OPENCV_PC_LIBS
+-  "-L\${exec_prefix}/${OPENCV_LIB_INSTALL_PATH}"
++  "-L${OPENCV_LIB_INSTALL_PATH}"
+   "${_modules}"
+ )
+ if(BUILD_SHARED_LIBS)
+   set(OPENCV_PC_LIBS_PRIVATE "${_extra}")
+ else()
+   set(OPENCV_PC_LIBS_PRIVATE
+-    "-L\${exec_prefix}/${OPENCV_3P_LIB_INSTALL_PATH}"
++    "-L${OPENCV_3P_LIB_INSTALL_PATH}"
+     "${_3rdparty}"
+     "${_extra}"
+   )
+@@ -142,7 +142,7 @@
+ #generate the .pc file
+ set(prefix      "${CMAKE_INSTALL_PREFIX}")
+ set(exec_prefix "\${prefix}")
+-set(libdir      "\${exec_prefix}/${OPENCV_LIB_INSTALL_PATH}")
++set(libdir      "${OPENCV_LIB_INSTALL_PATH}")
+ set(includedir  "\${prefix}/${OPENCV_INCLUDE_INSTALL_PATH}")
+ 
+ configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/opencv-XXX.pc.in"


### PR DESCRIPTION
Fixes #35886

###### Motivation for this change

The library path pkg-config supplies for an OpenCV built from the `opencv3` definition in nixpkgs is wrong: it appends the absolute path of the `lib` directory to the `$out` directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

