### PR TITLE
tevent: 0.9.30 -> 0.9.35

### DIFF
--- a/pkgs/development/libraries/tevent/default.nix
+++ b/pkgs/development/libraries/tevent/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "tevent-0.9.30";
+  name = "tevent-0.9.35";
 
   src = fetchurl {
     url = "mirror://samba/tevent/${name}.tar.gz";
-    sha256 = "1gccqiibf6ia129xhqrg18anax3sxwfbwm8h4pvsga3ndxg931ap";
+    sha256 = "1s8nbkmqz8dzdlsd6qynhvyl05pw93r151f3i2kgjfpbck9ak8r5";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.9.35 with grep in /nix/store/i0wf9rm4gv5l2sd6rfssr7nql1dkpdx4-tevent-0.9.35
- found 0.9.35 in filename of file in /nix/store/i0wf9rm4gv5l2sd6rfssr7nql1dkpdx4-tevent-0.9.35

cc "@wkennington"