### PR TITLE
rdkafka: 0.9.5 -> 0.11.3

### DIFF
--- a/pkgs/development/libraries/rdkafka/default.nix
+++ b/pkgs/development/libraries/rdkafka/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "rdkafka-${version}";
-  version = "0.9.5";
+  version = "0.11.3";
 
   src = fetchFromGitHub {
     owner = "edenhill";
     repo = "librdkafka";
     rev = "v${version}";
-    sha256 = "0yp8vmj3yc564hcmhx46ssyn8qayywnsrg4wg67qk6jw967qgwsn";
+    sha256 = "17ghq0kzk2fdpxhr40xgg3s0p0n0gkvd0d85c6jsww3mj8v5xd14";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.11.3 with grep in /nix/store/z53qgvkdj04v2wspk7ril70qy1ckwh8k-rdkafka-0.11.3
- found 0.11.3 in filename of file in /nix/store/z53qgvkdj04v2wspk7ril70qy1ckwh8k-rdkafka-0.11.3

cc "@boothead @wkennington"