### PR TITLE
soundtouch: 1.9.2 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/soundtouch/default.nix
+++ b/pkgs/development/libraries/soundtouch/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   pName = "soundtouch";
-  name = "${pName}-1.9.2";
+  name = "${pName}-2.0.0";
   src = fetchurl {
     url = "http://www.surina.net/soundtouch/${name}.tar.gz";
-    sha256 = "04y5l56yn4jvwpv9mn1p3m2vi5kdym9xpdac8pmhwhl13r8qdsya";
+    sha256 = "09cxr02mfyj2bg731bj0i9hh565x8l9p91aclxs8wpqv8b8zf96j";
   };
 
   buildInputs = [ autoconf automake libtool ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.0.0 with grep in /nix/store/mccg5fjzlk40fic8crh6mj0nknwmr774-soundtouch-2.0.0
- found 2.0.0 in filename of file in /nix/store/mccg5fjzlk40fic8crh6mj0nknwmr774-soundtouch-2.0.0
