### PR TITLE
pew: 1.1.0 -> 1.1.2

### DIFF
--- a/pkgs/development/tools/pew/default.nix
+++ b/pkgs/development/tools/pew/default.nix
@@ -2,11 +2,11 @@
 with python3Packages; buildPythonApplication rec {
     name = "${pname}-${version}";
     pname = "pew";
-    version = "1.1.0";
+    version = "1.1.2";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0b8z1vjsll1kgnh3mmdjps5rr9gayy091rapp2dra71jrwkx3yfh";
+      sha256 = "04anak82p4v9w0lgfs55s7diywxil6amq8c8bhli143ca8l2fcdq";
     };
 
     propagatedBuildInputs = [ virtualenv virtualenv-clone setuptools ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/jr9kc24yp5cxdsk6m0f7iiqviz4q5s8y-pew-1.1.2/bin/.pew-wrapped version` and found version 1.1.2
- ran `/nix/store/jr9kc24yp5cxdsk6m0f7iiqviz4q5s8y-pew-1.1.2/bin/pew version` and found version 1.1.2
- found 1.1.2 with grep in /nix/store/jr9kc24yp5cxdsk6m0f7iiqviz4q5s8y-pew-1.1.2
- found 1.1.2 in filename of file in /nix/store/jr9kc24yp5cxdsk6m0f7iiqviz4q5s8y-pew-1.1.2

cc "@berdario"