### PR TITLE
par2cmdline: 0.7.3 -> 0.8.0

### DIFF
--- a/pkgs/tools/networking/par2cmdline/default.nix
+++ b/pkgs/tools/networking/par2cmdline/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name    = "par2cmdline-${version}";
-  version = "0.7.3";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "Parchive";
     repo = "par2cmdline";
     rev = "v${version}";
-    sha256 = "1hkb1brz70p79rv7dlzhnl1invjmkll81rcpnhwvafv1yriklfai";
+    sha256 = "0f1jsd5sw2wynjzi7yjqjaf13yhyjfdid91p8yh0jn32y03kjyrz";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/j0cc1ys2lb4hxa5zqcq2a43pkaii585d-par2cmdline-0.8.0/bin/par2 -h` got 0 exit code
- ran `/nix/store/j0cc1ys2lb4hxa5zqcq2a43pkaii585d-par2cmdline-0.8.0/bin/par2 --help` got 0 exit code
- ran `/nix/store/j0cc1ys2lb4hxa5zqcq2a43pkaii585d-par2cmdline-0.8.0/bin/par2 -V` and found version 0.8.0
- found 0.8.0 with grep in /nix/store/j0cc1ys2lb4hxa5zqcq2a43pkaii585d-par2cmdline-0.8.0
- found 0.8.0 in filename of file in /nix/store/j0cc1ys2lb4hxa5zqcq2a43pkaii585d-par2cmdline-0.8.0

cc "@muflax"