### PR TITLE
vis: 0.3 -> 0.4

### DIFF
--- a/pkgs/applications/editors/vis/default.nix
+++ b/pkgs/applications/editors/vis/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "vis-${version}";
-  version  = "0.3";
+  version  = "0.4";
 
   src = fetchFromGitHub {
     rev = "v${version}";
-    sha256 = "13xyyq30dg66v4azl2jvlyfyglxmc3r9p7p87vrganq0p6lmb0bk";
+    sha256 = "1crsg3ssqv4xix9z16hwl0zyx7hxk686s52zmrp7yfak3m5igf9k";
     repo = "vis";
     owner = "martanne";
   };


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis -v` and found version 0.4
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-menu -v` and found version 0.4
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/.vis-wrapped -v` and found version 0.4
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-complete -h` got 0 exit code
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-complete --help` got 0 exit code
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-complete help` got 0 exit code
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-complete -V` and found version 0.4
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-complete -v` and found version 0.4
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-complete --version` and found version 0.4
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-complete version` and found version 0.4
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-complete help` and found version 0.4
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-open -h` got 0 exit code
- ran `/nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4/bin/vis-open --help` got 0 exit code
- found 0.4 with grep in /nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4
- found 0.4 in filename of file in /nix/store/zr63rvkc5wimxwiwglp97yvdg71yj1jx-vis-0.4

cc "@vrthra @ramkromberg"