### PR TITLE
peek: 1.2.0 -> 1.2.2

### DIFF
--- a/pkgs/applications/video/peek/default.nix
+++ b/pkgs/applications/video/peek/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "peek-${version}";
-  version = "1.2.0";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "phw";
     repo = "peek";
     rev = version;
-    sha256 = "04sc6gfrqvnx288rmgsywpjx9l6jcfn2qdbwjcbdvx4wl3gna0qm";
+    sha256 = "1ihmq914g2h5iw86bigkkblzqimr50yq6z883lzq656xkcayd8gh";
   };
 
   nativeBuildInputs = [ cmake gettext pkgconfig libxml2.bin txt2man vala wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2/bin/peek -h` got 0 exit code
- ran `/nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2/bin/peek --help` got 0 exit code
- ran `/nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2/bin/peek -v` and found version 1.2.2
- ran `/nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2/bin/peek --version` and found version 1.2.2
- ran `/nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2/bin/.peek-wrapped -h` got 0 exit code
- ran `/nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2/bin/.peek-wrapped --help` got 0 exit code
- ran `/nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2/bin/.peek-wrapped -v` and found version 1.2.2
- ran `/nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2/bin/.peek-wrapped --version` and found version 1.2.2
- found 1.2.2 with grep in /nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2
- found 1.2.2 in filename of file in /nix/store/yliisdhqdlkyp3l95as34c04j45z5j87-peek-1.2.2

cc "@puffnfresh"