### PR TITLE
teleport: 2.4.0 -> 2.4.1

### DIFF
--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -3,14 +3,14 @@
 
 buildGoPackage rec {
   name = "teleport-${version}";
-  version = "2.4.0";
+  version = "2.4.1";
 
   # This repo has a private submodule "e" which fetchgit cannot handle without failing.
   src = fetchFromGitHub {
     owner = "gravitational";
     repo = "teleport";
     rev = "v${version}";
-    sha256 = "1x4xnqjyb87pzmn2c59fwmzfx1f2k0xhqn2xgki3722qmj2ss846";
+    sha256 = "09kmlihv4aqc39f9cyv2vm0kqgdf9vmdrgds5krnzqdgy3svyg7y";
   };
 
   goPackagePath = "github.com/gravitational/teleport";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/kp6byd77bjr0k67js1z2a24p8kb81ddb-teleport-2.4.1-bin/bin/tsh help` got 0 exit code
- ran `/nix/store/kp6byd77bjr0k67js1z2a24p8kb81ddb-teleport-2.4.1-bin/bin/tsh version` and found version 2.4.1
- ran `/nix/store/kp6byd77bjr0k67js1z2a24p8kb81ddb-teleport-2.4.1-bin/bin/tctl help` got 0 exit code
- ran `/nix/store/kp6byd77bjr0k67js1z2a24p8kb81ddb-teleport-2.4.1-bin/bin/tctl version` and found version 2.4.1
- ran `/nix/store/kp6byd77bjr0k67js1z2a24p8kb81ddb-teleport-2.4.1-bin/bin/teleport help` got 0 exit code
- ran `/nix/store/kp6byd77bjr0k67js1z2a24p8kb81ddb-teleport-2.4.1-bin/bin/teleport version` and found version 2.4.1
- found 2.4.1 with grep in /nix/store/kp6byd77bjr0k67js1z2a24p8kb81ddb-teleport-2.4.1-bin
- found 2.4.1 in filename of file in /nix/store/kp6byd77bjr0k67js1z2a24p8kb81ddb-teleport-2.4.1-bin

cc "@tomberek @ehmry @lethalman"