### PR TITLE
nagios: 4.2.4 -> 4.3.4

### DIFF
--- a/pkgs/servers/monitoring/nagios/default.nix
+++ b/pkgs/servers/monitoring/nagios/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nagios-${version}";
-  version = "4.2.4";
+  version = "4.3.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/nagios/nagios-4.x/${name}/${name}.tar.gz";
-    sha256 = "0w0blbwiw0ps04b7gkyyk89qkgwsxh6gydhmggbm1kl3ar3mq1dh";
+    sha256 = "1wa4m952sb23dqi5w759adimsp21bkhp598rpq9dnhz3v497h2y9";
   };
 
   patches = [ ./nagios.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/h6fdhwd698dwp4v91x1hqsjymrhr230b-nagios-4.3.4/bin/nagios -V` and found version 4.3.4
- ran `/nix/store/h6fdhwd698dwp4v91x1hqsjymrhr230b-nagios-4.3.4/bin/nagios --version` and found version 4.3.4
- ran `/nix/store/h6fdhwd698dwp4v91x1hqsjymrhr230b-nagios-4.3.4/bin/nagiostats -V` and found version 4.3.4
- ran `/nix/store/h6fdhwd698dwp4v91x1hqsjymrhr230b-nagios-4.3.4/bin/nagiostats --version` and found version 4.3.4
- found 4.3.4 with grep in /nix/store/h6fdhwd698dwp4v91x1hqsjymrhr230b-nagios-4.3.4
- found 4.3.4 in filename of file in /nix/store/h6fdhwd698dwp4v91x1hqsjymrhr230b-nagios-4.3.4

cc "@thoughtpolice @relrod"