### PR TITLE
sassc: 3.4.5 -> 3.4.8

### DIFF
--- a/pkgs/development/tools/sassc/default.nix
+++ b/pkgs/development/tools/sassc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "sassc-${version}";
-  version = "3.4.5";
+  version = "3.4.8";
 
   src = fetchurl {
     url = "https://github.com/sass/sassc/archive/${version}.tar.gz";
-    sha256 = "1xk4kmmvziz9sal3swpqa10q0s289xjpcz8aggmly8mvxvmngsi9";
+    sha256 = "02lnibrl6zgczkhvz01bdp0d2b0rbl69dfv5mdnbr4l8km7sa7b1";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/wwc3p4pi03aj49w3qgmp5sq8d1hx2h6f-sassc-3.4.8/bin/sassc -h` got 0 exit code
- ran `/nix/store/wwc3p4pi03aj49w3qgmp5sq8d1hx2h6f-sassc-3.4.8/bin/sassc --help` got 0 exit code
- ran `/nix/store/wwc3p4pi03aj49w3qgmp5sq8d1hx2h6f-sassc-3.4.8/bin/sassc -v` and found version 3.4.8
- ran `/nix/store/wwc3p4pi03aj49w3qgmp5sq8d1hx2h6f-sassc-3.4.8/bin/sassc --version` and found version 3.4.8
- ran `/nix/store/wwc3p4pi03aj49w3qgmp5sq8d1hx2h6f-sassc-3.4.8/bin/sassc -h` and found version 3.4.8
- ran `/nix/store/wwc3p4pi03aj49w3qgmp5sq8d1hx2h6f-sassc-3.4.8/bin/sassc --help` and found version 3.4.8
- found 3.4.8 with grep in /nix/store/wwc3p4pi03aj49w3qgmp5sq8d1hx2h6f-sassc-3.4.8
- found 3.4.8 in filename of file in /nix/store/wwc3p4pi03aj49w3qgmp5sq8d1hx2h6f-sassc-3.4.8

cc "@codyopel @pjones"