### PR TITLE
tulip: 4.9.0 -> 5.1.0

### DIFF
--- a/pkgs/applications/science/misc/tulip/default.nix
+++ b/pkgs/applications/science/misc/tulip/default.nix
@@ -1,13 +1,13 @@
 { fetchurl, stdenv, libxml2, freetype, mesa, glew, qt4
 , cmake, makeWrapper, libjpeg, python }:
 
-let version = "4.9.0"; in
+let version = "5.1.0"; in
 stdenv.mkDerivation rec {
   name = "tulip-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/auber/${name}_src.tar.gz";
-    sha256 = "0phc7972brvm0v6lfk4ghq9b2b4jsj6c15xlbgnvhhcxhc99wba3";
+    sha256 = "1i70y8b39gkpxfalr9844pa3l4bnnyw5y7ngxdqibil96k2b9q9h";
   };
 
   buildInputs = [ libxml2 freetype glew mesa qt4 libjpeg python ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/z17wdp6l55y3b18875c9zj2pw1lywrqd-tulip-5.1.0/bin/tulip-config -h` got 0 exit code
- ran `/nix/store/z17wdp6l55y3b18875c9zj2pw1lywrqd-tulip-5.1.0/bin/tulip-config --help` got 0 exit code
- ran `/nix/store/z17wdp6l55y3b18875c9zj2pw1lywrqd-tulip-5.1.0/bin/tulip-config help` got 0 exit code
- ran `/nix/store/z17wdp6l55y3b18875c9zj2pw1lywrqd-tulip-5.1.0/bin/tulip-config --version` and found version 5.1.0
- found 5.1.0 with grep in /nix/store/z17wdp6l55y3b18875c9zj2pw1lywrqd-tulip-5.1.0

cc ""