### PR TITLE
kernel-headers: fix asm symlinks

### DIFF
--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -41,8 +41,8 @@ let
 
     # !!! hacky
     fixupPhase = ''
-      ln -s asm $out/include/asm-$platform
-      if test "$platform" = "i386" -o "$platform" = "x86_64"; then
+      ln -s asm $out/include/asm-$ARCH
+      if test "$ARCH" = "i386" -o "$ARCH" = "x86_64"; then
         ln -s asm $out/include/asm-x86
       fi
     '';


### PR DESCRIPTION
We no longer set "platform", so the code referring to it
did the wrong thing.

Happened to notice that we created an "asm-" symlink.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---