### PR TITLE
x86_64-musl bootstrap: refresh bootstrap tools package

### DIFF
--- a/pkgs/stdenv/linux/bootstrap-files/x86_64-musl.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/x86_64-musl.nix
@@ -1,11 +1,11 @@
 {
   busybox = import <nix/fetchurl.nix> {
-    url = https://wdtz.org/files/030q34q7fk6jdfxkgcqp5rzr4yhw3pgx-stdenv-bootstrap-tools-x86_64-unknown-linux-musl/on-server/busybox;
-    sha256 = "16lzrwwvdk6q3g08gs45pldz0rh6xpln2343xr444960h6wqxl5v";
+    url = https://wdtz.org/files/6bh4giyw5rf8mc28621rxipw8d6w6w8d-stdenv-bootstrap-tools/on-server/busybox;
+    sha256 = "0779c2wn00467h76xpqil678gfi1y2p57c7zq2d917jsv2qj5009";
     executable = true;
   };
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = https://wdtz.org/files/2m15z3pmg495w52jc8dg2nbxxzmzvb04-stdenv-bootstrap-tools/on-server/bootstrap-tools.tar.xz;
-    sha256 = "1w66l0ra0sfy83hs80w6l0lb015hrhdg3xd89xh4c5kr8bcrjriw";
+    url = https://wdtz.org/files/6bh4giyw5rf8mc28621rxipw8d6w6w8d-stdenv-bootstrap-tools/on-server/bootstrap-tools.tar.xz;
+    sha256 = "197h8gjw51q3i25myapzgqba2l4h2skzwi3q1iry26mzjjmbcvys";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/x86_64-musl.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/x86_64-musl.nix
@@ -5,7 +5,7 @@
     executable = true;
   };
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = https://wdtz.org/files/030q34q7fk6jdfxkgcqp5rzr4yhw3pgx-stdenv-bootstrap-tools-x86_64-unknown-linux-musl/on-server/bootstrap-tools.tar.xz;
-    sha256 = "0ly0wj8wzbikn2j8sn727vikk90bq36drh98qvfx1kkh5k5azm2j";
+    url = https://wdtz.org/files/2m15z3pmg495w52jc8dg2nbxxzmzvb04-stdenv-bootstrap-tools/on-server/bootstrap-tools.tar.xz;
+    sha256 = "1w66l0ra0sfy83hs80w6l0lb015hrhdg3xd89xh4c5kr8bcrjriw";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/x86_64-musl.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/x86_64-musl.nix
@@ -1,11 +1,11 @@
 {
   busybox = import <nix/fetchurl.nix> {
-    url = https://wdtz.org/files/6bh4giyw5rf8mc28621rxipw8d6w6w8d-stdenv-bootstrap-tools/on-server/busybox;
+    url = https://wdtz.org/files/gywxhjgl70sxippa0pxs0vj5qcgz1wi8-stdenv-bootstrap-tools/on-server/busybox;
     sha256 = "0779c2wn00467h76xpqil678gfi1y2p57c7zq2d917jsv2qj5009";
     executable = true;
   };
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = https://wdtz.org/files/6bh4giyw5rf8mc28621rxipw8d6w6w8d-stdenv-bootstrap-tools/on-server/bootstrap-tools.tar.xz;
-    sha256 = "197h8gjw51q3i25myapzgqba2l4h2skzwi3q1iry26mzjjmbcvys";
+    url = https://wdtz.org/files/gywxhjgl70sxippa0pxs0vj5qcgz1wi8-stdenv-bootstrap-tools/on-server/bootstrap-tools.tar.xz;
+    sha256 = "1dwiqw4xvnm0b5fdgl89lz2qq45f6s9icwxn6n6ams71xw0dbqyi";
   };
 }


### PR DESCRIPTION
"Native"-built: Seems to work better in non-sandboxed builds[1]
Symlinks preserved: (#36364)
Significantly smaller: (#36383)

Resulting size is about the same as what is currently
used in nixpkgs master (compressed), but smaller
(161M -> 101M).

Most notable difference is that this uses gcc7.

[1] such as often used in docker containers.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---