### PR TITLE
pythonPackages.pymetar: 0.20 -> 0.21

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -226,6 +226,7 @@
   erictapen = "Justin Humm <justin.humm@posteo.de>";
   erikryb = "Erik Rybakken <erik.rybakken@math.ntnu.no>";
   ertes = "Ertugrul Söylemez <esz@posteo.de>";
+  erosennin = "Andrey Golovizin <ag@sologoc.com>";
   ethercrow = "Dmitry Ivanov <ethercrow@gmail.com>";
   etu = "Elis Hirwing <elis@hirwing.se>";
   exfalso = "Andras Slemmer <0slemi0@gmail.com>";

--- a/pkgs/development/python-modules/pymetar/default.nix
+++ b/pkgs/development/python-modules/pymetar/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, isPy3k, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pymetar";
+  version = "0.21";
+
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sh3nm5ilnsgpnzbb2wv4xndnizjayw859qp72798jadqpcph69k";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A command-line tool to show the weather report by a given station ID";
+    homepage = http://www.schwarzvogel.de/software/pymetar.html;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ erosennin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12420,13 +12420,13 @@ in {
   pymetar = buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "pymetar";
-    version = "0.20";
+    version = "0.21";
 
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/${pname}/${name}.tar.gz";
-      sha256 = "1rxyg9465cp6nc47pqxqf092wmbvv2zhffzvaf2w74laal43pgxw";
+      sha256 = "1sh3nm5ilnsgpnzbb2wv4xndnizjayw859qp72798jadqpcph69k";
     };
 
     meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12417,25 +12417,7 @@ in {
 
   pylibmc = callPackage ../development/python-modules/pylibmc {};
 
-  pymetar = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "pymetar";
-    version = "0.21";
-
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
-      sha256 = "1sh3nm5ilnsgpnzbb2wv4xndnizjayw859qp72798jadqpcph69k";
-    };
-
-    meta = {
-      description = "A command-line tool to show the weather report by a given station ID";
-      homepage = http://www.schwarzvogel.de/software/pymetar.html;
-      license = licenses.gpl2;
-      maintainers = with maintainers; [ erosennin ];
-    };
-  };
+  pymetar = callPackage ../development/python-modules/pymetar { };
 
   pysftp = buildPythonPackage rec {
     name = "pysftp-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12433,6 +12433,7 @@ in {
       description = "A command-line tool to show the weather report by a given station ID";
       homepage = http://www.schwarzvogel.de/software/pymetar.html;
       license = licenses.gpl2;
+      maintainers = with maintainers; [ erosennin ];
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

pymetar-0.20 tries to fetch METAR data from an URL that no longer exits, 0.21 fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

