### PR TITLE
poco: 1.7.8 -> 1.8.1

### DIFF
--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "poco-${version}";
 
-  version = "1.7.8";
+  version = "1.8.1";
 
   src = fetchurl {
     url = "https://pocoproject.org/releases/${name}/${name}-all.tar.gz";
-    sha256 = "17y6kvj4qdpb3p1im8n9qfylfh4bd2xsvbpn24jv97x7f146nhjf";
+    sha256 = "1pg48kk0354vsc6j2wnrk893l5xcsr3bjmkgykd3harcnvfqs7l8";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/i0mvrxm8vlgilmmkqrlp33g122iw5zlm-poco-1.8.1/bin/cpspc -h` got 0 exit code
- ran `/nix/store/i0mvrxm8vlgilmmkqrlp33g122iw5zlm-poco-1.8.1/bin/cpspc --help` got 0 exit code
- ran `/nix/store/i0mvrxm8vlgilmmkqrlp33g122iw5zlm-poco-1.8.1/bin/cpspc help` got 0 exit code
- ran `/nix/store/i0mvrxm8vlgilmmkqrlp33g122iw5zlm-poco-1.8.1/bin/f2cpsp -h` got 0 exit code
- ran `/nix/store/i0mvrxm8vlgilmmkqrlp33g122iw5zlm-poco-1.8.1/bin/f2cpsp --help` got 0 exit code
- ran `/nix/store/i0mvrxm8vlgilmmkqrlp33g122iw5zlm-poco-1.8.1/bin/f2cpsp help` got 0 exit code
- found 1.8.1 with grep in /nix/store/i0mvrxm8vlgilmmkqrlp33g122iw5zlm-poco-1.8.1

cc "@orivej"