### PR TITLE
ccl: add MacOS version

### DIFF
--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -2,7 +2,7 @@
 
 let
   options = rec {
-    /* TODO: there are also MacOS, FreeBSD and Windows versions */
+    /* TODO: there are also FreeBSD and Windows versions */
     x86_64-linux = {
       arch = "linuxx86";
       sha256 = "0hs1f3z7crgzvinpj990kv9gvbsipxvcvwbmk54n51nasvc5025q";
@@ -21,6 +21,18 @@ let
       runtime = "armcl";
       kernel = "linuxarm";
     };
+    x86_64-darwin = {
+      arch = "darwinx86";
+      sha256 = "5adbea3d8b4a2e29af30d141f781c6613844f468c0ccfa11bae908c3e9641939";
+      runtime = "dx86cl64";
+      kernel = "darwinx8664";
+    };
+    i686-darwin = {
+      arch = "darwinx86";
+      sha256 = x86_64-darwin.sha256;
+      runtime = "dx86cl";
+      kernel = "darwinx8632";
+    };
     armv6l-linux = armv7l-linux;
   };
   cfg = options.${stdenv.system};
@@ -37,12 +49,22 @@ stdenv.mkDerivation rec {
     sha256 = cfg.sha256;
   };
 
-  buildInputs = [ gcc glibc m4 ];
+  buildInputs = if stdenv.isDarwin then [ m4 ] else [ gcc glibc m4 ];
 
   CCL_RUNTIME = cfg.runtime;
   CCL_KERNEL = cfg.kernel;
 
-  postPatch = ''
+  postPatch = if stdenv.isDarwin then ''
+    substituteInPlace lisp-kernel/${CCL_KERNEL}/Makefile \
+      --replace "M4 = gm4"   "M4 = m4" \
+      --replace "dtrace"     "/usr/sbin/dtrace" \
+      --replace "mig"        "/usr/bin/mig" \
+      --replace "/bin/rm"    "${coreutils}/bin/rm" \
+      --replace "/bin/echo"  "${coreutils}/bin/echo"
+
+    substituteInPlace lisp-kernel/m4macros.m4 \
+      --replace "/bin/pwd" "${coreutils}/bin/pwd"
+  '' else ''
     substituteInPlace lisp-kernel/${CCL_KERNEL}/Makefile \
       --replace "/bin/rm"    "${coreutils}/bin/rm" \
       --replace "/bin/echo"  "${coreutils}/bin/echo"
@@ -63,7 +85,7 @@ stdenv.mkDerivation rec {
     cp -r .  "$out/share/ccl-installation"
 
     mkdir -p "$out/bin"
-    echo -e '#!/bin/sh\n'"$out/share/ccl-installation/${CCL_RUNTIME}"' "$@"\n' > "$out"/bin/"${CCL_RUNTIME}"
+    echo -e '#!${stdenv.shell}\n'"$out/share/ccl-installation/${CCL_RUNTIME}"' "$@"\n' > "$out"/bin/"${CCL_RUNTIME}"
     chmod a+x "$out"/bin/"${CCL_RUNTIME}"
     ln -s "$out"/bin/"${CCL_RUNTIME}" "$out"/bin/ccl
   '';


### PR DESCRIPTION
###### ccl: add MacOS version to nixpkgs
- changed derivation to be able to build for MacOS.
- changed /bin/sh for ${stdenv.shell}

cc: @muflax @tohl @7c6f434c 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---