### PR TITLE
you-get: 0.4.1025 -> 0.4.1040

### DIFF
--- a/pkgs/tools/misc/you-get/default.nix
+++ b/pkgs/tools/misc/you-get/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonApplication rec {
   pname = "you-get";
-  version = "0.4.1025";
+  version = "0.4.1040";
 
   # Tests aren't packaged, but they all hit the real network so
   # probably aren't suitable for a build environment anyway.
@@ -10,7 +10,7 @@ buildPythonApplication rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1dbalpwhzn39kgswjy84720wfjssa087adavbwig53krsjdvhj6k";
+    sha256 = "1a4ciizj87kqp9115i07p1rkbym81sw78v5xsjm3dy8wicg05jgx";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/.you-get-wrapped -h` got 0 exit code
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/.you-get-wrapped --help` got 0 exit code
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/.you-get-wrapped -V` and found version 0.4.1040
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/.you-get-wrapped --version` and found version 0.4.1040
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/.you-get-wrapped -h` and found version 0.4.1040
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/.you-get-wrapped --help` and found version 0.4.1040
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/you-get -h` got 0 exit code
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/you-get --help` got 0 exit code
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/you-get -V` and found version 0.4.1040
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/you-get --version` and found version 0.4.1040
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/you-get -h` and found version 0.4.1040
- ran `/nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040/bin/you-get --help` and found version 0.4.1040
- found 0.4.1040 with grep in /nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040
- found 0.4.1040 in filename of file in /nix/store/g7h3hqb20qkqwkjs5c1p84ns20aybwdc-you-get-0.4.1040

cc maintainers