### PR TITLE
wavemon: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/tools/networking/wavemon/default.nix
+++ b/pkgs/tools/networking/wavemon/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, ncurses, libnl, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.1";
+  version = "0.8.2";
   baseName = "wavemon";
   name = "${baseName}-${version}";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "uoaerg";
     repo = "wavemon";
     rev = "v${version}";
-    sha256 = "0mx61rzl8a66pmigv2fh75zgdalxx75a5s1b7ydbviz18ihhjyls";
+    sha256 = "0rqpp7rhl9rlwnihsapaiy62v33h45fm3d0ia2nhdjw7fwkwcqvs";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/kzknr8h49w4xv1qam0049r4ygd65vkab-wavemon-0.8.2/bin/wavemon -h` got 0 exit code
- ran `/nix/store/kzknr8h49w4xv1qam0049r4ygd65vkab-wavemon-0.8.2/bin/wavemon -v` and found version 0.8.2
- found 0.8.2 with grep in /nix/store/kzknr8h49w4xv1qam0049r4ygd65vkab-wavemon-0.8.2
- found 0.8.2 in filename of file in /nix/store/kzknr8h49w4xv1qam0049r4ygd65vkab-wavemon-0.8.2

cc "@raskin @fpletz"