### PR TITLE
demo: make virtualbox more usable

### DIFF
--- a/nixos/modules/installer/virtualbox-demo.nix
+++ b/nixos/modules/installer/virtualbox-demo.nix
@@ -19,4 +19,6 @@ with lib;
   # Add some more video drivers to give X11 a shot at working in
   # VMware and QEMU.
   services.xserver.videoDrivers = mkOverride 40 [ "virtualbox" "vmware" "cirrus" "vesa" "modesetting" ];
+
+  powerManagement.enable = false;
 }

--- a/nixos/modules/profiles/demo.nix
+++ b/nixos/modules/profiles/demo.nix
@@ -10,4 +10,10 @@
       password = "demo";
       uid = 1000;
     };
+
+  services.xserver.displayManager.sddm.autoLogin = {
+    enable = true;
+    relogin = true;
+    user = "demo";
+  };
 }


### PR DESCRIPTION
Also disable upower on virtualbox

Fixes #36348.

###### Motivation for this change

This should give new users a better experience (no password entry for VirtualBox). It also fixes what I've described in #36348 where KDE tries to suspends and can't recover properly. All virtualbox images should be fine disabling powerManagement, leaving it to the host system.

If possible, it would be great to get these including in 18.03.