### PR TITLE
root: 6.10.08 -> 6.12.06

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "root-${version}";
-  version = "6.10.08";
+  version = "6.12.06";
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
-    sha256 = "12mddl6pqwwc9nr4jqzp6h1jm4zycazd3v88dz306m1nmk97dlic";
+    sha256 = "1557b9sdragsx9i15qh6lq7fn056bgi87d31kxdl4vl0awigvp5f";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/genreflex -h` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/genreflex --help` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/pq2 -h` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/rootn.exe -h` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/rootn.exe --help` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/rootn.exe -h` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/rootn.exe --help` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/xpdtest -h` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/xpdtest --help` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/root.exe -h` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/root.exe --help` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/root.exe -h` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/root.exe --help` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/root-config --help` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/root-config --version` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory -h` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory --help` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory help` got 0 exit code
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory -V` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory -v` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory --version` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory version` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory -h` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory --help` and found version 6.12.06
- ran `/nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06/bin/prepareHistFactory help` and found version 6.12.06
- found 6.12.06 with grep in /nix/store/4gcl610xv4sj6vzwnksm825qp29f8ibx-root-6.12.06

cc "@veprbl"