### PR TITLE
nomad: 0.6.2 -> 0.7.1

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/default.nix
+++ b/pkgs/applications/networking/cluster/nomad/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "nomad-${version}";
-  version = "0.6.2";
+  version = "0.7.1";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/nomad";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "hashicorp";
     repo = "nomad";
     inherit rev;
-    sha256 = "12bxqn7yldri5cwyxybd1lwg4c66mxd7g9syf54va5788c0hj8ij";
+    sha256 = "0hn80dqzxkwvk1zjk6px725mb2i3c06smqfj0yyjz96vgf7qbqy2";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/glm49diswdg3qi1vxpffqmdrzmkykvqj-nomad-0.7.1-bin/bin/nomad -h` got 0 exit code
- ran `/nix/store/glm49diswdg3qi1vxpffqmdrzmkykvqj-nomad-0.7.1-bin/bin/nomad --help` got 0 exit code
- ran `/nix/store/glm49diswdg3qi1vxpffqmdrzmkykvqj-nomad-0.7.1-bin/bin/nomad -v` and found version 0.7.1
- ran `/nix/store/glm49diswdg3qi1vxpffqmdrzmkykvqj-nomad-0.7.1-bin/bin/nomad --version` and found version 0.7.1
- ran `/nix/store/glm49diswdg3qi1vxpffqmdrzmkykvqj-nomad-0.7.1-bin/bin/nomad version` and found version 0.7.1
- found 0.7.1 with grep in /nix/store/glm49diswdg3qi1vxpffqmdrzmkykvqj-nomad-0.7.1-bin
- found 0.7.1 in filename of file in /nix/store/glm49diswdg3qi1vxpffqmdrzmkykvqj-nomad-0.7.1-bin

cc "@rushmorem @pradeepchhetri @ehmry @lethalman"