### PR TITLE
nftables: 0.8 -> 0.8.2

### DIFF
--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -2,11 +2,11 @@
 , flex, bison, libmnl, libnftnl, gmp, readline }:
 
 stdenv.mkDerivation rec {
-  name = "nftables-0.8";
+  name = "nftables-0.8.2";
 
   src = fetchurl {
     url = "http://netfilter.org/projects/nftables/files/${name}.tar.bz2";
-    sha256 = "16iq9x0qxikdhp1nan500rk33ycqddl1k57876m4dfv3n7kqhnrz";
+    sha256 = "1v370wzh3fzby0cdb9iykkhdj1yjcp5qkp33xyn7w7pii2phlpv7";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ahcr1zyg4sp38rwch6vvvziwm9afj2ja-nftables-0.8.2/bin/nft -h` got 0 exit code
- ran `/nix/store/ahcr1zyg4sp38rwch6vvvziwm9afj2ja-nftables-0.8.2/bin/nft --help` got 0 exit code
- ran `/nix/store/ahcr1zyg4sp38rwch6vvvziwm9afj2ja-nftables-0.8.2/bin/nft -v` and found version 0.8.2
- ran `/nix/store/ahcr1zyg4sp38rwch6vvvziwm9afj2ja-nftables-0.8.2/bin/nft --version` and found version 0.8.2
- ran `/nix/store/ahcr1zyg4sp38rwch6vvvziwm9afj2ja-nftables-0.8.2/bin/nft -h` and found version 0.8.2
- ran `/nix/store/ahcr1zyg4sp38rwch6vvvziwm9afj2ja-nftables-0.8.2/bin/nft --help` and found version 0.8.2
- found 0.8.2 with grep in /nix/store/ahcr1zyg4sp38rwch6vvvziwm9afj2ja-nftables-0.8.2
- found 0.8.2 in filename of file in /nix/store/ahcr1zyg4sp38rwch6vvvziwm9afj2ja-nftables-0.8.2

cc "@wkennington"