### PR TITLE
BAP update to 1.4

### DIFF
--- a/pkgs/development/libraries/libbap/default.nix
+++ b/pkgs/development/libraries/libbap/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "libbap-${version}";
-  version = "master-2017-02-08";
+  version = "master-2018-03-01";
 
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "bap-bindings";
-    rev = "b3da5bd5cdb3d646015ccdeb886b5ea8fd85a108";
-    sha256 = "0cwfyfpxbi9bm4kkpamyd7mgsm5b6j1rh217fqb5gi05wg45rkbb";
+    rev = "bd125c379a784d4265c2ddcf1f6e34bde2e568d4";
+    sha256 = "0dp90djyjc262v1b1cw5irp424a8394y86fyprdk8z741wg56m3v";
   };
 
   nativeBuildInputs = [ autoreconfHook which ];

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -1,18 +1,21 @@
-{stdenv, buildOcaml, fetchFromGitHub, fetchurl, camlp4, ocaml_oasis, bitstring, camlzip, cmdliner, core_kernel, ezjsonm, faillib, fileutils, ocaml_lwt, ocamlgraph, ocurl, re, uri, zarith, piqi, piqi-ocaml, uuidm, llvm_38, ulex, easy-format, xmlm, frontc, ounit, utop, which, makeWrapper, writeText, ocaml}:
+{stdenv, buildOcaml, fetchFromGitHub, fetchurl, camlp4, ocaml_oasis,
+ bitstring, camlzip, cmdliner, core_kernel, ezjsonm, faillib, fileutils, ocaml_lwt, ocamlgraph, ocurl, re, uri, zarith, piqi, piqi-ocaml, uuidm, llvm_38, ulex, easy-format, xmlm, frontc, ounit, ppx_jane, parsexp,
+ utop,
+ which, makeWrapper, writeText, ocaml}:
 
 buildOcaml rec {
   name = "bap";
-  version = "1.2.0";
+  version = "1.4.0";
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "bap";
     rev = "v${version}";
-    sha256 = "0dn1gvj73pma0rsw8r50cmjddibnf42w1kbskb2vpzq0kb79jlkw";
+    sha256 = "0329m65x8q5q8vgvsqgyz2vz7q6qkh2rh11j7x29hckk3fzxsf8g";
   };
 
   sigs = fetchurl {
      url = "https://github.com/BinaryAnalysisPlatform/bap/releases/download/v${version}/sigs.zip";
-     sha256 = "0mpsq2pinbrynlisnh8j3nrlamlsls7lza0bkqnm9szqjjdmcgfn";
+     sha256 = "0k761w82zkmi5dwsfqq61dbjnb8mmmpb2xwp7vp85xs14g5fjz19";
   };
 
   createFindlibDestdir = true;
@@ -28,7 +31,7 @@ buildOcaml rec {
                   llvm_38
                   utop ];
 
-  propagatedBuildInputs = [ bitstring camlzip cmdliner core_kernel ezjsonm faillib fileutils ocaml_lwt ocamlgraph ocurl re uri zarith piqi
+  propagatedBuildInputs = [ bitstring camlzip cmdliner ppx_jane core_kernel ezjsonm faillib fileutils ocaml_lwt ocamlgraph ocurl re uri zarith piqi parsexp
                             piqi-ocaml uuidm frontc ounit ];
 
   installPhase = ''
@@ -45,11 +48,7 @@ buildOcaml rec {
 
   disableIda = "--disable-ida --disable-fsi-benchmark";
 
-  doCheck = true;
-
-  checkTarget = "check test";
-
-  configureFlags = "--enable-everything --enable-tests ${disableIda} --with-llvm-config=${llvm_38}/bin/llvm-config";
+  configureFlags = "--enable-everything ${disableIda} --with-llvm-config=${llvm_38}/bin/llvm-config";
 
   BAPBUILDFLAGS = "-j $(NIX_BUILD_CORES)";
 
@@ -58,6 +57,6 @@ buildOcaml rec {
     homepage = https://github.com/BinaryAnalysisPlatform/bap/;
     maintainers = [ maintainers.maurer ];
     license = licenses.mit;
-    broken = versionAtLeast ocaml.version "4.03";
+    broken = versionOlder ocaml.version "4.03";
   };
 }

--- a/pkgs/development/python-modules/bap/default.nix
+++ b/pkgs/development/python-modules/bap/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "bap";
-  version = "1.1.0";
+  version = "1.3.1";
   name = "${pname}-${version}";
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "bap-python";
-    rev = "v${version}";
-    sha256 = "0wd46ksxscgb2dci69sbndzxs6drq5cahraqq42cdk114hkrsxs3";
+    rev = "${version}";
+    sha256 = "1ahkrmcn7qaivps1gar8wd9mq2qqyx6zzvznf5r9rr05h17x5lbp";
   };
 
   propagatedBuildInputs = [bap requests];

--- a/pkgs/development/tools/ocaml/jbuilder/default.nix
+++ b/pkgs/development/tools/ocaml/jbuilder/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "jbuilder-${version}";
-  version = "1.0+beta18";
+  version = "1.0+beta17";
   src = fetchFromGitHub {
     owner = "ocaml";
     repo = "dune";
     rev = "${version}";
-    sha256 = "1xw4i5qd2ndnddzb8b14fb52qxnjpr3lr9wx3mprv4f294kdg0l6";
+    sha256 = "04pyry459hp2r2s9m5xkcq1glzp20ddz5wb1w8nzp3zgygy0431x";
   };
 
   buildInputs = [ ocaml ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9456,7 +9456,7 @@ with pkgs;
   libb2 = callPackage ../development/libraries/libb2 { };
 
   libbap = callPackage ../development/libraries/libbap {
-    inherit (ocamlPackages_4_02) bap ocaml findlib ctypes;
+    inherit (ocamlPackages) bap ocaml findlib ctypes;
   };
 
   libbass = (callPackage ../development/libraries/audio/libbass { }).bass;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -54,7 +54,7 @@ let
 
     base64 = callPackage ../development/ocaml-modules/base64 { };
 
-    bap = callPackage ../development/ocaml-modules/bap { cmdliner = cmdliner_0_9; };
+    bap = callPackage ../development/ocaml-modules/bap { };
 
     batteries = callPackage ../development/ocaml-modules/batteries { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -184,7 +184,7 @@ in {
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   bap = callPackage ../development/python-modules/bap {
-    bap = pkgs.ocamlPackages_4_02.bap;
+    bap = pkgs.ocamlPackages.bap;
   };
 
   bash_kernel = callPackage ../development/python-modules/bash_kernel { };


### PR DESCRIPTION
###### Motivation for this change
Update BAP to latest version. Needed to roll back `jbuilder` (now `dune`) due to an [issue](https://github.com/ocaml/dune/issues/567) which should be fixed in the next release of `jbuilder`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

