### PR TITLE
nsd: 4.1.19 -> 4.1.20

### DIFF
--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -15,11 +15,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "nsd-4.1.19";
+  name = "nsd-4.1.20";
 
   src = fetchurl {
     url = "http://www.nlnetlabs.nl/downloads/nsd/${name}.tar.gz";
-    sha256 = "1i82kvgxv4vz79dqd0ckz6syr1fdf6q60r4b926qh5klnnwjqy5h";
+    sha256 = "04zph9zli3a0zx1sfphwbxx6f8whdxcjai6w0k7a565vgcfzd5wa";
   };
 
   prePatch = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/4za086gx5nlvf44i0syc2y6lprhh49kz-nsd-4.1.20/bin/nsd -h` got 0 exit code
- ran `/nix/store/4za086gx5nlvf44i0syc2y6lprhh49kz-nsd-4.1.20/bin/nsd -v` and found version 4.1.20
- ran `/nix/store/4za086gx5nlvf44i0syc2y6lprhh49kz-nsd-4.1.20/bin/nsd -h` and found version 4.1.20
- ran `/nix/store/4za086gx5nlvf44i0syc2y6lprhh49kz-nsd-4.1.20/bin/nsd-checkzone -h` got 0 exit code
- ran `/nix/store/4za086gx5nlvf44i0syc2y6lprhh49kz-nsd-4.1.20/bin/nsd-checkzone -h` and found version 4.1.20
- found 4.1.20 with grep in /nix/store/4za086gx5nlvf44i0syc2y6lprhh49kz-nsd-4.1.20
- found 4.1.20 in filename of file in /nix/store/4za086gx5nlvf44i0syc2y6lprhh49kz-nsd-4.1.20

cc "@hrdinka"