### PR TITLE
mycroft: init at 0.9.19 [WIP]

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -341,6 +341,7 @@
   ./services/misc/mesos-master.nix
   ./services/misc/mesos-slave.nix
   ./services/misc/mwlib.nix
+  ./services/misc/mycroft.nix
   ./services/misc/nix-daemon.nix
   ./services/misc/nix-gc.nix
   ./services/misc/nix-optimise.nix

--- a/nixos/modules/services/misc/mycroft.nix
+++ b/nixos/modules/services/misc/mycroft.nix
@@ -17,6 +17,14 @@ in {
         Run mycroft as a system-wide service. You probably only want to do this on purpose-built hardware like a Raspberry Pi or similar.
       '';
     };
+
+    voice = lib.mkOption {
+      type = lib.enum [ "ap" "slt" "kal" "awb" "kal16" "rms" "awb_time" ];
+      default = "ap";
+      description = ''
+        The voice used by Mycroft.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {

--- a/nixos/modules/services/misc/mycroft.nix
+++ b/nixos/modules/services/misc/mycroft.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.mycroft;
+  uid = 9000;
+
+in {
+  meta.maintainers = with lib.maintainers; [ peterhoeg ];
+
+  options.services.mycroft = {
+    enable = lib.mkEnableOption "Mycroft AI";
+
+    applianceMode = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Run mycroft as a system-wide service. You probably only want to do this on purpose-built hardware like a Raspberry Pi or similar.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.pulseaudio.systemWide = lib.mkIf cfg.applianceMode true;
+
+    systemd = {
+      packages = with pkgs; [ mycroft ];
+      targets.mycroft.wantedBy = lib.mkIf cfg.applianceMode [ "multi-user.target" ];
+    };
+  };
+}

--- a/pkgs/development/python-modules/pyalsaaudio/default.nix
+++ b/pkgs/development/python-modules/pyalsaaudio/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, alsaLib }:
+
+buildPythonPackage rec {
+  pname = "pyalsaaudio";
+  version = "0.8.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "84e8f8da544d7f4bd96479ce4a237600077984d9be1d7f16c1d9a492ecf50085";
+  };
+
+  buildInputs = [ alsaLib ];
+
+  # it requires physical hardware for testing
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "ALSA bindings";
+    homepage = http://larsimmisch.github.io/pyalsaaudio;
+    license = licenses.psfl;
+  };
+}

