### PR TITLE
pjsip: 2.7.1 -> 2.7.2

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pjsip-${version}";
-  version = "2.7.1";
+  version = "2.7.2";
 
   src = fetchurl {
     url = "http://www.pjsip.org/release/${version}/pjproject-${version}.tar.bz2";
-    sha256 = "09ii5hgl5s7grx4fiimcl3s77i385h7b3kwpfa2q0arbl1ibryjr";
+    sha256 = "0wiph6g51wanzwjjrpwsz63amgvly8g08jz033gnwqmppa584b4w";
   };
 
   buildInputs = [ openssl libsamplerate alsaLib ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua -h` got 0 exit code
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua --help` got 0 exit code
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua help` got 0 exit code
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua -V` and found version 2.7.2
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua -v` and found version 2.7.2
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua --version` and found version 2.7.2
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua version` and found version 2.7.2
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua -h` and found version 2.7.2
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua --help` and found version 2.7.2
- ran `/nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2/bin/pjsua help` and found version 2.7.2
- found 2.7.2 with grep in /nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2
- found 2.7.2 in filename of file in /nix/store/3wqj8kyahgi1r25wp8vfhhsg0m1mzpkx-pjsip-2.7.2

cc "@viric @olynch"