### PR TITLE
peco: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/tools/text/peco/default.nix
+++ b/pkgs/tools/text/peco/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "peco-${version}";
-  version = "0.5.1";
+  version = "0.5.2";
 
   goPackagePath = "github.com/peco/peco";
   subPackages = [ "cmd/peco" ];
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "peco";
     repo = "peco";
     rev = "v${version}";
-    sha256 = "0jnlpr3nxx8xmjb6w4jlwshzz0p9hlww9919qbkm66afv16k0vm8";
+    sha256 = "0cgfwbnz4jp2nvmqf2i03xf69by8g0xgd3k5k9aj46y9hps1ka92";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/57j66n7s9hxkrgbzvgxvrbvab1ipgakz-peco-0.5.2-bin/bin/peco -h` got 0 exit code
- ran `/nix/store/57j66n7s9hxkrgbzvgxvrbvab1ipgakz-peco-0.5.2-bin/bin/peco --help` got 0 exit code
- ran `/nix/store/57j66n7s9hxkrgbzvgxvrbvab1ipgakz-peco-0.5.2-bin/bin/peco --version` and found version 0.5.2
- found 0.5.2 with grep in /nix/store/57j66n7s9hxkrgbzvgxvrbvab1ipgakz-peco-0.5.2-bin
- found 0.5.2 in filename of file in /nix/store/57j66n7s9hxkrgbzvgxvrbvab1ipgakz-peco-0.5.2-bin

cc "@ehmry @lethalman"