### PR TITLE
xdo: 0.5.6 -> 0.5.7

### DIFF
--- a/pkgs/tools/misc/xdo/default.nix
+++ b/pkgs/tools/misc/xdo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
    name = "xdo-${version}";
-   version = "0.5.6";
+   version = "0.5.7";
 
    src = fetchFromGitHub {
      owner = "baskerville";
      repo = "xdo";
      rev = version;
-     sha256 = "1i8xlsp36ji7cvyh66ajqsf59hxpwm0xvnn9laq7nbajcx3qqlnh";
+     sha256 = "1h3jrygcjjbavdbkpx2hscsf0yf97gk487lzjdlvymd7dxdv9hy9";
    };
 
    makeFlags = "PREFIX=$(out)";


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/qbdnwwzhmilpjybrw73nn632d531w2n3-xdo-0.5.7/bin/xdo -h` got 0 exit code
- ran `/nix/store/qbdnwwzhmilpjybrw73nn632d531w2n3-xdo-0.5.7/bin/xdo -v` and found version 0.5.7
- found 0.5.7 with grep in /nix/store/qbdnwwzhmilpjybrw73nn632d531w2n3-xdo-0.5.7
- found 0.5.7 in filename of file in /nix/store/qbdnwwzhmilpjybrw73nn632d531w2n3-xdo-0.5.7

cc "@meisternu"