### PR TITLE
pacman: init at 5.0.2

### DIFF
--- a/pkgs/tools/package-management/pacman/default.nix
+++ b/pkgs/tools/package-management/pacman/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchurl, autoreconfHook, pkgconfig, perl, libarchive, openssl,
+zlib, bzip2, lzma }:
+
+stdenv.mkDerivation rec {
+  name = "pacman-${version}";
+  version = "5.0.2";
+
+  src = fetchurl {
+    url = "https://git.archlinux.org/pacman.git/snapshot/pacman-${version}.tar.gz";
+    sha256 = "1lk54k7d281v55fryqsajl4xav7rhpk8x8pxcms2v6dapp959hgi";
+  };
+
+  # trying to build docs fails with a2x errors, unable to fix through asciidoc
+  configureFlags = [ "--disable-doc" ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ perl libarchive openssl zlib bzip2 lzma ];
+
+  meta = with lib; {
+    description = "A simple library-based package manager";
+    homepage = https://www.archlinux.org/pacman/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mt-caret ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4043,6 +4043,8 @@ with pkgs;
 
   packetdrill = callPackage ../tools/networking/packetdrill { };
 
+  pacman = callPackage ../tools/package-management/pacman { };
+
   padthv1 = callPackage ../applications/audio/padthv1 { };
 
   pakcs = callPackage ../development/compilers/pakcs {};


### PR DESCRIPTION
###### Motivation for this change

Because...why not?
I'm thinking about getting an archlinux systemd-nspawn container running with pacstrap, which depends on pacman.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

