### PR TITLE
rt: 4.4.0 -> 4.4.2

### DIFF
--- a/pkgs/servers/rt/default.nix
+++ b/pkgs/servers/rt/default.nix
@@ -33,11 +33,11 @@
 stdenv.mkDerivation rec {
   name = "rt-${version}";
 
-  version = "4.4.0";
+  version = "4.4.2";
 
   src = fetchurl {
     url = "https://download.bestpractical.com/pub/rt/release/${name}.tar.gz";
-    sha256 = "1hgz50fxv9zdcngww083aqh8vzyk148lm7mcivxflpnsqfw3696x";
+    sha256 = "0s5ykc5imcii66zkzcb8lf8adkr8zlbc2ikcpkaxzcccikhndqxj";
   };
 
   patches = [ ./override-generated.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2/bin/rt help` got 0 exit code
- ran `/nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2/bin/.rt-ldapimport-wrapped -h` got 0 exit code
- ran `/nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2/bin/.rt-ldapimport-wrapped --help` got 0 exit code
- ran `/nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2/bin/.rt-ldapimport-wrapped help` got 0 exit code
- ran `/nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2/bin/rt-ldapimport -h` got 0 exit code
- ran `/nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2/bin/rt-ldapimport --help` got 0 exit code
- ran `/nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2/bin/rt-ldapimport help` got 0 exit code
- ran `/nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2/bin/rt-test-dependencies help` got 0 exit code
- found 4.4.2 with grep in /nix/store/5n51wrhcy36qriag40rrfz0iq8li887q-rt-4.4.2
