### PR TITLE
a single version attribute for expressions previously using "majorVersion"

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -24,7 +24,7 @@ let
     maintainers = callLibs ./maintainers.nix;
     meta = callLibs ./meta.nix;
     sources = callLibs ./sources.nix;
-
+    versions = callLibs ./versions.nix;
 
     # module system
     modules = callLibs ./modules.nix;

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -1,0 +1,47 @@
+/* Version string functions. */
+{ lib }:
+
+let
+
+  splitVersion = builtins.splitVersion or (lib.splitString ".");
+
+in
+
+rec {
+
+  /* Get the major version string from a string.
+
+    Example:
+      major "1.2.3"
+      => "1"
+  */
+  major = v: builtins.elemAt (splitVersion v) 0;
+
+  /* Get the minor version string from a string.
+
+    Example:
+      minor "1.2.3"
+      => "2"
+  */
+  minor = v: builtins.elemAt (splitVersion v) 1;
+
+  /* Get the patch version string from a string.
+
+    Example:
+      patch "1.2.3"
+      => "3"
+  */
+  patch = v: builtins.elemAt (splitVersion v) 2;
+
+  /* Get string of the first two parts (major and minor)
+     of a version string.
+
+     Example:
+       majorMinor "1.2.3"
+       => "1.2"
+  */
+  majorMinor = v:
+    builtins.concatStringsSep "."
+    (lib.take 2 (splitVersion v));
+
+}

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -9,13 +9,11 @@ assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
-  majorVersion = "1.7";
-  minorVersion = "9";
-  version = "${majorVersion}.${minorVersion}";
+  version = "1.7.9";
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://www.haproxy.org/download/${majorVersion}/src/${name}.tar.gz";
+    url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${name}.tar.gz";
     sha256 = "1072337e54fa188dc6e0cfe3ba4c2200b07082e321cbfe5a0882d85d54db068e";
   };
 


### PR DESCRIPTION
Many packages in nixpkgs split the version string into a "major" and "minor" part because the upstream source distribution URL is something like "/project/2.3/projectname-2.3.4.tar.gz". This PR introduces a new function `majorMinorVersion` that lets us declare the version with a single attribute, allowing for easier expression updating via tooling. 

Say the package is at version "1.2.3", the expressions currently use the terminology `majorVersion` to mean "1.2", and `minorVersion` to mean "3". I chose to use the Semantic Versioning terminology in this function, which means `majorMinorVersion` refers to "1.2" ("3" would be the "patch" part of the version, but isn't relevant to this). I don't care too much about the name, though I did think about it carefully, so if someone some other preference that's fine.

This PR includes an example usage of `majorMinorVersion` in the haproxy package.