### PR TITLE
xen 4.8: add xsa security patches 252-256

### DIFF
--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -170,6 +170,12 @@ callPackage (import ./generic.nix (rec {
     XSA_249
     XSA_250
     XSA_251_48
+    XSA_252_49
+    # 253: 4.8 not affected
+    # 254: no patch supplied by xen project (Meltdown/Spectre)
+    XSA_255_49_1
+    XSA_255_49_2
+    XSA_256_48
     xenlockprofpatch
     xenpmdpatch
   ];

--- a/pkgs/applications/virtualization/xen/xsa-patches.nix
+++ b/pkgs/applications/virtualization/xen/xsa-patches.nix
@@ -863,5 +863,34 @@ in rec {
       sha256 = "079wi0j6iydid2zj7k584w2c393kgh588w7sjz2nn4039qn8k9mq";
     })
   ];
+  # 4.8
+  XSA_252_49 = [
+   (xsaPatch {
+      name = "252-4.9";
+      sha256 = "03sbn90nlkk5ba1n168rxjkc7x3mqj7rfqvspbwblmwikfbnms2n";
+    })
+  ];
+  # 4.8
+  XSA_255_49_1= [
+   (xsaPatch {
+      name = "255-4.9-1";
+      sha256 = "0gbin7yxbkq40lvm3gvj1vffavvbng3zpd2m8l1kqyz0rv4vm9zc";
+    })
+  ];
+  # 4.8
+  XSA_255_49_2= [
+   (xsaPatch {
+      name = "255-4.9-2";
+      sha256 = "0fyg5nnyfpfr80qq83pr64zjp5w1nx94bdblzsjap8gaqcahyr12";
+    })
+  ];
+  # 4.8
+  XSA_256_48= [
+   (xsaPatch {
+      name = "256-4.8";
+      sha256 = "1w84f717kxwx0h3rw18r4f8pl0l1h5xlj5fy80sr0ws4xkp1qdn4";
+    })
+  ];
+
 
 }


### PR DESCRIPTION
###### Motivation for this change

Apply latest upstream security patches up to XSA-256.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

