### PR TITLE
tvheadend: 4.2.4 -> 4.2.5

### DIFF
--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -3,7 +3,7 @@
 , which, zlib }:
 
 let
-  version = "4.2.4";
+  version = "4.2.5";
 
 in stdenv.mkDerivation rec {
   name = "tvheadend-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
     owner  = "tvheadend";
     repo   = "tvheadend";
     rev    = "v${version}";
-    sha256 = "1kydjmgv0nrllgi2s6aczq4x9ag01c8qm8w962qb52fzdfw7fs6k";
+    sha256 = "199b0xm4lfdspmrirvzzg511yh358awciz23zmccvlvq86b548pz";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend -h` got 0 exit code
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend --help` got 0 exit code
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend help` got 0 exit code
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend -V` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend -v` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend --version` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend version` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend -h` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend --help` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/tvheadend help` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped -h` got 0 exit code
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped --help` got 0 exit code
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped help` got 0 exit code
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped -V` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped -v` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped --version` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped version` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped -h` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped --help` and found version 4.2.5
- ran `/nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5/bin/.tvheadend-wrapped help` and found version 4.2.5
- found 4.2.5 with grep in /nix/store/ffbiwxbfdywyhn0ng9lz8zpzjkvaswah-tvheadend-4.2.5

cc "@simonvandel"