### PR TITLE
newt: 0.52.15 -> 0.52.20

### DIFF
--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, slang, popt }:
 
 stdenv.mkDerivation rec {
-  name = "newt-0.52.15";
+  name = "newt-0.52.20";
 
   src = fetchurl {
     url = "https://fedorahosted.org/releases/n/e/newt/${name}.tar.gz";
-    sha256 = "0hg2l0siriq6qrz6mmzr6l7rpl40ay56c8cak87rb2ks7s952qbs";
+    sha256 = "1g3dpfnvaw7vljbr7nzq1rl88d6r8cmrvvng9inphgzwxxmvlrld";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/xbjik2b7dbm76gjy47mrvi27iwri304z-newt-0.52.20/bin/whiptail -h` got 0 exit code
- ran `/nix/store/xbjik2b7dbm76gjy47mrvi27iwri304z-newt-0.52.20/bin/whiptail --help` got 0 exit code
- ran `/nix/store/xbjik2b7dbm76gjy47mrvi27iwri304z-newt-0.52.20/bin/whiptail -v` and found version 0.52.20
- ran `/nix/store/xbjik2b7dbm76gjy47mrvi27iwri304z-newt-0.52.20/bin/whiptail --version` and found version 0.52.20
- found 0.52.20 with grep in /nix/store/xbjik2b7dbm76gjy47mrvi27iwri304z-newt-0.52.20
- found 0.52.20 in filename of file in /nix/store/xbjik2b7dbm76gjy47mrvi27iwri304z-newt-0.52.20

cc "@viric"