### PR TITLE
mynewt-newt: 1.0.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/package-management/mynewt-newt/default.nix
+++ b/pkgs/tools/package-management/mynewt-newt/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "mynewt-newt-${version}";
-  version = "1.0.0";
+  version = "1.3.0";
 
   goPackagePath = "mynewt.apache.org/newt";
   goDeps = ./deps.nix;
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "apache";
     repo = "incubator-mynewt-newt";
     rev = "mynewt_${builtins.replaceStrings ["."] ["_"] version}_tag";
-    sha256 = "1ixqxqizd957prd4j2nijgnkv84rffj8cx5f7aqyjq9nkawjksf6";
+    sha256 = "0ia6q1wf3ki2yw8ngw5gnbdrb7268qwi078j05f8gs1sppb3g563";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin/bin/newt -h` got 0 exit code
- ran `/nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin/bin/newt --help` got 0 exit code
- ran `/nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin/bin/newt help` got 0 exit code
- ran `/nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin/bin/newt version` and found version 1.3.0
- ran `/nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin/bin/newtmgr -h` got 0 exit code
- ran `/nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin/bin/newtmgr --help` got 0 exit code
- ran `/nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin/bin/newtmgr help` got 0 exit code
- found 1.3.0 with grep in /nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin
- found 1.3.0 in filename of file in /nix/store/cjkfm1v60ykkmnqbpwc5ikhrrghklj1n-mynewt-newt-1.3.0-bin

cc "@pjones @ehmry @lethalman"