### PR TITLE
telepresence: 0.65 -> 0.67

### DIFF
--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -16,14 +16,14 @@ let
   });
 in stdenv.mkDerivation rec {
   pname = "telepresence";
-  version = "0.65";
+  version = "0.67";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "datawire";
     repo = "telepresence";
     rev = version;
-    sha256 = "01hwaybhdmfzmyzvwdx19nc5px2grf4k1vbbj9jdmsh5pmzfrby4";
+    sha256 = "1bpyzgvrf43yvhwp5bzkp2qf3z9dhjma165w8ssca9g00v4b5vg9";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qfccj05hr9r246apckmfg4yjj0lwxc5r-telepresence-0.67/bin/telepresence -h` got 0 exit code
- ran `/nix/store/qfccj05hr9r246apckmfg4yjj0lwxc5r-telepresence-0.67/bin/telepresence --help` got 0 exit code
- ran `/nix/store/qfccj05hr9r246apckmfg4yjj0lwxc5r-telepresence-0.67/bin/telepresence --version` and found version 0.67
- found 0.67 with grep in /nix/store/qfccj05hr9r246apckmfg4yjj0lwxc5r-telepresence-0.67
- found 0.67 in filename of file in /nix/store/qfccj05hr9r246apckmfg4yjj0lwxc5r-telepresence-0.67

cc "@offline"