### PR TITLE
xen 4.8: fix gcc7-related build errors

### DIFF
--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -29,6 +29,18 @@ let
 
   xsa = import ./xsa-patches.nix { inherit fetchpatch; };
 
+  xenlockprofpatch = (fetchpatch {
+    name = "xenlockprof-gcc7.patch";
+    url = "https://xenbits.xen.org/gitweb/?p=xen.git;a=patch;h=f49fa658b53580cf2ad354d2bf1796766cc11222";
+    sha256 = "1lvzfvkqirknivm8q4cg5byfqz49s16zjk65fkwl3kwb03chky70";
+  });
+
+  xenpmdpatch = (fetchpatch {
+    name = "xenpmd-gcc7.patch";
+    url = "https://xenbits.xen.org/gitweb/?p=xen.git;a=patch;h=2d78f78a14528752266982473c07118f1bc336e3";
+    sha256 = "1ki295pymbcfc64sjb9wqfwpv19p8vwgmnxankada3vm4fxg2rhq";
+  });
+
   qemuDeps = [
     udev pciutils xorg.libX11 SDL pixman acl glusterfs spice-protocol usbredir
     alsaLib
@@ -158,6 +170,8 @@ callPackage (import ./generic.nix (rec {
     XSA_249
     XSA_250
     XSA_251_48
+    xenlockprofpatch
+    xenpmdpatch
   ];
 
   # Fix build on Glibc 2.24.


### PR DESCRIPTION
###### Motivation for this change

didn't build with gcc7. fixed with 2 upstream patches.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @oxij 
