### PR TITLE
postgrey: 1.36 -> 1.37

### DIFF
--- a/pkgs/servers/mail/postgrey/default.nix
+++ b/pkgs/servers/mail/postgrey/default.nix
@@ -8,12 +8,12 @@ let
     policy-test-flags = mk-perl-flags (with perlPackages; [
       ParseSyslog
     ]);
-    version = "1.36";
+    version = "1.37";
     name = "postgrey-${version}";
 in runCommand name {
   src = fetchurl {
     url = "http://postgrey.schweikert.ch/pub/${name}.tar.gz";
-    sha256 = "09jzb246ki988389r9gryigriv9sravk40q75fih5n0q4p2ghax2";
+    sha256 = "1xx51xih4711vrvc6d57il9ccallbljj5zhgqdb07jzmz11rakgz";
   };
   meta = with stdenv.lib; {
     description = "A postfix policy server to provide greylisting";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/axvpmnbhi27rca2476cj66mv1xk92w2f-postgrey-1.37/bin/postgrey --version` and found version 1.37
- found 1.37 with grep in /nix/store/axvpmnbhi27rca2476cj66mv1xk92w2f-postgrey-1.37
- found 1.37 in filename of file in /nix/store/axvpmnbhi27rca2476cj66mv1xk92w2f-postgrey-1.37
