### PR TITLE
systemtap: 2017.02.04 -> 2017.10.18

### DIFF
--- a/pkgs/development/tools/profiling/systemtap/default.nix
+++ b/pkgs/development/tools/profiling/systemtap/default.nix
@@ -5,9 +5,9 @@
 let
   ## fetchgit info
   url = git://sourceware.org/git/systemtap.git;
-  rev = "276ed27a3cc64531542ab73bb36bb04784e79bbc";
-  sha256 = "11967dx3cjs96v3ncfljw0h7blsgg9wm8g9z2270q9a90988g2c2";
-  version = "2017-02-04";
+  rev = "4051c70c9318c837981384cbb23f3e9eb1bd0892";
+  sha256 = "0sd8n3j3rishks3gyqj2jyqhps7hmlfjyz8i0w8v98cczhhh04rq";
+  version = "2017.10.18";
 
   inherit (kernel) stdenv;
   inherit (stdenv) lib;
@@ -16,7 +16,7 @@ let
   stapBuild = stdenv.mkDerivation {
     name = "systemtap-${version}";
     src = fetchgit { inherit url rev sha256; };
-  nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ elfutils gettext python2 python2Packages.setuptools ];
     # FIXME: Workaround for bug in kbuild, where quoted -I"/foo" flags would get mangled in out-of-tree kbuild dirs
     postPatch = ''


### PR DESCRIPTION

###### Motivation for this change

Version 2017.02.04 doesn't work with current kernel giving "function not found" errors during script compilation.

###### Things done

Version changed to last release version 3.2 (commited 2017.10.18).  Now it works: `# stap -ve 'probe begin { print("it works!\n"); exit() }` runs successfully.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

