### PR TITLE
thrift: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "thrift-${version}";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchurl {
     url = "http://archive.apache.org/dist/thrift/${version}/${name}.tar.gz";
-    sha256 = "02x1xw0l669idkn6xww39j60kqxzcbmim4mvpb5h9nz8wqnx1292";
+    sha256 = "1hk0zb9289gf920rdl0clmwqx6kvygz92nj01lqrhd2arfv3ibf4";
   };
 
   #enableParallelBuilding = true; problems on hydra


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/3vw7qlk7mlknydvnfps6wsp1wqrmcv08-thrift-0.11.0/bin/thrift --version` and found version 0.11.0
- found 0.11.0 with grep in /nix/store/3vw7qlk7mlknydvnfps6wsp1wqrmcv08-thrift-0.11.0
- found 0.11.0 in filename of file in /nix/store/3vw7qlk7mlknydvnfps6wsp1wqrmcv08-thrift-0.11.0

cc "@bjornfor"