### PR TITLE
rangev3: 2017-01-30 -> 0.3.5, build and run tests

### DIFF
--- a/pkgs/development/libraries/range-v3/default.nix
+++ b/pkgs/development/libraries/range-v3/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "range-v3-${version}";
-  version = "2017-01-30";
+  version = "0.3.5";
 
   src = fetchFromGitHub {
     owner = "ericniebler";
     repo = "range-v3";
-    rev = "bab29767cce120e11872d79a2537bc6f0be76963";
-    sha256 = "0kncpxms3f0nmn6jppp484244xq15d9298g3h3nlm1wvq8ib1jhi";
+    rev = version;
+    sha256 = "00bwm7n3wyf49xpr7zjhm08dzwx3lwibgafi6isvfls3dhk1m4kp";
   };
 
   dontBuild = true;

--- a/pkgs/development/libraries/range-v3/default.nix
+++ b/pkgs/development/libraries/range-v3/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   name = "range-v3-${version}";
@@ -11,11 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "00bwm7n3wyf49xpr7zjhm08dzwx3lwibgafi6isvfls3dhk1m4kp";
   };
 
-  dontBuild = true;
-  installPhase = ''
-    mkdir -p $out/include
-    mv include/ $out/
-  '';
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+  checkTarget = "test";
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Experimental range library for C++11/14/17";


### PR DESCRIPTION
Tests ensure everything's working for a particular
compiler and c++ library.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---