### PR TITLE
bitwig-studio2: update version 2.2.2 -> 2.3.1

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio2.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio2.nix
@@ -3,11 +3,11 @@
 
 bitwig-studio1.overrideAttrs (oldAttrs: rec {
   name = "bitwig-studio-${version}";
-  version = "2.2.2";
+  version = "2.3.1";
 
   src = fetchurl {
     url    = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
-    sha256 = "1x4wka32xlygmhdh9rb15s37zh5qjrgap2qk35y34c52lf5aak22";
+    sha256 = "18gghx0ygwh01cidj8mkf82l9qhq2dy1b3yc4ajksvj762yg6cf2";
   };
 
   buildInputs = bitwig-studio1.buildInputs ++ [ ffmpeg ];


### PR DESCRIPTION
###### Motivation for this change

New version of Bitwig Studio 2 have been released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

