### PR TITLE
sabnzbd: 1.2.1 -> 2.3.2

### DIFF
--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -4,7 +4,7 @@ let
   pythonEnv = python2.withPackages(ps: with ps; [ cryptography cheetah yenc ]);
   path = stdenv.lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {
-  version = "1.2.1";
+  version = "2.3.2";
   pname = "sabnzbd";
   name = "${pname}-${version}";
 
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "1rw6f455p0n8qigzkvnlr0d6rzkx2mpzhcp7m0j8fwqdbq831q8y";
+    sha256 = "0c0ap8bygvz643fgfvvmwshcyfblq2c5jziqwgpf30g6rsbfv2v0";
   };
 
   buildInputs = [ pythonEnv makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2/bin/.sabnzbd-wrapped -h` got 0 exit code
- ran `/nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2/bin/.sabnzbd-wrapped --help` got 0 exit code
- ran `/nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2/bin/.sabnzbd-wrapped -v` and found version 2.3.2
- ran `/nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2/bin/.sabnzbd-wrapped --version` and found version 2.3.2
- ran `/nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2/bin/sabnzbd -h` got 0 exit code
- ran `/nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2/bin/sabnzbd --help` got 0 exit code
- ran `/nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2/bin/sabnzbd -v` and found version 2.3.2
- ran `/nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2/bin/sabnzbd --version` and found version 2.3.2
- found 2.3.2 with grep in /nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2
- found 2.3.2 in filename of file in /nix/store/3xqw8f0fsgx591sh0b1rbdapbki6faqx-sabnzbd-2.3.2

cc "@fridh"