### PR TITLE
ola: 0.10.5 -> 0.10.6

### DIFF
--- a/pkgs/applications/misc/ola/default.nix
+++ b/pkgs/applications/misc/ola/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "ola-${version}";
-  version = "0.10.5";
+  version = "0.10.6";
 
   src = fetchFromGitHub {
     owner = "OpenLightingProject";
     repo = "ola";
     rev = version;
-    sha256 = "1296iiq8fxbvv8sghpj3nambfmixps48dd77af0gpwf7hmjjm8al";
+    sha256 = "1qazhkcakvzkf1dvav0alk33aaklawf8vckgwpf6fvwf7g2kyh63";
   };
 
   nativeBuildInputs = [ autoreconfHook bison flex pkgconfig perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_dev_info -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_dev_info --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_dev_info -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_dev_info --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_rdm_discover -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_rdm_discover --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_rdm_discover -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_rdm_discover --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_rdm_discover -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_rdm_discover --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_recorder help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_streaming_client -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_streaming_client --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_streaming_client -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_streaming_client --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_streaming_client -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_streaming_client --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_timecode -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_timecode --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_timecode -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_timecode --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_timecode -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_timecode --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_uni_stats -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_uni_stats --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_uni_stats -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_uni_stats --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_uni_stats -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_uni_stats --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_e131 -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_e131 --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_e131 -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_e131 --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_e131 -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_e131 --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_usbpro -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_usbpro --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_usbpro -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_usbpro --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_usbpro -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_usbpro --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_artnet -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_artnet --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_artnet -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_artnet --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_artnet -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_artnet --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/olad -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/olad --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/olad -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/olad --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/olad -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/olad --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_trigger -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_trigger --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_trigger -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_trigger --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_trigger -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/ola_trigger --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/usbpro_firmware -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/usbpro_firmware --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/usbpro_firmware -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/usbpro_firmware --help` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/rdmpro_sniffer -h` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/rdmpro_sniffer --help` got 0 exit code
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/rdmpro_sniffer -v` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/rdmpro_sniffer --version` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/rdmpro_sniffer -h` and found version 0.10.6
- ran `/nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6/bin/rdmpro_sniffer --help` and found version 0.10.6
- found 0.10.6 with grep in /nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6
- found 0.10.6 in filename of file in /nix/store/vsgqasz32h5fmhmka4s357yf5341bmh0-ola-0.10.6

cc "@globin"