### PR TITLE
readosm: 1.0.0b -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/readosm/default.nix
+++ b/pkgs/development/libraries/readosm/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, expat, zlib, geos, libspatialite }:
 
 stdenv.mkDerivation rec {
-  name = "readosm-1.0.0b";
+  name = "readosm-1.1.0";
 
   src = fetchurl {
     url = "http://www.gaia-gis.it/gaia-sins/readosm-sources/${name}.tar.gz";
-    sha256 = "042pv31smc7l6y111rvp0hza5sw86wa8ldg2jyq78xgwzcbhszpd";
+    sha256 = "1v20pnda67imjd70fn0zw30aar525xicy3d3v49md5cvqklws265";
   };
 
   buildInputs = [ expat zlib geos libspatialite ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.1.0 with grep in /nix/store/fxmc6jijyscbyhiyjdflbpmbf7hn9v41-readosm-1.1.0
- found 1.1.0 in filename of file in /nix/store/fxmc6jijyscbyhiyjdflbpmbf7hn9v41-readosm-1.1.0
