### PR TITLE
zsh-autosuggestions: 0.4.0 -> 0.4.2

### DIFF
--- a/pkgs/shells/zsh-autosuggestions/default.nix
+++ b/pkgs/shells/zsh-autosuggestions/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "zsh-autosuggestions-${version}";
-  version = "0.4.0";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "zsh-users";
     repo = "zsh-autosuggestions";
     rev = "v${version}";
-    sha256 = "0z6i9wjjklb4lvr7zjhbphibsyx51psv50gm07mbb0kj9058j6kc";
+    sha256 = "1yvbhfaaqzhmjmwjh75i1p4mrqp3ksw74bp8lrll81c6zf8bmvig";
   };
 
   buildInputs = [ zsh ];


### PR DESCRIPTION
Semi-automatic update. These checks were performed:

- built on NixOS
- found 0.4.2 with grep in /nix/store/pgilg1imys99x1i42dslrv4qvqkp0p4d-zsh-autosuggestions-0.4.2
- found 0.4.2 in filename of file in /nix/store/pgilg1imys99x1i42dslrv4qvqkp0p4d-zsh-autosuggestions-0.4.2

cc "@loskutov"