### PR TITLE
rocksndiamonds: 4.0.0.2 -> 4.0.1.1

### DIFF
--- a/pkgs/games/rocksndiamonds/default.nix
+++ b/pkgs/games/rocksndiamonds/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "${project}-${version}";
   project = "rocksndiamonds";
-  version = "4.0.0.2";
+  version = "4.0.1.1";
 
   src = fetchurl {
     url = "https://www.artsoft.org/RELEASES/unix/${project}/${name}.tar.gz";
-    sha256 = "0dzn6vlayvnkjm64zwva337rn07lc21kq93m2h8zz8j3wpl11pb4";
+    sha256 = "0f2m29m53sngg2kv4km91nxbr53rzhchbpqx5dzrv3p5hq1hp936";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/y37n0z2rpyhf1iv0m0a1n066wy5c87ik-rocksndiamonds-4.0.1.1/bin/rocksndiamonds -h` got 0 exit code
- ran `/nix/store/y37n0z2rpyhf1iv0m0a1n066wy5c87ik-rocksndiamonds-4.0.1.1/bin/rocksndiamonds --help` got 0 exit code
- ran `/nix/store/y37n0z2rpyhf1iv0m0a1n066wy5c87ik-rocksndiamonds-4.0.1.1/bin/rocksndiamonds -V` and found version 4.0.1.1
- ran `/nix/store/y37n0z2rpyhf1iv0m0a1n066wy5c87ik-rocksndiamonds-4.0.1.1/bin/rocksndiamonds --version` and found version 4.0.1.1
- found 4.0.1.1 with grep in /nix/store/y37n0z2rpyhf1iv0m0a1n066wy5c87ik-rocksndiamonds-4.0.1.1

cc "@orivej"