### PR TITLE
verilator: 3.900 -> 3.920

### DIFF
--- a/pkgs/applications/science/electronics/verilator/default.nix
+++ b/pkgs/applications/science/electronics/verilator/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "verilator-${version}";
-  version = "3.900";
+  version = "3.920";
 
   src = fetchurl {
     url    = "http://www.veripool.org/ftp/${name}.tgz";
-    sha256 = "0yvbibcysdiw6mphda0lfs56wz6v450px2420x0hbd3rc7k53s2b";
+    sha256 = "1zs3d6h5sbz455fwpgg89h81hkfn92ary8bmhjinc1rd8fm3hp1b";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_bin -V` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_bin --version` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_bin_dbg -V` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_bin_dbg --version` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_coverage_bin_dbg -V` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_coverage_bin_dbg --version` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator -V` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator --version` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_coverage -V` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_coverage --version` and found version 3.920
- ran `/nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920/bin/verilator_profcfunc help` got 0 exit code
- found 3.920 with grep in /nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920
- found 3.920 in filename of file in /nix/store/j0sz8wy56xhm5agjgjrzy3r35qzyrb5s-verilator-3.920

cc "@thoughtpolice"