### PR TITLE
nfdump: 1.6.15 -> 1.6.16

### DIFF
--- a/pkgs/tools/networking/nfdump/default.nix
+++ b/pkgs/tools/networking/nfdump/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, bzip2, yacc, flex }:
 
-let version = "1.6.15"; in
+let version = "1.6.16"; in
 
 stdenv.mkDerivation rec {
   name = "nfdump-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "phaag";
     repo = "nfdump";
     rev = "v${version}";
-    sha256 = "07grsfkfjy05yfqfcmgp5xpavpck9ps6q7x8x8j79fym5d8gwak5";
+    sha256 = "0dgrzf9m4rg5ygibjw21gjdm9am3570wys7wdh5k16nsnyai1gqm";
   };
 
   nativeBuildInputs = [yacc flex];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfcapd -h` got 0 exit code
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfcapd -V` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfcapd -h` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfdump -h` got 0 exit code
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfdump --help` got 0 exit code
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfdump -V` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfdump -v` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfdump --version` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfdump -h` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfdump --help` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfreplay -h` got 0 exit code
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfreplay --help` got 0 exit code
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfreplay -V` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfreplay -v` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfreplay --version` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfreplay -h` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfreplay --help` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfexpire -h` got 0 exit code
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfexpire -h` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfanon -h` got 0 exit code
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfanon --help` got 0 exit code
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfanon -V` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfanon -v` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfanon --version` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfanon -h` and found version 1.6.16
- ran `/nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16/bin/nfanon --help` and found version 1.6.16
- found 1.6.16 with grep in /nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16
- found 1.6.16 in filename of file in /nix/store/jddz0kmz55knai4a07m9c7awarb4zsq5-nfdump-1.6.16

cc "@takikawa"