### PR TITLE
lib/tests: Add check-eval.nix to run simple tests.

### DIFF
--- a/lib/tests/check-eval.nix
+++ b/lib/tests/check-eval.nix
@@ -1,0 +1,7 @@
+# Throws an error if any of our lib tests fail.
+
+let tests = [ "misc" "systems" ];
+    all = builtins.concatLists (map (f: import (./. + "/${f}.nix")) tests);
+in if all == []
+     then null
+   else throw (builtins.toJSON all)


### PR DESCRIPTION
This can be used by evaluation-only tools to validate tests are still
working.