### PR TITLE
haproxy: 1.7.9 -> 1.8.4

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -9,12 +9,12 @@ assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
-  version = "1.7.9";
+  version = "1.8.4";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${name}.tar.gz";
-    sha256 = "1072337e54fa188dc6e0cfe3ba4c2200b07082e321cbfe5a0882d85d54db068e";
+    sha256 = "19l4i0p92ahm3vaw42gz3rmmidfivk36mvqyhir81h6ywyjb01g3";
   };
 
   buildInputs = [ openssl zlib ]


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/vh158gs5y12g1rdd1dhbd1ng2mz1761s-haproxy-1.8.4/bin/haproxy -v` and found version 1.8.4
- found 1.8.4 with grep in /nix/store/vh158gs5y12g1rdd1dhbd1ng2mz1761s-haproxy-1.8.4
- found 1.8.4 in filename of file in /nix/store/vh158gs5y12g1rdd1dhbd1ng2mz1761s-haproxy-1.8.4

cc @garbas