### PR TITLE
reiser4progs: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/tools/filesystems/reiser4progs/default.nix
+++ b/pkgs/tools/filesystems/reiser4progs/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, libaal}:
 
-let version = "1.1.0"; in
+let version = "1.2.1"; in
 stdenv.mkDerivation rec {
   name = "reiser4progs-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/reiser4/reiser4-utils/${name}.tar.gz";
-    sha256 = "18bgv0wd75q53642x5dsk4g0mil1hw1zrp7a4xkb0pxx4bzjlbqg";
+    sha256 = "03vdqvpyd48wxrpqpb9kg76giaffw9b8k334kr4wc0zxgybknhl7";
   };
 
   buildInputs = [libaal];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/debugfs.reiser4 -h` got 0 exit code
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/debugfs.reiser4 --help` got 0 exit code
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/debugfs.reiser4 -V` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/debugfs.reiser4 -v` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/debugfs.reiser4 --version` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/debugfs.reiser4 -h` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/debugfs.reiser4 --help` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/make_reiser4 -h` got 0 exit code
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/make_reiser4 --help` got 0 exit code
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/make_reiser4 -V` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/make_reiser4 -v` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/make_reiser4 --version` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/make_reiser4 -h` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/make_reiser4 --help` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/measurefs.reiser4 -h` got 0 exit code
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/measurefs.reiser4 --help` got 0 exit code
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/measurefs.reiser4 -V` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/measurefs.reiser4 -v` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/measurefs.reiser4 --version` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/measurefs.reiser4 -h` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/measurefs.reiser4 --help` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/mkfs.reiser4 -h` got 0 exit code
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/mkfs.reiser4 --help` got 0 exit code
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/mkfs.reiser4 -V` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/mkfs.reiser4 -v` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/mkfs.reiser4 --version` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/mkfs.reiser4 -h` and found version 1.2.1
- ran `/nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1/bin/mkfs.reiser4 --help` and found version 1.2.1
- found 1.2.1 with grep in /nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1
- found 1.2.1 in filename of file in /nix/store/frv798x9wv35ia6733bpwvq94w2mp9hm-reiser4progs-1.2.1
