### PR TITLE
pass-otp: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/tools/security/pass-otp/default.nix
+++ b/pkgs/tools/security/pass-otp/default.nix
@@ -1,12 +1,13 @@
 { stdenv, pass, fetchFromGitHub, oathToolkit }:
-stdenv.mkDerivation {
-  name = "pass-otp";
+stdenv.mkDerivation rec {
+  name = "pass-otp-${version}";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "tadfisher";
     repo = "pass-otp";
-    rev = "f2feb3082324a91089782af9b7fbb71d34aa213d";
-    sha256 = "0iklvcfgw1320dggdr02lq3bc7xvnd2934l1w9kkjpbsfmhs955c";
+    rev = "v${version}";
+    sha256 = "1cgj4zc8fq88n3h6c0vkv9i5al785mdprpgpbv5m22dz9p1wqvbb";
   };
 
   buildInputs = [ pass oathToolkit ];
@@ -23,7 +24,7 @@ stdenv.mkDerivation {
     description = "A pass extension for managing one-time-password (OTP) tokens";
     homepage = https://github.com/tadfisher/pass-otp;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ jwiegley ];
+    maintainers = with maintainers; [ jwiegley tadfisher ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

