### PR TITLE
vagrant: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,9 +1,9 @@
 { lib, fetchurl, buildRubyGem, bundlerEnv, ruby, libarchive }:
 
 let
-  version = "2.0.1";
+  version = "2.0.2";
   url = "https://github.com/hashicorp/vagrant/archive/v${version}.tar.gz";
-  sha256 = "1fjfl00n4rsq6khypm56g0vq6l153q128r35zky2ba30bz292ar1";
+  sha256 = "1sjfwgy2y6q5s1drd8h8xgz2a0sv1l3kx9jilgc02hlcdz070iir";
 
   deps = bundlerEnv rec {
     name = "${pname}-${version}";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.0.2 with grep in /nix/store/32zly5yhz0hcqgk6w5y0ish2rssfc6y9-vagrant-2.0.2

cc "@aneeshusa"