### PR TITLE
vault: 0.9.0 -> 0.9.4

### DIFF
--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -9,13 +9,13 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "vault-${version}";
-  version = "0.9.0";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "1c3jaajf3wpjczbncvdpyy5vaa62gb9287bj2zi2khvqzvii36b0";
+    sha256 = "1a12pfzln6qdff08j9l1807anrsgn3ggnaqda020p6y9zg1p8xzd";
   };
 
   nativeBuildInputs = [ go gox removeReferencesTo ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/kp72kh1a4dy4pdj5i4qnngmwz9083yjf-vault-0.9.4/bin/vault -h` got 0 exit code
- ran `/nix/store/kp72kh1a4dy4pdj5i4qnngmwz9083yjf-vault-0.9.4/bin/vault --help` got 0 exit code
- ran `/nix/store/kp72kh1a4dy4pdj5i4qnngmwz9083yjf-vault-0.9.4/bin/vault -v` and found version 0.9.4
- ran `/nix/store/kp72kh1a4dy4pdj5i4qnngmwz9083yjf-vault-0.9.4/bin/vault --version` and found version 0.9.4
- ran `/nix/store/kp72kh1a4dy4pdj5i4qnngmwz9083yjf-vault-0.9.4/bin/vault version` and found version 0.9.4
- found 0.9.4 with grep in /nix/store/kp72kh1a4dy4pdj5i4qnngmwz9083yjf-vault-0.9.4
- found 0.9.4 in filename of file in /nix/store/kp72kh1a4dy4pdj5i4qnngmwz9083yjf-vault-0.9.4

cc "@rushmorem @offline @pradeepchhetri"