### PR TITLE
nixos/gnome-keyring: add option to enable the daemon as systemd service

### DIFF
--- a/nixos/modules/services/desktops/gnome3/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-keyring.nix
@@ -4,6 +4,10 @@
 
 with lib;
 
+let
+  cfg = config.services.gnome3.gnome-keyring;
+in
+
 {
 
   ###### interface
@@ -12,13 +16,15 @@ with lib;
 
     services.gnome3.gnome-keyring = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
+      enable = mkEnableOption "gnome-keyring";
+
+      enableService = mkEnableOption "gnome-keyring-daemon" // {
         description = ''
-          Whether to enable GNOME Keyring daemon, a service designed to
-          take care of the user's security credentials,
-          such as user names and passwords.
+          Whether to run a systemd service which runs the keyring daemon.
+
+          This is enabled by default if `services.gnome3.gnome-keyring.enable = true` and
+          the gnome3 DE is not enabled. If gnome3 is enabled, it will take care of the keyring daemon and this
+          option can be `false`.
         '';
       };
 
@@ -29,11 +35,24 @@ with lib;
 
   ###### implementation
 
-  config = mkIf config.services.gnome3.gnome-keyring.enable {
+  config = mkIf cfg.enable {
 
     environment.systemPackages = [ pkgs.gnome3.gnome-keyring ];
 
     services.dbus.packages = [ pkgs.gnome3.gnome-keyring pkgs.gnome3.gcr ];
+
+    services.gnome3.gnome-keyring.enableService = mkDefault (!config.services.xserver.desktopManager.gnome3.enable);
+
+    systemd.user.services.gnome-keyring-daemon = mkIf cfg.enableService {
+      description = "Runs the gnome-keyring daemon";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+
+      serviceConfig = {
+        Restart = "always";
+        ExecStart = "${pkgs.gnome3.gnome-keyring}/bin/gnome-keyring-daemon -f";
+      };
+    };
 
   };
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -268,6 +268,7 @@ in rec {
   tests.gocd-server = callTest tests/gocd-server.nix {};
   tests.gnome3 = callTest tests/gnome3.nix {};
   tests.gnome3-gdm = callTest tests/gnome3-gdm.nix {};
+  tests.gnome-keyring = callTest tests/gnome-keyring.nix {};
   tests.grafana = callTest tests/grafana.nix {};
   tests.graphite = callTest tests/graphite.nix {};
   tests.hardened = callTest tests/hardened.nix { };

--- a/nixos/tests/gnome-keyring.nix
+++ b/nixos/tests/gnome-keyring.nix
@@ -1,0 +1,21 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+
+with lib;
+
+{
+  name = "gnome-keyring";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ ma27 ];
+
+  nodes.machine = {
+    imports = [ ./common/x11.nix ./common/user-account.nix ];
+    services.xserver.displayManager.auto.user = "bob";
+
+    services.gnome3.gnome-keyring.enable = true;
+  };
+
+  testScript = ''
+    $machine->start;
+    $machine->waitForX;
+    $machine->waitForUnit("gnome-keyring-daemon.service", "bob");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

On my minimalistic i3 setup without any DE I don't have this daemon
running, so it's impossible for other services to talk to it even when
enabling this module.

I added an option which allows to start a user service running the
keyring daemon in the foreground to capture its output properly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

