### PR TITLE
povray: 3.7.0.4 -> 3.7.0.7

### DIFF
--- a/pkgs/tools/graphics/povray/default.nix
+++ b/pkgs/tools/graphics/povray/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "povray-${version}";
-  version = "3.7.0.4";
+  version = "3.7.0.7";
 
   src = fetchFromGitHub {
     owner = "POV-Ray";
     repo = "povray";
     rev = "v${version}";
-    sha256 = "1wkwb43w5r9pa79yazy4w4s8n6g280igag97hgl7dyi289q39n0q";
+    sha256 = "0gqbc4ycjfqpnixzzqxlygmargk6sm77b0k3xzff9dxdrak3xng7";
   };
 
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/rk5yid5v5bb50v4pxzfwdl72939m1djr-povray-3.7.0.7/bin/povray -h` got 0 exit code
- ran `/nix/store/rk5yid5v5bb50v4pxzfwdl72939m1djr-povray-3.7.0.7/bin/povray --help` got 0 exit code
- ran `/nix/store/rk5yid5v5bb50v4pxzfwdl72939m1djr-povray-3.7.0.7/bin/povray --version` and found version 3.7.0.7
- ran `/nix/store/rk5yid5v5bb50v4pxzfwdl72939m1djr-povray-3.7.0.7/bin/povray -h` and found version 3.7.0.7
- ran `/nix/store/rk5yid5v5bb50v4pxzfwdl72939m1djr-povray-3.7.0.7/bin/povray --help` and found version 3.7.0.7
- found 3.7.0.7 with grep in /nix/store/rk5yid5v5bb50v4pxzfwdl72939m1djr-povray-3.7.0.7
