### PR TITLE
transcrypt: 1.0.2 -> 1.0.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/transcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/transcrypt/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "transcrypt-${version}";
-  version = "1.0.2";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "elasticdog";
     repo = "transcrypt";
     rev = "v${version}";
-    sha256 = "05q0rgcsphrkavmcsm3qghsl1pkgshvhdf6zpwkn1qcj288h8gkc";
+    sha256 = "1hvg4ipsxm27n5yn5jpk43qyvvx5gx3z3cczw1z3r6hrs4n8d5rz";
   };
 
   buildInputs = [ git makeWrapper openssl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3/bin/transcrypt -h` got 0 exit code
- ran `/nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3/bin/transcrypt --help` got 0 exit code
- ran `/nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3/bin/transcrypt -v` and found version 1.0.3
- ran `/nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3/bin/transcrypt --version` and found version 1.0.3
- ran `/nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3/bin/.transcrypt-wrapped -h` got 0 exit code
- ran `/nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3/bin/.transcrypt-wrapped --help` got 0 exit code
- ran `/nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3/bin/.transcrypt-wrapped -v` and found version 1.0.3
- ran `/nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3/bin/.transcrypt-wrapped --version` and found version 1.0.3
- found 1.0.3 with grep in /nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3
- found 1.0.3 in filename of file in /nix/store/dbpy65mkqdmjij53vjpcfisvhbwnrav5-transcrypt-1.0.3

cc "@elasticdog"