### PR TITLE
s3cmd: 1.6.1 -> 2.0.1

### DIFF
--- a/pkgs/tools/networking/s3cmd/default.nix
+++ b/pkgs/tools/networking/s3cmd/default.nix
@@ -2,13 +2,13 @@
 
 python2Packages.buildPythonApplication rec {
   name = "s3cmd-${version}";
-  version = "1.6.1";
+  version = "2.0.1";
   
   src = fetchFromGitHub {
     owner  = "s3tools";
     repo   = "s3cmd";
     rev    = "v${version}";
-    sha256 = "0aan6v1qj0pdkddhhkbaky44d54irm1pa8mkn52i2j86nb2rkcf9";
+    sha256 = "198hzzplci57sb8hdan30nbakslawmijfw0j71wjvq85n3xn6qsl";
   };
 
   propagatedBuildInputs = with python2Packages; [ python_magic dateutil ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/.s3cmd-wrapped -h` got 0 exit code
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/.s3cmd-wrapped --help` got 0 exit code
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/.s3cmd-wrapped --version` and found version 2.0.1
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/.s3cmd-wrapped -h` and found version 2.0.1
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/.s3cmd-wrapped --help` and found version 2.0.1
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/s3cmd -h` got 0 exit code
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/s3cmd --help` got 0 exit code
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/s3cmd --version` and found version 2.0.1
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/s3cmd -h` and found version 2.0.1
- ran `/nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1/bin/s3cmd --help` and found version 2.0.1
- found 2.0.1 with grep in /nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1
- found 2.0.1 in filename of file in /nix/store/pfd3ki3ylyx10vjkg99wjzhjs004iwb9-s3cmd-2.0.1

cc "@spwhitt"