### PR TITLE
openfortivpn: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/tools/networking/openfortivpn/default.nix
+++ b/pkgs/tools/networking/openfortivpn/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 let repo = "openfortivpn";
-    version = "1.5.0";
+    version = "1.6.0";
 
 in stdenv.mkDerivation {
   name = "${repo}-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "adrienverge";
     inherit repo;
     rev = "v${version}";
-    sha256 = "0fm0z73afghwmbshpsn5jfbyyfzz1v8s7scwycnvsk2cgv5f4r86";
+    sha256 = "0ca80i8m88f4vhwiq548wjyqwwszpbap92l83bl0wdppvp4nk192";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0/bin/openfortivpn -h` got 0 exit code
- ran `/nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0/bin/openfortivpn --help` got 0 exit code
- ran `/nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0/bin/openfortivpn help` got 0 exit code
- ran `/nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0/bin/openfortivpn -v` and found version 1.6.0
- ran `/nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0/bin/openfortivpn --version` and found version 1.6.0
- ran `/nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0/bin/openfortivpn -h` and found version 1.6.0
- ran `/nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0/bin/openfortivpn --help` and found version 1.6.0
- found 1.6.0 with grep in /nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0
- found 1.6.0 in filename of file in /nix/store/wj4dlazd3lk41w7865iyl082s5pk6g2a-openfortivpn-1.6.0

cc "@madjar"