### PR TITLE
svn2git: 2.3.2 -> 2.4.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/svn2git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/svn2git/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, ruby, makeWrapper, git }:
 
 let
-  version = "2.3.2";
+  version = "2.4.0";
 in
 stdenv.mkDerivation {
   name = "svn2git-${version}";
 
   src = fetchurl {
     url = "https://github.com/nirvdrum/svn2git/archive/v${version}.tar.gz";
-    sha256 = "1484mpcabqf9kr6xdpdgb1npkqav1bcah3w5lxj2djjx4bjf2g3y";
+    sha256 = "0ly2vrv6q31n0xhciwb7a1ilr5c6ndyi3bg81yfp4axiypps7l41";
   };
 
   buildInputs = [ ruby makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/zyvza6zasri7wnx6k92d7wb7shn66kxr-svn2git-2.4.0/bin/svn2git -h` got 0 exit code
- ran `/nix/store/zyvza6zasri7wnx6k92d7wb7shn66kxr-svn2git-2.4.0/bin/svn2git --help` got 0 exit code
- found 2.4.0 with grep in /nix/store/zyvza6zasri7wnx6k92d7wb7shn66kxr-svn2git-2.4.0
- found 2.4.0 in filename of file in /nix/store/zyvza6zasri7wnx6k92d7wb7shn66kxr-svn2git-2.4.0

cc "@the-kenny"