### PR TITLE
snd: 17.8 -> 18.1

### DIFF
--- a/pkgs/applications/audio/snd/default.nix
+++ b/pkgs/applications/audio/snd/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "snd-17.8";
+  name = "snd-18.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/snd/${name}.tar.gz";
-    sha256 = "161bx2xgz692iqmsmhv9yi8rvd7y31si4rniizwirwz7q4y4vwvf";
+    sha256 = "0wdifvpm54j5fxxp867jnrfdy3jb8iff2mxqvp08plp45zfjv6xh";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/h2s0m8v39bj1z84habnkrxidkip0vmbr-snd-18.1/bin/snd --help` got 0 exit code
- ran `/nix/store/h2s0m8v39bj1z84habnkrxidkip0vmbr-snd-18.1/bin/snd --version` and found version 18.1
- ran `/nix/store/h2s0m8v39bj1z84habnkrxidkip0vmbr-snd-18.1/bin/snd --help` and found version 18.1
- found 18.1 with grep in /nix/store/h2s0m8v39bj1z84habnkrxidkip0vmbr-snd-18.1
- found 18.1 in filename of file in /nix/store/h2s0m8v39bj1z84habnkrxidkip0vmbr-snd-18.1

cc "@fuuzetsu"