### PR TITLE
swagger-codegen: 2.2.1 -> 2.3.1

### DIFF
--- a/pkgs/tools/networking/swagger-codegen/default.nix
+++ b/pkgs/tools/networking/swagger-codegen/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, jre, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "2.2.1";
+  version = "2.3.1";
   pname = "swagger-codegen";
   name = "${pname}-${version}";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://oss.sonatype.org/content/repositories/releases/io/swagger/${pname}-cli/${version}/${jarfilename}";
-    sha256 = "1pwxkl3r93c8hsif9xm0h1hmbjrxz1q7hr5qn5n0sni1x3c3k0d1";
+    sha256 = "171qr0zx7i6cykv54vqjf3mplrf7w4a1fpq47wsj861lbf8xm322";
   };
 
   phases = [ "installPhase" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/x901ajf5y7i8xg81lnngw7p9fwyn73da-swagger-codegen-2.3.1/bin/swagger-codegen help` got 0 exit code
- ran `/nix/store/x901ajf5y7i8xg81lnngw7p9fwyn73da-swagger-codegen-2.3.1/bin/swagger-codegen version` and found version 2.3.1
- found 2.3.1 with grep in /nix/store/x901ajf5y7i8xg81lnngw7p9fwyn73da-swagger-codegen-2.3.1
- found 2.3.1 in filename of file in /nix/store/x901ajf5y7i8xg81lnngw7p9fwyn73da-swagger-codegen-2.3.1

cc "@jraygauthier"