### PR TITLE
cl-launch: change platforms to unix

### DIFF
--- a/pkgs/development/tools/misc/cl-launch/default.nix
+++ b/pkgs/development/tools/misc/cl-launch/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation {
     description = ''Common Lisp launcher script'';
     license = stdenv.lib.licenses.llgpl21 ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
this will alow to build / use cl-launch on other platforms
e.g. MacOS, FreeBSD

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

