### PR TITLE
claws-mail, jitsi: remove myself (khumba) from maintainers

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation rec {
     description = "Open Source Video Calls and Chat";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ khumba ndowens ];
+    maintainers = with maintainers; [ ndowens ];
   };
 }

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -101,6 +101,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.claws-mail.org/;
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ khumba fpletz globin ];
+    maintainers = with maintainers; [ fpletz globin ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I'm not running NixOS as a daily driver these days, so as much as I would like to be able to contribute more to this fantastic distro, I don't have time to maintain packages in Nixpkgs beyond my own projects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

