### PR TITLE
tnef: 1.4.15 -> 1.4.17

### DIFF
--- a/pkgs/applications/misc/tnef/default.nix
+++ b/pkgs/applications/misc/tnef/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.15";
+  version = "1.4.17";
   name = "tnef-${version}";
 
   src = fetchFromGitHub {
     owner  = "verdammelt";
     repo   = "tnef";
     rev    = version;
-    sha256 = "0wm5ylppkjg518ldb9kzlx58a9l8z66gpz9ljalmyq6a77khd7pj";
+    sha256 = "0cq2xh5wd74qn6k2nnw5rayxgqhjl3jbzf4zlc4babcwxrv32ldh";
   };
 
   doCheck = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ggbdpmwgrbzr50ck27qh6pd82f2hapd8-tnef-1.4.17/bin/tnef -h` got 0 exit code
- ran `/nix/store/ggbdpmwgrbzr50ck27qh6pd82f2hapd8-tnef-1.4.17/bin/tnef --help` got 0 exit code
- ran `/nix/store/ggbdpmwgrbzr50ck27qh6pd82f2hapd8-tnef-1.4.17/bin/tnef -V` and found version 1.4.17
- ran `/nix/store/ggbdpmwgrbzr50ck27qh6pd82f2hapd8-tnef-1.4.17/bin/tnef --version` and found version 1.4.17
- ran `/nix/store/ggbdpmwgrbzr50ck27qh6pd82f2hapd8-tnef-1.4.17/bin/tnef -h` and found version 1.4.17
- ran `/nix/store/ggbdpmwgrbzr50ck27qh6pd82f2hapd8-tnef-1.4.17/bin/tnef --help` and found version 1.4.17
- found 1.4.17 with grep in /nix/store/ggbdpmwgrbzr50ck27qh6pd82f2hapd8-tnef-1.4.17
- found 1.4.17 in filename of file in /nix/store/ggbdpmwgrbzr50ck27qh6pd82f2hapd8-tnef-1.4.17

cc "@peterhoeg"