### PR TITLE
opencsg: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/development/libraries/opencsg/default.nix
+++ b/pkgs/development/libraries/opencsg/default.nix
@@ -2,11 +2,11 @@
   }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.0";
+  version = "1.4.2";
   name = "opencsg-${version}";
   src = fetchurl {
     url = "http://www.opencsg.org/OpenCSG-${version}.tar.gz";
-    sha256 = "13c73jxadm27h7spdh3qj1v6rnn81v4xwqlv5a6k72pv9kjnpd7c";
+    sha256 = "1ysazynm759gnw1rdhn9xw9nixnzrlzrc462340a6iif79fyqlnr";
   };
 
   buildInputs = [mesa freeglut glew libXmu libXext libX11];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.4.2 with grep in /nix/store/g48a1pwdycdlx5q4ayxgdyhw1jqp6mn7-opencsg-1.4.2
- found 1.4.2 in filename of file in /nix/store/g48a1pwdycdlx5q4ayxgdyhw1jqp6mn7-opencsg-1.4.2

cc "@raskin"