### PR TITLE
gixy: 0.1.8 -> 0.1.9

### DIFF
--- a/pkgs/tools/admin/gixy/default.nix
+++ b/pkgs/tools/admin/gixy/default.nix
@@ -1,17 +1,18 @@
 { lib, fetchFromGitHub, python }:
 
 python.pkgs.buildPythonApplication rec {
-  name = "gixy-${version}";
-  version = "0.1.8";
+  pname = "gixy";
+  version = "0.1.9";
 
   # package is only compatible with python 2.7 and 3.5+
   disabled = with python.pkgs; !(pythonAtLeast "3.5" || isPy27);
 
+  # fetching from GitHub because the PyPi source is missing the tests
   src = fetchFromGitHub {
     owner = "yandex";
     repo = "gixy";
     rev = "v${version}";
-    sha256 = "0dg8j8pqlzdvmyfkphrizfqzggr64npb9mnm1dcwm6c3z6k2b0ii";
+    sha256 = "11aps8a8xg1nlw36jgrmnaf38imfz2rj67wnlalrrsqb616xipcv";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
[latest release](https://github.com/yandex/gixy/releases/tag/v0.1.9)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

