### PR TITLE
qca-qt5: 2.1.1 -> 2.1.3

### DIFF
--- a/pkgs/development/libraries/qca-qt5/default.nix
+++ b/pkgs/development/libraries/qca-qt5/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, openssl, pkgconfig, qtbase }:
 
 stdenv.mkDerivation rec {
-  name = "qca-qt5-2.1.1";
+  name = "qca-qt5-2.1.3";
 
   src = fetchurl {
-    url = "http://download.kde.org/stable/qca/2.1.1/src/qca-2.1.1.tar.xz";
-    sha256 = "10z9icq28fww4qbzwra8d9z55ywbv74qk68nhiqfrydm21wkxplm";
+    url = "http://download.kde.org/stable/qca/2.1.3/src/qca-2.1.3.tar.xz";
+    sha256 = "0lz3n652z208daxypdcxiybl0a9fnn6ida0q7fh5f42269mdhgq0";
   };
 
   buildInputs = [ openssl qtbase ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/mozcerts-qt5 -h` got 0 exit code
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/mozcerts-qt5 --help` got 0 exit code
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/mozcerts-qt5 help` got 0 exit code
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/qcatool-qt5 -h` got 0 exit code
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/qcatool-qt5 --help` got 0 exit code
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/qcatool-qt5 help` got 0 exit code
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/qcatool-qt5 -v` and found version 2.1.3
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/qcatool-qt5 --version` and found version 2.1.3
- ran `/nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3/bin/qcatool-qt5 version` and found version 2.1.3
- found 2.1.3 with grep in /nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3
- found 2.1.3 in filename of file in /nix/store/m57l1rvkq2yb9yk1hsjs5bnj0g0ylhsx-qca-qt5-2.1.3

cc "@ttuegel"