### PR TITLE
WIP: Updating android sdk and related tools to version 26.

### DIFF
--- a/pkgs/development/mobile/androidenv/sources.nix
+++ b/pkgs/development/mobile/androidenv/sources.nix
@@ -148,4 +148,15 @@ in
     };
   };
 
+  source_26 = buildSource {
+    name = "android-source-26";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-26_r01.zip;
+      sha1 = "p7wxhbwk0qfhnm48j9081m936bp03xra";
+    };
+    meta = {
+      description = "Source code for Android API 26";
+    };
+  };
+
 }


### PR DESCRIPTION
My Android application based on the reflex-platform does not yet build with this
changes. So please don't merge. I am just putting it here, because I won't get
to finishing this for at least a few weeks, so others needing this, can more
easily pick up the work, if needed.

Also full disclaimer: I am an absolute noob when it comes to Android
development, so if someone more involved can have a look at my changes - that
would be great.

###### Motivation for this change

If you build an Android application requiring APIs like Foreground service, you need at least version 26 of the androidsdk to have it compile.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

