### PR TITLE
untrunc: init at 2018.01.13

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -199,6 +199,7 @@
   dzabraev = "Maksim Dzabraev <dzabraew@gmail.com>";
   e-user = "Alexander Kahl <nixos@sodosopa.io>";
   earldouglas = "James Earl Douglas <james@earldouglas.com>";
+  earvstedt = "Erik Arvstedt <erik.arvstedt@gmail.com>";
   ebzzry = "Rommel Martinez <ebzzry@ebzzry.io>";
   edanaher = "Evan Danaher <nixos@edanaher.net>";
   edef = "edef <edef@edef.eu>";

--- a/pkgs/tools/video/untrunc/default.nix
+++ b/pkgs/tools/video/untrunc/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, gcc, libav_12, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "untrunc-${version}";
+  version = "2018.01.13";
+
+  src = fetchFromGitHub {
+    owner = "ponchio";
+    repo = "untrunc";
+    rev = "3a2e6d0718faf06589f7b9d95c8f966348e537f7";
+    sha256 = "03ka4lr69k7mikfpcpd95smzdj62v851ididnjyps5a0j06f8087";
+  };
+
+  buildInputs = [ gcc libav_12 ];
+
+  # Untrunc uses the internal libav headers 'h264dec.h' and 'config.h'.
+  # The latter must be created through 'configure'.
+  libavConfiguredSrc = libav_12.overrideAttrs (oldAttrs: {
+    name = "libav-configured-src";
+    outputs = [ "out" ];
+    phases = [ "unpackPhase" "patchPhase" "configurePhase" "installPhase" ];
+    installPhase = "cp -r . $out";
+  });
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    g++ -o $out/bin/untrunc \
+        -Wno-deprecated-declarations \
+        $src/file.cpp $src/main.cpp $src/track.cpp $src/atom.cpp $src/mp4.cpp \
+        -I$libavConfiguredSrc -lavformat -lavcodec -lavutil
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Restore a damaged (truncated) mp4, m4v, mov, 3gp video from a similar, undamaged video";
+    license = licenses.gpl2;
+    homepage = https://github.com/ponchio/untrunc;
+    maintainers = [ maintainers.earvstedt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5140,6 +5140,8 @@ with pkgs;
 
   untex = callPackage ../tools/text/untex { };
 
+  untrunc = callPackage ../tools/video/untrunc { };
+
   upx = callPackage ../tools/compression/upx { };
 
   uqmi = callPackage ../tools/networking/uqmi { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

