### PR TITLE
riemann: 0.2.12 -> 0.3.0

### DIFF
--- a/pkgs/servers/monitoring/riemann/default.nix
+++ b/pkgs/servers/monitoring/riemann/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "riemann-${version}";
-  version = "0.2.12";
+  version = "0.3.0";
 
   src = fetchurl {
     url = "https://github.com/riemann/riemann/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "1x57gi301rg6faxm4q5scq9dpp0v9nqiwjpsgigdb8whmjr1zwkr";
+    sha256 = "151zd8nkhigphdx6g9jhmza6963qvlnki013j1g7lyqaz43qyk1c";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/5pk3bc05rja1qsq11zlp7x4pz8j2wcin-riemann-0.3.0/bin/.riemann-wrapped -h` got 0 exit code
- ran `/nix/store/5pk3bc05rja1qsq11zlp7x4pz8j2wcin-riemann-0.3.0/bin/.riemann-wrapped -h` and found version 0.3.0
- ran `/nix/store/5pk3bc05rja1qsq11zlp7x4pz8j2wcin-riemann-0.3.0/bin/riemann -h` got 0 exit code
- ran `/nix/store/5pk3bc05rja1qsq11zlp7x4pz8j2wcin-riemann-0.3.0/bin/riemann -v` and found version 0.3.0
- ran `/nix/store/5pk3bc05rja1qsq11zlp7x4pz8j2wcin-riemann-0.3.0/bin/riemann -h` and found version 0.3.0
- found 0.3.0 with grep in /nix/store/5pk3bc05rja1qsq11zlp7x4pz8j2wcin-riemann-0.3.0
- found 0.3.0 in filename of file in /nix/store/5pk3bc05rja1qsq11zlp7x4pz8j2wcin-riemann-0.3.0

cc "@rickynils"