### PR TITLE
openimageio: 1.7.17 -> 1.8.8

### DIFF
--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "openimageio-${version}";
-  version = "1.7.17";
+  version = "1.8.8";
 
   src = fetchFromGitHub {
     owner = "OpenImageIO";
     repo = "oiio";
     rev = "Release-${version}";
-    sha256 = "0vx2pndgyfbnziwn36aylvq4jd889dvibzhw9ajzkm378l43lly9";
+    sha256 = "1jn4ph7giwxr65xxbm59i03wywnmxkqnpvqp0kcajl4k48vq3wkr";
   };
 
   outputs = [ "bin" "out" "dev" "doc" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/fmwizi71ki95gjzqrbcc64zspg3xik6d-openimageio-1.8.8-bin/bin/iinfo help` got 0 exit code
- ran `/nix/store/fmwizi71ki95gjzqrbcc64zspg3xik6d-openimageio-1.8.8-bin/bin/maketx -v` and found version 1.8.8
- ran `/nix/store/fmwizi71ki95gjzqrbcc64zspg3xik6d-openimageio-1.8.8-bin/bin/oiiotool --help` got 0 exit code
- ran `/nix/store/fmwizi71ki95gjzqrbcc64zspg3xik6d-openimageio-1.8.8-bin/bin/oiiotool --help` and found version 1.8.8
- found 1.8.8 with grep in /nix/store/fmwizi71ki95gjzqrbcc64zspg3xik6d-openimageio-1.8.8-bin
- found 1.8.8 in filename of file in /nix/store/fmwizi71ki95gjzqrbcc64zspg3xik6d-openimageio-1.8.8-bin

cc "@goibhniu"