### PR TITLE
ranger: 1.9.0 -> 1.9.1

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -7,13 +7,13 @@ assert imagePreviewSupport -> w3m != null;
 
 pythonPackages.buildPythonApplication rec {
   name = "ranger-${version}";
-  version = "1.9.0";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "ranger";
     repo = "ranger";
     rev = "v${version}";
-    sha256= "0h3qz0sr21390xdshhlfisvscja33slv1plzcisg1wrdgwgyr5j6";
+    sha256= "1zhds37j1scxa9b183qbrjwxqldrdk581c5xiy81vg17sndb1kqj";
   };
 
   checkInputs = with pythonPackages; [ pytest ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/.ranger-wrapped -h` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/.ranger-wrapped --help` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/.ranger-wrapped --version` and found version 1.9.1
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/ranger -h` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/ranger --help` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/ranger --version` and found version 1.9.1
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/.rifle-wrapped -h` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/.rifle-wrapped --help` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/.rifle-wrapped --version` and found version 1.9.1
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/rifle -h` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/rifle --help` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/rifle help` got 0 exit code
- ran `/nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1/bin/rifle --version` and found version 1.9.1
- found 1.9.1 with grep in /nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1
- found 1.9.1 in filename of file in /nix/store/q53safw1076ynmqdx4zkh1707d7swz9s-ranger-1.9.1

cc "@magnetophon"