### PR TITLE
snort: 2.9.8.2 -> 2.9.11.1

### DIFF
--- a/pkgs/applications/networking/ids/snort/default.nix
+++ b/pkgs/applications/networking/ids/snort/default.nix
@@ -1,13 +1,13 @@
 {stdenv, fetchurl, libpcap, pcre, libdnet, daq, zlib, flex, bison, makeWrapper}:
 
 stdenv.mkDerivation rec {
-  version = "2.9.8.2";
+  version = "2.9.11.1";
   name = "snort-${version}";
   
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://snort.org/downloads/archive/snort/${name}.tar.gz";
-    sha256 = "0cwk02jan0vw6r3jl3vrf31vfp7i4c1r4yhb42h4gyhd6lnh2xa0";
+    sha256 = "1ka67zrrhs32c729v4h76mvv2723mij0adxx0iaza2d1qpm3lswz";
   };
   
   buildInputs = [ makeWrapper libpcap pcre libdnet daq zlib flex bison ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qan26dfxzzbh27cd91hcvad69ls7xnhw-snort-2.9.11.1/bin/snort -V` and found version 2.9.11.1
- ran `/nix/store/qan26dfxzzbh27cd91hcvad69ls7xnhw-snort-2.9.11.1/bin/snort --version` and found version 2.9.11.1
- ran `/nix/store/qan26dfxzzbh27cd91hcvad69ls7xnhw-snort-2.9.11.1/bin/u2spewfoo help` got 0 exit code
- ran `/nix/store/qan26dfxzzbh27cd91hcvad69ls7xnhw-snort-2.9.11.1/bin/.snort-wrapped -V` and found version 2.9.11.1
- ran `/nix/store/qan26dfxzzbh27cd91hcvad69ls7xnhw-snort-2.9.11.1/bin/.snort-wrapped --version` and found version 2.9.11.1
- found 2.9.11.1 with grep in /nix/store/qan26dfxzzbh27cd91hcvad69ls7xnhw-snort-2.9.11.1
- found 2.9.11.1 in filename of file in /nix/store/qan26dfxzzbh27cd91hcvad69ls7xnhw-snort-2.9.11.1

cc "@aycanirican"