### PR TITLE
nanoflann: 1.1.9 -> 1.2.3

### DIFF
--- a/pkgs/development/libraries/nanoflann/default.nix
+++ b/pkgs/development/libraries/nanoflann/default.nix
@@ -1,14 +1,14 @@
 {stdenv, fetchFromGitHub, cmake}:
 
 stdenv.mkDerivation rec {
-  version = "1.1.9";
+  version = "1.2.3";
   name = "nanoflann-${version}";
   
   src = fetchFromGitHub {
     owner = "jlblancoc";
     repo = "nanoflann";
     rev = "v${version}";
-    sha256 = "1q588cf2aark45bp4ciqjiz3dkdv8dcijkhm1ybzs8qjdzz9fimn";
+    sha256 = "1jrh73kjvdv7s7zc1sc3z254i17lpvn77b19wx32nvzsfxs4g44i";
   };
 
   buildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.2.3 with grep in /nix/store/gglvdgfxscxg7hhdgbxyzdvd01kv4nxa-nanoflann-1.2.3
- found 1.2.3 in filename of file in /nix/store/gglvdgfxscxg7hhdgbxyzdvd01kv4nxa-nanoflann-1.2.3
