### PR TITLE
xen: add v 4.10

### DIFF
--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -262,7 +262,7 @@ in
         mkdir -p /var/lib/xen # so we create them here unconditionally.
         grep -q control_d /proc/xen/capabilities
         '';
-      serviceConfig = if cfg.package.version < "4.8" then
+      serviceConfig = if (builtins.compareVersions cfg.package.version "4.8" < 0) then
         { ExecStart = ''
             ${cfg.stored}${optionalString cfg.trace " -T /var/log/xen/xenstored-trace.log"} --no-fork
             '';
@@ -275,7 +275,7 @@ in
           NotifyAccess    = "all";
         };
       postStart = ''
-        ${optionalString (cfg.package.version < "4.8") ''
+        ${optionalString (builtins.compareVersions cfg.package.version "4.8" < 0) ''
           time=0
           timeout=30
           # Wait for xenstored to actually come up, timing out after 30 seconds
@@ -320,7 +320,7 @@ in
       serviceConfig = {
         ExecStart = ''
           ${cfg.package}/bin/xenconsoled\
-            ${optionalString ((cfg.package.version >= "4.8")) " -i"}\
+            ${optionalString ((builtins.compareVersions cfg.package.version "4.8" >= 0)) " -i"}\
             ${optionalString cfg.trace " --log=all --log-dir=/var/log/xen"}
           '';
       };

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -241,6 +241,12 @@ in
           '';
           target = "default/xendomains";
         }
+      ]
+      ++ lib.optionals (builtins.compareVersions cfg.package.version "4.10" >= 0) [
+        # in V 4.10 oxenstored requires /etc/xen/oxenstored.conf to start
+        { source = "${cfg.package}/etc/xen/oxenstored.conf";
+          target = "xen/oxenstored.conf";
+        }
       ];
 
     # Xen provides udev rules.

