### PR TITLE
aj-snapshot: 0.9.7 -> 0.9.8

### DIFF
--- a/pkgs/applications/audio/aj-snapshot/default.nix
+++ b/pkgs/applications/audio/aj-snapshot/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name =  packageName + "-" + version ;
   packageName = "aj-snapshot" ;
-  version = "0.9.7";
+  version = "0.9.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/${packageName}/${name}.tar.bz2";
-    sha256 = "0yxccgp9qw2cyqv719wlbq8wfsr5ga8czvwa7bmb8dh5s11n3rn8";
+    sha256 = "0wilky1g2mb88v2z0520s7sw1dsn10iwanc8id5p6z1xsnhg7b6p";
   };
 
   doCheck = false;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.8 in filename of file in /nix/store/20clx4g7349qaa4z00grmvncaszmmr9w-aj-snapshot-0.9.8

cc @mrVanDalo 