### PR TITLE
nanomsg: 1.0.0 -> 1.1.2

### DIFF
--- a/pkgs/development/libraries/nanomsg/default.nix
+++ b/pkgs/development/libraries/nanomsg/default.nix
@@ -1,14 +1,14 @@
 { stdenv, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.0";
+  version = "1.1.2";
   name = "nanomsg-${version}";
 
   src = fetchFromGitHub {
     owner = "nanomsg";
     repo = "nanomsg";
     rev = version;
-    sha256 = "1iqlmvz5k8m4srb120g3kfkmm1w2p16hyxmx2asvihd21j285fmw";
+    sha256 = "1zvs91afsg61azfv5fldv84gnhf76w3yndkdvpvaprlacxbxdvf5";
   };
 
   buildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/yzb91gfv6pvyvc662n9sc9rzf2mki8ss-nanomsg-1.1.2/bin/nanocat -h` got 0 exit code
- ran `/nix/store/yzb91gfv6pvyvc662n9sc9rzf2mki8ss-nanomsg-1.1.2/bin/nanocat --help` got 0 exit code
- ran `/nix/store/yzb91gfv6pvyvc662n9sc9rzf2mki8ss-nanomsg-1.1.2/bin/nanocat -h` and found version 1.1.2
- ran `/nix/store/yzb91gfv6pvyvc662n9sc9rzf2mki8ss-nanomsg-1.1.2/bin/nanocat --help` and found version 1.1.2
- found 1.1.2 with grep in /nix/store/yzb91gfv6pvyvc662n9sc9rzf2mki8ss-nanomsg-1.1.2
- found 1.1.2 in filename of file in /nix/store/yzb91gfv6pvyvc662n9sc9rzf2mki8ss-nanomsg-1.1.2