### PR TITLE
emacs: use unstable melpa for dependencies

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -385,9 +385,9 @@ let
 in
   lib.makeScope newScope (self:
     {}
+    // melpaStablePackages self
     // melpaPackages self
     // elpaPackages self
-    // melpaStablePackages self
     // orgPackages self
     // packagesFun self
   )


### PR DESCRIPTION
###### Motivation for this change
See #36345 for discussion. This should fix issues with MELPA stable being out of date occasionaly.

/cc @ttuegel 