### PR TITLE
gdk_pixbuf: 2.36.7 → 2.36.11

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -1,40 +1,46 @@
-{ stdenv, fetchurl, pkgconfig, glib, libtiff, libjpeg, libpng, libX11, gnome3
-, jasper, libintlOrEmpty, gobjectIntrospection, doCheck ? false }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, python3, libxml2, libxslt, docbook_xsl
+, docbook_xml_dtd_43, gtk-doc, glib, libtiff, libjpeg, libpng, libX11, gnome3
+, jasper, shared-mime-info, libintlOrEmpty, gobjectIntrospection, doCheck ? false, makeWrapper }:
 
 let
   pname = "gdk-pixbuf";
-  version = "2.36.7";
-  # TODO: since 2.36.8 gdk-pixbuf gets configured to use mime-type sniffing,
-  # which apparently requires access to shared-mime-info files during runtime.
+  version = "2.36.11";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "1b6e5eef09d98f05f383014ecd3503e25dfb03d7e5b5f5904e5a65b049a6a4d8";
+    sha256 = "1wz2vpciwdpdv612s8kbww08q80hgcs5dxrfsxp1a4q44n3snqmf";
   };
 
-  outputs = [ "out" "dev" "devdoc" ];
+  outputs = [ "out" "dev" "man" "devdoc" ];
 
   setupHook = ./setup-hook.sh;
 
   enableParallelBuilding = true;
 
   # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
-  buildInputs = [ libX11 gobjectIntrospection ] ++ libintlOrEmpty;
+  buildInputs = [ libX11 ] ++ stdenv.lib.optional (!stdenv.isDarwin) shared-mime-info ++ libintlOrEmpty;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    meson ninja pkgconfig gettext python3 libxml2 libxslt docbook_xsl docbook_xml_dtd_43
+    gtk-doc gobjectIntrospection makeWrapper
+  ];
 
   propagatedBuildInputs = [ glib libtiff libjpeg libpng jasper ];
 
-  configureFlags = "--with-libjasper --with-x11"
-    + stdenv.lib.optionalString (gobjectIntrospection != null) " --enable-introspection=yes"
-    ;
+  mesonFlags = [
+    # with_ & enable_will be removed in the future
+    "-Dwith_docs=true"
+    "-Denable_jasper=true"
+    "-Dx11=true" # will be added in the future (default atm)
+    "-Dwith_gir=${if gobjectIntrospection != null then "true" else "false"}"
+  ];
 
-  # on darwin, tests don't link
-  preBuild = stdenv.lib.optionalString (stdenv.isDarwin && !doCheck) ''
-    substituteInPlace Makefile --replace "docs tests" "docs"
+  postPatch = ''
+    chmod +x build-aux/* # patchShebangs only applies to executables
+    patchShebangs build-aux
   '';
 
   postInstall =
@@ -42,6 +48,17 @@ stdenv.mkDerivation rec {
     ''
       moveToOutput "bin" "$dev"
       moveToOutput "bin/gdk-pixbuf-thumbnailer" "$out"
+
+      # We require runtime access to shared-mime-info
+      ${stdenv.lib.optionalString (!stdenv.isDarwin) ''
+      for f in $dev/bin/*; do
+        wrapProgram $f --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
+      done
+      wrapProgram $out/bin/gdk-pixbuf-thumbnailer --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
+      ''}
+
+      # We need to install 'loaders.cache' in lib/gdk-pixbuf-2.0/2.10.0/
+      $dev/bin/gdk-pixbuf-query-loaders --update-cache
     '';
 
   # The tests take an excessive amount of time (> 1.5 hours) and memory (> 6 GB).


### PR DESCRIPTION
###### Motivation for this change
Depends on meson prefix patch (#36326)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

