### PR TITLE
waf: 1.9.0 -> 2.0.4

### DIFF
--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "waf-${version}";
-  version = "1.9.0";
+  version = "2.0.4";
 
   src = fetchurl {
     url = "https://waf.io/waf-${version}.tar.bz2";
-    sha256 = "1sjpqzm2fzm8pxi3fwfinpsbw4z9040qkrzbg3lxik7ppsbjhn58";
+    sha256 = "0zmnwgccq5j7ipfi2j0k5s40q27krp1m6v2bd650axgzdbpa7ain";
   };
 
   buildInputs = [ python2 ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.0.4 with grep in /nix/store/dr6xvrw483jr5vgznwpjj0hxx3jq86ha-waf-2.0.4
- found 2.0.4 in filename of file in /nix/store/dr6xvrw483jr5vgznwpjj0hxx3jq86ha-waf-2.0.4

cc "@vrthra"