### PR TITLE
idea: add `libsecret` to the library path

### DIFF
--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, makeDesktopItem, makeWrapper, patchelf, p7zip
-, coreutils, gnugrep, which, git, python, unzip }:
+, coreutils, gnugrep, which, git, python, unzip, libsecret
+}:
 
 { name, product, version, src, wmClass, jdk, meta } @ attrs:
 
@@ -65,7 +66,7 @@ with stdenv; lib.makeOverridable mkDerivation rec {
       --prefix PATH : "$out/libexec/${name}:${stdenv.lib.makeBinPath [ jdk coreutils gnugrep which git ]}" \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         # Some internals want libstdc++.so.6
-        stdenv.cc.cc.lib
+        stdenv.cc.cc.lib libsecret
       ]}" \
       --set JDK_HOME "$jdk" \
       --set ${hiName}_JDK "$jdk" \


### PR DESCRIPTION


###### Motivation for this change

This solves the `Cannot access native keychain` warning from
IntelliJ-based IDEs. Previously IDEA was unable to find `libsecret` as
it was not part of its library path.

Please keep in mind that the keyring daemon that can be enabled on
NixOS with `services.gnome3.gnome-keyring.enable = true` must be
running.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
