### PR TITLE
cpp_ethereum: mark as broken

### DIFF
--- a/pkgs/applications/misc/cpp-ethereum/default.nix
+++ b/pkgs/applications/misc/cpp-ethereum/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , cmake
+, gcc6
 , jsoncpp
 , libjson_rpc_cpp
 , curl
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     sha256 = "1fxgpqhmjhpv0zzs1m3yf9h8mh25dqpa7pmcfy7f9qiqpfdr4zq9";
   };
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" extraCmakeFlags ];
+  cmakeFlags = [ extraCmakeFlags ];
 
   configurePhase = ''
     export BOOST_INCLUDEDIR=${boost.dev}/include
@@ -56,6 +57,8 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
+    # broken on gcc7, see upstream issue: https://github.com/ethereum/cpp-ethereum/issues/4867
+    gcc6
     cmake
     jsoncpp
     libjson_rpc_cpp


### PR DESCRIPTION
Looks like it incompatible with current ethereum.

cc @artuuge

hydra build: https://hydra.nixos.org/build/70333858

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

