### PR TITLE
ttylog: 0.29 -> 0.31

### DIFF
--- a/pkgs/tools/misc/ttylog/default.nix
+++ b/pkgs/tools/misc/ttylog/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "ttylog-${version}";
-  version = "0.29";
+  version = "0.31";
 
   src = fetchFromGitHub {
     owner = "rocasa";
     repo = "ttylog";
     rev = version;
-    sha256 = "035i9slmdgds5azwxqwp6skxykvaq3mq4jckvm49fng8jq09z7zr";
+    sha256 = "0c746bpjpa77vsr88fxk8h1803p5np1di1mpjf4jy5bv5x3zwm07";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog -h` got 0 exit code
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog --help` got 0 exit code
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog help` got 0 exit code
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog -V` and found version 0.31
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog -v` and found version 0.31
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog --version` and found version 0.31
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog version` and found version 0.31
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog -h` and found version 0.31
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog --help` and found version 0.31
- ran `/nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31/bin/ttylog help` and found version 0.31
- found 0.31 with grep in /nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31
- found 0.31 in filename of file in /nix/store/fip4dfisnx3d9wg45s8bqip4rdnica0j-ttylog-0.31

cc "@wkennington"