### PR TITLE
 mkvtoolnix: 20.0.0. -> 21.0.0 

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -1,32 +1,36 @@
 { stdenv, fetchFromGitLab, pkgconfig, autoconf, automake, libiconv
-, drake, ruby, docbook_xsl, file, xdg_utils, gettext, expat, qt5, boost
+, drake, ruby, docbook_xsl, file, xdg_utils, gettext, expat, boost
 , libebml, zlib, libmatroska, libogg, libvorbis, flac, libxslt, cmark
 , withGUI ? true
+  , qtbase ? null
+  , qtmultimedia ? null
 }:
 
-assert withGUI -> qt5 != null;
+assert withGUI -> qtbase != null && qtmultimedia != null;
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mkvtoolnix-${version}";
-  version = "20.0.0";
+  version = "21.0.0";
 
   src = fetchFromGitLab {
-    owner = "mbunkus";
-    repo = "mkvtoolnix";
-    rev = "release-${version}";
-    sha256 = "0qrjvvp0pvw9i91rh0zrxpclq7xap2dpjip0s5bm4gv14gh4l4mc";
+    owner  = "mbunkus";
+    repo   = "mkvtoolnix";
+    rev    = "release-${version}";
+    sha256 = "06nixp0qqa6g2fv40f7l0i0sqbc7qswpgq4534l98nan08wjbk2r";
   };
 
-  nativeBuildInputs = [ pkgconfig autoconf automake gettext drake ruby docbook_xsl libxslt ];
+  nativeBuildInputs = [
+    pkgconfig autoconf automake gettext
+    drake ruby docbook_xsl libxslt
+  ];
 
   buildInputs = [
-    expat file xdg_utils boost libebml zlib libmatroska libogg
-    libvorbis flac cmark
-  ]
-  ++ optional stdenv.isDarwin libiconv
-  ++ optionals withGUI [qt5.qtbase qt5.qtmultimedia];
+    expat file xdg_utils boost libebml zlib
+    libmatroska libogg libvorbis flac cmark
+  ] ++ optional  stdenv.isDarwin libiconv
+    ++ optionals withGUI [ qtbase qtmultimedia ];
 
   preConfigure = "./autogen.sh; patchShebangs .";
   buildPhase   = "drake -j $NIX_BUILD_CORES";

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, lib
-, yad, mkvtoolnix, libnotify }:
+, yad, mkvtoolnix-cli, libnotify }:
 
 stdenv.mkDerivation {
   name = "mpv-convert-script-2016-03-18.lua";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
       substituteInPlace convert_script.lua \
         ${subs "NOTIFY_CMD" "notify-send" "${libnotify}/bin/notify-send"} \
         ${subs "YAD_CMD" "yad" "${yad}/bin/yad"} \
-        ${subs "MKVMERGE_CMD" "mkvmerge" "${mkvtoolnix}/bin/mkvmerge"}
+        ${subs "MKVMERGE_CMD" "mkvmerge" "${mkvtoolnix-cli}/bin/mkvmerge"}
   '';
 
   dontBuild = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10459,7 +10459,7 @@ with pkgs;
     ffmpeg = ffmpeg_2;
   };
 
-  mkvtoolnix = callPackage ../applications/video/mkvtoolnix { };
+  mkvtoolnix = libsForQt5.callPackage ../applications/video/mkvtoolnix { };
 
   mkvtoolnix-cli = callPackage ../applications/video/mkvtoolnix {
     withGUI = false;


### PR DESCRIPTION
###### Motivation for this change
Regular update

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I replace mkvtoolnix with the cli-only version in the mpv script since it only needs mkvmerge.
