### PR TITLE
nasm: 2.13.02 -> 2.13.03

### DIFF
--- a/pkgs/development/compilers/nasm/default.nix
+++ b/pkgs/development/compilers/nasm/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nasm-${version}";
-  version = "2.13.02";
+  version = "2.13.03";
 
   src = fetchurl {
     url = "http://www.nasm.us/pub/nasm/releasebuilds/${version}/${name}.tar.bz2";
-    sha256 = "1gmvjckxvkmx1kbglgrakc98qhy55xlqlk5flrdihz5yhv92hc4d";
+    sha256 = "04bh736zfj3xy5ihh1whshpjxsisv7hqkz954clzdw6kg93qdv33";
   };
 
   nativeBuildInputs = [ perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03/bin/nasm -h` got 0 exit code
- ran `/nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03/bin/nasm help` got 0 exit code
- ran `/nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03/bin/nasm -v` and found version 2.13.03
- ran `/nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03/bin/nasm --version` and found version 2.13.03
- ran `/nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03/bin/ndisasm -h` got 0 exit code
- ran `/nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03/bin/ndisasm help` got 0 exit code
- ran `/nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03/bin/ndisasm -V` and found version 2.13.03
- ran `/nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03/bin/ndisasm -v` and found version 2.13.03
- found 2.13.03 with grep in /nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03
- found 2.13.03 in filename of file in /nix/store/nppkg7zibkkfdsccavaxljl7x1svxvhj-nasm-2.13.03

cc "@pSub @willibutz"