### PR TITLE
wolfssl: 3.12.0 -> 3.13.0

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wolfssl-${version}";
-  version = "3.12.0";
+  version = "3.13.0";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     rev = "v${version}-stable";
-    sha256 = "0bjfzpgj50cd27lfz6vry9bdz0f0kvgq8plqdbhlk7kjp32nm2bv";
+    sha256 = "0mvq7ifcpckfrg0zzcxqfbrv08pnz4a8g2z2j3s9h3cwns9ipn6h";
   };
 
   outputs = [ "out" "dev" "doc" "lib" ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.13.0 in filename of file in /nix/store/pcakgwgq8k7ad2x10ji9z054z87z1pca-wolfssl-3.13.0

cc "@mcmtroffaes"