### PR TITLE
unittest-cpp: 1.6.1 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/unittest-cpp/default.nix
+++ b/pkgs/development/libraries/unittest-cpp/default.nix
@@ -4,13 +4,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "unittest-cpp-${version}";
-  version = "1.6.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "unittest-cpp";
     repo = "unittest-cpp";
     rev = "v${version}";
-    sha256 = "1sva2bm90z4vmwwvp0af82f7p4sdq5j2jjqzhs2ppihdkggn62d1";
+    sha256 = "0sxb3835nly1jxn071f59fwbdzmqi74j040r81fanxyw3s1azw0i";
   };
 
   buildInputs = [cmake];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.0.0 with grep in /nix/store/llszhnm3pshnbmp7cra1bkal6njag3nn-unittest-cpp-2.0.0
- found 2.0.0 in filename of file in /nix/store/llszhnm3pshnbmp7cra1bkal6njag3nn-unittest-cpp-2.0.0

cc ""