### PR TITLE
opendht: 1.3.4 -> 1.5.0

### DIFF
--- a/pkgs/development/libraries/opendht/default.nix
+++ b/pkgs/development/libraries/opendht/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   name = "opendht-${version}";
-  version = "1.3.4";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "savoirfairelinux";
     repo = "opendht";
     rev = "${version}";
-    sha256 = "0karj37f0zq39w0ip8ahrjr6lcrrn9jd6bpzylp1m92jzs8pfki8";
+    sha256 = "0zkxvs3vdlc4yzhfi2jh02bsnhh50fbfigqhnkmbx69lssnkyr05";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtnode -h` got 0 exit code
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtnode --help` got 0 exit code
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtchat -h` got 0 exit code
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtchat --help` got 0 exit code
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtscanner -h` got 0 exit code
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtscanner --help` got 0 exit code
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtscanner help` got 0 exit code
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtscanner -V` and found version 1.5.0
- ran `/nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0/bin/dhtscanner --version` and found version 1.5.0
- found 1.5.0 with grep in /nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0
- found 1.5.0 in filename of file in /nix/store/204499k26yrbhl1mq7spslsc5fvmb81b-opendht-1.5.0

cc "@taeer @olynch"