### PR TITLE
chromium, google-chrome: fix escaping of commandLineArgs

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -90,7 +90,7 @@ in stdenv.mkDerivation {
     mkdir -p "$out/bin"
 
     eval makeWrapper "${browserBinary}" "$out/bin/chromium" \
-      ${commandLineArgs} \
+      --add-flags ${escapeShellArg (escapeShellArg commandLineArgs)} \
       ${concatMapStringsSep " " getWrapperFlags chromium.plugins.enabled}
 
     ed -v -s "$out/bin/chromium" << EOF


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/21679 did not escape special chars properly, so it was not possible to write something like

```
commandLineArgs = ''$([ `whoami` == "root" ] && echo "--no-sandbox") --user-data-dir=$HOME/.config/chromium'';
```

@7c6f434c 