### PR TITLE
psi-plus: 0.16.575.639 -> 1.2.235

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "psi-plus-${version}";
-  version = "0.16.575.639";
+  version = "1.2.235";
 
   src = fetchFromGitHub {
     owner = "psi-plus";
     repo = "psi-plus-snapshots";
     rev = "${version}";
-    sha256 = "0mn24y3y4qybw81rjy0hr46y7y96dvwdl6kk61kizwj32z1in8cg";
+    sha256 = "0rc65gs6m3jxg407r99kikdylvrar5mq7x5m66ma604yk5igwg47";
   };
 
   resources = fetchFromGitHub {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.2.235 with grep in /nix/store/9z3lbwjmcvgxpicxnkqsqyn2bmkyqvsw-psi-plus-1.2.235

cc "@orivej"