### PR TITLE
vmtouch: 1.1.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/misc/vmtouch/default.nix
+++ b/pkgs/tools/misc/vmtouch/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vmtouch";
-  version = "1.1.0";
+  version = "1.3.0";
   name = "${pname}-git-${version}";
 
   src = fetchFromGitHub {
     owner = "hoytech";
     repo = "vmtouch";
     rev = "v${version}";
-    sha256 = "1cr8bw3favdvc3kc05n1r7f5fibqqv54bn3z2jwj70br8s5g0qx0";
+    sha256 = "0xpigfpwidk25k605y2m2g1952nzl5fgp0wn65hhn7hbra7srglf";
   };
 
   buildInputs = [perl];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/jqmzz76b0s6bchm35ijpyaa9j4x7863g-vmtouch-git-1.3.0/bin/vmtouch help` got 0 exit code
- found 1.3.0 with grep in /nix/store/jqmzz76b0s6bchm35ijpyaa9j4x7863g-vmtouch-git-1.3.0
- found 1.3.0 in filename of file in /nix/store/jqmzz76b0s6bchm35ijpyaa9j4x7863g-vmtouch-git-1.3.0

cc "@garrison"