### PR TITLE
ansible: init at 1.9.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -774,6 +774,7 @@
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
   xaverdh = "Dominik Xaver Hörl <hoe.dom@gmx.de>";
   xeji = "xeji <xeji@cat3.de>";
+  xnaveira = "Xavier Naveira <xnaveira@gmail.com>";
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
   xurei = "Olivier Bourdoux <olivier.bourdoux@gmail.com>";
   xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";

--- a/pkgs/tools/admin/ansible/1.9.nix
+++ b/pkgs/tools/admin/ansible/1.9.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, pythonPackages
+, windowsSupport ? false
+}:
+
+with pythonPackages;
+
+let
+  jinja = jinja2.overridePythonAttrs (old: rec {
+    version = "2.8.1";
+    name = "${old.pname}-${version}";
+    src = fetchFromGitHub {
+      owner = "pallets";
+      repo = "jinja";
+      rev = version;
+      sha256 = "0m6g6fx6flxb6hrkw757mbx1gxyrmj50w27m2afdsvmvz0zpdi2a";
+    };
+  });
+in buildPythonPackage rec {
+  version = "1.9.4";
+  name = "ansible-${version}";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "https://releases.ansible.com/ansible/${name}.tar.gz";
+    sha256 = "1qvgzb66nlyc2ncmgmqhzdk0x0p2px09967p1yypf5czwjn2yb4p";
+  };
+
+  prePatch = ''
+    sed -i "s,/usr/,$out," lib/ansible/constants.py
+  '';
+
+  doCheck = false;
+  dontStrip = true;
+  dontPatchELF = true;
+  dontPatchShebangs = true;
+
+  propagatedBuildInputs = with pythonPackages; [
+    pycrypto jinja paramiko pyyaml httplib2 boto six netaddr dnspython
+  ] ++ stdenv.lib.optional windowsSupport pywinrm;
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.ansible.com";
+    description = "A simple automation tool";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.xnaveira ];
+    platforms = platforms.linux ++ [ "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7322,6 +7322,7 @@ with pkgs;
 
   augeas = callPackage ../tools/system/augeas { };
 
+  ansible_1_9 = callPackage ../tools/admin/ansible/1.9.nix {};
   ansible_2_1 = callPackage ../tools/admin/ansible/2.1.nix {};
   ansible_2_2 = callPackage ../tools/admin/ansible/2.2.nix {};
   ansible_2_3 = callPackage ../tools/admin/ansible/2.3.nix {};


### PR DESCRIPTION
###### Motivation for this change
I needed to use ansible 1.9 for some old playbooks

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

