### PR TITLE
skrooge: 2.10.5 -> 2.11.0

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -7,11 +7,11 @@
 
 mkDerivation rec {
   name = "skrooge-${version}";
-  version = "2.10.5";
+  version = "2.11.0";
 
   src = fetchurl {
     url = "http://download.kde.org/stable/skrooge/${name}.tar.xz";
-    sha256 = "1c1yihypb6qgbzfcrw4ylqr9zivyba10xzvibrmfkrilxi6i582n";
+    sha256 = "11ns0j3ss09aqd8snfzd52xf0cgsjjcgzalb031p7v17rn14yqaq";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/a0n4s1xpwchl3d7d3pk50bd1pf2acldp-skrooge-2.11.0/bin/skroogeconvert -h` got 0 exit code
- ran `/nix/store/a0n4s1xpwchl3d7d3pk50bd1pf2acldp-skrooge-2.11.0/bin/skroogeconvert --help` got 0 exit code
- ran `/nix/store/a0n4s1xpwchl3d7d3pk50bd1pf2acldp-skrooge-2.11.0/bin/skroogeconvert -v` and found version 2.11.0
- ran `/nix/store/a0n4s1xpwchl3d7d3pk50bd1pf2acldp-skrooge-2.11.0/bin/skroogeconvert --version` and found version 2.11.0
- ran `/nix/store/a0n4s1xpwchl3d7d3pk50bd1pf2acldp-skrooge-2.11.0/bin/skroogeconvert -h` and found version 2.11.0
- ran `/nix/store/a0n4s1xpwchl3d7d3pk50bd1pf2acldp-skrooge-2.11.0/bin/skroogeconvert --help` and found version 2.11.0
- found 2.11.0 with grep in /nix/store/a0n4s1xpwchl3d7d3pk50bd1pf2acldp-skrooge-2.11.0

cc "@joko"