### PR TITLE
re2c: 0.16 -> 1.0.3

### DIFF
--- a/pkgs/development/tools/parsing/re2c/default.nix
+++ b/pkgs/development/tools/parsing/re2c/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "re2c-${version}";
-  version = "0.16";
+  version = "1.0.3";
 
   sourceRoot = "${src.name}/re2c";
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner  = "skvadrik";
     repo   = "re2c";
     rev    = version;
-    sha256 = "0cijgmbyx34nwl2jmsswggkgvzy364871rkbxz8biq9x8xrhhjw5";
+    sha256 = "0grx7nl9fwcn880v5ssjljhcb9c5p2a6xpwil7zxpmv0rwnr3yqi";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3/bin/re2c -h` got 0 exit code
- ran `/nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3/bin/re2c --help` got 0 exit code
- ran `/nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3/bin/re2c help` got 0 exit code
- ran `/nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3/bin/re2c -V` and found version 1.0.3
- ran `/nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3/bin/re2c -v` and found version 1.0.3
- ran `/nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3/bin/re2c --version` and found version 1.0.3
- ran `/nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3/bin/re2c version` and found version 1.0.3
- ran `/nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3/bin/re2c help` and found version 1.0.3
- found 1.0.3 with grep in /nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3
- found 1.0.3 in filename of file in /nix/store/nakhmqvpq4y9jdqs0n974wqmasvsypp9-re2c-1.0.3

cc "@thoughtpolice"