### PR TITLE
1709 xscreensaver

### DIFF
--- a/pkgs/misc/screensavers/xscreensaver/default.nix
+++ b/pkgs/misc/screensavers/xscreensaver/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "5.36";
+  version = "5.37";
   name = "xscreensaver-${version}";
 
   src = fetchurl {
     url = "http://www.jwz.org/xscreensaver/${name}.tar.gz";
-    sha256 = "0v60mdhvv42jla5hljp77igng11kxpah5fs9j7ci65kz0hw552vb";
+    sha256 = "1ng5ddzb4k2h1w54pvk9hzxvnxxmc54bc4a2ibk974nzjjjaxivs";
   };
 
   buildInputs =

--- a/pkgs/misc/screensavers/xscreensaver/default.nix
+++ b/pkgs/misc/screensavers/xscreensaver/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "5.37";
+  version = "5.38";
   name = "xscreensaver-${version}";
 
   src = fetchurl {
-    url = "http://www.jwz.org/xscreensaver/${name}.tar.gz";
-    sha256 = "1ng5ddzb4k2h1w54pvk9hzxvnxxmc54bc4a2ibk974nzjjjaxivs";
+    url = "https://www.jwz.org/xscreensaver/${name}.tar.gz";
+    sha256 = "1f58h5rgjbxr4hh40m6zkpkzbzg68l7nqzjwal0b17yysafbmsf6";
   };
 
   buildInputs =
@@ -47,12 +47,12 @@ stdenv.mkDerivation rec {
   ;
 
   meta = {
-    homepage = http://www.jwz.org/xscreensaver/;
+    homepage = https://www.jwz.org/xscreensaver/;
     description = "A set of screensavers";
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = with stdenv.lib.platforms; allBut cygwin;
     inherit version;
-    downloadPage = "http://www.jwz.org/xscreensaver/download.html";
+    downloadPage = "https://www.jwz.org/xscreensaver/download.html";
     updateWalker = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The old version displays warnings, asking for an upgrade.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

