### PR TITLE
scanbd: 1.4.4 -> 1.5.1

### DIFF
--- a/pkgs/tools/graphics/scanbd/default.nix
+++ b/pkgs/tools/graphics/scanbd/default.nix
@@ -3,10 +3,10 @@
 
 stdenv.mkDerivation rec {
   name = "scanbd-${version}";
-  version = "1.4.4";
+  version = "1.5.1";
 
   src = fetchurl {
-    sha256 = "07a59jk9b2hh49v5lcpckp64f5lny9sq8h0h2p2jcs9cqazf6q9s";
+    sha256 = "0pvy4qirfjdfm8aj6x5rkbgl7hk3jfa2s21qkk8ic5dqfjjab75n";
     url = "mirror://sourceforge/scanbd/${name}.tgz";
   };
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.5.1 with grep in /nix/store/liydcxfgnz54imzgmgkzbc2g6k0awxkm-scanbd-1.5.1
- found 1.5.1 in filename of file in /nix/store/liydcxfgnz54imzgmgkzbc2g6k0awxkm-scanbd-1.5.1
