### PR TITLE
dcrd: init at version 1.1.2

### DIFF
--- a/pkgs/applications/altcoins/dcrd.nix
+++ b/pkgs/applications/altcoins/dcrd.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, go, buildGoPackage, dep, fetchgit, git, cacert }:
+
+buildGoPackage rec {
+  name = "dcrd-${version}";
+  version = "1.1.2";
+  rev = "refs/tags/v${version}";
+  goPackagePath = "github.com/decred/dcrd";
+
+  buildInputs = [ go git dep cacert ];
+
+  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://${goPackagePath}";
+    sha256 = "0xcynipdn9zmmralxj0hjrwyanvhkwfj2b1vvjk5zfc95s2xc1q9";
+  };
+
+  preBuild = ''
+    export CWD=$(pwd)
+    cd go/src/github.com/decred/dcrd
+    dep ensure
+    go install . ./cmd/...
+    cd $CWD
+  '';
+
+  meta = {
+    homepage = "https://decred.org";
+    description = "Decred daemon in Go (golang)";
+    license = with lib.licenses; [ isc ];
+  };
+}

--- a/pkgs/applications/altcoins/dcrwallet.nix
+++ b/pkgs/applications/altcoins/dcrwallet.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, go, buildGoPackage, dep, fetchgit, git, cacert }:
+
+buildGoPackage rec {
+  name = "dcrwallet-${version}";
+  version = "1.1.2";
+  rev = "refs/tags/v${version}";
+  goPackagePath = "github.com/decred/dcrwallet";
+
+  buildInputs = [ go git dep cacert ];
+
+  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://${goPackagePath}";
+    sha256 = "058im4vmcmxcl5ir14h17wik5lagp2ay0p8qc3r99qmpfwvvz39x";
+  };
+
+  preBuild = ''
+    export CWD=$(pwd)
+    cd go/src/github.com/decred/dcrwallet
+    dep ensure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    go build
+  '';
+
+  installPhase = ''
+    mkdir -pv $bin/bin
+    cp -v dcrwallet $bin/bin
+  '';
+
+
+  meta = {
+    homepage = "https://decred.org";
+    description = "Decred daemon in Go (golang)";
+    license = with lib.licenses; [ isc ];
+  };
+}

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -26,6 +26,9 @@ rec {
 
   dashpay = callPackage ./dashpay.nix { };
 
+  dcrd = callPackage ./dcrd.nix { };
+  dcrwallet = callPackage ./dcrwallet.nix { };
+
   dero = callPackage ./dero.nix { };
 
   dogecoin  = callPackage ./dogecoin.nix { withGui = true; };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
