### PR TITLE
vim-vint: 0.3.11 -> 0.3.18

### DIFF
--- a/pkgs/development/tools/vim-vint/default.nix
+++ b/pkgs/development/tools/vim-vint/default.nix
@@ -4,13 +4,13 @@ with python3Packages;
 
 buildPythonApplication rec {
   name = "vim-vint-${version}";
-  version = "0.3.11";
+  version = "0.3.18";
 
   src = fetchFromGitHub {
     owner = "kuniwak";
     repo = "vint";
     rev = "v${version}";
-    sha256 = "0xl166xs7sm404f1qz2s0xcry7fr1hgyvhqhyj1qj0dql9i3xx8v";
+    sha256 = "0qrlimg385sxq4y6vqbanby31inaa1q47w9qcw5knwffbz96whrs";
   };
 
   # For python 3.5 > version > 2.7 , a nested dependency (pythonPackages.hypothesis) fails.


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18/bin/.vint-wrapped -h` got 0 exit code
- ran `/nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18/bin/.vint-wrapped --help` got 0 exit code
- ran `/nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18/bin/.vint-wrapped -v` and found version 0.3.18
- ran `/nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18/bin/.vint-wrapped --version` and found version 0.3.18
- ran `/nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18/bin/vint -h` got 0 exit code
- ran `/nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18/bin/vint --help` got 0 exit code
- ran `/nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18/bin/vint -v` and found version 0.3.18
- ran `/nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18/bin/vint --version` and found version 0.3.18
- found 0.3.18 with grep in /nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18
- found 0.3.18 in filename of file in /nix/store/c0vdpjgxib99lnhsvvn440jbppnmiqi0-vim-vint-0.3.18

cc "@andsild"