### PR TITLE
rabbitvcs: 0.16 -> 0.17.1

### DIFF
--- a/pkgs/applications/version-management/rabbitvcs/default.nix
+++ b/pkgs/applications/version-management/rabbitvcs/default.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub, lib, python2Packages, meld, subversion, gvfs, xdg_utils }:
 python2Packages.buildPythonApplication rec {
   name = "rabbitvcs-${version}";
-  version = "0.16";
+  version = "0.17.1";
   namePrefix = "";
 
   src = fetchFromGitHub {
     owner = "rabbitvcs";
     repo = "rabbitvcs";
     rev = "v${version}";
-    sha256 = "0964pdylrx4n9c9l8ncwv4q1p63y4hadb5v4pgvm0m2fah2jlkly";
+    sha256 = "01cr16zf3gzsci1hhfli79m34fcx5m1pvswl16rkxxn212yc9fhy";
   };
 
   pythonPath = with python2Packages; [ configobj dbus-python pygobject2 pygtk simplejson pysvn dulwich tkinter gvfs xdg_utils ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.17.1 with grep in /nix/store/9ywl856gxvav8j93ggk0jy4isclimhk3-rabbitvcs-0.17.1
- found 0.17.1 in filename of file in /nix/store/9ywl856gxvav8j93ggk0jy4isclimhk3-rabbitvcs-0.17.1

cc "@mathnerd314"