### PR TITLE
qgis: 2.18.15 -> 2.18.16

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "qgis-2.18.15";
+  name = "qgis-2.18.16";
 
   buildInputs = [ gdal qt4 flex openssl bison proj geos xlibsWrapper sqlite gsl qwt qscintilla
     fcgi libspatialindex libspatialite postgresql qjson qca2 txt2tags ] ++
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://qgis.org/downloads/${name}.tar.bz2";
-    sha256 = "1jpprkk91s2wwx0iiqlnsngxnn52zs32bad799fjai58nrsh8b7b";
+    sha256 = "0d880m013kzi4qiyr27yjx6hzpb652slp66gyqgw9ziw03wy12c9";
   };
 
   cmakeFlags = stdenv.lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/cqjd4b5av6rrmmz9qvagqgq2vqwi5mmi-qgis-2.18.16/bin/qgis_bench -h` got 0 exit code
- found 2.18.16 with grep in /nix/store/cqjd4b5av6rrmmz9qvagqgq2vqwi5mmi-qgis-2.18.16

cc "@viric"