### PR TITLE
tilda: 1.3.3 -> 1.4.1

### DIFF
--- a/pkgs/applications/misc/tilda/default.nix
+++ b/pkgs/applications/misc/tilda/default.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
 
   name = "tilda-${version}";
-  version = "1.3.3";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "https://github.com/lanoxx/tilda/archive/${name}.tar.gz";
-    sha256 = "1cc4qbg1m3i04lj5p6i6xbd0zvy1320pxdgmjhz5p3j95ibsbfki";
+    sha256 = "0w2hry2bqcqrkik4l100b1a9jlsih6sq8zwhfpl8zzfq20i00lfs";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/gkd67acmm6flkyisqmxpfc1njfyc6xqc-tilda-1.4.1/bin/wrapped/tilda --help` got 0 exit code
- ran `/nix/store/gkd67acmm6flkyisqmxpfc1njfyc6xqc-tilda-1.4.1/bin/wrapped/tilda -v` and found version 1.4.1
- ran `/nix/store/gkd67acmm6flkyisqmxpfc1njfyc6xqc-tilda-1.4.1/bin/wrapped/tilda --version` and found version 1.4.1
- ran `/nix/store/gkd67acmm6flkyisqmxpfc1njfyc6xqc-tilda-1.4.1/bin/tilda --help` got 0 exit code
- ran `/nix/store/gkd67acmm6flkyisqmxpfc1njfyc6xqc-tilda-1.4.1/bin/tilda -v` and found version 1.4.1
- ran `/nix/store/gkd67acmm6flkyisqmxpfc1njfyc6xqc-tilda-1.4.1/bin/tilda --version` and found version 1.4.1
- found 1.4.1 with grep in /nix/store/gkd67acmm6flkyisqmxpfc1njfyc6xqc-tilda-1.4.1
- found 1.4.1 in filename of file in /nix/store/gkd67acmm6flkyisqmxpfc1njfyc6xqc-tilda-1.4.1

cc "@AndersonTorres"
