### PR TITLE
Fix a dirty hack in the python wheel extractor that did not work if a…

### DIFF
--- a/pkgs/development/interpreters/python/build-python-package-wheel.nix
+++ b/pkgs/development/interpreters/python/build-python-package-wheel.nix
@@ -8,7 +8,8 @@
 attrs // {
   unpackPhase = ''
     mkdir dist
-    cp $src dist/"''${src#*-}"
+    wheel_filename="$(basename $src)"
+    cp $src dist/"''${wheel_filename#*-}"
   '';
 
   # Wheels are pre-compiled


### PR DESCRIPTION
Fix a dirty hack in the python wheel extractor that did not work if any "-" char exist in the nix store path....

###### Motivation for this change

Make possible to install nix wheel-based package when the nix store path is something else than /nix/store..... and has a "-" char inside.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

