### PR TITLE
openspecfun: 0.4 -> 0.5.3

### DIFF
--- a/pkgs/development/libraries/science/math/openspecfun/default.nix
+++ b/pkgs/development/libraries/science/math/openspecfun/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, gfortran }:
 
 stdenv.mkDerivation {
-  name = "openspecfun-0.4";
+  name = "openspecfun-0.5.3";
   src = fetchurl {
-    url = "https://github.com/JuliaLang/openspecfun/archive/v0.4.tar.gz";
-    sha256 = "0nsa3jjmlhcqkw5ba5ypbn3n0c8b6lc22zzlxnmxkxi9shhdx65z";
+    url = "https://github.com/JuliaLang/openspecfun/archive/v0.5.3.tar.gz";
+    sha256 = "1rs1bv8jq751fv9vq79890wqf9xlbjc7lvz3ighzyfczbyjcf18m";
   };
 
   makeFlags = [ "prefix=$(out)" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.5.3 in filename of file in /nix/store/yqsgs9hw8c3rdia75rswgk98lz3c52ih-openspecfun-0.5.3

cc "@ttuegel"