### PR TITLE
pamixer: 1.3 -> 1.3.1

### DIFF
--- a/pkgs/applications/audio/pamixer/default.nix
+++ b/pkgs/applications/audio/pamixer/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   name = "pamixer-${version}";
-  version = "1.3";
+  version = "1.3.1";
 
   src = fetchurl {
     url = "https://github.com/cdemoulins/pamixer/archive/${version}.tar.gz";
-    sha256 = "091676ww4jbf4jr728gjfk7fkd5nisy70mr6f3s1p7n05hjpmfjx";
+    sha256 = "1lsvb4xk1dq762w9c0jn7xvj3v1lzppql9mj1b55fhzdypbrkm6x";
   };
 
   buildInputs = [ boost libpulseaudio ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/8979bf7x9s5dk9la9j1lnnvc8s7dkxim-pamixer-1.3.1/bin/pamixer -h` got 0 exit code
- ran `/nix/store/8979bf7x9s5dk9la9j1lnnvc8s7dkxim-pamixer-1.3.1/bin/pamixer --help` got 0 exit code
- ran `/nix/store/8979bf7x9s5dk9la9j1lnnvc8s7dkxim-pamixer-1.3.1/bin/pamixer help` got 0 exit code
- found 1.3.1 in filename of file in /nix/store/8979bf7x9s5dk9la9j1lnnvc8s7dkxim-pamixer-1.3.1
