### PR TITLE
opencollada: 1.6.59 -> 1.6.62

### DIFF
--- a/pkgs/development/libraries/opencollada/default.nix
+++ b/pkgs/development/libraries/opencollada/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "opencollada-${version}";
 
-  version = "1.6.59";
+  version = "1.6.62";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCOLLADA";
     rev = "v${version}";
-    sha256 = "0gpjvzcfyilb96x5ywajxgkw42ipwp4my36z9cq686bd9vpp3q0g";
+    sha256 = "0bqki6sdvxsp9drzj87ma6n7m98az9pr0vyxhgw8b8b9knk8c48r";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.6.62 with grep in /nix/store/4ss521i0480p31fgmlqkv4rcrrfv8zw2-opencollada-1.6.62
- found 1.6.62 in filename of file in /nix/store/4ss521i0480p31fgmlqkv4rcrrfv8zw2-opencollada-1.6.62

cc "@eelco"