### PR TITLE
openspades: 0.1.1b -> 0.1.2

### DIFF
--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -5,14 +5,14 @@
 
 stdenv.mkDerivation rec {
   name = "openspades-${version}";
-  version = "0.1.1b";
+  version = "0.1.2";
   devPakVersion = "33";
 
   src = fetchFromGitHub {
     owner = "yvt";
     repo = "openspades";
     rev = "v${version}";
-    sha256 = "1xk3il5ykxg68hvwb42kpspcxppdib7y3ysaxb8anmmcsk1m3drn";
+    sha256 = "1mfj46c3pnn1f6awy3b6faxs26i93a5jsrvkdlr12ndsykvi6ng6";
   };
 
   nativeBuildInputs = [ cmake imagemagick unzip zip file ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades -h` got 0 exit code
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades --help` got 0 exit code
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades help` got 0 exit code
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades -V` and found version 0.1.2
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades -v` and found version 0.1.2
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades --version` and found version 0.1.2
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades version` and found version 0.1.2
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades -h` and found version 0.1.2
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades --help` and found version 0.1.2
- ran `/nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2/bin/openspades help` and found version 0.1.2
- found 0.1.2 with grep in /nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2
- found 0.1.2 in filename of file in /nix/store/8s6lwg583x8867mjc29znp9a1cdiqdri-openspades-0.1.2
