### PR TITLE
rtl_433: init at 51d275c

### DIFF
--- a/pkgs/applications/misc/rtl_433/default.nix
+++ b/pkgs/applications/misc/rtl_433/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libusb1, rtl-sdr }:
+stdenv.mkDerivation rec {
+
+  version = "2018-02-23";
+  name = "rtl_433-${version}";
+
+  src = fetchFromGitHub {
+    owner = "merbanan";
+    repo = "rtl_433";
+    rev = "51d275c";
+    sha256 = "1j443wmws5xgc18s47bvw3pqljk747izypz52rmlrvs16v96cg2g";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ libusb1 rtl-sdr ];
+
+  meta = with stdenv.lib; {
+    description = "Decode traffic from devices that broadcast on 433.9 MHz";
+    homepage = https://github.com/merbanan/rtl_433;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ earldouglas ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17266,6 +17266,8 @@ with pkgs;
   };
   rrsync = callPackage ../applications/networking/sync/rsync/rrsync.nix {};
 
+  rtl_433 = callPackage ../applications/misc/rtl_433 { };
+
   rtl-sdr = callPackage ../applications/misc/rtl-sdr { };
 
   rtv = callPackage ../applications/misc/rtv { };


### PR DESCRIPTION
###### Motivation for this change

Allow nix users to easily install [rtl_433](https://github.com/merbanan/rtl_433).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

