### PR TITLE
pgroonga: 1.1.9 -> 2.0.2

### DIFF
--- a/pkgs/servers/sql/postgresql/pgroonga/default.nix
+++ b/pkgs/servers/sql/postgresql/pgroonga/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pgroonga-${version}";
-  version = "1.1.9";
+  version = "2.0.2";
 
   src = fetchurl {
     url = "http://packages.groonga.org/source/pgroonga/${name}.tar.gz";
-    sha256 = "07afgwll8nxfb7ziw3qrvw0ryjjw3994vj2f6alrjwpg7ynb46ag";
+    sha256 = "0023747i2x3j50z54l78maq7dya5ldd2sdydn6l5l7k6b6g4yr2d";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.0.2 with grep in /nix/store/6wff31scywzmgmv4hqab1jfj391vv95y-pgroonga-2.0.2
- found 2.0.2 in filename of file in /nix/store/6wff31scywzmgmv4hqab1jfj391vv95y-pgroonga-2.0.2

cc "@DerTim1"