### PR TITLE
bear: fix LD_PRELOAD error

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -71,6 +71,7 @@
   auntie = "Jonathan Glines <auntieNeo@gmail.com>";
   avnik = "Alexander V. Nikolaev <avn@avnik.info>";
   aycanirican = "Aycan iRiCAN <iricanaycan@gmail.com>";
+  babariviere = "Bastien Riviere <babariviere@protonmail.com>";
   bachp = "Pascal Bach <pascal.bach@nextrem.ch>";
   backuitist = "Bruno Bieth";
   badi = "Badi' Abdul-Wahid <abdulwahidc@gmail.com>";

--- a/pkgs/development/tools/build-managers/bear/cmakepaths.patch
+++ b/pkgs/development/tools/build-managers/bear/cmakepaths.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 04c5c58..429ca47 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,7 +24,7 @@ set(CMAKE_OSX_ARCHITECTURES "i386;x86_64" CACHE STRING  "Rogue")
+ 
+ set(EAR_LIB_FILE ${CMAKE_SHARED_LIBRARY_PREFIX}ear${CMAKE_SHARED_LIBRARY_SUFFIX})
+ set(EAR_LIB_PATH "${CMAKE_INSTALL_LIBDIR}/bear")
+-set(DEFAULT_PRELOAD_FILE ${CMAKE_INSTALL_PREFIX}/${EAR_LIB_PATH}/${EAR_LIB_FILE} CACHE STRING "Default path to libear.")
++set(DEFAULT_PRELOAD_FILE ${EAR_LIB_PATH}/${EAR_LIB_FILE} CACHE STRING "Default path to libear.")
+ 
+ add_subdirectory(libear)
+ add_subdirectory(bear)

--- a/pkgs/development/tools/build-managers/bear/default.nix
+++ b/pkgs/development/tools/build-managers/bear/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # all fail
 
-  patches = [ ./ignore_wrapper.patch ];
+  patches = [ ./ignore_wrapper.patch ./cmakepaths.patch ];
 
   meta = with stdenv.lib; {
     description = "Tool that generates a compilation database for clang tooling";
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/rizsotto/Bear;
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
-    maintainers = [ maintainers.vcunat ];
+    maintainers = [ maintainers.vcunat maintainers.babariviere ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Bear wasn't able to execute properly. Each time I run it, I have this error:
```
[nix-shell:~/42/libft]$ bear make re
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11//nix/store/c5fmm1470zbsfrw2cysjsfcl4yihznhi-bear-2.3.11/lib/bear/libear.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```
###### Things done

I just removed `CMAKE_INSTALL_PREFIX` in CMakeFiles.txt to avoid having twice the same prefix.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---