### PR TITLE
securefs: 0.3.2 -> 0.8.1

### DIFF
--- a/pkgs/tools/filesystems/securefs/default.nix
+++ b/pkgs/tools/filesystems/securefs/default.nix
@@ -4,10 +4,10 @@
 
 stdenv.mkDerivation rec {
   name = "securefs-${version}";
-  version = "0.3.2";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
-    sha256 = "1drksvwfgfpgcn2mzb65ljqlg2kgn6nald9fnz60hliw8f1wiqvh";
+    sha256 = "065n3mskv0b2dlk9w4b3pa70h5ymrnanydbanwyx74mf7n8c80r2";
     rev = version;
     repo = "securefs";
     owner = "netheril96";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/r1icgafqy02cz35kjkxr86hxj8mj1nyv-securefs-0.8.1/bin/securefs version` and found version 0.8.1
- found 0.8.1 with grep in /nix/store/r1icgafqy02cz35kjkxr86hxj8mj1nyv-securefs-0.8.1
- found 0.8.1 in filename of file in /nix/store/r1icgafqy02cz35kjkxr86hxj8mj1nyv-securefs-0.8.1
