### PR TITLE
gpredict: Added hamlib to buildInputs to control radios, and wrapped …

### DIFF
--- a/pkgs/applications/science/astronomy/gpredict/default.nix
+++ b/pkgs/applications/science/astronomy/gpredict/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool
 , gtk3, glib, curl, goocanvas2, gpsd
+, hamlib, wrapGAppsHook
 }:
 
 let
@@ -12,8 +13,8 @@ in stdenv.mkDerivation {
     sha256 = "0hwf97kng1zy8rxyglw04x89p0bg07zq30hgghm20yxiw2xc8ng7";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool ];
-  buildInputs = [ curl glib gtk3 goocanvas2 gpsd ];
+  nativeBuildInputs = [ pkgconfig intltool wrapGAppsHook ];
+  buildInputs = [ curl glib gtk3 goocanvas2 gpsd hamlib ];
 
   meta = with stdenv.lib; {
     description = "Real time satellite tracking and orbit prediction";
@@ -27,6 +28,6 @@ in stdenv.mkDerivation {
     license = licenses.gpl2;
     platforms = platforms.linux;
     homepage = http://gpredict.oz9aec.net/;
-    maintainers = [ maintainers.markuskowa ];
+    maintainers = [ maintainers.markuskowa maintainers.cmcdragonkai ];
   };
 }


### PR DESCRIPTION
…with wrapGAppsHook to fix gnome errors

###### Motivation for this change

Gpredict requires `wrapGAppsHook` to fix gnome settings error. `Glib-GIO-ERROR **: No Gsettings scehmas are installed on the system`...

Also added `hamlib` to buildInputs so that gpredict can be used to control radios.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

