### PR TITLE
gnomeExtensions.system-monitor: fix this package and upgrade to v33

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
@@ -1,6 +1,4 @@
-# This package needs the following configuration in configuration.nix:
-# services.xserver.desktopManager.gnome3.sessionPath = [ pkgs.libgtop pkgs.glib_networking ];
-{ config, stdenv, fetchFromGitHub, glib, glib_networking, libgtop, pkgs }:
+{ config, stdenv, substituteAll, fetchFromGitHub, glib, glib_networking, libgtop, pkgs }:
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-system-monitor-${version}";
@@ -19,7 +17,13 @@ stdenv.mkDerivation rec {
     libgtop
   ];
 
-  patches = [ ./remove_nonexisting_mounts.patch ];
+  patches = [
+    (substituteAll {
+      src = ./paths_and_nonexisting_dirs.patch;
+      gtop_path = "${libgtop}/lib/girepository-1.0";
+      glib_net_path = "${glib_networking}/lib/girepository-1.0";
+    })
+  ];
 
   buildPhase = ''
     ${glib.dev}/bin/glib-compile-schemas --targetdir=${uuid}/schemas ${uuid}/schemas

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-system-monitor-${version}";
-  version = "v33";
+  version = "33";
 
   src = fetchFromGitHub {
     owner = "paradoxxxzero";
     repo = "gnome-shell-system-monitor-applet";
-    rev = version;
+    rev = "v${version}";
     sha256 = "0abqaanl5r26x8f0mm0jgrjsr86hcx7mk75dx5c3zz7csw4nclkk";
   };
 

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
@@ -1,26 +1,33 @@
-{ stdenv, fetchFromGitHub, glib }:
+# This package needs the following configuration in configuration.nix:
+# services.xserver.desktopManager.gnome3.sessionPath = [ pkgs.libgtop pkgs.glib_networking ];
+{ config, stdenv, fetchFromGitHub, glib, glib_networking, libgtop, pkgs }:
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-system-monitor-${version}";
-  version = "8b31f070e9e59109d729661ced313d6a63e31787";
+  version = "v33";
 
   src = fetchFromGitHub {
     owner = "paradoxxxzero";
     repo = "gnome-shell-system-monitor-applet";
     rev = version;
-    sha256 = "0fm5zb6qp53jjy2mnkb8ybxygzjwpb314giiq0ywq87hhrpch8m3";
+    sha256 = "0abqaanl5r26x8f0mm0jgrjsr86hcx7mk75dx5c3zz7csw4nclkk";
   };
 
   buildInputs = [
     glib
+    glib_networking
+    libgtop
   ];
+
+  patches = [ ./remove_nonexisting_mounts.patch ];
 
   buildPhase = ''
     ${glib.dev}/bin/glib-compile-schemas --targetdir=${uuid}/schemas ${uuid}/schemas
   '';
 
   installPhase = ''
-    cp -r ${uuid} $out
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ${uuid} $out/share/gnome-shell/extensions
   '';
 
   uuid = "system-monitor@paradoxxx.zero.gmail.com";
@@ -28,7 +35,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Display system informations in gnome shell status bar";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ aneeshusa ];
+    maintainers = with maintainers; [ aneeshusa tiramiseb ];
     homepage = https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet;
   };
 }

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/paths_and_nonexisting_dirs.patch
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/paths_and_nonexisting_dirs.patch
@@ -1,8 +1,18 @@
 diff --git a/system-monitor@paradoxxx.zero.gmail.com/extension.js b/system-monitor@paradoxxx.zero.gmail.com/extension.js
-index b4b7f15..d645654 100644
+index b4b7f15..d139135 100644
 --- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
 +++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
-@@ -386,7 +386,7 @@ const smMountsMonitor = new Lang.Class({
+@@ -18,6 +18,9 @@
+ 
+ // Author: Florian Mounier aka paradoxxxzero
+ 
++imports.gi.GIRepository.Repository.prepend_search_path('@gtop_path@');
++imports.gi.GIRepository.Repository.prepend_search_path('@glib_net_path@');
++
+ /* Ugly. This is here so that we don't crash old libnm-glib based shells unnecessarily
+  * by loading the new libnm.so. Should go away eventually */
+ const libnm_glib = imports.gi.GIRepository.Repository.get_default().is_registered("NMClient", "1.0");
+@@ -386,7 +389,7 @@ const smMountsMonitor = new Lang.Class({
      connected: false,
      _init: function () {
          this._volumeMonitor = Gio.VolumeMonitor.get();

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/remove_nonexisting_mounts.patch
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/remove_nonexisting_mounts.patch
@@ -1,0 +1,13 @@
+diff --git a/system-monitor@paradoxxx.zero.gmail.com/extension.js b/system-monitor@paradoxxx.zero.gmail.com/extension.js
+index b4b7f15..d645654 100644
+--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
++++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
+@@ -386,7 +386,7 @@ const smMountsMonitor = new Lang.Class({
+     connected: false,
+     _init: function () {
+         this._volumeMonitor = Gio.VolumeMonitor.get();
+-        let sys_mounts = ['/home', '/tmp', '/boot', '/usr', '/usr/local'];
++        let sys_mounts = ['/home', '/tmp', '/boot'];
+         this.base_mounts = ['/'];
+         sys_mounts.forEach(Lang.bind(this, function (sMount) {
+             if (this.is_sys_mount(sMount + '/')) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19289,6 +19289,7 @@ with pkgs;
     nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
     no-title-bar = callPackage ../desktops/gnome-3/extensions/no-title-bar { };
     remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };
+    system-monitor = callPackage ../desktops/gnome-3/extensions/system-monitor { };
     taskwhisperer = callPackage ../desktops/gnome-3/extensions/taskwhisperer { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };


### PR DESCRIPTION
###### Motivation for this change

Having a working extension :)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See the mailing list for a discussion about the sessionPath parameter in gnome3 (https://groups.google.com/forum/#!topic/nix-devel/jJevoZx2ZFo)...