### PR TITLE
sqlcipher: 3.4.0 -> 3.4.2

### DIFF
--- a/pkgs/development/libraries/sqlcipher/default.nix
+++ b/pkgs/development/libraries/sqlcipher/default.nix
@@ -4,13 +4,13 @@ assert readline != null -> ncurses != null;
 
 stdenv.mkDerivation rec {
   name = "sqlcipher-${version}";
-  version = "3.4.0";
+  version = "3.4.2";
 
   src = fetchFromGitHub {
     owner = "sqlcipher";
     repo = "sqlcipher";
     rev = "v${version}";
-    sha256 = "1lwc2m21sax3pnjfqddldbpbwr3b51s91fxz7dd7hf6ly8swnsvp";
+    sha256 = "168wb6fvyap7y8j86fb3xl5rd4wmhiq0dxvx9wxwi5kwm1j4vn1a";
   };
 
   buildInputs = [ readline ncurses openssl tcl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.4.2 with grep in /nix/store/ad99ha1vvigs8zaw6mb4cwjb0an9gdlp-sqlcipher-3.4.2
- found 3.4.2 in filename of file in /nix/store/ad99ha1vvigs8zaw6mb4cwjb0an9gdlp-sqlcipher-3.4.2
