### PR TITLE
kicad-unstable: Bump git commit

### DIFF
--- a/pkgs/applications/science/electronics/kicad/unstable.nix
+++ b/pkgs/applications/science/electronics/kicad/unstable.nix
@@ -10,13 +10,13 @@
 with lib;
 stdenv.mkDerivation rec {
   name = "kicad-unstable-${version}";
-  version = "2017-12-11";
+  version = "2018-03-10";
 
   src = fetchFromGitHub {
     owner = "KICad";
     repo = "kicad-source-mirror";
-    rev = "1955f252265c38a313f6c595d6c4c637f38fd316";
-    sha256 = "15cc81h7nh5dk6gj6mc4ylcgdznfriilhb43n1g3xwyq3s8iaibz";
+    rev = "17c0917dac12ea0be50ff95cee374a0cd8b7f862";
+    sha256 = "1yn5hj5hjnpb5fkzzlyawg62a96fbfvha49395s22dcp95riqvf0";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

The previous commit had a number of rather terrible bugs; I believe the new commit is somewhere after 5.0-rc2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

