### PR TITLE
tudu: 0.10 -> 0.10.2

### DIFF
--- a/pkgs/applications/office/tudu/default.nix
+++ b/pkgs/applications/office/tudu/default.nix
@@ -2,11 +2,11 @@
 stdenv.mkDerivation rec {
 
   name = "tudu-${version}";
-  version = "0.10";
+  version = "0.10.2";
 
   src = fetchurl {
     url = "https://code.meskio.net/tudu/${name}.tar.gz";
-    sha256 = "0571wh5hn0hgadyx34zq1zi35pzd7vpwkavm7kzb9hwgn07443x4";
+    sha256 = "1xsncvd1c6v8y0dzc5mspy9rrwc89pabhz6r2lihsirk83h2rqym";
   };
 
   buildInputs = [ ncurses ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/kiyy2m9ck5hgnw5y1cvs77y2465r7cag-tudu-0.10.2/bin/tudu -h` got 0 exit code
- ran `/nix/store/kiyy2m9ck5hgnw5y1cvs77y2465r7cag-tudu-0.10.2/bin/tudu --help` got 0 exit code
- ran `/nix/store/kiyy2m9ck5hgnw5y1cvs77y2465r7cag-tudu-0.10.2/bin/tudu -v` and found version 0.10.2
- ran `/nix/store/kiyy2m9ck5hgnw5y1cvs77y2465r7cag-tudu-0.10.2/bin/tudu -h` and found version 0.10.2
- ran `/nix/store/kiyy2m9ck5hgnw5y1cvs77y2465r7cag-tudu-0.10.2/bin/tudu --help` and found version 0.10.2
- found 0.10.2 with grep in /nix/store/kiyy2m9ck5hgnw5y1cvs77y2465r7cag-tudu-0.10.2
- found 0.10.2 in filename of file in /nix/store/kiyy2m9ck5hgnw5y1cvs77y2465r7cag-tudu-0.10.2
