### PR TITLE
diceware: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/tools/security/diceware/default.nix
+++ b/pkgs/tools/security/diceware/default.nix
@@ -7,28 +7,16 @@ with pythonPackages;
 
 buildPythonApplication rec {
   pname = "diceware";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0p09q6945qvdmvckjl8rfqx0g8nf6igc3c6rab6v74k9bsmbf15p";
+    sha256 = "0855n4dh16ws1dhw1ixxwk3wx7qr45xff7pn32pjg58p4z4cx168";
   };
 
   nativeBuildInputs = [ pytestrunner ];
 
-  checkInputs = [ pytest ];
-
-  # NOTE: remove once 0.9.4 is released
-  patches = [
-    (fetchpatch {
-      url = "${meta.homepage}/commit/86379bf49ade2b486071d6d330515f01ecb06ab4.patch";
-      sha256 = "0nxvxiqvxfsa9y6zwy9k7shsd0fk92psdzi4klqwd4wy3lbmw8di";
-    })
-    (fetchpatch {
-      url = "${meta.homepage}/commit/a7d844df76cd4b95a717f21ef5aa6167477b6733.patch";
-      sha256 = "0ab4fc2pbl2hcxqw5rr6awbhlnmdna6igqjijywwr1byzb7ga4iq";
-    })
-  ];
+  checkInputs = [ coverage pytest ];
 
   # see https://github.com/ulif/diceware/commit/a7d844df76cd4b95a717f21ef5aa6167477b6733
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update to latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

