### PR TITLE
pure-ftpd: 1.0.46 -> 1.0.47

### DIFF
--- a/pkgs/servers/ftp/pure-ftpd/default.nix
+++ b/pkgs/servers/ftp/pure-ftpd/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "pure-ftpd-1.0.46";
+  name = "pure-ftpd-1.0.47";
 
   src = fetchurl {
     url = "https://download.pureftpd.org/pub/pure-ftpd/releases/${name}.tar.gz";
-    sha256 = "0p0arcaz63fbb03fkavbc8z6m1f90p5vbnxb8mqlvpma6mrq0286";
+    sha256 = "1b97ixva8m10vln8xrfwwwzi344bkgxqji26d0nrm1yzylbc6h27";
   };
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-statsdecode help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw -h` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw --help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw -V` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw -v` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw --version` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw version` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw -h` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw --help` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pw help` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pwconvert -h` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pwconvert --help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-pwconvert help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-authd -h` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-authd --help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-authd help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpd -h` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpd --help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpd help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpd -V` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpd -v` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpd --version` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpwho -h` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpwho --help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-ftpwho help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-mrtginfo -h` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-mrtginfo --help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-mrtginfo help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-quotacheck -h` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-quotacheck --help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-quotacheck -V` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-quotacheck -v` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-quotacheck --version` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-quotacheck --help` and found version 1.0.47
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-uploadscript -h` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-uploadscript --help` got 0 exit code
- ran `/nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47/bin/pure-uploadscript help` got 0 exit code
- found 1.0.47 with grep in /nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47
- found 1.0.47 in filename of file in /nix/store/w574k17jp6zx54xy328z4c143lpzv87k-pure-ftpd-1.0.47

cc "@lethalman"