### PR TITLE
trytond: 4.2.1 -> 4.6.2

### DIFF
--- a/pkgs/applications/office/trytond/default.nix
+++ b/pkgs/applications/office/trytond/default.nix
@@ -5,10 +5,10 @@ with stdenv.lib;
 
 python2Packages.buildPythonApplication rec {
   name = "trytond-${version}";
-  version = "4.2.1";
+  version = "4.6.2";
   src = fetchurl {
     url = "mirror://pypi/t/trytond/${name}.tar.gz";
-    sha256 = "1ijjpbsf3s0s7ksbi7xgzss4jgr14q5hqsyf6d68l8hwardrwpj7";
+    sha256 = "0asc3pd37h8ky8j66iqxr0fv0k6mpjcwxwm0xgm5hrdi32l5cdda";
   };
 
   # Tells the tests which database to use


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-wrapped -h` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-wrapped --help` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-wrapped --version` and found version 4.6.2
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond -h` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond --help` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond --version` and found version 4.6.2
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-admin-wrapped -h` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-admin-wrapped --help` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-admin-wrapped --version` and found version 4.6.2
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond-admin -h` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond-admin --help` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond-admin --version` and found version 4.6.2
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-cron-wrapped -h` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-cron-wrapped --help` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/.trytond-cron-wrapped --version` and found version 4.6.2
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond-cron -h` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond-cron --help` got 0 exit code
- ran `/nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2/bin/trytond-cron --version` and found version 4.6.2
- found 4.6.2 with grep in /nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2
- found 4.6.2 in filename of file in /nix/store/7xmbfsniz5i0wfl7rcqmmhx5pvifqp24-trytond-4.6.2

cc "@johbo"