### PR TITLE
check-varnish-syntax: make error visible

### DIFF
--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -90,7 +90,7 @@ in
     system.extraDependencies = [
       (pkgs.stdenv.mkDerivation {
         name = "check-varnish-syntax";
-        buildCommand = "${pkgs.varnish}/sbin/varnishd -C ${commandLine} 2> $out";
+        buildCommand = "${pkgs.varnish}/sbin/varnishd -C ${commandLine} 2> $out || cat $out";
       })
     ];
 


### PR DESCRIPTION
###### Motivation for this change

as stderr is redirected to ```$out```, the details of an error were not visible

why not just ```| tee $out```? in case of success, there are too much text written to stderr