### PR TITLE
strongswan: 5.6.1 -> 5.6.2

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -12,11 +12,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "strongswan-${version}";
-  version = "5.6.1";
+  version = "5.6.2";
 
   src = fetchurl {
     url = "http://download.strongswan.org/${name}.tar.bz2";
-    sha256 = "0lxbyiary8iapx3ysw40czrmxf983fhfzs5mvz2hk1j1mpc85hp0";
+    sha256 = "14ifqay54brw2b2hbmm517bxw8bs9631d7jm4g139igkxcq0m9p0";
   };
 
   dontPatchELF = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/pki -h` got 0 exit code
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/pki --help` got 0 exit code
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/pki -h` and found version 5.6.2
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/pki --help` and found version 5.6.2
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/charon-cmd --help` got 0 exit code
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/charon-cmd --version` and found version 5.6.2
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/charon-cmd --help` and found version 5.6.2
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/ipsec --help` got 0 exit code
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/ipsec --version` and found version 5.6.2
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/ipsec version` and found version 5.6.2
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/swanctl -h` got 0 exit code
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/swanctl --help` got 0 exit code
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/swanctl -h` and found version 5.6.2
- ran `/nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2/bin/swanctl --help` and found version 5.6.2
- found 5.6.2 with grep in /nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2
- found 5.6.2 in filename of file in /nix/store/jd04xpik9zwmy39nh0axfss0m4hmw8yv-strongswan-5.6.2
