### PR TITLE
Update message to reflect nix 2.0 availability of imperative nix-update

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,10 @@ if ! builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.
 
     This version of Nixpkgs requires Nix >= ${requiredVersion}, please upgrade:
 
-    - If you are running NixOS, use `nixos-rebuild' to upgrade your system.
+    - If you are running NixOS, `nixos-rebuild' can be used to upgrade your system.
+
+    - Alternatively, with Nix > 2.0 `nix upgrade-nix' can be used to imperatively
+      upgrade Nix. You may use `nix-env --version' to check which version you have.
 
     - If you installed Nix using the install script (https://nixos.org/nix/install),
       it is safe to upgrade by running it again:


### PR DESCRIPTION
###### Motivation for this change
With Nix 2.0 out, there is a new way of updating which should be reflected in the message printed to users.

###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

