### PR TITLE
translate-shell: 0.9.4 -> 0.9.6.6

### DIFF
--- a/pkgs/applications/misc/translate-shell/default.nix
+++ b/pkgs/applications/misc/translate-shell/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "translate-shell";
-  version = "0.9.4";
+  version = "0.9.6.6";
 
   src = fetchFromGitHub {
     owner = "soimort";
     repo = "translate-shell";
     rev = "v" + version;
-    sha256 = "166zhic3k4z37vc8p1fnhc4xx7i7q0j30nr324frmp1mrnwrdib8";
+    sha256 = "0hbwvc554v6fi4ardidwsnn8hk7p68p155yjllvljjawkbq4qljq";
   };
 
   phases = [ "buildPhase" "installPhase" "postFixup" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.9.6.6 with grep in /nix/store/b8w2c7x6vy16bdfcyxnsv40r88ybdqhy-translate-shell-0.9.6.6
- found 0.9.6.6 in filename of file in /nix/store/b8w2c7x6vy16bdfcyxnsv40r88ybdqhy-translate-shell-0.9.6.6

cc "@ebzzry"
