### PR TITLE
ocaml: 4.06.0 -> 4.06.1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.06.nix
+++ b/pkgs/development/compilers/ocaml/4.06.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "06";
-  patch_version = "0";
-  sha256 = "1dy542yfnnw10zvh5s9qzswliq11mg7l0bcyss3501qw3vwvadhj";
+  patch_version = "1";
+  sha256 = "1n3pygfssd6nkrq876wszm5nm3v4605q4k16a66h1nmq9wvf01vg";
 
   # If the executable is stipped it does not work
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

Update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

