### PR TITLE
haskellPackages.callCabal2nix: Depend on the expression.

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -145,17 +145,21 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     callHackage = name: version: self.callPackage (self.hackage2nix name version);
 
     # Creates a Haskell package from a source package by calling cabal2nix on the source.
-    callCabal2nix = name: src: args:
-      overrideCabal (self.callPackage (haskellSrc2nix {
+    callCabal2nix = name: src: args: let
+      filter = path: type:
+                 pkgs.lib.hasSuffix "${name}.cabal" path ||
+                 baseNameOf path == "package.yaml";
+      expr = haskellSrc2nix {
         inherit name;
-        src =
-          let filter = path: type:
-                pkgs.lib.hasSuffix "${name}.cabal" path ||
-                baseNameOf path == "package.yaml";
-          in if pkgs.lib.canCleanSource src
-               then pkgs.lib.cleanSourceWith { inherit src filter; }
-             else src;
-      }) args) (_: { inherit src; });
+        src = if pkgs.lib.canCleanSource src
+                then pkgs.lib.cleanSourceWith { inherit src filter; }
+              else src;
+      };
+    in overrideCabal (self.callPackage expr args) (orig: {
+         inherit src;
+         preConfigure =
+           "# Generated from ${expr}\n${orig.preConfigure or ""}";
+       });
 
     # : { root : Path
     #   , source-overrides : Defaulted (Either Path VersionNumber)


### PR DESCRIPTION
This ensures that as long as the package derivation is alive, its nix
expressions do not need to be regenerated.

Fixes #36190.