### PR TITLE
ponysay: 3.0.2 -> 3.0.3

### DIFF
--- a/pkgs/tools/misc/ponysay/default.nix
+++ b/pkgs/tools/misc/ponysay/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, python3, texinfo, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "ponysay-3.0.2";
+  name = "ponysay-3.0.3";
 
   src = fetchurl {
-    url = "https://github.com/erkin/ponysay/archive/3.0.2.tar.gz";
-    sha256 = "03avcbl96rv718lgg6yyrq5mvg3xxzccrnnb6brf4g9mcrwqmsb9";
+    url = "https://github.com/erkin/ponysay/archive/3.0.3.tar.gz";
+    sha256 = "12mjabf5cpp5dgg63s19rlyq3dhhpzzy2sa439yncqzsk7rdg0n3";
   };
 
   buildInputs = [ python3 texinfo makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/gjj3sdwcxbdcgz730lh2sj9svfadifdf-ponysay-3.0.3/bin/ponysay -h` got 0 exit code
- ran `/nix/store/gjj3sdwcxbdcgz730lh2sj9svfadifdf-ponysay-3.0.3/bin/ponysay --help` got 0 exit code
- ran `/nix/store/gjj3sdwcxbdcgz730lh2sj9svfadifdf-ponysay-3.0.3/bin/ponysay help` got 0 exit code
- ran `/nix/store/gjj3sdwcxbdcgz730lh2sj9svfadifdf-ponysay-3.0.3/bin/ponysay -v` and found version 3.0.3
- ran `/nix/store/gjj3sdwcxbdcgz730lh2sj9svfadifdf-ponysay-3.0.3/bin/ponysay --version` and found version 3.0.3
- found 3.0.3 with grep in /nix/store/gjj3sdwcxbdcgz730lh2sj9svfadifdf-ponysay-3.0.3

cc "@bodil"