### PR TITLE
openshot-qt: 2.3.4 -> 2.4.1

### DIFF
--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -4,13 +4,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "openshot-qt-${version}";
-  version = "2.3.4";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "openshot-qt";
     rev = "v${version}";
-    sha256 = "026zxvg5mij49g021hipv3hspsx8m5bs4v9pm2axqw6rvszjk90z";
+    sha256 = "182dldj9ybs6aqjfrc9dqx1mifdyhv0rf3ifxcp52cm9rz5yv8ml";
   };
 
   nativeBuildInputs = [ doxygen wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/v3kr4pyvqih44nkanbcs50574wz6gjcv-openshot-qt-2.4.1/bin/openshot-qt --version` and found version 2.4.1
- ran `/nix/store/v3kr4pyvqih44nkanbcs50574wz6gjcv-openshot-qt-2.4.1/bin/..openshot-qt-wrapped-wrapped --version` and found version 2.4.1
- ran `/nix/store/v3kr4pyvqih44nkanbcs50574wz6gjcv-openshot-qt-2.4.1/bin/.openshot-qt-wrapped --version` and found version 2.4.1
- found 2.4.1 with grep in /nix/store/v3kr4pyvqih44nkanbcs50574wz6gjcv-openshot-qt-2.4.1

cc "@AndersonTorres"