### PR TITLE
stubby: init at 0.2.2

### DIFF
--- a/pkgs/tools/networking/stubby/default.nix
+++ b/pkgs/tools/networking/stubby/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, getdns, libtool, m4, file , doxygen
+, autoreconfHook, automake, check, libbsd, libyaml, darwin }:
+
+stdenv.mkDerivation rec {
+  pname = "stubby";
+  name = "${pname}-${version}";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "getdnsapi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zq7h3jx6v821phcbjp348ncdicx9s4gqkj7mcz8kd6ps902iag8";
+  };
+
+  nativeBuildInputs = [ libtool m4 libbsd libyaml autoreconfHook ];
+
+  buildInputs = [ doxygen getdns automake file check ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.Security ];
+
+  meta = with stdenv.lib; {
+    description = "A local DNS Privacy stub resolver (using DNS-over-TLS)";
+    longDescription = ''
+      Stubby is an application that acts as a local DNS Privacy stub
+      resolver (using RFC 7858, aka DNS-over-TLS). Stubby encrypts DNS
+      queries sent from a client machine (desktop or laptop) to a DNS
+      Privacy resolver increasing end user privacy. Stubby is developed by
+      the getdns team.
+'';
+    homepage = https://dnsprivacy.org/wiki/x/JYAT;
+    downloadPage = "https://github.com/getdnsapi/stubby";
+    maintainers = with maintainers; [ leenaars ];
+    license = licenses.bsd3; platforms = platforms.all;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4781,6 +4781,8 @@ with pkgs;
 
   storebrowse = callPackage ../tools/system/storebrowse { };
 
+  stubby = callPackage ../tools/networking/stubby { };
+
   syntex = callPackage ../tools/graphics/syntex {};
 
   fusesmb = callPackage ../tools/filesystems/fusesmb { samba = samba3; };


### PR DESCRIPTION
###### Motivation for this change

Previous pull request was autoclosed (https://github.com/NixOS/nixpkgs/pull/34975)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

