### PR TITLE
nixos home-assistant: a couple of fixes

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -104,7 +104,6 @@ in {
   config = mkIf cfg.enable {
     systemd.services.home-assistant = {
       description = "Home Assistant";
-      wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       preStart = lib.optionalString (cfg.config != null) ''
         rm -f ${cfg.configDir}/configuration.yaml
@@ -121,6 +120,19 @@ in {
         ReadWritePaths = "${cfg.configDir}";
         PrivateTmp = true;
       };
+      restartTriggers = [
+        configFile
+      ];
+      path = [
+        "/run/wrappers" # needed for ping
+      ];
+    };
+
+    systemd.targets.home-assistant = rec {
+      description = "Home Assistant";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "home-assistant.service" ];
+      after = wants;
     };
 
     users.extraUsers.hass = {

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -120,9 +120,6 @@ in {
         ReadWritePaths = "${cfg.configDir}";
         PrivateTmp = true;
       };
-      restartTriggers = [
-        configFile
-      ];
       path = [
         "/run/wrappers" # needed for ping
       ];


### PR DESCRIPTION
###### Motivation for this change

a) set path to /run/wrappers so ping works (what gets added is /run/wrappers/{bin,sbin})
b) restart if the configuration file changes
c) run via a target so we can easily inject other components (config copier, appdaemon)

Cc: @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

