### PR TITLE
sec: 2.7.7 -> 2.7.12

### DIFF
--- a/pkgs/tools/admin/sec/default.nix
+++ b/pkgs/tools/admin/sec/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, perl, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "sec-2.7.7";
+  name = "sec-2.7.12";
 
   src = fetchurl {
     url = "mirror://sourceforge/simple-evcorr/${name}.tar.gz";
-    sha256 = "116nn8fg24nwcimm8gcfp52bsgh1ckrspjr8sk4i0arvpl3d12m9";
+    sha256 = "0f5a2nkd5cmg1rziizz2gmgdwb5dz99x9pbxw30p384rjh79zcaa";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12/bin/sec -h` got 0 exit code
- ran `/nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12/bin/sec --help` got 0 exit code
- ran `/nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12/bin/sec -V` and found version 2.7.12
- ran `/nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12/bin/sec -v` and found version 2.7.12
- ran `/nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12/bin/sec --version` and found version 2.7.12
- ran `/nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12/bin/sec -h` and found version 2.7.12
- ran `/nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12/bin/sec --help` and found version 2.7.12
- found 2.7.12 with grep in /nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12
- found 2.7.12 in filename of file in /nix/store/586lmj690hk6bvlsbzmx44kfcpamxs1l-sec-2.7.12

cc "@tv"