### PR TITLE
squirrel-sql: 3.7.1 -> 3.8.1

### DIFF
--- a/pkgs/development/tools/database/squirrel-sql/default.nix
+++ b/pkgs/development/tools/database/squirrel-sql/default.nix
@@ -5,13 +5,13 @@
 , drivers ? []
 }:
 let
-  version = "3.7.1";
+  version = "3.8.1";
 in stdenv.mkDerivation rec {
   name = "squirrel-sql-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/squirrel-sql/1-stable/${version}-plainzip/squirrelsql-${version}-standard.zip";
-    sha256 = "1v141ply57k5krwbnnmz4mbs9hs8rbys0bkjz69gvxlqjizyiq23";
+    sha256 = "1vv38i4rwm8c8h0p9mmz21dyafd71pqprj7b8i5vx7f4q8xns2d2";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/d1xb2sv0zhj3q10zrggffmsjlgl8a4n9-squirrel-sql-3.8.1/bin/squirrel-sql -h` got 0 exit code
- ran `/nix/store/d1xb2sv0zhj3q10zrggffmsjlgl8a4n9-squirrel-sql-3.8.1/bin/squirrel-sql --help` got 0 exit code
- ran `/nix/store/d1xb2sv0zhj3q10zrggffmsjlgl8a4n9-squirrel-sql-3.8.1/bin/squirrel-sql help` got 0 exit code
- found 3.8.1 with grep in /nix/store/d1xb2sv0zhj3q10zrggffmsjlgl8a4n9-squirrel-sql-3.8.1
- found 3.8.1 in filename of file in /nix/store/d1xb2sv0zhj3q10zrggffmsjlgl8a4n9-squirrel-sql-3.8.1

cc "@khumba"