### PR TITLE
nq: 0.1 -> 0.2.2

### DIFF
--- a/pkgs/tools/system/nq/default.nix
+++ b/pkgs/tools/system/nq/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "nq-${version}";
-  version = "0.1";
+  version = "0.2.2";
   src = fetchFromGitHub {
     owner = "chneukirchen";
     repo = "nq";
     rev = "v${version}";
-    sha256 = "17n0yqhpsys3s872ki5rf82ky73ylahz6xi9x0rfrv7fqr5nzsz4";
+    sha256 = "0348r3j5y445psm8lj35z100cfvbfp05s7ji6bxd0gg4n66l2c4l";
   };
   makeFlags = "PREFIX=$(out)";
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/gfc63cqbz4z2fr3isin4lnchlgh0kwfm-nq-0.2.2/bin/nq help` got 0 exit code
- ran `/nix/store/gfc63cqbz4z2fr3isin4lnchlgh0kwfm-nq-0.2.2/bin/fq help` got 0 exit code
- ran `/nix/store/gfc63cqbz4z2fr3isin4lnchlgh0kwfm-nq-0.2.2/bin/tq help` got 0 exit code
- found 0.2.2 with grep in /nix/store/gfc63cqbz4z2fr3isin4lnchlgh0kwfm-nq-0.2.2
- found 0.2.2 in filename of file in /nix/store/gfc63cqbz4z2fr3isin4lnchlgh0kwfm-nq-0.2.2

cc "@cstrahan"