### PR TITLE
prosody: 0.9.12 -> 0.10.0

### DIFF
--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -27,12 +27,12 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "0.9.12";
+  version = "0.10.0";
   name = "prosody-${version}";
 
   src = fetchurl {
     url = "http://prosody.im/downloads/source/${name}.tar.gz";
-    sha256 = "139yxqpinajl32ryrybvilh54ddb1q6s0ajjhlcs4a0rnwia6n8s";
+    sha256 = "1644jy5dk46vahmh6nna36s79k8k668sbi3qamjb4q3c4m3y853l";
   };
 
   communityModules = fetchhg {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/l1z88ka2184d62bd6giypnq2gqvg1gc0-prosody-0.10.0/bin/prosody -h` got 0 exit code
- ran `/nix/store/l1z88ka2184d62bd6giypnq2gqvg1gc0-prosody-0.10.0/bin/prosody --help` got 0 exit code
- ran `/nix/store/l1z88ka2184d62bd6giypnq2gqvg1gc0-prosody-0.10.0/bin/prosody help` got 0 exit code
- ran `/nix/store/l1z88ka2184d62bd6giypnq2gqvg1gc0-prosody-0.10.0/bin/.prosody-wrapped -h` got 0 exit code
- ran `/nix/store/l1z88ka2184d62bd6giypnq2gqvg1gc0-prosody-0.10.0/bin/.prosody-wrapped --help` got 0 exit code
- ran `/nix/store/l1z88ka2184d62bd6giypnq2gqvg1gc0-prosody-0.10.0/bin/.prosody-wrapped help` got 0 exit code
- found 0.10.0 with grep in /nix/store/l1z88ka2184d62bd6giypnq2gqvg1gc0-prosody-0.10.0
- found 0.10.0 in filename of file in /nix/store/l1z88ka2184d62bd6giypnq2gqvg1gc0-prosody-0.10.0

cc ""