### PR TITLE
tcpkali: 0.9 -> 1.1.1

### DIFF
--- a/pkgs/applications/networking/tcpkali/default.nix
+++ b/pkgs/applications/networking/tcpkali/default.nix
@@ -1,6 +1,6 @@
 {stdenv, autoreconfHook, fetchFromGitHub, bison}:
 
-let version = "0.9"; in
+let version = "1.1.1"; in
 
 stdenv.mkDerivation rec {
   name = "tcpkali-${version}";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "machinezone";
     repo = "tcpkali";
     rev = "v${version}";
-    sha256 = "03cbmnc60wkd7f4bapn5cbm3c4zas2l0znsbpci2mn8ms8agif82";
+    sha256 = "09ky3cccaphcqc6nhfs00pps99lasmzc2pf5vk0gi8hlqbbhilxf";
   };
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ bison];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/651sa1wikygbqqvimg3a609n37isc78w-tcpkali-1.1.1/bin/tcpkali --version` and found version 1.1.1
- found 1.1.1 with grep in /nix/store/651sa1wikygbqqvimg3a609n37isc78w-tcpkali-1.1.1
- found 1.1.1 in filename of file in /nix/store/651sa1wikygbqqvimg3a609n37isc78w-tcpkali-1.1.1

cc "@ethercrow"