### PR TITLE
subsonic: 6.0 -> 6.1.3

### DIFF
--- a/pkgs/servers/misc/subsonic/default.nix
+++ b/pkgs/servers/misc/subsonic/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, jre }:
 
-let version = "6.0"; in
+let version = "6.1.3"; in
 
 stdenv.mkDerivation rec {
   name = "subsonic-${version}";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/subsonic/subsonic-${version}-standalone.tar.gz";
-    sha256 = "0aw7lz7bkhqvjj3lkk68n2aqr5l84s91cgifg2379w2j7dgd056z";
+    sha256 = "1v21gfymaqcx6n6d88hvha60q9hgj5z1wsac5gcwq7cjah1893jx";
   };
 
   inherit jre;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 6.1.3 with grep in /nix/store/vg2w75wy8kk8qky8lca2ammzixzrzyzv-subsonic-6.1.3
- found 6.1.3 in filename of file in /nix/store/vg2w75wy8kk8qky8lca2ammzixzrzyzv-subsonic-6.1.3

cc "@telotortium"