### PR TITLE
picard: 1.4 -> 1.4.2

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -1,7 +1,7 @@
 { stdenv, python2Packages, fetchurl, gettext, chromaprint }:
 
 let
-  version = "1.4";
+  version = "1.4.2";
   pythonPackages = python2Packages;
 in pythonPackages.buildPythonApplication {
   name = "picard-${version}";
@@ -9,7 +9,7 @@ in pythonPackages.buildPythonApplication {
 
   src = fetchurl {
     url = "http://ftp.musicbrainz.org/pub/musicbrainz/picard/picard-${version}.tar.gz";
-    sha256 = "0gi7f1h7jcg7n18cx8iw38sd868viv3w377xmi7cq98f1g76d4h6";
+    sha256 = "0d12k40d9fbcn801gp5zdsgvjdrh4g97vda3ga16rmmvfwwfxbgh";
   };
 
   buildInputs = [ gettext ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/.picard-wrapped -h` got 0 exit code
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/.picard-wrapped --help` got 0 exit code
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/.picard-wrapped -V` and found version 1.4.2
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/.picard-wrapped -v` and found version 1.4.2
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/.picard-wrapped --version` and found version 1.4.2
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/picard -h` got 0 exit code
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/picard --help` got 0 exit code
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/picard -V` and found version 1.4.2
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/picard -v` and found version 1.4.2
- ran `/nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2/bin/picard --version` and found version 1.4.2
- found 1.4.2 with grep in /nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2
- found 1.4.2 in filename of file in /nix/store/qi3f0w0hbwajdys4r22g2hhfkcx8bm4d-picard-1.4.2

cc "@ehmry"