### PR TITLE
partio: 1.1.0 -> 2018-03-01

### DIFF
--- a/pkgs/development/libraries/partio/default.nix
+++ b/pkgs/development/libraries/partio/default.nix
@@ -3,28 +3,26 @@
 stdenv.mkDerivation rec
 {
   name = "partio-${version}";
-  version = "1.1.0";
+  version = "2018-03-01";
 
   src = fetchFromGitHub {
     owner = "wdas";
     repo = "partio";
-    rev = "v${version}";
-    sha256 = "0z7n5ay21ca7g7xb80v6jmr96x9k7vm7zawawvmx71yj32rg1n34";
+    rev = "8b6ea0d20f1ab77cd7f18390999251e60932de4a";
+    sha256 = "16sdj103v02l2dgq9y9cna9jakafabz9jxzdxsd737ir6wn10ksb";
   };
 
   outputs = [ "dev" "out" "lib" ];
 
-  buildInputs = [ unzip cmake freeglut mesa zlib swig python doxygen xorg.libXi xorg.libXmu ];
+  nativeBuildInputs = [ unzip cmake doxygen ];
+  buildInputs = [ freeglut mesa zlib swig python xorg.libXi xorg.libXmu ];
 
   enableParallelBuilding = true;
 
   buildPhase = ''
-    sed 's/ADD_LIBRARY (partio /ADD_LIBRARY (partio SHARED /' -i ../src/lib/CMakeLists.txt
-    CXXFLAGS="-std=c++11" cmake .
     make partio
 
     mkdir $dev
-    mkdir -p $lib/lib
     mkdir $out
       '';
 
@@ -32,19 +30,16 @@ stdenv.mkDerivation rec
   # Sexpr support
 
   installPhase = ''
-    mkdir $dev/lib
-    mkdir -p $dev/include/partio
-
-    mv lib/libpartio.so $lib/lib
-
-    mv ../src/lib/* $dev/include/partio
+    make install prefix=$out
+    mkdir $dev/include/partio
+    mv $dev/include/*.h $dev/include/partio
   '';
 
   meta = with stdenv.lib; {
     description = "C++ (with python bindings) library for easily reading/writing/manipulating common animation particle formats such as PDB, BGEO, PTC";
     homepage = "https://www.disneyanimation.com/technology/partio.html";
     license = licenses.bsd3;
-    platforms = platforms.all;
+    platforms = platforms.linux;
     maintainers = [ maintainers.guibou ];
   };
 }


### PR DESCRIPTION
- The version 1.1.0 is 6 years old and was not compiling anymore with GCC 7.0
- Fixed buildInputs / nativeBuildInputs

###### Motivation for this change

Partio was not building anymore since recent GCC 7.0 changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [X ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested with our proprietary tool, it build / link / works.

---


