### PR TITLE
[WIP] pythonPackages.astropy: fix build

### DIFF
--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -1,23 +1,50 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, cython
+, jinja2
 , numpy
-, pytest }:
+, sphinx
+, pytest
+, pytest-doctestplus
+, pytest-remotedata
+, pytest-openfiles
+, pytest-arraydiff
+}:
 
-buildPythonPackage rec {
-  
+let
+  # This meta-package is only used to pull in the test dependencies for astropy
+  pytest-astropy = buildPythonPackage rec {
+    pname = "pytest-astropy";
+    version = "0.2.1";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "ced990fe65145ba87a9d0ce16b9d0c162f0c339b47c04d51f54aa382acb55425";
+    };
+
+    propagatedBuildInputs = [ pytest pytest-doctestplus pytest-remotedata pytest-openfiles pytest-arraydiff ]; 
+  };
+
+in buildPythonPackage rec {
   pname = "astropy";
   version = "3.0";
 
-  name = "${pname}-${version}";
-  doCheck = false; #Some tests are failing. More importantly setup.py hangs on completion. Needs fixing with a proper shellhook.
   src = fetchPypi {
     inherit pname version;
     sha256 = "9e0ad19b9d6d227bdf0932bbe64a8c5dd4a47d4ec078586cf24bf9f0c61d9ecf";
   };
 
-  propagatedBuildInputs = [ pytest numpy ]; # yes it really has pytest in install_requires
+  buildInputs = [ cython jinja2 ];
 
+  # FIXME: astropy tries to download astropy-helpers using pip
+  propagatedBuildInputs = [ numpy ];
+
+  checkInputs = [ pytest-astropy ];
+
+  checkPhase = ''
+    pytest --open-files
+  '';
 
   meta = {
     description = "Astronomy/Astrophysics library for Python";
@@ -27,5 +54,3 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ kentjames ];
   };
 }
-
-

--- a/pkgs/development/python-modules/pytest-arraydiff/default.nix
+++ b/pkgs/development/python-modules/pytest-arraydiff/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, python, numpy, six, pytest }:
+
+buildPythonPackage rec {
+  pname = "pytest-arraydiff";
+  version = "0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0145edfa8830aba07150fc09443da74d0ec4074e3de702445453415a744d3ad9";
+  };
+
+  propagatedBuildInputs = [ numpy six pytest ];
+
+  checkPhase = ''
+    ${python.interpreter} -c 'import pytest_arraydiff.plugin'
+    # The remaining tests depend on astropy, which in turn depends on pytest-arraydiff
+    # pytest -vv --arraydiff --cov pytest_arraydiff tests
+    # pytest -vv --cov pytest_arraydiff --cov-append tests
+  '';
+
+  meta = with lib; {
+    description = "Pytest plugin to help with comparing array output from tests";
+    homepage = https://github.com/astrofrog/pytest-arraydiff;
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/development/python-modules/pytest-doctestplus/default.nix
+++ b/pkgs/development/python-modules/pytest-doctestplus/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, six, pytest, numpy }:
+
+buildPythonPackage rec {
+  pname = "pytest-doctestplus";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07672d4a6950d5f5ad48648edd30663be9770435af5baa6c692810c39e0f6648";
+  };
+
+  propagatedBuildInputs = [ six pytest numpy ];
+
+  checkPhase = ''
+    py.test --doctest-plus --doctest-rst
+  '';
+
+  meta = with lib; {
+    description = "Pytest plugin with advanced doctest features";
+    homepage = https://github.com/astropy/pytest-doctestplus;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/pytest-openfiles/default.nix
+++ b/pkgs/development/python-modules/pytest-openfiles/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, pytest, psutil }:
+
+buildPythonPackage rec {
+  pname = "pytest-openfiles";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "254d8a4326fa60c2532419c44932d529fb7172616ff126b154a09907d398d0b2";
+  };
+
+  propagatedBuildInputs = [ pytest psutil ];
+
+  checkPhase = ''
+    py.test --open-files
+  '';
+
+  meta = with lib; {
+    description = "Pytest plugin for detecting inadvertent open file handles";
+    homepage = https://github.com/astropy/pytest-openfiles;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/pytest-remotedata/default.nix
+++ b/pkgs/development/python-modules/pytest-remotedata/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, six, pytest }:
+
+buildPythonPackage rec {
+  pname = "pytest-remotedata";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8ee2212818d89653132a7ffea0fb219eb2b00ecabc43f4d84f12e1fdf4853234";
+  };
+
+  propagatedBuildInputs = [ six pytest ];
+
+  # network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pytest plugin for controlling remote data access";
+    homepage = https://github.com/astropy/pytest-remotedata;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3265,6 +3265,8 @@ in {
 
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };
 
+  pytest-openfiles = callPackage ../development/python-modules/pytest-openfiles { };
+
   pytest-remotedata = callPackage ../development/python-modules/pytest-remotedata { };
 
   pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3265,6 +3265,8 @@ in {
 
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };
 
+  pytest-remotedata = callPackage ../development/python-modules/pytest-remotedata { };
+
   pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };
 
   pytest-warnings = callPackage ../development/python-modules/pytest-warnings { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3206,6 +3206,8 @@ in {
 
   pytest-django = callPackage ../development/python-modules/pytest-django { };
 
+  pytest-doctestplus = callPackage ../development/python-modules/pytest-doctestplus { };
+
   pytest-fixture-config = buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "pytest-fixture-config";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3151,9 +3151,11 @@ in {
 
   pytest-httpbin = callPackage ../development/python-modules/pytest-httpbin { };
 
-  pytest-asyncio = callPackage ../development/python-modules/pytest-asyncio { };
-
   pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
+
+  pytest-arraydiff = callPackage ../development/python-modules/pytest-arraydiff { };
+
+  pytest-asyncio = callPackage ../development/python-modules/pytest-asyncio { };
 
   pytestcache = buildPythonPackage rec {
     name = "pytest-cache-1.0";


### PR DESCRIPTION
###### Motivation for this change
@KentJames Astropy is broken on staging. I tried for at least an hour to fix it but a lot of work is still required. I'm opening this PR so you can continue work on this.

Btw, pytest-astropy should probably be moved out of `default.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

