### PR TITLE
padthv1: 0.8.5 -> 0.8.6

### DIFF
--- a/pkgs/applications/audio/padthv1/default.nix
+++ b/pkgs/applications/audio/padthv1/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "padthv1-${version}";
-  version = "0.8.5";
+  version = "0.8.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/padthv1/${name}.tar.gz";
-    sha256 = "0dyrllxgd74nknixjcz6n7m4gw70v246s8z1qss7zfl5yllhb712";
+    sha256 = "1mikab2f9n5q1sfgnp3sbm1rf3v57k4085lsgh0a5gzga2h4hwxq";
   };
 
   buildInputs = [ libjack2 alsaLib libsndfile liblo lv2 qt5.qtbase qt5.qttools fftw ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.8.6 with grep in /nix/store/qym51fhm41wgvcfjx3r36n9ldh5y25qv-padthv1-0.8.6
- found 0.8.6 in filename of file in /nix/store/qym51fhm41wgvcfjx3r36n9ldh5y25qv-padthv1-0.8.6

cc "@magnetophon"