### PR TITLE
cfitsio: 3.41 -> 3.43

### DIFF
--- a/pkgs/development/libraries/cfitsio/default.nix
+++ b/pkgs/development/libraries/cfitsio/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv }:
 
  stdenv.mkDerivation {
-  name = "cfitsio-3.41";
+  name = "cfitsio-3.43";
 
   src = fetchurl {
-    url = "ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3410.tar.gz";
-    sha256 = "0k3knn5hz1vhzzvm46xa1y6fnpliwkwgw76lnkf4amcnl5zaqmm5";
+    url = "ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3430.tar.gz";
+    sha256 = "1rw481bv5srfmldf1h8bqmyljjh0siqh87xh6rip67ms59ssxpn8";
   };
 
   # Shared-only build


### PR DESCRIPTION
###### Motivation for this change

Version update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

###### Additional notes

I tried `nix-shell -p nox --run "nox-review wip"` but it failed building `dcraw` with what looked to me a completely-unrelated issue: there were a lot of warnings from `gcc-7.3.0` about misleading indentation and other recently-added warnings, with the error apparently being (there was a long trace-back and I didn't investigate thoroughly):

```
dcraw.cc:9245:25: error: call of overloaded 'abs(unsigned int&)' is ambiguous
       if (abs(i) < abs(c)) {
```

The `cfitsio` library now has (as of version 3.42) support for using the `curl` library to support file access via the `https` protocol. I did try adding a flag to build this, but it wasn't clear to me if I had truly succeeded due to what appears to be https://github.com/NixOS/nix/issues/598 - namely I couldn't flip the flag from its default value (I am a nix neophyte).

The `cfitsio` library also has optional support for bzip-encoded files, which suffered a similar fate.

The `cfitsio` library has a simple test-suite - build a program against the library, run it and it produces screen output, and then compare this output to the expected value. Is it worth adding a test suite for this?