### PR TITLE
harfbuzz: 1.7.1 -> 1.7.5

### DIFF
--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "1.7.1";
+  version = "1.7.5";
   inherit (stdenv.lib) optional optionals optionalString;
 in
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${version}.tar.bz2";
-    sha256 = "9645a6e83313b690602017f18d4eb2adf81f2e54c6fc4471e19331304965154e";
+    sha256 = "0qwmybi6x27zz1bj6ccay653dh35jqq0asgvp166kjk53wdlwmw4";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.7.5 with grep in /nix/store/6w64dajinqqnbdyb78p92wa9xy7p7bcz-harfbuzz-1.7.5
- found 1.7.5 in filename of file in /nix/store/6w64dajinqqnbdyb78p92wa9xy7p7bcz-harfbuzz-1.7.5

cc @garbas