### PR TITLE
shc: 3.9.3 -> 3.9.6

### DIFF
--- a/pkgs/tools/security/shc/default.nix
+++ b/pkgs/tools/security/shc/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "shc-${version}";
-  version = "3.9.3";
+  version = "3.9.6";
   rev = "${version}";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "neurobin";
     repo = "shc";
-    sha256 = "00fqzg4a0f4kp4wr8swhi5zqds3gh3gf7cgi1cipn16av0818xsa";
+    sha256 = "07l6m24ivjnvbglxkx9mvarpzc453qrlq5ybkyz7jdilh481aj33";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/9gwfzrfmah4n4lf69anhqgxrj0p9f77l-shc-3.9.6/bin/shc -h` got 0 exit code
- ran `/nix/store/9gwfzrfmah4n4lf69anhqgxrj0p9f77l-shc-3.9.6/bin/shc --help` got 0 exit code
- ran `/nix/store/9gwfzrfmah4n4lf69anhqgxrj0p9f77l-shc-3.9.6/bin/shc -h` and found version 3.9.6
- ran `/nix/store/9gwfzrfmah4n4lf69anhqgxrj0p9f77l-shc-3.9.6/bin/shc --help` and found version 3.9.6
- found 3.9.6 with grep in /nix/store/9gwfzrfmah4n4lf69anhqgxrj0p9f77l-shc-3.9.6
- found 3.9.6 in filename of file in /nix/store/9gwfzrfmah4n4lf69anhqgxrj0p9f77l-shc-3.9.6
