### PR TITLE
airtame 3.0.1 -> 3.1.1

### DIFF
--- a/pkgs/applications/misc/airtame/default.nix
+++ b/pkgs/applications/misc/airtame/default.nix
@@ -44,13 +44,13 @@ let libPath = lib.makeLibraryPath [
 ];
 in stdenv.mkDerivation rec {
   pname = "airtame";
-  version = "3.0.1";
+  version = "3.1.1";
   name = "${pname}-${version}";
   longName = "${pname}-application";
 
   src = fetchurl {
     url = "https://downloads.airtame.com/application/ga/lin_x64/releases/${longName}-${version}.tar.gz";
-    sha256 = "1z5v9dwcvcmz190acm89kr4mngirha1v2jpvfzvisi0vidl2ba60";
+    sha256 = "1am1qz280r5g9i0vwwx5lr24fpdl5lazhpr2bhb34nlr5d8rsmzr";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

