### PR TITLE
riot-web: make package configurable

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, fetchpatch }:
+{ lib, stdenv, fetchurl, fetchpatch, writeText, conf ? null }:
 
+let configFile = writeText "riot-config.json" conf; in
 stdenv.mkDerivation rec {
   name= "riot-web-${version}";
   version = "0.13.5";
@@ -12,6 +13,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/
     cp -R . $out/
+    ${lib.optionalString (conf != null) "ln -s ${configFile} $out/config.json"}
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1321,7 +1321,9 @@ with pkgs;
 
   ring-daemon = callPackage ../applications/networking/instant-messengers/ring-daemon { };
 
-  riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix { };
+  riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {
+    conf = config.riot-web.conf or null;
+  };
 
   rsyslog = callPackage ../tools/system/rsyslog {
     hadoop = null; # Currently Broken


### PR DESCRIPTION
Make `riot-web` more easy to configure for eg. a NixOS install: having a configured `riot-web` vhost becomes a matter of:
```nix
{
  services.nginx.virtualHosts."riot.example.org" = {
    enableACME = true; forceSSL = true;
    root = pkgs.riot-web.override {
      config = ''
        { the config.json contents }
      '';
    };
  };
}
```

cc @bachp 