### PR TITLE
vcvrack: init at 0.5.1

### DIFF
--- a/pkgs/applications/audio/vcvrack/default.nix
+++ b/pkgs/applications/audio/vcvrack/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, curl, libzip, jansson, openssl,
+  mesa_glu, vulkan-loader, glew, glfw, gtk2, xorg,
+  alsaLib, rtaudio, rtmidi, speexdsp }:
+
+plugins:
+
+stdenv.mkDerivation rec {
+  name = "Rack-${version}";
+  version = "53fdea1cd15415f60a3c1dc8d8e4340bd06e65e6";
+
+  src = fetchFromGitHub {
+    owner = "VCVRack";
+    repo = "Rack";
+    rev = "${version}";
+    sha256 = "0zac3y4x7iypidxp8x7m0ia4ky9h6gdxq3lwm61s69xygnr92w1r";
+    fetchSubmodules = true;
+  };
+
+  prePatch = ''
+    sed -i "1,51s|dir = \".\"|dir = \"$out\"|g" src/asset.cpp
+  '';
+  patches = [ ./makefile.diff ];
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    curl libzip jansson openssl
+    mesa_glu vulkan-loader glew glfw gtk2
+    xorg.libX11 xorg.libXrandr xorg.libXinerama xorg.libXcursor xorg.libXi xorg.libXext
+    alsaLib rtaudio rtmidi speexdsp
+  ];
+
+  preBuild = ''
+    LIBS="libcurl libzip glew glfw3 jansson gtk+-2.0 rtaudio rtmidi speexdsp openssl"
+    makeFlagsArray=(LIBS=$LIBS);
+
+    pushd dep
+    mkdir -p include
+    make include/nanovg.h
+    make include/nanosvg.h
+    make include/blendish.h
+    make include/osdialog.h
+    popd
+  ''
+  +
+  lib.concatStrings (lib.mapAttrsToList(name: plugin: ''
+    mkdir -p plugins/${name}
+    cp -r ${plugin}/* plugins/${name}
+  '') plugins);
+
+  postBuild = lib.concatStrings (lib.mapAttrsToList (name: plugin: ''
+    pushd plugins/${name}/
+    make LIBS="$LIBS"
+    popd
+  '') plugins);
+
+  installPhase = ''
+    install -D -t $out/bin/ Rack
+    cp -r res $out/
+    cp -r plugins $out/
+  '';
+
+  meta = {
+    description = "Rack is the engine for the VCV open-source virtual modular synthesizer.";
+    homepage =  https://vcvrack.com/;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.skeidel ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/audio/vcvrack/makefile.diff
+++ b/pkgs/applications/audio/vcvrack/makefile.diff
@@ -1,0 +1,103 @@
+From a6bf9231a27628209ede1c13bef7815d5224fb25 Mon Sep 17 00:00:00 2001
+From: Sven Keidel <svenkeidel@gmail.com>
+Date: Mon, 26 Feb 2018 21:52:57 +0100
+Subject: [PATCH 1/2] fix makefile for nixos
+
+---
+ Makefile   | 13 ++++++-------
+ compile.mk |  3 ++-
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 1d429d3..0378ac0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,8 +1,9 @@
+ VERSION = 0.6.0dev
+
+ FLAGS += \
+-	-Iinclude \
+-	-Idep/include -Idep/lib/libzip/include
++       -Iinclude \
++       -Idep/include
++LIBS += gtk+-2.0 libcurl libzip glew glfw3 jansson openssl rtaudio rtmidi speexdsp
+
+ ifdef RELEASE
+	FLAGS += -DRELEASE=$(RELEASE)
+@@ -16,11 +17,9 @@ include arch.mk
+
+ ifeq ($(ARCH), lin)
+	SOURCES += dep/osdialog/osdialog_gtk2.c
+-	CFLAGS += $(shell pkg-config --cflags gtk+-2.0)
+-	LDFLAGS += -rdynamic \
+-		-lpthread -lGL -ldl \
+-		$(shell pkg-config --libs gtk+-2.0) \
+-		-Ldep/lib -lGLEW -lglfw -ljansson -lspeexdsp -lcurl -lzip -lrtaudio -lrtmidi -lcrypto -lssl
++	CFLAGS += $(shell pkg-config --cflags $(LIBS))
++	LDFLAGS += -rdynamic -ldl \
++		$(shell pkg-config --libs $(LIBS))
+	TARGET = Rack
+ endif
+
+diff --git a/compile.mk b/compile.mk
+index 307c6fe..d56ee0d 100644
+--- a/compile.mk
++++ b/compile.mk
+@@ -15,7 +15,8 @@ CXXFLAGS += -std=c++11
+
+
+ ifeq ($(ARCH), lin)
+-	FLAGS += -DARCH_LIN
++	FLAGS += -DARCH_LIN \
++          $(shell pkg-config --cflags $(LIBS))
+ endif
+
+ ifeq ($(ARCH), mac)
+--
+2.16.2
+
+
+From 3d5840f3c58cd39a82c23c9850760c5ddf56f7a9 Mon Sep 17 00:00:00 2001
+From: Sven Keidel <svenkeidel@gmail.com>
+Date: Sat, 3 Mar 2018 23:02:36 +0100
+Subject: [PATCH 2/2] xmonad bug
+
+---
+ Makefile         | 1 -
+ src/settings.cpp | 2 ++
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 0378ac0..b963f4b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -3,7 +3,6 @@ VERSION = 0.6.0dev
+ FLAGS += \
+        -Iinclude \
+        -Idep/include
+-LIBS += gtk+-2.0 libcurl libzip glew glfw3 jansson openssl rtaudio rtmidi speexdsp
+
+ ifdef RELEASE
+	FLAGS += -DRELEASE=$(RELEASE)
+diff --git a/src/settings.cpp b/src/settings.cpp
+index 78737b0..cbf7e10 100644
+--- a/src/settings.cpp
++++ b/src/settings.cpp
+@@ -20,6 +20,7 @@ static json_t *settingsToJson() {
+	json_t *tokenJ = json_string(gToken.c_str());
+	json_object_set_new(rootJ, "token", tokenJ);
+
++        /*
+	if (!windowIsMaximized()) {
+		// windowSize
+		Vec windowSize = windowGetWindowSize();
+@@ -31,6 +32,7 @@ static json_t *settingsToJson() {
+		json_t *windowPosJ = json_pack("[f, f]", windowPos.x, windowPos.y);
+		json_object_set_new(rootJ, "windowPos", windowPosJ);
+	}
++        */
+
+	// opacity
+	float opacity = gToolbar->wireOpacitySlider->value;
+--
+2.16.2

--- a/pkgs/applications/audio/vcvrack/plugins.nix
+++ b/pkgs/applications/audio/vcvrack/plugins.nix
@@ -1,0 +1,51 @@
+{ fetchFromGitHub }:
+
+{
+  Fundamental = fetchFromGitHub {
+    owner = "VCVRack";
+    repo = "Fundamental";
+    rev = "760f6ea76f9dc01af832932343eb427a95cde775";
+    sha256 = "18mmijjf4qj18bhpmbxhkw3km43a6a8sfk5wd48y2pda7i64zqhq";
+    fetchSubmodules = true;
+  };
+  AudibleInstruments = fetchFromGitHub {
+    owner = "VCVRack";
+    repo = "AudibleInstruments";
+    rev = "2fc0a0589b3d7b091d4cb7c3392a9deca202bb71";
+    sha256 = "0dadbmbxcifn60fw1cjni9v95jb9hlimncq8h4l1gisf9nxl7cwl";
+    fetchSubmodules = true;
+  };
+  Befaco = fetchFromGitHub {
+    owner = "VCVRack";
+    repo = "Befaco";
+    rev = "e80a5bc922c3c6a75fadd326eeb64761c76592bf";
+    sha256 = "0bki1miapllw6hyhngwchq3p7rmnxvm4afs5knr6v038ib3m0cfd";
+    fetchSubmodules = true;
+  };
+  ESeries = fetchFromGitHub {
+    owner = "VCVRack";
+    repo = "ESeries";
+    rev = "6c6c75528859a7464ed22a9e6131b77ea6f6b9ea";
+    sha256 = "03xdkwmdnpf709wqb6dx0xd66nzrxp7x6i9wlqjr0zv3604cd3y9";
+    fetchSubmodules = true;
+  };
+
+  # Does not compile because it requires samplerate.h, which got removed in recent releases of vcvrack.
+  # AepelzensModules = fetchFromGitHub {
+  #   owner = "Aepelzen";
+  #   repo = "AepelzensModules";
+  #   rev = "61c686389c56af1a05acbf62abb10f434ec83027";
+  #   sha256 = "0lyb5zpajvv1mkl1a71jgs7yfnw522h8lb0ckx05bkqhsgzi5qzm";
+  #   fetchSubmodules = true;
+  # };
+
+  # AepelzensParasites = fetchFromGitHub {
+  #   owner = "Aepelzen";
+  #   repo = "AepelzensParasites";
+  #   rev = "b8ae026f79f46928d01754374f58d08ea4f85cdc";
+  #   sha256 = "1raj5cghd9lybz6n334968zf08an8mw7i8hsaw29vrj5847hfxbr";
+  #   fetchSubmodules = true;
+  # };
+
+
+}

--- a/pkgs/development/libraries/audio/rtaudio/default.nix
+++ b/pkgs/development/libraries/audio/rtaudio/default.nix
@@ -1,22 +1,23 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, libjack2,  alsaLib, rtmidi }:
 
 stdenv.mkDerivation rec {
-  version = "4.1.2";
+  version = "5.0.0";
   name = "rtaudio-${version}";
 
   src = fetchFromGitHub {
     owner = "thestk";
     repo = "rtaudio";
     rev = "${version}";
-    sha256 = "09j84l9l3q0g238z5k89rm8hgk0i1ir8917an7amq474nwjp80pq";
+    sha256 = "0jkqnhc2pq31nmq4daxhmqdjgv2qi4ib27hwms2r5zhnmvvzlr67";
   };
 
   buildInputs = [ autoconf automake libtool libjack2 alsaLib rtmidi ];
 
   preConfigure = ''
     ./autogen.sh --no-configure
-    ./configure
   '';
+
+  configureFlags = [ "--with-alsa" "--with-jack" ];
 
   meta = {
     description = "A set of C++ classes that provide a cross platform API for realtime audio input/output";

--- a/pkgs/development/libraries/audio/rtmidi/default.nix
+++ b/pkgs/development/libraries/audio/rtmidi/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, libjack2, alsaLib, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "2.1.1";
+  version = "3.0.0";
   name = "rtmidi-${version}";
 
   src = fetchFromGitHub {
     owner = "thestk";
     repo = "rtmidi";
-    rev = "${version}";
+    rev = "v${version}";
     sha256 = "11pl45lp8sq5xkpipwk622w508nw0qcxr03ibicqn1lsws0hva96";
   };
 
@@ -16,8 +16,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     ./autogen.sh --no-configure
-    ./configure
   '';
+
+  configureFlags = [ "--with-alsa" "--with-jack" ];
 
   meta = {
     description = "A set of C++ classes that provide a cross platform API for realtime MIDI input/output";

--- a/pkgs/development/libraries/glfw/3.3-prerelease.nix
+++ b/pkgs/development/libraries/glfw/3.3-prerelease.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, cmake, mesa_noglu, libXrandr, libXinerama, libXcursor, libX11, libXext, libXi
+, darwin, fixDarwinDylibNames
+}:
+
+stdenv.mkDerivation rec {
+  version = "0d4534733b7a748a21a1b1177bb37a9b224e3582";
+  name = "glfw-${version}";
+
+  src = fetchFromGitHub {
+    owner = "glfw";
+    repo = "GLFW";
+    rev = "${version}";
+    sha256 = "12dhfvphhy7gx1n6jsdqsklkda2493csmrssx69wm0z8zwpp67q4";
+  };
+
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = [ mesa_noglu ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    libX11 libXrandr libXinerama libXcursor libXext libXi
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa Kernel fixDarwinDylibNames ]);
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+
+  meta = with stdenv.lib; {
+    description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time";
+    homepage = http://www.glfw.org/;
+    license = licenses.zlib;
+    maintainers = with maintainers; [ marcweber ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8864,6 +8864,7 @@ with pkgs;
   glfw = glfw3;
   glfw2 = callPackage ../development/libraries/glfw/2.x.nix { };
   glfw3 = callPackage ../development/libraries/glfw/3.x.nix { };
+  glfw_3_3_prerelease = callPackage ../development/libraries/glfw/3.3-prerelease.nix { };
 
   glibc_2_26 = callPackage ../development/libraries/glibc {
     installLocales = config.glibc.locales or false;
@@ -17819,6 +17820,11 @@ with pkgs;
   vbindiff = callPackage ../applications/editors/vbindiff { };
 
   vcprompt = callPackage ../applications/version-management/vcprompt { };
+
+  vcvrackWithPlugins = callPackage ../applications/audio/vcvrack {
+    glfw = glfw_3_3_prerelease;
+  };
+  vcvrack = pkgs.vcvrackWithPlugins (import ../applications/audio/vcvrack/plugins.nix { inherit fetchFromGitHub; });
 
   vdirsyncer = callPackage ../tools/misc/vdirsyncer { };
 


### PR DESCRIPTION
###### Motivation for this change
Hi, I ported [VCVRack ](https://vcvrack.com/), an open-source modular synthesizer, to Nixos. It is pretty cool, you should check it out. I'm open for suggestion how to improve the packaging code.

###### Things done
I created a function `vcvrackWithPlugins`, which can be found in `pkgs/applications/audio/vcvrack/default.nix` that takes a list of plugins (modules for the synthesizer) and creates derivation for VCVRack with all specified plugins.

###### Changes to nixpkgs
I had to update `rtaudio` and `rtmidi` to the latest versions. Furthermore, VCVRack depends on a not release version of GLFW, for which I created a new expressions `glfw_3_3_prerelease`. This expression can be removed after GLFW releases version 3.3.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/CC rtaudio, rtmidi maintainer: @magnetophon 