### PR TITLE
Add dockerTools test: on top of pulled image

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -10,7 +10,7 @@ import ./make-test.nix ({ pkgs, ... }: {
     docker =
       { config, pkgs, ... }: {
         virtualisation = {
-          diskSize = 1024;
+          diskSize = 2048;
           docker.enable = true;
         };
       };
@@ -21,19 +21,29 @@ import ./make-test.nix ({ pkgs, ... }: {
       $docker->waitForUnit("sockets.target");
 
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.bash}'");
-      $docker->succeed("docker run ${pkgs.dockerTools.examples.bash.imageName} /bin/bash --version");
+      $docker->succeed("docker run --rm ${pkgs.dockerTools.examples.bash.imageName} /bin/bash --version");
+      $docker->succeed("docker rmi ${pkgs.dockerTools.examples.bash.imageName}");
 
+      # Check if the nix store is correctly initialized by listing dependencies of the installed Nix binary
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.nix}'");
-      $docker->succeed("docker run ${pkgs.dockerTools.examples.nix.imageName} /bin/nix-store -qR ${pkgs.nix}");
+      $docker->succeed("docker run --rm ${pkgs.dockerTools.examples.nix.imageName} /bin/nix-store -qR ${pkgs.nix}");
+      $docker->succeed("docker rmi ${pkgs.dockerTools.examples.nix.imageName}");
 
       # To test the pullImage tool
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.nixFromDockerHub}'");
-      $docker->succeed("docker run nixos/nix:1.11 nix-store --version");
+      $docker->succeed("docker run --rm nixos/nix:1.11 nix-store --version");
+      $docker->succeed("docker rmi nixos/nix:1.11");
 
       # To test runAsRoot and entry point
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.nginx}'");
       $docker->succeed("docker run --name nginx -d -p 8000:80 ${pkgs.dockerTools.examples.nginx.imageName}");
       $docker->waitUntilSucceeds('curl http://localhost:8000/');
       $docker->succeed("docker rm --force nginx");
+      $docker->succeed("docker rmi '${pkgs.dockerTools.examples.nginx.imageName}'");
+
+      # An pulled image can be used as base image
+      $docker->succeed("docker load --input='${pkgs.dockerTools.examples.onTopOfPulledImage}'");
+      $docker->succeed("docker run --rm ontopofpulledimage hello");
+      $docker->succeed("docker rmi ontopofpulledimage");
     '';
 })

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -116,4 +116,12 @@ rec {
       Env = [ "NIX_PAGER=cat" ];
     };
   };
+
+  # 7. example of adding something on top of an image pull by our
+  # dockerTools chain.
+  onTopOfPulledImage = buildImage {
+    name = "onTopOfPulledImage";
+    fromImage = nixFromDockerHub;
+    contents = [ pkgs.hello ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
This is to ensure a pulled image can be used as base image. This is not trivial since our current docker tooling relies on the legacy Docker image format. 

cc @Profpatsch 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

