### PR TITLE
pgmanage: fix build

### DIFF
--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0g9kvhs9b6kc1s7j90fqv71amiy9v0w5p906yfvl0j7pf3ayq35a";
   };
 
+  patchPhase = ''
+    patchShebangs src/configure
+  '';
+
   buildInputs = [ postgresql openssl ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION

###### Motivation for this change

Recent backport of postgresql to 17.09 broke few things, including pgmanage (https://hydra.nixos.org/eval/1437029). While I do not see why this is related, this fixes pgmanage. I’ll check later how this is affecting master.

The configure script uses the `command` builtin command which is bash
specific[1] while having a "#!/bin/sh" head.

This forces the use nix default shell (bash)

[1] https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#Bash-Builtins

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

