### PR TITLE
nixos/initrd-network: add udhcpc.extraArgs option

### DIFF
--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -50,7 +50,7 @@ in
     };
 
     boot.initrd.network.udhcpc.extraArgs = mkOption {
-      default = "";
+      default = [];
       type = types.listOf types.str;
       description = ''
         Additional command-line arguments passed verbatim to udhcpc if

--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -23,6 +23,8 @@ let
       fi
     '';
 
+  udhcpcArgs = toString cfg.udhcpc.extraArgs;
+
 in
 
 {
@@ -44,6 +46,16 @@ in
         You should add the module(s) required for your network card to
         boot.initrd.availableKernelModules. lspci -v -s &lt;ethernet controller&gt;
         will tell you which.
+      '';
+    };
+
+    boot.initrd.network.udhcpc.extraArgs = mkOption {
+      default = "";
+      type = types.listOf types.str;
+      description = ''
+        Additional command-line arguments passed verbatim to udhcpc if
+        <option>boot.initrd.network.enable</option> and <option>networking.useDHCP</option>
+        are enabled.
       '';
     };
 
@@ -91,7 +103,7 @@ in
 
           # Acquire a DHCP lease.
           echo "acquiring IP address via DHCP..."
-          udhcpc --quit --now --script ${udhcpcScript} && hasNetwork=1
+          udhcpc --quit --now --script ${udhcpcScript} ${udhcpcArgs} && hasNetwork=1
         fi
       ''
 


### PR DESCRIPTION
###### Motivation for this change

This can be used to fix issues where udhcpc times out before
acquiring a lease. For example of these issues, see:

https://bugs.alpinelinux.org/issues/3105#note-8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

