### PR TITLE
peru: 1.1.0 -> 1.1.3

### DIFF
--- a/pkgs/applications/version-management/peru/default.nix
+++ b/pkgs/applications/version-management/peru/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "peru-${version}";
-  version = "1.1.0";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "buildinspace";
     repo = "peru";
     rev = "${version}";
-    sha256 = "0hvp6pvpsz0f98az4f1wl93gqlz6wj24pjnc5zs1har9rqlpq8y8";
+    sha256 = "02kr3ib3ppbmcsjy8i8z41vp9gw9gdivy2l5aps12lmaa3rc6727";
   };
 
   propagatedBuildInputs = with python3Packages; [ pyyaml docopt ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3/bin/.peru-wrapped -h` got 0 exit code
- ran `/nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3/bin/.peru-wrapped --help` got 0 exit code
- ran `/nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3/bin/.peru-wrapped help` got 0 exit code
- ran `/nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3/bin/.peru-wrapped --version` and found version 1.1.3
- ran `/nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3/bin/peru -h` got 0 exit code
- ran `/nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3/bin/peru --help` got 0 exit code
- ran `/nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3/bin/peru help` got 0 exit code
- ran `/nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3/bin/peru --version` and found version 1.1.3
- found 1.1.3 with grep in /nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3
- found 1.1.3 in filename of file in /nix/store/am3inbmcx4clhav76xvryzy9bs2laiwb-peru-1.1.3
