### PR TITLE
pagemon: 0.01.10 -> 0.01.12

### DIFF
--- a/pkgs/os-specific/linux/pagemon/default.nix
+++ b/pkgs/os-specific/linux/pagemon/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "pagemon-${version}";
-  version = "0.01.10";
+  version = "0.01.12";
 
   src = fetchFromGitHub {
-    sha256 = "04dbcr7bzgp4kvhw1rsn084cz4qbfhf7ifyh3ikgdka9w98057h1";
+    sha256 = "0bddn22daf33dbghwfjxxgsn4gmr5knr6h9sbqhs7g7p85dla6wa";
     rev = "V${version}";
     repo = "pagemon";
     owner = "ColinIanKing";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/kayj1xp8j8dd280y98rajpmqh0sgmg8n-pagemon-0.01.12/bin/pagemon -h` got 0 exit code
- ran `/nix/store/kayj1xp8j8dd280y98rajpmqh0sgmg8n-pagemon-0.01.12/bin/pagemon -h` and found version 0.01.12
- found 0.01.12 with grep in /nix/store/kayj1xp8j8dd280y98rajpmqh0sgmg8n-pagemon-0.01.12
- found 0.01.12 in filename of file in /nix/store/kayj1xp8j8dd280y98rajpmqh0sgmg8n-pagemon-0.01.12