### PR TITLE
sakura: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/applications/misc/sakura/default.nix
+++ b/pkgs/applications/misc/sakura/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "sakura-${version}";
-  version = "3.4.0";
+  version = "3.5.0";
 
   src = fetchurl {
     url = "http://launchpad.net/sakura/trunk/${version}/+download/${name}.tar.bz2";
-    sha256 = "1vj07xnkalb8q6ippf4bmv5cf4266p1j9m80sxb6hncx0h8paj04";
+    sha256 = "0fhcn3540iw22l5zg3njh5z8cj0g2n9p6fvagjqa5zc323jfsc7b";
   };
 
   nativeBuildInputs = [ cmake perl pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/7kvykp5j43060lmrkillcd05fml0sg3p-sakura-3.5.0/bin/sakura --help` got 0 exit code
- ran `/nix/store/7kvykp5j43060lmrkillcd05fml0sg3p-sakura-3.5.0/bin/.sakura-wrapped --help` got 0 exit code
- found 3.5.0 with grep in /nix/store/7kvykp5j43060lmrkillcd05fml0sg3p-sakura-3.5.0
- found 3.5.0 in filename of file in /nix/store/7kvykp5j43060lmrkillcd05fml0sg3p-sakura-3.5.0

cc "@astsmtl @codyopel"