### PR TITLE
pidgin-xmpp-receipts: 0.7 -> 0.8

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-xmpp-receipts/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-xmpp-receipts/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pidgin } :
 
 let
-  version = "0.7";
+  version = "0.8";
 in
 stdenv.mkDerivation rec {
   name = "pidgin-xmpp-receipts-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "noonien-d";
     repo = "pidgin-xmpp-receipts";
     rev = "release_${version}";
-    sha256 = "1ackqwsqgy1nfggl9na4jicv7hd542aazkg629y2jmbyj1dl3kjm";
+    sha256 = "13kwaymzkymjsdv8q95byd173i4vanj211vgx9cm0y8ag2r3cjsb";
   };
 
   buildInputs = [ pidgin ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.8 with grep in /nix/store/di49z3ic9sk7mrg6rhf0c67qk8pda3kg-pidgin-xmpp-receipts-0.8
- found 0.8 in filename of file in /nix/store/di49z3ic9sk7mrg6rhf0c67qk8pda3kg-pidgin-xmpp-receipts-0.8

cc "@orivej"