### PR TITLE
tgt: 1.0.63 -> 1.0.73

### DIFF
--- a/pkgs/tools/networking/tgt/default.nix
+++ b/pkgs/tools/networking/tgt/default.nix
@@ -2,7 +2,7 @@
 , docbook_xsl }:
 
 let
-  version = "1.0.63";
+  version = "1.0.73";
 in stdenv.mkDerivation rec {
   name = "tgt-${version}";
 
@@ -10,7 +10,7 @@ in stdenv.mkDerivation rec {
     owner = "fujita";
     repo = "tgt";
     rev = "v${version}";
-    sha256 = "1x3irnbfikdqhlikhwqazg0g0hc1df5r2bp001f13sr0nvw28y1n";
+    sha256 = "0alrdrklh5wq8x4xbp30zwnxkp0brx1mjkbp70dhaz0zbzvyydr0";
   };
 
   buildInputs = [ libxslt systemd libaio docbook_xsl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgt-admin -h` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgt-admin --help` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgt-admin help` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtadm -h` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtadm --help` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtadm -V` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtadm --version` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtadm -h` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtadm --help` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtd -h` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtd --help` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtd help` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtd -V` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtd --version` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtd -h` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtd --help` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtimg -h` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtimg --help` got 0 exit code
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtimg -h` and found version 1.0.73
- ran `/nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73/bin/tgtimg --help` and found version 1.0.73
- found 1.0.73 with grep in /nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73
- found 1.0.73 in filename of file in /nix/store/65rigw0ss2lj29y55xxf6cfwbs00g01j-tgt-1.0.73
