### PR TITLE
pam_mount: 2.15 -> 2.16

### DIFF
--- a/pkgs/os-specific/linux/pam_mount/default.nix
+++ b/pkgs/os-specific/linux/pam_mount/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoconf, automake, pkgconfig, libtool, pam, libHX, libxml2, pcre, perl, openssl, cryptsetup, utillinux }:
 
 stdenv.mkDerivation rec {
-  name = "pam_mount-2.15";
+  name = "pam_mount-2.16";
 
   src = fetchurl {
-    url = "mirror://sourceforge/pam-mount/pam_mount/2.15/${name}.tar.xz";
-    sha256 = "091aq5zyc60wh21m1ryanjwknwxlaj9nvlswn5vjrmcdir5gnkm5";
+    url = "mirror://sourceforge/pam-mount/pam_mount/2.16/${name}.tar.xz";
+    sha256 = "1rvi4irb7ylsbhvx1cr6islm2xxw1a4b19q6z4a9864ndkm0f0mf";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ylk3vdmg5vk7c21fxg54yvrclvj5cpx1-pam_mount-2.16/bin/mount.crypt --help` got 0 exit code
- ran `/nix/store/ylk3vdmg5vk7c21fxg54yvrclvj5cpx1-pam_mount-2.16/bin/mount.crypt --help` and found version 2.16
- ran `/nix/store/ylk3vdmg5vk7c21fxg54yvrclvj5cpx1-pam_mount-2.16/bin/pmt-ehd --help` got 0 exit code
- ran `/nix/store/ylk3vdmg5vk7c21fxg54yvrclvj5cpx1-pam_mount-2.16/bin/pmt-ehd --help` and found version 2.16
- ran `/nix/store/ylk3vdmg5vk7c21fxg54yvrclvj5cpx1-pam_mount-2.16/bin/pmvarrun -h` got 0 exit code
- found 2.16 with grep in /nix/store/ylk3vdmg5vk7c21fxg54yvrclvj5cpx1-pam_mount-2.16
- found 2.16 in filename of file in /nix/store/ylk3vdmg5vk7c21fxg54yvrclvj5cpx1-pam_mount-2.16

cc "@tstrobel"