### PR TITLE
gecode_3: use bash to run "configure", fix error

### DIFF
--- a/pkgs/development/libraries/gecode/3.nix
+++ b/pkgs/development/libraries/gecode/3.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchurl, bash, perl }:
 
 stdenv.mkDerivation rec {
   name = "gecode-${version}";
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0k45jas6p3cyldgyir1314ja3174sayn2h2ly3z9b4dl3368pk77";
   };
 
-  buildInputs = [ perl ];
+  nativeBuildInputs = [ bash perl ];
+
+  preConfigure = "patchShebangs configure";
 
   meta = with stdenv.lib; {
     license = licenses.mit;


### PR DESCRIPTION
Error:

/configure: ./configure.lineno: line 11561: syntax error: unexpected "("


Likely is specific to builder's /bin/sh.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---