### PR TITLE
rtaudio: 4.1.2 -> 5.0.0

### DIFF
--- a/pkgs/development/libraries/audio/rtaudio/default.nix
+++ b/pkgs/development/libraries/audio/rtaudio/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, libjack2,  alsaLib, rtmidi }:
 
 stdenv.mkDerivation rec {
-  version = "4.1.2";
+  version = "5.0.0";
   name = "rtaudio-${version}";
 
   src = fetchFromGitHub {
     owner = "thestk";
     repo = "rtaudio";
     rev = "${version}";
-    sha256 = "09j84l9l3q0g238z5k89rm8hgk0i1ir8917an7amq474nwjp80pq";
+    sha256 = "0jkqnhc2pq31nmq4daxhmqdjgv2qi4ib27hwms2r5zhnmvvzlr67";
   };
 
   buildInputs = [ autoconf automake libtool libjack2 alsaLib rtmidi ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 5.0.0 with grep in /nix/store/sxxwa9mma9933vxb4w3d2szxjqx5w773-rtaudio-5.0.0
- found 5.0.0 in filename of file in /nix/store/sxxwa9mma9933vxb4w3d2szxjqx5w773-rtaudio-5.0.0

cc "@magnetophon"