### PR TITLE
Openldap module declarative contents

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -322,6 +322,7 @@ in rec {
   tests.leaps = callTest tests/leaps.nix { };
   tests.nsd = callTest tests/nsd.nix {};
   tests.openssh = callTest tests/openssh.nix {};
+  tests.openldap = callTest tests/openldap.nix {};
   tests.owncloud = callTest tests/owncloud.nix {};
   tests.pam-oath-login = callTest tests/pam-oath-login.nix {};
   #tests.panamax = callTestOnTheseSystems ["x86_64-linux"] tests/panamax.nix {};

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -1,0 +1,35 @@
+import ./make-test.nix {
+  name = "dovecot";
+
+  machine = { pkgs, ... }: {
+    services.openldap = {
+      enable = true;
+      extraConfig = ''
+        include ${pkgs.openldap}/etc/schema/core.schema
+        include ${pkgs.openldap}/etc/schema/cosine.schema
+        include ${pkgs.openldap}/etc/schema/inetorgperson.schema
+        include ${pkgs.openldap}/etc/schema/nis.schema
+        database bdb
+        suffix dc=example
+        directory /var/db/openldap
+        rootdn cn=root,dc=example
+        rootpw notapassword
+      '';
+      declarativeContents = ''
+        dn: dc=example
+        objectClass: domain
+        dc: example
+
+        dn: ou=users,dc=example
+        objectClass: organizationalUnit
+        ou: users
+      '';
+    };
+  };
+
+  testScript = ''
+    $machine->succeed('systemctl status openldap.service');
+    $machine->waitForUnit('openldap.service');
+    $machine->succeed('ldapsearch -LLL -D "cn=root,dc=example" -w notapassword -b "dc=example"');
+  '';
+}


### PR DESCRIPTION
This PR allows to declaratively set the contents of the LDAP database. I've tested it on my machine by replacing the stock module with the post-PR one, and it appears to work.