### PR TITLE
conkeror: use firefox-esr, 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/applications/networking/browsers/conkeror/default.nix
+++ b/pkgs/applications/networking/browsers/conkeror/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, unzip, firefox, makeWrapper }:
+{ stdenv, fetchgit, unzip, firefox-esr, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pkgname = "conkeror";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/libexec/conkeror
     cp -r * $out/libexec/conkeror
 
-    makeWrapper ${firefox}/bin/firefox $out/bin/conkeror \
+    makeWrapper ${firefox-esr}/bin/firefox $out/bin/conkeror \
       --add-flags "-app $out/libexec/conkeror/application.ini"
   '';
 

--- a/pkgs/applications/networking/browsers/conkeror/default.nix
+++ b/pkgs/applications/networking/browsers/conkeror/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pkgname = "conkeror";
-  version = "1.0.3";
+  version = "1.0.4";
   name = "${pkgname}-${version}";
  
   src = fetchgit {
     url = git://repo.or.cz/conkeror.git;
     rev = "refs/tags/${version}";
-    sha256 = "06fhfk8km3gd1lc19543zn0c71zfbn8wsalinvm1dbgi724f52pd";
+    sha256 = "10c57wqybp9kcjpkb01wxq0h3vafcdb1g5kb4k8sb2zajg59afv8";
   };
 
   buildInputs = [ unzip makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

- use `firefox-esr` as a workaround as the app doesn't initialize with the current `firefox`, I don't know much js/xulrunner to troubleshoot this effectively cc @astsmtl @chaoflow 
- bump to latest upstream

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).