### PR TITLE
resolv_wrapper: 1.1.3 -> 1.1.5

### DIFF
--- a/pkgs/development/libraries/resolv_wrapper/default.nix
+++ b/pkgs/development/libraries/resolv_wrapper/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "resolv_wrapper-1.1.3";
+  name = "resolv_wrapper-1.1.5";
 
   src = fetchurl {
     url = "mirror://samba/cwrap/${name}.tar.gz";
-    sha256 = "1h76155pnmd3pqxfyi00q0fg6v45ad9dhnjsqcsbzg18s626wyad";
+    sha256 = "0v5hw5ipq2rrpraf4ck4r9w9xihmgwzkpf5wgppz7gc52fmgv2g9";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.1.5 with grep in /nix/store/wfbq0x34zgwrazsib5pv5wbv1zb1yrpk-resolv_wrapper-1.1.5
- found 1.1.5 in filename of file in /nix/store/wfbq0x34zgwrazsib5pv5wbv1zb1yrpk-resolv_wrapper-1.1.5

cc "@wkennington"