### PR TITLE
sysstat: 11.2.5 -> 11.7.2

### DIFF
--- a/pkgs/os-specific/linux/sysstat/default.nix
+++ b/pkgs/os-specific/linux/sysstat/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, gettext, bzip2 }:
 
 stdenv.mkDerivation rec {
-  name = "sysstat-11.2.5";
+  name = "sysstat-11.7.2";
 
   src = fetchurl {
     url = "http://perso.orange.fr/sebastien.godard/${name}.tar.xz";
-    sha256 = "1r7869pnylamjry5f5l5m1jn68v61js9wdkz8yn37a9a2bcrqp2d";
+    sha256 = "169yh9d0ags9xrn5g0k42wd1c895117zbzs257cjxqnb2vk0a38v";
   };
 
   buildInputs = [ gettext ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/sar --help` got 0 exit code
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/sar -V` and found version 11.7.2
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/sar --help` and found version 11.7.2
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/sadf -V` and found version 11.7.2
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/iostat -h` got 0 exit code
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/iostat help` got 0 exit code
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/iostat -V` and found version 11.7.2
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/tapestat -V` and found version 11.7.2
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/mpstat -V` and found version 11.7.2
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/pidstat -h` got 0 exit code
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/pidstat -V` and found version 11.7.2
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/cifsiostat -h` got 0 exit code
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/cifsiostat help` got 0 exit code
- ran `/nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2/bin/cifsiostat -V` and found version 11.7.2
- found 11.7.2 with grep in /nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2
- found 11.7.2 in filename of file in /nix/store/m8nm4ifgh3j31wnlz6ixn737d29sv3dx-sysstat-11.7.2

cc "@eelco"