### PR TITLE
sslmate: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/development/tools/sslmate/default.nix
+++ b/pkgs/development/tools/sslmate/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perlPackages, perl, makeWrapper, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "sslmate-1.5.0";
+  name = "sslmate-1.6.0";
 
   src = fetchurl {
     url = "https://packages.sslmate.com/other/${name}.tar.gz";
-    sha256 = "1vxdkydwww4awi6ishvq68jvlj6vkbfw7pin1cdqpl84vs9q7ycg";
+    sha256 = "1ypabdk0nlqjzpmn3m1szjyw7yq20svgbm92sqd5wqmsapyn3a6s";
   };
 
   makeFlags = "PREFIX=$(out)";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/cifmnprcfrgiz551lg7n5js4fblmhrr4-sslmate-1.6.0/bin/sslmate help` got 0 exit code
- ran `/nix/store/cifmnprcfrgiz551lg7n5js4fblmhrr4-sslmate-1.6.0/bin/sslmate version` and found version 1.6.0
- found 1.6.0 with grep in /nix/store/cifmnprcfrgiz551lg7n5js4fblmhrr4-sslmate-1.6.0
- found 1.6.0 in filename of file in /nix/store/cifmnprcfrgiz551lg7n5js4fblmhrr4-sslmate-1.6.0

cc "@domenkozar"