--- a/pkgs/applications/virtualization/xen/4.10.nix
+++ b/pkgs/applications/virtualization/xen/4.10.nix
@@ -1,0 +1,176 @@
+{ stdenv, callPackage, fetchurl, fetchpatch, fetchgit
+, withInternalQemu ? true
+, withInternalTraditionalQemu ? true
+, withInternalSeabios ? true
+, withSeabios ? !withInternalSeabios, seabios ? null
+, withInternalOVMF ? false # FIXME: tricky to build
+, withOVMF ? false, OVMF
+, withLibHVM ? true
+
+# qemu
+, udev, pciutils, xorg, SDL, pixman, acl, glusterfs, spice-protocol, usbredir
+, alsaLib, glib, python2
+, ... } @ args:
+
+assert withInternalSeabios -> !withSeabios;
+assert withInternalOVMF -> !withOVMF;
+
+with stdenv.lib;
+
+# Patching XEN? Check the XSAs at
+# https://xenbits.xen.org/xsa/
+# and try applying all the ones we don't have yet.
+
+let
+  xsaPatch = { name , sha256 }: (fetchpatch {
+    url = "https://xenbits.xen.org/xsa/xsa${name}.patch";
+    inherit sha256;
+  });
+
+  xsa = import ./xsa-patches.nix { inherit fetchpatch; };
+
+  qemuDeps = [
+    udev pciutils xorg.libX11 SDL pixman acl glusterfs spice-protocol usbredir
+    alsaLib glib python2
+  ];
+in
+
+callPackage (import ./generic.nix (rec {
+  version = "4.10.0";
+
+  src = fetchurl {
+    url = "https://downloads.xenproject.org/release/xen/${version}/xen-${version}.tar.gz";
+    sha256 = "0i38ap5b5m1kix6xb0vn9ya1yab35adyc98bzfnbq4lb7w1afqh2";
+  };
+
+  # Sources needed to build tools and firmwares.
+  xenfiles = optionalAttrs withInternalQemu {
+    "qemu-xen" = {
+      src = fetchgit {
+        url = https://xenbits.xen.org/git-http/qemu-xen.git;
+        # rev = "refs/tags/qemu-xen-${version}";
+        # use revision hash - reproducible but must be updated with each new version
+        rev = "b79708a8ed1b3d18bee67baeaf33b3fa529493e2";
+        sha256 = "1yxxad6nvlfmrbgyc8ix19qmrsn1rx4zpyiqnfi4x4kg94acwa5w";
+      };
+      buildInputs = qemuDeps;
+      postPatch = ''
+        # needed in build but /usr/bin/env is not available in sandbox
+        substituteInPlace scripts/tracetool.py \
+          --replace "/usr/bin/env python" "${python2}/bin/python"
+      '';
+      meta.description = "Xen's fork of upstream Qemu";
+    };
+  } // optionalAttrs withInternalTraditionalQemu {
+    "qemu-xen-traditional" = {
+      src = fetchgit {
+        url = https://xenbits.xen.org/git-http/qemu-xen-traditional.git;
+        # rev = "refs/tags/xen-${version}";
+        # use revision hash - reproducible but must be updated with each new version
+        rev = "c8ea0457495342c417c3dc033bba25148b279f60";
+        sha256 = "0v5nl3c08kpjg57fb8l191h1y57ykp786kz6l525jgplif28vx13";
+      };
+      buildInputs = qemuDeps;
+      patches = [
+      ];
+      postPatch = ''
+        substituteInPlace xen-hooks.mak \
+          --replace /usr/include/pci ${pciutils}/include/pci
+      '';
+      meta.description = "Xen's fork of upstream Qemu that uses old device model";
+    };
+  } // optionalAttrs withInternalSeabios {
+    "firmware/seabios-dir-remote" = {
+      src = fetchgit {
+        url = https://xenbits.xen.org/git-http/seabios.git;
+        rev = "f0cdc36d2f2424f6b40438f7ee7cc502c0eff4df";
+        sha256 = "1wq5pjkjrfzqnq3wyr15mcn1l4c563m65gdyf8jm97kgb13pwwfm";
+      };
+      patches = [ ./0000-qemu-seabios-enable-ATA_DMA.patch ];
+      meta.description = "Xen's fork of Seabios";
+    };
+  } // optionalAttrs withInternalOVMF {
+    "firmware/ovmf-dir-remote" = {
+      src = fetchgit {
+        url = https://xenbits.xen.org/git-http/ovmf.git;
+        rev = "173bf5c847e3ca8b42c11796ce048d8e2e916ff8";
+        sha256 = "07zmdj90zjrzip74fvd4ss8n8njk6cim85s58mc6snxmqqv7gmcr";
+      };
+      meta.description = "Xen's fork of OVMF";
+    };
+  } // {
+    # TODO: patch Xen to make this optional?
+    "firmware/etherboot/ipxe.git" = {
+      src = fetchgit {
+        url = https://git.ipxe.org/ipxe.git;
+        rev = "356f6c1b64d7a97746d1816cef8ca22bdd8d0b5d";
+        sha256 = "15n400vm3id5r8y3k6lrp9ab2911a9vh9856f5gvphkazfnmns09";
+      };
+      meta.description = "Xen's fork of iPXE";
+    };
+  } // optionalAttrs withLibHVM {
+    "xen-libhvm-dir-remote" = {
+      src = fetchgit {
+        name = "xen-libhvm";
+        url = https://github.com/michalpalka/xen-libhvm;
+        rev = "83065d36b36d6d527c2a4e0f5aaf0a09ee83122c";
+        sha256 = "1jzv479wvgjkazprqdzcdjy199azmx2xl3pnxli39kc5mvjz3lzd";
+      };
+      buildPhase = ''
+        make
+        cd biospt
+        cc -Wall -g -D_LINUX -Wstrict-prototypes biospt.c -o biospt -I../libhvm -L../libhvm -lxenhvm
+      '';
+      installPhase = ''
+        make install
+        cp biospt/biospt $out/bin/
+      '';
+      meta = {
+        description = ''
+          Helper library for reading ACPI and SMBIOS firmware values
+          from the host system for use with the HVM guest firmware
+          pass-through feature in Xen'';
+        license = licenses.bsd2;
+      };
+    };
+  };
+
+  configureFlags = []
+    ++ optional (!withInternalQemu) "--with-system-qemu" # use qemu from PATH
+    ++ optional (withInternalTraditionalQemu) "--enable-qemu-traditional"
+    ++ optional (!withInternalTraditionalQemu) "--disable-qemu-traditional"
+
+    ++ optional (withSeabios) "--with-system-seabios=${seabios}"
+    ++ optional (!withInternalSeabios && !withSeabios) "--disable-seabios"
+
+    ++ optional (withOVMF) "--with-system-ovmf=${OVMF.fd}/FV/OVMF.fd"
+    ++ optional (withInternalOVMF) "--enable-ovmf";
+
+  patches = with xsa; flatten [
+    XSA_252
+    XSA_253
+    XSA_255_1
+    XSA_255_2
+    XSA_256
+  ];
+
+  # Fix build on Glibc 2.24.
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
+  postPatch = ''
+    # Avoid a glibc >= 2.25 deprecation warnings that get fatal via -Werror.
+    sed 1i'#include <sys/sysmacros.h>' \
+      -i tools/blktap2/control/tap-ctl-allocate.c \
+      -i tools/libxl/libxl_device.c
+    # Makefile didn't include previous PKG_CONFIG_PATH so glib wasn't found
+    substituteInPlace tools/Makefile \
+      --replace 'PKG_CONFIG_PATH=$(XEN_ROOT)/tools/pkg-config' 'PKG_CONFIG_PATH=$(XEN_ROOT)/tools/pkg-config:$(PKG_CONFIG_PATH)'
+  '';
+
+  passthru = {
+    qemu-system-i386 = if withInternalQemu
+      then "lib/xen/bin/qemu-system-i386"
+      else throw "this xen has no qemu builtin";
+  };
+
+})) args

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -154,12 +154,12 @@ stdenv.mkDerivation (rec {
     substituteInPlace tools/xenstat/Makefile \
       --replace /usr/include/curses.h ${ncurses.dev}/include/curses.h
 
-    ${optionalString (config.version >= "4.8") ''
+    ${optionalString (builtins.compareVersions config.version "4.8" >= 0) ''
       substituteInPlace tools/hotplug/Linux/launch-xenstore.in \
         --replace /bin/mkdir mkdir
     ''}
 
-    ${optionalString (config.version < "4.6") ''
+    ${optionalString (builtins.compareVersions config.version "4.6" < 0) ''
       # TODO: use this as a template and support our own if-up scripts instead?
       substituteInPlace tools/hotplug/Linux/xen-backend.rules.in \
         --replace "@XEN_SCRIPT_DIR@" $out/etc/xen/scripts

--- a/pkgs/applications/virtualization/xen/packages.nix
+++ b/pkgs/applications/virtualization/xen/packages.nix
@@ -103,6 +103,52 @@ rec {
     };
   };
 
+  xen_4_10-vanilla = callPackage ./4.10.nix {
+    meta = {
+      description = "vanilla";
+      longDescription = ''
+        Vanilla version of Xen. Uses forks of Qemu and Seabios bundled
+        with Xen. This gives vanilla experince, but wastes space and
+        build time: typical NixOS setup that runs lots of VMs will
+        build three different versions of Qemu when using this (two
+        forks and upstream).
+      '';
+    };
+  };
+
+  xen_4_10-slim = xen_4_10-vanilla.override {
+    withInternalQemu = false;
+    withInternalTraditionalQemu = true;
+    withInternalSeabios = false;
+    withSeabios = true;
+
+    meta = {
+      description = "slim";
+      longDescription = ''
+        Slimmed-down version of Xen that reuses nixpkgs packages as
+        much as possible. Different parts may get out of sync, but
+        this builds faster and uses less space than vanilla. Use with
+        `qemu_xen` from nixpkgs.
+      '';
+    };
+  };
+
+  xen_4_10-light = xen_4_10-vanilla.override {
+    withInternalQemu = false;
+    withInternalTraditionalQemu = false;
+    withInternalSeabios = false;
+    withSeabios = true;
+
+    meta = {
+      description = "light";
+      longDescription = ''
+        Slimmed-down version of Xen without `qemu-traditional` (you
+        don't need it if you don't know what it is). Use with
+        `qemu_xen-light` from nixpkgs.
+      '';
+    };
+  };
+
   xen-vanilla = xen_4_5-vanilla;
   xen-slim = xen_4_5-slim;
   xen-light = xen_4_5-light;

--- a/pkgs/applications/virtualization/xen/xsa-patches.nix
+++ b/pkgs/applications/virtualization/xen/xsa-patches.nix
@@ -893,4 +893,44 @@ in rec {
   ];
 
 
+  # 4.10
+  XSA_252 = [
+   (xsaPatch {
+      name = "252";
+      sha256 = "0v4sg20dnvnwrjh3x69gk81v2kmcql7g2s044vg3wcxhzvij1rrn";
+    })
+  ];
+
+  # 4.10
+  XSA_253 = [
+   (xsaPatch {
+      name = "253";
+      sha256 = "0445vzlzy3gd499xraqh5r4qjar6qr0y3813h22jy1n84nhxz27i";
+    })
+  ];
+
+  # 4.10
+  XSA_255_1 = [
+   (xsaPatch {
+      name = "255-1";
+      sha256 = "05g2f3ji1rrjlw3yw4nrns50pnmsib8ybrf64scr1817mj0q9myr";
+    })
+  ];
+
+  # 4.10
+  XSA_255_2 = [
+   (xsaPatch {
+      name = "255-2";
+      sha256 = "08wbngw5z0f9g8di59hww3hhi7j9z49bpc4xlwn5akfcwbgf0961";
+    })
+  ];
+
+  # 4.10
+  XSA_256 = [
+   (xsaPatch {
+      name = "256";
+      sha256 = "1hicwhbwj6k25px55f4ncx1c5xiihi8pfvsb3kv57k7kaicb7pza";
+    })
+  ];
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13672,6 +13672,8 @@ with pkgs;
   qemu_xen-light = lowPrio (qemu.override { hostCpuOnly = true; xenSupport = true; xen = xen-light; });
   qemu_xen_4_8 = lowPrio (qemu.override { hostCpuOnly = true; xenSupport = true; xen = xen_4_8-slim; });
   qemu_xen_4_8-light = lowPrio (qemu.override { hostCpuOnly = true; xenSupport = true; xen = xen_4_8-light; });
+  qemu_xen_4_10 = lowPrio (qemu.override { hostCpuOnly = true; xenSupport = true; xen = xen_4_10-slim; });
+  qemu_xen_4_10-light = lowPrio (qemu.override { hostCpuOnly = true; xenSupport = true; xen = xen_4_10-light; });
 
   qemu_test = lowPrio (qemu.override { hostCpuOnly = true; nixosTestRunner = true; });
 
@@ -18313,6 +18315,9 @@ with pkgs;
   xen_4_8 = xenPackages.xen_4_8-vanilla;
   xen_4_8-slim = xenPackages.xen_4_8-slim;
   xen_4_8-light = xenPackages.xen_4_8-light;
+  xen_4_10 = xenPackages.xen_4_10-vanilla;
+  xen_4_10-slim = xenPackages.xen_4_10-slim;
+  xen_4_10-light = xenPackages.xen_4_10-light;
 
   xkbset = callPackage ../tools/X11/xkbset { };
 


### PR DESCRIPTION
###### Motivation for this change

Would like to experiment with latest xen version (in particular, try to enable xen-uefi boot in NixOS - which appears to require xen >= 4.9).
This change only adds xen 4.10. It does not modify the other versions (4.5 and 4.8) and leaves the default at 4.5 to prevent breaking existing installations.

###### Current Status

- xen_4_10-vanilla, -light and -slim build
- hypervisor and dom0 boot in a vm
- oxenstored fails to start (caused by missing config file)

###### Things done

- [x] fix broken version check in generic.nix (previous string comparison broke with 4.10)
- [x] bump versions
- [x] add relevant xsa patches for 4.10
- [x] fix broken build of xen_4_10-vanilla

###### Things to do

- [ ] test, test, test

---

/CC xen maintainers: @edolstra  @oxij  @tstrobel 