### PR TITLE
radare2-cutter: 1.1 -> 1.2

### DIFF
--- a/pkgs/development/tools/analysis/radare2-cutter/default.nix
+++ b/pkgs/development/tools/analysis/radare2-cutter/default.nix
@@ -1,38 +1,17 @@
 { stdenv, fetchFromGitHub, fetchpatch, qmake, pkgconfig, qtbase, qtsvg, radare2 }:
 
-
 stdenv.mkDerivation rec {
   name = "radare2-cutter-${version}";
-  version = "1.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "radareorg";
     repo = "cutter";
     rev = "v${version}";
-    sha256 = "02m5sf45n455hn34y7hrqanj830rc5xhz2ppp1z3mzbz0s515pfl";
+    sha256 = "1ph8kvpai7kr7kcqfp0aagvrm098bbh9ygzg5fp8z8y51mwq898g";
   };
 
   postUnpack = "export sourceRoot=$sourceRoot/src";
-
-  patches = [
-    # Fixup version number :D
-    (fetchpatch {
-      url = "https://github.com/radareorg/cutter/commit/69506b64600df632afdca8b680baa7d946c78644.patch";
-      sha256 = "0ks3ixz8bycjcfi26bd0p6z7qaplhq00alw44hsfzpdm4bmr01x0";
-    })
-    (fetchpatch {
-      url = "https://github.com/radareorg/cutter/commit/8b52c66f4f0091cd9d97389b32aa519c2c602e2b.patch";
-      sha256 = "0wcdn35lx2943pfzm7mkg4sr82pm0qz3yxf74m8fxbd70s3w0gkm";
-    })
-
-    # case-insensitive filtering
-    (fetchpatch {
-      url = "https://github.com/radareorg/cutter/commit/0ebd34370bcaed00000168147572bb78106eeab1.patch";
-      sha256 = "0sc50jwhncfnd2i5mlyld4dbdzi2ws7nh4yglkhlap9l9h1jxn20";
-    })
-  ];
-
-  patchFlags = [ "-p2" ];
 
   nativeBuildInputs = [ qmake pkgconfig ];
   buildInputs = [ qtbase qtsvg radare2 ];


### PR DESCRIPTION
###### Motivation for this change

cc @dtzWill 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

