### PR TITLE
traefik: 1.5.0 -> 1.5.2

### DIFF
--- a/pkgs/servers/traefik/default.nix
+++ b/pkgs/servers/traefik/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "traefik-${version}";
-  version = "1.5.0";
+  version = "1.5.2";
 
   goPackagePath = "github.com/containous/traefik";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "containous";
     repo = "traefik";
     rev = "v${version}";
-    sha256 = "0yvmw99knjdfgaa3snk4fmrbf3bqnj78ix5hr0mcqj5pwjx1dihb";
+    sha256 = "0cv05nm7jj1g2630l5zmzpmsrjx712ba3l7klh8nqs02mzykzsha";
   };
 
   buildInputs = [ go-bindata bash ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/byzavm86fdpdnigaj0j4r9bd755pqylq-traefik-1.5.2-bin/bin/traefik -h` got 0 exit code
- ran `/nix/store/byzavm86fdpdnigaj0j4r9bd755pqylq-traefik-1.5.2-bin/bin/traefik --help` got 0 exit code
- ran `/nix/store/byzavm86fdpdnigaj0j4r9bd755pqylq-traefik-1.5.2-bin/bin/traefik version` and found version 1.5.2
- found 1.5.2 with grep in /nix/store/byzavm86fdpdnigaj0j4r9bd755pqylq-traefik-1.5.2-bin
- found 1.5.2 in filename of file in /nix/store/byzavm86fdpdnigaj0j4r9bd755pqylq-traefik-1.5.2-bin

cc "@hamhut1066 @ehmry @lethalman"