### PR TITLE
petsc: 3.7.6 -> 3.8.3

### DIFF
--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   name = "petsc-${version}";
-  version = "3.7.6";
+  version = "3.8.3";
 
   src = fetchurl {
     url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${version}.tar.gz";
-    sha256 = "0jfl35lrhzvv982z6h1v5rcp39g0x16ca43rm9dx91wm6i8y13iw";
+    sha256 = "1b1yr93g6df8kx10ri2y26bp3l3w3jv10r80krnarbvyjgnw7y81";
   };
 
   nativeBuildInputs = [ blas gfortran.cc.lib liblapack python ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/saws/getSAWs.bash -h` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/saws/getSAWs.bash --help` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/saws/getSAWs.bash help` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py -h` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py --help` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py help` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py -V` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py -v` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py --version` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py version` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py -h` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py --help` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/update.py help` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/petscnagupgrade.py -h` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/petscnagupgrade.py --help` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/petscnagupgrade.py help` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/sendToJenkins -h` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/sendToJenkins --help` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/sendToJenkins -h` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/sendToJenkins --help` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/petscdiff -h` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/petscdiff --help` got 0 exit code
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/petscdiff -h` and found version 3.8.3
- ran `/nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3/bin/petscdiff --help` and found version 3.8.3
- found 3.8.3 with grep in /nix/store/fgr3yvhrnvfhr0czc4ygx1mnjsrv4f4i-petsc-3.8.3
