### PR TITLE
rsbep: init at 0.1.0

### DIFF
--- a/pkgs/tools/backup/rsbep/default.nix
+++ b/pkgs/tools/backup/rsbep/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, python, coreutils, gnused, gawk, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "rsbep-${version}";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://www.thanassis.space/rsbep-0.1.0-ttsiodras.tar.bz2";
+    sha256 = "1zji34kc9srxp0h1s1m7k60mvgsir1wrx1n3wc990jszfplr32zc";
+  };
+
+  buildInputs = [ (python.withPackages (ps: [ ps.fuse ])) ];
+
+  postFixup = ''
+    cd $out/bin
+
+    # Move internal tool 'rsbep_chopper' to libexec
+    libexecDir=$out/libexec/rsbep
+    mkdir -p $libexecDir
+    mv rsbep_chopper $libexecDir
+
+    # Fix store dependencies in scripts
+    path="export PATH=$out/bin:$libexecDir:${lib.makeBinPath [ coreutils gnused gawk ]}"
+    sed -i "2i$path" freeze.sh
+    sed -i "2i$path" melt.sh
+
+    substituteInPlace freeze.sh --replace /bin/ls ls
+
+    substituteInPlace poorZFS.py \
+      --replace melt.sh $out/bin/melt.sh \
+      --replace freeze.sh $out/bin/freeze.sh
+  '';
+
+  meta = with lib; {
+    description = "Create resilient backups with Reed-Solomon error correction and byte-spreading";
+    homepage = https://www.thanassis.space/rsbep.html;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.earvstedt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1330,6 +1330,8 @@ with pkgs;
 
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix { };
 
+  rsbep = callPackage ../tools/backup/rsbep { };
+
   rsyslog = callPackage ../tools/system/rsyslog {
     hadoop = null; # Currently Broken
     czmq = czmq3;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

