### PR TITLE
unclutter-xfixes: 1.2 -> 1.3

### DIFF
--- a/pkgs/tools/misc/unclutter-xfixes/default.nix
+++ b/pkgs/tools/misc/unclutter-xfixes/default.nix
@@ -2,7 +2,7 @@
   xlibsWrapper, libev, libXi, libXfixes,
   pkgconfig, asciidoc, libxslt, docbook_xsl }:
 
-let version = "1.2"; in
+let version = "1.3"; in
 
 stdenv.mkDerivation {
   name = "unclutter-xfixes-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     owner = "Airblader";
     repo = "unclutter-xfixes";
     rev = "v${version}";
-    sha256 = "1pw567mj7mq5kr8mqnyrvy7jj62qfg6zgqfyzz21nncslddnjzg8";
+    sha256 = "1iikrz0023wygv29ny20xj1hlv9ry7hghlwjii6rj4jm59vl0mlz";
   };
 
   nativeBuildInputs = [pkgconfig];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/ypik1dbi5xwyf65q8qgs6l4xg1siiinm-unclutter-xfixes-1.3/bin/unclutter -v` and found version 1.3
- ran `/nix/store/ypik1dbi5xwyf65q8qgs6l4xg1siiinm-unclutter-xfixes-1.3/bin/unclutter --version` and found version 1.3
- found 1.3 with grep in /nix/store/ypik1dbi5xwyf65q8qgs6l4xg1siiinm-unclutter-xfixes-1.3
- found 1.3 in filename of file in /nix/store/ypik1dbi5xwyf65q8qgs6l4xg1siiinm-unclutter-xfixes-1.3
