### PR TITLE
tdb: 1.3.11 -> 1.3.15

### DIFF
--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "tdb-1.3.11";
+  name = "tdb-1.3.15";
 
   src = fetchurl {
     url = "mirror://samba/tdb/${name}.tar.gz";
-    sha256 = "0i1l38h0vyck6zkcj4fn2l03spadlmyr1qa1xpdp9dy2ccbm3s1r";
+    sha256 = "0a37jhpij8wr4f4pjqdlwnffy2l6a2vkqdpz1bqxj6v06cwbz8dl";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3dmmnilw4rsyrnz164vy04advblps0h5-tdb-1.3.15/bin/tdbdump -h` got 0 exit code
- ran `/nix/store/3dmmnilw4rsyrnz164vy04advblps0h5-tdb-1.3.15/bin/tdbbackup -h` got 0 exit code
- ran `/nix/store/3dmmnilw4rsyrnz164vy04advblps0h5-tdb-1.3.15/bin/tdbbackup --help` got 0 exit code
- ran `/nix/store/3dmmnilw4rsyrnz164vy04advblps0h5-tdb-1.3.15/bin/tdbbackup --help` and found version 1.3.15
- found 1.3.15 with grep in /nix/store/3dmmnilw4rsyrnz164vy04advblps0h5-tdb-1.3.15
- found 1.3.15 in filename of file in /nix/store/3dmmnilw4rsyrnz164vy04advblps0h5-tdb-1.3.15

cc "@wkennington"