### PR TITLE
rtlwifi: 2017-07-18 -> 2018-02-17

### DIFF
--- a/pkgs/os-specific/linux/rtlwifi_new/default.nix
+++ b/pkgs/os-specific/linux/rtlwifi_new/default.nix
@@ -6,13 +6,13 @@ let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wi
 
 in stdenv.mkDerivation rec {
   name = "rtlwifi_new-${version}";
-  version = "2017-07-18";
+  version = "2018-02-17";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtlwifi_new";
-    rev = "a24cb561b4d23187ea103255336daa7ca88791a7";
-    sha256 = "1w9rx5wafcp1vc4yh7lj332bv78szl6gmx3ckr8yl6c39alqcv0d";
+    rev = "0588ac0cc5f530e7764705416370b70d3c2afedc";
+    sha256 = "1vs8rfw19lcs04bapa97zlnl5x0kf02sdw5ik0hdm27wgk0z969m";
   };
 
   hardeningDisable = [ "pic" "format" ];


### PR DESCRIPTION
###### Motivation for this change
rtlwifi_new does not build on kernel > 4.15, update to a version that does

###### Things done

tested build (but not boot) with:

nix-shell -p linuxPackages_4_4.rtlwifi_new
nix-shell -p linuxPackages_4_9.rtlwifi_new
nix-shell -p linuxPackages_latest.rtlwifi_new

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

