### PR TITLE
quota: 4.03 -> 4.04

### DIFF
--- a/pkgs/tools/misc/quota/default.nix
+++ b/pkgs/tools/misc/quota/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, e2fsprogs, openldap, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "4.03";
+  version = "4.04";
   name = "quota-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/linuxquota/quota-${version}.tar.gz";
-    sha256 = "0jv7vhxhjp3gc4hwgmrhg448sbzzqib80gdas9nm0c5zwyd4sv4w";
+    sha256 = "1pwfxza923j75z5lx0w89pj09745zi1swy77cm0zalbzgs4f2nvk";
   };
 
   outputs = [ "out" "dev" "doc" "man" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quota -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quota --version` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotasync -h` got 0 exit code
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotasync --help` got 0 exit code
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotasync -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotasync --version` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/convertquota -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/convertquota --version` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/edquota help` got 0 exit code
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/edquota -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/edquota --version` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quot help` got 0 exit code
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quot -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotacheck -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotacheck --version` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotaon help` got 0 exit code
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotaon -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotaon --version` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotastats -h` got 0 exit code
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotastats --help` got 0 exit code
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/quotastats help` got 0 exit code
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/repquota -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/repquota --version` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/setquota -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/setquota --version` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/warnquota -V` and found version 4.04
- ran `/nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04/bin/warnquota --version` and found version 4.04
- found 4.04 with grep in /nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04
- found 4.04 in filename of file in /nix/store/0lz0a0vk7zzlqjry9xak94pckrfy77rd-quota-4.04

cc "@dezgeg"