### PR TITLE
yank: 0.8.2 -> 0.8.3

### DIFF
--- a/pkgs/tools/misc/yank/default.nix
+++ b/pkgs/tools/misc/yank/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "mptre";
     repo = "yank";
     rev = "v${meta.version}";
-    sha256 = "0nf9y3jsvfjxa3mgigywnyirznn1m4zjm1glnwndrjsjrkcpnzb5";
+    sha256 = "0v5aynrilm4fj7gz03q0yz6806ssjxhlv4bsa0213bgkin5iiws7";
     inherit name;
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     '';
     downloadPage = "https://github.com/mptre/yank/releases";
     license = licenses.mit;
-    version = "0.8.2";
+    version = "0.8.3";
     maintainers = [ maintainers.dochang ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/bzk4wbsksyjga0f8nccwrbangv2416vz-yank-0.8.3/bin/yank -v` and found version 0.8.3
- found 0.8.3 with grep in /nix/store/bzk4wbsksyjga0f8nccwrbangv2416vz-yank-0.8.3
- found 0.8.3 in filename of file in /nix/store/bzk4wbsksyjga0f8nccwrbangv2416vz-yank-0.8.3

cc "@dochang"