### PR TITLE
unixODBC: 2.3.4 -> 2.3.5

### DIFF
--- a/pkgs/development/libraries/unixODBC/default.nix
+++ b/pkgs/development/libraries/unixODBC/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unixODBC-${version}";
-  version = "2.3.4";
+  version = "2.3.5";
 
   src = fetchurl {
     url = "ftp://ftp.unixodbc.org/pub/unixODBC/${name}.tar.gz";
-    sha256 = "0f8y88rcc2akjvjv5y66yx7k0ms9h1s0vbcfy25j93didflhj59f";
+    sha256 = "0ns93daph4wmk92d7m2w48x0yki4m1yznxnn97p1ldn6bkh742bn";
   };
 
   configureFlags = [ "--disable-gui" "--sysconfdir=/etc" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/isql --help` got 0 exit code
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/isql --version` and found version 2.3.5
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/isql --help` and found version 2.3.5
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/odbcinst --help` got 0 exit code
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/odbcinst --version` and found version 2.3.5
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/odbcinst --help` and found version 2.3.5
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/iusql --help` got 0 exit code
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/iusql --version` and found version 2.3.5
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/iusql --help` and found version 2.3.5
- ran `/nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5/bin/odbc_config --version` and found version 2.3.5
- found 2.3.5 with grep in /nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5
- found 2.3.5 in filename of file in /nix/store/vs2i1mz87r31icar1kp880wq81bk2wy5-unixODBC-2.3.5
