### PR TITLE
recoll: 1.23.5 -> 1.23.7

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -7,12 +7,12 @@
 assert stdenv.system != "powerpc-linux";
 
 stdenv.mkDerivation rec {
-  ver = "1.23.5";
+  ver = "1.23.7";
   name = "recoll-${ver}";
 
   src = fetchurl {
     url = "http://www.lesbonscomptes.com/recoll/${name}.tar.gz";
-    sha256 = "0ps7ckrv63ydviqkqxs57hn04z53s2jnjnp94n1prs63xx0njswv";
+    sha256 = "186bj8zx2xw9hwrzvzxdgdin9nj7msiqh5j57w5g7j4abdlsisjn";
   };
 
   configureFlags = [ "--with-inotify" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/l9d50wqwzrfqgj3wj9456kiapygmacr0-recoll-1.23.7/bin/recollindex -h` got 0 exit code
- ran `/nix/store/l9d50wqwzrfqgj3wj9456kiapygmacr0-recoll-1.23.7/bin/recollindex -h` and found version 1.23.7
- found 1.23.7 with grep in /nix/store/l9d50wqwzrfqgj3wj9456kiapygmacr0-recoll-1.23.7
- found 1.23.7 in filename of file in /nix/store/l9d50wqwzrfqgj3wj9456kiapygmacr0-recoll-1.23.7

cc "@jcumming"