### PR TITLE
munge: 0.5.12 -> 0.5.13

### DIFF
--- a/pkgs/tools/security/munge/default.nix
+++ b/pkgs/tools/security/munge/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, autoreconfHook, gawk, gnused, libgcrypt, zlib, bzip2 }:
 
 stdenv.mkDerivation rec {
-  name = "munge-0.5.12";
+  name = "munge-0.5.13";
 
   src = fetchFromGitHub {
     owner = "dun";
     repo = "munge";
     rev = "${name}";
-    sha256 = "1wvkc63bqclpm5xmp3rn199x3jqd99255yicyydgz83cixp7wdbh";
+    sha256 = "1c4ff3d8ad3inbliszr4slym3b4cn19bn6mxm13mzy20jyi2rm70";
   };
 
   nativeBuildInputs = [ autoreconfHook gawk gnused ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munge -h` got 0 exit code
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munge --help` got 0 exit code
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munge -V` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munge --version` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/unmunge -h` got 0 exit code
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/unmunge --help` got 0 exit code
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/unmunge -V` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/unmunge --version` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/remunge -h` got 0 exit code
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/remunge --help` got 0 exit code
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/remunge -V` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/remunge --version` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munged -h` got 0 exit code
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munged --help` got 0 exit code
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munged -V` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munged --version` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munged -h` and found version 0.5.13
- ran `/nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13/bin/munged --help` and found version 0.5.13
- found 0.5.13 with grep in /nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13
- found 0.5.13 in filename of file in /nix/store/lgayw7d562299m06kmdp15zb35j9r0gg-munge-0.5.13

cc "@rickynils"