--- a/pkgs/development/python-modules/pyaudio/default.nix
+++ b/pkgs/development/python-modules/pyaudio/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy
+, portaudio }:
+
+buildPythonPackage rec {
+  pname = "PyAudio";
+  version = "0.2.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bfd694272b3d1efc51726d0c27650b3c3ba1345f7f8fdada7e86c9751ce0f2a1";
+  };
+
+  disabled = isPyPy;
+
+  buildInputs = [ portaudio ];
+
+  meta = with stdenv.lib; {
+    description = "Python bindings for PortAudio";
+    homepage = https://people.csail.mit.edu/hubert/pyaudio/;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/mycroft/default.nix
+++ b/pkgs/servers/mycroft/default.nix
@@ -1,0 +1,416 @@
+{ stdenv, lib, fetchFromGitHub, python27
+, autoreconfHook, pkgconfig, swig
+, alsaLib, curl, flac, glib, icu, libfann, libffi, libjpeg
+, libpulseaudio, vlc, mimic, mpg123, openssl, pocketsphinx, portaudio, s3cmd
+, swig2, xxHash, zlib }:
+
+# TODO:
+# 1. use the new fork for libfann:
+#    https://github.com/andersfylling/fann/releases
+# 2. fix up msm paths
+
+let
+  depends = service:
+    lib.concatStringsSep " " (if (service != "bus")
+      then [ "mycroft-bus.service" ]
+      else [ "pulseaudio.service" ]);
+
+  py = python27.override {
+    packageOverrides = self: super: rec {
+      adapt-parser = super.buildPythonPackage rec {
+        pname = "adapt-parser";
+        version = "0.3.0";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "0zrk9p6147dn88ibf7aqxg1137ili6i5wq5w3yfm2g6g9yzcjicl";
+        };
+        postPatch = ''
+          sed -i 's/six==1.10.0/six/' setup.py
+        '';
+        propagatedBuildInputs = with super; [ pyee six ];
+      };
+
+      fann2 = super.buildPythonPackage rec {
+        pname = "fann2";
+        version = "1.1.2";
+
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "07nlpncl5cx2kzdy3r91g3i1bsnl7n6f7zracwh87q28mmjhmjnd";
+        };
+
+        postPatch = ''
+          substituteInPlace setup.py \
+            --replace /lib ${libfann}/lib
+        '';
+
+        buildInputs = [ libfann ];
+
+        nativeBuildInputs = [ swig ];
+        # propagatedBuildInputs = with super; [ gtts-token requests ];
+      };
+
+      gtts = super.buildPythonPackage rec {
+        pname = "gTTS";
+        version = "1.2.2";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "05j5dq8mifdlck84gsdha9w7bv7rc64pjspx52ihpipbmdxvvvb3";
+        };
+        propagatedBuildInputs = with super; [ gtts-token requests ];
+      };
+
+      gtts-token = super.buildPythonPackage rec {
+        pname = "gTTS-token";
+        version = "1.1.1";
+        src = super.fetchPypi {
+          inherit pname version;
+          extension = "zip";
+          sha256 = "1vw3j8hw4hdhznk6gmhm82yhwsp79nv0jaj69axdhwvplcxxzfkl";
+        };
+        propagatedBuildInputs = with super; [ requests ];
+      };
+
+      padatious = super.buildPythonPackage rec {
+        pname = "padatious";
+        version = "0.4.0";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "132p8ayx5kz9fbnk27r3ii9kz6p14ig5aannb7yd6s3swabdwwcz";
+        };
+        propagatedBuildInputs = [ fann2 xxhash ];
+        # checkInputs = with super; [ mock pytest pytestrunner twisted ];
+      };
+
+      pulsectl = super.buildPythonPackage rec {
+        pname = "pulsectl";
+        version = "18.2.0";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "1lnhfnwsi8rllnw1r3ydlcn6rdb50nsqx6s7q97rphj4dcdwvf3f";
+        };
+        postPatch = ''
+          substituteInPlace pulsectl/_pulsectl.py \
+            --replace libpulse.so.0 ${libpulseaudio}/lib/libpulse.so.0
+        '';
+        doCheck = true;
+        buildInputs = [ libpulseaudio.dev ];
+        propagatedBuildInputs = [ ];
+        checkInputs = with super; [ ];
+      };
+
+      pocketsphinx-python = super.buildPythonPackage rec {
+        pname = "pocketsphinx";
+        version = "0.1.3";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "0v9l43s6s256qy4bs31akvmqkkrxdkk8mld40s3vfnn8xynml4mc";
+        };
+        buildInputs = [ libpulseaudio ];
+        nativeBuildInputs = [ swig ];
+        doCheck = false;
+        # propagatedBuildInputs = with super; [ vcversioner ];
+        # checkInputs = with super; [ pytest ];
+      };
+
+      pyaudio = super.pyaudio.overridePythonAttrs (oldAttrs: rec {
+        version = "0.2.11";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0x7vdsigm7xgvyg3shd3lj113m8zqj2pxmrgdyj66kmnw0qdxgwk";
+        };
+      });
+
+      pyee = super.buildPythonPackage rec {
+        pname = "pyee";
+        version = "1.0.1";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "0s4gqzwc9sribl7a2vwgpz5l5wgfc0ls0janvpiywgm527c9qp24";
+        };
+        propagatedBuildInputs = with super; [ vcversioner ];
+        checkInputs = with super; [ mock pytest pytestrunner twisted ];
+      };
+
+      # we need vlc 3 for this to work
+      python-vlc = super.buildPythonPackage rec {
+        pname = "python-vlc";
+        version = "3.0.102";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "19ckynl5rpm9n82q1iayzw3xb9xx2lz4gpkn47cqp82j71aiq6n5";
+        };
+        buildInputs = [ vlc ];
+      };
+
+      requests-futures = super.buildPythonPackage rec {
+        pname = "requests-futures";
+        version = "0.9.7";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "1bbvx99dnkh9cqbmhs4c1yvb4aiffi3c2nfyqngc5ymnh0s2rjm9";
+        };
+        propagatedBuildInputs = with super; [ futures requests ];
+        # checkInputs = with super; [ mock pytest pytestrunner twisted ];
+        doCheck = false;
+      };
+
+      speechrecognition = super.buildPythonPackage rec {
+        pname = "SpeechRecognition";
+        version = "3.8.1";
+        src = fetchFromGitHub {
+          owner = "Uberi";
+          repo = "speech_recognition";
+          rev = "${version}";
+          sha256 = "1lq6g4kl3y1b4ch3b6wik7xy743x6pp5iald0jb9zxqgyxy1zsz4";
+        };
+        buildInputs = [ flac ];
+        propagatedBuildInputs = with super; [ pocketsphinx-python ];
+        doCheck = false;
+        # checkInputs = with super; [ mock pytest pytestrunner twisted ];
+      };
+
+      xxhash = super.buildPythonPackage rec {
+        pname = "xxhash";
+        version = "1.0.1";
+        src = super.fetchPypi {
+          inherit pname version;
+          extension = "zip";
+          sha256 = "0ca8577ldyipv20v69cxk2cki82zklkxdryh4dg3hx13s34nkgks";
+        };
+        # propagatedBuildInputs = [ fann2 xxhash ];
+        checkInputs = with super; [ nose ];
+      };
+    };
+  };
+
+  components = [
+    { name = "audio";           bin = false; path = "audio/main.py"; }
+    { name = "bus";             bin = false; path = "messagebus/service/main.py"; }
+    { name = "cli";             bin = true;  path = "client/text/main.py"; }
+    # { name = "enclosure";       bin = false; path = "client/enclosure/main.py"; }
+    { name = "skill_container"; bin = true;  path = "skills/container.py"; }
+    { name = "skills";          bin = false; path = "skills/main.py"; }
+    { name = "voice";           bin = false; path = "client/speech/main.py"; }
+    # wifisetup is referenced in the msm script but nowhere to be found
+    # { name = "wifi";            bin = false; path = "client/wifisetup/main.py"; }
+  ];
+
+in py.pkgs.buildPythonApplication rec {
+  pname = "mycroft";
+  version = "0.9.19";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner  = "MycroftAI";
+    repo   = "mycroft-core";
+    rev    = "release/v${version}";
+    sha256 = "1hvgl246ngg5r3l9qr73s2038iali9iwnqbfl1f361x1f3z0f0r9";
+  };
+
+  patches = [ ./paths.patch ];
+
+  postPatch = ''
+    for f in msm/msm mycroft/configuration/mycroft.conf mycroft/configuration/config.py mycroft/util/log.py ; do
+      substituteInPlace $f \
+        --replace /etc/mycroft $out/etc/mycroft \
+        --replace /opt/mycroft /var/lib/mycroft
+    done
+
+    sed -i mycroft/__init__.py \
+      -e "s,MYCROFT_ROOT_PATH.*,MYCROFT_ROOT_PATH='$out',"
+
+    substituteInPlace mycroft/tts/mimic_tts.py \
+      --replace @mimic@ ${mimic}
+
+    substituteInPlace mycroft/configuration/mycroft.conf \
+      --replace 'mpg123 %1' "${lib.getBin mpg123}/bin/mpg123 %1" \
+      --replace 'paplay %1' "${lib.getBin libpulseaudio}/bin/paplay %1"
+  '';
+
+  buildInputs = [
+    alsaLib
+    curl
+    flac
+    glib
+    libfann
+    libffi
+    libjpeg
+    mimic
+    openssl
+    pocketsphinx
+    portaudio
+    libpulseaudio
+    s3cmd
+    # swig2
+    xxHash
+    zlib
+  ];
+
+  propagatedBuildInputs = with py.pkgs; [
+    adapt-parser
+    # websocket-client
+
+    dateutil
+    future
+    futures
+    inflection
+    monotonic
+    parsedatetime
+    pillow
+    psutil
+    pulsectl
+    pyaudio
+    PyChromecast
+    pyee
+    pyserial
+    pyyaml
+    requests
+    # six
+    tornado
+    websocket_client
+
+  #   backports.ssl-match-hostname
+  #   google-api-python-client
+    gtts
+    padatious
+    # pocketsphinx-python # used by speechrecog
+    pyalsaaudio
+    # python-vlc # we need vlc 3 in nixpkgs
+    requests-futures
+    speechrecognition
+  #   xmlrunner
+  ];
+
+  checkInputs = with py.pkgs; [ mock nose2 pep8 ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = false;
+
+  installPhase = let
+    services=lib.concatStringsSep " " (map (e: if e.bin then "" else "mycroft-${e.name}.service" ) components);
+    dirs = [ "user" "system" ];
+  in ''
+    runHook preInstall
+
+    dir=$out/${py.sitePackages}
+    mkdir -p $out/{bin,lib/systemd/{user,system},libexec} $dir/msm
+    cp -r mycroft $dir/
+
+    ${lib.concatStringsSep "\n" (map (e: ''
+      if [ ! -f $dir/mycroft/${e.path} ]; then
+        echo "Unable to find: ${e.path}"
+        exit 1
+      fi
+
+      f=$out/${if e.bin then "bin" else "libexec"}/mycroft-${e.name}
+      cat >> $f << _EOF
+      #!${stdenv.shell} -e
+
+      export HOME=/var/lib/mycroft
+      export PATH=$PATH:${lib.makeBinPath [ flac mimic mpg123 ]}
+      export PYTHONPATH=$dir:${py.pkgs.makePythonPath propagatedBuildInputs}
+
+      exec ${py.pkgs.python.interpreter} $dir/mycroft/${e.path} "$@"
+      _EOF
+      chmod 755 $f
+
+      ${lib.concatStringsSep "\n" (map (d: ''
+        ${lib.optionalString (!e.bin) ''
+          cat >> $out/lib/systemd/${d}/mycroft-${e.name}.service << _EOF
+          [Unit]
+          Description=Mycroft AI - ${e.name}
+          After=network.target dbus.service ${depends e.name}
+          PartOf=mycroft.target
+
+          [Service]
+          ${lib.optionalString (d == "system") ''
+            DynamicUser=true
+            User=mycroft
+            Group=mycroft
+            StateDirectory=mycroft
+          ''}
+          WorkingDirectory=~
+          ExecStart=$out/libexec/mycroft-${e.name}
+          ProtectSystem=true
+          PrivateTmp=true
+          TimeoutStopSec=5s
+          Slice=mycroft.slice
+          Restart=on-failure
+          RestartSec=2s
+
+          [Install]
+          WantedBy=mycroft.target
+          _EOF
+        ''}
+    '') dirs)}
+    '') components)}
+
+    ${lib.concatStringsSep "\n" (map (d: ''
+      cat >> $out/lib/systemd/${d}/mycroft.target << _EOF
+      [Unit]
+      Description=Mycroft AI
+      Requires=${services}
+      After=${services}
+      _EOF
+    '') dirs)}
+
+    install -Dm755 msm/msm            $out/bin/msm
+    install -Dm644 msm/man/man1/msm.1 $out/share/man/man1/msm.1
+
+    install -Dm644 -t $out/share/doc/mycroft *.md
+
+    ln -s $out/bin/msm $dir/msm/
+    # ln -s ${mimic} $out/mimic
+
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    export HOME=/tmp
+    nose2 -t ./ -s test/unittests/ --with-coverage --config=test/unittests/unittest.cfg
+  '';
+
+  meta = with lib; {
+    homepage = https://mycroft.ai;
+    description = "Personal assistant";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}
+
+# six==1.10.0
+# requests==2.13.0
+# gTTS==1.1.7
+# gTTS-token==1.1.1
+# backports.ssl-match-hostname==3.4.0.2
+# PyAudio==0.2.11
+# pyee==1.0.1
+# SpeechRecognition==3.8.1
+# tornado==4.2.1
+# websocket-client==0.32.0
+# adapt-parser==0.3.0
+# futures==3.0.3
+# future==0.16.0
+# requests-futures==0.9.5
+# parsedatetime==1.5
+# pyyaml==3.11
+# pyalsaaudio==0.8.2
+# xmlrunner==1.7.7
+# pyserial==3.0
+# psutil==5.2.1
+# pocketsphinx==0.1.0
+# inflection==0.3.1
+# pillow==4.1.1
+# python-dateutil==2.6.0
+# pychromecast==0.7.7
+# python-vlc==1.1.2
+# pulsectl==17.7.4
+# google-api-python-client==1.6.4
+# monotonic
+
+# # dev setup tools
+# pep8==1.7.0
+# # Also update in mycroft/skills/padatious_service.py

--- a/pkgs/servers/mycroft/default.nix
+++ b/pkgs/servers/mycroft/default.nix
@@ -184,6 +184,8 @@ let
     };
   };
 
