### PR TITLE
gdb: Flexible target matching for darwin

### DIFF
--- a/pkgs/development/tools/misc/gdb/darwin-target-match.patch
+++ b/pkgs/development/tools/misc/gdb/darwin-target-match.patch
@@ -1,0 +1,11 @@
+--- a/configure	2017-06-05 00:51:26.000000000 +0900
++++ b/configure	2018-03-06 23:12:58.000000000 +0900
+@@ -3603,7 +3603,7 @@
+     noconfigdirs="$noconfigdirs ld gprof"
+     noconfigdirs="$noconfigdirs sim target-rda"
+     ;;
+-  x86_64-*-darwin[912]*)
++  x86_64-*-darwin*)
+     noconfigdirs="$noconfigdirs ld gas gprof"
+     noconfigdirs="$noconfigdirs sim target-rda"
+     ;;

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation rec {
     sha256 = "0d2bpqk58fqlx21rbnk8mbcjlggzc9kb5sjirrfrrrjq70ka0qdg";
   };
 
-  patches = [ ./debug-info-from-env.patch ];
+  patches = [ ./debug-info-from-env.patch ]
+    ++ stdenv.lib.optional stdenv.isDarwin ./darwin-target-match.patch;
 
   nativeBuildInputs = [ pkgconfig texinfo perl setupDebugInfoDirs ]
     # TODO(@Ericson2314) not sure if should be host or target


### PR DESCRIPTION
Outside of the nix-build the target is `x86_64-apple-darwin17.4.0`,
while inside the target is `x86_64-apple-darwin`. This difference
causes the fallback target configuration for darwin, which disables
gdb. Add a patch to make the target matching more flexible.

This feels like patching a symptom more than a cause, is there a more principled alternative?

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/35677

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

