### PR TITLE
neo4j: 3.1.2 -> 3.3.2

### DIFF
--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "neo4j-${version}";
-  version = "3.1.2";
+  version = "3.3.2";
 
   src = fetchurl {
     url = "http://dist.neo4j.org/neo4j-community-${version}-unix.tar.gz";
-    sha256 = "0kvbsm9mjwqyl3q2myif28a0f11i4rfq3hik07w9cdnrwyd75s40";
+    sha256 = "0vjzc38sacnbcw781qzng9lqwwahndfc3wia5yvxji094zqp8ala";
   };
 
   buildInputs = [ makeWrapper jre8 which gawk ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j help` got 0 exit code
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j --version` and found version 3.3.2
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j version` and found version 3.3.2
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j help` and found version 3.3.2
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j-admin help` got 0 exit code
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j-admin --version` and found version 3.3.2
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j-import --help` got 0 exit code
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j-import help` got 0 exit code
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j-shell -h` got 0 exit code
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j-shell --help` got 0 exit code
- ran `/nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2/bin/neo4j-shell --version` and found version 3.3.2
- found 3.3.2 with grep in /nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2
- found 3.3.2 in filename of file in /nix/store/h7gmk2gjradg84isbn8hpb05cirpkind-neo4j-3.3.2

cc "@offline"