### PR TITLE
yubikey-personalization-gui: 3.1.24 -> 3.1.25

### DIFF
--- a/pkgs/tools/misc/yubikey-personalization-gui/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization-gui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, yubikey-personalization, qt4, qmake4Hook, libyubikey }:
 
 stdenv.mkDerivation rec {
-  name = "yubikey-personalization-gui-3.1.24";
+  name = "yubikey-personalization-gui-3.1.25";
 
   src = fetchurl {
     url = "https://developers.yubico.com/yubikey-personalization-gui/Releases/${name}.tar.gz";
-    sha256 = "0aj8cvajswkwzig0py0mjnfw0m8xsilisdcnixpjx9xxsxz5yacq";
+    sha256 = "1knyv5yss8lhzaff6jpfqv12fjf1b8b21mfxzx3qi0hw4nl8n2v8";
   };
 
   nativeBuildInputs = [ pkgconfig qmake4Hook ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 3.1.25 with grep in /nix/store/zf6w45davybf2ajmcsd9p9gbhja441n3-yubikey-personalization-gui-3.1.25
- found 3.1.25 in filename of file in /nix/store/zf6w45davybf2ajmcsd9p9gbhja441n3-yubikey-personalization-gui-3.1.25

cc "@wkennington"