### PR TITLE
speedtest-cli: 1.0.6 -> 2.0.0

### DIFF
--- a/pkgs/tools/networking/speedtest-cli/default.nix
+++ b/pkgs/tools/networking/speedtest-cli/default.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "speedtest-cli-${version}";
-  version = "1.0.6";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "sivel";
     repo = "speedtest-cli";
     rev = "v${version}";
-    sha256 = "008a0wymn06h93gdkxwlgxg8039ybdni96i4blhpayj52jkbflnv";
+    sha256 = "06fini7bqf5paphp8dpck1zpmb33cdxlf4hg6xg2g9k4bdm2k26d";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/.speedtest-wrapped -h` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/.speedtest-wrapped --help` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/.speedtest-wrapped help` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/.speedtest-wrapped --version` and found version 2.0.0
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/speedtest -h` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/speedtest --help` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/speedtest help` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/speedtest --version` and found version 2.0.0
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/.speedtest-cli-wrapped -h` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/.speedtest-cli-wrapped --help` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/.speedtest-cli-wrapped help` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/.speedtest-cli-wrapped --version` and found version 2.0.0
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/speedtest-cli -h` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/speedtest-cli --help` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/speedtest-cli help` got 0 exit code
- ran `/nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0/bin/speedtest-cli --version` and found version 2.0.0
- found 2.0.0 with grep in /nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0
- found 2.0.0 in filename of file in /nix/store/8xa3h2k85qyh2w141r0j0cb1984g2zsx-speedtest-cli-2.0.0

cc "@domenkozar @ndowens"