### PR TITLE
zimg: 2.7 -> 2.7.4

### DIFF
--- a/pkgs/development/libraries/zimg/default.nix
+++ b/pkgs/development/libraries/zimg/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec{
   name = "zimg-${version}";
-  version = "2.7";
+  version = "2.7.4";
 
   src = fetchFromGitHub {
     owner  = "sekrit-twc";
     repo   = "zimg";
     rev    = "release-${version}";
-    sha256 = "1jvx3a523mzkc54rrjab9kz66kc6q1snry9ymwmsx7rrd3kv3j6m";
+    sha256 = "1gpmf6algpl1g1z891jfnsici84scg2cq1kj4v90glgik9z99mci";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 2.7.4 with grep in /nix/store/3881hzp2frwjsw7xyafvr3zzlyacv7a8-zimg-2.7.4
- found 2.7.4 in filename of file in /nix/store/3881hzp2frwjsw7xyafvr3zzlyacv7a8-zimg-2.7.4

cc "@rnhmjoj"