### PR TITLE
nlohmann_json: 2.1.0 -> 3.1.1

### DIFF
--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "nlohmann_json-${version}";
-  version = "2.1.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "nlohmann";
     repo = "json";
     rev = "v${version}";
-    sha256 = "116309lx77m31x4krln0g7mra900g0knk9lbkxbpxnmamkagjyl9";
+    sha256 = "0s5xiyvnvxc2k0zkyb12mm5cwn61lavyxlfpknlx5f243g1xi6f6";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.1.1 with grep in /nix/store/4pydihqzddnsfmlc2zcn6qlwi7m2p1k1-nlohmann_json-3.1.1
- found 3.1.1 in filename of file in /nix/store/4pydihqzddnsfmlc2zcn6qlwi7m2p1k1-nlohmann_json-3.1.1