### PR TITLE
sphinxsearch: 2.2.8 -> 2.2.11

### DIFF
--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, pkgconfig,
-  version ? "2.2.8",
+  version ? "2.2.11",
   mainSrc ? fetchurl {
     url = "http://sphinxsearch.com/files/sphinx-${version}-release.tar.gz";
-    sha256 = "1q6jdw5g81k7ciw9fhwklb5ifgb8zna39795m0x0lbvwjbk3ampv";
+    sha256 = "1aa1mh32y019j8s3sjzn4vwi0xn83dwgl685jnbgh51k16gh6qk6";
   }
 }:
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/rd3zgq55rdmmyd4rfbv2ij98bk55icic-sphinxsearch-2.2.11/bin/sphinxsearch-searchd -h` got 0 exit code
- ran `/nix/store/rd3zgq55rdmmyd4rfbv2ij98bk55icic-sphinxsearch-2.2.11/bin/sphinxsearch-searchd --help` got 0 exit code
- ran `/nix/store/rd3zgq55rdmmyd4rfbv2ij98bk55icic-sphinxsearch-2.2.11/bin/sphinxsearch-searchd -h` and found version 2.2.11
- ran `/nix/store/rd3zgq55rdmmyd4rfbv2ij98bk55icic-sphinxsearch-2.2.11/bin/sphinxsearch-searchd --help` and found version 2.2.11
- found 2.2.11 with grep in /nix/store/rd3zgq55rdmmyd4rfbv2ij98bk55icic-sphinxsearch-2.2.11
- found 2.2.11 in filename of file in /nix/store/rd3zgq55rdmmyd4rfbv2ij98bk55icic-sphinxsearch-2.2.11

cc "@ederoyd46"