### PR TITLE
pythia: 8.219 -> 8.226

### DIFF
--- a/pkgs/development/libraries/physics/pythia/default.nix
+++ b/pkgs/development/libraries/physics/pythia/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pythia-${version}";
-  version = "8.219";
+  version = "8.226";
 
   src = fetchurl {
     url = "http://home.thep.lu.se/~torbjorn/pythia8/pythia${builtins.replaceStrings ["."] [""] version}.tgz";
-    sha256 = "13fhphddl0jir8jyjvj6a9qz14wiv02q9lby8mcdyv8gsw0ir8hy";
+    sha256 = "1jfjkq78d1llrrm2k5pgsl92a5z8af9rx3n83rzv28lxrqdjix4g";
   };
 
   buildInputs = [ boost fastjet hepmc zlib rsync lhapdf ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226/bin/pythia8-config -h` got 0 exit code
- ran `/nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226/bin/pythia8-config --help` got 0 exit code
- ran `/nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226/bin/pythia8-config help` got 0 exit code
- ran `/nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226/bin/pythia8-config -V` and found version 8.226
- ran `/nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226/bin/pythia8-config -v` and found version 8.226
- ran `/nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226/bin/pythia8-config --version` and found version 8.226
- ran `/nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226/bin/pythia8-config version` and found version 8.226
- ran `/nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226/bin/pythia8-config help` and found version 8.226
- found 8.226 with grep in /nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226
- found 8.226 in filename of file in /nix/store/whxh0pc4qfz97dhxsn8ya9pwy1w9msz1-pythia-8.226

cc "@veprbl"