### PR TITLE
praat: 5.4.17 -> 6.0.37

### DIFF
--- a/pkgs/applications/audio/praat/default.nix
+++ b/pkgs/applications/audio/praat/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "praat-${version}";
-  version = "5.4.17";
+  version = "6.0.37";
 
   src = fetchurl {
     url = "https://github.com/praat/praat/archive/v${version}.tar.gz";
-    sha256 = "0s2hrksghg686059vc90h3ywhd2702pqcvy99icw27q5mdk6dqsx";
+    sha256 = "1c675jfzcrwfn8lcswm5y5kmazkhnb0p4mzlf5sim57hms88ffjq";
   };
 
   configurePhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/igl5hb1k2wwkms75y5vfs5cvd7a32i34-praat-6.0.37/bin/praat --help` got 0 exit code
- ran `/nix/store/igl5hb1k2wwkms75y5vfs5cvd7a32i34-praat-6.0.37/bin/praat help` got 0 exit code
- ran `/nix/store/igl5hb1k2wwkms75y5vfs5cvd7a32i34-praat-6.0.37/bin/praat --version` and found version 6.0.37
- found 6.0.37 with grep in /nix/store/igl5hb1k2wwkms75y5vfs5cvd7a32i34-praat-6.0.37
- found 6.0.37 in filename of file in /nix/store/igl5hb1k2wwkms75y5vfs5cvd7a32i34-praat-6.0.37
