### PR TITLE
nxproxy: 3.5.0.32 -> 3.5.0.33

### DIFF
--- a/pkgs/tools/admin/nxproxy/default.nix
+++ b/pkgs/tools/admin/nxproxy/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "nxproxy-${version}";
-  version = "3.5.0.32";
+  version = "3.5.0.33";
 
   src = fetchurl {
-    sha256 = "02n5bdc1jsq999agb4w6dmdj5l2wlln2lka84qz6rpswwc59zaxm";
+    sha256 = "17qjsd6v2ldpfmyjrkdnlq4qk05hz5l6qs54g8h0glzq43w28f74";
     url = "http://code.x2go.org/releases/source/nx-libs/nx-libs-${version}-lite.tar.gz";
   };
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/0q7isf3b9x0yan8dpzmm6qch9cdp95mn-nxproxy-3.5.0.33/bin/nxproxy -h` got 0 exit code
- ran `/nix/store/0q7isf3b9x0yan8dpzmm6qch9cdp95mn-nxproxy-3.5.0.33/bin/nxproxy --help` got 0 exit code
- ran `/nix/store/0q7isf3b9x0yan8dpzmm6qch9cdp95mn-nxproxy-3.5.0.33/bin/nxproxy help` got 0 exit code
- ran `/nix/store/0q7isf3b9x0yan8dpzmm6qch9cdp95mn-nxproxy-3.5.0.33/bin/nxproxy -v` and found version 3.5.0.33
- found 3.5.0.33 with grep in /nix/store/0q7isf3b9x0yan8dpzmm6qch9cdp95mn-nxproxy-3.5.0.33
- found 3.5.0.33 in filename of file in /nix/store/0q7isf3b9x0yan8dpzmm6qch9cdp95mn-nxproxy-3.5.0.33
