### PR TITLE
shapelib: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/development/libraries/shapelib/default.nix
+++ b/pkgs/development/libraries/shapelib/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, proj }:
 
 stdenv.mkDerivation rec {
-  name = "shapelib-1.4.0";
+  name = "shapelib-1.4.1";
 
   src = fetchurl {
     url = "http://download.osgeo.org/shapelib/${name}.tar.gz";
-    sha256 = "18d7j5pn5srika7q3f90j0l2l4526xsjd64pin6z2b0gd7rdbp9y";
+    sha256 = "1cr3b5jfglwisbyzj7fnxp9xysqad0fcmcqvqaja6qap6qblijd4";
   };
 
   buildInputs =  [ proj ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/dc39wljsqrwrdnz2c0072wsch1qdf03v-shapelib-1.4.1/bin/dbfcreate -h` got 0 exit code
- ran `/nix/store/dc39wljsqrwrdnz2c0072wsch1qdf03v-shapelib-1.4.1/bin/dbfcreate --help` got 0 exit code
- ran `/nix/store/dc39wljsqrwrdnz2c0072wsch1qdf03v-shapelib-1.4.1/bin/dbfcreate help` got 0 exit code
- ran `/nix/store/dc39wljsqrwrdnz2c0072wsch1qdf03v-shapelib-1.4.1/bin/dbfinfo -h` got 0 exit code
- ran `/nix/store/dc39wljsqrwrdnz2c0072wsch1qdf03v-shapelib-1.4.1/bin/dbfinfo --help` got 0 exit code
- ran `/nix/store/dc39wljsqrwrdnz2c0072wsch1qdf03v-shapelib-1.4.1/bin/dbfinfo help` got 0 exit code
- found 1.4.1 with grep in /nix/store/dc39wljsqrwrdnz2c0072wsch1qdf03v-shapelib-1.4.1
- found 1.4.1 in filename of file in /nix/store/dc39wljsqrwrdnz2c0072wsch1qdf03v-shapelib-1.4.1

cc "@ehmry"