### PR TITLE
smcroute: 2.3.1 -> 2.4.0

### DIFF
--- a/pkgs/servers/smcroute/default.nix
+++ b/pkgs/servers/smcroute/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "smcroute-${version}";
-  version = "2.3.1";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "troglobit";
     repo = "smcroute";
     rev = version;
-    sha256 = "0a1sgf9p39gbfrh7bhfg1hjqa6y18i7cig7bffmv7spqnvb50zx5";
+    sha256 = "12xwdwvl9h269armwak7grm4g944j2c89srha4lqx2zndx1ycg1r";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcroutectl -h` got 0 exit code
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcroutectl --help` got 0 exit code
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcroutectl help` got 0 exit code
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcroutectl -V` and found version 2.4.0
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcroutectl -v` and found version 2.4.0
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcroutectl --version` and found version 2.4.0
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcroutectl version` and found version 2.4.0
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcroutectl --help` and found version 2.4.0
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcrouted -h` got 0 exit code
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcrouted -v` and found version 2.4.0
- ran `/nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0/bin/smcrouted -h` and found version 2.4.0
- found 2.4.0 with grep in /nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0
- found 2.4.0 in filename of file in /nix/store/7i72915zqm0xq840hj0qr6ff57syljc9-smcroute-2.4.0

cc "@fpletz"