### PR TITLE
uid_wrapper: 1.2.0 -> 1.2.4

### DIFF
--- a/pkgs/development/libraries/uid_wrapper/default.nix
+++ b/pkgs/development/libraries/uid_wrapper/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "uid_wrapper-1.2.0";
+  name = "uid_wrapper-1.2.4";
 
   src = fetchurl {
     url = "mirror://samba/cwrap/${name}.tar.gz";
-    sha256 = "0sfznk53kmz9m3rxwbv4pwwqs4bw3kr917y4n53h5jaxjym0m4c0";
+    sha256 = "1yjhrm3rcyiykkrgpifmig117mzjxrms75kp8gpp8022f59zcq1w";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.2.4 with grep in /nix/store/dqq7n2sk0fdzn7dnz88yhgms5dq6s39x-uid_wrapper-1.2.4
- found 1.2.4 in filename of file in /nix/store/dqq7n2sk0fdzn7dnz88yhgms5dq6s39x-uid_wrapper-1.2.4

cc "@wkennington"