### PR TITLE
dovecot: 2.2.33.2 -> 2.2.34

### DIFF
--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -8,7 +8,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.2.33.2";
+  name = "dovecot-2.2.34";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs = [ openssl bzip2 zlib clucene_core_2 icu openldap ]
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://dovecot.org/releases/2.2/${name}.tar.gz";
-    sha256 = "117f9i62liz2pm96zi2lpldzlj2knzj7g410zhifwmlsc1w3n7py";
+    sha256 = "0lw3h0n7wyqbxdp2qyfzs21ww8c99cbngaka7ws6prh9ahra94jy";
   };
 
   preConfigure = ''
@@ -46,16 +46,6 @@ stdenv.mkDerivation rec {
     # so we can symlink plugins from several packages there.
     # The symlinking needs to be done in NixOS.
     ./2.2.x-module_dir.patch
-    (fetchpatch {
-      name = "CVE-2017-14132_part1.patch";
-      url = https://github.com/dovecot/core/commit/1a29ed2f96da1be22fa5a4d96c7583aa81b8b060.patch;
-      sha256 = "1pcfzxr8xlwbpa7z19grp7mlvdnan6ln8zw74dj4pdmynmlk4aw9";
-    })
-    (fetchpatch {
-      name = "CVE-2017-14132_part2.patch";
-      url = https://github.com/dovecot/core/commit/a9b135760aea6d1790d447d351c56b78889dac22.patch;
-      sha256 = "0082iid5rvjmh003xi9s09jld2rb31hbvni0yai1h1ggbmd5zf8l";
-    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
Release notes: https://dovecot.org/list/dovecot-news/2018-February/000370.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @andir 