### PR TITLE
desmume: avoid errors with with -fpermissive

### DIFF
--- a/pkgs/misc/emulators/desmume/default.nix
+++ b/pkgs/misc/emulators/desmume/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
      })
   ];
 
+  CXXFLAGS = "-fpermissive";
+
   buildInputs =
   [ pkgconfig libtool intltool libXmu lua agg alsaLib soundtouch
     openal desktop-file-utils gtk2 gtkglext libglade pangox_compat


### PR DESCRIPTION
Prior to this change, `desmume` would fail to build on `nixos-unstable` due to an error:

`utils/libfat/directory.cpp:142:33: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]`

I guess this is due to the recent switch to GCC7.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

