### PR TITLE
libcloudproviders: init at 0.2.5

### DIFF
--- a/pkgs/development/libraries/libcloudproviders/default.nix
+++ b/pkgs/development/libraries/libcloudproviders/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, pkgconfig, meson, ninja, gtk-doc, docbook_xsl, glib }:
+
+# TODO: Add installed tests once https://gitlab.gnome.org/Incubator/libcloudproviders/issues/4 is fixed
+
+let
+  pname = "libcloudproviders";
+  version = "0.2.5";
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://gitlab.gnome.org/Incubator/${pname}/repository/archive.tar.gz?ref=${version}";
+    sha256 = "1c3vfg8wlsv0fmi1lm9qhsqdvp4k33yvwn6j680rh49laayf7k3g";
+  };
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  mesonFlags = [
+    "-Denable-gtk-doc=true"
+  ];
+
+  nativeBuildInputs = [ meson ninja pkgconfig gtk-doc docbook_xsl ];
+
+  buildInputs = [ glib ];
+
+  meta = with stdenv.lib; {
+    description = "DBus API that allows cloud storage sync clients to expose their services";
+    homepage = https://gitlab.gnome.org/Incubator/libcloudproviders;
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3153,6 +3153,8 @@ with pkgs;
 
   libscrypt = callPackage ../development/libraries/libscrypt { };
 
+  libcloudproviders = callPackage ../development/libraries/libcloudproviders { };
+
   libsmi = callPackage ../development/libraries/libsmi { };
 
   lesspipe = callPackage ../tools/misc/lesspipe { };


### PR DESCRIPTION
###### Motivation for this change
A new GTK dependency: https://bugzilla.gnome.org/show_bug.cgi?id=786123

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

