### PR TITLE
openntpd: 6.2p1 -> 6.2p3

### DIFF
--- a/pkgs/tools/networking/openntpd/default.nix
+++ b/pkgs/tools/networking/openntpd/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "openntpd-${version}";
-  version = "6.2p1";
+  version = "6.2p3";
 
   src = fetchurl {
     url = "mirror://openbsd/OpenNTPD/${name}.tar.gz";
-    sha256 = "1g6hi03ylhv47sbar3xxgsrar8schqfwn4glckh6m6lni67ndq85";
+    sha256 = "0fn12i4kzsi0zkr4qp3dp9bycmirnfapajqvdfx02zhr4hanj0kv";
   };
 
   prePatch = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 6.2p3 in filename of file in /nix/store/1f3fs4fxlnx749gqcmlwjg1ifc67q5jp-openntpd-6.2p3

cc "@wkennington"