### PR TITLE
lib/options: teach showOptions about funny option names

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -127,7 +127,20 @@ rec {
 
 
   /* Helper functions. */
-  showOption = concatStringsSep ".";
+
+  # Convert an option, described as a list of the option parts in to a
+  # safe, human readable version. ie:
+  #
+  # (showOption ["foo" "bar" "baz"]) == "foo.bar.baz"
+  # (showOption ["foo" "bar.baz" "tux"]) == "foo.\"bar.baz\".tux"
+  showOption = parts: let
+    escapeOptionPart = part:
+      let
+        escaped = lib.strings.escapeNixString part;
+      in if escaped == "\"${part}\""
+         then part
+         else escaped;
+    in (concatStringsSep ".") (map escapeOptionPart parts);
   showFiles = files: concatStringsSep " and " (map (f: "`${f}'") files);
   unknownModule = "<unknown-file>";
 


### PR DESCRIPTION
Handle the case where options have funny symbols inside of them.

Example:

If I reference the following attribute without it being defined:

    security.acme.certs."example.com".webroot

I now get the error:

    The option `security.acme.certs."example.com".webroot' is used but
    not defined.

where before I got:

    The option `security.acme.certs.example.com.webroot' is used but
    not defined.

which is not true.
