### PR TITLE
ansible-lint: init at 3.4.20

### DIFF
--- a/lib/maintainers-list.nix
+++ b/lib/maintainers-list.nix
@@ -3155,6 +3155,11 @@
     github = "sellout";
     name = "Greg Pfeil";
   };
+  sengaya = {
+    email = "tlo@sengaya.de";
+    github = "sengaya";
+    name = "Thilo Uttendorfer";
+  };
   sepi = {
     email = "raffael@mancini.lu";
     github = "sepi";

--- a/pkgs/development/tools/ansible-lint/default.nix
+++ b/pkgs/development/tools/ansible-lint/default.nix
@@ -1,16 +1,27 @@
-{ stdenv, pythonPackages, ansible }:
+{ stdenv, fetchFromGitHub, pythonPackages, ansible }:
 
 pythonPackages.buildPythonPackage rec {
   pname = "ansible-lint";
   version = "3.4.20";
-  doCheck = false;
 
-  src = pythonPackages.fetchPypi {
-    inherit pname version;
-    sha256 = "1e7f1d5d5ee91b817dedc0b612c2beb5ff44879d592ea17a2eaa6571aa9a2bff";
+  src = fetchFromGitHub {
+    owner = "willthames";
+    repo = "ansible-lint";
+    rev = "v${version}";
+    sha256 = "0wgczijrg5azn2f63hjbkas1w0f5hbvxnk3ia53w69mybk0gy044";
   };
 
   propagatedBuildInputs = with pythonPackages; [ pyyaml six ] ++ [ ansible ];
+
+  checkInputs = [ pythonPackages.nose ];
+
+  postPatch = ''
+    patchShebangs bin/ansible-lint
+  '';
+
+  checkPhase = ''
+    nosetests test
+  '';
 
   meta = {
     homepage = "https://github.com/willthames/ansible-lint";

--- a/pkgs/development/tools/ansible-lint/default.nix
+++ b/pkgs/development/tools/ansible-lint/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, pythonPackages, ansible }:
+
+pythonPackages.buildPythonPackage rec {
+  pname = "ansible-lint";
+  version = "3.4.20";
+  doCheck = false;
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "1e7f1d5d5ee91b817dedc0b612c2beb5ff44879d592ea17a2eaa6571aa9a2bff";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ pyyaml six ] ++ [ ansible ];
+
+  meta = {
+    homepage = "https://github.com/willthames/ansible-lint";
+    description = "Best practices checker for Ansible";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.sengaya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7338,6 +7338,8 @@ with pkgs;
   ansible  = ansible_2_4;
   ansible2 = ansible_2_4;
 
+  ansible-lint = callPackage ../development/tools/ansible-lint {};
+
   antlr = callPackage ../development/tools/parsing/antlr/2.7.7.nix { };
 
   antlr3_4 = callPackage ../development/tools/parsing/antlr/3.4.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add ansible-lint, a linter for ansible playbooks

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).