### PR TITLE
quagga: 1.2.2 -> 1.2.4

### DIFF
--- a/pkgs/servers/quagga/default.nix
+++ b/pkgs/servers/quagga/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "quagga-${version}";
-  version = "1.2.2";
+  version = "1.2.4";
 
   src = fetchurl {
     url = "mirror://savannah/quagga/${name}.tar.gz";
-    sha256 = "0c99rjjc62xl5kwvx2pwyvs0709vbwax1qydqbqf6r7fpvr24bjj";
+    sha256 = "1lsksqxij5f1llqn86pkygrf5672kvrqn1kvxghi169hqf1c0r73";
   };
 
   buildInputs =


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/z0zqfqwd6ap5k8s5i8ss498a4jqj2h67-quagga-1.2.4/bin/bgp_btoa help` got 0 exit code
- ran `/nix/store/z0zqfqwd6ap5k8s5i8ss498a4jqj2h67-quagga-1.2.4/bin/vtysh -h` got 0 exit code
- ran `/nix/store/z0zqfqwd6ap5k8s5i8ss498a4jqj2h67-quagga-1.2.4/bin/vtysh --help` got 0 exit code
- found 1.2.4 with grep in /nix/store/z0zqfqwd6ap5k8s5i8ss498a4jqj2h67-quagga-1.2.4
- found 1.2.4 in filename of file in /nix/store/z0zqfqwd6ap5k8s5i8ss498a4jqj2h67-quagga-1.2.4

cc "@tavyc"