### PR TITLE
uncrustify: 0.66 -> 0.66.1

### DIFF
--- a/pkgs/development/tools/misc/uncrustify/default.nix
+++ b/pkgs/development/tools/misc/uncrustify/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "uncrustify";
-  version = "0.66";
+  version = "0.66.1";
 
   src = fetchFromGitHub {
     owner = product;
     repo = product;
     rev = name;
-    sha256 = "156y71yf2xxskvikbn6yjfv8xgnsrrjij08irv21z0n7nx35jgmm";
+    sha256 = "1y69b0g07ksynf1fwfh5qqwmscxfbvs1yi3n3lbdd4vplb9zakyx";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/bg2nls3ahz6jd32nxdaax1akz2hjh8ma-uncrustify-0.66.1/bin/uncrustify -h` got 0 exit code
- ran `/nix/store/bg2nls3ahz6jd32nxdaax1akz2hjh8ma-uncrustify-0.66.1/bin/uncrustify --help` got 0 exit code
- ran `/nix/store/bg2nls3ahz6jd32nxdaax1akz2hjh8ma-uncrustify-0.66.1/bin/uncrustify -v` and found version 0.66.1
- ran `/nix/store/bg2nls3ahz6jd32nxdaax1akz2hjh8ma-uncrustify-0.66.1/bin/uncrustify --version` and found version 0.66.1
- found 0.66.1 with grep in /nix/store/bg2nls3ahz6jd32nxdaax1akz2hjh8ma-uncrustify-0.66.1
- found 0.66.1 in filename of file in /nix/store/bg2nls3ahz6jd32nxdaax1akz2hjh8ma-uncrustify-0.66.1

cc "@bjornfor"