### PR TITLE
sysbench: 1.0.6 -> 1.0.13

### DIFF
--- a/pkgs/development/tools/misc/sysbench/default.nix
+++ b/pkgs/development/tools/misc/sysbench/default.nix
@@ -2,7 +2,7 @@
 , libaio }:
 
 stdenv.mkDerivation rec {
-  name = "sysbench-1.0.6";
+  name = "sysbench-1.0.13";
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ vim mysql.connector-c libaio ];
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "akopytov";
     repo = "sysbench";
-    rev = "1.0.6";
-    sha256 = "0y3hlhzrggyyxwf378n006zlg2kwhmhh6vq6il0qn9agjmjmhl5l";
+    rev = "1.0.13";
+    sha256 = "1inxyjpcyv2ag3k5riwlaq91362y16yks75vs2crmhjxlxdspy8c";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/g7j0xbs2izhmr4jy7zj4q7b2nqgs5wn2-sysbench-1.0.13/bin/sysbench --help` got 0 exit code
- ran `/nix/store/g7j0xbs2izhmr4jy7zj4q7b2nqgs5wn2-sysbench-1.0.13/bin/sysbench --version` and found version 1.0.13
- found 1.0.13 with grep in /nix/store/g7j0xbs2izhmr4jy7zj4q7b2nqgs5wn2-sysbench-1.0.13
- found 1.0.13 in filename of file in /nix/store/g7j0xbs2izhmr4jy7zj4q7b2nqgs5wn2-sysbench-1.0.13
