### PR TITLE
vo-amrwbenc: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -63,6 +63,10 @@
     github = "DmitryTsygankov";
     name = "Dmitry Tsygankov";
   };
+  Esteth = {
+    email = "adam.copp@gmail.com";
+    name = "Adam Copp";
+  };
   FireyFly = {
     email = "nix@firefly.nu";
     github = "FireyFly";

--- a/pkgs/development/libraries/vo-amrwbenc/default.nix
+++ b/pkgs/development/libraries/vo-amrwbenc/default.nix
@@ -17,5 +17,6 @@ stdenv.mkDerivation {
     description = "VisualOn Adaptive Multi Rate Wideband (AMR-WB) encoder";
     license = "stdenv.lib.licenses.apache";
     maintainers = [ stdenv.lib.maintainers.Esteth ];
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/vo-amrwbenc/default.nix
+++ b/pkgs/development/libraries/vo-amrwbenc/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation {
     homepage = "http://sourceforge.net/projects/opencore-amr/";
     description = "VisualOn Adaptive Multi Rate Wideband (AMR-WB) encoder";
     license = "stdenv.lib.licenses.apache";
-    maintainers = [ stdenv.lib.maintainers.esteth ];
+    maintainers = [ stdenv.lib.maintainers.Esteth ];
   };
 }

--- a/pkgs/development/libraries/vo-amrwbenc/default.nix
+++ b/pkgs/development/libraries/vo-amrwbenc/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, autoreconfHook }:
+
+let
+    version = "0.1.3";
+in
+stdenv.mkDerivation {
+  name = "vo-amrwbenc-${version}";
+  version = "0.1.3";
+  buildInputs = [ autoreconfHook ];
+  src = fetchurl {
+    url = "https://github.com/mstorsjo/vo-amrwbenc/archive/v${version}.tar.gz";
+    sha256 = "85c79997ba7ddb9c95b5ddbe9ea032e27595390f3cbd686ed46a69e485cc053c";
+  };
+
+  meta = {
+    homepage = "http://sourceforge.net/projects/opencore-amr/";
+    description = "VisualOn Adaptive Multi Rate Wideband (AMR-WB) encoder";
+    license = "stdenv.lib.licenses.apache";
+    maintainers = [ stdenv.lib.maintainers.esteth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5222,6 +5222,8 @@ with pkgs;
 
   vncrec = callPackage ../tools/video/vncrec { };
 
+  vo-amrwbenc = callPackage ../development/libraries/vo-amrwbenc { };
+
   vobcopy = callPackage ../tools/cd-dvd/vobcopy { };
 
   vobsub2srt = callPackage ../tools/cd-dvd/vobsub2srt { };


### PR DESCRIPTION
###### Motivation for this change

Adding new package for AMR-WB encoder/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

