### PR TITLE
nixos/networking: add hostname to /etc/hosts by default

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -222,7 +222,7 @@ in
           in
           ''
             ${optionalString cfg.hostnameInHosts ''
-              127.0.0.1 ${cfg.hostName}
+              127.0.1.1 ${cfg.hostName}
               ${optionalString cfg.enableIPv6 ''
                 ::1 ${userLocalHosts6} ${cfg.hostName}
               ''}

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -213,6 +213,10 @@ in
               otherHosts = allToString ( removeAttrs cfg.hosts [ "127.0.0.1" "::1" ]);
           in
           ''
+            127.0.0.1 ${cfg.hostName}
+            ${optionalString cfg.enableIPv6 ''
+              ::1 ${userLocalHosts6} ${cfg.hostName}
+            ''}
             127.0.0.1 ${userLocalHosts} localhost
             ${optionalString cfg.enableIPv6 ''
               ::1 ${userLocalHosts6} localhost

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -43,6 +43,14 @@ in
       '';
     };
 
+    networking.hostnameInHosts = lib.mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether or not to include this machine's hostname in <filename>/etc/hosts</filename>.
+      '';
+    };
+
     networking.hostConf = lib.mkOption {
       type = types.lines;
       default = "multi on";
@@ -213,9 +221,11 @@ in
               otherHosts = allToString ( removeAttrs cfg.hosts [ "127.0.0.1" "::1" ]);
           in
           ''
-            127.0.0.1 ${cfg.hostName}
-            ${optionalString cfg.enableIPv6 ''
-              ::1 ${userLocalHosts6} ${cfg.hostName}
+            ${optionalString cfg.hostnameInHosts ''
+              127.0.0.1 ${cfg.hostName}
+              ${optionalString cfg.enableIPv6 ''
+                ::1 ${userLocalHosts6} ${cfg.hostName}
+              ''}
             ''}
             127.0.0.1 ${userLocalHosts} localhost
             ${optionalString cfg.enableIPv6 ''


### PR DESCRIPTION
###### Motivation for this change

I'm testing some kubernetes related stuff, and it's assumed in a bunch of places that the hostname is resolvable. I could add this with `networking.extraHosts`, but I think it should be the default. See #1248 for some past discussion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

