### PR TITLE
cantarell_fonts: 0.0.25 → 0.100

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -124,7 +124,7 @@ in {
     # If gnome3 is installed, build vim for gtk3 too.
     nixpkgs.config.vim.gui = "gtk3";
 
-    fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell_fonts ];
+    fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell-fonts ];
 
     services.xserver.desktopManager.session = singleton
       { name = "gnome3";

--- a/pkgs/data/fonts/cantarell-fonts/default.nix
+++ b/pkgs/data/fonts/cantarell-fonts/default.nix
@@ -20,7 +20,6 @@ in stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;
-      attrPath = "cantarell_fonts";
     };
   };
 

--- a/pkgs/data/fonts/cantarell-fonts/default.nix
+++ b/pkgs/data/fonts/cantarell-fonts/default.nix
@@ -1,18 +1,28 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, meson, ninja, gettext, appstream-glib, gnome3 }:
 
-stdenv.mkDerivation rec {
-  major = "0.0";
-  minor = "25";
-  name = "cantarell-fonts-${major}.${minor}";
+let
+  pname = "cantarell-fonts";
+  version = "0.100";
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/cantarell-fonts/${major}/${name}.tar.xz";
-    sha256 = "0zvkd8cm1cg2919v1js9qmzwa02sjl7qajj3gcvgqvai1fm2i8hl";
+    url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
+    sha256 = "1286rx1z7mrmi6snx957fprpcmd5p00l6drdfpbgf6mqapl6kb81";
   };
+
+  nativeBuildInputs = [ meson ninja gettext appstream-glib ];
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "13w5qj1lx4vk875yna35v9lnc80cwmphcafnmp0d5grg4d98cry2";
+  outputHash = "12ia41pr0rzjfay6y84asw3nxhyp1scq9zl0w4f6wkqj7vf1qfn1";
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "cantarell_fonts";
+    };
+  };
 
   meta = {
     description = "Default typeface used in the user interface of GNOME since version 3.0";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -42,6 +42,7 @@ mapAliases (rec {
   bridge_utils = bridge-utils;  # added 2015-02-20
   btrfsProgs = btrfs-progs; # added 2016-01-03
   bundler_HEAD = bundler; # added 2015-11-15
+  cantarell_fonts = cantarell-fonts; # added 2018-03-03
   checkbashism = checkbashisms; # added 2016-08-16
   cifs_utils = cifs-utils; # added 2016-08
   clangAnalyzer = clang-analyzer;  # added 2015-02-20

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13940,7 +13940,7 @@ with pkgs;
 
   caladea = callPackage ../data/fonts/caladea {};
 
-  cantarell_fonts = callPackage ../data/fonts/cantarell-fonts { };
+  cantarell-fonts = callPackage ../data/fonts/cantarell-fonts { };
 
   carlito = callPackage ../data/fonts/carlito {};
 


### PR DESCRIPTION
###### Motivation for this change
Update & add `updateScript`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @fuuzetsu