### PR TITLE
dd-agent:  exclude tracefs from datadog disk checks

### DIFF
--- a/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
+++ b/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
@@ -56,6 +56,8 @@ let
 
     instances:
       - use_mount: no
+    excluded_filesystems:
+      - tracefs
   '';
   
   networkConfig = pkgs.writeText "network.yaml" ''


### PR DESCRIPTION
###### Motivation for this change

Datadog complains about permissions to access tracefs every run:

`dd-agent:2018-02-14 11:00:40,697 | WARNING | dd.collector | checks.disk(disk.py:106) | Unable to get disk metrics for /sys/kernel/debug/tracing: [Errno 13] Permission denied: '/sys/kernel/debug/tracing'`
Being unable to imagine a scenario where this FS needs monitoring, I assume it's wise to exclude it.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

