### PR TITLE
rosegarden: 17.04 -> 17.12.1

### DIFF
--- a/pkgs/applications/audio/rosegarden/default.nix
+++ b/pkgs/applications/audio/rosegarden/default.nix
@@ -3,12 +3,12 @@
 , liblo, liblrdf, libsamplerate, libsndfile, lirc ? null, qtbase }:
 
 stdenv.mkDerivation (rec {
-  version = "17.04";
+  version = "17.12.1";
   name = "rosegarden-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/rosegarden/${name}.tar.bz2";
-    sha256 = "1khfcj22asdhjh0jvhkqsz200wgmigkhsrcz09ffia5hqm0n32lq";
+    sha256 = "155kqbxg85wqv0w97cmmx8wq0r4xb3qpnk20lfma04vj8k6hc1mg";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/6q311ykga5a001jk8x80whj4cr3jp1y5-rosegarden-17.12.1/bin/rosegarden --version` and found version 17.12.1
- found 17.12.1 with grep in /nix/store/6q311ykga5a001jk8x80whj4cr3jp1y5-rosegarden-17.12.1
- found 17.12.1 in filename of file in /nix/store/6q311ykga5a001jk8x80whj4cr3jp1y5-rosegarden-17.12.1

cc "@lebastr"