### PR TITLE
maintainers: remove null fields

### DIFF
--- a/lib/maintainers-list.nix
+++ b/lib/maintainers-list.nix
@@ -470,7 +470,7 @@
     name = "Pascal Bach";
   };
   backuitist = {
-    email = null;
+    email = "biethb@gmail.com";
     github = "backuitist";
     name = "Bruno Bieth";
   };
@@ -2691,9 +2691,9 @@
     name = "Pierre Carrier";
   };
   periklis = {
-    email = null;
+    email = "theopompos@gmail.com";
     github = "periklis";
-    name = "theopompos@gmail.com";
+    name = "Periklis Tsirakidis";
   };
   pesterhazy = {
     email = "pesterhazy@gmail.com";


### PR DESCRIPTION
###### Motivation for this change

@peti noticed  nix-env was emitting errors to stderr about invalid meta field maintainers. Turns out the structured PR from @Profpatsch added some null fields to the maintainer list, causing this problem. I fixed the only two null fields present, and nix-env now shows no errors.

See: https://github.com/NixOS/nixpkgs/commit/f7da7fa0c3ab40b79a2358861831b925d2cb5a6b#commitcomment-27930583
