### PR TITLE
neovim-gtk: init at 0.1.1

### DIFF
--- a/pkgs/applications/editors/neovim/neovim-gtk.nix
+++ b/pkgs/applications/editors/neovim/neovim-gtk.nix
@@ -17,8 +17,8 @@ buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "daa84";
     repo = "neovim-gtk";
-    rev = "30b7fc87e1e92ac2bb102fd6af6a960fc75017ac";
-    sha256 = "14yy611b6pgy3qay0g1nnwss66xckz0ljw7ixpsqbwi0imjvda27";
+    rev = "74d7417564012ff9a98df179470cedd5677b1018";
+    sha256 = "0x031vjm2a9kr1cn2gsfd33bp7y43n4yznprdqb4ligm22ddlwjz";
   };
 
   propagatedBuildInputs= [

--- a/pkgs/applications/editors/neovim/neovim-gtk.nix
+++ b/pkgs/applications/editors/neovim/neovim-gtk.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, rustPlatform
+, gtk3
+, atk
+, pango
+, cairo
+, gdk_pixbuf
+, glib
+, gobjectIntrospection
+}:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "neovim-gtk-${version}";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "daa84";
+    repo = "neovim-gtk";
+    rev = "30b7fc87e1e92ac2bb102fd6af6a960fc75017ac";
+    sha256 = "14yy611b6pgy3qay0g1nnwss66xckz0ljw7ixpsqbwi0imjvda27";
+  };
+
+  propagatedBuildInputs= [
+    gtk3
+    gdk_pixbuf
+    atk
+    pango
+    cairo
+    glib
+    gobjectIntrospection
+  ];
+
+  cargoSha256 = "0zpdsq96xffdcgi4b9s5gj0v0j4riqp0frqwqv8d4sczhlp2yq31";
+
+  meta = with stdenv.lib; {
+    description = "GTK ui for neovim written in rust using gtk-rs bindings. With ligatures support.";
+    homepage = https://github.com/daa84/neovim-gtk;
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18091,6 +18091,8 @@ with pkgs;
 
   neovim-qt = libsForQt5.callPackage ../applications/editors/neovim/qt.nix { };
 
+  neovim-gtk = callPackage ../applications/editors/neovim/neovim-gtk.nix { };
+
   neovim-pygui = pythonPackages.neovim_gui;
 
   neovim-remote = callPackage ../applications/editors/neovim/neovim-remote.nix { pythonPackages = python3Packages; };


### PR DESCRIPTION
neovim ui that supports ligatures.

As usual with gtk applications, I don't have icons (be it libreoffice or other gtk apps)
![2018-02-28-154812_956x949_scrot](https://user-images.githubusercontent.com/886074/36773822-e43c48ec-1c9e-11e8-8ac7-89622a19b5ac.png)

First time packaging a rust program, it seems to compile quite a bit of stuff.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

