### PR TITLE
redshift, xarchiver: add hicolor-icon-theme to buildInputs

### DIFF
--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchurl, autoconf, automake, gettext, intltool
 , libtool, pkgconfig, wrapGAppsHook, wrapPython, geoclue2, gobjectIntrospection
-, gtk3, python, pygobject3, pyxdg, libdrm, libxcb }:
+, gtk3, python, pygobject3, pyxdg, libdrm, libxcb, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "redshift-${version}";
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     libdrm
     libxcb
     python
+    hicolor-icon-theme
   ];
 
   pythonPath = [ pygobject3 pyxdg ];

--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3, pkgconfig, intltool, libxslt }:
+{ stdenv, fetchFromGitHub, gtk3, pkgconfig, intltool, libxslt, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   version = "0.5.4.12";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk3 intltool libxslt ];
+  buildInputs = [ gtk3 intltool libxslt hicolor-icon-theme ];
 
   meta = {
     description = "GTK+ frontend to 7z,zip,rar,tar,bzip2, gzip,arj, lha, rpm and deb (open and extract only)";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/10370

maintainers @domenkozar @yegortimoshenko 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

