### PR TITLE
thepeg: 2.1.1 -> 2.1.2

### DIFF
--- a/pkgs/development/libraries/physics/thepeg/default.nix
+++ b/pkgs/development/libraries/physics/thepeg/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "thepeg-${version}";
-  version = "2.1.1";
+  version = "2.1.2";
 
   src = fetchurl {
     url = "http://www.hepforge.org/archive/thepeg/ThePEG-${version}.tar.bz2";
-    sha256 = "1082n4q036sah5r4asyl3hpcyc05cymg40dnk3jsdjgv2v0vvc71";
+    sha256 = "0jbz70ax05w3lpjvz71fnfz35rcjp0jry1nyjpa662714xd6f3va";
   };
 
   buildInputs = [ boost fastjet gsl hepmc lhapdf rivet zlib ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/s8bdx22ycxz8j072244q8sng0jxh3sjc-thepeg-2.1.2/bin/setupThePEG help` got 0 exit code
- ran `/nix/store/s8bdx22ycxz8j072244q8sng0jxh3sjc-thepeg-2.1.2/bin/setupThePEG -v` and found version 2.1.2
- ran `/nix/store/s8bdx22ycxz8j072244q8sng0jxh3sjc-thepeg-2.1.2/bin/setupThePEG --version` and found version 2.1.2
- ran `/nix/store/s8bdx22ycxz8j072244q8sng0jxh3sjc-thepeg-2.1.2/bin/runThePEG -v` and found version 2.1.2
- ran `/nix/store/s8bdx22ycxz8j072244q8sng0jxh3sjc-thepeg-2.1.2/bin/runThePEG --version` and found version 2.1.2
- found 2.1.2 with grep in /nix/store/s8bdx22ycxz8j072244q8sng0jxh3sjc-thepeg-2.1.2

cc "@veprbl"