### PR TITLE
Add opentimestamps

### DIFF
--- a/pkgs/development/python-modules/opentimestamps/default.nix
+++ b/pkgs/development/python-modules/opentimestamps/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
+, bitcoinlib, GitPython, pysha3 }:
+
+buildPythonPackage rec {
+  name = "opentimestamps-${version}";
+  version = "0.2.1";
+  disabled = (!isPy3k);
+
+  src = fetchFromGitHub {
+    owner = "opentimestamps";
+    repo = "python-opentimestamps";
+    rev = "python-opentimestamps-v0.2.1";
+    sha256 = "1cilv1ls9mdqk8zriqfkz7xcl8i1ncm0f89n4c8k4s82kf5y56rm";
+  };
+
+  # Remove a failing test which expects the test source file to reside in the
+  # project's Git repo
+  patchPhase = ''
+    rm opentimestamps/tests/core/test_git.py
+  '';
+
+  propagatedBuildInputs = [ bitcoinlib GitPython pysha3 ];
+
+  meta = {
+    description = "Create and verify OpenTimestamps proofs";
+    homepage = https://github.com/opentimestamps/python-opentimestamps;
+    license = lib.licenses.lgpl3;
+  };
+}

--- a/pkgs/development/python-modules/pysha3/default.nix
+++ b/pkgs/development/python-modules/pysha3/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "pysha3";
+  version = "1.0.2";
+  name = "${pname}-${version}";
+  disabled = pythonOlder "2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17kkjapv6sr906ib0r5wpldmzw7scza08kv241r98vffy9rqx67y";
+  };
+
+  meta = {
+    description = "Backport of hashlib.sha3 for 2.7 to 3.5";
+    homepage = https://github.com/tiran/pysha3;
+    license = lib.licenses.psfl;
+  };
+}

--- a/pkgs/tools/misc/opentimestamps-client/default.nix
+++ b/pkgs/tools/misc/opentimestamps-client/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonApplication, fetchFromGitHub, isPy3k
+, opentimestamps, GitPython, pysocks }:
+
+buildPythonApplication rec {
+  name = "opentimestamps-client-${version}";
+  version = "0.5.1";
+  disabled = (!isPy3k);
+
+  src = fetchFromGitHub {
+    owner = "opentimestamps";
+    repo = "opentimestamps-client";
+    rev = "opentimestamps-client-v0.5.1";
+    sha256 = "0s549xkb75r5wyvjlfmac8a1df6w0y55l98f492zsihdns1d6rzq";
+  };
+
+  propagatedBuildInputs = [ opentimestamps GitPython pysocks ];
+
+  meta = {
+    description = "Command-line tool to create and verify OpenTimestamps proofs";
+    homepage = https://github.com/opentimestamps/opentimestamps-client;
+    license = lib.licenses.lgpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16860,6 +16860,8 @@ with pkgs;
 
   openscad = callPackage ../applications/graphics/openscad {};
 
+  opentimestamps-client = python3Packages.callPackage ../tools/misc/opentimestamps-client {};
+
   opentx = callPackage ../applications/misc/opentx { };
 
   opera = callPackage ../applications/networking/browsers/opera {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13362,6 +13362,8 @@ in {
 
   pyrr = callPackage ../development/python-modules/pyrr { };
 
+  pysha3 = callPackage ../development/python-modules/pysha3 { };
+
   pyshp = callPackage ../development/python-modules/pyshp { };
 
   pysmbc = callPackage ../development/python-modules/pysmbc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11400,6 +11400,8 @@ in {
 
   openpyxl = callPackage ../development/python-modules/openpyxl { };
 
+  opentimestamps = callPackage ../development/python-modules/opentimestamps { };
+
   ordereddict = buildPythonPackage rec {
     name = "ordereddict-${version}";
     version = "1.1";


### PR DESCRIPTION
## Motivation for this change
Add [opentimestamps](https://opentimestamps.org/)-client with all Python dependencies

## Additional info to help reviewing

### pysha3
Dependency of `opentimestamps`
https://github.com/tiran/pysha3
https://pypi.python.org/pypi/pysha3

### opentimestamps
Main library, used by the client
https://github.com/opentimestamps/python-opentimestamps
https://pypi.python.org/pypi/opentimestamps/0.2.1

### opentimestamps-client
https://pypi.python.org/pypi/opentimestamps-client/0.5.1
https://github.com/opentimestamps/opentimestamps-client

We can't use the pypi source because it doesn't include `README.md` which is
[needed in setup.py](https://github.com/opentimestamps/opentimestamps-client/blob/9ac6cc53780b76c8c72e3c6553dc16b651fa55de/setup.py#L12). Fetch the pypi source:
```
nix-build --no-out-link  -E '(import <nixpkgs> {}).pythonPackages.fetchPypi {
   pname = "opentimestamps-client";
   version = "0.5.1";
   sha256 = "1pcch5fnazaw5dxbh4r0nx5f16xrbky81hgq10gs4hgip9zf9z2a";
}'
```

## Further additions
If you'd welcome it, I could also add [opentimestamps-server](https://github.com/opentimestamps/opentimestamps-server)



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

