### PR TITLE
thttpd: 2.27 -> 2.28

### DIFF
--- a/pkgs/servers/http/thttpd/default.nix
+++ b/pkgs/servers/http/thttpd/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "thttpd-${version}";
-  version = "2.27";
+  version = "2.28";
 
   src = fetchurl {
     url = "http://acme.com/software/thttpd/${name}.tar.gz";
-    sha256 = "0ykda5k1zzzag59zbd4bkzj1psavq0xnpy7vpk19rhx7mlvvri5i";
+    sha256 = "0a03w7wg994dizdb37pf4kd9s5lf2q414721jfqnrqpdshlzjll5";
   };
 
   prePatch = ''


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/y5ysgh6ivjgwngq37kgzlamkh91mp0qk-thttpd-2.28/bin/syslogtocern --help` got 0 exit code
- ran `/nix/store/y5ysgh6ivjgwngq37kgzlamkh91mp0qk-thttpd-2.28/bin/syslogtocern help` got 0 exit code
- ran `/nix/store/y5ysgh6ivjgwngq37kgzlamkh91mp0qk-thttpd-2.28/bin/syslogtocern version` and found version 2.28
- ran `/nix/store/y5ysgh6ivjgwngq37kgzlamkh91mp0qk-thttpd-2.28/bin/syslogtocern help` and found version 2.28
- ran `/nix/store/y5ysgh6ivjgwngq37kgzlamkh91mp0qk-thttpd-2.28/bin/thttpd -V` and found version 2.28
- found 2.28 with grep in /nix/store/y5ysgh6ivjgwngq37kgzlamkh91mp0qk-thttpd-2.28
- found 2.28 in filename of file in /nix/store/y5ysgh6ivjgwngq37kgzlamkh91mp0qk-thttpd-2.28
