### PR TITLE
infiniband-diags: init at 2.0.0

### DIFF
--- a/pkgs/tools/networking/infiniband-diags/default.nix
+++ b/pkgs/tools/networking/infiniband-diags/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pkgconfig, rdma-core,
+  glib, opensm, perl, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "infiniband-diags-${version}";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "linux-rdma";
+    repo = "infiniband-diags";
+    rev = version;
+    sha256 = "06x8yy3ly1vzraznc9r8pfsal9mjavxzhgrla3q2493j5jz0sx76";
+  };
+
+  nativeBuildInputs = [ autoconf automake libtool pkgconfig makeWrapper ];
+
+  buildInputs = [ rdma-core glib opensm perl ];
+
+  preConfigure = ''
+    export CFLAGS="-I${opensm}/include/infiniband"
+    ./autogen.sh
+  '';
+
+  configureFlags = "--with-perl-installdir=\${out}/lib/perl5/site_perl --sbindir=\${out}/bin";
+
+  postInstall = ''
+    rmdir $out/var/run $out/var
+  '';
+
+  postFixup = ''
+    for pls in $out/bin/{ibfindnodesusing.pl,ibidsverify.pl}; do
+      echo "wrapping $pls"
+      wrapProgram $pls --prefix PERL5LIB : "$out/lib/perl5/site_perl"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Utilities designed to help configure, debug, and maintain infiniband fabrics";
+    homepage = http://linux-rdma.org/;
+    license =  licenses.bsd2; # Or GPL 2
+    maintainers = [ maintainers.aij ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2918,6 +2918,8 @@ with pkgs;
 
   inetutils = callPackage ../tools/networking/inetutils { };
 
+  infiniband-diags = callPackage ../tools/networking/infiniband-diags { };
+
   inform7 = callPackage ../development/compilers/inform7 { };
 
   infamousPlugins = callPackage ../applications/audio/infamousPlugins { };


### PR DESCRIPTION
###### Motivation for this change

Tools for InfiniBand 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Executables tested (some quite minimally):

- [x] check_lft_balance.pl
- [x] dump_fts
- [x] dump_lfts.sh
- [x] dump_mfts.sh
- [x] ibaddr
- [x] ibcacheedit
- [x] ibccconfig
- [x] ibccquery
- [x] ibfindnodesusing.pl
- [x] ibhosts
- [x] ibidsverify.pl
- [x] iblinkinfo
- [x] ibnetdiscover
- [x] ibnodes
- [x] ibping
- [x] ibportstate
- [x] ibqueryerrors
- [x] ibroute
- [x] ibrouters
- [x] ibstat
- [x] ibstatus
- [x] ibswitches
- [x] ibsysstat
- [x] ibtracert
- [x] perfquery
- [x] saquery
- [x] sminfo
- [x] smpdump
- [x] smpquery
- [x] vendstat

I'm only just learning about these tools though, so testing is minimal at best... 

@markuskowa I saw you packaged rdma-core. Do you happen to have IB hardware to test on?

cc @Mic92 