### PR TITLE
surfraw: 2.2.9 -> 2.3.0

### DIFF
--- a/pkgs/tools/networking/surfraw/default.nix
+++ b/pkgs/tools/networking/surfraw/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, perl}:
 
 stdenv.mkDerivation rec {
-  name = "surfraw-2.2.9";
+  name = "surfraw-2.3.0";
 
   src = fetchurl {
-    url = "http://surfraw.alioth.debian.org/dist/surfraw-2.2.9.tar.gz";
-    sha256 = "1fy4ph5h9kp0jzj1m6pfylxnnmgdk0mmdppw76z9jhna4jndk5xa";
+    url = "http://surfraw.alioth.debian.org/dist/surfraw-2.3.0.tar.gz";
+    sha256 = "099nbif0x5cbcf18snc58nx1a3q7z0v9br9p2jiq9pcc7ic2015d";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3w61z4y841pb4zykywl9p7ajb6lhqjf8-surfraw-2.3.0/bin/surfraw-update-path -h` got 0 exit code
- ran `/nix/store/3w61z4y841pb4zykywl9p7ajb6lhqjf8-surfraw-2.3.0/bin/surfraw-update-path --help` got 0 exit code
- ran `/nix/store/3w61z4y841pb4zykywl9p7ajb6lhqjf8-surfraw-2.3.0/bin/surfraw-update-path -h` and found version 2.3.0
- ran `/nix/store/3w61z4y841pb4zykywl9p7ajb6lhqjf8-surfraw-2.3.0/bin/surfraw-update-path --help` and found version 2.3.0
- found 2.3.0 with grep in /nix/store/3w61z4y841pb4zykywl9p7ajb6lhqjf8-surfraw-2.3.0
- found 2.3.0 in filename of file in /nix/store/3w61z4y841pb4zykywl9p7ajb6lhqjf8-surfraw-2.3.0

cc ""