### PR TITLE
qmidiroute: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/applications/audio/qmidiroute/default.nix
+++ b/pkgs/applications/audio/qmidiroute/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, qt4, alsaLib }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.0";
+  version = "0.4.0";
   name = "qmidiroute-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/alsamodular/QMidiRoute/${version}/${name}.tar.gz";
-    sha256 = "11bfjz14z37v6hk2xyg4vrw423b5h3qgcbviv07g00ws1fgjygm2";
+    sha256 = "0vmjwarsxr5540rafhmdcc62yarf0w2l05bjjl9s28zzr5m39z3n";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/w7khf4yy94gb9dq36dwyhd5v11wvlnc0-qmidiroute-0.4.0/bin/qmidiroute -h` got 0 exit code
- ran `/nix/store/w7khf4yy94gb9dq36dwyhd5v11wvlnc0-qmidiroute-0.4.0/bin/qmidiroute --help` got 0 exit code
- ran `/nix/store/w7khf4yy94gb9dq36dwyhd5v11wvlnc0-qmidiroute-0.4.0/bin/qmidiroute -v` and found version 0.4.0
- ran `/nix/store/w7khf4yy94gb9dq36dwyhd5v11wvlnc0-qmidiroute-0.4.0/bin/qmidiroute --version` and found version 0.4.0
- found 0.4.0 with grep in /nix/store/w7khf4yy94gb9dq36dwyhd5v11wvlnc0-qmidiroute-0.4.0
- found 0.4.0 in filename of file in /nix/store/w7khf4yy94gb9dq36dwyhd5v11wvlnc0-qmidiroute-0.4.0

cc "@lebastr"