### PR TITLE
pmd: 5.2.3 -> 6.0.1

### DIFF
--- a/pkgs/development/tools/analysis/pmd/default.nix
+++ b/pkgs/development/tools/analysis/pmd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pmd-${version}";
-  version = "5.2.3";
+  version = "6.0.1";
 
   buildInputs = [ unzip ];
 
   src = fetchurl {
     url = "mirror://sourceforge/pmd/pmd-bin-${version}.zip";
-    sha256 = "03frkyiii7304qrcypdqcxqxjf5n3p59zjib0r802mbbx1nzcisn";
+    sha256 = "13wmmy345p8bzvxdb8ldpkv85m3m8x9qs5f0jjhn0gkn65a988iq";
   };
 
   installPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 6.0.1 with grep in /nix/store/bi514yar6zzf7i7c78ndlha1pba51ld2-pmd-6.0.1
- found 6.0.1 in filename of file in /nix/store/bi514yar6zzf7i7c78ndlha1pba51ld2-pmd-6.0.1
