### PR TITLE
tcpreplay: 4.2.5 -> 4.2.6

### DIFF
--- a/pkgs/tools/networking/tcpreplay/default.nix
+++ b/pkgs/tools/networking/tcpreplay/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "tcpreplay-${version}";
-  version = "4.2.5";
+  version = "4.2.6";
 
   src = fetchurl {
     url = "https://github.com/appneta/tcpreplay/releases/download/v${version}/tcpreplay-${version}.tar.gz";
-    sha256 = "1mw9r97blczm70rjf7p83sd1fxpzdzfvsbnjsc0m3nz16jz2c44l";
+    sha256 = "07aklkc1s13hwrd098bqj8izfh8kdgs7wl9swcmkxffs6b2mcdq4";
   };
 
   buildInputs = [ libpcap ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpreplay --help` got 0 exit code
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpreplay -V` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpreplay --version` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpreplay --help` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpprep --help` got 0 exit code
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpprep -V` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpprep --version` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpprep --help` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcprewrite --help` got 0 exit code
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcprewrite -V` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcprewrite --version` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcprewrite --help` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpreplay-edit --help` got 0 exit code
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpreplay-edit -V` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpreplay-edit --version` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpreplay-edit --help` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpcapinfo --help` got 0 exit code
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpcapinfo -V` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpcapinfo --version` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpbridge --help` got 0 exit code
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpbridge -V` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpbridge --version` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpbridge --help` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpliveplay --help` got 0 exit code
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpliveplay help` got 0 exit code
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpliveplay -V` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpliveplay --version` and found version 4.2.6
- ran `/nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6/bin/tcpliveplay --help` and found version 4.2.6
- found 4.2.6 with grep in /nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6
- found 4.2.6 in filename of file in /nix/store/px3r1zrv2ri4w11xvx95yx8a0p1yj4li-tcpreplay-4.2.6

cc "@eleanor"