### PR TITLE
tryton: 4.2.1 -> 4.6.2

### DIFF
--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -4,10 +4,10 @@ with stdenv.lib;
 
 python2Packages.buildPythonApplication rec {
   name = "tryton-${version}";
-  version = "4.2.1";
+  version = "4.6.2";
   src = fetchurl {
     url = "mirror://pypi/t/tryton/${name}.tar.gz";
-    sha256 = "1ry3kvbk769m8rwqa90pplfvmmgsv4jj9w1aqhv892smia8f0ybm";
+    sha256 = "0bamr040np02gfjk8c734rw3mbgg75irfgpdcl2npgkdzyw1ksf9";
   };
   propagatedBuildInputs = with python2Packages; [
     chardet


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ns61c2rgvmivvyfi3bnglp0mcgj6a511-tryton-4.6.2/bin/.tryton-wrapped -h` got 0 exit code
- ran `/nix/store/ns61c2rgvmivvyfi3bnglp0mcgj6a511-tryton-4.6.2/bin/.tryton-wrapped --help` got 0 exit code
- ran `/nix/store/ns61c2rgvmivvyfi3bnglp0mcgj6a511-tryton-4.6.2/bin/.tryton-wrapped --version` and found version 4.6.2
- ran `/nix/store/ns61c2rgvmivvyfi3bnglp0mcgj6a511-tryton-4.6.2/bin/tryton -h` got 0 exit code
- ran `/nix/store/ns61c2rgvmivvyfi3bnglp0mcgj6a511-tryton-4.6.2/bin/tryton --help` got 0 exit code
- ran `/nix/store/ns61c2rgvmivvyfi3bnglp0mcgj6a511-tryton-4.6.2/bin/tryton --version` and found version 4.6.2
- found 4.6.2 with grep in /nix/store/ns61c2rgvmivvyfi3bnglp0mcgj6a511-tryton-4.6.2
- found 4.6.2 in filename of file in /nix/store/ns61c2rgvmivvyfi3bnglp0mcgj6a511-tryton-4.6.2

cc "@johbo"