### PR TITLE
pptp: 1.9.0 -> 1.10.0

### DIFF
--- a/pkgs/tools/networking/pptp/default.nix
+++ b/pkgs/tools/networking/pptp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pptp-${version}";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/pptpclient/${name}.tar.gz";
-    sha256 = "00cj3jqj1hqri856jif4kkzan684qv1cb1zf2amzblvqqnzqq7hb";
+    sha256 = "1x2szfp96w7cag2rcvkdqbsl836ja5148zzfhaqp7kl7wjw2sjc2";
   };
 
   patchPhase =


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/fg5s243j07wch18a51gi22ayyyq6l2wl-pptp-1.10.0/bin/pptp --version` and found version 1.10.0
- ran `/nix/store/fg5s243j07wch18a51gi22ayyyq6l2wl-pptp-1.10.0/bin/pptpsetup -h` got 0 exit code
- ran `/nix/store/fg5s243j07wch18a51gi22ayyyq6l2wl-pptp-1.10.0/bin/pptpsetup --help` got 0 exit code
- found 1.10.0 with grep in /nix/store/fg5s243j07wch18a51gi22ayyyq6l2wl-pptp-1.10.0
- found 1.10.0 in filename of file in /nix/store/fg5s243j07wch18a51gi22ayyyq6l2wl-pptp-1.10.0

cc ""