### PR TITLE
meson: set multiple output dirs in setup hook

### DIFF
--- a/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
+++ b/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
@@ -1,0 +1,25 @@
+--- a/mesonbuild/coredata.py
++++ b/mesonbuild/coredata.py
+@@ -266,18 +266,13 @@
+         '''
+         if option.endswith('dir') and os.path.isabs(value) and \
+            option not in builtin_dir_noprefix_options:
+-            # Value must be a subdir of the prefix
+             # commonpath will always return a path in the native format, so we
+             # must use pathlib.PurePath to do the same conversion before
+             # comparing.
+-            if commonpath([value, prefix]) != str(PurePath(prefix)):
+-                m = 'The value of the {!r} option is {!r} which must be a ' \
+-                    'subdir of the prefix {!r}.\nNote that if you pass a ' \
+-                    'relative path, it is assumed to be a subdir of prefix.'
+-                raise MesonException(m.format(option, value, prefix))
+-            # Convert path to be relative to prefix
+-            skip = len(prefix) + 1
+-            value = value[skip:]
++            if commonpath([value, prefix]) == str(PurePath(prefix)):
++                # Convert path to be relative to prefix
++                skip = len(prefix) + 1
++                value = value[skip:]
+         return value
+ 
+     def init_builtins(self, options):

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -21,6 +21,12 @@ in python3Packages.buildPythonApplication rec {
   '';
 
   patches = [
+    # Upstream insists on not allowing bindir and other dir options
+    # outside of prefix for some reason:
+    # https://github.com/mesonbuild/meson/issues/2561
+    # We remove the check so multiple outputs can work sanely.
+    ./allow-dirs-outside-of-prefix.patch
+
     # Unlike libtool, vanilla Meson does not pass any information
     # about the path library will be installed to to g-ir-scanner,
     # breaking the GIR when path other than ${!outputLib}/lib is used.

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -10,6 +10,15 @@ mesonConfigurePhase() {
       crossMesonFlags="--cross-file=@crossFile@/cross-file.conf"
     fi
 
+    # See multiple-outputs.sh and meson’s coredata.py
+    mesonFlags="\
+        --libdir=${!outputLib}/lib --libexecdir=${!outputLib}/libexec \
+        --bindir=${!outputBin}/bin --sbindir=${!outputBin}/sbin \
+        --includedir=${!outputInclude}/include \
+        --mandir=${!outputMan}/share/man --infodir=${!outputInfo}/share/info \
+        --localedir=${!outputLib}/share/locale \
+        $mesonFlags"
+
     mesonFlags="${crossMesonFlags+$crossMesonFlags }--buildtype=${mesonBuildType:-release} $mesonFlags"
 
     echo "meson flags: $mesonFlags ${mesonFlagsArray[@]}"


### PR DESCRIPTION
###### Motivation for this change
Will allow us to build gdk_pixbuf using meson (#36312)

Closes: #32636

###### Things done

I built `json-glib` with this and the include directory was created correctly (did not need to be moved).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

