### PR TITLE
numix-icon-theme-circle,numix-icon-theme-square: 17-12-25 -> 18-02-16, build GTK icon cache

### DIFF
--- a/pkgs/data/icons/numix-icon-theme-circle/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-circle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, numix-icon-theme }:
+{ stdenv, fetchFromGitHub, gtk3, numix-icon-theme }:
 
 stdenv.mkDerivation rec {
   version = "18-02-16";
@@ -14,13 +14,17 @@ stdenv.mkDerivation rec {
     sha256 = "0q08q1czsk6h0dxqscbgryr12xaakp4zbch37z0jxpwh087gnq4f";
   };
 
-  buildInputs = [ numix-icon-theme ];
-
-  dontBuild = true;
+  nativeBuildInputs = [ gtk3 numix-icon-theme ];
 
   installPhase = ''
     install -dm 755 $out/share/icons
     cp -dr --no-preserve='ownership' Numix-Circle{,-Light} $out/share/icons/
+  '';
+
+  postFixup = ''
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/data/icons/numix-icon-theme-circle/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-circle/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, numix-icon-theme }:
 
 stdenv.mkDerivation rec {
-  version = "17-12-25";
+  version = "18-02-16";
 
   package-name = "numix-icon-theme-circle";
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "numixproject";
     repo = package-name;
     rev = version;
-    sha256 = "10sn2w9xzmh7arbw0vn516p9nfym1bs8bf7i8zzvz7y09s61lkxh";
+    sha256 = "0q08q1czsk6h0dxqscbgryr12xaakp4zbch37z0jxpwh087gnq4f";
   };
 
   buildInputs = [ numix-icon-theme ];

--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, numix-icon-theme }:
+{ stdenv, fetchFromGitHub, gtk3, numix-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
@@ -12,13 +12,17 @@ stdenv.mkDerivation rec {
     sha256 = "1gjwc0s6a7q1jby5bcwxkcmbs470m81y8s0clsm0qhcmcn1c36xj";
   };
 
-  buildInputs = [ numix-icon-theme ];
-
-  dontBuild = true;
+  nativeBuildInputs = [ gtk3 numix-icon-theme ];
 
   installPhase = ''
     mkdir -p $out/share/icons
     cp -a Numix-Square{,-Light} $out/share/icons/
+  '';
+
+  postFixup = ''
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
   package-name = "numix-icon-theme-square";
-  version = "17-12-25";
+  version = "18-02-16";
 
   src = fetchFromGitHub {
     owner = "numixproject";
     repo = package-name;
     rev = version;
-    sha256 = "07rcfkz3c1z5fwqiib4r1bm964mpwf1f128xm8kz55xp6w1c7zgl";
+    sha256 = "1gjwc0s6a7q1jby5bcwxkcmbs470m81y8s0clsm0qhcmcn1c36xj";
   };
 
   buildInputs = [ numix-icon-theme ];


### PR DESCRIPTION
###### Motivation for this change

`numix-icon-theme-circle`: 17-12-25 -> 18-02-16
`numix-icon-theme-circle`: build GTK icon cache
`numix-icon-theme-square`: 17-12-25 -> 18-02-16
`numix-icon-theme-square`: build GTK icon cache

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).