### PR TITLE
tree-wide: fix pulseaudio references; fix SDL expressions

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, config, wrapGAppsHook
+{ lib, stdenv, fetchurl, config, wrapGAppsHook
 , alsaLib
 , atk
 , cairo
@@ -87,7 +87,7 @@ stdenv.mkDerivation {
   libPath = stdenv.lib.makeLibraryPath
     [ stdenv.cc.cc
       alsaLib
-      alsaLib.dev
+      (lib.getDev alsaLib)
       atk
       cairo
       curl
@@ -124,7 +124,7 @@ stdenv.mkDerivation {
       pango
       libheimdal
       libpulseaudio
-      libpulseaudio.dev
+      (lib.getDev libpulseaudio)
       systemd
     ] + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [
       stdenv.cc.cc

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -4,6 +4,8 @@
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
 }:
 
+with lib;
+
 mkDerivation rec {
   name = "telegram-desktop-${version}";
   version = "1.2.6";
@@ -45,7 +47,7 @@ mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  GYP_DEFINES = lib.concatStringsSep "," [
+  GYP_DEFINES = concatStringsSep "," [
     "TDESKTOP_DISABLE_CRASH_REPORTS"
     "TDESKTOP_DISABLE_AUTOUPDATE"
     "TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME"
@@ -57,14 +59,14 @@ mkDerivation rec {
     "-DTDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME"
     "-I${minizip}/include/minizip"
     # See Telegram/gyp/qt.gypi
-    "-I${qtbase.dev}/mkspecs/linux-g++"
-  ] ++ lib.concatMap (x: [
-    "-I${qtbase.dev}/include/${x}"
-    "-I${qtbase.dev}/include/${x}/${qtbase.version}"
-    "-I${qtbase.dev}/include/${x}/${qtbase.version}/${x}"
-    "-I${libopus.dev}/include/opus"
-    "-I${alsaLib.dev}/include/alsa"
-    "-I${libpulseaudio.dev}/include/pulse"
+    "-I${getDev qtbase}/mkspecs/linux-g++"
+  ] ++ concatMap (x: [
+    "-I${getDev qtbase}/include/${x}"
+    "-I${getDev qtbase}/include/${x}/${qtbase.version}"
+    "-I${getDev qtbase}/include/${x}/${qtbase.version}/${x}"
+    "-I${getDev libopus}/include/opus"
+    "-I${getDev alsaLib}/include/alsa"
+    "-I${getDev libpulseaudio}/include/pulse"
   ]) [ "QtCore" "QtGui" "QtDBus" ];
   CPPFLAGS = NIX_CFLAGS_COMPILE;
 
@@ -121,7 +123,7 @@ mkDerivation rec {
       -e "s,'XDG-RUNTIME-DIR',\"\''${XDG_RUNTIME_DIR:-/run/user/\$(id --user)}\","
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Telegram Desktop messaging app";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, audiofile, libcap, libiconv
+{ stdenv, lib, fetchurl, fetchpatch, pkgconfig, audiofile, libcap, libiconv
 , openglSupport ? false, libGL, libGLU
 , alsaSupport ? true, alsaLib
 , x11Support ? hostPlatform == buildPlatform, libXext, libICE, libXrandr
@@ -7,13 +7,32 @@
 , hostPlatform, buildPlatform
 }:
 
-# OSS is no longer supported, for it's much crappier than ALSA and
-# PulseAudio.
-assert hostPlatform.isLinux -> alsaSupport || pulseaudioSupport;
+# NOTE: When editing this expression see if the same change applies to
+# SDL2 expression too
+
+with lib;
+
+assert !stdenv.isDarwin -> alsaSupport || pulseaudioSupport;
+assert openglSupport -> (stdenv.isDarwin || x11Support && libGL != null && libGLU != null);
 
 let
-  inherit (stdenv.lib) optional optionals;
+
+  # XXX: By default, SDL wants to dlopen() PulseAudio, in which case
+  # we must arrange to add it to its RPATH; however, `patchelf' seems
+  # to fail at doing this, hence `--disable-pulseaudio-shared'.
+  configureFlagsFun = attrs: [
+    "--disable-oss"
+    "--disable-video-x11-xme"
+    "--disable-x11-shared"
+    "--disable-alsa-shared"
+    "--enable-rpath"
+    "--disable-pulseaudio-shared"
+    "--disable-osmesa-shared"
+  ] ++ optional (!x11Support) "--without-x"
+    ++ optional alsaSupport "--with-alsa-prefix=${attrs.alsaLib.out}/lib";
+
 in
+
 stdenv.mkDerivation rec {
   name    = "SDL-${version}";
   version = "1.2.15";
@@ -29,35 +48,27 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   # Since `libpulse*.la' contain `-lgdbm', PulseAudio must be propagated.
-  propagatedBuildInputs =
-    optionals x11Support [ libXext libICE libXrandr ] ++
-    optional alsaSupport alsaLib ++
-    optional stdenv.isLinux libcap ++
-    optionals openglSupport [ libGL libGLU ] ++
-    optional pulseaudioSupport libpulseaudio ++
-    optional stdenv.isDarwin Cocoa;
+  propagatedBuildInputs = [ ]
+    ++ optionals x11Support [ libXext libICE libXrandr ]
+    ++ optional stdenv.isLinux libcap
+    ++ optionals openglSupport [ libGL libGLU ]
+    ++ optional alsaSupport alsaLib
+    ++ optional pulseaudioSupport libpulseaudio
+    ++ optional stdenv.isDarwin Cocoa;
 
-  buildInputs = let
-    notMingw = !hostPlatform.isMinGW;
-  in optional notMingw audiofile
-  ++ optionals stdenv.isDarwin [ OpenGL CoreAudio CoreServices AudioUnit Kernel ]
-  ++ [ libiconv ];
+  buildInputs = [ libiconv ]
+    ++ optional (!hostPlatform.isMinGW) audiofile
+    ++ optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreServices Kernel OpenGL ];
 
-  # XXX: By default, SDL wants to dlopen() PulseAudio, in which case
-  # we must arrange to add it to its RPATH; however, `patchelf' seems
-  # to fail at doing this, hence `--disable-pulseaudio-shared'.
-  configureFlags = [
-    "--disable-oss"
-    "--disable-video-x11-xme"
-    "--disable-x11-shared"
-    "--disable-alsa-shared"
-    "--enable-rpath"
-    "--disable-pulseaudio-shared"
-    "--disable-osmesa-shared"
-  ] ++ optional (!x11Support) "--without-x"
-    ++ optional (alsaSupport && hostPlatform != buildPlatform) "--with-alsa-prefix=${alsaLib.out}/lib";
+  configureFlags = configureFlagsFun { inherit alsaLib; };
+
+  crossAttrs = {
+    configureFlags = configureFlagsFun { alsaLib = alsaLib.crossDrv; };
+  };
 
   patches = [
+    ./find-headers.patch
+
     # Fix window resizing issues, e.g. for xmonad
     # Ticket: http://bugzilla.libsdl.org/show_bug.cgi?id=1430
     (fetchpatch {
@@ -97,10 +108,11 @@ stdenv.mkDerivation rec {
       url = "http://hg.libsdl.org/SDL/raw-rev/bbfb41c13a87";
       sha256 = "1336g7waaf1c8yhkz11xbs500h8bmvabh4h437ax8l1xdwcppfxv";
     })
-    ./find-headers.patch
   ];
 
-  postFixup = ''moveToOutput share/aclocal "$dev" '';
+  postInstall = ''
+    moveToOutput share/aclocal "$dev"
+  '';
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -21,7 +21,14 @@ let
     "--disable-oss"
     "--disable-video-x11-xme"
     "--enable-rpath"
-  ] ++ optional (!x11Support) "--without-x"
+  # Building without this fails on Darwin with
+  #
+  #   ./src/video/x11/SDL_x11sym.h:168:17: error: conflicting types for '_XData32'
+  #   SDL_X11_SYM(int,_XData32,(Display *dpy,register long *data,unsigned len),(dpy,data,len),return)
+  #
+  # Please try revert the change that introduced this comment when updating SDL.
+  ] ++ optional stdenv.isDarwin "--disable-x11-shared"
+    ++ optional (!x11Support) "--without-x"
     ++ optional alsaSupport "--with-alsa-prefix=${attrs.alsaLib.out}/lib";
 
 in
@@ -41,7 +48,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   propagatedBuildInputs = [ ]
-    ++ optionals x11Support [ libXext libICE libXrandr ]
+    ++ optionals (x11Support && !stdenv.isDarwin) [ libXext libICE libXrandr ]
     ++ optional stdenv.isLinux libcap
     ++ optionals openglSupport [ libGL libGLU ]
     ++ optional alsaSupport alsaLib
@@ -49,6 +56,7 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin Cocoa;
 
   buildInputs = [ libiconv ]
+    ++ optionals (x11Support && stdenv.isDarwin) [ libXext libICE libXrandr ]
     ++ optional (!hostPlatform.isMinGW) audiofile
     ++ optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreServices Kernel OpenGL ];
 

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -17,17 +17,10 @@ assert openglSupport -> (stdenv.isDarwin || x11Support && libGL != null && libGL
 
 let
 
-  # XXX: By default, SDL wants to dlopen() PulseAudio, in which case
-  # we must arrange to add it to its RPATH; however, `patchelf' seems
-  # to fail at doing this, hence `--disable-pulseaudio-shared'.
   configureFlagsFun = attrs: [
     "--disable-oss"
     "--disable-video-x11-xme"
-    "--disable-x11-shared"
-    "--disable-alsa-shared"
     "--enable-rpath"
-    "--disable-pulseaudio-shared"
-    "--disable-osmesa-shared"
   ] ++ optional (!x11Support) "--without-x"
     ++ optional alsaSupport "--with-alsa-prefix=${attrs.alsaLib.out}/lib";
 
@@ -47,7 +40,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  # Since `libpulse*.la' contain `-lgdbm', PulseAudio must be propagated.
   propagatedBuildInputs = [ ]
     ++ optionals x11Support [ libXext libICE libXrandr ]
     ++ optional stdenv.isLinux libcap
@@ -112,6 +104,15 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     moveToOutput share/aclocal "$dev"
+  '';
+
+  # See the same place in the expression for SDL2
+  postFixup = ''
+    for lib in $out/lib/*.so* ; do
+      if [[ -L "$lib" ]]; then
+        patchelf --set-rpath "$(patchelf --print-rpath $lib):${lib.makeLibraryPath propagatedBuildInputs}" "$lib"
+      fi
+    done
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -75,6 +75,11 @@ stdenv.mkDerivation rec {
       url = "http://hg.libsdl.org/SDL/raw-rev/95abff7adcc2";
       sha256 = "0i8x0kx0pw12ld5bfxhyzs466y3c0n9dscw1ijhq1b96r72xyhqq";
     })
+    # https://bugzilla.libsdl.org/show_bug.cgi?id=1769
+    (fetchpatch {
+      url = "http://hg.libsdl.org/SDL/raw-rev/91ad7b43317a";
+      sha256 = "15g537vbl2my4mfrjxfkcx9ri6bk2gjvaqj650rjdxwk2nkdkn4b";
+    })
     # Workaround X11 bug to allow changing gamma
     # Ticket: https://bugs.freedesktop.org/show_bug.cgi?id=27222
     (fetchpatch {

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -57,9 +57,6 @@ stdenv.mkDerivation rec {
     ++ optional  ibusSupport ibus
     ++ optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
 
-  # https://bugzilla.libsdl.org/show_bug.cgi?id=1431
-  dontDisableStatic = true;
-
   # /build/SDL2-2.0.7/src/video/wayland/SDL_waylandevents.c:41:10: fatal error:
   #   pointer-constraints-unstable-v1-client-protocol.h: No such file or directory
   enableParallelBuilding = false;

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -11,19 +11,27 @@
 , libiconv
 }:
 
-# OSS is no longer supported, for it's much crappier than ALSA and
-# PulseAudio.
-assert !stdenv.isDarwin -> alsaSupport || pulseaudioSupport;
+# NOTE: When editing this expression see if the same change applies to
+# SDL expression too
 
-assert openglSupport -> (stdenv.isDarwin || libGL != null && x11Support);
+with lib;
+
+assert !stdenv.isDarwin -> alsaSupport || pulseaudioSupport;
+assert openglSupport -> (stdenv.isDarwin || x11Support && libGL != null);
 
 let
+
+  # XXX: By default, SDL wants to dlopen() PulseAudio, in which case
+  # we must arrange to add it to its RPATH; however, `patchelf' seems
+  # to fail at doing this, hence `--disable-pulseaudio-shared'.
   configureFlagsFun = attrs: [
       "--disable-oss" "--disable-x11-shared" "--disable-wayland-shared"
       "--disable-pulseaudio-shared" "--disable-alsa-shared"
-    ] ++ lib.optional alsaSupport "--with-alsa-prefix=${attrs.alsaLib.out}/lib"
-      ++ lib.optional (!x11Support) "--without-x";
+    ] ++ optional alsaSupport "--with-alsa-prefix=${attrs.alsaLib.out}/lib"
+      ++ optional (!x11Support) "--without-x";
+
 in
+
 stdenv.mkDerivation rec {
   name = "SDL2-${version}";
   version = "2.0.7";
@@ -34,24 +42,25 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ];
+  outputBin = "dev"; # sdl-config
 
   patches = [ ./find-headers.patch ];
 
   nativeBuildInputs = [ pkgconfig ];
 
   # Since `libpulse*.la' contain `-lgdbm', PulseAudio must be propagated.
-  propagatedBuildInputs = lib.optionals x11Support [ libICE libXi libXScrnSaver libXcursor libXinerama libXext libXrandr libXxf86vm ] ++
-    lib.optionals waylandSupport [ wayland wayland-protocols libxkbcommon ] ++
-    lib.optional pulseaudioSupport libpulseaudio
-    ++ [ libiconv ];
+  propagatedBuildInputs = [ libiconv ]
+    ++ optionals x11Support [ libICE libXi libXScrnSaver libXcursor libXinerama libXext libXrandr libXxf86vm ]
+    ++ optionals waylandSupport [ wayland wayland-protocols libxkbcommon ]
+    ++ optional  pulseaudioSupport libpulseaudio;
 
-  buildInputs = [ audiofile ] ++
-    lib.optional openglSupport libGL ++
-    lib.optional alsaSupport alsaLib ++
-    lib.optional dbusSupport dbus ++
-    lib.optional udevSupport udev ++
-    lib.optional ibusSupport ibus ++
-    lib.optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
+  buildInputs = [ audiofile ]
+    ++ optional openglSupport libGL
+    ++ optional alsaSupport alsaLib
+    ++ optional dbusSupport dbus
+    ++ optional udevSupport udev
+    ++ optional ibusSupport ibus
+    ++ optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
 
   # https://bugzilla.libsdl.org/show_bug.cgi?id=1431
   dontDisableStatic = true;
@@ -60,9 +69,6 @@ stdenv.mkDerivation rec {
   #   pointer-constraints-unstable-v1-client-protocol.h: No such file or directory
   enableParallelBuilding = false;
 
-  # XXX: By default, SDL wants to dlopen() PulseAudio, in which case
-  # we must arrange to add it to its RPATH; however, `patchelf' seems
-  # to fail at doing this, hence `--disable-pulseaudio-shared'.
   configureFlags = configureFlagsFun { inherit alsaLib; };
 
   crossAttrs = {


### PR DESCRIPTION
###### Motivation for this change

Side-effect of me building everything with `libcardiacarrest` instead of `libpulseaudio` (see #35374).
That branch has quite a lot of changes ATM and some will likely to cause bikeshedding, so I split fixes that I tested to be real nice into here.

Finally, a properly compiled SDL!

I'm building on top of an older revision so that you could just merge with this without hitting any master bugs like #36268.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Tested compilation of many pkgs that depend on this change
- [X] Tested execution of many said pkgs
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
