### PR TITLE
yaws: 2.0 -> 2.0.4

### DIFF
--- a/pkgs/servers/http/yaws/default.nix
+++ b/pkgs/servers/http/yaws/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "yaws-${version}";
-  version = "2.0";
+  version = "2.0.4";
 
   src = fetchurl {
     url = "http://yaws.hyber.org/download/${name}.tar.gz";
-    sha256 = "1gwk44a07n7yvg900yrlfc6qpvjl64k2h2hddd1jaaay8lgpcch6";
+    sha256 = "1ig6q4waqlb6h1hhrly7hslfnqczlbm79vvhr5j7rp5a2p1pfrns";
   };
 
   # The tarball includes a symlink yaws -> yaws-1.95, which seems to be


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/946hqpkgmb964ilf2sbk9ln4kfy7jnkr-yaws-2.0.4/bin/yaws -v` and found version 2.0.4
- ran `/nix/store/946hqpkgmb964ilf2sbk9ln4kfy7jnkr-yaws-2.0.4/bin/yaws --version` and found version 2.0.4
- found 2.0.4 with grep in /nix/store/946hqpkgmb964ilf2sbk9ln4kfy7jnkr-yaws-2.0.4
- found 2.0.4 in filename of file in /nix/store/946hqpkgmb964ilf2sbk9ln4kfy7jnkr-yaws-2.0.4

cc "@goibhniu @the-kenny"