### PR TITLE
ts: 0.7.6 -> 1.0

### DIFF
--- a/pkgs/tools/system/ts/default.nix
+++ b/pkgs/tools/system/ts/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
 
-  name = "ts-0.7.6";
+  name = "ts-1.0";
 
   installPhase=''make install "PREFIX=$out"'';
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://viric.name/~viric/soft/ts/${name}.tar.gz";
-    sha256 = "07b61sx3hqpdxlg5a1xrz9sxww9yqdix3bmr0sm917r3rzk87lwk";
+    sha256 = "15dkzczx10fhl0zs9bmcgkxfbwq2znc7bpscljm4rchbzx7y6lsg";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/fx773gqzc7zwjjyyr13s1rqa6z96ipw7-ts-1.0/bin/ts -h` got 0 exit code
- ran `/nix/store/fx773gqzc7zwjjyyr13s1rqa6z96ipw7-ts-1.0/bin/ts help` got 0 exit code
- ran `/nix/store/fx773gqzc7zwjjyyr13s1rqa6z96ipw7-ts-1.0/bin/ts -V` and found version 1.0
- ran `/nix/store/fx773gqzc7zwjjyyr13s1rqa6z96ipw7-ts-1.0/bin/ts -h` and found version 1.0
- found 1.0 with grep in /nix/store/fx773gqzc7zwjjyyr13s1rqa6z96ipw7-ts-1.0
- found 1.0 in filename of file in /nix/store/fx773gqzc7zwjjyyr13s1rqa6z96ipw7-ts-1.0

cc "@viric"