### PR TITLE
skhd: init at 0.0.10

### DIFF
--- a/pkgs/os-specific/darwin/skhd/default.nix
+++ b/pkgs/os-specific/darwin/skhd/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, Carbon }:
+
+stdenv.mkDerivation rec {
+  name = "skhd-${version}";
+  version = "0.0.10";
+
+  src = fetchFromGitHub {
+    owner = "koekeishiya";
+    repo = "skhd";
+    rev = "v${version}";
+    sha256 = "0a0r8z9bvb1pzqag7nqa84xm99n0xvg27cw11qcv65snr06bqc9w";
+  };
+
+  buildInputs = [ Carbon ];
+
+  makeFlags = [ "BUILD_PATH=$(out)/bin" ];
+
+  postInstall = ''
+    mkdir -p $out/Library/LaunchDaemons
+    cp ${./org.nixos.skhd.plist} $out/Library/LaunchDaemons/org.nixos.skhd.plist
+    substituteInPlace $out/Library/LaunchDaemons/org.nixos.skhd.plist --subst-var out
+  '';
+
+  # See https://github.com/koekeishiya/skhd/issues/28
+  hardeningDisable = [ "all" ];
+
+  meta = with stdenv.lib; {
+    description = "Simple hotkey daemon for macOS";
+    homepage = https://github.com/koekeishiya/skhd;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ lnl7 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/os-specific/darwin/skhd/org.nixos.skhd.plist
+++ b/pkgs/os-specific/darwin/skhd/org.nixos.skhd.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.nixos.skhd</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@out@/bin/skhd</string>
+  </array>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>@out@/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -676,6 +676,10 @@ with pkgs;
 
   reattach-to-user-namespace = callPackage ../os-specific/darwin/reattach-to-user-namespace {};
 
+  skhd = callPackage ../os-specific/darwin/skhd {
+    inherit (darwin.apple_sdk.frameworks) Carbon;
+  };
+
   qes = callPackage ../os-specific/darwin/qes {
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
@@ -10440,7 +10444,7 @@ with pkgs;
   ## libGL/libGLU/Mesa stuff
 
   # Default libGL implementation, should provide headers and libGL.so/libEGL.so/... to link agains them
-  # Default implementation is `mesa`, but can be eventually replaced with `libglvnd`, 
+  # Default implementation is `mesa`, but can be eventually replaced with `libglvnd`,
   # or other runtime dispatcher
   libGL = mesa_noglu;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] macOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

