### PR TITLE
tintin: 2.01.1 -> 2.01.4

### DIFF
--- a/pkgs/games/tintin/default.nix
+++ b/pkgs/games/tintin/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, zlib, pcre }:
 
 stdenv.mkDerivation rec {
-  name = "tintin-2.01.1";
+  name = "tintin-2.01.4";
 
   src = fetchurl {
     url    = "mirror://sourceforge/tintin/${name}.tar.gz";
-    sha256 = "195wrfcys8yy953gdrl1gxryhjnx9lg1vqgxm3dyzm8bi18aa2yc";
+    sha256 = "1g7bh8xs1ml0iyraps3a3dzaycci922y7fk5j0wyr4ssyjzsy8nx";
   };
 
   buildInputs = [ zlib pcre ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.01.4 with grep in /nix/store/pbqmal61ij37i421gy0fjrjv7awg3r7p-tintin-2.01.4
- found 2.01.4 in filename of file in /nix/store/pbqmal61ij37i421gy0fjrjv7awg3r7p-tintin-2.01.4

cc "@lovek323"