### PR TITLE
wireshark: Add Darwin support

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/cmake.patch
+++ b/pkgs/applications/networking/sniffers/wireshark/cmake.patch
@@ -1,0 +1,19 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,6 +19,7 @@
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ #
+ 
++cmake_minimum_required(VERSION 3.7)
+ project(Wireshark C CXX)
+ 
+ # Updated by make-version.pl
+@@ -40,7 +41,7 @@
+ 	# Needed for GREATER_EQUAL operator
+ 	cmake_minimum_required(VERSION 3.7)
+ else()
+-	cmake_minimum_required(VERSION 2.8.8)
++	cmake_minimum_required(VERSION 3.7)
+ endif()
+ 
+ # Needs to be set after cmake_minimum_required or cmake_policy(VERSION)

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, pkgconfig, pcre, perl, flex, bison, gettext, libpcap, libnl, c-ares
 , gnutls, libgcrypt, libgpgerror, geoip, openssl, lua5, makeDesktopItem, python, libcap, glib
-, libssh, zlib, cmake, extra-cmake-modules, fetchpatch
+, libssh, zlib, cmake, extra-cmake-modules, fetchpatch, makeWrapper
 , withGtk ? false, gtk3 ? null, librsvg ? null, gsettings-desktop-schemas ? null, wrapGAppsHook ? null
 , withQt ? false, qt5 ? null
 , ApplicationServices, SystemConfiguration, gmp
@@ -26,6 +26,8 @@ in stdenv.mkDerivation {
   cmakeFlags = [
     "-DBUILD_wireshark_gtk=${if withGtk then "ON" else "OFF"}"
     "-DBUILD_wireshark=${if withQt then "ON" else "OFF"}"
+    "-DENABLE_QT5=${if withQt then "ON" else "OFF"}"
+    "-DENABLE_APPLICATION_BUNDLE=${if withQt && stdenv.isDarwin then "ON" else "OFF"}"
   ];
 
   nativeBuildInputs = [
@@ -34,11 +36,12 @@ in stdenv.mkDerivation {
 
   buildInputs = [
     gettext pcre perl libpcap lua5 libssh openssl libgcrypt
-    libgpgerror gnutls geoip c-ares python glib zlib
+    libgpgerror gnutls geoip c-ares python glib zlib makeWrapper
   ] ++ optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
     ++ optionals withGtk [ gtk3 librsvg gsettings-desktop-schemas ]
     ++ optionals stdenv.isLinux  [ libcap libnl ]
-    ++ optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ];
+    ++ optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ]
+    ++ optionals (withQt && stdenv.isDarwin) (with qt5; [ qtmacextras ]);
 
   patches = [ ./wireshark-lookup-dumpcap-in-path.patch ]
     # https://code.wireshark.org/review/#/c/23728/
@@ -46,9 +49,24 @@ in stdenv.mkDerivation {
       name = "fix-timeout.patch";
       url = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=commitdiff_plain;h=8b5b843fcbc3e03e0fc45f3caf8cf5fc477e8613;hp=94af9724d140fd132896b650d10c4d060788e4f0";
       sha256 = "1g2dm7lwsnanwp68b9xr9swspx7hfj4v3z44sz3yrfmynygk8zlv";
-    });
+    })
+    ++ stdenv.lib.optional stdenv.isDarwin ./cmake.patch;
 
-  postInstall = optionalString (withQt || withGtk) ''
+  postInstall = if stdenv.isDarwin then ''
+    ${optionalString withQt ''
+      mkdir -p $out/Applications
+      mv $out/bin/Wireshark.app $out/Applications/Wireshark.app
+
+      for so in $out/Applications/Wireshark.app/Contents/PlugIns/wireshark/*.so; do
+        install_name_tool $so -change libwireshark.10.dylib $out/lib/libwireshark.10.dylib
+        install_name_tool $so -change libwiretap.7.dylib $out/lib/libwiretap.7.dylib
+        install_name_tool $so -change libwsutil.8.dylib $out/lib/libwsutil.8.dylib
+      done
+
+      wrapProgram $out/Applications/Wireshark.app/Contents/MacOS/Wireshark \
+        --set QT_PLUGIN_PATH ${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}
+    ''}
+  '' else optionalString (withQt || withGtk) ''
     ${optionalString withGtk ''
       install -Dm644 -t $out/share/applications ../wireshark-gtk.desktop
     ''}
@@ -75,7 +93,7 @@ in stdenv.mkDerivation {
       experts. It runs on UNIX, macOS and Windows.
     '';
 
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor fpletz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

wireshark did not work for Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm not sure why tshark plugins have correct dynamic library paths, but the Wireshark.app does not.

CMake patch fixes a problem where CMake cannot detect compiler features.