### PR TITLE
openvdb: 4.0.2 -> 5.0.0

### DIFF
--- a/pkgs/development/libraries/openvdb/default.nix
+++ b/pkgs/development/libraries/openvdb/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec
 {
   name = "openvdb-${version}";
-  version = "4.0.2";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "dreamworksanimation";
     repo = "openvdb";
     rev = "v${version}";
-    sha256 = "0kqlsfa9rdpxpw7v61vfknvs11axh196ilqk6bnyyfkslmmcak45";
+    sha256 = "162l1prgdyf571bgxc621gicl40b050ny64f0jmnhz0h5xq6sfrv";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 5.0.0 with grep in /nix/store/6shm8j674fk7290pb838wy9df9r42ydh-openvdb-5.0.0
- found 5.0.0 in filename of file in /nix/store/6shm8j674fk7290pb838wy9df9r42ydh-openvdb-5.0.0

cc "@guibou"