### PR TITLE
okular: add support for CHM, ZIP and markdown files

### DIFF
--- a/pkgs/applications/kde/okular.nix
+++ b/pkgs/applications/kde/okular.nix
@@ -1,25 +1,27 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, kdoctools,
-  djvulibre, ebook_tools, kactivities, karchive, kbookmarks, kcompletion,
-  kconfig, kconfigwidgets, kcoreaddons, kdbusaddons, kdegraphics-mobipocket,
-  kiconthemes, kjs, khtml, kio, kparts, kpty, kwallet, kwindowsystem, libkexiv2,
-  libspectre, phonon, poppler, qca-qt5, qtdeclarative, qtsvg, threadweaver
+  chmlib, discount, djvulibre, ebook_tools, kactivities, karchive, kbookmarks,
+  kcompletion, kconfig, kconfigwidgets, kcoreaddons, kdbusaddons,
+  kdegraphics-mobipocket, kiconthemes, kjs, khtml, kio, kparts, kpty, kwallet,
+  kwindowsystem, libkexiv2, libspectre, libzip, phonon, poppler, qca-qt5,
+  qtdeclarative, qtsvg, threadweaver
 }:
 
 mkDerivation {
   name = "okular";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    djvulibre ebook_tools kactivities karchive kbookmarks kcompletion kconfig kconfigwidgets
-    kcoreaddons kdbusaddons kdegraphics-mobipocket kiconthemes kjs khtml kio
-    kparts kpty kwallet kwindowsystem libkexiv2 libspectre phonon poppler
-    qca-qt5 qtdeclarative qtsvg threadweaver
+    chmlib discount djvulibre ebook_tools kactivities karchive kbookmarks
+    kcompletion kconfig kconfigwidgets kcoreaddons kdbusaddons
+    kdegraphics-mobipocket kiconthemes kjs khtml kio kparts kpty kwallet
+    kwindowsystem libkexiv2 libspectre libzip phonon poppler qca-qt5
+    qtdeclarative qtsvg threadweaver
   ];
-  meta = {
-    platforms = lib.platforms.linux;
+  meta = with lib; {
     homepage = http://www.kde.org;
-    license = with lib.licenses; [ gpl2 lgpl21 fdl12 bsd3 ];
-    maintainers = [ lib.maintainers.ttuegel ];
+    license = with licenses; [ gpl2 lgpl21 fdl12 bsd3 ];
+    maintainers = with maintainers; [ ttuegel ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/kde/okular.nix
+++ b/pkgs/applications/kde/okular.nix
@@ -1,7 +1,7 @@
 {
-  mkDerivation, lib,
+  stdenv, mkDerivation, lib,
   extra-cmake-modules, kdoctools,
-  chmlib, discount, djvulibre, ebook_tools, kactivities, karchive, kbookmarks,
+  chmlib ? null, discount, djvulibre, ebook_tools, kactivities, karchive, kbookmarks,
   kcompletion, kconfig, kconfigwidgets, kcoreaddons, kdbusaddons,
   kdegraphics-mobipocket, kiconthemes, kjs, khtml, kio, kparts, kpty, kwallet,
   kwindowsystem, libkexiv2, libspectre, libzip, phonon, poppler, qca-qt5,
@@ -12,12 +12,12 @@ mkDerivation {
   name = "okular";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    chmlib discount djvulibre ebook_tools kactivities karchive kbookmarks
+    discount djvulibre ebook_tools kactivities karchive kbookmarks
     kcompletion kconfig kconfigwidgets kcoreaddons kdbusaddons
     kdegraphics-mobipocket kiconthemes kjs khtml kio kparts kpty kwallet
     kwindowsystem libkexiv2 libspectre libzip phonon poppler qca-qt5
     qtdeclarative qtsvg threadweaver
-  ];
+  ] ++ lib.optional (!stdenv.isAarch64) chmlib;
   meta = with lib; {
     homepage = http://www.kde.org;
     license = with licenses; [ gpl2 lgpl21 fdl12 bsd3 ];


### PR DESCRIPTION
###### Motivation for this change

I wanted to open a .chm file and noticed we're missing out on ZIP and MD files as well.

Apologies for the slightly messy diff - all that happens is the addition of chmlib, libzip and discount.

Cc: @ttuegel 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

