### PR TITLE
mpc-qt: init at 17.11

### DIFF
--- a/pkgs/applications/video/mpc-qt/default.nix
+++ b/pkgs/applications/video/mpc-qt/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qtx11extras, qttools, mpv }:
+
+stdenv.mkDerivation rec {
+  name = "mpc-qt-${version}";
+  version = "17.11";
+
+  src = fetchFromGitHub {
+    owner = "cmdrkotori";
+    repo = "mpc-qt";
+    rev = "v${version}";
+    sha256 = "1vi4zsmbzxj6ms8wls9zv15vrskdrhgnj6l41m1fk4scs4jzvbkm";
+  };
+
+  nativeBuildInputs = [ pkgconfig qmake qttools ];
+
+  buildInputs = [ mpv qtx11extras ];
+
+  qmakeFlags = [ "QMAKE_LUPDATE=${qttools.dev}/bin/lupdate" ];
+
+  meta = with stdenv.lib; {
+    description = "Media Player Classic Qute Theater";
+    homepage = https://github.com/cmdrkotori/mpc-qt;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16544,6 +16544,8 @@ with pkgs;
 
   mm = callPackage ../applications/networking/instant-messengers/mm { };
 
+  mpc-qt = libsForQt5.callPackage ../applications/video/mpc-qt { };
+
   mplayer = callPackage ../applications/video/mplayer ({
     pulseSupport = config.pulseaudio or false;
     libdvdnav = libdvdnav_4_2_1;


### PR DESCRIPTION
###### Motivation for this change

Add [mpc-qt](https://github.com/cmdrkotori/mpc-qt) (Media Player Classic Qute Theater),  a  clone of Media Player Classic reimplemented in Qt.

> [Media Player Classic Home Cinema](https://mpc-hc.org/) (mpc-hc) is considered by many to be the quintessential media player for the Windows desktop. Media Player Classic Qute Theater (mpc-qt) aims to reproduce most of the interface and functionality of mpc-hc while using [libmpv](https://github.com/mpv-player/mpv) to play video instead of DirectShow.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).