### PR TITLE
screen-message: clean up icon-theme.cache

### DIFF
--- a/pkgs/tools/X11/screen-message/default.nix
+++ b/pkgs/tools/X11/screen-message/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "execgamesdir=$(out)/bin" ];
 
   meta = {
-    homepage = http://darcs.nomeata.de/cgi-bin/darcsweb.cgi?r=screen-message.debian;
+    homepage = "https://www.joachim-breitner.de/en/projects#screen-message";
     description = "Displays a short text fullscreen in an X11 window";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.fpletz ];

--- a/pkgs/tools/X11/screen-message/default.nix
+++ b/pkgs/tools/X11/screen-message/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, gtk3 }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, gtk3, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "screen-message-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ gtk3 ];
+  buildInputs = [ gtk3 hicolor-icon-theme ];
 
   # screen-message installs its binary in $(prefix)/games per default
   makeFlags = [ "execgamesdir=$(out)/bin" ];


### PR DESCRIPTION
To remove the icon-theme.cache file from the output since it can cause collisions. Also change homepage field to something that exists.

CC @fpletz