### PR TITLE
youtube-dl: 2018.02.08 -> 2018.02.22

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -16,11 +16,11 @@ with stdenv.lib;
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2018.02.08";
+  version = "2018.02.22";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "0iq5mav782gz0gm00rry3v7gdxkkx4y1k0p20pvz32ga4id5k1mg";
+    sha256 = "112qmwrkd0cpyx2h20k6y07lw7iixvj8yya7r97h3k1y1py9vbz8";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- ran `/nix/store/a520a1ddi4fyfyjmkqpf5kgmdy481mpf-youtube-dl-2018.02.22/bin/.youtube-dl-wrapped -h` got 0 exit code
- ran `/nix/store/a520a1ddi4fyfyjmkqpf5kgmdy481mpf-youtube-dl-2018.02.22/bin/.youtube-dl-wrapped --help` got 0 exit code
- ran `/nix/store/a520a1ddi4fyfyjmkqpf5kgmdy481mpf-youtube-dl-2018.02.22/bin/.youtube-dl-wrapped --version` and found version 2018.02.22
- ran `/nix/store/a520a1ddi4fyfyjmkqpf5kgmdy481mpf-youtube-dl-2018.02.22/bin/youtube-dl -h` got 0 exit code
- ran `/nix/store/a520a1ddi4fyfyjmkqpf5kgmdy481mpf-youtube-dl-2018.02.22/bin/youtube-dl --help` got 0 exit code
- ran `/nix/store/a520a1ddi4fyfyjmkqpf5kgmdy481mpf-youtube-dl-2018.02.22/bin/youtube-dl --version` and found version 2018.02.22
- found 2018.02.22 with grep in /nix/store/a520a1ddi4fyfyjmkqpf5kgmdy481mpf-youtube-dl-2018.02.22

cc "@bluescreen303 @phreedom @AndersonTorres @fuuzetsu @fpletz"