### PR TITLE
facter: 3.9.3 -> 3.10.0 and deps

### DIFF
--- a/pkgs/development/libraries/libwhereami/default.nix
+++ b/pkgs/development/libraries/libwhereami/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "libwhereami-${version}";
-  version = "0.1.3";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
-    sha256 = "0mpy2rkxcm2nz1qvldih01czxlsksqfkzgh58pnrw8yva31wv9q6";
+    sha256 = "10phq4a11m8ly6b4dc2yg3dnjzg8ad5wnjv0ilvwylnw32800pxr";
     rev = version;
     repo = "libwhereami";
     owner = "puppetlabs";

--- a/pkgs/development/libraries/libwhereami/default.nix
+++ b/pkgs/development/libraries/libwhereami/default.nix
@@ -11,6 +11,9 @@ stdenv.mkDerivation rec {
     owner = "puppetlabs";
   };
 
+  # post gcc7, upstream bug: https://tickets.puppetlabs.com/browse/FACT-1828
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated";
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ boost curl leatherman ];

--- a/pkgs/tools/system/facter/default.nix
+++ b/pkgs/tools/system/facter/default.nix
@@ -2,17 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "facter-${version}";
-  version = "3.9.3";
+  version = "3.10.0";
 
   src = fetchFromGitHub {
-    sha256 = "1qd0xsw49nbj22czddxk90di31gx43hacvnmh08gp3001a8g0qcj";
+    sha256 = "0qj23n5h98iirwhnjpcqzmirqf92sjd8mws5dky0pap359j6w792";
     rev = version;
     repo = "facter";
     owner = "puppetlabs";
   };
 
   CXXFLAGS = "-fpermissive";
-  NIX_CFLAGS_COMPILE = "-Wno-error";
   NIX_LDFLAGS = "-lblkid";
 
   cmakeFlags = [ "-DFACTER_RUBY=${ruby}/lib/libruby.so" ];


### PR DESCRIPTION
###### Motivation for this change

- update to latest upstream
- fix and update libwhereami dependency

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).