### PR TITLE
sleuthkit: 4.5.0 -> 4.6.0

### DIFF
--- a/pkgs/tools/system/sleuthkit/default.nix
+++ b/pkgs/tools/system/sleuthkit/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoreconfHook, libewf, afflib, openssl, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "4.5.0";
+  version = "4.6.0";
   name = "sleuthkit-${version}";
 
   src = fetchFromGitHub {
     owner = "sleuthkit";
     repo = "sleuthkit";
     rev = name;
-    sha256 = "0h9l9yl5ibbgriq12gizg8k0r6jw6bnii3iljjp4p963wc0ms9b9";
+    sha256 = "0m5ll5sx0pxkn58y582b3v90rsfdrh8dm02kmv61psd0k6q0p91x";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/img_cat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/img_stat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/mmls -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/mmstat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/mmcat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/blkcalc -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/blkcat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/blkls -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/blkstat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/ffind -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/fls -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/fcat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/fsstat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/icat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/ifind -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/ils -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/istat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/jcat -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/jls -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/usnjls -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/hfind -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/srch_strings -h` got 0 exit code
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/srch_strings -h` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/sigfind -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/tsk_recover -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/tsk_loaddb -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/tsk_comparedir -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/tsk_gettimes -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/fiwalk help` got 0 exit code
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/fiwalk -V` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/fiwalk version` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/fiwalk help` and found version 4.6.0
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/jpeg_extract -h` got 0 exit code
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/jpeg_extract --help` got 0 exit code
- ran `/nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0/bin/jpeg_extract help` got 0 exit code
- found 4.6.0 with grep in /nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0
- found 4.6.0 in filename of file in /nix/store/p9a3kmrv42f95z3a7lm7lb7g7dwbi0wq-sleuthkit-4.6.0

cc "@raskin"