### PR TITLE
uftp: 4.9.4 -> 4.9.5

### DIFF
--- a/pkgs/servers/uftp/default.nix
+++ b/pkgs/servers/uftp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "uftp-${version}";
-  version = "4.9.4";
+  version = "4.9.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/uftp-multicast/source-tar/uftp-${version}.tar.gz";
-    sha256 = "1npfl7n1w2l0j6c6iizw1szzq0lz9wy6jb55qmwhfkzwj0zd7mqp";
+    sha256 = "1alsha0mhscp0jha2wlb5mqqkx2967s7rpm0x8c2v7jws1d0m1w3";
   };
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftpd help` got 0 exit code
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftp_keymgt -h` got 0 exit code
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftp_keymgt --help` got 0 exit code
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftp_keymgt help` got 0 exit code
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftp_keymgt -V` and found version 4.9.5
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftp_keymgt -v` and found version 4.9.5
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftp_keymgt --version` and found version 4.9.5
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftp_keymgt -h` and found version 4.9.5
- ran `/nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5/bin/uftp_keymgt --help` and found version 4.9.5
- found 4.9.5 with grep in /nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5
- found 4.9.5 in filename of file in /nix/store/d88xbp1gzaf2jllb4k3mclrghgm0yp10-uftp-4.9.5

cc "@fadenb"