### PR TITLE
Eduvpn client: init at 1.0.1

### DIFF
--- a/pkgs/tools/networking/python-eduvpn-client/default.nix
+++ b/pkgs/tools/networking/python-eduvpn-client/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, gdk_pixbuf, gobjectIntrospection, gtk3
+, libnotify, networkmanager_openvpn, pythonPackages, wrapGAppsHook }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "eduvpn-client";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "eduvpn";
+    repo = "python-${pname}";
+    rev = version;
+    sha256 = "1jy8dv6i8rhmz5q59xcmwmf5n4bpfchkm4xjc1yi1x77qy8gi7bv";
+  };
+
+  prePatch = ''
+    substituteInPlace eduvpn/util.py \
+      --replace "/usr/local" "$out"
+  '';
+
+  checkInputs = with pythonPackages; [ pytest mock pytestrunner ];
+  nativeBuildInputs = with pythonPackages; [ wrapGAppsHook ];
+
+  propagatedBuildInputs = with pythonPackages; [
+    # Non-Python Dependencies
+    gdk_pixbuf gobjectIntrospection gtk3 libnotify networkmanager_openvpn
+    # Python Dependencies
+    configparser dateutil dbus-python future pygobject3 pynacl requests
+    requests_oauthlib six repoze_lru pillow qrcode pytestrunner
+    ];
+
+  # Checks need X environment
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://eduvpn.org;
+    description = "Linux client and Python client API for eduVPN";
+    longDescription = ''
+      This is the GNU/Linux desktop client and Python API for eduVPN.
+      The Desktop client only works on Linux, but most parts of the
+      API are usable on other platforms also. For the API Python 2.7,
+      3.4+ and pypy are supported.
+    '';
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1226,6 +1226,8 @@ with pkgs;
 
   edac-utils = callPackage ../os-specific/linux/edac-utils { };
 
+  eduvpn-client = python3Packages.eduvpn-client;
+
   eggdrop = callPackage ../tools/networking/eggdrop { };
 
   elementary-icon-theme = callPackage ../data/icons/elementary-icon-theme { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16945,6 +16945,8 @@ EOF
 
   ed25519 = callPackage ../development/python-modules/ed25519 { };
 
+  eduvpn-client = callPackage ../tools/networking/python-eduvpn-client { };
+
   trezor = callPackage ../development/python-modules/trezor { };
 
   trezor_agent = buildPythonPackage rec{


### PR DESCRIPTION
###### Motivation for this change
 
A user-friendly tool for people inside  educational and research institutions to set up their VPN networks. Useful for many people to protect against rogue networks, snooping etc.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

