### PR TITLE
you-get: 0.4.1011 -> 0.4.1025

### DIFF
--- a/pkgs/tools/misc/you-get/default.nix
+++ b/pkgs/tools/misc/you-get/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonApplication rec {
   pname = "you-get";
-  version = "0.4.1011";
+  version = "0.4.1025";
 
   # Tests aren't packaged, but they all hit the real network so
   # probably aren't suitable for a build environment anyway.
@@ -10,7 +10,7 @@ buildPythonApplication rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0h6aspnfic30s89xsv6qss1jfka9px4ll60bqrjbds4y0k3h818g";
+    sha256 = "1dbalpwhzn39kgswjy84720wfjssa087adavbwig53krsjdvhj6k";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/.you-get-wrapped -h` got 0 exit code
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/.you-get-wrapped --help` got 0 exit code
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/.you-get-wrapped -V` and found version 0.4.1025
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/.you-get-wrapped --version` and found version 0.4.1025
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/.you-get-wrapped -h` and found version 0.4.1025
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/.you-get-wrapped --help` and found version 0.4.1025
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/you-get -h` got 0 exit code
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/you-get --help` got 0 exit code
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/you-get -V` and found version 0.4.1025
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/you-get --version` and found version 0.4.1025
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/you-get -h` and found version 0.4.1025
- ran `/nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025/bin/you-get --help` and found version 0.4.1025
- found 0.4.1025 with grep in /nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025
- found 0.4.1025 in filename of file in /nix/store/yf9zmzfn5f41n3w55ss5bla25b3bp2is-you-get-0.4.1025

cc "@ryneeverett"