### PR TITLE
mongodb: Add authentication support

### DIFF
--- a/nixos/modules/services/databases/mongodb.nix
+++ b/nixos/modules/services/databases/mongodb.nix
@@ -65,6 +65,7 @@ in
         default = false;
         description = "Enable client authentication. Creates a default superuser with username root!";
       };
+      
       initialRootPassword = mkOption {
         type = types.nullOr types.string;
         default = null;

--- a/nixos/modules/services/databases/mongodb.nix
+++ b/nixos/modules/services/databases/mongodb.nix
@@ -142,7 +142,7 @@ in
         };
 
         preStart = let
-          cfg_ = cfg // { enableAuth = false; };
+          cfg_ = cfg // { enableAuth = false; bind_ip = "127.0.0.1"; };
         in ''
           rm ${cfg.dbpath}/mongod.lock || true
           if ! test -e ${cfg.dbpath}; then

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -8,7 +8,7 @@ import ./make-test.nix ({ pkgs, ...} : let
 in {
   name = "mongodb";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ bluescreen303 offline cstrahan rvl ];
+    maintainers = [ bluescreen303 offline cstrahan rvl phile314 ];
   };
 
   nodes = {
@@ -17,6 +17,12 @@ in {
         {
           services = {
            mongodb.enable = true;
+           mongodb.enableAuth = true;
+           mongodb.initialRootPassword = "root";
+           mongodb.initialScript = pkgs.writeText "mongodb_initial.js" ''
+             db = db.getSiblingDB("nixtest");
+             db.createUser({user:"nixtest",pwd:"nixtest",roles:[{role:"readWrite",db:"nixtest"}]});
+           '';
            mongodb.extraConfig = ''
              # Allow starting engine with only a small virtual disk
              storage.journal.enabled: false
@@ -29,6 +35,6 @@ in {
   testScript = ''
     startAll;
     $one->waitForUnit("mongodb.service");
-    $one->succeed("mongo nixtest ${testQuery}") =~ /hello/ or die;
+    $one->succeed("mongo -u nixtest -p nixtest nixtest ${testQuery}") =~ /hello/ or die;
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Add support for authentication to the MongoDB NixOS module.

MongoDB makes this a bit difficult, because it has no default admin/root user. So if we would just enable authentication this would make MongoDB completely inaccessible. I chose to instead create a default root db user. Users can then change the root password or create additional users using the normal MongoDB functions. There is a minimal security risk, as during initial setup MongoDB is started without authorization on the local loopback interface. Similarly, there will be a time window between the first startup and the time the initial root password can be changed by the user.

This is the best approach I have come up so far. Better ideas are welcome ;-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

