### PR TITLE
slurm: 17.02.9 -> 17.11.3

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-${version}";
-  version = "17.02.9";
+  version = "17.11.3";
 
   src = fetchurl {
     url = "https://download.schedmd.com/slurm/${name}.tar.bz2";
-    sha256 = "0w8v7fzbn7b3f9kg6lcj2jpkzln3vcv9s2cz37xbdifz0m2p1x7s";
+    sha256 = "1x3i6z03d9m46fvj1cslrapm1drvgyqch9pn4xf23kvbz4gkhaps";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lp32291f98zl5fzhbzvd4icjl2s6mdad-slurm-17.11.3/bin/sattach -h` got 0 exit code
- ran `/nix/store/lp32291f98zl5fzhbzvd4icjl2s6mdad-slurm-17.11.3/bin/sattach --help` got 0 exit code
- ran `/nix/store/lp32291f98zl5fzhbzvd4icjl2s6mdad-slurm-17.11.3/bin/sattach -V` and found version 17.11.3
- ran `/nix/store/lp32291f98zl5fzhbzvd4icjl2s6mdad-slurm-17.11.3/bin/sattach --version` and found version 17.11.3
- ran `/nix/store/lp32291f98zl5fzhbzvd4icjl2s6mdad-slurm-17.11.3/bin/slurmd -h` got 0 exit code
- ran `/nix/store/lp32291f98zl5fzhbzvd4icjl2s6mdad-slurm-17.11.3/bin/slurmd -V` and found version 17.11.3
- found 17.11.3 with grep in /nix/store/lp32291f98zl5fzhbzvd4icjl2s6mdad-slurm-17.11.3
- found 17.11.3 in filename of file in /nix/store/lp32291f98zl5fzhbzvd4icjl2s6mdad-slurm-17.11.3

cc "@jagajaga"