### PR TITLE
worker: 3.8.5 -> 3.15.0

### DIFF
--- a/pkgs/applications/misc/worker/default.nix
+++ b/pkgs/applications/misc/worker/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "worker-${version}";
-  version = "3.8.5";
+  version = "3.15.0";
 
   src = fetchurl {
     url = "http://www.boomerangsworld.de/cms/worker/downloads/${name}.tar.gz";
-    sha256 = "1xy02jdf60wg2jycinl6682xg4zvphdj80f8xgs26ip45iqgkmvw";
+    sha256 = "0baaxa10jnf4nralhjdi7525wd1wj0161z2ixz1j5pb0rl38brl8";
   };
 
   buildInputs = [ libX11 ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0/bin/worker -h` got 0 exit code
- ran `/nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0/bin/worker --help` got 0 exit code
- ran `/nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0/bin/worker help` got 0 exit code
- ran `/nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0/bin/worker -V` and found version 3.15.0
- ran `/nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0/bin/worker -v` and found version 3.15.0
- ran `/nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0/bin/worker --version` and found version 3.15.0
- ran `/nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0/bin/worker -h` and found version 3.15.0
- ran `/nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0/bin/worker --help` and found version 3.15.0
- found 3.15.0 with grep in /nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0
- found 3.15.0 in filename of file in /nix/store/r4nbmymh7w5xqig9szbc6rmw2ld2gc91-worker-3.15.0

cc "@ndowens"