### PR TITLE
release-17.09: update haskell package set to lts-9.21 plus latest versions of stack, cabal2nix, and  git-annex

### DIFF
--- a/pkgs/data/misc/hackage/default.nix
+++ b/pkgs/data/misc/hackage/default.nix
@@ -1,6 +1,6 @@
 { fetchurl }:
 
 fetchurl {
-  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/4c8b3501ea6fc9f41cd192ddc08e2d9583a1e679.tar.gz";
-  sha256 = "0aa4pimgllqgn8bcy2p2cdwbpz6s6wk8j41w35jvzaqfj15gysnq";
+  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/feb92dae1ac8b10f66a7ddb0dc4bbbe5ed69b274.tar.gz";
+  sha256 = "1prr20qayajvwfhgchjghrw1q2iijyzdflhg8m4hgicf3l8ydp0x";
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -939,9 +939,15 @@ self: super: {
     path-io = self.path-io_1_3_3;
     unliftio = self.unliftio_0_2_4_0;
   })).override {
+    # Avoiding the deep-override here saves us from dealing with an infinite
+    # recursion, because ansi-terminal is a dependency of the test suite of
+    # some dependencies of ansi-terminal.
     ansi-terminal = self.ansi-terminal_0_7_1_1;
   };
-
-  cabal2nix = super.cabal2nix.overrideScope (self: super: { hackage-db = self.hackage-db_2_0; hpack = self.hpack_0_27_0; });
+  cabal2nix = super.cabal2nix.overrideScope (self: super: {
+    aeson = self.aeson_1_2_4_0;
+    hackage-db = self.hackage-db_2_0;
+    hpack = self.hpack_0_27_0;
+  });
 
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -79,7 +79,7 @@ self: super: {
       name = "git-annex-${drv.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + drv.version;
-      sha256 = "15d29hmbl146axjgbm4qhxpz6ypcq1bjf2aj29yhwh5jmznh58i2";
+      sha256 = "0fdcv9nig896ckl9x51ximxsvja1ii8qysf6c9ickvc0511hvr9w";
     };
   })).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -937,6 +937,7 @@ self: super: {
   path_0_6_1 = dontCheck super.path_0_6_1;
   quickcheck-instances_0_3_16_1 = super.quickcheck-instances_0_3_16_1.override { QuickCheck = self.QuickCheck_2_11_3; };
   unliftio_0_2_4_0 = super.unliftio_0_2_4_0.override { unliftio-core = self.unliftio-core_0_1_1_0; };
+  weeder = super.weeder.override { extra = self.extra_1_6_4; };
   yaml_0_8_28 = (dontCheck super.yaml_0_8_28).override { aeson = self.aeson_1_2_4_0; };
 
   stack = (super.stack.overrideScope (self: super: {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -29,7 +29,7 @@ self: super: {
 
   # cabal-install needs Cabal 2.x. hackage-security's test suite does not compile with
   # Cabal 2.x, though. See https://github.com/haskell/hackage-security/issues/188.
-  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_2_0_0_2; });
+  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_2_0_1_1; });
   hackage-security = dontCheck super.hackage-security;
 
   # Link statically to avoid runtime dependency on GHC.
@@ -73,7 +73,7 @@ self: super: {
   # The Hackage tarball is purposefully broken, because it's not intended to be, like, useful.
   # https://git-annex.branchable.com/bugs/bash_completion_file_is_missing_in_the_6.20160527_tarball_on_hackage/
   git-annex = (overrideCabal (super.git-annex.overrideScope (self: super: {
-      optparse-applicative = self.optparse-applicative_0_14_0_0;
+      optparse-applicative = self.optparse-applicative_0_14_2_0;
     })) (drv: {
     src = pkgs.fetchgit {
       name = "git-annex-${drv.version}-src";
@@ -616,7 +616,7 @@ self: super: {
       ln -s $lispdir $data/share/emacs/site-lisp
     '';
   })).override {
-    haskell-src-exts = self.haskell-src-exts_1_19_1;
+    haskell-src-exts = self.haskell-src-exts_1_20_1;
   };
 
   # Make elisp files available at a location where people expect it.
@@ -630,7 +630,7 @@ self: super: {
     '';
     doCheck = false; # https://github.com/chrisdone/hindent/issues/299
   })).override {
-    haskell-src-exts = self.haskell-src-exts_1_19_1;
+    haskell-src-exts = self.haskell-src-exts_1_20_1;
   };
 
   # https://github.com/bos/configurator/issues/22
@@ -697,7 +697,7 @@ self: super: {
   # test suite cannot find its own "idris" binary
   idris = doJailbreak (dontCheck super.idris);
 
-  idris_1_1_1 = overrideCabal (doJailbreak (dontCheck super.idris_1_1_1)) (drv: {
+  idris_1_2_0 = overrideCabal (doJailbreak (dontCheck super.idris_1_2_0)) (drv: {
     # The standard libraries are compiled separately
     configureFlags = (drv.configureFlags or []) ++ [ "-fexeconly" ];
   });
@@ -887,7 +887,7 @@ self: super: {
   html-entities = doJailbreak super.html-entities;
 
   # Needs a version that's newer than what we have in lts-9.
-  sbv = super.sbv.override { doctest = self.doctest_0_13_0; };
+  sbv = super.sbv.override { doctest = self.doctest_0_14_1; };
 
   # https://github.com/takano-akio/filelock/issues/5
   filelock = dontCheck super.filelock;
@@ -914,11 +914,34 @@ self: super: {
   yi = markBroken super.yi;
 
   # https://github.com/jwiegley/hnix/issues/65
-  hnix = super.hnix.override { data-fix = self.data-fix_0_0_7; };
+  hnix = super.hnix.override { data-fix = self.data-fix_0_2_0; };
 
   # Build with gi overloading feature disabled.
   ltk = super.ltk.overrideScope (self: super: { haskell-gi-overloading = self.haskell-gi-overloading_0_0; });
 
   # missing dependencies: Glob >=0.7.14 && <0.8, data-fix ==0.0.4
   stack2nix = doJailbreak super.stack2nix;
+
+  # These builds need newer versions of their dependencies than those available in LTS-9.x.
+  aeson_1_2_4_0 = dontCheck super.aeson_1_2_4_0;
+  extra_1_6_4 = super.extra_1_6_4.override { QuickCheck = self.QuickCheck_2_11_3; };
+  hpack_0_27_0 = (dontCheck super.hpack_0_27_0).override { Glob = self.Glob_0_9_2; aeson = self.aeson_1_2_4_0; yaml = self.yaml_0_8_28; };
+  path_0_6_1 = dontCheck super.path_0_6_1;
+  path-io_1_3_3 = super.path-io_1_3_3.override { path = self.path_0_6_1; };
+  quickcheck-instances_0_3_16_1 = super.quickcheck-instances_0_3_16_1.override { QuickCheck = self.QuickCheck_2_11_3; };
+  unliftio_0_2_4_0 = super.unliftio_0_2_4_0.override { unliftio-core = self.unliftio-core_0_1_1_0; };
+  yaml_0_8_28 = (dontCheck super.yaml_0_8_28).override { aeson = self.aeson_1_2_4_0; };
+  stack = (super.stack.overrideScope (self: super: {
+    aeson = self.aeson_1_2_4_0;
+    extra = self.extra_1_6_4;
+    hpack = self.hpack_0_27_0;
+    path = self.path_0_6_1;
+    path-io = self.path-io_1_3_3;
+    unliftio = self.unliftio_0_2_4_0;
+  })).override {
+    ansi-terminal = self.ansi-terminal_0_7_1_1;
+  };
+
+  cabal2nix = super.cabal2nix.overrideScope (self: super: { hackage-db = self.hackage-db_2_0; hpack = self.hpack_0_27_0; });
+
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -927,16 +927,18 @@ self: super: {
 
   # These builds need newer versions of their dependencies than those available in LTS-9.x.
   aeson_1_2_4_0 = dontCheck super.aeson_1_2_4_0;
-  extra_1_6_4 = super.extra_1_6_4.override { QuickCheck = self.QuickCheck_2_11_3; };
   doctest_0_14_1 = dontCheck super.doctest_0_14_1;
-  hpack_0_27_0 = (dontCheck super.hpack_0_27_0).override { Glob = self.Glob_0_9_2; aeson = self.aeson_1_2_4_0; yaml = self.yaml_0_8_28; };
-  path_0_6_1 = dontCheck super.path_0_6_1;
-  path-io_1_3_3 = super.path-io_1_3_3.override { path = self.path_0_6_1; };
-  hlint = super.hlint.override { haskell-src-exts = self.haskell-src-exts_1_20_1; haskell-src-exts-util = self.haskell-src-exts-util_0_2_2; };
+  extra_1_6_4 = super.extra_1_6_4.override { QuickCheck = self.QuickCheck_2_11_3; };
   haskell-src-exts-util_0_2_2 = super.haskell-src-exts-util_0_2_2.override { haskell-src-exts = self.haskell-src-exts_1_20_1; };
+  hlint = super.hlint.override { haskell-src-exts = self.haskell-src-exts_1_20_1; haskell-src-exts-util = self.haskell-src-exts-util_0_2_2; };
+  hoogle = super.hoogle.override { http-conduit = self.http-conduit_2_3_0; };
+  hpack_0_27_0 = (dontCheck super.hpack_0_27_0).override { Glob = self.Glob_0_9_2; aeson = self.aeson_1_2_4_0; yaml = self.yaml_0_8_28; };
+  path-io_1_3_3 = super.path-io_1_3_3.override { path = self.path_0_6_1; };
+  path_0_6_1 = dontCheck super.path_0_6_1;
   quickcheck-instances_0_3_16_1 = super.quickcheck-instances_0_3_16_1.override { QuickCheck = self.QuickCheck_2_11_3; };
   unliftio_0_2_4_0 = super.unliftio_0_2_4_0.override { unliftio-core = self.unliftio-core_0_1_1_0; };
   yaml_0_8_28 = (dontCheck super.yaml_0_8_28).override { aeson = self.aeson_1_2_4_0; };
+
   stack = (super.stack.overrideScope (self: super: {
     aeson = self.aeson_1_2_4_0;
     extra = self.extra_1_6_4;
@@ -950,6 +952,7 @@ self: super: {
     # some dependencies of ansi-terminal.
     ansi-terminal = self.ansi-terminal_0_7_1_1;
   };
+
   cabal2nix = super.cabal2nix.overrideScope (self: super: {
     aeson = self.aeson_1_2_4_0;
     hackage-db = self.hackage-db_2_0;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -594,7 +594,8 @@ self: super: {
     '';
   });
 
-  # Fine-tune the build.
+  # Build the latest git version instead of the official release. This isn't
+  # ideal, but Chris doesn't seem to make official releases any more.
   structured-haskell-mode = (overrideCabal super.structured-haskell-mode (drv: {
     src = pkgs.fetchFromGitHub {
       owner = "chrisdone";
@@ -615,9 +616,7 @@ self: super: {
       mkdir -p $data/share/emacs
       ln -s $lispdir $data/share/emacs/site-lisp
     '';
-  })).override {
-    haskell-src-exts = self.haskell-src-exts_1_20_1;
-  };
+  }));
 
   # Make elisp files available at a location where people expect it.
   hindent = (overrideCabal super.hindent (drv: {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -928,6 +928,7 @@ self: super: {
   # These builds need newer versions of their dependencies than those available in LTS-9.x.
   aeson_1_2_4_0 = dontCheck super.aeson_1_2_4_0;
   doctest_0_14_1 = dontCheck super.doctest_0_14_1;
+  dhall = (dontCheck super.dhall).overrideScope (self: super: { prettyprinter = self.prettyprinter_1_2_0_1; });
   extra_1_6_4 = super.extra_1_6_4.override { QuickCheck = self.QuickCheck_2_11_3; };
   haskell-src-exts-util_0_2_2 = super.haskell-src-exts-util_0_2_2.override { haskell-src-exts = self.haskell-src-exts_1_20_1; };
   hlint = super.hlint.override { haskell-src-exts = self.haskell-src-exts_1_20_1; haskell-src-exts-util = self.haskell-src-exts-util_0_2_2; };

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -887,7 +887,7 @@ self: super: {
   html-entities = doJailbreak super.html-entities;
 
   # Needs a version that's newer than what we have in lts-9.
-  sbv = super.sbv.override { doctest = self.doctest_0_14_1; };
+  sbv = super.sbv.overrideScope (self: super: { doctest = self.doctest_0_14_1; });
 
   # https://github.com/takano-akio/filelock/issues/5
   filelock = dontCheck super.filelock;
@@ -922,12 +922,18 @@ self: super: {
   # missing dependencies: Glob >=0.7.14 && <0.8, data-fix ==0.0.4
   stack2nix = doJailbreak super.stack2nix;
 
+  # Can't deal with newer versions.
+  cryptol = super.cryptol.override { happy = self.happy_1_19_5; };
+
   # These builds need newer versions of their dependencies than those available in LTS-9.x.
   aeson_1_2_4_0 = dontCheck super.aeson_1_2_4_0;
   extra_1_6_4 = super.extra_1_6_4.override { QuickCheck = self.QuickCheck_2_11_3; };
+  doctest_0_14_1 = dontCheck super.doctest_0_14_1;
   hpack_0_27_0 = (dontCheck super.hpack_0_27_0).override { Glob = self.Glob_0_9_2; aeson = self.aeson_1_2_4_0; yaml = self.yaml_0_8_28; };
   path_0_6_1 = dontCheck super.path_0_6_1;
   path-io_1_3_3 = super.path-io_1_3_3.override { path = self.path_0_6_1; };
+  hlint = super.hlint.override { haskell-src-exts = self.haskell-src-exts_1_20_1; haskell-src-exts-util = self.haskell-src-exts-util_0_2_2; };
+  haskell-src-exts-util_0_2_2 = super.haskell-src-exts-util_0_2_2.override { haskell-src-exts = self.haskell-src-exts_1_20_1; };
   quickcheck-instances_0_3_16_1 = super.quickcheck-instances_0_3_16_1.override { QuickCheck = self.QuickCheck_2_11_3; };
   unliftio_0_2_4_0 = super.unliftio_0_2_4_0.override { unliftio-core = self.unliftio-core_0_1_1_0; };
   yaml_0_8_28 = (dontCheck super.yaml_0_8_28).override { aeson = self.aeson_1_2_4_0; };

--- a/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
@@ -118,4 +118,7 @@ self: super: {
   comonad = dontCheck super.comonad;
   semigroupoids = dontCheck super.semigroupoids;
 
+  # Newer versions have "base >=4.8 && <5".
+  hashtables = self.hashtables_1_2_1_1;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -56,7 +56,8 @@ self: super: {
   # Newer versions require ghc>=8.2
   apply-refact = super.apply-refact_0_3_0_1;
 
-  # This builds needs the latest Cabal version.
-  cabal2nix = super.cabal2nix.overrideScope (self: super: { Cabal = self.Cabal_2_0_0_2; });
+  # These builds need the latest Cabal version.
+  cabal2nix = super.cabal2nix.overrideScope (self: super: { Cabal = self.Cabal_2_0_1_1; });
+  stack = super.stack.override { Cabal = self.Cabal_2_0_1_1; };
 
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -37,16 +37,16 @@ core-packages:
   - ghcjs-base-0
 
 default-package-overrides:
-  # LTS Haskell 9.3
+  # LTS Haskell 9.21
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
   - abstract-par ==0.3.3
-  - AC-Vector ==2.3.2
   - accelerate ==1.0.0.0
   - accuerr ==0.2.0.2
   - ace ==0.6
   - action-permutations ==0.0.0.1
   - active ==0.2.0.13
+  - AC-Vector ==2.3.2
   - ad ==4.3.4
   - adjunctions ==4.3
   - adler32 ==0.1.1.0
@@ -54,25 +54,25 @@ default-package-overrides:
   - aeson-better-errors ==0.9.1.0
   - aeson-casing ==0.1.0.5
   - aeson-compat ==0.3.6
-  - aeson-diff ==1.1.0.3
+  - aeson-diff ==1.1.0.4
   - aeson-extra ==0.4.0.0
-  - aeson-generic-compat ==0.0.1.0
+  - aeson-generic-compat ==0.0.1.1
   - aeson-injector ==1.0.10.0
   - aeson-lens ==0.5.0.0
   - aeson-pretty ==0.8.5
   - aeson-qq ==0.8.2
   - aeson-utils ==0.3.0.2
-  - Agda ==2.5.2
+  - Agda ==2.5.3
   - airship ==0.6.0
   - alarmclock ==0.4.0.3
-  - alerta ==0.1.0.4
-  - alex ==3.2.2
+  - alerta ==0.1.0.5
+  - alex ==3.2.3
   - algebraic-graphs ==0.0.5
   - alsa-core ==0.5.0.1
   - alsa-mixer ==0.2.0.3
   - alsa-pcm ==0.6.0.4
   - alsa-seq ==0.6.0.7
-  - alternators ==0.1.1.1
+  - alternators ==0.1.2.0
   - ALUT ==2.4.0.2
   - amazonka ==1.4.5
   - amazonka-apigateway ==1.4.5
@@ -167,22 +167,23 @@ default-package-overrides:
   - amqp ==0.15.1
   - annotated-wl-pprint ==0.7.0
   - anonymous-sums ==0.6.0.0
+  - ansigraph ==0.3.0.5
   - ansi-terminal ==0.6.3.1
   - ansi-wl-pprint ==0.6.7.3
-  - ansigraph ==0.3.0.3
+  - apecs ==0.2.4.7
   - api-field-json-th ==0.1.0.2
-  - app-settings ==0.2.0.11
   - appar ==0.1.4
   - apportionment ==0.0.0.2
   - approximate ==0.3.1
+  - app-settings ==0.2.0.11
   - arbtt ==0.9.0.13
   - arithmoi ==0.5.0.0
   - array-memoize ==0.6.0
   - arrow-extras ==0.1.0.1
   - arrow-list ==0.7
   - arrowp-qq ==0.1.1
-  - ascii-progress ==0.3.3.0
   - asciidiagram ==1.3.3
+  - ascii-progress ==0.3.3.0
   - asn1-encoding ==0.9.5
   - asn1-parse ==0.9.4
   - asn1-types ==0.3.2
@@ -191,11 +192,11 @@ default-package-overrides:
   - async-dejafu ==0.1.3.0
   - async-extra ==0.2.0.0
   - async-refresh ==0.2.0.2
-  - async-refresh-tokens ==0.3.0.0
+  - async-refresh-tokens ==0.3.0.1
   - async-timer ==0.1.4.0
   - atom-basic ==0.2.5
   - atom-conduit ==0.4.0.3
-  - atomic-primops ==0.8.1
+  - atomic-primops ==0.8.1.1
   - atomic-write ==0.2.0.5
   - attoparsec ==0.13.1.0
   - attoparsec-binary ==0.2
@@ -203,11 +204,11 @@ default-package-overrides:
   - attoparsec-iso8601 ==1.0.0.0
   - attoparsec-time ==0.1.4
   - audacity ==0.0.1.2
-  - authenticate ==1.3.3.2
+  - authenticate ==1.3.4
   - authenticate-oauth ==1.6
   - auto ==0.4.3.1
+  - autoexporter ==1.1.3
   - auto-update ==0.1.4
-  - autoexporter ==1.1.2
   - avers ==0.0.17.1
   - avers-api ==0.0.18.0
   - avers-api-docs ==0.0.18.0
@@ -215,23 +216,24 @@ default-package-overrides:
   - avwx ==0.3.0.2
   - aws ==0.16
   - axiom ==0.4.6
-  - b9 ==0.5.32
+  - b9 ==0.5.35
   - backprop ==0.0.3.0
   - bake ==0.5
   - bank-holidays-england ==0.1.0.6
-  - base-compat ==0.9.3
-  - base-noprelude ==4.9.1.0
-  - base-orphans ==0.6
-  - base-prelude ==1.2.0.1
-  - base-unicode-symbols ==0.2.2.4
   - base16-bytestring ==0.1.1.6
   - base32string ==0.9.1
   - base58string ==0.10.0
   - base64-bytestring ==1.0.0.1
   - base64-string ==0.2
+  - base-compat ==0.9.3
+  - basement ==0.0.4
+  - base-noprelude ==4.9.1.0
+  - base-orphans ==0.6
+  - base-prelude ==1.2.0.1
+  - base-unicode-symbols ==0.2.2.4
   - basic-prelude ==0.6.1.1
   - bcrypt ==0.0.10
-  - bench ==1.0.6
+  - bench ==1.0.7
   - benchpress ==0.2.2.10
   - bencode ==0.6.0.0
   - bento ==0.1.0
@@ -248,10 +250,11 @@ default-package-overrides:
   - binary-parser ==0.5.5
   - binary-parsers ==0.2.3.0
   - binary-search ==1.0.0.3
+  - binary-shared ==0.8.3
   - binary-tagged ==0.1.4.2
   - binary-typed ==1.0
-  - bindings-DSL ==1.0.23
-  - bindings-GLFW ==3.1.2.2
+  - bindings-DSL ==1.0.24
+  - bindings-GLFW ==3.1.2.3
   - bindings-libzip ==1.0.1
   - bioace ==0.0.1
   - bioalign ==0.0.5
@@ -270,7 +273,7 @@ default-package-overrides:
   - bits ==0.5.1
   - bitx-bitcoin ==0.11.0.1
   - blake2 ==0.2.0
-  - blank-canvas ==0.6
+  - blank-canvas ==0.6.1
   - BlastHTTP ==1.2.1
   - blastxml ==0.3.2
   - blaze-bootstrap ==0.1.0.1
@@ -289,9 +292,9 @@ default-package-overrides:
   - board-games ==0.1.0.6
   - boltzmann-samplers ==0.1.0.0
   - bookkeeping ==0.2.1.4
-  - bool-extras ==0.4.0
   - Boolean ==0.2.4
   - boolean-like ==0.1.1.0
+  - bool-extras ==0.4.0
   - boolsimplifier ==0.1.8
   - boomerang ==1.4.5.3
   - both ==0.1.1.0
@@ -316,29 +319,29 @@ default-package-overrides:
   - byteset ==0.1.1.0
   - bytestring-builder ==0.10.8.1.0
   - bytestring-conversion ==0.3.1
-  - bytestring-handle ==0.1.0.5
+  - bytestring-handle ==0.1.0.6
   - bytestring-lexing ==0.5.0.2
   - bytestring-progress ==1.0.7
   - bytestring-strict-builder ==0.4.5
   - bytestring-tree-builder ==0.2.7.1
   - bytestring-trie ==0.2.4.1
-  - bzlib-conduit ==0.2.1.4
+  - bzlib-conduit ==0.2.1.5
   - c2hs ==0.28.2
   - Cabal ==1.24.2.0
   - cabal-dependency-licenses ==0.2.0.0
-  - cabal-doctest ==1.0.2
+  - cabal-doctest ==1.0.4
   - cabal-file-th ==0.2.4
   - cabal-helper ==0.7.3.0
   - cabal-rpm ==0.11.2
-  - cache ==0.1.0.0
+  - cache ==0.1.0.1
   - cacophony ==0.10.0
-  - cairo ==0.13.3.1
+  - cairo ==0.13.4.2
   - calendar-recycling ==0.0
   - call-stack ==0.1.0
   - carray ==0.1.6.8
   - cartel ==0.18.0.2
-  - case-insensitive ==1.2.0.10
   - cased ==0.1.0.0
+  - case-insensitive ==1.2.0.10
   - cases ==0.1.3.2
   - casing ==0.1.2.1
   - cassava ==0.4.5.1
@@ -362,8 +365,8 @@ default-package-overrides:
   - cheapskate-highlight ==0.1.0.0
   - cheapskate-lucid ==0.1.0.0
   - check-email ==1.0.2
-  - checkers ==0.4.7
-  - chell ==0.4.0.1
+  - checkers ==0.4.9.5
+  - chell ==0.4.0.2
   - choice ==0.2.2
   - chunked-data ==0.3.0
   - cipher-aes ==0.2.11
@@ -398,17 +401,17 @@ default-package-overrides:
   - cmark ==0.5.6
   - cmark-highlight ==0.2.0.0
   - cmark-lucid ==0.1.0.0
-  - cmdargs ==0.10.17
+  - cmdargs ==0.10.18
   - code-builder ==0.1.3
   - code-page ==0.1.3
   - codo-notation ==0.5.2
   - colorful-monoids ==0.2.1.0
-  - colour ==2.3.3
-  - comfort-graph ==0.0.2
+  - colour ==2.3.4
+  - comfort-graph ==0.0.2.1
   - commutative ==0.0.1.4
   - comonad ==5.0.2
-  - comonad-transformers ==4.0
   - comonads-fd ==4.0
+  - comonad-transformers ==4.0
   - compactmap ==0.1.4.2.1
   - compensated ==0.7.2
   - composable-associations ==0.1.0.0
@@ -420,12 +423,12 @@ default-package-overrides:
   - concurrent-output ==1.9.2
   - concurrent-split ==0.0.1
   - concurrent-supply ==0.1.8
-  - conduit ==1.2.11
-  - conduit-combinators ==1.1.1
+  - conduit ==1.2.12.1
+  - conduit-combinators ==1.1.2
   - conduit-connection ==0.1.0.3
-  - conduit-extra ==1.1.16
+  - conduit-extra ==1.1.17
   - conduit-iconv ==0.1.1.2
-  - conduit-parse ==0.1.2.1
+  - conduit-parse ==0.1.2.2
   - ConfigFile ==1.1.4
   - configuration-tools ==0.2.15
   - configurator ==0.3.0.0
@@ -443,7 +446,7 @@ default-package-overrides:
   - control-monad-loop ==0.1
   - control-monad-omega ==0.3.1
   - convertible ==1.1.1.0
-  - cookie ==0.4.2.1
+  - cookie ==0.4.3
   - countable ==1.0
   - courier ==0.1.1.5
   - cpphs ==1.20.8
@@ -454,26 +457,26 @@ default-package-overrides:
   - cql-io ==0.16.0
   - criterion ==1.1.4.0
   - cron ==0.5.0
-  - crypt-sha512 ==0
   - crypto-api ==0.13.2
   - crypto-api-tests ==0.3
+  - cryptocipher ==0.6.2
   - crypto-cipher-tests ==0.0.11
   - crypto-cipher-types ==0.0.9
-  - crypto-enigma ==0.0.2.9
-  - crypto-pubkey-types ==0.4.3
-  - crypto-random ==0.0.9
-  - crypto-random-api ==0.2.0
-  - cryptocipher ==0.6.2
+  - crypto-enigma ==0.0.2.10
   - cryptohash ==0.11.9
   - cryptohash-conduit ==0.1.1
   - cryptohash-cryptoapi ==0.1.4
   - cryptohash-md5 ==0.11.100.1
   - cryptohash-sha1 ==0.11.100.1
-  - cryptohash-sha256 ==0.11.100.1
+  - cryptohash-sha256 ==0.11.101.0
   - cryptohash-sha512 ==0.11.100.1
   - cryptonite ==0.23
-  - cryptonite-conduit ==0.2.0
+  - cryptonite-conduit ==0.2.2
   - cryptonite-openssl ==0.6
+  - crypto-pubkey-types ==0.4.3
+  - crypto-random ==0.0.9
+  - crypto-random-api ==0.2.0
+  - crypt-sha512 ==0
   - csp ==1.3.1
   - css-syntax ==0.0.5
   - css-text ==0.1.2.2
@@ -504,7 +507,7 @@ default-package-overrides:
   - data-diverse-lens ==0.1.1.0
   - data-dword ==0.3.1.1
   - data-endian ==0.1.1
-  - data-fix ==0.0.6
+  - data-fix ==0.0.7
   - data-has ==0.2.1.0
   - data-hash ==0.2.0.1
   - data-inttrie ==0.1.2
@@ -515,7 +518,7 @@ default-package-overrides:
   - data-ordlist ==0.4.7.0
   - data-ref ==0.0.1.1
   - data-reify ==0.6.1
-  - data-serializer ==0.3
+  - data-serializer ==0.3.2
   - data-textual ==0.3.0.2
   - dataurl ==0.1.0.0
   - DAV ==1.3.1
@@ -525,7 +528,7 @@ default-package-overrides:
   - Decimal ==0.4.2
   - declarative ==0.5.1
   - deepseq-generics ==0.2.0.0
-  - dejafu ==0.7.1.2
+  - dejafu ==0.7.3.0
   - dependent-map ==0.2.4.0
   - dependent-sum ==0.4
   - derive ==2.6.3
@@ -539,19 +542,19 @@ default-package-overrides:
   - diagrams-core ==1.4.0.1
   - diagrams-gtk ==1.4
   - diagrams-html5 ==1.4
-  - diagrams-lib ==1.4.1.2
+  - diagrams-lib ==1.4.2
   - diagrams-postscript ==1.4
   - diagrams-rasterific ==1.4
   - diagrams-solve ==0.1.1
-  - diagrams-svg ==1.4.1
+  - diagrams-svg ==1.4.1.1
   - dictionaries ==0.2.0.3
   - Diff ==0.3.4
   - diff3 ==0.3.0
   - digest ==0.0.1.2
   - digits ==0.3.1
   - dimensional ==1.0.1.3
-  - direct-sqlite ==2.3.20
   - directory-tree ==0.12.1
+  - direct-sqlite ==2.3.21
   - discord-gateway ==0.2.2
   - discord-hs ==0.4.2
   - discord-rest ==0.2.2
@@ -574,23 +577,23 @@ default-package-overrides:
   - dmenu-pkill ==0.1.0.1
   - dmenu-pmount ==0.1.0.1
   - dmenu-search ==0.1.0.1
-  - dns ==2.0.12
-  - do-list ==1.0.1
+  - dns ==2.0.13
   - dockerfile ==0.1.0.1
   - docopt ==0.7.0.5
   - doctemplates ==0.1.0.2
   - doctest ==0.11.4
   - doctest-discover ==0.1.0.7
+  - do-list ==1.0.1
   - dotenv ==0.3.4.0
   - dotnet-timespan ==0.0.1.0
   - double-conversion ==2.0.2.0
-  - download ==0.3.2.5
+  - download ==0.3.2.6
   - dpor ==0.2.0.0
   - drawille ==0.1.2.0
   - DRBG ==0.5.5
   - drifter ==0.2.3
   - drifter-postgresql ==0.1.0
-  - dsp ==0.2.3.1
+  - dsp ==0.2.4
   - dual-tree ==0.2.1
   - dvorak ==0.1.0.0
   - dynamic-state ==0.2.2.0
@@ -611,22 +614,22 @@ default-package-overrides:
   - either ==4.4.1.1
   - either-unwrap ==1.1
   - ekg ==0.4.0.14
-  - ekg-core ==0.1.1.2
+  - ekg-core ==0.1.1.3
   - ekg-json ==0.1.0.6
-  - ekg-statsd ==0.2.1.1
+  - ekg-statsd ==0.2.2.0
   - ekg-wai ==0.1.0.2
   - elerea ==2.9.0
   - elm-bridge ==0.4.1
   - elm-core-sources ==1.0.0
   - elm-export ==0.6.0.1
   - elm-export-persistent ==0.1.2
-  - email-validate ==2.3.1
   - emailaddress ==0.2.0.0
+  - email-validate ==2.3.2
   - enclosed-exceptions ==1.0.2
   - encoding-io ==0.0.1
   - engine-io ==1.2.17
-  - engine-io-wai ==1.0.6
-  - EntrezHTTP ==1.0.4
+  - engine-io-wai ==1.0.7
+  - EntrezHTTP ==1.0.3
   - entropy ==0.3.8
   - enummapset ==0.5.2.1
   - enummapset-th ==0.6.1.1
@@ -639,7 +642,7 @@ default-package-overrides:
   - equal-files ==0.0.5.3
   - equivalence ==0.3.2
   - erf ==2.0.0.0
-  - errors ==2.2.1
+  - errors ==2.2.2
   - ersatz ==0.4.1
   - esqueleto ==2.5.3
   - etc ==0.2.0.0
@@ -647,7 +650,6 @@ default-package-overrides:
   - ether ==0.5.1.0
   - euphoria ==0.8.0.0
   - event ==0.1.4
-  - event-list ==0.1.1.3
   - eventful-core ==0.1.3
   - eventful-dynamodb ==0.1.3
   - eventful-memory ==0.1.3
@@ -655,52 +657,54 @@ default-package-overrides:
   - eventful-sql-common ==0.1.3
   - eventful-sqlite ==0.1.3
   - eventful-test-helpers ==0.1.3
+  - event-list ==0.1.1.3
   - eventstore ==0.15.0.2
   - exact-combinatorics ==0.2.0.8
   - exact-pi ==0.4.1.2
-  - exception-mtl ==0.4.0.1
-  - exception-transformers ==0.4.0.5
   - exceptional ==0.3.0.0
+  - exception-mtl ==0.4.0.1
   - exceptions ==0.8.3
+  - exception-transformers ==0.4.0.5
   - executable-hash ==0.2.0.4
   - executable-path ==0.0.3.1
   - exhaustive ==1.1.5
-  - exp-pairs ==0.1.5.2
   - expiring-cache-map ==0.0.6.1
   - explicit-exception ==0.1.9
-  - extensible ==0.4.4
+  - exp-pairs ==0.1.5.2
+  - extensible ==0.4.7
   - extensible-effects ==1.11.1.0
   - extensible-exceptions ==0.1.1.4
   - extra ==1.5.3
-  - extract-dependencies ==0.2.0.1
   - extractable-singleton ==0.0.1
+  - extract-dependencies ==0.2.0.1
   - fail ==4.9.0.0
   - farmhash ==0.1.0.5
-  - fast-builder ==0.0.0.6
+  - fasta ==0.10.4.2
+  - fast-builder ==0.0.1.0
   - fast-digits ==0.2.1.0
   - fast-logger ==2.4.10
   - fast-math ==1.0.2
-  - fasta ==0.10.4.2
   - fb ==1.1.1
   - fclabels ==2.0.3.2
   - fdo-notify ==0.3.1
   - feature-flags ==0.1.0.1
+  - fedora-haskell-tools ==0.3
   - feed ==0.3.12.0
   - FenwickTree ==0.1.2.1
   - fft ==0.1.8.6
-  - fgl ==5.5.4.0
+  - fgl ==5.5.3.1
   - fgl-arbitrary ==0.2.0.3
-  - file-embed ==0.0.10
-  - file-modules ==0.1.2.4
   - filecache ==0.2.9
+  - file-embed ==0.0.10
   - filelock ==0.1.1.2
   - filemanip ==0.3.6.3
+  - file-modules ==0.1.2.4
   - fileplow ==0.1.0.0
   - filter-logger ==0.6.0.0
-  - find-clumpiness ==0.2.2.0
-  - fingertree ==0.1.1.0
+  - find-clumpiness ==0.2.3.1
+  - fingertree ==0.1.3.1
   - fingertree-psqueue ==0.3
-  - finite-typelits ==0.1.2.0
+  - finite-typelits ==0.1.3.0
   - fixed ==0.2.1.1
   - fixed-length ==0.2
   - fixed-vector ==0.9.0.0
@@ -712,10 +716,10 @@ default-package-overrides:
   - flexible-defaults ==0.0.1.2
   - floatshow ==0.2.4
   - flock ==0.3.1.8
-  - flow ==1.0.9
+  - flow ==1.0.10
   - fmlist ==0.9
   - fmt ==0.3.0.0
-  - fn ==0.3.0.1
+  - fn ==0.3.0.2
   - focus ==0.1.5.2
   - fold-debounce ==0.2.0.6
   - fold-debounce-conduit ==0.1.0.5
@@ -728,17 +732,17 @@ default-package-overrides:
   - ForestStructures ==0.0.0.2
   - forma ==0.2.0
   - format-numbers ==0.1.0.0
-  - formatting ==6.2.4
-  - foundation ==0.0.13
+  - formatting ==6.2.5
+  - foundation ==0.0.17
   - Frames ==0.1.9
   - free ==4.12.4
-  - free-vl ==0.1.4
   - freenect ==1.2.1
   - freer ==0.2.4.1
   - freer-effects ==0.3.0.1
   - freetype2 ==0.1.2
+  - free-vl ==0.1.4
   - friendly-time ==0.4.1
-  - frisby ==0.2
+  - frisby ==0.2.2
   - from-sum ==0.2.1.0
   - frontmatter ==0.1.0.2
   - fsnotify ==0.2.1.1
@@ -747,50 +751,52 @@ default-package-overrides:
   - functor-classes-compat ==1
   - fuzzcheck ==0.1.1
   - fuzzy ==0.1.0.0
+  - gauge ==0.1.3
   - gd ==3000.7.3
   - Genbank ==1.0.3
   - general-games ==1.0.5
   - generic-aeson ==0.2.0.9
   - generic-deriving ==1.11.2
   - generic-random ==0.5.0.0
-  - generic-xmlpickler ==0.1.0.5
   - generics-eot ==0.2.1.1
   - generics-sop ==0.3.1.0
   - generics-sop-lens ==0.1.2.1
+  - generic-xmlpickler ==0.1.0.5
   - geniplate-mirror ==0.7.5
   - getopt-generics ==0.13.0.1
   - ghc-events ==0.6.0
   - ghc-exactprint ==0.5.5.0
   - ghc-heap-view ==0.5.10
+  - ghcid ==0.6.8
+  - ghcjs-base-stub ==0.1.0.4
+  - ghcjs-codemirror ==0.0.0.1
+  - ghcjs-perch ==0.3.3.2
   - ghc-paths ==0.1.0.9
-  - ghc-prof ==1.4.0.2
-  - ghc-syb-utils ==0.2.3.2
+  - ghc-prof ==1.4.0.4
+  - ghc-syb-utils ==0.2.3.3
   - ghc-tcplugins-extra ==0.2.1
   - ghc-typelits-extra ==0.2.3
   - ghc-typelits-knownnat ==0.3.1
-  - ghc-typelits-natnormalise ==0.5.3
-  - ghcid ==0.6.6
-  - ghcjs-base-stub ==0.1.0.2
-  - ghcjs-codemirror ==0.0.0.1
-  - ghcjs-perch ==0.3.3.2
+  - ghc-typelits-natnormalise ==0.5.4
   - gi-atk ==2.0.14
   - gi-cairo ==1.0.14
   - gi-gdk ==3.0.14
   - gi-gdkpixbuf ==2.0.14
   - gi-gio ==2.0.14
-  - gi-glib ==2.0.14
+  - gi-glib ==2.0.15
   - gi-gobject ==2.0.15
-  - gi-gtk ==3.0.17
+  - gi-gtk ==3.0.18
+  - gi-gtk-hs ==0.3.5.0
+  - gi-gtksource ==3.0.15
   - gi-javascriptcore ==3.0.14
-  - gi-pango ==1.0.15
-  - gi-soup ==2.4.14
-  - gi-webkit ==3.0.14
   - ginger ==0.5.3.0
-  - gio ==0.13.3.1
+  - gio ==0.13.4.0
+  - gi-pango ==1.0.15
   - giphy-api ==0.5.2.0
-  - git ==0.2.0
+  - gi-soup ==2.4.14
+  - git ==0.2.1
   - github ==0.16.0
-  - github-release ==1.0.6
+  - github-release ==1.0.7
   - github-types ==0.2.1
   - github-webhook-handler ==0.0.8
   - github-webhook-handler-snap ==0.0.7
@@ -799,15 +805,16 @@ default-package-overrides:
   - gitlib-test ==3.1.0.3
   - gitrev ==1.3.1
   - gitson ==0.5.2
+  - gi-webkit ==3.0.14
   - gl ==0.8.0
-  - glabrous ==0.3.2
+  - glabrous ==0.3.4
   - glaze ==0.3.0.1
   - glazier ==0.11.0.1
   - glazier-pipes ==0.1.5.1
   - glazier-react ==0.6.0.0
   - glazier-react-widget ==0.6.0.0
   - GLFW-b ==1.4.8.1
-  - glib ==0.13.4.1
+  - glib ==0.13.5.0
   - Glob ==0.8.0
   - glob-posix ==0.1.0.1
   - gloss ==1.11.1.1
@@ -915,13 +922,13 @@ default-package-overrides:
   - gogol-youtube-reporting ==0.3.0
   - google-cloud ==0.0.4
   - google-oauth2-jwt ==0.2.2
-  - GPipe ==2.2.1
+  - GPipe ==2.2.3
   - GPipe-GLFW ==1.4.1.1
   - gpolyline ==0.1.0.1
   - graph-core ==0.3.0.0
-  - graph-wrapper ==0.2.5.1
   - graphs ==0.7
   - graphviz ==2999.18.1.2
+  - graph-wrapper ==0.2.5.1
   - gravatar ==0.8.0
   - graylog ==0.1.0.1
   - groom ==0.1.2.1
@@ -930,15 +937,16 @@ default-package-overrides:
   - groundhog-mysql ==0.8
   - groundhog-postgresql ==0.8.0.1
   - groundhog-sqlite ==0.8
-  - groundhog-th ==0.8.0.1
-  - group-by-date ==0.1.0.1
-  - grouped-list ==0.2.1.3
+  - groundhog-th ==0.8.0.2
+  - group-by-date ==0.1.0.2
+  - grouped-list ==0.2.1.4
   - groupoids ==4.0
-  - groups ==0.4.0.0
-  - gtk ==0.14.6
-  - gtk2hs-buildtools ==0.13.2.2
-  - gtk3 ==0.14.6
+  - groups ==0.4.1.0
+  - gtk ==0.14.7
+  - gtk2hs-buildtools ==0.13.3.1
+  - gtk3 ==0.14.8
   - gtksourceview3 ==0.13.3.1
+  - gym-http-api ==0.1.0.0
   - H ==0.9.0.1
   - h2c ==1.0.0
   - hackage-db ==1.22
@@ -948,7 +956,7 @@ default-package-overrides:
   - haddock-api ==2.17.4
   - haddock-library ==1.4.3
   - haddock-test ==0.0.1
-  - hailgun ==0.4.1.5
+  - hailgun ==0.4.1.6
   - hailgun-simple ==0.1.0.0
   - hakyll ==4.9.8.0
   - hakyll-favicon ==0.1.0
@@ -957,31 +965,34 @@ default-package-overrides:
   - hamlet ==1.2.0
   - HandsomeSoup ==0.4.2
   - handwriting ==0.1.0.3
-  - hapistrano ==0.3.2.4
+  - hapistrano ==0.3.5.0
   - happstack-hsp ==7.3.7.3
   - happstack-jmacro ==7.0.12
   - happstack-server ==7.4.6.4
   - happstack-server-tls ==7.1.6.4
-  - happy >1.19.6
-  - harp ==0.4.2
-  - hasbolt ==0.1.2.1
+  - happy ==1.19.8
+  - harp ==0.4.3
+  - hasbolt ==0.1.3.0
   - hashable ==1.2.6.1
   - hashable-time ==0.2.0.1
   - hashmap ==1.3.2
-  - hashtables ==1.2.1.1
-  - haskeline ==0.7.4.0
+  - hashtables ==1.2.2.1
+  - haskeline ==0.7.4.2
   - haskell-gi ==0.20.3
-  - haskell-gi-base ==0.20.4
+  - haskell-gi-base ==0.20.8
   - haskell-gi-overloading ==1.0
-  - haskell-import-graph ==1.0.2
+  - haskell-import-graph ==1.0.3
   - haskell-lexer ==1.0.1
   - haskell-lsp ==0.1.0.0
   - haskell-neo4j-client ==0.3.2.4
+  - HaskellNet ==0.5.1
+  - HaskellNet-SSL ==0.3.4.0
   - haskell-packages ==0.5
   - haskell-spacegoo ==0.2.0.1
   - haskell-src ==1.0.2.0
   - haskell-src-exts ==1.18.2
   - haskell-src-exts-simple ==1.19.0.0
+  - haskell-src-exts-util ==0.2.1.2
   - haskell-src-meta ==0.8.0.1
   - haskell-tools-ast ==0.8.1.0
   - haskell-tools-backend-ghc ==0.8.1.0
@@ -992,14 +1003,12 @@ default-package-overrides:
   - haskell-tools-prettyprint ==0.8.1.0
   - haskell-tools-refactor ==0.8.1.0
   - haskell-tools-rewrite ==0.8.1.0
-  - HaskellNet ==0.5.1
-  - HaskellNet-SSL ==0.3.4.0
   - haskintex ==0.7.0.1
-  - hasmin ==0.3.2.4
-  - hasql ==0.19.18.1
+  - hasmin ==0.3.3.1
+  - hasql ==0.19.18.2
   - hasql-migration ==0.1.3
-  - hasql-pool ==0.4.1
-  - hasql-transaction ==0.5
+  - hasql-pool ==0.4.3
+  - hasql-transaction ==0.5.2
   - hastache ==0.6.1
   - hasty-hamiltonian ==1.3.0
   - HaTeX ==3.17.3.1
@@ -1016,23 +1025,23 @@ default-package-overrides:
   - HDBC ==2.4.0.2
   - HDBC-mysql ==0.7.1.0
   - HDBC-session ==0.1.1.1
-  - hdevtools ==0.1.6.0
+  - hdevtools ==0.1.6.1
   - hdocs ==0.5.2.1
   - heap ==1.0.3
   - heaps ==0.3.5
   - heatshrink ==0.1.0.0
   - hebrew-time ==0.1.1
-  - hedgehog ==0.5
+  - hedgehog ==0.5.1
   - hedgehog-quickcheck ==0.1
-  - hedis ==0.9.9
-  - here ==1.2.11
+  - hedis ==0.9.12
+  - here ==1.2.12
   - heredoc ==0.2.0.0
-  - heterocephalus ==1.0.5.0
+  - heterocephalus ==1.0.5.1
   - hex ==0.1.2
-  - hexml ==0.3.2
+  - hexml ==0.3.3
   - hexpat ==0.20.13
   - hexstring ==0.11.1
-  - hformat ==0.3.0.0
+  - hformat ==0.3.1.0
   - hfsevents ==0.1.6
   - hid ==0.2.2
   - hidapi ==0.1.4
@@ -1053,10 +1062,9 @@ default-package-overrides:
   - hjsonschema ==1.6.3
   - hlibgit2 ==0.18.0.16
   - hlibsass ==0.1.6.1
-  - hlint ==2.0.9
   - hmatrix ==0.18.0.0
   - hmatrix-gsl ==0.18.0.1
-  - hmatrix-gsl-stats ==0.4.1.6
+  - hmatrix-gsl-stats ==0.4.1.7
   - hmatrix-special ==0.4.0.1
   - hmpfr ==0.4.3
   - hoauth2 ==1.3.0
@@ -1069,9 +1077,10 @@ default-package-overrides:
   - hourglass ==0.2.10
   - hourglass-orphans ==0.1.0.0
   - hp2pretty ==0.8.0.2
+  - hpack ==0.18.1
   - hpc-coveralls ==1.0.10
-  - hPDB ==1.2.0.9
-  - hPDB-examples ==1.2.0.7
+  - hPDB ==1.2.0.10
+  - hPDB-examples ==1.2.0.8
   - HPDF ==1.4.10
   - hpio ==0.8.0.10
   - hpp ==0.4.1
@@ -1079,21 +1088,21 @@ default-package-overrides:
   - hquantlib ==0.0.4.0
   - hreader ==1.1.0
   - hreader-lens ==0.1.3.0
-  - hruby ==0.3.4.4
-  - hs-bibutils ==5.5
-  - hs-GeoIP ==0.3
+  - hruby ==0.3.5.1
   - hsass ==0.4.2
   - hsb2hs ==0.3.1
-  - hscolour ==1.24.1
+  - hs-bibutils ==5.5
+  - hscolour ==1.24.2
   - hscurses ==1.4.2.0
   - hsdev ==0.2.5.1
   - hsdns ==1.7
-  - hse-cpp ==0.2
   - hsebaysdk ==0.4.0.0
+  - hse-cpp ==0.2
   - hsemail ==2
   - HSet ==0.0.1
   - hset ==2.2.0
-  - hsexif ==0.6.1.2
+  - hsexif ==0.6.1.5
+  - hs-GeoIP ==0.3
   - hsignal ==0.2.7.5
   - hsinstall ==1.6
   - hslogger ==1.2.10
@@ -1113,7 +1122,7 @@ default-package-overrides:
   - hspec-expectations ==0.8.2
   - hspec-expectations-lifted ==0.10.0
   - hspec-expectations-pretty-diff ==0.7.2.4
-  - hspec-golden-aeson ==0.2.0.3
+  - hspec-golden-aeson ==0.2.1.0
   - hspec-megaparsec ==0.3.1
   - hspec-meta ==2.4.4
   - hspec-pg-transact ==0.1.0.2
@@ -1122,53 +1131,53 @@ default-package-overrides:
   - hspec-wai ==0.8.0
   - hspec-wai-json ==0.8.0
   - hspec-webdriver ==1.2.0
-  - hsshellscript ==3.4.1
+  - hsshellscript ==3.4.5
   - hstatistics ==0.3
   - hstatsd ==0.1
   - HStringTemplate ==0.8.6
   - HSvm ==0.1.0.3.22
-  - hsx-jmacro ==7.3.8
   - hsx2hs ==0.14.1.1
+  - hsx-jmacro ==7.3.8
   - hsyslog ==5.0.1
   - htaglib ==1.1.1
   - HTF ==0.13.2.2
   - html ==1.0.1.2
-  - html-conduit ==1.2.1.1
+  - html-conduit ==1.2.1.2
   - html-email-validate ==0.2.0.0
   - htoml ==1.0.0.3
-  - HTTP ==4000.3.7
+  - HTTP ==4000.3.9
+  - http2 ==1.6.3
   - http-api-data ==0.3.7.1
-  - http-client ==0.5.7.0
-  - http-client-openssl ==0.2.0.5
+  - http-client ==0.5.7.1
+  - http-client-openssl ==0.2.1.1
   - http-client-tls ==0.3.5.1
   - http-common ==0.8.2.0
-  - http-conduit ==2.2.3.2
+  - http-conduit ==2.2.4
   - http-date ==0.0.6.1
+  - httpd-shed ==0.4.0.3
   - http-link-header ==1.0.3
   - http-media ==0.6.4
   - http-reverse-proxy ==0.4.5
-  - http-streams ==0.8.5.3
+  - http-streams ==0.8.5.5
   - http-types ==0.9.1
-  - http2 ==1.6.3
-  - httpd-shed ==0.4.0.3
   - human-readable-duration ==0.2.0.3
   - HUnit ==1.5.0.0
-  - HUnit-approx ==1.1
+  - HUnit-approx ==1.1.1.1
   - hunit-dejafu ==0.6.0.0
   - hvect ==0.4.0.0
   - hw-balancedparens ==0.1.0.2
   - hw-bits ==0.5.0.3
   - hw-diagnostics ==0.0.0.5
+  - hweblib ==0.6.3
   - hw-excess ==0.1.0.1
   - hw-int ==0.0.0.3
+  - hworker ==0.1.0.1
   - hw-parser ==0.0.0.3
   - hw-prim ==0.4.0.5
   - hw-rankselect ==0.8.0.2
   - hw-rankselect-base ==0.2.0.2
   - hw-string-parse ==0.0.0.4
   - hw-succinct ==0.1.0.1
-  - hweblib ==0.6.3
-  - hworker ==0.1.0.1
   - hxt ==9.3.1.16
   - hxt-charproperties ==9.2.0.1
   - hxt-css ==0.1.0.3
@@ -1196,27 +1205,27 @@ default-package-overrides:
   - imagesize-conduit ==1.1
   - Imlib ==0.1.2
   - imm ==1.2.0.0
-  - immortal ==0.2.2
+  - immortal ==0.2.2.1
   - include-file ==0.1.0.3
-  - incremental-parser ==0.2.5.1
+  - incremental-parser ==0.2.5.2
   - indentation-core ==0.0.0.1
   - indentation-parsec ==0.0.0.1
-  - indents ==0.4.0.0
+  - indents ==0.4.0.1
   - inflections ==0.3.0.0
   - ini ==0.3.5
   - inline-c ==0.5.6.1
   - inline-c-cpp ==0.1.0.0
   - inline-java ==0.6.5
-  - inline-r ==0.9.0.1
+  - inline-r ==0.9.0.2
   - insert-ordered-containers ==0.2.1.0
-  - instance-control ==0.1.1.1
+  - instance-control ==0.1.2.0
   - integer-logarithms ==1.0.2
   - integration ==0.2.1
-  - intero ==0.1.21
+  - intero ==0.1.24
   - interpolate ==0.1.1
   - interpolatedstring-perl6 ==1.0.0
-  - interpolation ==0.1.0.1
-  - IntervalMap ==0.5.2.0
+  - interpolation ==0.1.0.2
+  - IntervalMap ==0.5.3.1
   - intervals ==0.8.1
   - intro ==0.3.0.1
   - invariant ==0.4.3
@@ -1228,14 +1237,14 @@ default-package-overrides:
   - io-region ==0.1.1
   - io-storage ==0.3
   - io-streams ==1.4.1.0
-  - io-streams-haproxy ==1.0.0.1
+  - io-streams-haproxy ==1.0.0.2
   - ip6addr ==0.5.3
   - iproute ==1.7.1
   - IPv6Addr ==1.0.1
-  - IPv6DB ==0.2.2
+  - IPv6DB ==0.2.3
   - irc ==0.6.1.0
   - irc-client ==0.4.4.4
-  - irc-conduit ==0.2.2.3
+  - irc-conduit ==0.2.2.4
   - irc-ctcp ==0.1.3.0
   - irc-dcc ==2.0.1
   - islink ==0.1.0.0
@@ -1244,34 +1253,34 @@ default-package-overrides:
   - iso8601-time ==0.1.4
   - isotope ==0.5.0.1
   - iterable ==3.0
-  - ix-shapable ==0.1.0
   - ixset-typed ==0.3.1.1
+  - ix-shapable ==0.1.0
   - jack ==0.7.1.1
   - jailbreak-cabal ==1.3.2
-  - javascript-extras ==0.3.1.0
+  - javascript-extras ==0.3.2.0
   - jmacro ==0.6.14
   - jmacro-rpc ==0.3.2
   - jmacro-rpc-happstack ==0.3.2
   - jmacro-rpc-snap ==0.3
   - jni ==0.3.1
   - jose ==0.6.0.3
-  - jose-jwt ==0.7.7
+  - jose-jwt ==0.7.8
   - js-flot ==0.8.3
   - js-jquery ==3.2.1
   - json ==0.9.1
   - json-builder ==0.3
-  - json-rpc-generic ==0.2.1.2
+  - json-rpc-generic ==0.2.1.3
   - json-schema ==0.7.4.1
-  - json-stream ==0.4.1.4
-  - JuicyPixels ==3.2.8.3
-  - JuicyPixels-extra ==0.2.1
+  - json-stream ==0.4.1.5
+  - JuicyPixels ==3.2.9.1
+  - JuicyPixels-extra ==0.2.2
   - JuicyPixels-scale-dct ==0.1.1.2
   - jvm ==0.2.2
   - jvm-streaming ==0.2
   - jwt ==0.7.2
   - kan-extensions ==5.0.2
   - kansas-comet ==0.4
-  - katip ==0.5.0.0
+  - katip ==0.5.2.0
   - kawhi ==0.3.0
   - kdt ==0.2.4
   - keter ==1.4.3.2
@@ -1283,7 +1292,7 @@ default-package-overrides:
   - kraken ==0.0.3
   - l10n ==0.1.0.1
   - labels ==0.3.3
-  - lackey ==0.4.3
+  - lackey ==0.4.7
   - lame ==0.1.1
   - language-c ==0.6.1
   - language-c-quote ==0.12.1
@@ -1303,7 +1312,7 @@ default-package-overrides:
   - lattices ==1.5.0
   - lazyio ==0.1.0.4
   - lca ==0.3
-  - leancheck ==0.6.5
+  - leancheck ==0.6.7
   - leapseconds-announced ==2017
   - lens ==4.15.4
   - lens-action ==0.2.2
@@ -1315,7 +1324,7 @@ default-package-overrides:
   - lens-labels ==0.1.0.2
   - lens-regex ==0.1.0
   - lens-simple ==0.1.0.9
-  - lentil ==1.0.9.0
+  - lentil ==1.0.9.1
   - leveldb-haskell ==0.6.5
   - lexer-applicative ==2.1.0.1
   - lhs2tex ==1.19
@@ -1329,40 +1338,40 @@ default-package-overrides:
   - libxml-sax ==0.7.5
   - LibZip ==1.0.1
   - licensor ==0.2.1
-  - lift-generics ==0.1.1
-  - lifted-async ==0.9.3
+  - lifted-async ==0.9.3.2
   - lifted-base ==0.2.3.11
+  - lift-generics ==0.1.2
   - line ==3.1.0
   - linear ==1.20.7
   - linear-accelerate ==0.4.1
   - linked-list-with-iterator ==0.1.1.0
   - linux-file-extents ==0.2.0.0
   - linux-namespaces ==0.1.2.0
-  - List ==0.6.0
-  - list-fusion-probe ==0.1.0.6
-  - list-prompt ==0.1.1.0
-  - list-t ==1.0.0.1
+  - List ==0.6.2
+  - list-fusion-probe ==0.1.0.7
   - ListLike ==4.5.1
+  - list-prompt ==0.1.1.0
   - listsafe ==0.1.0.1
+  - list-t ==1.0.0.1
   - llvm-hs ==4.2.0
   - llvm-hs-pure ==4.1.0.0
   - lmdb ==0.2.5
   - loch-th ==0.2.1
   - log ==0.9.0.1
-  - log-base ==0.7.2.0
+  - log-base ==0.7.4.0
   - log-domain ==0.11.2
   - log-elasticsearch ==0.9.1.0
-  - log-postgres ==0.7.0.2
   - logfloat ==0.13.3.3
   - logger-thread ==0.1.0.2
-  - logging-effect ==1.2.0
+  - logging-effect ==1.2.1
   - logging-facade ==0.3.0
   - logging-facade-syslog ==1
   - logict ==0.6.0.2
+  - log-postgres ==0.7.0.2
   - loop ==0.3.0
   - lrucache ==1.2.0.0
   - lrucaching ==0.3.2
-  - lucid ==2.9.8.1
+  - lucid ==2.9.9
   - lucid-svg ==0.7.0.0
   - lzma-conduit ==1.1.3.3
   - machines ==0.6.3
@@ -1371,19 +1380,19 @@ default-package-overrides:
   - machines-io ==0.2.0.13
   - machines-process ==0.2.0.8
   - magic ==1.1
-  - magicbane ==0.1.1
+  - magicbane ==0.1.4
   - mainland-pretty ==0.6.1
   - makefile ==1.0.0.4
   - managed ==1.0.5
   - mandrill ==0.5.3.2
   - markdown ==0.1.16
-  - markdown-unlit ==0.4.0
+  - markdown-unlit ==0.4.1
   - markov-chain ==0.0.3.4
   - markup ==3.1.0
-  - marvin ==0.2.3
+  - marvin ==0.2.5
   - marvin-interpolate ==1.1.2
-  - math-functions ==0.2.1.0
   - mathexpr ==0.3.0.0
+  - math-functions ==0.2.1.0
   - matplotlib ==0.5.0
   - matrices ==0.4.5
   - matrix ==0.3.5.0
@@ -1392,13 +1401,13 @@ default-package-overrides:
   - mbox ==0.3.4
   - mbox-utility ==0.0.1
   - mcmc-types ==1.0.3
-  - med-module ==0.1.1
   - mediabus ==0.4.0.1
   - mediabus-rtp ==0.4.0.1
   - median-stream ==0.7.0.0
-  - mega-sdist ==0.3.0.2
+  - med-module ==0.1.1
   - megaparsec ==5.3.1
-  - memory ==0.14.6
+  - mega-sdist ==0.3.0.5
+  - memory ==0.14.11
   - MemoTrie ==0.6.8
   - mersenne-random-pure64 ==0.2.2.0
   - messagepack ==0.5.4
@@ -1408,7 +1417,7 @@ default-package-overrides:
   - mfsolve ==0.3.2.0
   - microformats2-parser ==1.0.1.7
   - microlens ==0.4.8.1
-  - microlens-aeson ==2.2.0.1
+  - microlens-aeson ==2.2.0.2
   - microlens-contra ==0.1.0.1
   - microlens-ghc ==0.4.8.0
   - microlens-mtl ==0.1.11.0
@@ -1421,7 +1430,7 @@ default-package-overrides:
   - mime-mail ==0.4.14
   - mime-mail-ses ==0.3.2.3
   - mime-types ==0.1.0.7
-  - minio-hs ==0.3.1
+  - minio-hs ==0.3.2
   - mintty ==0.1.1
   - miso ==0.4.0.0
   - missing-foreign ==0.1.1
@@ -1437,39 +1446,39 @@ default-package-overrides:
   - monad-control ==1.0.2.2
   - monad-control-aligned ==0.0.1
   - monad-coroutine ==0.9.0.3
+  - monadcryptorandom ==0.7.1
   - monad-extras ==0.6.0
   - monad-http ==0.1.0.0
+  - monadic-arrays ==0.2.2
   - monad-journal ==0.7.2
-  - monad-logger ==0.3.25
+  - monadloc ==0.7.1
+  - monad-logger ==0.3.25.1
   - monad-logger-json ==0.1.0.0
   - monad-logger-prefix ==0.1.6
   - monad-logger-syslog ==0.1.4.0
   - monad-loops ==0.4.3
   - monad-metrics ==0.1.0.2
   - monad-par ==0.3.4.8
-  - monad-par-extras ==0.3.3
   - monad-parallel ==0.7.2.2
+  - monad-par-extras ==0.3.3
   - monad-peel ==0.2.1.2
-  - monad-products ==4.0.1
-  - monad-skeleton ==0.1.5
-  - monad-time ==0.2
-  - monad-unlift ==0.2.0
-  - monad-unlift-ref ==0.2.0
-  - monadcryptorandom ==0.7.1
-  - monadic-arrays ==0.2.2
-  - monadloc ==0.7.1
   - monadplus ==1.4.2
+  - monad-products ==4.0.1
   - MonadPrompt ==1.0.0.5
   - MonadRandom ==0.5.1
+  - monad-skeleton ==0.1.5
   - monads-tf ==0.1.0.3
+  - monad-time ==0.2
+  - monad-unlift ==0.2.0
+  - monad-unlift-ref ==0.2.1
   - mongoDB ==2.3.0
-  - mono-traversable ==1.0.2.1
-  - mono-traversable-instances ==0.1.0.0
+  - monoidal-containers ==0.3.0.2
   - monoid-extras ==0.4.2
   - monoid-subclasses ==0.4.4
   - monoid-transformer ==0.0.3
-  - monoidal-containers ==0.3.0.2
-  - morte ==1.6.10
+  - mono-traversable ==1.0.6.0
+  - mono-traversable-instances ==0.1.0.0
+  - morte ==1.6.13
   - mountpoints ==1.0.2
   - mstate ==0.2.7
   - mtl ==2.2.1
@@ -1482,7 +1491,7 @@ default-package-overrides:
   - multistate ==0.7.1.2
   - murmur-hash ==0.1.0.9
   - mushu ==0.1.1
-  - MusicBrainz ==0.3
+  - MusicBrainz ==0.3.1
   - mustache ==2.2.3
   - mutable-containers ==0.3.3
   - mwc-probability ==1.3.0
@@ -1490,7 +1499,7 @@ default-package-overrides:
   - mysql ==0.1.4
   - mysql-haskell ==0.8.0.0
   - mysql-haskell-openssl ==0.8.0.0
-  - mysql-simple ==0.4.1.0
+  - mysql-simple ==0.4.4
   - nagios-check ==0.3.2
   - names-th ==0.2.0.3
   - nano-erl ==0.1.0.1
@@ -1504,7 +1513,7 @@ default-package-overrides:
   - netpbm ==1.0.2
   - netwire ==5.0.2
   - netwire-input ==0.0.6
-  - netwire-input-glfw ==0.0.6
+  - netwire-input-glfw ==0.0.7
   - network ==2.6.3.2
   - network-anonymous-i2p ==0.10.0
   - network-anonymous-tor ==0.11.0
@@ -1512,7 +1521,7 @@ default-package-overrides:
   - network-carbon ==1.0.10
   - network-conduit-tls ==1.2.2
   - network-house ==0.1.0.2
-  - network-info ==0.2.0.8
+  - network-info ==0.2.0.9
   - network-ip ==0.3.0.2
   - network-msgpack-rpc ==0.0.3
   - network-multicast ==0.2.0
@@ -1522,7 +1531,7 @@ default-package-overrides:
   - network-transport-composed ==0.2.0.1
   - network-transport-inmemory ==0.5.2
   - network-transport-tcp ==0.5.1
-  - network-transport-tests ==0.2.4.1
+  - network-transport-tests ==0.2.4.2
   - network-uri ==2.6.1.0
   - newtype ==0.2
   - newtype-generics ==0.5.1
@@ -1530,14 +1539,14 @@ default-package-overrides:
   - nfc ==0.1.0
   - nicify-lib ==1.0.1
   - NineP ==0.0.2.1
-  - nix-paths ==1.0.0.1
+  - nix-paths ==1.0.1
+  - nonce ==1.0.5
+  - nondeterminism ==1.4
   - non-empty ==0.3
   - non-empty-sequence ==0.2.0.2
   - non-negative ==0.1.1.2
-  - nonce ==1.0.4
-  - nondeterminism ==1.4
   - NoTrace ==0.3.0.2
-  - nsis ==0.3.1
+  - nsis ==0.3.2
   - numbers ==3000.2.0.1
   - numeric-extras ==0.1
   - numeric-prelude ==0.4.2
@@ -1550,10 +1559,10 @@ default-package-overrides:
   - nvim-hs-contrib ==0.2.0
   - nvim-hs-ghcid ==0.2.0
   - oanda-rest-api ==0.4.1
-  - objective ==1.1.1
+  - objective ==1.1.2
   - ObjectName ==1.1.0.1
   - octane ==0.20.2
-  - Octree ==0.5.4.3
+  - Octree ==0.5.4.4
   - oeis ==0.3.9
   - ofx ==0.4.2.0
   - old-locale ==1.0.0.7
@@ -1565,25 +1574,25 @@ default-package-overrides:
   - Only ==0.1
   - oo-prototypes ==0.1.0.0
   - opaleye ==0.5.4.0
-  - opaleye-trans ==0.3.5
-  - open-browser ==0.2.1.0
-  - open-witness ==0.4.0.1
+  - opaleye-trans ==0.3.7
   - OpenAL ==1.7.0.4
+  - open-browser ==0.2.1.0
   - openexr-write ==0.1.0.1
   - OpenGL ==3.0.2.0
-  - OpenGLRaw ==3.2.5.0
+  - OpenGLRaw ==3.2.7.0
   - openpgp-asciiarmor ==0.1
   - opensource ==0.1.0.0
-  - openssl-streams ==1.2.1.1
+  - openssl-streams ==1.2.1.3
+  - open-witness ==0.4.0.1
   - operational ==0.2.3.5
   - operational-class ==0.3.0.0
-  - opml-conduit ==0.6.0.3
+  - opml-conduit ==0.6.0.4
   - optional-args ==1.0.1
   - options ==1.2.1.1
   - optparse-applicative ==0.13.2.0
   - optparse-generic ==1.2.2
   - optparse-helper ==0.2.1.1
-  - optparse-simple ==0.0.3
+  - optparse-simple ==0.0.4
   - optparse-text ==0.1.1.0
   - osdkeys ==0.0
   - overloaded-records ==0.4.2.0
@@ -1594,10 +1603,10 @@ default-package-overrides:
   - pagerduty ==0.0.8
   - pagination ==0.2.1
   - palette ==0.1.0.5
-  - pandoc ==1.19.2.1
+  - pandoc ==1.19.2.4
   - pandoc-citeproc ==0.10.5.1
   - pandoc-types ==1.17.0.5
-  - pango ==0.13.3.1
+  - pango ==0.13.4.0
   - papillon ==0.1.0.4
   - parallel ==3.2.1.1
   - parallel-io ==0.3.3
@@ -1606,13 +1615,13 @@ default-package-overrides:
   - parsec-numeric ==0.1.0.0
   - ParsecTools ==0.0.2.0
   - parser-combinators ==0.1.0
-  - parsers ==0.12.7
+  - parsers ==0.12.8
   - partial-handler ==1.0.2
   - partial-isomorphisms ==0.2.2.1
   - partial-order ==0.1.2.1
   - patat ==0.5.2.2
   - path ==0.5.13
-  - path-extra ==0.0.3
+  - path-extra ==0.0.6
   - path-io ==1.2.2
   - path-pieces ==0.2.1
   - pathtype ==0.8
@@ -1622,102 +1631,102 @@ default-package-overrides:
   - pcre-heavy ==1.0.0.2
   - pcre-light ==0.4.0.4
   - pcre-utils ==0.1.8.1.1
+  - pdfinfo ==1.5.4
   - pdf-toolbox-content ==0.0.5.1
   - pdf-toolbox-core ==0.0.4.1
   - pdf-toolbox-document ==0.0.7.1
-  - pdfinfo ==1.5.4
   - pem ==0.2.2
   - perf ==0.1.2
   - persistable-record ==0.5.1.1
   - persistable-types-HDBC-pg ==0.0.1.5
-  - persistent ==2.7.0
+  - persistent ==2.7.1
   - persistent-mongoDB ==2.6.0
-  - persistent-mysql ==2.6.1
+  - persistent-mysql ==2.6.2.1
   - persistent-mysql-haskell ==0.3.0.0
-  - persistent-postgresql ==2.6.1
+  - persistent-postgresql ==2.6.2.1
   - persistent-redis ==2.5.2
   - persistent-refs ==0.4
-  - persistent-sqlite ==2.6.2
-  - persistent-template ==2.5.2
-  - pg-transact ==0.1.0.1
+  - persistent-sqlite ==2.6.3
+  - persistent-template ==2.5.3
   - pgp-wordlist ==0.1.0.2
+  - pg-transact ==0.1.0.1
   - phantom-state ==0.2.1.2
   - picedit ==0.2.3.0
   - picoparsec ==0.1.2.3
   - picosat ==0.1.4
   - pid1 ==0.1.2.0
-  - pinboard ==0.9.12.5
+  - pinboard ==0.9.12.6
   - pinch ==0.3.2.0
   - pinchot ==0.24.0.0
-  - pipes ==4.3.4
+  - pipes ==4.3.7
   - pipes-attoparsec ==0.5.1.5
   - pipes-bytestring ==2.1.6
   - pipes-cacophony ==0.5.0
   - pipes-category ==0.2.0.1
-  - pipes-concurrency ==2.0.7
-  - pipes-extras ==1.0.10
+  - pipes-concurrency ==2.0.8
+  - pipes-extras ==1.0.12
   - pipes-fluid ==0.5.0.3
-  - pipes-group ==1.0.7
+  - pipes-group ==1.0.8
   - pipes-misc ==0.3.0.0
   - pipes-mongodb ==0.1.0.0
   - pipes-parse ==3.0.8
-  - pipes-random ==1.0.0.3
-  - pipes-safe ==2.2.5
+  - pipes-random ==1.0.0.4
+  - pipes-safe ==2.2.6
   - pipes-text ==0.0.2.5
   - pipes-wai ==3.2.0
   - pixelated-avatar-generator ==0.1.3
   - pkcs10 ==0.2.0.0
   - placeholders ==0.1
   - plan-b ==0.2.1
-  - plot ==0.2.3.7
+  - plot ==0.2.3.9
   - plot-gtk ==0.2.0.4
-  - plot-gtk-ui ==0.3.0.2
   - plot-gtk3 ==0.1.0.2
+  - plot-gtk-ui ==0.3.0.2
   - plot-light ==0.2.7
-  - point-octree ==0.5.5.3
   - pointed ==5
   - pointedlist ==0.6.1
   - pointful ==1.0.9
   - pointless-fun ==1.1.0.6
+  - point-octree ==0.5.5.3
   - poll ==0.0
   - poly-arity ==0.1.0
   - polynomials-bernstein ==1.1.2
   - polyparse ==1.12
   - pooled-io ==0.0.2.1
-  - posix-paths ==0.2.1.1
+  - posix-paths ==0.2.1.3
   - posix-realtime ==0.0.0.4
-  - post-mess-age ==0.2.1.0
   - postgresql-binary ==0.12.1
   - postgresql-libpq ==0.9.3.1
-  - postgresql-schema ==0.1.11
+  - postgresql-schema ==0.1.14
   - postgresql-simple ==0.5.3.0
   - postgresql-simple-migration ==0.1.11.0
   - postgresql-simple-opts ==0.2.0.2
-  - postgresql-simple-queue ==0.5.0.1
+  - postgresql-simple-queue ==0.5.1.1
   - postgresql-simple-url ==0.2.0.0
   - postgresql-transactional ==1.1.1
-  - postgresql-typed ==0.5.1
+  - postgresql-typed ==0.5.2
+  - post-mess-age ==0.2.1.0
   - pqueue ==1.3.2.3
+  - prednote ==0.36.0.4
   - pred-set ==0.0.1
   - pred-trie ==0.5.1.2
-  - prednote ==0.36.0.4
   - prefix-units ==0.2.0
   - prelude-compat ==0.0.0.1
   - prelude-extras ==0.4.0.3
   - prelude-safeenum ==0.1.1.2
   - preprocessor-tools ==1.0.1
   - present ==4.1.0
+  - prettyclass ==1.0.0.0
   - pretty-class ==1.0.1.1
   - pretty-hex ==1.0
-  - pretty-show ==1.6.13
-  - pretty-simple ==2.0.0.0
-  - pretty-types ==0.2.3.1
-  - prettyclass ==1.0.0.0
   - prettyprinter ==1.1.1
   - prettyprinter-ansi-terminal ==1.1.1.1
   - prettyprinter-compat-annotated-wl-pprint ==1
   - prettyprinter-compat-ansi-wl-pprint ==1.0.1
   - prettyprinter-compat-wl-pprint ==1.0.0.1
+  - pretty-show ==1.6.15
+  - pretty-simple ==2.0.1.0
+  - pretty-types ==0.2.3.1
   - primes ==0.2.1.0
   - primitive ==0.6.2.0
   - printcess ==0.1.0.3
@@ -1725,14 +1734,18 @@ default-package-overrides:
   - process-extras ==0.7.2
   - product-profunctors ==0.8.0.3
   - profiterole ==0.1
-  - profiteur ==0.4.3.0
+  - profiteur ==0.4.4.0
   - profunctor-extras ==4.0
   - profunctors ==5.2.1
-  - project-template ==0.2.0
   - projectroot ==0.2.0.1
+  - project-template ==0.2.0
   - prometheus-client ==0.2.0
   - prometheus-metrics-ghc ==0.2.0
   - prompt ==0.1.1.2
+  - protobuf ==0.2.1.1
+  - protobuf-simple ==0.1.0.5
+  - protocol-buffers ==2.4.6
+  - protocol-buffers-descriptor ==2.4.6
   - proto-lens ==0.2.1.0
   - proto-lens-arbitrary ==0.1.1.1
   - proto-lens-combinators ==0.1.0.7
@@ -1740,19 +1753,15 @@ default-package-overrides:
   - proto-lens-optparse ==0.1.0.4
   - proto-lens-protobuf-types ==0.2.1.0
   - proto-lens-protoc ==0.2.1.0
-  - protobuf ==0.2.1.1
-  - protobuf-simple ==0.1.0.4
-  - protocol-buffers ==2.4.3
-  - protocol-buffers-descriptor ==2.4.3
   - protolude ==0.1.10
   - proxied ==0.3
   - psql-helpers ==0.1.0.0
   - PSQueue ==1.1
-  - psqueues ==0.2.3.0
+  - psqueues ==0.2.4.0
   - publicsuffix ==0.20170508
   - pure-io ==0.2.1
   - pureMD5 ==2.1.3
-  - purescript-bridge ==0.11.0.0
+  - purescript-bridge ==0.11.1.2
   - pusher-http-haskell ==1.2.0.1
   - pwstore-fast ==2.4.4
   - QuasiText ==0.1.2.6
@@ -1765,9 +1774,11 @@ default-package-overrides:
   - quickcheck-instances ==0.3.12
   - quickcheck-io ==0.2.0
   - quickcheck-simple ==0.1.0.2
-  - quickcheck-special ==0.1.0.5
+  - quickcheck-special ==0.1.0.6
+  - quickcheck-state-machine ==0.3.0
   - quickcheck-text ==0.1.2.1
   - quickcheck-unicode ==1.0.1.0
+  - quickcheck-with-counterexamples ==1.0
   - raaz ==0.1.1
   - rainbow ==0.28.0.4
   - rainbox ==0.18.0.10
@@ -1779,32 +1790,32 @@ default-package-overrides:
   - random-tree ==0.6.0.5
   - range ==0.1.2.0
   - range-set-list ==0.1.2.0
-  - rank-product ==0.2.0.1
   - rank1dynamic ==0.3.3.0
+  - rank-product ==0.2.0.1
   - Rasterific ==0.7.2.1
   - rasterific-svg ==0.3.3
-  - ratel ==0.3.5
+  - ratel ==0.3.8
   - ratel-wai ==0.2.0
   - rattletrap ==2.5.0
-  - raw-strings-qq ==1.1
   - rawfilepath ==0.2.4
   - rawstring-qm ==0.2.3.0
+  - raw-strings-qq ==1.1
   - rdf ==0.1.0.2
   - rdtsc ==1.3.0.1
   - reactive-banana ==1.1.0.1
-  - read-editor ==0.1.0.2
-  - read-env-var ==1.0.0.0
   - readable ==0.3.1
   - ReadArgs ==1.2.3
+  - read-editor ==0.1.0.2
+  - read-env-var ==1.0.0.0
   - readline ==1.0.3.0
   - rebase ==1.0.8.1
   - recursion-schemes ==5.0.2
   - redis-io ==0.7.0
   - redis-resp ==0.4.0
-  - reducers ==3.12.1
-  - ref-fd ==0.4.0.1
+  - reducers ==3.12.2
   - refact ==0.3.0.2
-  - references ==0.3.2.2
+  - references ==0.3.3.1
+  - ref-fd ==0.4.0.1
   - refined ==0.1.2.1
   - reflection ==2.1.2
   - reform ==0.2.7.1
@@ -1827,13 +1838,13 @@ default-package-overrides:
   - regex-tdfa-text ==1.0.0.3
   - regex-with-pcre ==1.0.1.3
   - reinterpret-cast ==0.1.0
-  - relational-query ==0.9.5.0
-  - relational-query-HDBC ==0.6.4.1
+  - relational-query ==0.9.5.1
+  - relational-query-HDBC ==0.6.4.2
   - relational-record ==0.1.8.0
-  - relational-schemas ==0.1.4.1
+  - relational-schemas ==0.1.4.2
   - renderable ==0.2.0.1
   - RepLib ==0.5.4
-  - repline ==0.1.6.0
+  - repline ==0.1.7.0
   - req ==0.2.0
   - req-conduit ==0.1.0
   - rerebase ==1.0.3
@@ -1851,8 +1862,8 @@ default-package-overrides:
   - rest-wai ==0.2.0.1
   - result ==0.2.6.0
   - rethinkdb ==2.2.0.10
-  - rethinkdb-client-driver ==0.0.24
-  - retry ==0.7.4.2
+  - rethinkdb-client-driver ==0.0.25
+  - retry ==0.7.5.1
   - rev-state ==0.1.2
   - rfc5051 ==0.1.0.3
   - rng-utils ==0.2.1
@@ -1865,10 +1876,10 @@ default-package-overrides:
   - rvar ==0.2.0.3
   - s3-signer ==0.3.0.0
   - safe ==0.3.15
+  - safecopy ==0.9.3.3
   - safe-exceptions ==0.1.6.0
   - safe-exceptions-checked ==0.1.0
-  - safecopy ==0.9.3.3
-  - safeio ==0.0.3.0
+  - safeio ==0.0.4.0
   - SafeSemaphore ==0.10.1
   - sample-frame ==0.0.3
   - sample-frame-np ==0.0.4.1
@@ -1884,7 +1895,7 @@ default-package-overrides:
   - scotty ==0.11.0
   - scrape-changes ==0.1.0.5
   - scrypt ==0.5.0
-  - SDL ==0.6.5.1
+  - SDL ==0.6.6.0
   - sdl2 ==2.2.0
   - sdl2-gfx ==0.2
   - sdl2-image ==2.0.0
@@ -1893,8 +1904,8 @@ default-package-overrides:
   - search-algorithms ==0.2.0
   - securemem ==0.1.9
   - SegmentTree ==0.3
-  - selda ==0.1.10.1
-  - selda-postgresql ==0.1.6.0
+  - selda ==0.1.11.2
+  - selda-postgresql ==0.1.7.0
   - selda-sqlite ==0.1.6.0
   - semigroupoid-extras ==5
   - semigroupoids ==5.2.1
@@ -1910,36 +1921,36 @@ default-package-overrides:
   - servant-auth-cookie ==0.5.0.5
   - servant-blaze ==0.7.1
   - servant-cassava ==0.9
-  - servant-checked-exceptions ==0.4.0.0
+  - servant-checked-exceptions ==0.4.1.0
   - servant-client ==0.11
   - servant-docs ==0.11
   - servant-elm ==0.4.0.1
   - servant-foreign ==0.10.1
-  - servant-js ==0.9.3
+  - servant-js ==0.9.3.1
   - servant-JuicyPixels ==0.3.0.3
   - servant-lucid ==0.7.1
-  - servant-mock ==0.8.2
+  - servant-mock ==0.8.3
   - servant-purescript ==0.8.0.1
   - servant-ruby ==0.2.1.0
-  - servant-server ==0.11
-  - servant-static-th ==0.1.0.5
+  - servant-server ==0.11.0.1
+  - servant-static-th ==0.1.0.6
   - servant-subscriber ==0.6.0.0
-  - servant-swagger ==1.1.3.1
-  - servant-swagger-ui ==0.2.4.3.0.20
+  - servant-swagger ==1.1.4
+  - servant-swagger-ui ==0.2.4.3.4.0
   - servant-yaml ==0.1.0.0
   - serversession ==1.0.1
   - serversession-frontend-wai ==1.0
   - serversession-frontend-yesod ==1.0
-  - servius ==1.2.0.2
+  - servius ==1.2.0.3
   - set-cover ==0.0.8
-  - set-monad ==0.2.0.0
   - setenv ==0.1.1.3
   - setlocale ==1.0.0.5
+  - set-monad ==0.2.0.0
   - sets ==0.0.5.2
   - SHA ==1.6.4.2
   - shake ==0.15.11
   - shake-language-c ==0.10.1
-  - shakespeare ==2.0.14
+  - shakespeare ==2.0.14.1
   - shell-conduit ==4.6.1
   - shelly ==1.6.8.3
   - shikensu ==0.3.7
@@ -1953,7 +1964,7 @@ default-package-overrides:
   - simple-download ==0.0.2
   - simple-log ==0.9.3
   - simple-reflect ==0.3.2
-  - simple-sendfile ==0.2.25
+  - simple-sendfile ==0.2.26
   - simple-session ==0.10.1.1
   - simple-templates ==0.8.0.1
   - singleton-bool ==0.1.2.0
@@ -1970,8 +1981,8 @@ default-package-overrides:
   - smoothie ==0.4.2.7
   - smtp-mail ==0.1.4.6
   - snap-blaze ==0.2.1.5
-  - snap-core ==1.0.3.0
-  - snap-server ==1.0.3.0
+  - snap-core ==1.0.3.1
+  - snap-server ==1.0.3.3
   - snowflake ==0.1.1.1
   - snowtify ==0.1.0.3
   - soap ==0.2.3.5
@@ -1979,7 +1990,7 @@ default-package-overrides:
   - soap-tls ==0.1.1.2
   - socket ==0.8.0.1
   - socket-activation ==0.1.0.2
-  - socks ==0.5.5
+  - socks ==0.5.6
   - solga ==0.1.0.2
   - solga-swagger ==0.1.0.2
   - sort ==1.0.0.0
@@ -1989,16 +2000,17 @@ default-package-overrides:
   - sox ==0.2.2.7
   - soxlib ==0.0.3
   - sparkle ==0.5.0.1
-  - sparse-linear-algebra ==0.2.9.7
+  - sparse-linear-algebra ==0.2.9.8
   - spdx ==0.2.2.0
+  - special-values ==0.1.0.0
   - speculation ==1.5.0.3
   - speedy-slice ==0.3.0
   - sphinx ==0.6.0.2
   - Spintax ==0.3.2
   - splice ==0.6.1.1
   - split ==0.2.3.2
-  - split-record ==0.1.1.3
   - splitmix ==0
+  - split-record ==0.1.1.3
   - Spock ==0.12.0.0
   - Spock-api ==0.12.0.0
   - Spock-api-server ==0.12.0.0
@@ -2006,17 +2018,17 @@ default-package-overrides:
   - Spock-lucid ==0.4.0.1
   - Spock-worker ==0.3.1.0
   - spool ==0.1
-  - spreadsheet ==0.1.3.5
-  - sql-words ==0.1.5.1
+  - spreadsheet ==0.1.3.7
   - sqlite-simple ==0.4.14.0
   - sqlite-simple-errors ==0.6.0.0
+  - sql-words ==0.1.5.1
   - srcloc ==0.5.1.1
   - stache ==0.2.2
+  - stackage-curator ==0.14.5
+  - stackage-query ==0.1.2
+  - stackage-types ==1.2.0
   - stack-run-auto ==0.1.1.4
   - stack-type ==0.1.0.0
-  - stackage-curator ==0.14.5
-  - stackage-query ==0.1.1
-  - stackage-types ==1.2.0
   - stateref ==0.3
   - statestack ==0.2.0.5
   - StateVar ==1.1.0.4
@@ -2029,16 +2041,16 @@ default-package-overrides:
   - stm-conduit ==3.0.0
   - stm-containers ==0.2.16
   - stm-delay ==0.1.1.1
-  - stm-extras ==0.1.0.2
+  - stm-extras ==0.1.0.3
+  - STMonadTrans ==0.4.3
   - stm-split ==0.0.2
   - stm-stats ==0.2.0.0
   - stm-supply ==0.2.0.0
-  - STMonadTrans ==0.4.3
   - stopwatch ==0.1.0.4
   - storable-complex ==0.2.2
   - storable-endian ==0.2.6
   - storable-record ==0.0.3.1
-  - storable-tuple ==0.0.3.2
+  - storable-tuple ==0.0.3.3
   - storablevector ==0.2.12.1
   - storablevector-carray ==0.0
   - store ==0.4.3.2
@@ -2055,13 +2067,13 @@ default-package-overrides:
   - streams ==3.3
   - strict ==0.3.2
   - strict-base-types ==0.5.0
+  - stringable ==0.1.3
+  - stringbuilder ==0.5.0
   - string-class ==0.1.6.5
   - string-combinators ==0.6.0.5
   - string-conv ==0.1.2
   - string-conversions ==0.4.0.1
   - string-qq ==0.0.2
-  - stringable ==0.1.3
-  - stringbuilder ==0.5.0
   - stringsearch ==0.3.6.6
   - strive ==3.0.4
   - stylish-haskell ==0.8.1.0
@@ -2070,14 +2082,14 @@ default-package-overrides:
   - superbuffer ==0.3.1.1
   - superrecord ==0.3.0.0
   - svg-builder ==0.1.0.2
-  - svg-tree ==0.6.2
-  - SVGFonts ==1.6.0.2
+  - SVGFonts ==1.6.0.3
+  - svg-tree ==0.6.2.1
   - swagger ==0.3.0
-  - swagger2 ==2.1.4.1
+  - swagger2 ==2.1.6
   - syb ==0.7
   - symbol ==0.2.4
   - symengine ==0.1.2.0
-  - synthesizer-core ==0.8.1.1
+  - synthesizer-core ==0.8.1.2
   - synthesizer-dimensional ==0.8.0.2
   - synthesizer-midi ==0.6.0.4
   - sysinfo ==0.1.1
@@ -2091,32 +2103,32 @@ default-package-overrides:
   - tagged-binary ==0.2.0.1
   - tagged-identity ==0.1.2
   - tagshare ==0.0
-  - tagsoup ==0.14.1
+  - tagsoup ==0.14.2
   - tagstream-conduit ==0.5.5.3
   - tar ==0.5.0.3
   - tar-conduit ==0.1.1
   - tardis ==0.4.1.0
-  - tasty ==0.11.2.5
-  - tasty-ant-xml ==1.1.0
+  - tasty ==0.11.3
+  - tasty-ant-xml ==1.1.1
   - tasty-auto ==0.2.0.0
   - tasty-dejafu ==0.6.0.0
   - tasty-discover ==3.0.2
   - tasty-expected-failure ==0.11.0.4
-  - tasty-fail-fast ==0.0.2
-  - tasty-golden ==2.3.1.1
+  - tasty-fail-fast ==0.0.3
+  - tasty-golden ==2.3.1.2
   - tasty-hspec ==1.1.3.2
   - tasty-html ==0.4.1.1
   - tasty-hunit ==0.9.2
   - tasty-kat ==0.0.3
   - tasty-program ==1.0.5
   - tasty-quickcheck ==0.8.4
-  - tasty-rerun ==1.1.7
+  - tasty-rerun ==1.1.8
   - tasty-silver ==3.1.10
   - tasty-smallcheck ==0.8.1
   - tasty-stats ==0.2.0.3
   - tasty-tap ==0.0.4
   - tasty-th ==0.1.7
-  - Taxonomy ==1.0.3
+  - Taxonomy ==1.0.2
   - TCache ==0.12.1
   - tce-conf ==1.3
   - tcp-streams ==0.6.0.0
@@ -2137,14 +2149,14 @@ default-package-overrides:
   - terminal-progress-bar ==0.1.1.1
   - terminal-size ==0.3.2.1
   - terminfo ==0.4.1.0
-  - test-fixture ==0.5.0.2
+  - test-fixture ==0.5.1.0
   - test-framework ==0.8.1.1
   - test-framework-hunit ==0.3.0.2
   - test-framework-quickcheck2 ==0.3.0.4
   - test-framework-smallcheck ==0.2
   - test-framework-th ==0.2.4
   - testing-feat ==0.4.0.3
-  - texmath ==0.9.4.1
+  - texmath ==0.9.4.4
   - text ==1.2.2.2
   - text-all ==0.4.1.1
   - text-binary ==0.2.1.1
@@ -2153,7 +2165,8 @@ default-package-overrides:
   - text-generic-pretty ==1.2.1
   - text-icu ==0.7.0.1
   - text-latin1 ==0.3
-  - text-ldap ==0.1.1.8
+  - text-ldap ==0.1.1.10
+  - textlocal ==0.1.0.5
   - text-manipulate ==0.2.0.1
   - text-metrics ==0.3.0
   - text-postgresql ==0.0.2.3
@@ -2161,40 +2174,39 @@ default-package-overrides:
   - text-region ==0.3.0.0
   - text-show ==3.6
   - text-show-instances ==3.6
-  - text-zipper ==0.10
-  - textlocal ==0.1.0.5
-  - tf-random ==0.5
+  - text-zipper ==0.10.1
   - tfp ==1.0.0.2
-  - th-abstraction ==0.2.5.0
+  - tf-random ==0.5
+  - th-abstraction ==0.2.6.0
   - th-data-compat ==0.0.2.4
   - th-desugar ==1.6
-  - th-expand-syns ==0.4.3.0
+  - these ==0.7.3
+  - th-expand-syns ==0.4.4.0
   - th-extras ==0.0.0.4
   - th-lift ==0.7.7
   - th-lift-instances ==0.1.11
   - th-orphans ==0.13.4
-  - th-reify-compat ==0.0.1.2
-  - th-reify-many ==0.1.8
-  - th-to-exp ==0.0.1.1
-  - th-utilities ==0.2.0.1
-  - these ==0.7.3
   - thread-local-storage ==0.1.1
   - threads ==0.5.1.5
   - threepenny-editors ==0.4.1
-  - threepenny-gui ==0.8.1.0
+  - threepenny-gui ==0.8.2.0
   - threepenny-gui-flexbox ==0.4.2
+  - th-reify-compat ==0.0.1.3
+  - th-reify-many ==0.1.8
   - through-text ==0.1.0.0
-  - throwable-exceptions ==0.1.0.8
+  - throwable-exceptions ==0.1.0.9
+  - th-to-exp ==0.0.1.1
   - thumbnail-plus ==1.0.5
+  - th-utilities ==0.2.0.1
   - thyme ==0.3.5.5
-  - tidal ==0.9.4
+  - tidal ==0.9.5
   - time-compat ==0.1.0.3
-  - time-lens ==0.4.0.1
-  - time-locale-compat ==0.1.1.3
-  - time-parsers ==0.1.2.0
   - timeit ==1.0.0.0
   - timelens ==0.2.0.2
-  - timemap ==0.0.4
+  - time-lens ==0.4.0.1
+  - time-locale-compat ==0.1.1.3
+  - timemap ==0.0.6
+  - time-parsers ==0.1.2.0
   - timerep ==2.0.0.2
   - timespan ==0.3.0.0
   - timezone-olson ==0.1.8
@@ -2202,11 +2214,11 @@ default-package-overrides:
   - tinylog ==0.14.0
   - tinytemplate ==0.1.2.0
   - titlecase ==1.0.1
-  - tldr ==0.2.2
+  - tldr ==0.2.3
   - tls ==1.3.11
   - tls-debug ==0.4.4
-  - tls-session-manager ==0.0.0.1
-  - tmp-postgres ==0.1.0.8
+  - tls-session-manager ==0.0.0.2
+  - tmp-postgres ==0.1.1.1
   - token-bucket ==0.1.0.1
   - torrent ==10000.1.1
   - tostring ==0.2.1.1
@@ -2226,36 +2238,36 @@ default-package-overrides:
   - ttrie ==0.1.2.1
   - tttool ==1.7.0.3
   - tuple ==0.3.0.2
-  - tuple-th ==0.2.5
   - tuples-homogenous-h98 ==0.1.1.0
+  - tuple-th ==0.2.5
   - turtle ==1.3.6
   - turtle-options ==0.1.0.4
-  - twitter-conduit ==0.2.2.2
+  - twitter-conduit ==0.2.3
   - twitter-feed ==0.2.0.11
   - twitter-types ==0.7.2.2
   - twitter-types-lens ==0.7.2
   - type-aligned ==0.9.6
   - type-assertions ==0.1.0.0
   - type-combinators ==0.2.4.3
+  - TypeCompose ==0.9.12
+  - typed-process ==0.1.1
   - type-fun ==0.1.1
   - type-hint ==0.1
   - type-level-integers ==0.0.1
   - type-level-kv-list ==1.1.0
   - type-level-numbers ==0.1.1.1
   - type-list ==0.5.0.0
+  - typelits-witnesses ==0.2.3.0
   - type-operators ==0.1.0.4
   - type-spec ==0.3.0.1
-  - TypeCompose ==0.9.12
-  - typed-process ==0.1.0.1
-  - typelits-witnesses ==0.2.3.0
   - typography-geometry ==1.0.0.1
   - tz ==0.1.3.0
   - tzdata ==0.1.20170320.0
-  - ua-parser ==0.7.4
+  - ua-parser ==0.7.4.1
   - uglymemo ==0.1.0.1
   - unbound ==0.5.1
-  - unbound-generics ==0.3.1
   - unbounded-delays ==0.1.1.0
+  - unbound-generics ==0.3.1
   - uncertain ==0.3.1.0
   - unexceptionalio ==0.3.0
   - unfoldable ==0.9.4
@@ -2268,12 +2280,12 @@ default-package-overrides:
   - union-find ==0.2
   - uniplate ==1.6.12
   - uniq-deep ==1.1.0.0
-  - Unique ==0.4.6.1
   - unique ==0
+  - Unique ==0.4.7.1
   - unit-constraint ==0.0.0
-  - units ==2.4
+  - units ==2.4.1
   - units-defs ==2.0.1.1
-  - units-parser ==0.1.0.1
+  - units-parser ==0.1.1.2
   - universe ==1.0
   - universe-base ==1.0.2.1
   - universe-instances-base ==1.0
@@ -2283,13 +2295,13 @@ default-package-overrides:
   - unix-bytestring ==0.3.7.3
   - unix-compat ==0.4.3.1
   - unix-time ==0.3.7
-  - unliftio ==0.1.0.0
+  - unliftio ==0.1.1.0
   - unliftio-core ==0.1.0.0
   - unlit ==0.4.0.0
   - unordered-containers ==0.2.8.0
   - unsafe ==0.0
   - uri-bytestring ==0.2.3.3
-  - uri-bytestring-aeson ==0.1.0.2
+  - uri-bytestring-aeson ==0.1.0.4
   - uri-encode ==1.5.0.5
   - uri-templater ==0.2.2.0
   - url ==2.1.3
@@ -2300,13 +2312,13 @@ default-package-overrides:
   - utf8-light ==0.4.2
   - utf8-string ==1.0.1.1
   - utility-ht ==0.0.14
-  - uu-interleaved ==0.2.0.0
-  - uu-parsinglib ==2.9.1.1
   - uuid ==1.3.13
   - uuid-types ==1.0.3
+  - uu-interleaved ==0.2.0.0
+  - uu-parsinglib ==2.9.1.1
   - vado ==0.0.9
   - validate-input ==0.4.0.0
-  - validation ==0.5.4
+  - validation ==0.5.5
   - validationt ==0.2.0.0
   - varying ==0.7.0.3
   - vault ==0.3.0.7
@@ -2321,12 +2333,12 @@ default-package-overrides:
   - vector-space ==0.10.4
   - vector-split ==1.0.0.2
   - vector-th-unbox ==0.2.1.6
-  - vectortiles ==1.2.0.5
+  - vectortiles ==1.2.0.6
   - verbosity ==0.2.3.0
   - versions ==3.1.1
   - vhd ==0.2.2
-  - ViennaRNAParser ==1.3.2
-  - viewprof ==0.0.0.8
+  - ViennaRNAParser ==1.3.3
+  - viewprof ==0.0.0.12
   - vinyl ==0.5.3
   - vinyl-utils ==0.3.0.0
   - void ==0.7.2
@@ -2335,11 +2347,11 @@ default-package-overrides:
   - wai-app-static ==3.1.6.1
   - wai-cli ==0.1.1
   - wai-conduit ==3.0.0.3
-  - wai-cors ==0.2.5
+  - wai-cors ==0.2.6
   - wai-eventsource ==3.0.0
-  - wai-extra ==3.0.20.0
-  - wai-handler-launch ==3.0.2.2
-  - wai-logger ==2.3.0
+  - wai-extra ==3.0.21.0
+  - wai-handler-launch ==3.0.2.3
+  - wai-logger ==2.3.1
   - wai-middleware-auth ==0.1.2.1
   - wai-middleware-caching ==0.1.0.2
   - wai-middleware-caching-lru ==0.1.0.0
@@ -2348,24 +2360,30 @@ default-package-overrides:
   - wai-middleware-content-type ==0.5.1
   - wai-middleware-crowd ==0.1.4.2
   - wai-middleware-metrics ==0.2.4
+  - wai-middleware-prometheus ==0.2.0
   - wai-middleware-rollbar ==0.4.0
   - wai-middleware-static ==0.8.1
-  - wai-middleware-throttle ==0.2.1.0
+  - wai-middleware-throttle ==0.2.2.0
   - wai-middleware-verbs ==0.3.2
   - wai-predicates ==0.9.0
   - wai-route ==0.3.1.1
   - wai-routes ==0.10.0
   - wai-routing ==0.13.0
   - wai-session ==0.3.2
-  - wai-session-postgresql ==0.2.1.0
+  - wai-session-postgresql ==0.2.1.2
   - wai-slack-middleware ==0.2.0
+  - waitra ==0.0.4.0
   - wai-transformers ==0.0.7
   - wai-websockets ==3.0.1.1
-  - waitra ==0.0.4.0
   - warp ==3.2.13
   - warp-tls ==3.2.4
   - wave ==0.1.5
   - wavefront-obj ==0.1.0.1
+  - webdriver ==0.8.5
+  - webdriver-angular ==0.1.11
+  - webkitgtk3 ==0.14.2.1
+  - webkitgtk3-javascriptcore ==0.14.2.1
+  - webpage ==0.0.5
   - web-plugins ==0.2.9
   - web-routes ==0.27.12
   - web-routes-boomerang ==0.28.4.2
@@ -2373,18 +2391,12 @@ default-package-overrides:
   - web-routes-hsp ==0.24.6.1
   - web-routes-th ==0.22.6.2
   - web-routes-wai ==0.24.3
-  - webdriver ==0.8.5
-  - webdriver-angular ==0.1.11
-  - webkitgtk3 ==0.14.2.1
-  - webkitgtk3-javascriptcore ==0.14.2.1
-  - webpage ==0.0.5
   - webrtc-vad ==0.1.0.3
   - websockets ==0.10.0.0
   - websockets-rpc ==0.4.0
   - websockets-simple ==0.0.2
-  - websockets-snap ==0.10.2.3
-  - weeder ==0.1.7
-  - weigh ==0.0.5
+  - websockets-snap ==0.10.2.4
+  - weigh ==0.0.7
   - wikicfp-scraper ==0.1.0.9
   - wild-bind ==0.1.0.3
   - wild-bind-indicator ==0.1.0.1
@@ -2392,11 +2404,11 @@ default-package-overrides:
   - wild-bind-x11 ==0.1.0.7
   - Win32 ==2.3.1.1
   - Win32-extras ==0.2.0.1
-  - Win32-notify ==0.3.0.1
+  - Win32-notify ==0.3.0.3
   - wire-streams ==0.1.1.0
-  - with-location ==0.1.0
   - withdependencies ==0.2.4.1
   - witherable ==0.1.3.4
+  - with-location ==0.1.0
   - witness ==0.4
   - wizards ==1.0.2
   - wl-pprint ==1.2
@@ -2405,9 +2417,9 @@ default-package-overrides:
   - wl-pprint-extras ==3.5.0.5
   - wl-pprint-terminfo ==3.7.1.4
   - wl-pprint-text ==1.1.1.0
-  - word-trie ==0.3.0
   - word24 ==2.0.1
   - word8 ==0.1.3
+  - word-trie ==0.3.0
   - Workflow ==0.8.3
   - wrap ==0.0.0
   - wreq ==0.5.0.1
@@ -2416,7 +2428,7 @@ default-package-overrides:
   - writer-cps-morph ==0.1.0.2
   - writer-cps-mtl ==0.1.1.4
   - writer-cps-transformers ==0.1.1.3
-  - wuss ==1.1.5
+  - wuss ==1.1.6
   - X11 ==1.8
   - X11-xft ==0.3.1
   - x11-xim ==0.0.9.0
@@ -2435,9 +2447,10 @@ default-package-overrides:
   - xml ==1.3.14
   - xml-basic ==0.1.2
   - xml-conduit ==1.5.1
-  - xml-conduit-parse ==0.3.1.1
-  - xml-conduit-writer ==0.1.1.1
-  - xml-hamlet ==0.4.1
+  - xml-conduit-parse ==0.3.1.2
+  - xml-conduit-writer ==0.1.1.2
+  - xmlgen ==0.6.2.1
+  - xml-hamlet ==0.4.1.1
   - xml-html-qq ==0.1.0.1
   - xml-indexed-cursor ==0.1.1.0
   - xml-lens ==0.1.6.3
@@ -2445,45 +2458,44 @@ default-package-overrides:
   - xml-to-json ==2.0.1
   - xml-to-json-fast ==2.0.0
   - xml-types ==0.3.6
-  - xmlgen ==0.6.2.1
   - xmonad ==0.13
   - xmonad-contrib ==0.13
-  - xmonad-extras ==0.13.0
+  - xmonad-extras ==0.13.2
   - xss-sanitize ==0.3.5.7
   - xturtle ==0.2.0.0
   - yackage ==0.8.1
-  - yahoo-finance-api ==0.2.0.2
-  - yaml ==0.8.23.3
-  - Yampa ==0.10.6.2
+  - yahoo-finance-api ==0.2.0.3
+  - yaml ==0.8.25
+  - Yampa ==0.10.7
   - YampaSynth ==0.2
-  - yes-precure5-command ==5.5.3
   - yesod ==1.4.5
-  - yesod-auth ==1.4.18
+  - yesod-auth ==1.4.21
   - yesod-auth-account ==1.4.3
   - yesod-auth-basic ==0.1.0.2
   - yesod-auth-fb ==1.8.1
   - yesod-auth-hashdb ==1.6.2
-  - yesod-bin ==1.5.2.5
-  - yesod-core ==1.4.36
+  - yesod-bin ==1.5.2.6
+  - yesod-core ==1.4.37.2
   - yesod-default ==1.2.0
   - yesod-eventsource ==1.4.1
   - yesod-fb ==0.4.0
-  - yesod-form ==1.4.15
-  - yesod-form-bootstrap4 ==0.1.0.1
+  - yesod-form ==1.4.16
+  - yesod-form-bootstrap4 ==0.1.0.2
   - yesod-form-richtext ==0.1.0.2
   - yesod-gitrepo ==0.2.1.0
   - yesod-gitrev ==0.1.0.0
   - yesod-job-queue ==0.3.0.4
   - yesod-markdown ==0.11.4
   - yesod-newsfeed ==1.6
-  - yesod-persistent ==1.4.2
-  - yesod-recaptcha2 ==0.1.0.0
+  - yesod-persistent ==1.4.3
+  - yesod-recaptcha2 ==0.1.0.1
   - yesod-sitemap ==1.4.0.1
   - yesod-static ==1.5.3.1
   - yesod-static-angular ==0.1.8
   - yesod-table ==2.0.3
   - yesod-test ==1.5.8
   - yesod-websockets ==0.2.6
+  - yes-precure5-command ==5.5.3
   - yi-core ==0.14.1
   - yi-frontend-vty ==0.14.1
   - yi-fuzzy-open ==0.14.1
@@ -2499,7 +2511,7 @@ default-package-overrides:
   - yi-snippet ==0.14.1
   - yjsvg ==0.2.0.1
   - yjtools ==0.9.18
-  - yoga ==0.0.0.1
+  - yoga ==0.0.0.2
   - youtube ==0.2.1.1
   - zero ==0.1.4
   - zeromq4-haskell ==0.6.7
@@ -2519,6 +2531,7 @@ extra-packages:
   - aeson < 0.8                         # newer versions don't work with GHC 7.6.x or earlier
   - aeson < 1                           # required by liquidhaskell-0.8.0.0
   - aeson-pretty < 0.8                  # required by elm compiler
+  - ansi-terminal >=0.7.1.1 && <0.8     # required by stack-1.6.5
   - apply-refact < 0.4                  # newer versions don't work with GHC 8.0.x
   - base-orphans < 0.6                  # required by liquidhaskell-0.8.0.0
   - binary > 0.7 && < 0.8               # keep a 7.x major release around for older compilers
@@ -2536,6 +2549,7 @@ extra-packages:
   - haddock-api == 2.16.*               # required on GHC 7.10.x
   - haddock-library == 1.2.*            # required for haddock-api-2.16.x
   - happy <1.19.6                       # newer versions break Agda
+  - hashtables == 1.2.1.1               # required on GHC 7.6.x
   - haskell-gi-overloading == 0.0       # gi-* packages use this dependency to disable overloading support
   - haskell-src-exts == 1.18.*          # required by hoogle-5.0.4
   - mtl < 2.2                           # newer versions require transformers > 0.4.x, which we cannot provide in GHC 7.8.x
@@ -2655,6 +2669,7 @@ dont-distribute-packages:
 
   # these packages depend on software with an unfree license
   accelerate-bignum:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  accelerate-blas:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-cublas:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-cuda:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-cufft:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2677,6 +2692,7 @@ dont-distribute-packages:
   yices-painless:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
 
   # these packages don't evaluate because they have broken dependencies
+  comark:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   diagrams-reflex:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   dialog:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   fltkhs-demos:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2713,10 +2729,11 @@ dont-distribute-packages:
   spike:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   tianbar:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   trasa-reflex:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  wai-middleware-brotli:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   web-browser-in-haskell:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  webkitgtk3:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  webkitgtk3-javascriptcore:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   webkit:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  webkitgtk3-javascriptcore:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  webkitgtk3:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   websnap:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
 
   # soft restrictions because of build errors
@@ -2733,31 +2750,34 @@ dont-distribute-packages:
   abstract-par-accelerate:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   abt:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   AC-BuildPlatform:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AC-EasyRaster-GTK:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AC-HalfInteger:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ac-machine-conduit:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ac-machine:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AC-MiniTest:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AC-Terminal:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AC-VanillaArray:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-arithmetic:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-fftw:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-fourier:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  accelerate-llvm:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-llvm-native:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  accelerate-llvm:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-random:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-typelits:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   accelerate-utility:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   accentuateus:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   access-time:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AC-EasyRaster-GTK:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AC-HalfInteger:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   acid-state-dist:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   acid-state-tls:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ac-machine-conduit:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ac-machine:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-all-monad:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-comonad:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-flipping-tables:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-hq9plus:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ACME:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-inator:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-io:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-left-pad:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-miscorder:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  acme-mutable-package:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-now:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-numbersystem:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-operators:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2766,46 +2786,54 @@ dont-distribute-packages:
   acme-strfry:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-stringly-typed:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   acme-zero:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AC-MiniTest:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AC-Terminal:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ACME:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ActionKid:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   activehs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   activitystreams-aeson:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   actor:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AC-VanillaArray:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   Adaptive-Blaisorblade:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   adaptive-containers:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Adaptive:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   adaptive-tuple:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Adaptive:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   adb:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   adblock2privoxy:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   adhoc-network:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   adict:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   adobe-swatch-exchange:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  adp-multi:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   adp-multi-monadiccp:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  adp-multi:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ADPfusionForest:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   Advgame:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   AERN-Basics:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   AERN-Net:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   AERN-Real-Double:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AERN-Real:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   AERN-Real-Interval:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AERN-RnToRm:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AERN-Real:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   AERN-RnToRm-Plot:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AERN-RnToRm:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aern2-mp:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aern2-real:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-applicative:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-bson:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AesonBson:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aeson-diff:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-flowtyped:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-native:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aeson-options:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aeson-picker:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-quick:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-schema:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-smart:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-streams:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-t:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aeson-tiled:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aeson-typescript:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aeson-value-parser:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   aeson-yak:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AesonBson:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   affection:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   affine-invariant-ensemble-mcmc:               [ i686-linux, x86_64-linux, x86_64-darwin ]
   afv:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ag-pictgen:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Agata:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Agda-executable:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   agda-server:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2815,29 +2843,30 @@ dont-distribute-packages:
   AGI:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   AhoCorasick:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   aip:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  airbrake:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   air-th:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  airbrake:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   aivika-distributed:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   ajhc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  al:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   AlanDeniseEricLauren:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   alga:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  algebra-sql:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   algebraic-classes:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   algebraic:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  algebra-sql:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AlgorithmW:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   algo-s:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  al:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  AlignmentAlgorithms:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AlgorithmW:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   align-text:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  AlignmentAlgorithms:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Allure:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   alms:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  alphachar:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   alpha:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  alphachar:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   alpino-tools:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   alsa-gui:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  alsa:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   alsa-midi:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   alsa-pcm-tests:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   alsa-seq-tests:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  alsa:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   alternative-io:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   altfloat:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   alure:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2845,19 +2874,43 @@ dont-distribute-packages:
   amazon-emailer-client-snap:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   amazon-emailer:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   amazon-products:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-athena:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-batch:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-clouddirectory:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-cloudhsmv2:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-codestar:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-cur:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-dynamodb-dax:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-glue:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-greengrass:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-lex-models:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-lex-runtime:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-marketplace-entitlement:             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-mechanicalturk:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-migrationhub:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-mobile:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-organizations:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-pricing:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-resourcegroupstagging:               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-waf-regional:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amazonka-workdocs:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   amby:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   AMI:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   ampersand:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   amqp-conduit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  amqp-utils:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   analyze-client:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   anansi-pandoc:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   anatomy:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  android:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  android-activity:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   android-lint-summary:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  android:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   AndroidViewHierarchyImporter:                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   angel:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   angle:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Animas:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  animate-example:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  animate:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   annah:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Annotations:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   anonymous-sums-tests:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2870,39 +2923,40 @@ dont-distribute-packages:
   anydbm:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   aosd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   apelsin:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  api-builder:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  api-tools:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-authenticate:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-clientsession:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-cookie:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-eventsource:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-helics:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-http-client:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  apiary:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-logger:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-memcached:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-mongoDB:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-persistent:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-purescript:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  apiary-redis:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-session:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   apiary-websockets:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  api-builder:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  apiary:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   apis:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  api-tools:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   apotiki:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  appc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   app-lens:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  appc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ApplePush:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   AppleScript:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   applicative-fail:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   applicative-parsec:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   applicative-splice:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ApproxFun-hs:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   approx-rand-test:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  arbb-vm:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ApproxFun-hs:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   arb-fft:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  arbb-vm:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   arbtt:                                        [ "x86_64-darwin" ]
   archiver:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  archlinux:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   archlinux-web:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  archlinux:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   arff:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   arghwxhaskell:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   argon2:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2913,21 +2967,21 @@ dont-distribute-packages:
   arion:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   arith-encode:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   armada:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  arpack:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   arpa:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  arpack:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   array-forth:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   array-primops:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ArrayRef:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  arrowapply-utils:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   arrow-improve:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  arrowp:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  arrowapply-utils:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   arrowp-qq:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  arrowp:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ArrowVHDL:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   artery:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ascii85-conduit:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   ascii-flatten:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ascii:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   ascii-vector-avc:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ascii85-conduit:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ascii:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   asic:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   asil:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   asn1-codec:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2935,17 +2989,23 @@ dont-distribute-packages:
   assimp:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   astrds:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   astview:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  async-combinators:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   async-dejafu:                                 [ "x86_64-darwin" ]
-  asynchronous-exceptions:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   async-manager:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  asynchronous-exceptions:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   aterm-utils:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   atlassian-connect-core:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   atlassian-connect-descriptor:                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   atndapi:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  atom-conduit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  atom-msp430:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   atomic-primops-foreign:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   atomic-primops-vector:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  atom-msp430:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   atomo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ats-format:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ats-pkg:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ats-setup:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ats-storable:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   attic-schedule:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   AttoBencode:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   AttoJson:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2972,16 +3032,16 @@ dont-distribute-packages:
   avatar-generator:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   avers-api-docs:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   avers-api:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  avers:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   avers-server:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  avers:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   avl-static:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   AvlTree:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  avro:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   avr-shake:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  avro:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   awesome-prelude:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   awesomium-glut:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  awesomium:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   awesomium-raw:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  awesomium:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-configuration-tools:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-dynamodb-conduit:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-dynamodb-streams:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -2989,14 +3049,14 @@ dont-distribute-packages:
   aws-elastic-transcoder:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-general:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-kinesis-client:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  aws-kinesis:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-kinesis-reshard:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aws-kinesis:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-lambda:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-performance-tests:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-route53:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  aws-sdk:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-sdk-text-converter:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-sdk-xml-unordered:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  aws-sdk:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-sign4:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   aws-sns:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   axiom:                                        [ "x86_64-darwin" ]
@@ -3004,19 +3064,20 @@ dont-distribute-packages:
   azure-service-api:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   azure-servicebus:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   azurify:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  b-tree:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   babylon:                                      [ "x86_64-darwin" ]
   backdropper:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   backtracking-exceptions:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   backward-state:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Baggins:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   bag:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Baggins:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ballast:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  bamboo:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   bamboo-launcher:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   bamboo-plugin-highlight:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   bamboo-plugin-photo:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   bamboo-theme-blueprint:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   bamboo-theme-mini-html5:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bamboo:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   bamse:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Bang:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   banwords:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3027,26 +3088,29 @@ dont-distribute-packages:
   Barracuda:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   barrie:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   barrier-monad:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  base32-bytestring:                            [ "x86_64-darwin" ]
-  base64-conduit:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   base-generics:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   base-io-access:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  base32-bytestring:                            [ "x86_64-darwin" ]
+  base64-bytestring-type:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  base64-conduit:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   BASIC:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   baskell:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   batchd:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  battlenet:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   battlenet-yesod:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  battlenet:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   battleships:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   bayes-stack:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   BCMtools:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  beamable:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  beam:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bdcs:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   beam-th:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  beam:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  beamable:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   beautifHOL:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   bed-and-breakfast:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   beeminder-api:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   Befunge93:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   bein:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  belka:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   BenchmarkHistory:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   bencoding:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   berkeleydb:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3054,8 +3118,8 @@ dont-distribute-packages:
   BerlekampAlgorithm:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   berp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   besout:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  betacode:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   bet:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  betacode:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   bff:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   bgzf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   bibdb:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3071,12 +3135,15 @@ dont-distribute-packages:
   binary-derive:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   binary-file:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   binary-indexed-tree:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  binary-protocol:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   binary-protocol-zmq:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  binary-protocol:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   binary-streams:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  binary-tree:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bind-marshal:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   binding-gtk:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  bindings-apr:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  binding-wx:                                   [ "x86_64-darwin" ]
   bindings-apr-util:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bindings-apr:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   bindings-bfd:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   bindings-cctools:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   bindings-codec2:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3108,22 +3175,21 @@ dont-distribute-packages:
   bindings-sc3:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   bindings-sipc:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   bindings-wlc:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  binding-wx:                                   [ "x86_64-darwin" ]
-  bind-marshal:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   bindynamic:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   binembed-example:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   binembed:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bio:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Biobase:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  BiobaseBlast:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   BiobaseDotP:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   BiobaseFasta:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   BiobaseFR3D:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Biobase:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   BiobaseInfernal:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   BiobaseMAF:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   BiobaseTrainingData:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   BiobaseTurner:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   BiobaseVienna:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   biohazard:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  bio:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   bioinformatics-toolkit:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   biophd:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   biosff:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3131,15 +3197,15 @@ dont-distribute-packages:
   bird:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   BirdPP:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   bit-array:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bit-stream:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   bitcoin-rpc:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   bitly-cli:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Bitly:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   bitmaps:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   bits-conduit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  bitset:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   bits-extras:                                  [ "x86_64-darwin" ]
+  bitset:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   bitspeak:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  bit-stream:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   bitstream:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   bittorrent:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   bkr:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3147,6 +3213,8 @@ dont-distribute-packages:
   blakesum-demo:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   blakesum:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   blank-canvas:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  blas-carray:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  blas-ffi:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   blas-hs:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   blas:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   blatex:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3167,8 +3235,8 @@ dont-distribute-packages:
   blogination:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   bloomfilter-redis:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   bloxorz:                                      [ "x86_64-darwin" ]
-  blubber:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   blubber-server:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  blubber:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Blueprint:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   bluetile:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   bluetileutils:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3180,19 +3248,25 @@ dont-distribute-packages:
   bond-haskell-compiler:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   bond-haskell:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   bond:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  bookkeeper:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   bookkeeper-permissions:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bookkeeper:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Bookshelf:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   boolean-list:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   boolean-normal-forms:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   boomslang:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   borel:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   bot:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bowntz:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   braid:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   brainheck:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Bravo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   breakout:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   brians-brain:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  brick-skylighting:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bricks-parsec:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bricks-rendering:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bricks-syntax:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bricks:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   brillig:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   brittany:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   broccoli:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3201,7 +3275,6 @@ dont-distribute-packages:
   bson-generic:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   bson-generics:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   btree-concurrent:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  b-tree:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   btree:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   btrfs:                                        [ "x86_64-darwin" ]
   buchhaltung:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3215,59 +3288,68 @@ dont-distribute-packages:
   burnt-explorer:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   burst-detection:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   buster-gtk:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  buster-network:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   buster:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Buster:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  buster-network:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   bustle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   butcher:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   butterflies:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   bytable:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bytearray-parsing:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   bytestring-class:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   bytestring-csv:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  bytestringparser:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bytestring-encodings:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   bytestring-read:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  bytestringreadp:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   bytestring-rematch:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   bytestring-typenats:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bytestringparser:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  bytestringreadp:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  c-dsl:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  c-io:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  c-mosquitto:                                  [ "x86_64-darwin" ]
   c2hsc:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabal2arch:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabal2doap:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabal2ghci:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabal2spec:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-audit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabal-bounds:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabal-cargs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-constraints:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-db:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-dev:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-ghc-dynflags:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-ghci:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-graphdeps:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabalgraph:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Cabal-ide-backend:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-install-bundle:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-install-ghc72:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-install-ghc74:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabalish:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabalmdvrpm:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabal-lenses:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-mon:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-nirvana:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-plan:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-progdeps:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-query:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabalQuery:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cabalrpmdeps:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  CabalSearch:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-setup:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-sort:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-test:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabal-upload:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabal2arch:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabal2doap:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabal2ghci:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabal2spec:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabalgraph:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabalish:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabalmdvrpm:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabalQuery:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cabalrpmdeps:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  CabalSearch:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabalvchk:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   cabocha:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cacophony:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   caffegraph:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   cake3:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   cakyrespa:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   cal3d-examples:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cal3d:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   cal3d-opengl:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cal3d:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   calc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   calculator:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   caldims:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3275,41 +3357,45 @@ dont-distribute-packages:
   call:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   camfort:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   campfire:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  canon:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   canonical-filepath:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   canteven-listen-http:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   canteven-parsedate:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   cantor:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   cao:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Capabilities:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   cap:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Capabilities:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  capataz:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   capri:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  car-pool:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   caramia:                                      [ "x86_64-darwin" ]
   carboncopy:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  car-pool:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   carte:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Cartesian:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   casadi-bindings-control:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   casadi-bindings-core:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  casadi-bindings:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   casadi-bindings-internal:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   casadi-bindings-ipopt-interface:              [ i686-linux, x86_64-linux, x86_64-darwin ]
   casadi-bindings-snopt-interface:              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  casadi-bindings:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   Cascade:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   cascading:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   cash:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   casr-logbook-html:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  casr-logbook:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   casr-logbook-meta-html:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   casr-logbook-meta:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   casr-logbook-reports-html:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  casr-logbook-reports:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   casr-logbook-reports-meta-html:               [ i686-linux, x86_64-linux, x86_64-darwin ]
   casr-logbook-reports-meta:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  casr-logbook-reports:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   casr-logbook-types:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  casr-logbook:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   cassandra-cql:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   cassandra-thrift:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   cassava-megaparsec:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cassava-records:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   cassava-streams:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Cassava:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   cassy:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   castle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   casui:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3319,20 +3405,20 @@ dont-distribute-packages:
   categorical-algebra:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   category-extras:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   category-traced:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  category:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   catnplus:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   cayley-client:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   cblrepo:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   CBOR:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  CCA:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   CC-delcont-alt:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   CC-delcont-cxe:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   CC-delcont-exc:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  CC-delcont-ref:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   CC-delcont-ref-tf:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  CC-delcont-ref:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  CCA:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   cci:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   ccnx:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   cctools-workqueue:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  c-dsl:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   cedict:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   cef3-raw:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   cef3-simple:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3350,13 +3436,14 @@ dont-distribute-packages:
   cfipu:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   cflp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   cfopu:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cgen:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   cg:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cgen:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   cgi-utils:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   cgrep:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  chalkboard:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   chalkboard-viewer:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  chalkboard:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   charade:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Chart-gtk:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   chart-histogram:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   Chart-simple:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   chart-unit:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3364,9 +3451,10 @@ dont-distribute-packages:
   chatty-text:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   chatwork:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   cheapskate-terminal:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  check-pvp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   checked:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Checked:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  check-pvp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  checkmate:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   chell-hunit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   chell-quickcheck:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   chevalier-common:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3374,11 +3462,13 @@ dont-distribute-packages:
   Chitra:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   chorale-geo:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   chorale:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  chp:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   chp-mtl:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   chp-plus:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   chp-spec:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   chp-transformers:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  chp:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  chr-core:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  chr-lang:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ChristmasTree:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   chronograph:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   chronos:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3389,29 +3479,30 @@ dont-distribute-packages:
   cielo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   cil:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   cinvoke:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  c-io:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   cio:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   circlehs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   citation-resolve:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  citeproc-hs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   citeproc-hs-pandoc-filter:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  citeproc-hs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   cjk:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   clac:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   clafer:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   claferIG:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   claferwiki:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  clang-compilation-database:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   clang-pure:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   clanki:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   clarifai:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   CLASE:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  clash:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   clash-prelude-quickcheck:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Clash-Royale-Hack-Cheats:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  clash:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   ClassLaws:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   classy-parallel:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  classyplate:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   ClassyPrelude:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   clckwrks-cli:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   clckwrks-dot-com:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  clckwrks:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   clckwrks-plugin-bugs:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   clckwrks-plugin-ircbot:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   clckwrks-plugin-mailinglist:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3420,30 +3511,33 @@ dont-distribute-packages:
   clckwrks-theme-bootstrap:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   clckwrks-theme-clckwrks:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   clckwrks-theme-geo-bootstrap:                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  clckwrks:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   cld2:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Clean:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   clean-unions:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Clean:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   cless:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   clevercss:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  clexer:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   cli-builder:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  click-clack:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  clifford:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  clif:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   CLI:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  click-clack:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  clif:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  clifford:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   clingo:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   clippard:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   clipper:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   clippings:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  clist:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   clit:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   cloben:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   clocked:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   clogparse:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   clone-all:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   closure:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cloudfront-signer:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   cloud-haskell:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cloudi:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   cloud-seeder:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cloudfront-signer:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cloudi:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   cloudyfs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   clr-bindings:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   clr-inline:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3457,25 +3551,25 @@ dont-distribute-packages:
   cmath:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   cmathml3:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   CMCompare:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cmdargs-browser:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   cmd-item:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cmdargs-browser:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   cmdtheline:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   cmonad:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  c-mosquitto:                                  [ "x86_64-darwin" ]
   cmph:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   cmv:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   cnc-spec-compiler:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   cndict:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Coadjute:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  coalpit:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   codec-libevent:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  codecov-haskell:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   codec-rpm:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  codecov-haskell:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   codemonitor:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   codepad:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   codeworld-api:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   cognimeta-utils:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  coinbase-exchange:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   coin:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  coinbase-exchange:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   colada:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   colchis:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   collada-output:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3486,31 +3580,35 @@ dont-distribute-packages:
   collections:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   colonnade:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   color-counter:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  colorless-http-client:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  colorless-scotty:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  colorless:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  colour-accelerate:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   colour-space:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   coltrane:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   columbia:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  combinatorial-problems:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  com:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   combinator-interactive:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  combinatorial-problems:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Combinatorrent:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   combobuffer:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  com:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   commander:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Commando:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  commsec:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   commsec-keyexchange:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  commsec:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   commutative:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   comonad-extras:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   comonad-random:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   ComonadSheet:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  compact:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   compact-map:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   compact-mutable:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   compact-socket:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   compact-string:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  compact:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   compdata-automata:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   compdata-dags:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  compdata:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   compdata-param:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  compdata:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   competition:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   compilation:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   complexity:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3523,17 +3621,17 @@ dont-distribute-packages:
   comptrans:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   computational-algebra:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   concraft-hr:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  concraft:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   concraft-pl:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  concraft:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   concrete-haskell-autogen:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   concrete-haskell:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   concrete-typerep:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Concurrential:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   concurrent-state:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Concurrential:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ConcurrentUtils:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  condorcet:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   condor:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Condor:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  condorcet:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   conductive-hsc3:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   conduit-algorithms:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   conduit-audio-lame:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3541,22 +3639,28 @@ dont-distribute-packages:
   conduit-find:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   conduit-network-stream:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   conduit-resumablesink:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  conffmt:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  conduit-throttle:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  conduit-zstd:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   conf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  conffmt:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  config-ini:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  config-select:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ConfigFileTH:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   Configger:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   configifier:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  config-ini:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  config-select:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   Configurable:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   congruence-relation:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   conjure:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  conkin:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   conlogger:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  connection-string:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   Conscript:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   consistent:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   console-program:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   const-math-ghc-plugin:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  constaparser:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   constrained-monads:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  constraint:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   ConstraintKinds:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   constructive-algebra:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   consul-haskell:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3565,8 +3669,8 @@ dont-distribute-packages:
   container:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   containers-benchmark:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ContArrow:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ContextAlgebra:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   context-stack:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ContextAlgebra:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   continue:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   continuum-client:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   continuum:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3574,8 +3678,8 @@ dont-distribute-packages:
   control-event:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   control-monad-attempt:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   control-monad-exception-monadsfd:             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  control-monad-failure:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   control-monad-failure-mtl:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  control-monad-failure:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Control-Monad-MultiPass:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Control-Monad-ST2:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   contstuff-monads-tf:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3585,29 +3689,31 @@ dont-distribute-packages:
   convertible-ascii:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   convertible-text:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   copilot-cbmc:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  copilot:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   copilot-language:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   copilot-libraries:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   copilot-theorem:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  copilot:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   copr:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   COrdering:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  core-haskell:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  core:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   corebot-bliki:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   CoreDump:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   CoreErlang:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   CoreFoundation:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  core-haskell:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  core:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   coroutine-enumerator:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Coroutine:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   coroutine-iteratee:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Coroutine:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  couch-hs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  couch-simple:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   couchdb-conduit:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   couchdb-enumerator:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   CouchDB:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  couch-hs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  couch-simple:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   counter:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  courier:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   court:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   coverage:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cparsing:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   CPBrainfuck:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   cpio-conduit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   cplex-hs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3621,6 +3727,7 @@ dont-distribute-packages:
   cqrs-sqlite3:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   cqrs-test:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   cqrs-testkit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cr:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   crack:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Craft3e:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   craft:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3631,18 +3738,18 @@ dont-distribute-packages:
   craze:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   crc16:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   crc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  crdt:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   creatur:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  credentials-cli:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   credential-store:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  credentials-cli:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   crf-chain1-constrained:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   crf-chain1:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   crf-chain2-generic:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   crf-chain2-tiers:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cr:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   criterion-plus:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   criterion-to-html:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  criu-rpc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   criu-rpc-types:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  criu-rpc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   crjdt-haskell:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   crocodile:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   cron-compat:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3650,26 +3757,27 @@ dont-distribute-packages:
   crunghc:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   crypto-cipher-benchmarks:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   crypto-classical:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cryptoconditions:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   crypto-conduit:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   crypto-multihash:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   crypto-random-effect:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   crypto-simple:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cryptocompare:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cryptoconditions:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   cryptsy-api:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   crystalfontz:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   cse-ghc-plugin:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   csound-catalog:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   csound-expression-dynamic:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  csound-expression:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   csound-expression-opcodes:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   csound-expression-typed:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  csound-expression:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   csound-sampler:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  cspmchecker:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   CSPM-cspm:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   CSPM-FiringRules:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   CSPM-Frontend:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   CSPM-Interpreter:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   CSPM-ToProlog:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  cspmchecker:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   cspretty:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   css:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   ctemplate:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3679,67 +3787,66 @@ dont-distribute-packages:
   cudd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   currency-convert:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   curry-base:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  CurryDB:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   curry-frontend:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  curry:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  CurryDB:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   curryrs:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   curve25519:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   curves:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   custom-prelude:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   CV:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   cypher:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  d-bus:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   d3js:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  dag:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   DAG-Tournament:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dag:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   damnpacket:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Dangerous:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   dao:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Dao:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   dapi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  darcs2dot:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   darcs-benchmark:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   darcs-beta:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   darcs-buildpackage:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   darcs-cabalized:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  darcsden:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   darcs-fastconvert:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   darcs-graph:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  DarcsHelpers:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   darcs-monitor:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  darcs2dot:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  darcsden:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  DarcsHelpers:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   darcswatch:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   darkplaces-demo:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  darkplaces-rcon:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   darkplaces-rcon-util:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  darkplaces-rcon:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   dash-haskell:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-accessor-monadLib:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-accessor-monads-fd:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-accessor-monads-tf:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-base:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  database-study:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-concurrent-queue:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-construction:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-cycle:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-dispersal:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  datadog:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-easy:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-embed:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-filepath:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  data-fin:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-fin-simple:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  data-fin:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-flagset:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-interval:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-ivar:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-kiln:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-layer:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-lens-fd:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  data-lens:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-lens-ixset:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-lens-template:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  datalog:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  data-lens:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-map-multikey:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-nat:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  data-object:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-object-json:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-object-yaml:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  data-object:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-quotientref:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-repr:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-result:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3750,10 +3857,13 @@ dont-distribute-packages:
   data-spacepart:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-store:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-structure-inferrer:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  DataTreeView:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   data-type:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  datetime:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  database-study:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  datadog:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  datalog:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  DataTreeView:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   datetime-sb:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  datetime:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   dawdle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   dbcleaner:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   dbjava:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3762,10 +3872,9 @@ dont-distribute-packages:
   dbmigrations-postgresql:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   dbus-client:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   dbus-core:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  d-bus:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  DBus:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   dbus-qq:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   dbus-th-introspection:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  DBus:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   dclabel:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   dcpu16:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-base:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3773,17 +3882,17 @@ dont-distribute-packages:
   ddc-core-babel:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-core-eval:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-core-flow:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ddc-core:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-core-llvm:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-core-salt:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-core-simpl:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-core-tetra:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ddc-core:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-driver:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ddci-core:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-interface:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-source-tetra:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-tools:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   ddc-war:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ddci-core:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   dead-code-detection:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   dead-simple-json:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   debug-me:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3807,14 +3916,16 @@ dont-distribute-packages:
   definitive-sound:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   deiko-config:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   dejafu:                                       [ "x86_64-darwin" ]
-  deka:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   deka-tests:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  deka:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   delicious:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  delimiter-separated:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   delta-h:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  delta:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Delta-Lambda:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  delta:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   demarcate:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   denominate:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dependency:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   dependent-state:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   depends:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   dephd:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3824,8 +3935,8 @@ dont-distribute-packages:
   derive-enumerable:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   derive-gadt:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   derive-IG:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  derive-storable:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   derive-storable-plugin:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  derive-storable:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   derive-topdown:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   derive-trie:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   derp-lib:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3846,12 +3957,12 @@ dont-distribute-packages:
   diagrams-canvas:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   diagrams-contrib:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   diagrams-hsqml:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  diagrams:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   diagrams-pandoc:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   diagrams-pdf:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   diagrams-qrcode:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   diagrams-tikz:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   diagrams-wx:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  diagrams:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   dice-entropy-conduit:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   dicom:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   dictparser:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3863,8 +3974,8 @@ dont-distribute-packages:
   digestive-functors-blaze:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   digestive-functors-heist:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   digestive-functors-hsp:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  DigitalOcean:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   digitalocean-kzs:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  DigitalOcean:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   dimensional-codata:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   DimensionalHash:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   dimensions:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3872,24 +3983,26 @@ dont-distribute-packages:
   dingo-example:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   dingo-widgets:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   diophantine:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  diplomacy:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   diplomacy-server:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  diplomacy:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   direct-binary-files:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  directed-cubical:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   direct-fastcgi:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   direct-http:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   direct-plugins:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  direct-rocksdb:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  directed-cubical:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   dirfiles:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   discogs-haskell:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   discord-hs:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  discordian-calendar:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   discord-rest:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  discordian-calendar:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   DiscussionSupportSystem:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Dish:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  disjoint-containers:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   disjoint-set:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   diskhash:                                     [ "x86_64-darwin" ]
-  distance-of-time:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   Dist:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  distance-of-time:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   DisTract:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-async:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-azure:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3898,7 +4011,6 @@ dont-distribute-packages:
   distributed-process-execution:                [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-extras:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-fsm:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  distributed-process:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-lifted:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-monad-control:            [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-p2p:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3910,6 +4022,7 @@ dont-distribute-packages:
   distributed-process-task:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-tests:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   distributed-process-zookeeper:                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  distributed-process:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   distribution-plot:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   dixi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   djembe:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3919,24 +4032,27 @@ dont-distribute-packages:
   dnscache:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   dnsrbl:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   dnssd:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  doc-review:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   doccheck:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   docidx:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  dockercook:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   docker:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  doc-review:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dockercook:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   doctest-discover-configurator:                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  doctest-driver-gen:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   DocTest:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   docvim:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   DOH:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   doi:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   DOM:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  domain-auth:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   domplate:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  dotfs:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   dot-linker:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  download-media-content:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dotfs:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   dow:                                          [ "x86_64-darwin" ]
+  download-media-content:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   dozenal:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   dozens:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  DP:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   dph-base:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   dph-examples:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   dph-lifted-base:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -3945,40 +4061,40 @@ dont-distribute-packages:
   dph-prim-interface:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   dph-prim-par:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   dph-prim-seq:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  DP:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   dpkg:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   DPM:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   drClickOn:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   dresdner-verkehrsbetriebe:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   DrHylo:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   DrIFT-cabalized:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  drifter-postgresql:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   DrIFT:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  drifter-postgresql:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   drmaa:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   dropbox-sdk:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   dropsolve:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  DSH:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  dsh-sql:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ds-kanren:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  dsmc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dsh-sql:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  DSH:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   dsmc-tools:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  dson:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dsmc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   dson-parsec:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dson:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   DSTM:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   dstring:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   dtab:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   DTC:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  dtd:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   dtd-text:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   dtd-types:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dtd:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   dtw:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  dual:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   duckling:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   dumb-cas:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   duplo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Dust-crypto:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Dust:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Dust-tools:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Dust-tools-pcap:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Dust-tools:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Dust:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   dvda:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   dvdread:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   dvi-processing:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4013,20 +4129,23 @@ dont-distribute-packages:
   edenskel:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   edentv:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   edge:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  editable:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   edit-lenses:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  editable:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   editline:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   EditTimeReport:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   EEConfig:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  effective-aspects:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   effective-aspects-mzv:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  effective-aspects:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   egison-quote:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   ehaskell:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ehs:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   eibd-client-simple:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   eigen:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Eight-Ball-Pool-Hack-Cheats:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   EitherT:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ekg-elasticsearch:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   ekg-log:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ekg-prometheus-adapter:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ekg-push:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ekg-rrd:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   elerea-examples:                              [ "x86_64-darwin" ]
@@ -4034,13 +4153,14 @@ dont-distribute-packages:
   elevator:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   eliminators:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   elision:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  elm-websocket:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   elocrypt:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   elsa:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   emacs-keys:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  email:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  emailparse:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   email-postmark:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   email-validator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  email:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  emailparse:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   embeddock-example:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   embeddock:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   embroidery:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4062,8 +4182,8 @@ dont-distribute-packages:
   epass:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   epic:                                         [ "x86_64-darwin" ]
   epoll:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  epubname:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   epub-tools:                                   [ "x86_64-darwin" ]
+  epubname:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Eq:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   EqualitySolver:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   erd:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4076,8 +4196,8 @@ dont-distribute-packages:
   error-loc:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   error-message:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   error-util:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ersatz:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ersatz-toysat:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ersatz:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ert:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   escape-artist:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   esotericbot:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4090,25 +4210,33 @@ dont-distribute-packages:
   EtaMOO:                                       [ "x86_64-darwin" ]
   Eternal10Seconds:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   eternal:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eternity-timestamped:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eternity:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Etherbunny:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   ethereum-analyzer-cli:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   ethereum-analyzer-deps:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ethereum-analyzer:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   ethereum-analyzer-webui:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ethereum-analyzer:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   ethereum-client-haskell:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ethereum-merkle-patricia-db:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   eurofxref:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Euterpea:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   event-driven:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  eventful-dynamodb:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  eventful-postgresql:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  eventloop:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   event-monad:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eventful-core:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eventful-dynamodb:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eventful-memory:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eventful-postgresql:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eventful-sql-common:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eventful-sqlite:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eventful-test-helpers:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  eventloop:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   EventSocket:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   eventsource-geteventstore-store:              [ i686-linux, x86_64-linux, x86_64-darwin ]
   eventstore:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   every-bit-counts:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   ewe:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ex-pool:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   exact-real:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   exception-hierarchy:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   exception-monads-fd:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4120,18 +4248,19 @@ dont-distribute-packages:
   exinst-bytes:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   exinst-deepseq:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   exinst-hashable:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  exinst:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   exists:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   expand:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   expat-enumerator:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   explain:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   explicit-determinant:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   explicit-iomodes-bytestring:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  explicit-iomodes:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   explicit-iomodes-text:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  explicit-iomodes:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   explicit-sharing:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   explore:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ex-pool:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   exposed-containers:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  expressions-z3:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   expressions:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   extcore:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   extemp:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4139,8 +4268,8 @@ dont-distribute-packages:
   extended-reals:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   extensible-data:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   extensible-effects:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  extractelf:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Extra:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  extractelf:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   extralife:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   extrapolate:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   ez-couch:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4149,11 +4278,14 @@ dont-distribute-packages:
   factual-api:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   fadno-braids:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   fadno-xml:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fadno:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   FailureT:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   fake-type:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fallingblocks:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   falling-turnip:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fallingblocks:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   family-tree:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fast-arithmetic:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fast-combinatorics:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   fastbayes:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   fastedit:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   fastirc:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4165,28 +4297,29 @@ dont-distribute-packages:
   fay-dom:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   fay-geoposition:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   fay-hsx:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fay:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   fay-jquery:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   fay-ref:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   fay-simplejson:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   fay-text:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   fay-uri:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fbmessenger-api:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fay:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   fb-persistent:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fbmessenger-api:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   fca:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   fcd:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fcg:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   fckeditor:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   fclabels-monadlib:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   FComp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   fdo-trash:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   feature-flipper-postgres:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   fedora-packages:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  feed2lj:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  feed2twitter:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   feed-cli:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   feed-crawl:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   feed-gipeda:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   feed-translator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  feed2lj:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  feed2twitter:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   feldspar-compiler:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   feldspar-language:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   fenfire:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4203,67 +4336,78 @@ dont-distribute-packages:
   fields:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   FieldTrip:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   fieldwise:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  filecache:                                    [ "x86_64-darwin" ]
   file-collection:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   file-command-qq:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  filediff:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   file-location:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  FileManipCompat:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  filecache:                                    [ "x86_64-darwin" ]
+  filediff:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   FileManip:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  FileManipCompat:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  filepath-io-access:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   filepather:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   FilePather:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  filepath-io-access:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   Files:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   filesystem-conduit:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   filesystem-enumerator:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  FileSystem:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   filesystem-trees:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  FileSystem:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   fillit:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   filtrable:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Fin:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fin:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Finance-Quote-Yahoo:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Finance-Treasury:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   find-conduit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   FiniteMap:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  firefly-example:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   first-and-last:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   firstify:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   FirstOrderTheory:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   fit:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   fitsio:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   fitspec:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fixed-point:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fixed-point-vector:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fix-parser-simple:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fix-symbols-gitit:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   fixed-point-vector-space:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fixed-point-vector:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fixed-point:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   fixed-precision:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   fixed-storable-array:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fixed-vector-binary:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fixed-vector-cborg:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fixed-vector-cereal:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   fixed-width:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fixer:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   fixfile:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fix-parser-simple:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   fixplate:                                     [ "x86_64-darwin" ]
-  fix-symbols-gitit:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  flac:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   flac-picture:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  flac:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  flaccuraterip:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   flamethrower:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   flamingra:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   flat-maybe:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   flexible-time:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  flexiwrap:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   flexiwrap-smallcheck:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  flexiwrap:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   flickr:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  flight-igc:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Flippi:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   flite:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   floating-bits:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  flow-er:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   flow2dot:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   flowdock-api:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  flowdock:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   flowdock-rest:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  flow-er:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  flowdock:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   flower:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   flowlocks-framework:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   flowsim:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fluffy-parser:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fluffy:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   fluidsynth:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  FM-SBLEX:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   fmark:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   FModExRaw:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  FM-SBLEX:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   fn-extra:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   foldl-incremental:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   foldl-statistics:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4272,25 +4416,28 @@ dont-distribute-packages:
   foma:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   font-opengl-basic4x6:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   foo:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  for-free:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   forbidden-fruit:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   fordo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   forecast-io:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   foreign-var:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  for-free:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  forest-fire:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Forestry:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   forger:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   forkable-monad:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   ForkableT:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  FormalGrammars:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   formal:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  format:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  FormalGrammars:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   format-status:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  format:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   formattable:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  forml:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   formlets-hsp:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   formlets:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  forml:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   formura:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ForSyDe:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   forth-hll:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Fortnite-Hack-Cheats-Free-V-Bucks-Generator:  [ i686-linux, x86_64-linux, x86_64-darwin ]
   foscam-directory:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   foscam-filename:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   foscam-sort:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4309,17 +4456,19 @@ dont-distribute-packages:
   free-functors:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   free-game:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   free-http:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  freekick2:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   free-operational:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  free-theorems-counterexamples:                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  free-theorems-seq-webui:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  free-theorems-seq:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  free-theorems-webui:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  free-theorems:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  free-vector-spaces:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  freekick2:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  freelude:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   freesect:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   freesound:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  free-theorems-counterexamples:                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  free-theorems:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  free-theorems-seq:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  free-theorems-seq-webui:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  free-theorems-webui:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  FreeTypeGL:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   freetype-simple:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  FreeTypeGL:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   fresh:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   friday-devil:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   friday-scale-dct:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4330,6 +4479,7 @@ dont-distribute-packages:
   fsmActions:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   fsnotify-conduit:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   fsutils:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fswatch:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   fswatcher:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   ftdi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   FTGL-bytestring:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4337,17 +4487,18 @@ dont-distribute-packages:
   FTPLine:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ftshell:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   full-sessions:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fullstop:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   full-text-search:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fullstop:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   funbot-client:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   funbot-git-hook:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   funbot:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   funcons-tools:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  functional-arrow:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   function-combine:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   function-instances-algebra:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  functorm:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  functional-arrow:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   functor-utils:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  functor:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  functorm:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Fungi:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   funion:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   funpat:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4355,29 +4506,33 @@ dont-distribute-packages:
   fusion:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   futun:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   future:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fuzzytime:                                    [ "x86_64-darwin" ]
   fuzzy-timings:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fuzzytime:                                    [ "x86_64-darwin" ]
   fwgl-glfw:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  fwgl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   fwgl-javascript:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  fwgl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  g-npm:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   g4ip:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gact:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gameclock:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   game-probability:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gameclock:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Gamgine:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Ganymede:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   garepinoh:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   gbu:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   gc-monitoring-wai:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   gcodehs:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gdax:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gdiff-ig:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   gdiff-th:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   GeBoP:                                        [ "x86_64-darwin" ]
-  geek:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gedcom:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   geek-server:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  geek:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gegl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gelatin:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   gemstone:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gen-passwd:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   gencheck:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   gender:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   genders:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4385,38 +4540,40 @@ dont-distribute-packages:
   general-prelude:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   GeneralTicTacToe:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   generators:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  generic-accessors:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   generic-binary:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   generic-church:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   generic-lens:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   generic-maybe:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   generic-pretty:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  genericserialize:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   generic-storable:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   generic-xml:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  genesis:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  genericserialize:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   genesis-test:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  genesis:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   genetics:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  geniconvert:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   geni-gui:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  geni-util:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   GenI:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  geniconvert:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   geniplate:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   geniserver:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  geni-util:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gen-passwd:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   genprog:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   GenSmsPdu:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   gentlemark:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   GenussFold:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   genvalidity-hspec-hashable:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  geo-resolver:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   GeocoderOpenCage:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   geodetic:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   GeoIp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  geojson:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   geojson-types:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  geojson:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   geolite-csv:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   geom2d:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   GeomPredicates-SSE:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  geo-resolver:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  geos:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Get:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   getemx:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   getflag:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   GGg:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4427,18 +4584,11 @@ dont-distribute-packages:
   ghc-events-analyze:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-events-parallel:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-generic-instances:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghci-diagrams:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghci-haskeline:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghci-history-parser:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghci-lib:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-imported-from:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghci-ng:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghcjs-dom-jsffi:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghcjs-hplay:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghcjs-promise:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghcjs-xhr:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ghclive:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghc-justdoit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghc-make:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-man-completion:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghc-mod:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-parser:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-pkg-autofix:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-pkg-lib:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4448,48 +4598,69 @@ dont-distribute-packages:
   ghc-syb:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-usage:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   ghc-vis:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghci-diagrams:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghci-haskeline:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghci-history-parser:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghci-lib:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghci-ng:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghcjs-dom-jsffi:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghcjs-hplay:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghcjs-promise:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghcjs-xhr:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ghclive:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ght:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  giak:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-cairo:                                     [ "x86_64-darwin" ]
-  Gifcurry:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gi-gdkx11:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-gdk:                                       [ "x86_64-darwin" ]
+  gi-gdkx11:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-ggit:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-girepository:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-gst:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-gstaudio:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-gstbase:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-gstpbutils:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-gsttag:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-gstvideo:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-gtk-hs:                                    [ "x86_64-darwin" ]
+  gi-gtk:                                       [ "x86_64-darwin" ]
   gi-gtkosxapplication:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-gtksource:                                 [ "x86_64-darwin" ]
-  gi-gtk:                                       [ "x86_64-darwin" ]
   gi-notify:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-ostree:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-pangocairo:                                [ "x86_64-darwin" ]
-  gipeda:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-pangocairo:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-poppler:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-secret:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-vte:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gi-xlib:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  giak:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Gifcurry:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gipeda:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   gist:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   GiST:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-all:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-checklist:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  git-config:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-date:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gitdo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-fmt:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-freq:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-gpush:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  github-backup:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  github-utils:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gitignore:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gitit:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-jump:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gitlib-cross:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gitlib-s3:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gitlib-utils:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-monitor:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-object:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-repair:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   git-sanity:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  git-vogue:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gitdo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  github-backup:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  github-utils:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  github-webhooks:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gitignore:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gitit:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gitlib-cross:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gitlib-s3:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gitlib-utils:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   gitson:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   gitter:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  git-vogue:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gi-vte:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   glade:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   gladexml-accessor:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   glapp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4502,10 +4673,10 @@ dont-distribute-packages:
   glirc:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   gll:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   GLMatrix:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  global-config:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  global:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  global-variables:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   glob-posix:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  global-config:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  global-variables:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  global:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   glome-hs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   GlomeTrace:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   GlomeVec:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4520,7 +4691,6 @@ dont-distribute-packages:
   gnome-desktop:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   gnome-keyring:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   gnomevfs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  g-npm:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   gnss-converters:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   gnuidn:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   goa:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4528,18 +4698,20 @@ dont-distribute-packages:
   goal-geometry:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   goal-probability:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   goal-simulation:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  goat:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   goatee-gtk:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   goatee:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  goat:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gofer-prelude:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  goggles-gcs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  goggles:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   gogol-analytics:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   gogol-servicemanagement:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   gooey:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  GoogleDirections:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   google-drive:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   google-html5-slide:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   google-oauth2-for-cli:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   google-oauth2:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  GoogleDirections:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   googleplus:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   googlepolyline:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   GoogleSB:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4569,6 +4741,10 @@ dont-distribute-packages:
   GrammarProducts:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   grammatical-parsers:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   grapefruit-ui-gtk:                            [ "x86_64-darwin" ]
+  graph-rewriting-cl:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  graph-rewriting-trs:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  graph-utils:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  graph-visit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   Graph500:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   graphbuilder:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   graphene:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4578,30 +4754,28 @@ dont-distribute-packages:
   graphics-formats-collada:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   graphicsFormats:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   graphicstools:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  graph-rewriting-cl:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  graph-rewriting-trs:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  graphql-api:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   graphtype:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  graph-utils:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  graph-visit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   graql:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   grasp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   gray-extended:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   graylog:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  greencard:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   greencard-lib:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  greencard:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   greg-client:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   gremlin-haskell:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   Grempa:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   grenade:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  grid:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gridbounds:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   gridfs:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  grid:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gridland:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   grm:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   GroteTrap:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   groundhog-converters:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   group-by-date:                                [ "x86_64-darwin" ]
   group-with:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  groupBy:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Grow:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   growler:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   GrowlNotify:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4609,32 +4783,33 @@ dont-distribute-packages:
   gruff:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   gsl-random-fu:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   gsl-random:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gssapi:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   gssapi-wai:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gssapi:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gstorable:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   gstreamer:                                    [ "x86_64-darwin" ]
   GTALib:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtfs:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gtk-largeTreeStore:                           [ "x86_64-darwin" ]
+  gtk-mac-integration:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gtk-serialized-event:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gtk-toy:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gtk-traymanager:                              [ "x86_64-darwin" ]
   gtk2hs-cast-glade:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtk2hs-cast-gnomevfs:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gtk2hs-cast-gtkglext:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtk2hs-cast-gtk:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  gtk2hs-cast-gtkglext:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtk2hs-cast-gtksourceview2:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtk2hs-cast-th:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Gtk2hsGenerics:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtk2hs-hello:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtk2hs-rpn:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Gtk2hsGenerics:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtk3-mac-integration:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtk3:                                         [ "x86_64-darwin" ]
   gtkglext:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   GtkGLTV:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtkimageview:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gtk-largeTreeStore:                           [ "x86_64-darwin" ]
-  gtk-mac-integration:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtkrsync:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gtk-serialized-event:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gtksourceview3:                               [ "x86_64-darwin" ]
-  gtk-toy:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gtk-traymanager:                              [ "x86_64-darwin" ]
   guarded-rewriting:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   guess-combinator:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   guid:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4642,24 +4817,17 @@ dont-distribute-packages:
   GuiTV:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   gulcii:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   gyah-bin:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  h-booru:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  h-gpgme:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  h-reversi:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   h2048:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   h2c:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  H:                                            [ "x86_64-darwin" ]
   haar:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   habit:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hach:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hack2-handler-happstack-server:               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hack2-handler-mongrel2-http:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hack2-handler-snap-server:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hack2-handler-warp:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hackage2twitter:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hackage-diff:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hackage-mirror:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hackage-proxy:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hackage-server:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hackage-whatsnew:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hack-contrib:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-contrib-press:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hackernews:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hack-contrib:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-frontend-happstack:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-handler-cgi:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-handler-epoll:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4669,15 +4837,27 @@ dont-distribute-packages:
   hack-handler-hyena:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-handler-kibro:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-handler-simpleserver:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HackMail:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hackmanager:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-middleware-cleanpath:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-middleware-clientsession:                [ i686-linux, x86_64-linux, x86_64-darwin ]
   hack-middleware-jsonp:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hack2-handler-happstack-server:               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hack2-handler-mongrel2-http:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hack2-handler-snap-server:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hack2-handler-warp:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hackage-diff:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hackage-mirror:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hackage-proxy:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hackage-server:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hackage-whatsnew:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hackage2twitter:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hackernews:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HackMail:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hackmanager:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hactor:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hactors:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haddock-leksah:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   haddocset:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hadolint:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hadoop-formats:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   hadoop-rpc:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hadoop-tools:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4694,42 +4874,47 @@ dont-distribute-packages:
   hakyll-contrib-csv:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hakyll-contrib-elm:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hakyll-contrib-hyphenation:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hakyll-contrib:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   hakyll-contrib-links:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hakyll-contrib:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hakyll-dir-list:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hakyll-ogmarkup:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hakyll-R:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hakyll-sass:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hakyll-shortcode:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   halberd:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   halfs:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   halipeto:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   halive:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   halma-gui:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  halma:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   halma-telegram-bot:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  halma:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hamid:                                        [ "x86_64-darwin" ]
   HaMinitel:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hampp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hamsql:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hamtmap:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hamtsolo:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hamusic:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   handa-gdata:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   handsy:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hangman:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hannahci:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hans:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hans-pcap:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hans:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   haphviz:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   happindicator3:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   happindicator:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   happraise:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   HAppS-Data:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  happs-hsp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   happs-hsp-template:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  happs-hsp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   HAppS-IxSet:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   HAppS-Server:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   HAppS-State:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  happstack-authenticate:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  happs-tutorial:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HAppS-Util:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-auth:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  happstack-authenticate:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-contrib:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-data:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-dlg:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4740,7 +4925,6 @@ dont-distribute-packages:
   happstack-heist:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-helpers:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-hstringtemplate:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  happstack:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-ixset:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-monad-peel:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-plugins:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4748,11 +4932,11 @@ dont-distribute-packages:
   happstack-state:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-util:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   happstack-yui:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  happs-tutorial:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HAppS-Util:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  happybara:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  happybara-webkit:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  happstack:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   happybara-webkit-server:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  happybara-webkit:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  happybara:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HappyTree:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hapstone:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HaPy:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   harchive:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4766,73 +4950,52 @@ dont-distribute-packages:
   haroonga-httpd:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   haroonga:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   harvest-api:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  has-th:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  has:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   HasCacBDD:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hascar:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hascas:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hascat:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hascat-lib:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hascat-setup:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hascat-system:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hascat:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Haschoo:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   HasGP:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hash:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hashable-extras:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hashable-generics:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   hashed-storage:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hashell:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hash:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hashring:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hashtables-plus:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  has:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hasim:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hask-home:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hask:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskades:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskarrow:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskbot-core:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskdeep:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskeem:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskeline-class:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskell2010:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskell98:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskell98libraries:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-abci:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-aliyun:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-awk:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-brainfuck:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-cnc:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-coffee:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskell-compression:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-course-preludes:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-connect-hdbc-catchio-mtl:           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-connect-hdbc-catchio-tf:            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-connect-hdbc-catchio-transformers:  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-connect-hdbc:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-connect-hdbc-lifted:                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-dynamic:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-flat:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hdbc:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hdbc-mysql:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hdbc-odbc:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hdbc-postgresql:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hdbc-sqlite3:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hsql:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hsql-mysql:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hsql-odbc:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hsql-postgresql:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-hsql-sqlite3:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-th:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskelldb-wx:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-eigen-util:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-formatter:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-ftp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-generate:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-igraph:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-kubernetes:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HaskellLM:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskell-lsp-client:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-lsp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-mpfr:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-names:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-neo4j-client:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HaskellNN:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Haskelloids:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-openflow:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-pdf-presenter:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-platform-test:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4841,8 +5004,6 @@ dont-distribute-packages:
   haskell-read-editor:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-reflect:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-rules:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskellscrabble:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskellscript:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-src-exts-observe:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-src-exts-prisms:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-src-exts-qq:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4851,54 +5012,88 @@ dont-distribute-packages:
   haskell-tools-ast-fromghc:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-tools-ast-gen:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-tools-ast-trf:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskell-tools-builtin-refactorings:           [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-tools-cli:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskell-tools-experimental-refactorings:      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-tor:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HaskellTorrent:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HaskellTutorials:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-type-exts:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-typescript:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-tyrant:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskell-xmpp:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskell2010:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskell98:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskell98libraries:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-connect-hdbc-catchio-mtl:           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-connect-hdbc-catchio-tf:            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-connect-hdbc-catchio-transformers:  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-connect-hdbc-lifted:                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-connect-hdbc:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-dynamic:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-flat:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hdbc-mysql:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hdbc-odbc:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hdbc-postgresql:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hdbc-sqlite3:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hdbc:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hsql-mysql:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hsql-odbc:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hsql-postgresql:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hsql-sqlite3:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-hsql:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-th:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb-wx:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskelldb:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HaskellLM:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HaskellNN:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Haskelloids:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskellscrabble:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskellscript:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HaskellTorrent:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HaskellTutorials:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskgame:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskheap:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskhol-core:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hask-home:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hask:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskmon:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoin-core:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoin-crypto:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskoin:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoin-node:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoin-protocol:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoin-script:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoin-util:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoin-wallet:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskoin:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoon-httpspec:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskoon:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskoon-salvia:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haskore:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskoon:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskore-realtime:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskore-supercollider:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   haskore-synthesizer:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskore:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   HaskRel:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hasloGUI:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskus-binary:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskus-system-build:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haskus-utils:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haslo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hasloGUI:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hasparql-client:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hasql-backend:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   hasql-class:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hasql-cursor-query:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hasql-generic:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hasql-postgres:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   hasql-postgres-options:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hasql-postgres:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haste-app:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   haste-compiler:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   haste-gapi:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  haste:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haste-lib:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haste-markup:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   haste-perch:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  has-th:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haste-prim:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  haste:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hat:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hate:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   HaTeX-meta:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   HaTeX-qq:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hat:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hats:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   haverer:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   HaVSA:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4920,9 +5115,10 @@ dont-distribute-packages:
   hbeat:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hblas:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hblock:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  h-booru:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   HCard:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hcc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hcg-minus-cairo:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hcg-minus:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hcheat:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hchesslib:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   HCL:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4939,10 +5135,11 @@ dont-distribute-packages:
   hdbc-postgresql-hstore:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   HDBC-postgresql-hstore:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hdbi-conduit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hdbi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hdbi-postgresql:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hdbi-sqlite:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hdbi-tests:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hdbi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hdf:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hDFA:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hdigest:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hdirect:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4955,7 +5152,9 @@ dont-distribute-packages:
   HDRUtils:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   headergen:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hecc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hedgehog-gen-json:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hedi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hedis-config:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hedis-pile:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hedis-simple:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hedis-tags:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -4963,44 +5162,48 @@ dont-distribute-packages:
   heist-aeson:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   heist-async:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   heist:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  helics:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   helics-wai:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  helics:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   helium:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   helix:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hellage:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hell:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hellage:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hellnet:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   help-esb:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hemkay:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hemokit:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  henet:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hen:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  henet:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hepevt:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  her-lexer-parsec:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  her-lexer:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   HERA:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   herbalizer:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   HerbiePlugin:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   heredocs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  her-lexer:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  her-lexer-parsec:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hermes:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hermit:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hermit-syb:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hermit:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  herms:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   herringbone-embed:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  herringbone:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   herringbone-wai:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  herringbone:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hesh:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hesql:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  heterolist:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hetris:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   heukarya:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hevolisa-dph:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hevolisa:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hexchat:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hexif:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hexml-lens:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hexpat-iteratee:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hexpat-pickle-generic:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hexpress:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hexpr:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hexpress:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hexquote:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  heyefi:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hF2:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hfann:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hfd:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5012,6 +5215,7 @@ dont-distribute-packages:
   hfractal:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HFrequencyQueue:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hfusion:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hg-buildpackage:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hgalib:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-API:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-Audio:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5023,7 +5227,6 @@ dont-distribute-packages:
   HGamer3D-Enet-Binding:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-Graphics3D:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-GUI:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HGamer3D:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-InputSystem:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-Network:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-Ogre-Binding:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5032,7 +5235,7 @@ dont-distribute-packages:
   HGamer3D-SFML-Binding:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-WinEvent:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGamer3D-Wire:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hg-buildpackage:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HGamer3D:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hgdbmi:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGE2D:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hgearman:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5045,13 +5248,13 @@ dont-distribute-packages:
   hgithub:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hgom:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hgopher:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  h-gpgme:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   HGraphStorage:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   hgrev:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hgrib:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hharp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   HHDL:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hi3status:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hi:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hiccup:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hichi:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hid:                                          [ "x86_64-darwin" ]
@@ -5063,9 +5266,9 @@ dont-distribute-packages:
   Hieroglyph:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   HiggsSet:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   higher-leveldb:                               [ "x86_64-darwin" ]
+  higher-leveldb:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   higherorder:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   highWaterMark:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hi:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   himg:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   himpy:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hindley-milner:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5075,27 +5278,27 @@ dont-distribute-packages:
   hint-server:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hinvaders:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hinze-streams:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hip:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hipbot:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hipchat-hs:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hipe:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hip:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HipmunkPlayground:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hipmunk-Utils:                                [ "x86_64-darwin" ]
   Hipmunk:                                      [ "x86_64-darwin" ]
+  HipmunkPlayground:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   hircules:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hirt:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hish:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hissmetrics:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  historian:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hist-pl-fusion:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hist-pl:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hist-pl-lexicon:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hist-pl-lmf:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hist-pl-types:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hist-pl:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  historian:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   HJavaScript:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hjcase:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HJScript:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hjs:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HJScript:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HJVM:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hlatex:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hlbfgsb:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5114,14 +5317,17 @@ dont-distribute-packages:
   hlibfam:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hlibsass:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HList:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hlist:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   HListPP:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hlogger:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   HLogger:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hls:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hlwm:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hly:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   HMap:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmark:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmarkup:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hmatrix-backprop:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmatrix-banded:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmatrix-mmap:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmatrix-morpheus:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5131,9 +5337,10 @@ dont-distribute-packages:
   hmatrix-special:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmatrix-static:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmatrix-syntax:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hmeap:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmeap-utils:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hmeap:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmenu:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hmep:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmidi:                                        [ "x86_64-darwin" ]
   hmk:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmm-hmatrix:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5142,27 +5349,32 @@ dont-distribute-packages:
   hMollom:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmp3:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hmpf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hmt-diagrams:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hmt:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hmumps:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hnetcdf:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hnix:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   HNM:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hnormalise:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ho-rewriting:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoauth:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hob:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hobbes:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hobbits:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hob:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hocilib:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hocker:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hodatime:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HODE:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hoed:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hofix-mtl:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hogg:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hog:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hogg:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hogre-examples:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   hogre:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hois:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hol:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hold-em:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hole:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hol:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Holumbus-Distribution:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Holumbus-MapReduce:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   Holumbus-Searchengine:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5174,25 +5386,25 @@ dont-distribute-packages:
   honi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   honk:                                         [ "x86_64-darwin" ]
   hoobuddy:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hood-off:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoodie:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoodle-core:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoodle-extra:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hoodle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoodle-publish:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoodle-render:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hood-off:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hoodle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoogle-index:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hooks-dir:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoovie:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hopencc:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hopencl:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hOpenPGP:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hopenpgp-tools:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hOpenPGP:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hopfield:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hoq:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ho-rewriting:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   horizon:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   horname:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hosc-json:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hosts-server:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hothasktags:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hotswap:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5201,17 +5413,19 @@ dont-distribute-packages:
   hp2any-core:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hp2any-graph:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hp2any-manager:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hpaco:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hpack-dhall:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpaco-lib:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hpaco:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpage:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpapi:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpaste:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpasteit:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HPath:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpath:                                        [ "x86_64-darwin" ]
+  HPath:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpc-tracer:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpdft:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   HPi:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hpio:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hplayground:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hplaylist:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   HPlot:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5223,25 +5437,52 @@ dont-distribute-packages:
   hprotoc:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hps-cairo:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hps-kmeans:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hps:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hPushover:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpygments:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hpylos:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hquantlib:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hquery:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hR:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hranker:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   HRay:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  h-reversi:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hR:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hricket:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hricket:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hriemann:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HROOT-core:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   HROOT-graf:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   HROOT-hist:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  HROOT:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   HROOT-io:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HROOT-math:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   HROOT-tree:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  HROOT:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-blake2:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-carbon-examples:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-cdb:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-di:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-dotnet:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-excelx:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-ffmpeg:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-fltk:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-gchart:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-gen-iface:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-gizapp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-java:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-json-rpc:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-logo:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-mesos:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-multiaddr:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-nombre-generator:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-pgms:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-pkpass:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-re:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-rs-notify:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-scrape:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-twitter:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-twitterarchiver:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-vcard:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs-watchman:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hs2ats:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hs2bf:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hs2dot:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hs2lib:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5251,49 +5492,44 @@ dont-distribute-packages:
   hsbencher-codespeed:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsbencher-fusion:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsbencher:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-blake2:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsc3-auditor:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-cairo:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-data:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsc3-db:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsc3-dot:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-forth:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-graphs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-lang:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-lisp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-plot:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsc3-process:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-rec:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-rw:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-server:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-unsafe:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsc3-utils:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsc3:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hscaffold:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hscamwire:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-carbon-examples:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hscassandra:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-cdb:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hscd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsclock:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hscope:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hScraper:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsdev:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsdif:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-di:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsdip:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsdns-cache:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-dotnet:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hsed:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsemail-ns:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsenv:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-excelx:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsfacter:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsfcsh:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   HSFFIG:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-ffmpeg:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsfilt:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-fltk:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-gchart:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-gen-iface:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   HSGEP:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-gizapp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hsgnutls:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsgnutls-yj:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsgnutls:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsgsom:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   HsHaruPDF:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   HSHHelpers:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5301,24 +5537,21 @@ dont-distribute-packages:
   HsHyperEstraier:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsI2C:                                        [ "x86_64-darwin" ]
   hSimpleDB:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-java:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-json-rpc:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   HsJudy:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hskeleton:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hslackbuilder:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   hslibsvm:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HSlippyMap:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hslogger-reader:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-logo:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hslogstash:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hslua-module-text:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsluv-haskell:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsmagick:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HSmarty:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-mesos:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsmodetweaks:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   Hsmtlib:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsmtpclient:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-multiaddr:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsnock:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-nombre-generator:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsns:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsnsq:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsntp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5326,8 +5559,8 @@ dont-distribute-packages:
   hsoptions:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   HSoundFile:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsoz:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hsparql:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsp-cgi:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsparql:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspear:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspec-expectations-pretty:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspec-experimental:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5335,28 +5568,26 @@ dont-distribute-packages:
   hspec-jenkins:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspec-monad-control:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspec-pg-transact:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hspec-setup:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspec-shouldbe:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspec-snap:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspec-test-sandbox:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hspecVariant:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   HsPerl5:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-pgms:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspkcs11:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-pkpass:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspread:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hspresent:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsprocess:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsql-mysql:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hsqml-datamodel:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsqml-datamodel-vinyl:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsqml-datamodel:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsqml-demo-manic:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsqml-demo-morris:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsqml-demo-notes:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsqml-demo-samples:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hsqml:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsqml-morris:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsqml:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsreadability:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-re:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-scrape:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsseccomp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsshellscript:                                [ "x86_64-darwin" ]
   hssourceinfo:                                 [ "x86_64-darwin" ]
@@ -5369,19 +5600,15 @@ dont-distribute-packages:
   hstox:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hstradeking:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   HStringTemplateHelpers:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-twitterarchiver:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-twitter:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   hstyle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hstzaar:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsubconvert:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsudoku:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-vcard:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HSvm:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hs-watchman:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hswip:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hsXenCtrl:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hsx:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsx-xhtml:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsx:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hsXenCtrl:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsyscall:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsyslog-tcp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hsyslog-udp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5393,6 +5620,7 @@ dont-distribute-packages:
   html-entities:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   html-rules:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   html-tokenizer:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  htoml-megaparsec:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   hts:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   htsn-import:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   http-attoparsec:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5405,14 +5633,16 @@ dont-distribute-packages:
   http-enumerator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   http-kinder:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   http-proxy:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  https-everywhere-rules:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  https-everywhere-rules-raw:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   http-shed:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  httpspec:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   http-wget:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  http2-client:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  https-everywhere-rules-raw:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  https-everywhere-rules:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  httpspec:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   htune:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   htzaar:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hubris:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  huck:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   huckleberry:                                  [ "x86_64-darwin" ]
   HueAPI:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   huff:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5435,21 +5665,21 @@ dont-distribute-packages:
   huttons-razor:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   huzzy:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hVOIDP:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hwall-auth-iitk:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hw-kafka-avro:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   hw-kafka-client:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hw-kafka-conduit:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hworker:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hw-xml:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hwall-auth-iitk:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hwhile:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hworker-ses:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hworker:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hws:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hwsl2-bytevector:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hwsl2:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hwsl2-reducers:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hw-xml:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  H:                                            [ "x86_64-darwin" ]
+  hwsl2:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hXmixer:                                      [ "x86_64-darwin" ]
-  hxmppc:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   HXMPP:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hxmppc:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   hxournal:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HXQ:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   hxt-binary:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5463,14 +5693,14 @@ dont-distribute-packages:
   hydrogen-cli-args:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   hydrogen-cli:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   hydrogen-data:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hydrogen:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Hydrogen:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hydrogen-multimap:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   hydrogen-parsing:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hydrogen-prelude:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   hydrogen-prelude-parsec:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hydrogen-prelude:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   hydrogen-syntax:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hydrogen-util:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hydrogen:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Hydrogen:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   hyena:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   hylolib:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hylotab:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5480,16 +5710,17 @@ dont-distribute-packages:
   hyperloglogplus:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   hyperpublic:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   hypher:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hzenity:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   hzulip:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   i18n:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   iap-verifier:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   ib-api:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   IcoGrid:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   iconv-typed:                                  [ "x86_64-darwin" ]
-  ideas-math:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   ide-backend-common:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ide-backend:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   ide-backend-server:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ide-backend:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ideas-math:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   idempotent:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   idiii:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   idna2008:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5498,8 +5729,8 @@ dont-distribute-packages:
   iException:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   ifcxt:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   IFS:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ige-mac-integration:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   ig:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ige-mac-integration:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   igraph:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   igrf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihaskell-aeson:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5509,7 +5740,6 @@ dont-distribute-packages:
   ihaskell-diagrams:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihaskell-display:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihaskell-hatex:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ihaskell:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihaskell-inline-r:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihaskell-juicypixels:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihaskell-magic:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5517,23 +5747,31 @@ dont-distribute-packages:
   ihaskell-plot:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihaskell-rlangqq:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihaskell-widgets:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ihaskell:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ihttp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   illuminate:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   imagemagick:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   imagepaste:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  imapget:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   imap:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  imapget:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   imbib:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   imgurder:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  imj-animation:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  imj-base:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  imj-game-hamazed:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  imj-measure-stdout:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  imm:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   imparse:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  imperative-edsl:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   imperative-edsl-vhdl:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  imperative-edsl:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   ImperativeHaskell:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  implicit:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   implicit-logging:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   implicit-params:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  implicit:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  importify:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   imports:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   impossible:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  imprint:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   improve:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   INblobs:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   inch:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5544,12 +5782,12 @@ dont-distribute-packages:
   IndexedList:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   indices:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   indieweb-algorithms:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  infernu:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  infer-upstream:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  infinity:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   inf-interval:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  InfixApplicative:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  infer-upstream:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  infernu:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  infinity:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   infix:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  InfixApplicative:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   inflist:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   informative:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   inject-function:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5567,26 +5805,28 @@ dont-distribute-packages:
   interleavableGen:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   interleavableIO:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   internetmarke:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  interpolatedstring-qq:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  interpolatedstring-qq-mwotton:                [ i686-linux, x86_64-linux, x86_64-darwin ]
   interpol:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  interpolatedstring-qq-mwotton:                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  interpolatedstring-qq:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   interruptible:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   intricacy:                                    [ "x86_64-darwin" ]
-  introduction-test:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  intrinsic-superclasses:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   intro-prelude:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  introduction-test:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  introduction:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   intset:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   invertible-hlist:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   io-capture:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ion:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   io-reactive:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  IORefCAS:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ion:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   IOR:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  IORefCAS:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   iothread:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   iotransaction:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   ip2location:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ip:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   ipatch:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ipc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ip:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   ipopt-hs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   iptables-helpers:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   iptadmin:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5596,9 +5836,10 @@ dont-distribute-packages:
   irc-fun-client:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   irc-fun-color:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   Irc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  iri:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   iridium:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ironforge:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   iron-mq:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ironforge:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   isevaluated:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   isiz:                                         [ "x86_64-darwin" ]
   ismtp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5606,14 +5847,14 @@ dont-distribute-packages:
   iso8583-bitmaps:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   isobmff-builder:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   isohunt:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  iter-stats:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   iteratee-compress:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  iteratee:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   iteratee-mtl:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   iteratee-parsec:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   iteratee-stm:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  iterIO:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  iteratee:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   iterio-server:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  iter-stats:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  iterIO:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ivor:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ivory-backend-c:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   ivory-bitdata:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5625,10 +5866,10 @@ dont-distribute-packages:
   iyql:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   j2hs:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   jack-bindings:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  jack:                                         [ "x86_64-darwin" ]
   jack:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   jackminimix:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   JackMiniMix:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  jack:                                         [ "x86_64-darwin" ]
   jacobi-roots:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   jail:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   jalaali:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5639,6 +5880,7 @@ dont-distribute-packages:
   java-bridge-extras:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   java-bridge:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   java-reflect:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  javaclass:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   javasf:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Javasf:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   javav:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5648,75 +5890,82 @@ dont-distribute-packages:
   jdi:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   jenkinsPlugins2nix:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   jespresso:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  jml-web-service:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   jobqueue:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   join:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   joinlist:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   jonathanscard:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   jort:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  js-good-parts:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsaddle-hello:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsaddle-warp:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsaddle-wkwebview:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   JsContracts:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  js-good-parts:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsmw:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  json2-hdbc:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  json2:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-api:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-ast-quickcheck:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-autotype:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-b:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  JSONb:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  json-bytes-builder:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   JSON-Combinator-Examples:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   JSON-Combinator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-enumerator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-extra:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-feed:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  JsonGrammar:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-incremental-decoder:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-litobj:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-pointer-hasql:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-python:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   json-qq:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  json-togo:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  json-tools:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  json2-hdbc:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  json2:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  JSONb:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  JsonGrammar:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsonresume:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsonrpc-conduit:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsonsql:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  json-togo:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  json-tools:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsontsv:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   jsonxlsx:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   jspath:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  judge:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   judy:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   juicy-gcode:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   JuicyPixels-canvas:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   JunkDB-driver-gdbm:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   JunkDB-driver-hashtables:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   JunkDB:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  JuPyTer-notebook:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   jupyter:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  jvm-batching:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   JYU-Utils:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   kafka-client:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   kafka-device-glut:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  kafka-device:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   kafka-device-joystick:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   kafka-device-leap:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   kafka-device-spacenav:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   kafka-device-vrpn:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  kafka-device:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   kaleidoscope:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   kalman:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Kalman:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   kangaroo:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   kanji:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   kansas-lava-cores:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  kansas-lava:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   kansas-lava-papilio:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   kansas-lava-shake:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  kansas-lava:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   karakuri:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   karps:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   katip-elasticsearch:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  katip-rollbar:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  katip-syslog:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   katt:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   kawaii:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   kazura-queue:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  kdesrc-build-extra:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   kd-tree:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  kdesrc-build-extra:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-i18n:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-mvc-environment-gtk:              [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-mvc-model-lightmodel:             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5724,12 +5973,12 @@ dont-distribute-packages:
   keera-hails-mvc-solutions-gtk:                [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-reactive-fs:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-reactive-gtk:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  keera-hails-reactivelenses:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-reactive-network:                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-reactive-polling:                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  keera-hails-reactivevalues:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-reactive-wx:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-hails-reactive-yampa:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  keera-hails-reactivelenses:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  keera-hails-reactivevalues:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   keera-posture:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   keiretsu:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Ketchup:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5743,11 +5992,12 @@ dont-distribute-packages:
   kicad-data:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   kickass-torrents-dump-parser:                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   KiCS-debugger:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  KiCS:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   KiCS-prophecy:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  KiCS:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   kif-parser:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   kit:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   kmeans-par:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  kmeans-vector:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   knead-arithmetic:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   knead:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   knots:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5761,19 +6011,24 @@ dont-distribute-packages:
   KSP:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   ktx:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   kure-your-boilerplate:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  KyotoCabinet:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   kyotocabinet:                                 [ "x86_64-darwin" ]
+  KyotoCabinet:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  l-bfgs-b:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  L-seed:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   labeled-graph:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   laborantin-hs:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  labyrinth:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   labyrinth-server:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  labyrinth:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lagrangian:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   laika:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lambda-bridge:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lambda-calculator:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lambda-canvas:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lambda-devs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lambda-toolbox:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambda2js:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdaBase:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdabot-utils:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lambda-bridge:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lambda-canvas:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacms-core:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacms-media:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacube-bullet:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5783,56 +6038,61 @@ dont-distribute-packages:
   lambdacube-engine:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacube-examples:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacube-gl:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lambdacube:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacube-ir:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdacube-samples:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lambda-devs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lambdacube:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdaFeed:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  LambdaHack:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   LambdaINet:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Lambdajudge:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdaLit:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   LambdaNet:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   LambdaPrettyQuote:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lambda-toolbox:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdatwit:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdaya-bus:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   Lambdaya:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   lambdiff:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lame:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   lame-tester:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lame:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lang:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  language-ats:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-bash:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-boogie:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-c-comments:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-c-inline:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-conf:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  language-dockerfile:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-eiffel:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  language-elm:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-gcl:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-go:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-guess:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-java-classfile:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-kort:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  language-lua2:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-lua-qq:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  language-lua2:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-mixal:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-ninja:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-objc:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-pig:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-puppet:                              [ "x86_64-darwin" ]
   language-python-colour:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  language-python:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-python-test:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  language-python:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-qux:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-sh:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-spelling:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-sqlite:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lapack-carray:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lapack-ffi:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   LargeCardinalHierarchy:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Lastik:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lat:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   latest-npm-version:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   latex-formulae-hakyll:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   latex-formulae-image:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   latex-formulae-pandoc:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   latex-function-tables:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lat:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   LATS:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   launchpad-control:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   layers-game:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5842,7 +6102,6 @@ dont-distribute-packages:
   lazyset:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   lazysplines:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   LazyVault:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  l-bfgs-b:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   lcs:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   LDAP:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ldapply:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5860,13 +6119,13 @@ dont-distribute-packages:
   legion:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   leksah-server:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   lendingclub:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lenses:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   lens-properties:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lensref:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   lens-text-encoding:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   lens-time:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lens-tutorial:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   lens-utils:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lenses:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lensref:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   lenz-template:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   Level0:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   leveldb-haskell-fork:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5874,8 +6133,8 @@ dont-distribute-packages:
   levmar-chart:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   levmar:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   lgtk:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lhae:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   lha:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lhae:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   lhc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   lhe:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   lhs2TeX-hl:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5892,6 +6151,7 @@ dont-distribute-packages:
   liblinear-enumerator:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   libltdl:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   libmolude:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  liboath-hs:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   liboleg:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   libpafe:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   libpq:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5909,8 +6169,8 @@ dont-distribute-packages:
   lifter:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ligature:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   lightning-haskell:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lighttpd-conf:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   lighttpd-conf-qq:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lighttpd-conf:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   lilypond:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Limit:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   limp-cbc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5921,9 +6181,10 @@ dont-distribute-packages:
   linear-circuit:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   linear-maps:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   linear-opengl:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  linear-vect:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  linearmap-category:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   linearscan-hoopl:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   LinearSplit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  linear-vect:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   LinkChecker:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   linkchk:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   linkcore:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -5943,60 +6204,65 @@ dont-distribute-packages:
   lio-eci11:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lio-simple:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   lipsum-gen:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  liquid:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   liquidhaskell-cabal-demo:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   liquidhaskell-cabal:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   liquidhaskell:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  liquid:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  listlike-instances:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   list-mux:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   list-t-attoparsec:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   list-t-html-parser:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   list-t-http-client:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   list-t-text:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   list-zip-def:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  literals:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  listlike-instances:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ListT:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   lit:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  literals:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   live-sequencer:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   ll-picosat:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   llsd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-analysis:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  llvm-base:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-base-types:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-base-util:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  llvm-base:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-data-interop:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-extra:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-ffi:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  llvm-general:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-general-pure:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-general-quote:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  llvm-general:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  llvm-hs-pretty:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-hs:                                      [ "x86_64-darwin" ]
   llvm-ht:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  llvm:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-tf:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   llvm-tools:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  llvm:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   lmdb-high-level:                              [ "x86_64-darwin" ]
   lmdb-simple:                                  [ "x86_64-darwin" ]
+  lmdb-simple:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   lmdb:                                         [ "x86_64-darwin" ]
-  lmonad:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   lmonad-yesod:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lmonad:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  loc:                                          [ "x86_64-darwin" ]
   local-search:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  localization:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   loch:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   locked-poll:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  loc:                                          [ "x86_64-darwin" ]
-  log2json:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   log-effect:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  log-postgres:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  log-utils:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  log-warper:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  log2json:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  log:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   logentries:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   logger:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  log:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   logic-classes:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  LogicGrowsOnTrees:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Logic:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   LogicGrowsOnTrees-MPI:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   LogicGrowsOnTrees-network:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   LogicGrowsOnTrees-processes:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Logic:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  LogicGrowsOnTrees:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   logplex-parse:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  log-postgres:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  log-utils:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lojban:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   lojbanParser:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   lojbanXiragan:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6005,11 +6271,11 @@ dont-distribute-packages:
   lol-benches:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   lol-calculus:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   lol-cpp:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lol:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  loli:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   lol-repa:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   lol-tests:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lol-typing:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lol:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  loli:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   lookup-tables:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   loop-effin:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   loop-while:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6022,10 +6288,9 @@ dont-distribute-packages:
   loup:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   lowgl:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   lp-diagrams-svg:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lscabal:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  L-seed:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  LslPlus:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ls-usb:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lscabal:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  LslPlus:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   lsystem:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ltk:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   luachunk:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6034,19 +6299,20 @@ dont-distribute-packages:
   lui:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   luis-client:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   luka:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  luminance:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   luminance-samples:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  luminance:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   lushtags:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   luthor:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   lvish:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   lvmlib:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   lxc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lxd-client:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   lye:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Lykah:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   lz4-conduit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   lzma-enumerator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  lzma:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   lzma-streams:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  lzma:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   maam:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   macbeth-lib:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   machines-amazonka:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6055,25 +6321,26 @@ dont-distribute-packages:
   macosx-make-standalone:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   madlang:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mage:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  magic-wormhole:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   magico:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   magma:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mahoro:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   maid:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mailchimp-subscribe:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   mailchimp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   MailchimpSimple:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mailchimp-subscribe:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   mailgun:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   majordomo:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   majority:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  makedo:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   make-hard-links:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   make-package:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  makedo:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mallard:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-anything:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-core:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-curl:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-editor:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-filemanager:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  manatee:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-imageviewer:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-ircclient:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-mplayer:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6082,14 +6349,18 @@ dont-distribute-packages:
   manatee-template:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-terminal:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   manatee-welcome:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  manatee:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mandulia:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   mangopay:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   manifold-random:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  manifolds-core:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   manifolds:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  map-exts:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   mappy:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mapquest-api:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   marionetta:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  markdown2svg:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   markdown-kate:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  markdown2svg:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   markov-processes:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   marmalade-upload:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   marquise:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6104,16 +6375,16 @@ dont-distribute-packages:
   matplotlib:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   matsuri:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   matterhorn:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mattermost-api:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   mattermost-api-qc:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mattermost-api:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   maude:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  maxent:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   maxent-learner-hw-gui:                        [ "x86_64-darwin" ]
+  maxent:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   maxsharing:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   maybench:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MaybeT:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   MaybeT-monads-tf:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   MaybeT-transformers:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MaybeT:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   MazesOfMonad:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   mbox-tools:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   MC-Fold-DP:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6130,8 +6401,8 @@ dont-distribute-packages:
   MeanShift:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Measure:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mecab:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Mecha:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mech:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Mecha:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mechs:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Mechs:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mediabus-fdk-aac:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6145,26 +6416,29 @@ dont-distribute-packages:
   memcached-binary:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   memcached:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   memis:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  memoization-utils:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   memo-ptr:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   memo-sqlite:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  memoization-utils:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   merge-bash-history:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   merkle-patricia-db:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  merkle-tree:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   messente:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  metadata:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MetaHDBC:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   meta-misc:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   meta-par-accelerate:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  metadata:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MetaHDBC:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   metaplug:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   metric:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  metricsd-client:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   metrics:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Metrics:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  metricsd-client:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   metronome:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mezzo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mezzolens:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   mgeneric:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Mhailist:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   MHask:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mi:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   Michelangelo:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   microformats2-types:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   microlens-each:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6173,14 +6447,13 @@ dont-distribute-packages:
   mida:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   midair:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   midi-alsa:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  midi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  midimory:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   midi-music-box:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  midisurface:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   midi-util:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   midi-utils:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  midi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  midimory:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  midisurface:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   mighttpd:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mi:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   mime-string:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   minecraft-data:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   minesweeper:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6200,13 +6473,18 @@ dont-distribute-packages:
   MissingPy:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   mixed-strategies:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   mkbndl:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mlist:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   ml-w:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mlist:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mmark-cli:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mmark-ext:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mmark:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mmtf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   mmtl-base:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   mmtl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   moan:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Mobile-Legends-Hack-Cheats:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   modelicaparser:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  modern-uri:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   modsplit:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   modular-arithmetic:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   modular-prelude-classy:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6218,27 +6496,15 @@ dont-distribute-packages:
   mohws:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mole:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   mollie-api-haskell:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  monadacme:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  monad-atom:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-atom-simple:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MonadCatchIO-mtl-foreign:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MonadCatchIO-mtl:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MonadCatchIO-transformers-foreign:            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MonadCatchIO-transformers:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  monad-atom:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-codec:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MonadCompose:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-dijkstra:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-exception:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-fork:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  monadiccp-gecode:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  monadiccp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-interleave:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Monadius:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MonadLab:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-levels:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-lgbt:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  monadLib-compose:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  monadloc-pp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-log:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-lrs:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-memo:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6246,8 +6512,6 @@ dont-distribute-packages:
   monad-open:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-ran:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-resumption:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  monads-fd:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MonadStack:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-state:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-statevar:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-ste:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6256,34 +6520,53 @@ dont-distribute-packages:
   monad-task:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-tx:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   monad-unify:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  monadacme:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MonadCatchIO-mtl-foreign:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MonadCatchIO-mtl:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MonadCatchIO-transformers-foreign:            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MonadCatchIO-transformers:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MonadCompose:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  monadiccp-gecode:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  monadiccp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Monadius:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MonadLab:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  monadLib-compose:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  monadloc-pp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  monads-fd:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MonadStack:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   monarch:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Monaris:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Monatron:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Monatron-IO:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Monatron:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   mondo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   monetdb-mapi:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   money:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mongodb-queue:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   mongrel2-handler:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   monky:                                        [ "x86_64-darwin" ]
-  Monocle:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mono-foldable:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Monocle:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   monoid-owns:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  monoid-statistics:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   monoidplus:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   monoids:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   monte-carlo:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   monzo:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   moo:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   moonshine:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  more-containers:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   morfette:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   morfeusz:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   morph:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mosaico-lib:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  motor-diagrams:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  motor-reflection:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  motor:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mount:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   movie-monad:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   mp3decoder:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mpdmate:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mp:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mpdmate:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mpppc:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   mpretty:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mpris:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6291,12 +6574,12 @@ dont-distribute-packages:
   mps:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   mpvguihs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   mrm:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ms:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   msgpack-aeson:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  msgpack:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   msgpack-idl:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   msgpack-rpc:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  msgpack:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   msh:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ms:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   msi-kb-backlit:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   MSQueue:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   MTGBuilder:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6307,20 +6590,20 @@ dont-distribute-packages:
   mtp:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   MuCheck-Hspec:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   MuCheck-HUnit:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  MuCheck:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   MuCheck-QuickCheck:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   MuCheck-SmallCheck:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mudbath:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  MuCheck:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mud:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mudbath:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   mulang:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   multext-east-msd:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  multiaddr:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   multi-cabal:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  multiaddr:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   multifocal:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   multihash:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   multipass:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  multiplate:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   multiplate-simplified:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  multiplate:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   multirec-alt-deriver:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   multirec-binary:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   multirec:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6330,9 +6613,8 @@ dont-distribute-packages:
   Munkres-simple:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   muon:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   murder:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  murmurhash3:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   murmur:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  musicbrainz-email:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  murmurhash3:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   music-graphics:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   music-parts:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   music-pitch:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6340,18 +6622,22 @@ dont-distribute-packages:
   music-score:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   music-sibelius:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   music-suite:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  musicbrainz-email:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   musicxml:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mustache2hs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   mustache-haskell:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mustache2hs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   mutable-iter:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   MutationOrder:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   mute-unmute:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mvc-updates:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   mvc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   mvclient:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mvc-updates:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   mxnet-examples:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  mxnet:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mxnet-nn:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   mxnet-nnvm:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  mxnet:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  my-package-testing:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  my-test-docs:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   myo:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   MyPrimes:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   mysnapsession-example:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6364,23 +6650,25 @@ dont-distribute-packages:
   myTestlll:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   mzv:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   nagios-plugin-ekg:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nakadi-client:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   named-lock:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   NameGenerator:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   namelist:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  nanoAgda:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   nano-cryptr:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  nanocurses:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   nano-hmac:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   nano-md5:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nanoAgda:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nanocurses:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   nanomsg-haskell:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   nanomsg:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   nanoparsec:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   NanoProlog:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   nanovg:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   nanq:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Naperian:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   narc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  native:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   nat-sized-numbers:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  native:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   nats-queue:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   natural-number:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   naver-translate:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6390,26 +6678,30 @@ dont-distribute-packages:
   neet:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   nehe-tuts:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   neither:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  neko-lib:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Neks:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   nemesis-titan:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nemesis:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   nerf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  nero:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   nero-wai:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   nero-warp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nero:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nest:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nested-routes:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   NestedFunctor:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   nestedmap:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  nested-routes:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   netcore:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   netease-fm:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   netlines:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   netlink:                                      [ "x86_64-darwin" ]
+  netrium:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   NetSNMP:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   netspec:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   netstring-enumerator:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   nettle-frp:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  nettle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   nettle-netkit:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   nettle-openflow:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nettle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   netwire-input-javascript:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   netwire-vinylglfw-examples:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-address:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6436,11 +6728,12 @@ dont-distribute-packages:
   network-transport-amqp:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-transport-zeromq:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-uri-static:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  network-voicetext:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-wai-router:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   network-websocket:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  neural:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   neural-network-blashs:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   neural-network-hmatrix:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  neural:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   newports:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   newsynth:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   newt:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6448,47 +6741,51 @@ dont-distribute-packages:
   newtype-th:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   next-ref:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   nfc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  NGrams:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ngrams-loader:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  NGrams:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   niagra:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   nibblestring:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   nicovideo-translator:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   nikepub:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   nimber:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Ninjas:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nirum:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   nitro:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  nixfromnpm:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nix-deploy:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   nix-paths:                                    [ "x86_64-darwin" ]
+  nixfromnpm:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   nkjp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   nlopt-haskell:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   nlp-scores-scripts:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  nme:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   nm:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nme:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   nntp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  no-role-annots:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   noether:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   nofib-analyze:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   noise:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Nomyx-Core:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Nomyx:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Nomyx-Language:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   Nomyx-Rules:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   Nomyx-Web:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Nomyx:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  non-empty-text:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   NonEmptyList:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   nonlinear-optimization-ad:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   nonlinear-optimization:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   noodle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  no-role-annots:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   NoSlow:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  notcpp:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   not-gloss-examples:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  not-gloss:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  notcpp:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   notmuch-haskell:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   notmuch-web:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   np-linear:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   nptools:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ntrip-client:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   NTRU:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  nullary:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   null-canvas:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  nullary:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   nullpipe:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   number-length:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   NumberSieves:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6496,37 +6793,43 @@ dont-distribute-packages:
   numerals-base:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   numeric-ode:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   numeric-ranges:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  numhask:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  numhask-array:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  numhask-histogram:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   numhask-range:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  numhask:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Nussinov78:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Nutri:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  NXTDSL:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   NXT:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  NXTDSL:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   nylas:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   nymphaea:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  o-clock:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   oauthenticated:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  obdd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   obd:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  obdd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   oberon0:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  obj:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Object:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   objectid:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ObjectIO:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  obj:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ocaml-export:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   octane:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   octohat:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   octopus:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   oculus:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   OddWord:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   oden-go-packages:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  odpic-raw:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   off-simple:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   OGL:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   ogmarkup:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ohloh-hs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  oidc-client:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   oi:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  oidc-client:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   ois-input-manager:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   old-version:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   olwrapper:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  om-elm:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   omaketex:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   omega:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Omega:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6540,21 +6843,24 @@ dont-distribute-packages:
   onu-course:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   opaleye-classy:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   opaleye-sqlite:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  open-haddock:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  open-pandoc:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  open-typerep:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   OpenAL:                                       [ "x86_64-darwin" ]
   opench-meteo:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   OpenCL:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   OpenCLRaw:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   OpenCLWrappers:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   opencog-atomspace:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  opencv-extra:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   opencv-raw:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  opencv:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   opendatatable:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   openexchangerates:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   openflow:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   OpenGLCheck:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   opengles:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   OpenGLRaw21:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  open-haddock:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  open-pandoc:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   openpgp-crypto-api:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   openpgp-Crypto:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   OpenSCAD:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6570,14 +6876,14 @@ dont-distribute-packages:
   optimization:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   optimusprime:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   optparse-applicative-simple:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  OrchestrateDB:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   orchestrate:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  OrchestrateDB:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   orchid-demo:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   orchid:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   order-maintenance:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  orders:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  order-statistics:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   order-statistic-tree:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  order-statistics:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  orders:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ordrea:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   organize-imports:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   orgmode:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6593,11 +6899,13 @@ dont-distribute-packages:
   oso2pdf:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ot:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   otp-authenticator:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  overhang:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   overture:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pack:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   package-vt:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   packed-dawg:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  packed-multikey-map:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   packedstring:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pack:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   packman:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   pacman-memcache:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   padKONTROL:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6605,13 +6913,13 @@ dont-distribute-packages:
   PageIO:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Paillier:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   panda:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  PandocAgda:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pandoc-crossref:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   pandoc-include-code:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   pandoc-japanese-filters:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   pandoc-placetable:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   pandoc-plantuml-diagrams:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   pandoc-unlit:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  PandocAgda:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pang-a-lambda:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   panpipe:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   pansite:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6620,28 +6928,32 @@ dont-distribute-packages:
   paprika:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   paragon:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Paraiso:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Parallel-Arrows-Eden:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   parallel-tasks:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  parameterized:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   paranoia:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   parco-attoparsec:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  parco-parsec:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   parco:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   parconc-examples:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  parco-parsec:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   pareto:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   parport:                                      [ "x86_64-darwin" ]
   Parry:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  parse-help:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   parsec-parsers:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   parseerror-eq:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  parse-help:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   parsely:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  parser-helper:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   parser241:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   parsergen:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  parser-helper:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   parsestar:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   partage:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  partial:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   partial-lens:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  partial:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   partly:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   passage:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  passman-cli:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  passman-core:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   PasswordGenerator:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   pasta:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   pastis:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6655,8 +6967,8 @@ dont-distribute-packages:
   paypal-adaptive-hoops:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   paypal-api:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   paypal-rest-client:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pbc4hs:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   pb:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pbc4hs:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   PBKDF2:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   pcf:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   PCLT-DB:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6668,24 +6980,26 @@ dont-distribute-packages:
   peakachu:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   PeanoWitnesses:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   pec:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  peggy:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pedersen-commitment:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   peg:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  peggy:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   pell:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pencil:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   penny-bin:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  penny:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   penny-lib:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  penny:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   penrose:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   peparser:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   perceptron:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   perdure:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   peregrin:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  perf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   perfecthash:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   PerfectHash:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  perf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   periodic:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   perm:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  PermuteEffects:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   permute:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  PermuteEffects:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   persist2er:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   persistent-cereal:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   persistent-database-url:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6694,20 +7008,22 @@ dont-distribute-packages:
   persistent-map:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   persistent-protobuf:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   persistent-relational-record:                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  persistent-test:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   persistent-zookeeper:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  persona:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   persona-idp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  persona:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   pesca:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   peyotls-codec:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   peyotls:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   pez:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pg-harness:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pg-harness-server:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pg-harness:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pg-recorder:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pgsql-simple:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   pg-store:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pgstream:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   pg-transact:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pgdl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pgsql-simple:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pgstream:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   phasechange:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   phoityne:                                     [ "x86_64-darwin" ]
   phone-numbers:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6717,20 +7033,22 @@ dont-distribute-packages:
   phraskell:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Phsu:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   phybin:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pi-calculus:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pi-forall:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   pia-forward:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   pianola:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pi-calculus:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   picologic:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   picosat:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   piet:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pi-forall:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   piki:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pinpon:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Pipe:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-attoparsec-streaming:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-bgzf:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-binary:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pipes-cereal:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pipes-cacophony:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-cereal-plus:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pipes-cereal:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-conduit:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-core:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-courier:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6739,6 +7057,7 @@ dont-distribute-packages:
   pipes-files:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-illumina:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-io:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pipes-kafka:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-key-value-csv:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-lzma:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-network-tls:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6749,10 +7068,11 @@ dont-distribute-packages:
   pipes-s3:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-shell:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-sqlite-simple:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pipes-transduce:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   pipes-zlib:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pisigma:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pitchtrack:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pit:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pitchtrack:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pivotal-tracker:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   pixelated-avatar-generator:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pkggraph:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6766,6 +7086,7 @@ dont-distribute-packages:
   plocketed:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   plot-gtk3:                                    [ "x86_64-darwin" ]
   Plot-ho-matic:                                [ "x86_64-darwin" ]
+  Plot-ho-matic:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   plot-lab:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   plot-light:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   PlslTools:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6777,9 +7098,10 @@ dont-distribute-packages:
   pngload:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   pocket-dns:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pocket:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  point-octree:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pointfree-fancy:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   pointless-lenses:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   pointless-rewrite:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  point-octree:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   pokemon-go-protobuf-types:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   pokitdok:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   polar-configfile:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6791,8 +7113,9 @@ dont-distribute-packages:
   polynom:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   polynomial:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   polyseq:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  polytypeable:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   polytypeable-utils:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  polytypeable:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pomaps:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   pomodoro:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ponder:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   pong-server:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6808,25 +7131,32 @@ dont-distribute-packages:
   porter:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   PortFusion:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   ports:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  positron:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   posix-pty:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   posix-realtime:                               [ "x86_64-darwin" ]
   posix-timer:                                  [ "x86_64-darwin" ]
   posix-waitpid:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   postcodes:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  PostgreSQL:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  postgres-embedded:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  postgres-websockets:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   postgresql-named:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   postgresql-orm:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   postgresql-query:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   postgresql-simple-queue:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   postgresql-simple-sop:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   postgresql-simple-typed:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  postgresql-typed:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   postgresql-typed-lifted:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  postgresql-typed:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  PostgreSQL:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  postgrest-ws:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   postgrest:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   postie:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  postmark:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   postmark-streams:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  postmark:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   potato-tool:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  potoki-cereal:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  potoki-core:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  potoki:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   powermate:                                    [ "x86_64-darwin" ]
   powerpc:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   powerqueue-levelmem:                          [ "x86_64-darwin" ]
@@ -6837,8 +7167,8 @@ dont-distribute-packages:
   praglude:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   preamble:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   precis:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  prednote-test:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   pred-trie:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  prednote-test:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   prefork:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   prelude-generalize:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   prelude-plus:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6848,37 +7178,43 @@ dont-distribute-packages:
   presto-hdbc:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   prettyprinter-convert-ansi-wl-pprint:         [ i686-linux, x86_64-linux, x86_64-darwin ]
   prettyprinter-vty:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  PrimitiveArray-Pretty:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  primesieve:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   primitive-simd:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  PrimitiveArray-Pretty:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   primula-board:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   primula-bot:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   print-debugger:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   Printf-TH:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  PriorityChansConverger:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   priority-queue:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  PriorityChansConverger:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ProbabilityMonads:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  processing:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  probable:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  proc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   process-iterio:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   process-leksah:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   process-listlike:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   process-progress:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   process-qq:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  proc:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  process-streaming:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  processing:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   procrastinating-structure:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   procrastinating-variable:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   procstat:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  producer:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  product:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   prof2dot:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   prof2pretty:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  progressbar:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   progress:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  progressbar:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   progression:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   progressive:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   proj4-hs-bindings:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   project-m36:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  prolog-graph:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   prolog-graph-lib:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  prolog-graph:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   prolog:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   prologue:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  prometheus:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   promise:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   propane:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Proper:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6887,16 +7223,17 @@ dont-distribute-packages:
   proplang:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   prosper:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   proteaaudio:                                  [ "x86_64-darwin" ]
+  proto-lens-combinators:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  proto-lens-protobuf-types:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   protobuf-native:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   protocol-buffers-descriptor-fork:             [ i686-linux, x86_64-linux, x86_64-darwin ]
   protocol-buffers-fork:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  proto-lens-combinators:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  proto-lens-protobuf-types:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   protolude-lifted:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   proton-haskell:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   prove-everywhere-server:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   proxy-kindness:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   psc-ide:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ptr:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   publicsuffixlistcreate:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   pubnub:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   pubsub:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6909,17 +7246,19 @@ dont-distribute-packages:
   punkt:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Pup-Events-Demo:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   puppetresources:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pure-priority-queue:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   pure-priority-queue-tests:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  purescript-bundle-fast:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  purescript:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pure-priority-queue:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   pure-zlib:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  purescript-bundle-fast:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  purescript-tsd-gen:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  purescript:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   pursuit-client:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pusher-haskell:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  pushme:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  push-notify-apn:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   push-notify-ccs:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   push-notify-general:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   push-notify:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pusher-haskell:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  pushme:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   putlenses:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   puzzle-draw-cmdline:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   puzzle-draw:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6927,9 +7266,10 @@ dont-distribute-packages:
   pyffi:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   pyfi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   python-pickle:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  q4c12-twofinger:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   qc-oi-testgenerator:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  qd:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   qd-vec:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  qd:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   qed:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   qhull-simple:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   qif:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6937,11 +7277,11 @@ dont-distribute-packages:
   qm-interpolated-string:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   qr-imager:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   qr-repa:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  qt:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   qtah-cpp-qt5:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   qtah-examples:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   qtah-generator:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   qtah-qt5:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  qt:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   QuadEdge:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   quadratic-irrational:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   QuadTree:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6953,6 +7293,7 @@ dont-distribute-packages:
   quenya-verb:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   querystring-pickle:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   queuelike:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  quick-schema:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   QuickAnnotate:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   quickbooks:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   quickcheck-poly:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6964,15 +7305,16 @@ dont-distribute-packages:
   quickcheck-report:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   quickcheck-string-random:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   quickcheck-webdriver:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  QuickCheckVariant:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   QuickPlot:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   quickpull:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  quick-schema:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   quickset:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Quickson:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  quickspec:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   quicktest:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   quickwebapp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  quipper:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   quipper-rendering:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  quipper:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   quiver-binary:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   quiver-groups:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   quiver-http:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6980,6 +7322,7 @@ dont-distribute-packages:
   quiver-sort:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   quoridor-hs:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   qux:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  R-pandoc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   rad:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   radium-formula-parser:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   radix:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -6990,21 +7333,22 @@ dont-distribute-packages:
   rainbow-tests:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   raketka:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   rakhana:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rakuten:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ralist:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   rallod:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   raml:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rand-vars:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   randfile:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   random-access-list:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   random-derive:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  RandomDotOrg:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   random-eff:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   random-effin:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   random-hypergeometric:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   random-stream:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  rand-vars:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  RandomDotOrg:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  range-space:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   Range:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   rangemin:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  range-space:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   rank2classes:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   Ranka:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   rasa-example-config:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7028,10 +7372,12 @@ dont-distribute-packages:
   raz:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   razom-text-util:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   rbr:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rc:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   rcu:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   rdf4h:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   rdioh:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   react-haskell:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  react-tutorial-haskell-server:                [ i686-linux, x86_64-linux, x86_64-darwin ]
   reaction-logic:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   reactive-bacon:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   reactive-balsa:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7042,13 +7388,12 @@ dont-distribute-packages:
   reactive-banana-wx:                           [ "x86_64-darwin" ]
   reactive-fieldtrip:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   reactive-glut:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  reactive:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  reactive-jack:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   reactive-jack:                                [ "x86_64-darwin" ]
+  reactive-jack:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   reactive-midyim:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   reactive-thread:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  reactive:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   reactor:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  react-tutorial-haskell-server:                [ i686-linux, x86_64-linux, x86_64-darwin ]
   read-io:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   readline-statevar:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   readme-lhs:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7058,72 +7403,75 @@ dont-distribute-packages:
   reasonable-lens:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   record-aeson:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   record-gl:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  record:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   record-preprocessor:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  records:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  records-th:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   record-syntax:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  record:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  records-th:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  records:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   recursors:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   reddit:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   redHandlers:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  redland:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   reduce-equations:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   reedsolomon:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   reenact:                                      [ "x86_64-darwin" ]
+  ref-mtl:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ref:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Ref:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   refcount:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Referees:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   refh:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ref:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Ref:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   reflection-extras:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   reflex-animation:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  reflex-gloss:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   reflex-gloss-scene:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  reflex:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  reflex-gloss:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   reflex-orphans:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   reflex-sdl2:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   reflex-transformers:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ref-mtl:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  reflex:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  reformat:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   refresht:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-deriv:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-dfa:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-genex:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-parsec:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-pderiv:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  regexpr-symbolic:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  regexp-tries:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  regexqq:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-tdfa-pipes:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-tdfa-quasiquoter:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-tdfa-utf8:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-tre:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-type:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   regex-xmlschema:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  regexp-tries:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  regexpr-symbolic:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  regexqq:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   regional-pointers:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  regions:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   regions-monadsfd:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   regions-monadstf:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   regions-mtl:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  regions:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   register-machine-typelevel:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   regress:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   regular-extras:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  regular:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   regular-web:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   regular-xmlpickler:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  regular:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   reheat:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   reified-records:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   reify:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  relational-postgresql8:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   relation:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  relational-postgresql8:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  relational-record-examples:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   relative-date:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   reload:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   remark:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   remarks:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   remote-debugger:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  remote:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   remote-json-client:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  remote-json:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   remote-json-server:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  remote-json:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   remote-monad:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  remote:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   remotion:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   reorderable:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   repa-algorithms:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7143,13 +7491,14 @@ dont-distribute-packages:
   repl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   replicant:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   repo-based-blog:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  repr:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   representable-functors:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   representable-tries:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  repr:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   reprinter:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  reqcatcher:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   req-conduit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  req-url-extra:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   req:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  reqcatcher:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   request-monad:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   resin:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   resistor-cube:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7160,6 +7509,7 @@ dont-distribute-packages:
   respond:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   rest-example:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   restful-snap:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  restless-git:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   RESTng:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   restricted-workers:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   restyle:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7174,6 +7524,7 @@ dont-distribute-packages:
   rewrite:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   rewriting:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   rezoom:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rfc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   rhythm-game-tutorial:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   riak:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   RichConditional:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7181,14 +7532,15 @@ dont-distribute-packages:
   ridley:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   riff:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ring-buffer:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rio:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   riot:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   ripple-federation:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   ripple:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   risc386:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   rivers:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  rivet:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   rivet-migration:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   rivet-simple-deploy:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rivet:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   RJson:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Rlang-QQ:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   rlglue:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7201,15 +7553,19 @@ dont-distribute-packages:
   RNAFoldProgs:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   RNAwolf:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   rncryptor:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rob:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   robot:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   robots-txt:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   roc-cluster-demo:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   roc-cluster:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rocksdb-haskell:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   roguestar-engine:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   roguestar-gl:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   roguestar-glut:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rollbar-hs:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   roller:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   RollingDirectory:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rope-utf16-splay:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   rope:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   rose-trees:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   rose-trie:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7222,15 +7578,16 @@ dont-distribute-packages:
   route-generator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   route-planning:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   rowrecord:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  R-pandoc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   rpc-framework:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   rpc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rpf:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   rpm:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   rsagl-frp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  rsagl:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   rsagl-math:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rsagl:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   rset:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   rspp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  rss-conduit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   rss2irc:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   rtnetlink:                                    [ "x86_64-darwin" ]
   rtorrent-rpc:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7245,44 +7602,48 @@ dont-distribute-packages:
   runtime-arbitrary:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   rws:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   RxHaskell:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  s-cargot-letbind:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   SableCC2Hs:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  safecopy-store:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   safe-freeze:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   safe-globals:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  safeint:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   safe-lazy-io:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   safe-length:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   safe-plugins:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   safe-printf:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  safecopy-store:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  safeint:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  safepath:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   safer-file-handles-bytestring:                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  safer-file-handles:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   safer-file-handles-text:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  safer-file-handles:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   saferoute:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   sai-shape-syb:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sajson:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Salsa:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  saltine:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   saltine-quickcheck:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  saltine:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   salvia-demo:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   salvia-extras:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  salvia:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   salvia-protocol:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   salvia-sessions:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   salvia-websocket:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  salvia:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   samtools-conduit:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   samtools-iteratee:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   sandlib:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   sarasvati:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   sarsi:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sasl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sat-micro-hs:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sat:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   satchmo-backends:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   satchmo-examples:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   satchmo-funsat:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   satchmo-minisat:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   satchmo-toysat:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sat:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sat-micro-hs:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   SBench:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   sbvPlugin:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sc3-rdu:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   scalable-server:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   scaleimage:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   SCalendar:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7293,9 +7654,9 @@ dont-distribute-packages:
   schedevr:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   schedyield:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   scholdoc-citeproc:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  scholdoc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   scholdoc-texmath:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   scholdoc-types:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  scholdoc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   science-constants-dimensional:                [ i686-linux, x86_64-linux, x86_64-darwin ]
   science-constants:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   SciFlow:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7314,43 +7675,45 @@ dont-distribute-packages:
   scotty-view:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   scp-streams:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   scrabble-bot:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  scrape-changes:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   ScratchFs:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   scrobble:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   scrz:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   Scurry:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   scyther-proof:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sdl2-cairo-image:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sdl2-compositor:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sdl2-gfx:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   SDL-gfx:                                      [ "x86_64-darwin" ]
   SDL-image:                                    [ "x86_64-darwin" ]
   SDL-mixer:                                    [ "x86_64-darwin" ]
   SDL-mpeg:                                     [ "x86_64-darwin" ]
   SDL-ttf:                                      [ "x86_64-darwin" ]
+  sdl2-cairo-image:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sdl2-compositor:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sdl2-gfx:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   sdr:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   seacat:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   search:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  secdh:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sec:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  secdh:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   seclib:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   second-transfer:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   secret-santa:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   secret-sharing:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   secrm:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sednaDBXML:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  selectors:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   select:                                       [ "x86_64-darwin" ]
-  selenium:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  selectors:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   selenium-server:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  selenium:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   selinux:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Semantique:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   semdoc:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  semi-iso:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   semigroupoids-syntax:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   semigroups-actions:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  semi-iso:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  semiring:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   semiring-num:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  semiring:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   semver-range:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sendgrid-v3:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   sensei:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   sensenet:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   sentence-jp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7361,7 +7724,10 @@ dont-distribute-packages:
   seqloc-datafiles:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   sequent-core:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   sequor:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  serokell-util:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   serpentine:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  serv-wai:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  serv:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-aeson-specs:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-auth-client:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-auth-docs:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7371,18 +7737,24 @@ dont-distribute-packages:
   servant-auth-token-acid:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-auth-token-leveldb:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-auth-token-persistent:                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  servant-auth-token-rocksdb:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  servant-auth-token:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  servant-client-core:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-csharp:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  servant-db:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-db-postgresql:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  servant-db:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-ekg:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-examples:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  servant-github-webhook:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-github:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-haxl-client:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-jquery:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  servant-match:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-matrix-param:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-pandoc:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-pool:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-postgresql:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  servant-proto-lens:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-py:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-quickcheck:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   servant-router:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7393,17 +7765,17 @@ dont-distribute-packages:
   servant-zeppelin-server:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   server-generic:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   serversession-frontend-snap:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  serv:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   services:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  serv-wai:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ses-html:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ses-html-snaplet:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ses-html:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   SessionLogger:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   sessions:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sessiontypes-distributed:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  set-with:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   setgame:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  setop:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sets:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   setters:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  set-with:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   sexp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   sexpr:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sfml-audio:                                   [ "x86_64-darwin" ]
@@ -7412,16 +7784,19 @@ dont-distribute-packages:
   sfmt:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   sfnt2woff:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   SFont:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  SGdemo:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sgd:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sgf:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   SG:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sgd:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SGdemo:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sgf:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   sgrep:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sha-streams:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   shadower:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   shadowsocks:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   shady-gen:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   shady-graphics:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  shake-ats:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   shake-cabal-build:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  shake-ext:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   shake-extras:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   shake-minify:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   shake-persist:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7433,76 +7808,80 @@ dont-distribute-packages:
   shared-buffer:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   shared-fields:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   shared-memory:                                [ "x86_64-darwin" ]
-  sha-streams:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   she:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   shelduck:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Shellac-editline:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   shell-conduit:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  shellish:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   shell-pipe:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Shellac-editline:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  shellish:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   shelltestrunner:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   shikensu:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  shimmer:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   shoap:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   shorten-strings:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   ShortestPathProblems:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   showdown:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   shpider:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Shu-thing:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  shuffle:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   si-clock:                                     [ "x86_64-darwin" ]
-  sifflet:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   sifflet-lib:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sifflet:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   signals:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   signed-multiset:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  silvi:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   simd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   simgi:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-atom:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-bluetooth:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  simple-c-value:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-config:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-css:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  simple-c-value:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-eval:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-firewire:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-form:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-genetic-algorithm:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  SimpleGL:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  SimpleH:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-index:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  simpleirc:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  simpleirc-lens:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  simple-logging:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  SimpleLog:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-log-syslog:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  simple-logging:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-neural-networks:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-nix:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  simplenote:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-pascal:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   simple-postgresql-orm:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  simple-tabular:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  simple-vec3:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SimpleGL:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SimpleH:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  simpleirc-lens:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  simpleirc:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SimpleLog:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  simplenote:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   simpleprelude:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   SimpleServer:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   simplessh:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   simplest-sqlite:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   SimpleTableGenerator:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  simple-tabular:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   simseq:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   sink:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   siphon:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   sirkel:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   sitemap:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   sixfiguregroup:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sized:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sized-vector:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sized:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sjsp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   skeleton:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   skell:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   skemmtun:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   skylark-client:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   skype4hs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  slack:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   slack-web:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  slack:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  slate:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   slidemews:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Slides:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sloth:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   slot-lambda:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sloth:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   smallarray:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   smallcheck-laws:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   smallcheck-lens:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7512,16 +7891,17 @@ dont-distribute-packages:
   smartconstructor:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   smartGroup:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   smartword:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  smcdel:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   sme:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   smerdyakov:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Smooth:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  smt-lib:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   smtlib2-debug:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   smtlib2-pipe:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  smt-lib:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   SmtLib:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  smtp-mail-ng:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   smtp2mta:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   SMTPClient:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  smtp-mail-ng:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   snake-game:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   snake:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   snap-auth-cli:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7530,6 +7910,12 @@ dont-distribute-packages:
   snap-cors:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   snap-error-collector:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   snap-extras:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snap-loader-dynamic:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snap-predicates:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snap-routes:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snap-testing:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snap-utils:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snap-web-routes:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   snap:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-acid-state:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-actionlog:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7547,8 +7933,8 @@ dont-distribute-packages:
   snaplet-i18n:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-influxdb:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-mandrill:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snaplet-mongoDB:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-mongodb-minimalistic:                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snaplet-mongoDB:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-mysql-simple:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-oauth:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-persistent:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7564,21 +7950,15 @@ dont-distribute-packages:
   snaplet-scoped-session:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-sedna:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-ses-html:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snaplet-sqlite-simple:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-sqlite-simple-jwt-auth:               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snaplet-sqlite-simple:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-stripe:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-tasks:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-typed-sessions:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   snaplet-wordpress:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snap-loader-dynamic:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snap-predicates:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   snappy-conduit:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   snappy-framing:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   snappy-iteratee:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snap-routes:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snap-testing:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snap-utils:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snap-web-routes:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   sndfile-enumerators:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   sneakyterm:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   sneathlane-haste:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7586,16 +7966,16 @@ dont-distribute-packages:
   snm:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   snmp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   snorkels:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  snow-white:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   snowflake-core:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   snowflake-server:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  snow-white:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Snusmumrik:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  SoccerFunGL:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   SoccerFun:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SoccerFunGL:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   sock2stream:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  socket-sctp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   socketed:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   socketio:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  socket-sctp:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   socketson:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   sodium:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   soegtk:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7611,18 +7991,22 @@ dont-distribute-packages:
   SourceGraph:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   sousit:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   soyuz:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SpaceInvaders:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   spacepart:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   SpacePrivateers:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   spaceprobe:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  spake2:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   spanout:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   sparkle:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sparse:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   sparsebit:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   sparsecheck:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sparse:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   spata:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  spatial-math:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   special-functors:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   specialize-th:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   speculate:                                    [ "x86_64-darwin" ]
+  speculate:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   spelling-suggest:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   sphero:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   sphinx-cli:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7640,34 +8024,35 @@ dont-distribute-packages:
   Sprig:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   spritz:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   spsa:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sqlcipher:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sqlite-simple-typed:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sql-simple:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   sql-simple-mysql:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   sql-simple-pool:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   sql-simple-postgresql:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sql-simple-sqlite:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sql-simple:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sqlcipher:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sqlite-simple-typed:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   sqlvalue-list:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   sqsd-local:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   squeal-postgresql:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   srcinst:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   sscan:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   sscgi:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sshd-lint:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   ssh:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sshd-lint:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   sssp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   sstable:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   stable-heap:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   stable-maps:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   stable-tree:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stack2nix:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stackage2nix:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stackage-build-plan:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stackage-cabal:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stackage:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stackage-setup:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   stack-bump:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   stack-hpc-coveralls:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stack-lib:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stack2nix:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stackage-build-plan:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stackage-cabal:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stackage-setup:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stackage2nix:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stackage:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   standalone-derive-topdown:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   standalone-haddock:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   starling:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7675,15 +8060,16 @@ dont-distribute-packages:
   stash:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Stasis:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   state-bag:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stateful-mtl:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  state:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   state-record:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  state:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stateful-mtl:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   statgrab:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  static-tensor:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   statistics-dirichlet:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   statistics-fusion:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   statistics-hypergeometric-genvar:             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  statsd:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   stats:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  statsd:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   stb-truetype:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   stdata:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   stdf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7693,32 +8079,34 @@ dont-distribute-packages:
   stepwise:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   stgi:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   stm-chunked-queues:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stmcontrol:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   stm-firehose:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stmcontrol:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   stochastic:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Stomp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   storable-static-array:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   storablevector-streamfusion:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  str:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Strafunski-ATermLib:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   Strafunski-Sdf2Haskell:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   StrappedTemplates:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stratosphere:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   stratum-tool:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   stratux-http:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stratux:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   stratux-types:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   stratux-websockets:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  streamed:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stratux:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   stream-fusion:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stream:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  streaming-cassava:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   stream-monad:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stream:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  streamed:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  streaming-cassava:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   strelka:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  str:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  StrictBench:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   strict-concurrency:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  StrictBench:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   strictly:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  stringlike:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  string-isos:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   string-typelits:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stringlike:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   stripe-haskell:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   stripe-http-streams:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   stripe:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7729,10 +8117,12 @@ dont-distribute-packages:
   structures:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   stunts:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   stutter:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  stylish-cabal:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   stylized:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sub-state:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   subhask:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   subleq-toolchain:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sub-state:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  submark:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   suffixarray:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   SuffixStructures:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   suitable:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7741,14 +8131,17 @@ dont-distribute-packages:
   sunroof-compiler:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   sunroof-examples:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   sunroof-server:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  super-user-spark:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   supercollider-ht:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   supercollider-midi:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   superconstraints:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   superdoc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  superevent:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  supermonad:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   supero:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  super-user-spark:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   supervisor:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   supplemented:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SVD2HS:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   svg2q:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   SVG2Q:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   svgutils:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7762,32 +8155,36 @@ dont-distribute-packages:
   SWMMoutGetMB:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   sws:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   syb-extras:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  SybWidget:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   syb-with-class-instances-text:                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SybWidget:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   sylvia:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sym-plot:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sym:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  symantic-document:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  symantic-grammar:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   symantic-lib:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  symantic:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   symengine-hs:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   symengine:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sym:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sym-plot:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  sync:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   sync-mht:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  sync:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   syncthing-hs:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  syntactic:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   syntax-attoparsec:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  syntax-example:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   syntax-example-json:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  syntax:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  SyntaxMacros:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  syntaxnet-haskell:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  syntax-example:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   syntax-pretty:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   syntax-printer:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   syntax-trees-fork-bairyn:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   syntax-trees:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  syntax:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  SyntaxMacros:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  syntaxnet-haskell:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   synthesizer-alsa:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   synthesizer-filter:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  synthesizer:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   synthesizer-llvm:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   synthesizer-midi:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  synthesizer:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   sysinfo:                                      [ "x86_64-darwin" ]
   Sysmon:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   system-canonicalpath:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7795,42 +8192,45 @@ dont-distribute-packages:
   system-lifted:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   system-locale:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   system-random-effect:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  systemstats:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   system-time-monotonic:                        [ "x86_64-darwin" ]
+  systemstats:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  t-regex:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   t3-client:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   t3-server:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  table:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ta:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   table-layout:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  table-tennis:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  table:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   tables:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Tables:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   tablestorage:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  table-tennis:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   tablize:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   tabloid:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tabs:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   taffybar:                                     [ "x86_64-darwin" ]
   tag-bits:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   tagged-list:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   tagged-th:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   tagged-timers:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  taggy:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   taggy-lens:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  taggy:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   taglib-api:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   tagset-positional:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   tagsoup-ht:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   tagsoup-parsec:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   tagsoup-selection:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   Tahin:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  ta:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tailfile-hinotify:                            [ "x86_64-darwin" ]
   tai:                                          [ "x86_64-darwin" ]
-  Takusen:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tailfile-hinotify:                            [ "x86_64-darwin" ]
   takusen-oracle:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tamarin-prover:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Takusen:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   tamarin-prover-term:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   tamarin-prover-theory:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   tamarin-prover-utils:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tamarin-prover:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   Tape:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   target:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tart:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   task-distribution:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   task:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   tasty-auto:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7840,14 +8240,15 @@ dont-distribute-packages:
   tasty-jenkins-xml:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   tasty-laws:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   tasty-lens:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tasty-travis:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   TaxonomyTools:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   TBC:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   TBit:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   tbox:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   tccli:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   tcod-haskell:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tcp:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   tcp-streams-openssl:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tcp:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   tdd-util:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   TeaHS:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   teams:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7860,92 +8261,97 @@ dont-distribute-packages:
   template-default:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   template-haskell-util:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   template-hsml:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  template-yj:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   templateify:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   templatepg:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  template-yj:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   tempodb:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   temporal-csound:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   temporary-resourcet:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   tempus:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tensor:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   tensorflow-core-ops:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tensorflow:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   tensorflow-logging:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   tensorflow-opgen:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   tensorflow-ops:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   tensorflow-proto:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   tensorflow-records-conduit:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   tensorflow-records:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tensor:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tensorflow:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  term-rewriting:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   termbox-bindings:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   termination-combinators:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   termplot:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  term-rewriting:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   terntup:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   terrahs:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   tersmu:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  testbench:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-framework-doctest:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-framework-quickcheck:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-framework-sandbox:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-framework-skip:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-framework-th-prime:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  testloop:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  testpack:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  testpattern:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-pkg:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  testPkg:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  testrunner:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-sandbox-compose:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-sandbox-hunit:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   test-shouldbe:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tex2txt:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  testbench:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  testloop:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  testpack:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  testpattern:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  testPkg:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  testrunner:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   TeX-my-math:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tex2txt:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  texbuilder:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-and-plots:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  text-builder:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  text-containers:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-generic-pretty:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-icu-normalized:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-json-qq:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-ldap:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-lens:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-markup:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  textmatetags:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-normal:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  textocat-api:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-position:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-register-machine:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-render:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-short:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  textual:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-xml-generic:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-xml-qq:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   text-zipper-monad:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  textmatetags:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  textocat-api:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  textual:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   tfp-th:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   tftp:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   tga:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   th-build:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   th-context:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  th-fold:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  th-instance-reification:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  th-instances:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  th-kinds-fork:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  th-sccs:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  th-traced:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  th-typegraph:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  thank-you-stars:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   thentos-cookie-session:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Theora:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   theoremquest-client:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   theoremquest:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  th-fold:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   thih:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   thimk:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Thingie:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  th-instance-reification:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  th-instances:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  th-kinds-fork:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   thorn:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   threadscope:                                  [ "x86_64-darwin" ]
   threepenny-gui-contextmenu:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   thrift:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   Thrift:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   throttled-io-loop:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  th-sccs:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  th-traced:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  th-typegraph:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   tibetan-utils:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tictactoe3d:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   tic-tac-toe:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tickle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tictactoe3d:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   TicTacToe:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   tidal-midi:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   tidal-serial:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7955,21 +8361,22 @@ dont-distribute-packages:
   tightrope:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   tighttp:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   timberc:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  timecalc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   time-extras:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   time-exts:                                    [ "x86_64-darwin" ]
   time-http:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   time-io-access:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  timeout:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  timeparsers:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  time-machine:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   time-patterns:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  TimePiece:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  timeprint:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   time-recurrence:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   time-series:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  timeseries:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   time-w3c:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   time-warp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  timecalc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  timeout:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  timeparsers:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  TimePiece:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  timeprint:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  timeseries:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   timezone-unix:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   TinyLaunchbury:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   tinyMesh:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -7984,30 +8391,34 @@ dont-distribute-packages:
   tls-extra:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   tmp-postgres:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   tn:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  to-haskell:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  to-string-class:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  to-string-instances:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   toboggan:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   todos:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   tofromxml:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  to-haskell:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   toilet:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   tokenify:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   toktok:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   tokyocabinet-haskell:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   tomato-rubato-openal:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   toml:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tomlcheck:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Top:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  top:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   topkata:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   torch:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  to-string-class:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  to-string-instances:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  TORCS:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   touched:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Tournament:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   toxcore:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   toysolver:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   tpar:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tpb:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   trace-call:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  traced:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   trace-function-call:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   trace:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  traced:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   tracker:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   traildb:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   trajectory:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8027,12 +8438,13 @@ dont-distribute-packages:
   travis-meta-yaml:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   trawl:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   traypoweroff:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tree-diff:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   TreeCounter:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  treemap-html:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   treemap-html-tools:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  treemap-html:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   treersec:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  treeseq:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   TreeStructures:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  t-regex:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   Treiber:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   tremulous-query:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   TrendGraph:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8040,6 +8452,7 @@ dont-distribute-packages:
   triangulation:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   TrieMap:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   tries:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  trigger:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   trimpolya:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   triplesec:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   tripLL:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8048,20 +8461,20 @@ dont-distribute-packages:
   tsession:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   tskiplist:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   tslib:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tsparse:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   tsp-viz:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tsparse:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   tsvsql:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tuntap:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   tuntap-simple:                                [ "x86_64-darwin" ]
+  tuntap:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   tup-functor:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   tuple-gen:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   tuple-hlist:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  tupleinstances:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   tuple-lenses:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   tuple-morph:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  turingMachine:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tupleinstances:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   turing-machines:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   turing-music:                                 [ "x86_64-darwin" ]
+  turingMachine:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   tweak:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   twee:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   tweet-hs:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8084,49 +8497,51 @@ dont-distribute-packages:
   tx:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   txtblk:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   TYB:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  tyfam-witnesses:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   typalyze:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typeable-th:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-cache:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-cereal:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  TypeClass:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-combinators-quote:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-digits:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typedquery:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typed-spreadsheet:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typed-streams:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typed-wire:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typed-wire-utils:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typehash:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  TypeIlluminator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-int:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-level-bst:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typelevel:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-level-natural-number-induction:          [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-level-natural-number-operations:         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typelevel-tensor:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  TypeNat:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-of-html:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  type-ord:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-ord-spine-cereal:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typeparams:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  type-ord:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-prelude:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typesafe-precure:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  types-compat:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  typescript-docs:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-settheory:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-spine:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-structure:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   type-sub-th:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typeable-th:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  TypeClass:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typed-spreadsheet:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typed-streams:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typed-wire-utils:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typed-wire:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typedquery:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typehash:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  TypeIlluminator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typelevel-tensor:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typelevel:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  TypeNat:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typeparams:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  types-compat:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typesafe-precure:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  typescript-docs:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   tz:                                           [ "x86_64-darwin" ]
   u2f:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   uAgda:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   uber:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   uberlast:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   uconv:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  udbus:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   udbus-model:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  udbus:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   udp-conduit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   uhc-light:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  uhc-util:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   uhexdump:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   ui-command:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   UMM:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8140,9 +8555,10 @@ dont-distribute-packages:
   unicode-symbols:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   uniform-io:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   union-map:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  uniqueid:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  unique-logic:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   unique-logic-tf:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  unique-logic:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  uniqueid:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  uniquely-represented-sets:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   units-attoparsec:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   unittyped:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   universe-th:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8155,8 +8571,8 @@ dont-distribute-packages:
   unsafely:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   unscramble:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   unsequential:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  update-nix-fetchgit:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   up:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  update-nix-fetchgit:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   uploadcare:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   upskirt:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   ureader:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8164,15 +8580,15 @@ dont-distribute-packages:
   uri-conduit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   uri-enumerator-file:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   uri-enumerator:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  url-decoders:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  url-generic:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   urlcheck:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   urldecode:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  url-decoders:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   urldisp-happstack:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   UrlDisp:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  url-generic:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   URLT:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  urn:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   urn-random:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  urn:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   urxml:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   usb-enumerator:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   usb-hid:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8183,37 +8599,44 @@ dont-distribute-packages:
   utc:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   utf8-prelude:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   UTFTConverter:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  uuagc-diagrams:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  uuid-aeson:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  uu-cco-examples:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   uu-options:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  uuagc-cabal:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  uuagc-diagrams:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
+  uuagc:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  uuid-aeson:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   uvector-algorithms:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   uvector:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   v4l2-examples:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   v4l2:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   vacuum-cairo:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   vacuum-graphviz:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  vacuum:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   vacuum-opengl:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   vacuum-ubigraph:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  vacuum:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  valid-names:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   validated-literals:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   Validation:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  validation:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   validations:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
-  valid-names:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   vampire:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   var:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   variable-precision:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   variables:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
-  vaultaire-common:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   vault-tool-server:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  vaultaire-common:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   vcache-trie:                                  [ "x86_64-darwin" ]
   vcache:                                       [ "x86_64-darwin" ]
   vcatt:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   vcsgui:                                       [ "x86_64-darwin" ]
   Vec-Boolean:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   Vec-OpenGLRaw:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Vec-Transform:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  vec:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   vect-floating-accelerate:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   vect-floating:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   vect-opengl:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  vector-builder:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   vector-bytes-instances:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   vector-bytestring:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   vector-clock:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8225,16 +8648,17 @@ dont-distribute-packages:
   vector-read-instances:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   vector-space-opengl:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   vector-static:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Vec-Transform:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   Verba:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   verbalexpressions:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  verdict:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   verdict-json:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  verdict:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   verilog:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   vgrep:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  vicinity:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   views:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   vigilance:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   Villefort:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  vimeta:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   vimus:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   vintage-basic:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   vinyl-json:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8250,18 +8674,20 @@ dont-distribute-packages:
   vowpal-utils:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   voyeur:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   vrpn:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  vtegtk3:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   vte:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  vtegtk3:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   vty-examples:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   vty-menu:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   vty-ui-extras:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   vty-ui:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  vulkan-api:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   vulkan:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   wacom-daemon:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   waddle:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   wahsp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-devel:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-dispatch:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  wai-git-http:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-graceful:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-handler-devel:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-handler-scgi:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8273,8 +8699,8 @@ dont-distribute-packages:
   wai-lite:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-logger-prefork:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-make-assets:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  wai-middleware-cache:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-middleware-cache-redis:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  wai-middleware-cache:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-middleware-catch:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-middleware-consul:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   wai-middleware-content-type:                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8307,6 +8733,16 @@ dont-distribute-packages:
   wavesurfer:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   wavy:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   weather-api:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-css:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-encodings:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-fpco:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-mongrel2:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-output:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-push:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-routes-quasi:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-routes-regular:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-routes-transformers:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  web-routing:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   web3:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   webapi:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   webapp:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8315,36 +8751,26 @@ dont-distribute-packages:
   webcloud:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   WebCont:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   webcrank-dispatch:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
-  webcrank:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   webcrank-wai:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-css:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  webcrank:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   webdriver-snoy:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-encodings:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   WeberLogic:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   webfinger-client:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-fpco:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  webkit2gtk3-javascriptcore:                   [ "x86_64-darwin" ]
   webkit-javascriptcore:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-mongrel2:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-output:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-push:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  webkit2gtk3-javascriptcore:                   [ "x86_64-darwin" ]
   Webrexp:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-routes-quasi:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-routes-regular:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-routes-transformers:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  web-routing:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   webserver:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   webwire:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   wedged:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  weighted:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   weighted-regexp:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  weighted:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   welshy:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  werewolf:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   werewolf-slack:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Wheb:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  werewolf:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   wheb-mongo:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   wheb-redis:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   wheb-strapped:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Wheb:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   while-lang-parser:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   whim:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   whiskers:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8354,21 +8780,24 @@ dont-distribute-packages:
   WikimediaParser:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   wikipedia4epub:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   wild-bind-task-x11:                           [ "x86_64-darwin" ]
+  windns:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   windowslive:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   winerror:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   winio:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Wired:                                        [ "x86_64-darwin" ]
   wires:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   wkt:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  wl-pprint-ansiterm:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   WL500gPControl:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   WL500gPLib:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   wlc-hs:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
-  wl-pprint-ansiterm:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   WMSigner:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   wobsurv:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   woffex:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   wolf:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  word2vec-model:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   WordAlignment:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  wordchoice:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   Wordlint:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   WordNet-ghc74:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   WordNet:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8380,12 +8809,15 @@ dont-distribute-packages:
   workflow-windows:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   wp-archivebot:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   wraxml:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  wrecker-ui:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   wrecker:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   wreq-sb:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   wreq-stringless:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   wright:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  ws:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   wsdl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   wsedit:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  wsjtx-udp:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   wtk-gtk:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   wtk:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   wumpus-basic:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8394,17 +8826,18 @@ dont-distribute-packages:
   wumpus-microprint:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   wumpus-tree:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   WURFL:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  wx:                                           [ "x86_64-darwin" ]
   wxAsteroids:                                  [ "x86_64-darwin" ]
-  wxcore:                                       [ "x86_64-darwin" ]
   wxc:                                          [ "x86_64-darwin" ]
+  wxcore:                                       [ "x86_64-darwin" ]
   WXDiffCtrl:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   wxFruit:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   WxGeneric:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   wxhnotepad:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   wxSimpleCanvas:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   wxturtle:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  wx:                                           [ "x86_64-darwin" ]
   wyvern:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  x-dsp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   X11-extras:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   X11-rm:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   X11-xdamage:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8416,7 +8849,6 @@ dont-distribute-packages:
   xchat-plugin:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   xcp:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   xdot:                                         [ "x86_64-darwin" ]
-  x-dsp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   Xec:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   xfconf:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   xhaskell-library:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8427,18 +8859,15 @@ dont-distribute-packages:
   xing-api:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   xkbcommon:                                    [ "x86_64-darwin" ]
   xkcd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
-  xlsior:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  xleb:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   xls:                                          [ "x86_64-darwin" ]
+  xlsior:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   xlsx-templater:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
-  xml2json:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  xml2x:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-catalog:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-conduit-decode:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-enumerator-combinators:                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-enumerator:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-html-conduit-lens:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  xmlhtml:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  XmlHtmlWriter:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-isogen:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-monad:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-parsec:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8447,8 +8876,14 @@ dont-distribute-packages:
   xml-push:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-query-xml-conduit:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-query-xml-types:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  xmltv:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   xml-tydom-conduit:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  xml2json:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
+  xml2x:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  xmlbf-xeno:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  xmlbf-xmlhtml:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  xmlhtml:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  XmlHtmlWriter:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  xmltv:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   xmms2-client-glib:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   xmms2-client:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   XMMS:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8480,20 +8915,24 @@ dont-distribute-packages:
   yahoo-web-search:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   yajl-enumerator:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   yajl:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yam-job:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yam-servant:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yaml-rpc-scotty:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yaml-rpc-snap:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yaml-rpc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   yaml2owl:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   yamlkeysdiff:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   YamlReference:                                [ "x86_64-darwin" ]
-  yaml-rpc:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yaml-rpc-scotty:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yaml-rpc-snap:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yampa2048:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   yampa-canvas:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   yampa-glfw:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   yampa-glut:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yampa-sdl2:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yampa2048:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   yaop:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   yap:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yarr:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yarn2nix:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   yarr-image-io:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yarr:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   yate:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   yavie:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   ycextra:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8507,9 +8946,9 @@ dont-distribute-packages:
   yesod-auth-deskcom:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-auth-hmac-keccak:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-auth-kerberos:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yesod-auth-ldap:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-auth-ldap-mediocre:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-auth-ldap-native:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yesod-auth-ldap:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-auth-oauth2:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-auth-oauth:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-auth-pam:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8519,8 +8958,8 @@ dont-distribute-packages:
   yesod-comments:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-content-pdf:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-continuations:                          [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yesod-crud:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-crud-persist:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yesod-crud:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-datatables:                             [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-examples:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-fay:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8539,8 +8978,8 @@ dont-distribute-packages:
   yesod-raml-bin:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-raml-mock:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-recaptcha:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yesod-routes:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-routes-typescript:                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yesod-routes:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-rst:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-s3:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   yesod-sass:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8553,21 +8992,25 @@ dont-distribute-packages:
   yesod-worker:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   YFrob:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   yhccore:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yices:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   yi-contrib:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   yi-dynamic-configuration:                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yi:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yi-frontend-pango:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
   yi-monokai:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   yi-solarized:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   yi-spolsky:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  yjftp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yi:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yices:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   yjftp-libs:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
-  Yogurt:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yjftp:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yoga:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   Yogurt-Standalone:                            [ i686-linux, x86_64-linux, x86_64-darwin ]
+  Yogurt:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   yoko:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   york-lava:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   yql:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   yst:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yu-core:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
+  yu-launch:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   yuiGrid:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   yuuko:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   zabt:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8576,10 +9019,10 @@ dont-distribute-packages:
   ZEBEDDE:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   zendesk-api:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   zeno:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  zeromq-haskell:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   zeromq3-conduit:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   zeromq3-haskell:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   zeromq4-conduit:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
-  zeromq-haskell:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   zeroth:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   ZFS:                                          [ i686-linux, x86_64-linux, x86_64-darwin ]
   zifter-cabal:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8587,8 +9030,8 @@ dont-distribute-packages:
   zifter-google-java-format:                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   zifter-hindent:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   zifter-hlint:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  zifter:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   zifter-stack:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
+  zifter:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   zim-parser:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   zip-conduit:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   zipedit:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
@@ -8602,13 +9045,14 @@ dont-distribute-packages:
   zmidi-score:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   zmqat:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   zoneinfo:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  zoom-cache:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   zoom-cache-pcm:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   zoom-cache-sndfile:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
-  zoom:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  zoom-cache:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   zoom-refs:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
+  zoom:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   zot:                                          [ "x86_64-darwin" ]
   zsh-battery:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   zstd:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
+  zuramaru:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   Zwaluw:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   zxcvbn-c:                                     [ "x86_64-darwin" ]

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -458,7 +458,7 @@ self: super: builtins.intersectAttrs super {
   haskell-gi-base = addBuildDepend super.haskell-gi-base pkgs.gobjectIntrospection;
 
   # Requires gi-javascriptcore API version 4
-  gi-webkit2 = super.gi-webkit2.override { gi-javascriptcore = self.gi-javascriptcore_4_0_14; };
+  gi-webkit2 = super.gi-webkit2.override { gi-javascriptcore = self.gi-javascriptcore_4_0_15; };
 
   # requires valid, writeable $HOME
   hatex-guide = overrideCabal super.hatex-guide (drv: {

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -275,7 +275,7 @@ stdenv.mkDerivation ({
 
     echo configureFlags: $configureFlags
     ${setupCommand} configure $configureFlags 2>&1 | ${coreutils}/bin/tee "$NIX_BUILD_TOP/cabal-configure.log"
-    if ${gnugrep}/bin/egrep -q '^Warning:.*depends on multiple versions' "$NIX_BUILD_TOP/cabal-configure.log"; then
+    if ${gnugrep}/bin/egrep -q -z 'Warning:.*depends on multiple versions' "$NIX_BUILD_TOP/cabal-configure.log"; then
       echo >&2 "*** abort because of serious configure-time warning from Cabal"
       exit 1
     fi


### PR DESCRIPTION
This update bumps all Stackage packages from lts-9.3 to 9.21. These updates should be save since all those updates preserve the original API.

Furthermore, we update the following Stackage packages to their respective latest version:

- `cabal-install`
- `cabal2nix`
- `distribution-nixpkgs`
- `git-annex`
- `hindent`
- `hledger`
- `hlint`
- `hoogle`
- `hopenssl`
- `language-nix`
- `ShellCheck`
- `stack` (fixes https://github.com/NixOS/nixpkgs/issues/35260)
- `weeder`

These updates will include API changes, but since the list is rather small I think we can deal with any issues that might arise as a consequence of these updates.

Finally, all non-Stackage packages on Hackage are update to their latest version. This update is the riskiest one, because these updates will include API-breaking changes. There is precedent for taking that risk, however. We have done these kind of updates on release branches before and in the past everything has worked out okay.

The current state of these builds can be seen at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates.

Ping: @CMCDragonkai, @bjornfor, @rsoeldner