### PR TITLE
u-boot: 2017.11 -> v2018.03-rc3

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, bc, dtc, openssl, python2
+{ stdenv, fetchFromGitHub, fetchpatch, bc, dtc, openssl, python2
 , hostPlatform
 }:
 
@@ -13,11 +13,13 @@ let
            stdenv.mkDerivation (rec {
 
     name = "uboot-${defconfig}-${version}";
-    version = "2017.11";
+    version = "v2018.03-rc3";
 
-    src = fetchurl {
-      url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-      sha256 = "01bcsah5imy6m3fbjwhqywxg0pfk5fl8ks9ylb7kv3zmrb9qy0ba";
+    src = fetchFromGitHub {
+      owner = "u-boot";
+      repo = "u-boot";
+      rev = version;
+      sha256 = "056md2nx31p4mfnw01cps3kwpla3nm5q4khjfi3c98mf10csj8lc";
     };
 
     patches = [
@@ -34,8 +36,8 @@ let
         sha256 = "0bbw0q027xvzvdxxvpzjajg4rm30a8mb7z74b6ma9q0l7y7bi0c4";
       })
       (fetchpatch {
-        url = https://github.com/dezgeg/u-boot/commit/pythonpath-2017-11.patch;
-        sha256 = "162b2lglp307pzxsf9m7nnmzwxqd7xkwp5j85bm6bg1a38ngpl9v";
+        url = https://github.com/bendlas/u-boot/compare/f0f6917188ad660cf002c10095f46ecf748b8f58...d35c38015ea73db01466586ba7746f4a1fbf3890.patch;
+        sha256 = "1q0mxk1az11kqggylammdz4f2rwhv2vwcwx8ql19k1w9ys5w9x0a";
       })
     ];
 
@@ -150,9 +152,15 @@ in rec {
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
-  ubootQemuArm = buildUBoot rec {
+  ubootQemuArm_32bit = buildUBoot rec {
     defconfig = "qemu_arm_defconfig";
     targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot.bin"];
+  };
+
+  ubootQemuArm_64bit = buildUBoot rec {
+    defconfig = "qemu_arm64_defconfig";
+    targetPlatforms = ["aarch64-linux"];
     filesToInstall = ["u-boot.bin"];
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13787,7 +13787,8 @@ with pkgs;
     ubootOdroidXU3
     ubootOrangePiPc
     ubootPcduino3Nano
-    ubootQemuArm
+    ubootQemuArm_32bit
+    ubootQemuArm_64bit
     ubootRaspberryPi
     ubootRaspberryPi2
     ubootRaspberryPi3_32bit
@@ -13795,6 +13796,8 @@ with pkgs;
     ubootUtilite
     ubootWandboard
     ;
+
+  ubootQemuArm = ubootQemuArm_32bit;
 
   # Non-upstream U-Boots:
   ubootSheevaplug = callPackage ../misc/uboot/sheevaplug.nix { };


### PR DESCRIPTION
this includes qemu-aarch64 support

###### Motivation for this change

I needed an updated u-boot for running my rpi3 sdcard with qemu. I figured I'd push it upstream right away. 

Whether we can merge this as an `-rc` or not, I also wanted to document the patch I updated: It's based on https://github.com/dezgeg/u-boot/commit/pythonpath-2018-03, but also accounts for https://github.com/u-boot/u-boot/commit/15b97f5c5e6d88e0560c6928f3acd01c999a494d#diff-44b7a4b99d947fe1c4a313c4d890d8b6R384

cc @dezgeg does this look right to you?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

