### PR TITLE
memtester: fix cross build

### DIFF
--- a/pkgs/tools/system/memtester/default.nix
+++ b/pkgs/tools/system/memtester/default.nix
@@ -4,6 +4,11 @@ stdenv.mkDerivation rec {
   name = "memtester-${version}";
   version = "4.3.0";
 
+  preConfigure = ''
+    echo "$CC" > conf-cc
+    echo "$CC" > conf-ld
+  '';
+
   src = fetchurl {
     url = "http://pyropus.ca/software/memtester/old-versions/memtester-${version}.tar.gz";
     sha256 = "127xymmyzb9r6dxqrwd69v7gf8csv8kv7fjvagbglf3wfgyy5pzr";


### PR DESCRIPTION
###### Motivation for this change
Cross compilation didn't work, now it does

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

