### PR TITLE
emacs: give melpa and melpa-stable own scope

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -383,11 +383,21 @@ let
   };
 
 in
-  lib.makeScope newScope (self:
+
+  # melpaStable and melpa have the same packages
+  # so give each its own scope to make sure
+  # they don't interfere with each other
+
+  (lib.makeScope newScope (self:
     {}
     // melpaPackages self
     // elpaPackages self
-    // melpaStablePackages self
     // orgPackages self
     // packagesFun self
-  )
+  )) // (lib.makeScope newScope (self:
+    {}
+    // melpaStablePackages self
+    // elpaPackages self
+    // orgPackages self
+    // packagesFun self
+  ))


### PR DESCRIPTION
Melpa and Melpa Stable interfere with each other. Before this, Melpa
unstable will pull in dependencies from MelpaStable (even when Melpa
has the dependency). This moves melpa unstable and stable into their
own scopes to keep them separate.

Shouldn't break anything, but interested in feedback if it does.

/cc @mdorman @ttuegel @oxij 

Also fixes ttuegel/emacs2nix#43 and part of #11503.