+  baseDir = "/var/lib/mycroft";
+
   components = [
     { name = "audio";           bin = false; path = "audio/main.py"; }
     { name = "bus";             bin = false; path = "messagebus/service/main.py"; }
@@ -215,7 +217,7 @@ in py.pkgs.buildPythonApplication rec {
     for f in msm/msm mycroft/configuration/mycroft.conf mycroft/configuration/config.py mycroft/util/log.py ; do
       substituteInPlace $f \
         --replace /etc/mycroft $out/etc/mycroft \
-        --replace /opt/mycroft /var/lib/mycroft
+        --replace /opt/mycroft ${baseDir}
     done
 
     sed -i mycroft/__init__.py \
@@ -250,7 +252,6 @@ in py.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with py.pkgs; [
     adapt-parser
-    # websocket-client
 
     dateutil
     future
@@ -287,6 +288,7 @@ in py.pkgs.buildPythonApplication rec {
 
   dontConfigure = true;
   dontBuild = true;
+  # 2 out of 162 checks are failing
   doCheck = false;
 
   installPhase = let
@@ -309,7 +311,7 @@ in py.pkgs.buildPythonApplication rec {
       cat >> $f << _EOF
       #!${stdenv.shell} -e
 
-      export HOME=/var/lib/mycroft
+      export HOME=$${HOME:-${baseDir}}
       export PATH=$PATH:${lib.makeBinPath [ flac mimic mpg123 ]}
       export PYTHONPATH=$dir:${py.pkgs.makePythonPath propagatedBuildInputs}
 

--- a/pkgs/servers/mycroft/mimic.nix
+++ b/pkgs/servers/mycroft/mimic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, alsaLib, icu }:
+, alsaLib, icu, libpulseaudio, pcre, portaudio }:
 
 stdenv.mkDerivation rec {
   name = "mycroft-mimic-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wkpbwk88lsahzkc7pzbznmyy0lc02vsp0vkj8f1ags1gh0lc52j";
   };
 
-  buildInputs = [ alsaLib icu ];
+  buildInputs = [ alsaLib icu pcre portaudio ] ++ stdenv.lib.optional stdenv.isLinux libpulseaudio;
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 

--- a/pkgs/servers/mycroft/mimic.nix
+++ b/pkgs/servers/mycroft/mimic.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, alsaLib, icu }:
+
+stdenv.mkDerivation rec {
+  name = "mycroft-mimic-${version}";
+  version = "1.2.0.2";
+
+  src = fetchFromGitHub {
+    owner  = "mycroftai";
+    repo   = "mimic";
+    rev    = version;
+    sha256 = "1wkpbwk88lsahzkc7pzbznmyy0lc02vsp0vkj8f1ags1gh0lc52j";
+  };
+
+  buildInputs = [ alsaLib icu ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Mycroft's TTS engine, based on CMU's Flite (Festival Lite)";
+    homepage = https://mimic.mycroft.ai;
+  };
+}

--- a/pkgs/servers/mycroft/paths.patch
+++ b/pkgs/servers/mycroft/paths.patch
@@ -1,0 +1,14 @@
+diff --git a/mycroft/tts/mimic_tts.py b/mycroft/tts/mimic_tts.py
+index d104578cc6..a2736fd2dc 100644
+--- a/mycroft/tts/mimic_tts.py
++++ b/mycroft/tts/mimic_tts.py
+@@ -30,8 +30,7 @@ from threading import Thread
+
+ config = Configuration.get().get("tts").get("mimic")
+
+-BIN = config.get("path",
+-                 os.path.join(MYCROFT_ROOT_PATH, 'mimic', 'bin', 'mimic'))
++BIN = '@mimic@/bin/mimic'
+
+ if not os.path.isfile(BIN):
+     # Search for mimic on the path

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12281,6 +12281,8 @@ with pkgs;
 
   mlmmj = callPackage ../servers/mail/mlmmj { };
 
+  mimic = callPackage ../servers/mycroft/mimic.nix { };
+
   mycroft = callPackage ../servers/mycroft { };
 
   myserver = callPackage ../servers/http/myserver { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12281,6 +12281,8 @@ with pkgs;
 
   mlmmj = callPackage ../servers/mail/mlmmj { };
 
+  mycroft = callPackage ../servers/mycroft { };
+
   myserver = callPackage ../servers/http/myserver { };
 
   nas = callPackage ../servers/nas { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2801,6 +2801,7 @@ in {
 
   openidc-client = callPackage ../development/python-modules/openidc-client/default.nix {};
 
+  pyalsaaudio = callPackage ../development/python-modules/pyalsaaudio {};
 
   idna = callPackage ../development/python-modules/idna { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12765,25 +12765,7 @@ in {
 
   pyasn1-modules = callPackage ../development/python-modules/pyasn1-modules { };
 
-  pyaudio = buildPythonPackage rec {
-    name = "python-pyaudio-${version}";
-    version = "0.2.9";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/P/PyAudio/PyAudio-${version}.tar.gz";
-      sha256 = "bfd694272b3d1efc51726d0c27650b3c3ba1345f7f8fdada7e86c9751ce0f2a1";
-    };
-
-    disabled = isPyPy;
-
-    buildInputs = with self; [ pkgs.portaudio ];
-
-    meta = {
-      description = "Python bindings for PortAudio";
-      homepage = "http://people.csail.mit.edu/hubert/pyaudio/";
-      license = licenses.mit;
-    };
-  };
+  pyaudio = callPackage ../development/python-modules/pyaudio { };
 
   pysam = callPackage ../development/python-modules/pysam { };
 


### PR DESCRIPTION
###### Motivation for this change

Well, who doesn't want AI on your NixOS machine?

This is *VERY* much WIP but let's get it out there as soon as possible.

What works:

1. The services can be run manually or using the systemd services
2. Everything comes up (and doesn't crash) when run inside a VM using ```nixos-rebuild build-vm```.

But I don't *actually* know if it works, because there are a number of things that need to be fixed first:

1. We need to handle how to run a pulseaudio instance when it's not running inside the user session
2. All the python packages need to be separated out into their own packages
3. Tests need to be enabled for the various packages (I just disabled them if they were causing problems)
4. Mycroft itself has 2 failing tests - I haven't looked at all at why that isn't working
5. The skill script (msm) is borked (and not in the right place)
6. Need to figure out a way to have skills that are preloaded merged with skills dynamically installed - probably unionfs
7. Enclouse daemon isn't working

Cc: @dotlambda @bjornfor 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

