### PR TITLE
tclap: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/development/libraries/tclap/default.nix
+++ b/pkgs/development/libraries/tclap/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "tclap-1.2.1";
+  name = "tclap-1.2.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/tclap/${name}.tar.gz";
-    sha256 = "1fzf7l1wvlhxnpwi15jvvfizn836s7r0r8vckgbqk2lyf7ihz7wz";
+    sha256 = "0dsqvsgzam3mypj2ladn6v1yjq9zd47p3lg21jx6kz5azkkkn0gm";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.2.2 with grep in /nix/store/91iz6pnbmjn0lc0f6iyy22wavngbbxhm-tclap-1.2.2
- found 1.2.2 in filename of file in /nix/store/91iz6pnbmjn0lc0f6iyy22wavngbbxhm-tclap-1.2.2