### PR TITLE
netsniff-ng: 0.6.3 -> 0.6.4

### DIFF
--- a/pkgs/tools/networking/netsniff-ng/default.nix
+++ b/pkgs/tools/networking/netsniff-ng/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   name = "netsniff-ng-${version}";
-  version = "0.6.3";
+  version = "0.6.4";
 
   # Upstream recommends and supports git
   src = fetchFromGitHub rec {
     repo = "netsniff-ng";
     owner = repo;
     rev = "v${version}";
-    sha256 = "0g3105c5ha897bpwsnrp72gx4n61gspxmld594i37g8k7vwzny4l";
+    sha256 = "0nip1gmzxq5kak41n0y0qzbhk2876fypk83q14ssy32fk49lxjly";
   };
 
   patches = [ ./glibc-2.26.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/gazzj2la9diafgf11ay2a9pgvvwvjvd2-netsniff-ng-0.6.4/bin/mausezahn help` got 0 exit code
- found 0.6.4 with grep in /nix/store/gazzj2la9diafgf11ay2a9pgvvwvjvd2-netsniff-ng-0.6.4
- found 0.6.4 in filename of file in /nix/store/gazzj2la9diafgf11ay2a9pgvvwvjvd2-netsniff-ng-0.6.4
