### PR TITLE
collectd: kafka patch for 18.03

### DIFF
--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
   # Should be included in the next release of this package
   patches = fetchpatch {
     name = "collectd_kafka_fix";
-    url = "https://patch-diff.githubusercontent.com/raw/collectd/collectd/pull/2683.patch";
+    url = "https://github.com/collectd/collectd/commit/6c2eb3ad28f08f7e774b6eaea5ae01b0857cf884.patch";
     sha256 = "14wsyj5xghij9lz7c61bzdyh45zg8pv5xn490cvbqiaci948zzv6";
   };
   configureFlags = [ "--localstatedir=/var" ];

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, darwin
+{ stdenv, fetchurl, fetchpatch, darwin
 # optional:
 , pkgconfig ? null  # most of the extra deps need pkgconfig to be found
 , curl ? null
@@ -65,6 +65,13 @@ stdenv.mkDerivation rec {
     darwin.apple_sdk.frameworks.ApplicationServices
   ];
 
+  # Patch fixes broken build on 18.03
+  # Should be included in the next release of this package
+  patches = fetchpatch {
+    name = "collectd_kafka_fix";
+    url = "https://patch-diff.githubusercontent.com/raw/collectd/collectd/pull/2683.patch";
+    sha256 = "14wsyj5xghij9lz7c61bzdyh45zg8pv5xn490cvbqiaci948zzv6";
+  };
   configureFlags = [ "--localstatedir=/var" ];
 
   # do not create directories in /var during installPhase


### PR DESCRIPTION
###### Motivation for this change
Fixes collectd on 18.03 by adding upstream patch.

[Currently broken on hydra.](https://hydra.nixos.org/job/nixpkgs/trunk/collectd.x86_64-linux)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

