### PR TITLE
clamsmtp: fix build after linuxHeaders update to 4.15

### DIFF
--- a/pkgs/servers/mail/clamsmtp/default.nix
+++ b/pkgs/servers/mail/clamsmtp/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0apr1pxifw6f1rbbsdrrwzs1dnhybg4hda3qqhqcw7p14r5xnbx5";
   };
 
+  patches = [ ./header-order.patch ];
+
   meta = with stdenv.lib; {
     description = "SMTP filter that allows to check for viruses using the ClamAV
                    anti-virus software";

--- a/pkgs/servers/mail/clamsmtp/header-order.patch
+++ b/pkgs/servers/mail/clamsmtp/header-order.patch
@@ -1,0 +1,25 @@
+diff --git a/common/smtppass.c b/common/smtppass.c
+index d9be1ba..4a366f4 100644
+--- a/common/smtppass.c
++++ b/common/smtppass.c
+@@ -60,15 +60,15 @@
+ 
+ #include "usuals.h"
+ 
+-#ifdef LINUX_TRANSPARENT_PROXY
+-#include <linux/netfilter_ipv4.h>
+-#endif
+-
+ #include "compat.h"
+ #include "sock_any.h"
+ #include "stringx.h"
+ #include "sppriv.h"
+ 
++#ifdef LINUX_TRANSPARENT_PROXY
++#include <linux/netfilter_ipv4.h>
++#endif
++
+ /* -----------------------------------------------------------------------
+  *  STRUCTURES
+  */
+


### PR DESCRIPTION
###### Motivation for this change

`clamsmtp` stopped building after https://github.com/NixOS/nixpkgs/commit/fd0f15f11c0, according to `git bisect`. This patch fixes the issue, I'm sending it upstream right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

