### PR TITLE
flameshot: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "flameshot-${version}";
-  version = "0.5.0";
+  version = "0.5.1";
 
   nativeBuildInputs = [ qmake qttools ];
   buildInputs = [ qtbase ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "lupoDharkael";
     repo = "flameshot";
     rev = "v${version}";
-    sha256 = "1fy4il7rdj294l9cs642hx23bry25j9phn37274r2b87hwzy1rrv";
+    sha256 = "13h77np93r796jf289v4r687cmnpqkyqs34dm9gif4akaig74ky0";
   };
 
   enableParallelBuilding = true;
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/lupoDharkael/flameshot;
     maintainers = [ maintainers.scode ];
     license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upgrade.

This version might build on Darwin, but I didn't test that. The upstream patch mentioned in #34096 is rolled into this one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu 17.10)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

