### PR TITLE
libpqxx: Add dependency on doxygen and xmlto

### DIFF
--- a/pkgs/development/libraries/libpqxx/default.nix
+++ b/pkgs/development/libraries/libpqxx/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, python2, gnused }:
+{ lib, stdenv, fetchFromGitHub, postgresql, doxygen, xmlto, python2, gnused }:
 
 stdenv.mkDerivation rec {
   name = "libpqxx-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gnused python2 ];
-  buildInputs = [ postgresql ];
+  buildInputs = [ postgresql doxygen xmlto ];
 
   preConfigure = ''
     patchShebangs .


### PR DESCRIPTION
###### Motivation for this change

Unable to build hydra due to this error when building `libpqxx`:

```
if test -x "/cvmfs/lhcbdev.cern.ch/nix/store/mdxz9iba3irpy37jabkfx3aqra3wvpgb-doxygen-1.8.14/bin/doxygen"; then \
  /cvmfs/lhcbdev.cern.ch/nix/store/wgfllczzdy62a5q1wm1ibk2v1lvvqprw-coreutils-8.29/bin/mkdir -p html/Reference; \
  /cvmfs/lhcbdev.cern.ch/nix/store/mdxz9iba3irpy37jabkfx3aqra3wvpgb-doxygen-1.8.14/bin/doxygen Doxyfile; \
  touch reference-stamp; \
else \
  echo >&2; \
  echo >&2 "*****************************************************"; \
  echo >&2; \
  echo >&2 "Doxygen not found."; \
  echo >&2 "Install it, or configure with --disable-documentation"; \
  echo >&2; \
  echo >&2 "*****************************************************"; \
  exit 1; \
fi

*****************************************************

Doxygen not found.
Install it, or configure with --disable-documentation

*****************************************************
make[1]: *** [Makefile:484: reference-stamp] Error 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

