### PR TITLE
urh: 1.7.1 -> 1.9.2

### DIFF
--- a/pkgs/applications/misc/urh/default.nix
+++ b/pkgs/applications/misc/urh/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "urh-${version}";
-  version = "1.7.1";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "jopohl";
     repo = "urh";
     rev = "v${version}";
-    sha256 = "00l1zs3qw89z1hlylprzrpf6nf7h22h0nw43h97gv775vaqqgczv";
+    sha256 = "02jq2jas6gm08z4l09azi6dcsydaaaqbxfv4mb7pnrc1w8m593zr";
   };
 
   buildInputs = [ hackrf rtl-sdr ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/lmai5nljfdfka498cvh0b265qi22x8r8-urh-1.9.2/bin/.urh-wrapped --version` and found version 1.9.2
- ran `/nix/store/lmai5nljfdfka498cvh0b265qi22x8r8-urh-1.9.2/bin/urh --version` and found version 1.9.2
- found 1.9.2 with grep in /nix/store/lmai5nljfdfka498cvh0b265qi22x8r8-urh-1.9.2

cc "@fpletz"