### PR TITLE
pastebinit: 1.4.1 -> 1.5

### DIFF
--- a/pkgs/tools/misc/pastebinit/default.nix
+++ b/pkgs/tools/misc/pastebinit/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, python3 }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.1";
+  version = "1.5";
   name = "pastebinit-${version}";
 
   src = fetchurl {
     url = "https://launchpad.net/pastebinit/trunk/${version}/+download/${name}.tar.bz2";
-    sha256 = "1rl854izwn1fpaaib6zj7a1a9bis8n7w4zfxcapgfffj37zj0dy2";
+    sha256 = "0mw48fgm9lyh9d3pw997fccmglzsjccf2y347gxjas74wx6aira2";
   };
 
   buildInputs = [ python3 ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/5jkp246zcc0k7lbrkngsr005brnf3giy-pastebinit-1.5/bin/pastebinit -h` got 0 exit code
- ran `/nix/store/5jkp246zcc0k7lbrkngsr005brnf3giy-pastebinit-1.5/bin/pastebinit -v` and found version 1.5
- ran `/nix/store/5jkp246zcc0k7lbrkngsr005brnf3giy-pastebinit-1.5/bin/pastebinit -h` and found version 1.5
- found 1.5 with grep in /nix/store/5jkp246zcc0k7lbrkngsr005brnf3giy-pastebinit-1.5
- found 1.5 in filename of file in /nix/store/5jkp246zcc0k7lbrkngsr005brnf3giy-pastebinit-1.5

cc "@lethalman"