### PR TITLE
tpm-quote-tools: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/tools/security/tpm-quote-tools/default.nix
+++ b/pkgs/tools/security/tpm-quote-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec { 
   name = "tpm-quote-tools-${version}";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchurl { 
     url = "mirror://sourceforge/project/tpmquotetools/${version}/${name}.tar.gz";
-    sha256 = "1d6ry2c78sgv0z4phfrwrbvgag83xnnfri2cdzrd86w4yfgnfwdf";
+    sha256 = "1qjs83xb4np4yn1bhbjfhvkiika410v8icwnjix5ad96w2nlxp0h";
   };
 
   buildInputs = [ trousers openssl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_mkuuid -h` got 0 exit code
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_mkuuid -v` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_mkuuid -h` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_mkaik -h` got 0 exit code
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_mkaik -v` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_mkaik -h` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_getpcrhash -h` got 0 exit code
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_getpcrhash -v` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_getpcrhash -h` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_loadkey -h` got 0 exit code
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_loadkey -v` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_loadkey -h` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_unloadkey -h` got 0 exit code
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_unloadkey -v` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_unloadkey -h` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_getquote -h` got 0 exit code
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_getquote -v` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_getquote -h` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_verifyquote -h` got 0 exit code
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_verifyquote -v` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_verifyquote -h` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_updatepcrhash -h` got 0 exit code
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_updatepcrhash -v` and found version 1.0.4
- ran `/nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4/bin/tpm_updatepcrhash -h` and found version 1.0.4
- found 1.0.4 with grep in /nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4
- found 1.0.4 in filename of file in /nix/store/4xhrypy9qbx3ijfis7c84sdd08nrmlc8-tpm-quote-tools-1.0.4

cc "@ak @ndowens"