### PR TITLE
nss_wrapper: 1.0.3 -> 1.1.3

### DIFF
--- a/pkgs/development/libraries/nss_wrapper/default.nix
+++ b/pkgs/development/libraries/nss_wrapper/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "nss_wrapper-1.0.3";
+  name = "nss_wrapper-1.1.3";
 
   src = fetchurl {
     url = "mirror://samba/cwrap/${name}.tar.gz";
-    sha256 = "0bysdijvi9n0jk74iklbfhbp0kvv81a727lcfd5q03q2hkzjfm18";
+    sha256 = "18rsaw8r8xwn5003arc7xw8iliwbmzxfxgacmp6lhsdwqla4rf69";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.1.3 with grep in /nix/store/bd1rzjn4xykl4pqdcv2klym37sc7kbgb-nss_wrapper-1.1.3
- found 1.1.3 in filename of file in /nix/store/bd1rzjn4xykl4pqdcv2klym37sc7kbgb-nss_wrapper-1.1.3

cc "@wkennington"