### PR TITLE
keepassxc: 2.2.4 -> 2.3.0

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -1,5 +1,17 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper, qttools
-, libgcrypt, zlib, libmicrohttpd, libXtst, qtbase, libgpgerror, glibcLocales, libyubikey, yubikey-personalization, libXi, qtx11extras
+, curl
+, glibcLocales
+, libXi
+, libXtst
+, libargon2
+, libgcrypt
+, libgpgerror
+, libmicrohttpd
+, libyubikey
+, qtbase
+, qtx11extras
+, yubikey-personalization
+, zlib
 , withKeePassHTTP ? true
 }:
 
@@ -7,16 +19,14 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "keepassxc-${version}";
-  version = "2.2.4";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = "${version}";
-    sha256 = "0q913v2ka6p7jr7c4w9fq8aqh5v6nxqgcv9h7zllk5p0amsf8d80";
+    sha256 = "1zch1qbqgphhp2p2kvjlah8s337162m69yf4y00kcnfb3539ii5f";
   };
-
-  patches = [ ./cmake.patch ./darwin.patch ];
 
   cmakeFlags = [
     "-DWITH_GUI_TESTS=ON"
@@ -32,7 +42,21 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper qttools ];
 
-  buildInputs = [ libgcrypt zlib qtbase libXtst libmicrohttpd libgpgerror glibcLocales libyubikey yubikey-personalization libXi qtx11extras ];
+  buildInputs = [
+    curl
+    glibcLocales
+    libXi
+    libXtst
+    libargon2
+    libgcrypt
+    libgpgerror
+    libmicrohttpd
+    libyubikey
+    qtbase
+    qtx11extras
+    yubikey-personalization
+    zlib
+  ];
 
   postInstall = optionalString stdenv.isDarwin ''
     # Make it work without Qt in PATH.

--- a/pkgs/development/libraries/libargon2/default.nix
+++ b/pkgs/development/libraries/libargon2/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.argon2.com/;
     license = with licenses; [ asl20 cc0 ];
     maintainers = with maintainers; [ taeer olynch ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

HN-driven development. https://news.ycombinator.com/item?id=16483722

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

