### PR TITLE
Bluetooth MIDI support

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -3,8 +3,8 @@
 with lib;
 
 let
-  bluez-bluetooth = pkgs.bluez;
   cfg = config.hardware.bluetooth;
+  bluez-bluetooth = cfg.package;
 
 in {
 
@@ -19,6 +19,16 @@ in {
         type    = types.bool;
         default = true;
         description = "Whether to power up the default Bluetooth controller on boot.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.bluez;
+        defaultText = "pkgs.bluez";
+        example = "pkgs.bluez.override { enableMidi = true; }";
+        description = ''
+          Which BlueZ package to use.
+        '';
       };
 
       extraConfig = mkOption {

--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, dbus, glib, alsaLib,
   pythonPackages, readline, udev, libical,
-  systemd, enableWiimote ? false }:
+  systemd, enableWiimote ? false, enableMidi ? false }:
 
 assert stdenv.isLinux;
 
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--with-systemduserunitdir=$(out)/etc/systemd/user"
     "--with-udevdir=$(out)/lib/udev"
-    ] ++
-    stdenv.lib.optional enableWiimote [ "--enable-wiimote" ];
+    ] ++ stdenv.lib.optional enableWiimote [ "--enable-wiimote" ]
+    ++ stdenv.lib.optional enableMidi [ "--enable-midi" ];
 
   # Work around `make install' trying to create /var/lib/bluetooth.
   installFlags = "statedir=$(TMPDIR)/var/lib/bluetooth";


### PR DESCRIPTION
###### Motivation for this change

BlueZ has MIDI over BLE support, but it's not enabled by default. This commits allow to enable that support, and to configure `bluetooth` module to use midi-enabled bluez package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

