### PR TITLE
deepin-icon-theme: init at 15.12.52

### DIFF
--- a/pkgs/data/icons/deepin-icon-theme/default.nix
+++ b/pkgs/data/icons/deepin-icon-theme/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, gtk3, papirus-icon-theme }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-icon-theme";
+  version = "15.12.52";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "141in9jlflmckd8rg4605dfks84p1p6b1zdbhbiwrg11xbl66f3l";
+    
+    # Get rid of case collision in file names, which is an issue in
+    # darwin where file names are case insensitive.
+    extraPostFetch = ''
+      rm "$out"/Sea/apps/scalable/TeXmacs.svg
+      rm "$out"/deepin/apps/48/TeXmacs.svg
+    ''; 
+  };
+
+  nativeBuildInputs = [ gtk3 papirus-icon-theme ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postFixup = ''
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Deepin icon theme";
+    homepage = https://github.com/linuxdeepin/deepin-icon-theme;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13951,6 +13951,8 @@ with pkgs;
 
   crimson = callPackage ../data/fonts/crimson {};
 
+  deepin-icon-theme = callPackage ../data/icons/deepin-icon-theme { };
+
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts {
     inherit (perlPackages) FontTTF;
   });


### PR DESCRIPTION
###### Motivation for this change

Add [deepin-icon-theme](https://github.com/linuxdeepin/deepin-icon-theme).

[Here there is an image](https://www.gnome-look.org/p/1191167/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).