### PR TITLE
pari: 2.9.3 -> 2.9.4

### DIFF
--- a/pkgs/applications/science/math/pari/default.nix
+++ b/pkgs/applications/science/math/pari/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
 
   name = "pari-${version}";
-  version = "2.9.3";
+  version = "2.9.4";
 
   src = fetchurl {
     url = "http://pari.math.u-bordeaux.fr/pub/pari/unix/${name}.tar.gz";
-    sha256 = "0qqal1lpggd6dvs19svnz0dil86xk0xkcj5s3b7104ibkmvjfsp7";
+    sha256 = "0ir6m3a8r46md5x6zk4xf159qra7aqparby9zk03k81hjrrxr72g";
   };
 
   buildInputs = [ gmp readline libX11 libpthreadstubs tex perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/tex2mail help` got 0 exit code
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gphelp --help` got 0 exit code
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gphelp help` got 0 exit code
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gp-2.9 -h` got 0 exit code
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gp-2.9 --help` got 0 exit code
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gp-2.9 -V` and found version 2.9.4
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gp-2.9 -v` and found version 2.9.4
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gp-2.9 --version` and found version 2.9.4
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gp-2.9 -h` and found version 2.9.4
- ran `/nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4/bin/gp-2.9 --help` and found version 2.9.4
- found 2.9.4 with grep in /nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4
- found 2.9.4 in filename of file in /nix/store/v2rvjr4kl79kmn1w70lj7zf0dz00p3mf-pari-2.9.4

cc "@ertes @raskin @AndersonTorres"