### PR TITLE
zerofree: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/tools/filesystems/zerofree/default.nix
+++ b/pkgs/tools/filesystems/zerofree/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "zerofree-${version}";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchurl {
     url = "http://frippery.org/uml/${name}.tgz";
-    sha256 = "059g29x5r1xj6wcj4xj85l8w6qrxyl86yqbybjqqz6nxz4falxzf";
+    sha256 = "0rrqfa5z103ws89vi8kfvbks1cfs74ix6n1wb6vs582vnmhwhswm";
   };
 
   buildInputs = [ e2fsprogs ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 1.1.1 in filename of file in /nix/store/izfdcr9hld3rmcwcmvwfv9mc2pd414x3-zerofree-1.1.1

cc "@theuni"