### PR TITLE
sc-controller: 0.4.0.1 -> 0.4.0.2

### DIFF
--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonApplication rec {
   pname = "sc-controller";
-  version = "0.4.0.1";
+  version = "0.4.0.2";
 
   src = fetchFromGitHub {
     owner = "kozec";
     repo = "sc-controller";
     rev = "v${version}";
-    sha256 = "0vhgiqg4r4bnn004ql80rvi23y05wlax80sj8qsr91pvqsxwv3yl";
+    sha256 = "0v1fgmnsi70z52l6c3fg49vki5rrdswr38mc82wbpmgi68vxwnyy";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/sc-controller -h` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/sc-controller --help` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/sc-controller -V` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/sc-controller --version` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc -h` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc --help` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc help` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc -V` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc --version` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc version` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc -h` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc --help` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc help` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc-daemon -h` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/scc-daemon --help` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped help` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped -V` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped --version` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped version` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped -h` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped --help` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/..scc-wrapped-wrapped help` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped -h` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped --help` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped help` got 0 exit code
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped -V` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped --version` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped version` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped -h` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped --help` and found version 0.4.0.2
- ran `/nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2/bin/.scc-wrapped help` and found version 0.4.0.2
- found 0.4.0.2 with grep in /nix/store/yjhdx3zx9zivz9x2wl2z0c5kqv8b5hkv-sc-controller-0.4.0.2

cc "@orivej"