### PR TITLE
gnomeExtensions.impatience: fix the package and upgrade to version 0.4.5

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/impatience.nix
+++ b/pkgs/desktops/gnome-3/extensions/impatience.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-impatience-${version}";
-  version = "version-0.4.5";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "timbertson";
     repo = "gnome-shell-impatience";
-    rev = version;
+    rev = "version-${version}";
     sha256 = "0kvdhlz41fjyqdgcfw6mrr9nali6wg2qwji3dvykzfi0aypljzpx";
   };
 

--- a/pkgs/desktops/gnome-3/extensions/impatience.nix
+++ b/pkgs/desktops/gnome-3/extensions/impatience.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-impatience-${version}";
-  version = "6564c21e4caf4a6bc5fe2bf21116d7c15408d494";
+  version = "version-0.4.5";
 
   src = fetchFromGitHub {
     owner = "timbertson";
     repo = "gnome-shell-impatience";
     rev = version;
-    sha256 = "10zyj42i07dcvaciv47qgkcs5g5n2bpc8a0m6fsimfi0442iwlcn";
+    sha256 = "0kvdhlz41fjyqdgcfw6mrr9nali6wg2qwji3dvykzfi0aypljzpx";
   };
 
   buildInputs = [
@@ -20,7 +20,8 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    cp -r impatience $out
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r impatience $out/share/gnome-shell/extensions/${uuid}
   '';
 
   uuid = "impatience@gfxmonk.net";
@@ -28,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Speed up builtin gnome-shell animations";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ aneeshusa timbertson ];
+    maintainers = with maintainers; [ aneeshusa timbertson tiramiseb ];
     homepage = http://gfxmonk.net/dist/0install/gnome-shell-impatience.xml;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19285,6 +19285,7 @@ with pkgs;
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
+    impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix { };
     mediaplayer = callPackage ../desktops/gnome-3/extensions/mediaplayer { };
     nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
     no-title-bar = callPackage ../desktops/gnome-3/extensions/no-title-bar { };


### PR DESCRIPTION
###### Motivation for this change

Having a working extension :)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).