### PR TITLE
tribler: 7.0.0-rc3 -> 7.0.1

### DIFF
--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
   pname = "tribler";
   name = "${pname}-${version}";
-  version = "7.0.0-rc3";
+  version = "7.0.1";
 
   src = fetchurl {
     url = "https://github.com/Tribler/tribler/releases/download/v${version}/Tribler-v${version}.tar.xz";
-    sha256 = "0f1f8mzbk1ygkh8lv9y1s9mvslv12d94mxvmp3b4s2vm8w4syza7";
+    sha256 = "0cqg6319x2lid5la5vdlj6lwja8g712196j39jzv5yiaq8d0zym4";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 7.0.1 with grep in /nix/store/i8j96ydz0icrr9cbhfclpavivw0k9iy0-tribler-7.0.1

cc "@xvapx"