### PR TITLE
mlt: 6.4.1 -> 6.6.0

### DIFF
--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -6,27 +6,14 @@
 
 stdenv.mkDerivation rec {
   name = "mlt-${version}";
-  version = "6.4.1";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "mlt";
     rev = "v${version}";
-    sha256 = "0k9vj21n6qxdjd0vvj22cwi35igajjzh5fbjza766izdbijv2i2w";
+    sha256 = "0b2fq0819r7n141l6hhr66hpayqqcmjr2yxw9azxkapg1h0div6q";
   };
-
-  patches = [
-    # fix for glibc-2.26
-    (fetchurl {
-      url = "https://github.com/mltframework/mlt/commit/2125e3955a0d0be61571cf43b674f74b4b93c6f8.patch";
-      sha256 = "1bgs5a3dblsmdmb7hwval9nmq1as4r4f48b3amsc23v69nsl2g0a";
-    })
-    # fix for glibc-2.26
-    (fetchurl {
-      url = "https://github.com/mltframework/mlt/commit/fbf6a5187776f2f392cf258935ff49e4c0e87024.patch";
-      sha256 = "045vchpcznzsz47j67kxwdbg133kar66ssna3parnzrxdfqi72pv";
-    })
-  ];
 
   buildInputs = [
     SDL ffmpeg frei0r libjack2 libdv libsamplerate libvorbis libxml2

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL, ffmpeg, frei0r, libjack2, libdv, libsamplerate
+{ stdenv, fetchFromGitHub, SDL, ffmpeg, frei0r, libjack2, libdv, libsamplerate
 , libvorbis, libxml2, makeWrapper, movit, pkgconfig, sox, qtbase, qtsvg
 , fftw, vid-stab, opencv3, ladspa-sdk
 }:
@@ -7,24 +7,14 @@ let inherit (stdenv.lib) getDev; in
 
 stdenv.mkDerivation rec {
   name = "mlt-${version}";
-  version = "6.4.1";
+  version = "6.6.0";
 
-  src = fetchurl {
-    url = "https://github.com/mltframework/mlt/archive/v${version}.tar.gz";
-    sha256 = "10m3ry0b2pvqx3bk34qh5dq337nn8pkc2gzfyhsj4nv9abskln47";
+  src = fetchFromGitHub {
+    owner = "mltframework";
+    repo = "mlt";
+    rev = "v${version}";
+    sha256 = "0b2fq0819r7n141l6hhr66hpayqqcmjr2yxw9azxkapg1h0div6q";
   };
-  patches = [
-    # fix for glibc-2.26
-    (fetchurl {
-      url = "https://github.com/mltframework/mlt/commit/2125e3955a0d0be61571cf43b674f74b4b93c6f8.patch";
-      sha256 = "1bgs5a3dblsmdmb7hwval9nmq1as4r4f48b3amsc23v69nsl2g0a";
-    })
-    # fix for glibc-2.26
-    (fetchurl {
-      url = "https://github.com/mltframework/mlt/commit/fbf6a5187776f2f392cf258935ff49e4c0e87024.patch";
-      sha256 = "045vchpcznzsz47j67kxwdbg133kar66ssna3parnzrxdfqi72pv";
-    })
-  ];
 
   buildInputs = [
     SDL ffmpeg frei0r libjack2 libdv libsamplerate libvorbis libxml2


### PR DESCRIPTION
fix opencv incompatibility reported in #36170

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

