### PR TITLE
sage: Make build more platform independant

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -30,6 +30,7 @@
 , texinfo
 , hevea
 , buildDocs ? false
+, optimize ? false # optimize sage to the current system (obviously impure)
 }:
 
 stdenv.mkDerivation rec {
@@ -139,7 +140,6 @@ stdenv.mkDerivation rec {
   configureFlags = stdenv.lib.optionals(buildDocs) [ "--docdir=$(doc)" ];
   preConfigure = ''
     export SAGE_NUM_THREADS="$NIX_BUILD_CORES"
-    export SAGE_ATLAS_ARCH=fast
 
     export HOME=/tmp/sage-home
     export SAGE_ROOT="$PWD"
@@ -160,6 +160,9 @@ stdenv.mkDerivation rec {
     mkdir -p "$doc"
     export SAGE_DOC="$doc"
     export SAGE_DOCBUILD_OPTS="--no-pdf-links -k"
+  ''
+  + stdenv.lib.optionalString (!optimize) ''
+    export SAGE_FAT_BINARY=yes
   '';
 
   buildFlags = if (buildDocs) then "doc" else "build";


### PR DESCRIPTION
###### Motivation for this change

(Hopefully) fixes #36235 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

