### PR TITLE
pcapfix: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/tools/networking/pcapfix/default.nix
+++ b/pkgs/tools/networking/pcapfix/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "pcapfix-1.1.0";
+  name = "pcapfix-1.1.1";
 
   src = fetchurl {
     url = "https://f00l.de/pcapfix/${name}.tar.gz";
-    sha256 = "025jpsqav9wg9lql7jfpd67z1113j8gzmjc5nqf5q07b01nnpfgj";
+    sha256 = "07dfgl99iv88mgpnpfcb9y7h0zjq9fcf4sp5s7d0d3d5a5sshjay";
   };
 
   postPatch = ''sed -i "s|/usr|$out|" Makefile'';


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.1.1 with grep in /nix/store/bri5ks0ab6lf6plcklwlqanf271w0rlw-pcapfix-1.1.1
- found 1.1.1 in filename of file in /nix/store/bri5ks0ab6lf6plcklwlqanf271w0rlw-pcapfix-1.1.1

cc "@ehmry"