### PR TITLE
pythonPackages.pytest-mock: 1.7.0 -> 1.7.1

### DIFF
--- a/pkgs/development/python-modules/pytest-mock/default.nix
+++ b/pkgs/development/python-modules/pytest-mock/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pytest-mock";
-  version = "1.7.0";
+  version = "1.7.1";
  
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8ed6c9ac6b7565b226b4da2da48876c9198d76401ec8d9c5e4c69b45423e33f8";
+    sha256 = "0jgr1h1f0m9dl3alxiiw55as28pj2lpihz12gird9z1i3vvdyydq";
   };
 
   propagatedBuildInputs = [ pytest ] ++ lib.optional (!isPy3k) mock;


### PR DESCRIPTION
###### Motivation for this change
1.7.0 fails with ascii error, this results in aiohttp build to fail which results in home-assistant not being available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - Implicitly tested via home-assistant test
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
result of nox-review
```
/nix/store/xlr19z2x3q5h9nq81jms2fcmyg34dqyl-python3.6-jsonrpc-async-0.6
/nix/store/xxq8mb0qwkbhbvhzg18dp7cmvw7y7m27-buildbot-1.0.0
/nix/store/b7naikm5f838yhkq9fnmsnlnxnjiclz9-python2.7-ramlfications-0.1.9
/nix/store/r7lryc4pvdvwlrc28jv81g88n33957qf-python2.7-pytest-mock-1.7.1
/nix/store/pizvxhdyprgxnp59mcv5lgd5d54ilfcp-homeassistant-0.63.3
/nix/store/fyx0c2lm5vngiplkcf92qq2fpivfdcgq-td-watson-1.5.2
/nix/store/irzp6qd9yafiq8fr6raljibn25bx2gwb-python3.6-aiohttp-3.0.1
/nix/store/s9yh9j7crhhwxxg39kx42izw3d83xbmm-wrapped-buildbot-1.0.0
/nix/store/q5byrlapcfzqgqya5pax4za820xd46aq-python3.6-aiohttp-cors-0.6.0
/nix/store/cmgrmax8i5cj6y5b7jws0qbsfy0fbas3-python3.6-pytest-aiohttp-0.3.0
/nix/store/5nig4hkk0qgfiscmsxfp80i4p62ysszp-python3.6-pytest-mock-1.7.1
/nix/store/2rw3185j0kgff538dj2z8c6ms3wq699v-wrapped-buildbot-1.0.0
/nix/store/rn0s0hh8hxihgs3232ddi8d7vd5rg9jk-python3.6-gns3-server-2.1.3
/nix/store/f7fbsqz41l880drzd09863yv01bq3vnm-python3.6-jsonrpc-websocket-0.5
/nix/store/kb55wf6immky5d2vyjw38h4r5z57ay37-python3.6-ramlfications-0.1.9
/nix/store/rznq2k81j3sjf4n7fpaqsi3c1ajxsx8f-python3.6-luftdaten-0.1.4
Result in /run/user/9001/nox-review-vblcnedl
total 0
lrwxrwxrwx 1 makefu users 71 Mar  5 09:34 result -> /nix/store/xlr19z2x3q5h9nq81jms2fcmyg34dqyl-python3.6-jsonrpc-async-0.6
lrwxrwxrwx 1 makefu users 74 Mar  5 09:34 result-10 -> /nix/store/cmgrmax8i5cj6y5b7jws0qbsfy0fbas3-python3.6-pytest-aiohttp-0.3.0
lrwxrwxrwx 1 makefu users 71 Mar  5 09:34 result-11 -> /nix/store/5nig4hkk0qgfiscmsxfp80i4p62ysszp-python3.6-pytest-mock-1.7.1
lrwxrwxrwx 1 makefu users 66 Mar  5 09:34 result-12 -> /nix/store/2rw3185j0kgff538dj2z8c6ms3wq699v-wrapped-buildbot-1.0.0
lrwxrwxrwx 1 makefu users 71 Mar  5 09:34 result-13 -> /nix/store/rn0s0hh8hxihgs3232ddi8d7vd5rg9jk-python3.6-gns3-server-2.1.3
lrwxrwxrwx 1 makefu users 75 Mar  5 09:34 result-14 -> /nix/store/f7fbsqz41l880drzd09863yv01bq3vnm-python3.6-jsonrpc-websocket-0.5
lrwxrwxrwx 1 makefu users 73 Mar  5 09:34 result-15 -> /nix/store/kb55wf6immky5d2vyjw38h4r5z57ay37-python3.6-ramlfications-0.1.9
lrwxrwxrwx 1 makefu users 69 Mar  5 09:34 result-16 -> /nix/store/rznq2k81j3sjf4n7fpaqsi3c1ajxsx8f-python3.6-luftdaten-0.1.4
lrwxrwxrwx 1 makefu users 58 Mar  5 09:34 result-2 -> /nix/store/xxq8mb0qwkbhbvhzg18dp7cmvw7y7m27-buildbot-1.0.0
lrwxrwxrwx 1 makefu users 73 Mar  5 09:34 result-3 -> /nix/store/b7naikm5f838yhkq9fnmsnlnxnjiclz9-python2.7-ramlfications-0.1.9
lrwxrwxrwx 1 makefu users 71 Mar  5 09:34 result-4 -> /nix/store/r7lryc4pvdvwlrc28jv81g88n33957qf-python2.7-pytest-mock-1.7.1
lrwxrwxrwx 1 makefu users 64 Mar  5 09:34 result-5 -> /nix/store/pizvxhdyprgxnp59mcv5lgd5d54ilfcp-homeassistant-0.63.3
lrwxrwxrwx 1 makefu users 59 Mar  5 09:34 result-6 -> /nix/store/fyx0c2lm5vngiplkcf92qq2fpivfdcgq-td-watson-1.5.2
lrwxrwxrwx 1 makefu users 67 Mar  5 09:34 result-7 -> /nix/store/irzp6qd9yafiq8fr6raljibn25bx2gwb-python3.6-aiohttp-3.0.1
lrwxrwxrwx 1 makefu users 66 Mar  5 09:34 result-8 -> /nix/store/s9yh9j7crhhwxxg39kx42izw3d83xbmm-wrapped-buildbot-1.0.0
lrwxrwxrwx 1 makefu users 72 Mar  5 09:34 result-9 -> /nix/store/q5byrlapcfzqgqya5pax4za820xd46aq-python3.6-aiohttp-cors-0.6.0
```