### PR TITLE
Give working advice for running nix-prefetch-url

### DIFF
--- a/pkgs/applications/misc/kdbplus/default.nix
+++ b/pkgs/applications/misc/kdbplus/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
     message = ''
       Nix can't download kdb+ for you automatically. Go to
       http://kx.com and download the free, 32-bit version for
-      Linux. Then run "nix-prefetch-url file:///linux.zip" in the
-      directory where you saved it. Note you need version 3.3.
+      Linux. Then run "nix-prefetch-url file://\$PWD/linux.zip" in
+      the directory where you saved it. Note you need version 3.3.
     '';
     name   = "linux.zip";
     sha256 = "5fd0837599e24f0f437a8314510888a86ab0787684120a8fcf592299800aa940";

--- a/pkgs/applications/office/ib/tws/default.nix
+++ b/pkgs/applications/office/ib/tws/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
       Download the TWS from
       https://download2.interactivebrokers.com/download/unixmacosx_latest.jar,
       rename the file to ${name}, and add it to the nix store with
-      "nix-prefetch-url file://${name}".
+      "nix-prefetch-url file://\$PWD/${name}".
     '';
     sha256 = "1a2jiwwnr5g3xfba1a89c257bdbnq4zglri8hz021vk7f6s4rlrf";
   };

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -28,7 +28,7 @@ let
               This nix expression requires that ${args.name} is already part of the store.
               Register yourself to NVIDIA Accelerated Computing Developer Program, retrieve the CUDA toolkit
               at https://developer.nvidia.com/cuda-toolkit, and run the following command in the download directory:
-              nix-prefetch-url file://${args.name}
+              nix-prefetch-url file://\$PWD/${args.name}
             '';
             inherit (args) name sha256;
           }

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       This nix expression requires that ${name} is already part of the store.
       Register yourself to NVIDIA Accelerated Computing Developer Program, retrieve the cuDNN library
       at https://developer.nvidia.com/cudnn, and run the following command in the download directory:
-      nix-prefetch-url file://${name}
+      nix-prefetch-url file://\$PWD/${name}
     '';
   };
 

--- a/pkgs/development/libraries/science/math/nccl/generic.nix
+++ b/pkgs/development/libraries/science/math/nccl/generic.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       This nix expression requires that ${name} is already part of the store.
       Register yourself to NVIDIA Accelerated Computing Developer Program, retrieve the NCCL library
       at https://developer.nvidia.com/nccl, and run the following command in the download directory:
-      nix-prefetch-url file://${name}
+      nix-prefetch-url file://\$PWD/${name}
     '';
   };
 

--- a/pkgs/games/uqm/3dovideo.nix
+++ b/pkgs/games/uqm/3dovideo.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation {
       The reason for this is because the 3DO uses its own proprietary disk
       format.
 
-      Save the file as videos.tar and use "nix-prefetch-url file://${name}" to
+      Save the file as videos.tar and use "nix-prefetch-url file://\$PWD/${name}" to
       add it to the Nix store.
 
       [*] ${helper}/bin/uqm3donix CDIMAGE ${name}

--- a/pkgs/games/vessel/default.nix
+++ b/pkgs/games/vessel/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   goBuyItNow = '' 
     We cannot download the full version automatically, as you require a license.
     Once you bought a license, you need to add your downloaded version to the nix store.
-    You can do this by using "nix-prefetch-url file://${name}-bin" in the
+    You can do this by using "nix-prefetch-url file://\$PWD/${name}-bin" in the
     directory where you saved it.
   ''; 
 

--- a/pkgs/games/worldofgoo/default.nix
+++ b/pkgs/games/worldofgoo/default.nix
@@ -15,16 +15,16 @@ stdenv.mkDerivation rec {
   goBuyItNow = '' 
     We cannot download the full version automatically, as you require a license.
     Once you bought a license, you need to add your downloaded version to the nix store.
-    You can do this by using "nix-prefetch-url file://WorldOfGooSetup.1.41.tar.gz" in the
+    You can do this by using "nix-prefetch-url file://\$PWD/WorldOfGooSetup.1.41.tar.gz" in the
     directory where you saved it.
 
     Or you can install the demo version: 'nix-env -i -A pkgs.worldofgoo_demo'. 
   ''; 
 
   getTheDemo = ''
-    We cannot download the demo version automatically, please go to
+    We cannot download the demo version automatically. Please go to
     http://worldofgoo.com/dl2.php?lk=demo, then add it to your nix store.
-    You can do this by using "nix-prefetch-url file://WorldOfGooDemo.1.41.tar.gz" in the
+    You can do this by using "nix-prefetch-url file://\$PWD/WorldOfGooDemo.1.41.tar.gz" in the
     directory where you saved it.
   '';
 


### PR DESCRIPTION
###### Motivation for this change

`nix-prefetch-url file://…` requires a full path.  Suggest an invocation that will provide one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

