### PR TITLE
ocaml-ng.ocamlPackages_4_06.camlimages: 4.1.2 -> 5.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -1,0 +1,12 @@
+{ stdenv, fetchzip, findlib, jbuilder, ocaml, configurator, cppo, lablgtk }:
+stdenv.mkDerivation rec {
+  name = "camlimages-${version}";
+  version = "5.0.0";
+  src = fetchzip {
+    url = "https://bitbucket.org/camlspotter/camlimages/get/${version}.tar.gz";
+    sha256 = "00qvwxkfnhv93yi1iq7vy3p5lxyi9xigxcq464s4ii6bmp32d998";
+  };
+  buildInputs = [ findlib jbuilder ocaml configurator cppo lablgtk ];
+  buildPhase = "jbuilder build -p camlimages";
+  inherit (jbuilder) installPhase;
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -119,7 +119,10 @@ let
     camlimages_4_1 = callPackage ../development/ocaml-modules/camlimages/4.1.nix {
       giflib = pkgs.giflib_4_1;
     };
-    camlimages = camlimages_4_1;
+    camlimages =
+          if lib.versionOlder "4.05" ocaml.version
+          then callPackage ../development/ocaml-modules/camlimages { }
+          else camlimages_4_1;
 
     benchmark = callPackage ../development/ocaml-modules/benchmark { };
 


### PR DESCRIPTION
###### Motivation for this change

Bump camlimages (but only for OCaml 4.06).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

