### PR TITLE
scantailor-advanced: init at 1.0.12

### DIFF
--- a/pkgs/applications/graphics/scantailor/advanced.nix
+++ b/pkgs/applications/graphics/scantailor/advanced.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, makeDesktopItem
+, cmake, libjpeg, libpng, libtiff, boost
+, qtbase, qttools }:
+
+stdenv.mkDerivation rec {
+  name = "scantailor-advanced-${version}";
+  version = "1.0.12";
+
+  src = fetchFromGitHub {
+    owner = "4lex4";
+    repo = "scantailor-advanced";
+    rev = "v${version}";
+    sha256 = "0i80jzky7l8wdv0wqdx48x1q0wmj72hhm0050pd43q80pj5r78a0";
+  };
+
+  nativeBuildInputs = [ cmake qttools ];
+  buildInputs = [ libjpeg libpng libtiff boost qtbase ];
+
+  postInstall = ''
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp $src/resources/appicon.svg $out/share/icons/hicolor/scalable/apps/scantailor.svg
+
+    mkdir -p $out/share/applications
+    cp $desktopItem/share/applications/* $out/share/applications/
+    for entry in $out/share/applications/*.desktop; do
+      substituteAllInPlace $entry
+    done
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = "scantailor-advanced";
+    exec = "scantailor %f";
+    icon = "scantailor";
+    comment = meta.description;
+    desktopName = "Scan Tailor Advanced";
+    genericName = "Scan Processing Software";
+    mimeType = "image/png;image/tif;image/jpeg;";
+    categories = "Graphics;";
+    startupNotify = "true";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/4lex4/scantailor-advanced;
+    description = "Interactive post-processing tool for scanned pages";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jfrankenau ];
+    platforms = platforms.gnu;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17320,6 +17320,8 @@ with pkgs;
 
   scantailor = callPackage ../applications/graphics/scantailor { };
 
+  scantailor-advanced = qt5.callPackage ../applications/graphics/scantailor/advanced.nix { };
+
   sc-im = callPackage ../applications/misc/sc-im { };
 
   scite = callPackage ../applications/editors/scite { };


### PR DESCRIPTION
###### Motivation for this change

The [original project](https://github.com/scantailor/scantailor) has seen its last commit in 2016. This [fork](https://github.com/4lex4/scantailor-advanced) of Scan Tailor combines the efforts of two other forks (Scan Tailor Featured and Scan Tailor Enhanced), is actively developed and well received judging by this [thread](https://forum.diybookscanner.org/viewtopic.php?f=21&t=3455) on the DIY Book Scanner forum.

Additionally Scan Tailor Advanced supports Qt5 unlike Scan Tailor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @viric