### PR TITLE
omniorb: 4.2.0 -> 4.2.2

### DIFF
--- a/pkgs/development/tools/omniorb/default.nix
+++ b/pkgs/development/tools/omniorb/default.nix
@@ -3,11 +3,11 @@ stdenv.mkDerivation rec {
 
   name = "omniorb-${version}";
 
-  version = "4.2.0";
+  version = "4.2.2";
 
   src = fetchurl rec {
     url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
-    sha256 = "1g58xcw4641wyisp9wscrkzaqrz0vf123dgy52qq2a3wk7y77hkl";
+    sha256 = "1klf6ivhsisdnqxcbf161jxva0xzmfgmwypnxfzf4jq16770knfx";
   };
 
   buildInputs = [ python2 ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/h94k1a3vvna29as5663ch6vffml5p07w-omniorb-4.2.2/bin/omniidl -h` got 0 exit code
- ran `/nix/store/h94k1a3vvna29as5663ch6vffml5p07w-omniorb-4.2.2/bin/omkdepend -h` got 0 exit code
- ran `/nix/store/h94k1a3vvna29as5663ch6vffml5p07w-omniorb-4.2.2/bin/omkdepend --help` got 0 exit code
- ran `/nix/store/h94k1a3vvna29as5663ch6vffml5p07w-omniorb-4.2.2/bin/omniNames --help` got 0 exit code
- found 4.2.2 with grep in /nix/store/h94k1a3vvna29as5663ch6vffml5p07w-omniorb-4.2.2
- found 4.2.2 in filename of file in /nix/store/h94k1a3vvna29as5663ch6vffml5p07w-omniorb-4.2.2

cc "@smironov"