### PR TITLE
Haskell: Added haskellPackages.shellFor

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -188,6 +188,52 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
         };
       in withPackages (packages ++ [ hoogle ]);
 
+    # Returns a derivation whose environment contains a GHC with only
+    # the dependencies of packages listed in `packages`, not the
+    # packages themselves. Using nix-shell on this derivation will
+    # give you an environment suitable for developing the listed
+    # packages with an incremental tool like cabal-install.
+    #
+    #     # default.nix
+    #     with import <nixpkgs> {};
+    #     haskellPackages.extend (haskell.lib.packageSourceOverrides {
+    #       frontend = ./frontend;
+    #       backend = ./backend;
+    #       common = ./common;
+    #     })
+    #
+    #     # shell.nix
+    #     (import ./.).shellFor {
+    #       packages = p: [p.frontend p.backend p.common];
+    #       withHoogle = true;
+    #     }
+    #
+    #     -- cabal.project
+    #     packages:
+    #       frontend/
+    #       backend/
+    #       common/
+    #
+    #     bash$ nix-shell --run "cabal new-build all"
+    shellFor = { packages, withHoogle ? false, ... } @ args:
+      let
+        selected = packages self;
+        packageInputs = builtins.map (p: p.override { mkDerivation = haskellLib.extractBuildInputs p.compiler; }) selected;
+        haskellInputs =
+          builtins.filter
+            (input: pkgs.lib.all (p: input.outPath != p.outPath) selected)
+            (pkgs.lib.concatMap (p: p.haskellBuildInputs) packageInputs);
+        systemInputs = pkgs.lib.concatMap (p: p.systemBuildInputs) packageInputs;
+        withPackages = if withHoogle then self.ghcWithHoogle else self.ghcWithPackages;
+        mkDrvArgs = builtins.removeAttrs args ["packages" "withHoogle"];
+      in pkgs.stdenv.mkDerivation (mkDrvArgs // {
+        name = "ghc-shell-for-packages";
+        nativeBuildInputs = [(withPackages (_: haskellInputs))] ++ mkDrvArgs.nativeBuildInputs or [];
+        buildInputs = systemInputs ++ mkDrvArgs.buildInputs or [];
+        phases = ["installPhase"];
+        installPhase = "echo $nativeBuildInputs $buildInputs > $out";
+      });
+
     ghc = ghc // {
       withPackages = self.ghcWithPackages;
       withHoogle = self.ghcWithHoogle;


### PR DESCRIPTION
###### Motivation for this change

Building multi-package projects is pretty common, and nixpkgs currently doesn't provide a standard way to work on them simultaneously with an incremental tool like cabal new-build. This function achieves that by extracting your packages' build inputs and making a shell with those available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

