### PR TITLE
avrbinutils: 2.26 -> 2.30

### DIFF
--- a/pkgs/development/misc/avr/binutils/default.nix
+++ b/pkgs/development/misc/avr/binutils/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl }:
 
 let
-  version = "2.26";
+  version = "2.30";
 in
 stdenv.mkDerivation {
   name = "avr-binutils-${version}";
 
   src = fetchurl {
     url = "mirror://gnu/binutils/binutils-${version}.tar.bz2";
-    sha256 = "1ngc2h3knhiw8s22l8y6afycfaxr5grviqy7mwvm4bsl14cf9b62";
+    sha256 = "028cklfqaab24glva1ks2aqa1zxa6w6xmc8q34zs1sb7h22dxspg";
   };
   configureFlags = "--target=avr --enable-languages=c,c++";
 


### PR DESCRIPTION
###### Motivation for this change

The switch to gcc 7 has broken avrbinutils:
https://hydra.nixos.org/job/nixpkgs/trunk/avrbinutils.x86_64-linux

This upgrade to 2.30 fixes that.

CC @mguentner 
#31747

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

