### PR TITLE
wiggle: 1.0 -> 1.1

### DIFF
--- a/pkgs/development/tools/wiggle/default.nix
+++ b/pkgs/development/tools/wiggle/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation {
 
-  name = "wiggle-1.0";
+  name = "wiggle-1.1";
 
   src = fetchurl {
-    url = "https://github.com/neilbrown/wiggle/archive/v1.0.tar.gz";
-    sha256 = "0552dkdvl001b2jasj0jwb69s7zy6wbc8gcysqj69b4qgl9c54cs";
+    url = "https://github.com/neilbrown/wiggle/archive/v1.1.tar.gz";
+    sha256 = "0gg1c0zcrd5fgawvjccmdscm3fka8h1qz4v807kvy1b2y1cf9c4w";
   };
 
   buildInputs = [ ncurses groff ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/hs0xavmd2pyi30l05s20hp5q70bc63br-wiggle-1.1/bin/wiggle -h` got 0 exit code
- ran `/nix/store/hs0xavmd2pyi30l05s20hp5q70bc63br-wiggle-1.1/bin/wiggle --help` got 0 exit code
- ran `/nix/store/hs0xavmd2pyi30l05s20hp5q70bc63br-wiggle-1.1/bin/wiggle -V` and found version 1.1
- ran `/nix/store/hs0xavmd2pyi30l05s20hp5q70bc63br-wiggle-1.1/bin/wiggle --version` and found version 1.1
- found 1.1 with grep in /nix/store/hs0xavmd2pyi30l05s20hp5q70bc63br-wiggle-1.1
- found 1.1 in filename of file in /nix/store/hs0xavmd2pyi30l05s20hp5q70bc63br-wiggle-1.1
