### PR TITLE
radarr: 0.2.0.910 -> 0.2.0.980

### DIFF
--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "radarr-${version}";
-  version = "0.2.0.910";
+  version = "0.2.0.980";
 
   src = fetchurl {
     url = "https://github.com/Radarr/Radarr/releases/download/v${version}/Radarr.develop.${version}.linux.tar.gz";
-    sha256 = "0c4msk6hvlqyy81xkjhsvsy4igpc01s4a00zwhqnds2gj4y9yplk";
+    sha256 = "1939mmlp9hsmw0hd4c8m8p5fk6igvml30gk9ffi9mfhankas6fnf";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.2.0.980 with grep in /nix/store/cwvhpmnp8kiham83ap9hflk8bj12zjzv-radarr-0.2.0.980
- found 0.2.0.980 in filename of file in /nix/store/cwvhpmnp8kiham83ap9hflk8bj12zjzv-radarr-0.2.0.980

cc "@edwtjo"