### PR TITLE
supercollider: 3.8.1 -> 3.9.1

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -9,12 +9,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "supercollider-${version}";
-  version = "3.8.1";
+  version = "3.9.1";
 
 
   src = fetchurl {
     url = "https://github.com/supercollider/supercollider/releases/download/Version-${version}/SuperCollider-${version}-Source-linux.tar.bz2";
-    sha256 = "1y8yb20k3lvj7c93qz2srrkvfv175n4n7p3qj89w0dp085mj0qmw";
+    sha256 = "150fgnjcmb06r3pa3mbsvb4iwnqlimjwdxgbs6p55zz6g8wbln7a";
   };
 
   hardeningDisable = [ "stackprotector" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/4wlhzjj8k4a49dvpzgwhll2m03hvvcz9-supercollider-3.9.1/bin/scsynth -v` and found version 3.9.1
- ran `/nix/store/4wlhzjj8k4a49dvpzgwhll2m03hvvcz9-supercollider-3.9.1/bin/supernova -h` got 0 exit code
- ran `/nix/store/4wlhzjj8k4a49dvpzgwhll2m03hvvcz9-supercollider-3.9.1/bin/supernova --help` got 0 exit code
- ran `/nix/store/4wlhzjj8k4a49dvpzgwhll2m03hvvcz9-supercollider-3.9.1/bin/supernova -v` and found version 3.9.1
- ran `/nix/store/4wlhzjj8k4a49dvpzgwhll2m03hvvcz9-supercollider-3.9.1/bin/supernova --version` and found version 3.9.1
- ran `/nix/store/4wlhzjj8k4a49dvpzgwhll2m03hvvcz9-supercollider-3.9.1/bin/sclang -h` got 0 exit code
- ran `/nix/store/4wlhzjj8k4a49dvpzgwhll2m03hvvcz9-supercollider-3.9.1/bin/sclang -v` and found version 3.9.1
- found 3.9.1 with grep in /nix/store/4wlhzjj8k4a49dvpzgwhll2m03hvvcz9-supercollider-3.9.1