### PR TITLE
picard-tools: 2.17.4 -> 2.17.10

### DIFF
--- a/pkgs/applications/science/biology/picard-tools/default.nix
+++ b/pkgs/applications/science/biology/picard-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "picard-tools-${version}";
-  version = "2.17.4";
+  version = "2.17.10";
 
   src = fetchurl {
     url = "https://github.com/broadinstitute/picard/releases/download/${version}/picard.jar";
-    sha256 = "00ffi8kkrlh72vjjkjpgi8zys3r9hkdk4xi82kcahch8pix4qzf2";
+    sha256 = "0lf9appcs66mxmirzbys09xhq38kpa4ldxwwzrr9y2cklnxjn4hg";
   };
 
   buildInputs = [ jre makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.17.10 with grep in /nix/store/f74zildbrr99qmp5qkb579x9159n88c6-picard-tools-2.17.10
- found 2.17.10 in filename of file in /nix/store/f74zildbrr99qmp5qkb579x9159n88c6-picard-tools-2.17.10

cc "@jbedo"