### PR TITLE
pshs: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/servers/http/pshs/default.nix
+++ b/pkgs/servers/http/pshs/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pshs-${version}";
-  version = "0.3.1";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "mgorny";
     repo = "pshs";
     rev = "v${version}";
-    sha256 = "18mhxdjlyr21gghzkrrlp0imicb6bqf741p0a21c2rkvs4bv8c1w";
+    sha256 = "1ffdyv5qiqdg3jq8y91fsml046g88d7fyy2k81yii11jw3yx2js0";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2/bin/pshs -h` got 0 exit code
- ran `/nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2/bin/pshs --help` got 0 exit code
- ran `/nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2/bin/pshs -V` and found version 0.3.2
- ran `/nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2/bin/pshs -v` and found version 0.3.2
- ran `/nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2/bin/pshs --version` and found version 0.3.2
- ran `/nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2/bin/pshs -h` and found version 0.3.2
- ran `/nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2/bin/pshs --help` and found version 0.3.2
- found 0.3.2 with grep in /nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2
- found 0.3.2 in filename of file in /nix/store/s4z6nwhd7wqzkxaplrigy6xv9fk0pkgw-pshs-0.3.2

cc "@eduarrrd"