### PR TITLE
xtitle: 0.3 -> 0.4.3

### DIFF
--- a/pkgs/tools/misc/xtitle/default.nix
+++ b/pkgs/tools/misc/xtitle/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libxcb, xcbutil, xcbutilwm, git }:
 
 stdenv.mkDerivation rec {
-   name = "xtitle-0.3";
+   name = "xtitle-0.4.3";
 
    src = fetchurl {
-     url = "https://github.com/baskerville/xtitle/archive/0.3.tar.gz";
-     sha256 = "07r36f4ad1q0dpkx3ykd49xlmi24d8mjqwh40j228k81wsvzayl1";
+     url = "https://github.com/baskerville/xtitle/archive/0.4.3.tar.gz";
+     sha256 = "0bk4mxx0vky37f66b2y34nggi1f7fnrmsprkxyc8mskj6qcrbm5h";
    };
 
 


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/pxkzrgjcbd0ppv4xgnwml53xaswbb899-xtitle-0.4.3/bin/xtitle -h` got 0 exit code
- ran `/nix/store/pxkzrgjcbd0ppv4xgnwml53xaswbb899-xtitle-0.4.3/bin/xtitle --help` got 0 exit code
- ran `/nix/store/pxkzrgjcbd0ppv4xgnwml53xaswbb899-xtitle-0.4.3/bin/xtitle -v` and found version 0.4.3
- ran `/nix/store/pxkzrgjcbd0ppv4xgnwml53xaswbb899-xtitle-0.4.3/bin/xtitle --version` and found version 0.4.3
- ran `/nix/store/pxkzrgjcbd0ppv4xgnwml53xaswbb899-xtitle-0.4.3/bin/xtitle --help` and found version 0.4.3
- found 0.4.3 with grep in /nix/store/pxkzrgjcbd0ppv4xgnwml53xaswbb899-xtitle-0.4.3
- found 0.4.3 in filename of file in /nix/store/pxkzrgjcbd0ppv4xgnwml53xaswbb899-xtitle-0.4.3

cc "@meisternu"