### PR TITLE
tcllib: 1.18 -> 1.19

### DIFF
--- a/pkgs/development/libraries/tcllib/default.nix
+++ b/pkgs/development/libraries/tcllib/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "tcllib-${version}";
-  version = "1.18";
+  version = "1.19";
 
   src = fetchurl {
     url = "mirror://sourceforge/tcllib/tcllib-${version}.tar.gz";
-    sha256 = "05dmrk9qsryah2n17z6z85dj9l9lfyvnsd7faw0p9bs1pp5pwrkj";
+    sha256 = "173abxaazdmf210v651708ab6h7xhskvd52krxk6ifam337qgzh1";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.19 with grep in /nix/store/6125kc5ryhd9vxwf6j7bbdv57ajsi2hs-tcllib-1.19