### PR TITLE
seafile-client: 6.1.0 -> 6.1.5

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, writeScript, pkgconfig, cmake, qtbase, qttools
+{ stdenv, fetchFromGitHub, writeScript, pkgconfig, cmake, qtbase, qttools
 , seafile-shared, ccnet, makeWrapper
 , withShibboleth ? true, qtwebengine }:
 
@@ -8,9 +8,11 @@ stdenv.mkDerivation rec {
   version = "6.1.5";
   name = "seafile-client-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/haiwen/seafile-client/archive/v${version}.tar.gz";
-    sha256 = "09m1k99pb8vj37zfr8a0j5xyghyvxindmdpgxvvxh589q4ngfsx8";
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seafile-client";
+    rev = "v${version}";
+    sha256 = "1ahz55cw2p3s78x5f77drz4h2jhknfzpkk83qd0ggma31q1pnpl9";
   };
 
   nativeBuildInputs = [ pkgconfig cmake makeWrapper ];

--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -5,12 +5,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "6.1.0";
+  version = "6.1.5";
   name = "seafile-client-${version}";
 
   src = fetchurl {
     url = "https://github.com/haiwen/seafile-client/archive/v${version}.tar.gz";
-    sha256 = "16rn6b9ayaccgwx8hs3yh1wb395pp8ffh8may8a8bpcc4gdry7bd";
+    sha256 = "09m1k99pb8vj37zfr8a0j5xyghyvxindmdpgxvvxh589q4ngfsx8";
   };
 
   nativeBuildInputs = [ pkgconfig cmake makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 6.1.5 with grep in /nix/store/7y211zn1irykpjfgf8n38vbhh57xgaq2-seafile-client-6.1.5
- found 6.1.5 in filename of file in /nix/store/7y211zn1irykpjfgf8n38vbhh57xgaq2-seafile-client-6.1.5

cc "@calrama"