### PR TITLE
gsettings-qt: init at 0.1.20170824

### DIFF
--- a/pkgs/development/libraries/gsettings-qt/default.nix
+++ b/pkgs/development/libraries/gsettings-qt/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchbzr, pkgconfig, qmake, qtbase, qtdeclarative, glib, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "gsettings-qt-${version}";
+  version = "0.1.20170824";
+
+  src = fetchbzr {
+    url = http://bazaar.launchpad.net/~system-settings-touch/gsettings-qt/trunk;
+    rev = "85";
+    sha256 = "1kcw0fgdyndx9c0dyha11wkj0gi05spdc1adf1609mrinbb4rnyi";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    gobjectIntrospection
+  ];
+
+  buildInputs = [
+    glib
+    qtdeclarative
+  ];
+
+  patchPhase = ''
+    # force ordered build of subdirs
+    sed -i -e "\$aCONFIG += ordered" gsettings-qt.pro
+
+    # It seems that there is a bug in qtdeclarative: qmlplugindump fails
+    # because it can not find or load the Qt platform plugin "minimal".
+    # A workaround is to set QT_PLUGIN_PATH and QML2_IMPORT_PATH explicitly.
+    export QT_PLUGIN_PATH=${qtbase.bin}/${qtbase.qtPluginPrefix}
+    export QML2_IMPORT_PATH=${qtdeclarative.bin}/${qtbase.qtQmlPrefix}
+
+    substituteInPlace GSettings/gsettings-qt.pro \
+      --replace '$$[QT_INSTALL_QML]' "$out/$qtQmlPrefix" \
+      --replace '$$[QT_INSTALL_BINS]/qmlplugindump' "qmlplugindump"
+
+    substituteInPlace src/gsettings-qt.pro \
+      --replace '$$[QT_INSTALL_LIBS]' "$out/lib" \
+      --replace '$$[QT_INSTALL_HEADERS]' "$out/include"
+  '';
+
+  preInstall = ''
+    # do not install tests
+    for f in tests/Makefile{,.cpptest}; do
+      substituteInPlace $f \
+        --replace "install: install_target" "install: "
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qt/QML bindings for GSettings";
+    homepage = https://launchpad.net/gsettings-qt;
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8986,6 +8986,8 @@ with pkgs;
 
   grpc = callPackage ../development/libraries/grpc { };
 
+  gsettings-qt = libsForQt5.callPackage ../development/libraries/gsettings-qt { };
+
   gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer {
     callPackage = pkgs.newScope (pkgs // { libav = pkgs.ffmpeg; });
   });


### PR DESCRIPTION
###### Motivation for this change

Add [gsettings-qt](https://launchpad.net/gsettings-qt) (Qml bindings for GSettings) package.

It is a dependency for the deepin desktop environment.

_I need help to conclude this derivation. Installation is failing. It uses QT5 and it is built with qmake._

cc @ttuegel 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).