### PR TITLE
pioneers: 0.12.3 -> 15.4

### DIFF
--- a/pkgs/games/pioneers/default.nix
+++ b/pkgs/games/pioneers/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, gtk2, pkgconfig, intltool } :
 
 stdenv.mkDerivation rec {
-  name = "pioneers-0.12.3";
+  name = "pioneers-15.4";
   src = fetchurl {
     url = "mirror://sourceforge/pio/${name}.tar.gz";
-    sha256 = "1yqypk5wmia8fqyrg9mn9xw6yfd0fpkxj1355csw1hgx8mh44y1d";
+    sha256 = "1p1d18hrfmqcnghip3shkzcs5qkz6j99jvkdkqfi7pqdvjc323cs";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneersai -h` got 0 exit code
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneersai --help` got 0 exit code
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneersai help` got 0 exit code
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneersai --version` and found version 15.4
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneers-server-console -h` got 0 exit code
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneers-server-console --help` got 0 exit code
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneers-server-console --version` and found version 15.4
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneers-metaserver -h` got 0 exit code
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneers-metaserver --help` got 0 exit code
- ran `/nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4/bin/pioneers-metaserver --version` and found version 15.4
- found 15.4 with grep in /nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4
- found 15.4 in filename of file in /nix/store/524fd6bk2g3158rgmsc460p1ml0cqzlm-pioneers-15.4

cc "@viric"