### PR TITLE
usb-modeswitch: 2.5.0 -> 2.5.2

### DIFF
--- a/pkgs/development/tools/misc/usb-modeswitch/default.nix
+++ b/pkgs/development/tools/misc/usb-modeswitch/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "usb-modeswitch-${version}";
-  version = "2.5.0";
+  version = "2.5.2";
 
   src = fetchurl {
     url    = "http://www.draisberghof.de/usb_modeswitch/${name}.tar.bz2";
-    sha256 = "0cvnd16n2sp3w46fy507nl29q39jxxdk5qqbvk1rxaa91llbxh1i";
+    sha256 = "19ifi80g9ns5dmspchjvfj4ykxssq9yrci8m227dgb3yr04srzxb";
   };
 
   makeFlags = [


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/g9jg6pc3vwnpfgbypnzv2v5gp4r7gnnn-usb-modeswitch-2.5.2/bin/usb_modeswitch -h` got 0 exit code
- ran `/nix/store/g9jg6pc3vwnpfgbypnzv2v5gp4r7gnnn-usb-modeswitch-2.5.2/bin/usb_modeswitch --help` got 0 exit code
- ran `/nix/store/g9jg6pc3vwnpfgbypnzv2v5gp4r7gnnn-usb-modeswitch-2.5.2/bin/usb_modeswitch --version` and found version 2.5.2
- ran `/nix/store/g9jg6pc3vwnpfgbypnzv2v5gp4r7gnnn-usb-modeswitch-2.5.2/bin/usb_modeswitch -h` and found version 2.5.2
- ran `/nix/store/g9jg6pc3vwnpfgbypnzv2v5gp4r7gnnn-usb-modeswitch-2.5.2/bin/usb_modeswitch --help` and found version 2.5.2
- found 2.5.2 with grep in /nix/store/g9jg6pc3vwnpfgbypnzv2v5gp4r7gnnn-usb-modeswitch-2.5.2
- found 2.5.2 in filename of file in /nix/store/g9jg6pc3vwnpfgbypnzv2v5gp4r7gnnn-usb-modeswitch-2.5.2

cc "@marcweber @peterhoeg"