### PR TITLE
programs/bash: install nix-bash-completions if completion is enabled

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1803.xml
+++ b/nixos/doc/manual/release-notes/rl-1803.xml
@@ -430,6 +430,13 @@ following incompatible changes:</para>
       and <literal>stopJob</literal> provide an optional <literal>$user</literal> argument for that purpose.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      Enabling bash completion on NixOS, <literal>programs.bash.enableCompletion</literal>, will now also enable
+      completion for the Nix command line tools by installing the
+      <link xlink:href="https://github.com/hedning/nix-bash-completions">nix-bash-completions</link> package.
+    </para>
+  </listitem>
 </itemizedlist>
 
 </section>

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -211,6 +211,9 @@ in
       "/share/bash-completion"
     ];
 
+    environment.systemPackages = optional cfg.enableCompletion
+      pkgs.nix-bash-completions;
+
     environment.shells =
       [ "/run/current-system/sw/bin/bash"
         "/var/run/current-system/sw/bin/bash"

--- a/pkgs/shells/nix-bash-completions/default.nix
+++ b/pkgs/shells/nix-bash-completions/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.3";
+  version = "0.6.4";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "1zmk9f53xpwk5j6qqisjlddgm2fr68p1q6pn3wa14bd777lranhj";
+    sha256 = "1kdysrfc8dx24q438wj3aisn64g2w5yb6mx91qa385p5hz7b1yz2";
   };
 
   # To enable lazy loading via. bash-completion we need a symlink to the script


### PR DESCRIPTION
###### Motivation for this change

Enable completion for the Nix command line tools when bash completion is enabled.

The completion scripts should be pretty solid now, and I think it would be good for the user experience to install it automatically when the user have toggled `programs.bash.enableCompletion`.

###### Things done

Removed spotty nixops completion, which wasn't ready for prime time, from nix-bash-completions.

Added a note to the 18.03 changelog.

Tested VMs with `nixos-rebuild build-vm` configured with `programs.bash.enableCompletion` turned on and off.

cc @bjornfor 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

