### PR TITLE
ostinato: 0.8 -> 0.9

### DIFF
--- a/pkgs/applications/networking/ostinato/default.nix
+++ b/pkgs/applications/networking/ostinato/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name    = "ostinato-${version}";
-  version = "0.8";
+  version = "0.9";
 
   src = fetchFromGitHub  {
     owner  = "pstavirs";
     repo   = "ostinato";
     rev    = "v${version}";
-    sha256 = "1b5a5gypcy9i03mj6md3lkrq05rqmdyhfykrr1z0sv8n3q48xca3";
+    sha256 = "109gxj6djdsk7rp1nxpx39kfi75xfl9p9qgffh1cpcdpbsbvq5bx";
   };
 
   ostinatoIcon = fetchurl {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.9 with grep in /nix/store/k19kx1lh4211srqcgnrwq7yfkvqclf9m-ostinato-0.9
- found 0.9 in filename of file in /nix/store/k19kx1lh4211srqcgnrwq7yfkvqclf9m-ostinato-0.9

cc "@rick68"