### PR TITLE
pythonPackages.isort: 4.2.5 -> 4.3.4

### DIFF
--- a/pkgs/development/python-modules/isort/default.nix
+++ b/pkgs/development/python-modules/isort/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, futures, mock, pytest }:
+
+buildPythonPackage rec {
+  pname = "isort";
+  version = "4.3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1y0yfv56cqyh9wyg7kxxv9y5wmfgcq18n7a49mp7xmzka2bhxi5r";
+  };
+
+  propagatedBuildInputs = lib.optional isPy27 futures;
+
+  checkInputs = [ mock pytest ];
+
+  checkPhase = ''
+    py.test test_isort.py -k "not test_long_line_comments \
+                          and not test_import_case_produces_inconsistent_results_issue_472 \
+                          and not test_no_extra_lines_issue_557"
+  '';
+
+  meta = with lib; {
+    description = "A Python utility / library to sort Python imports";
+    homepage = https://github.com/timothycrosley/isort;
+    license = licenses.mit;
+    maintainers = with maintainers; [ couchemar nand0p ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6802,24 +6802,7 @@ in {
 
   iso8601 = callPackage ../development/python-modules/iso8601 { };
 
-  isort = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "isort";
-    version = "4.2.5";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/i/${pname}/${name}.tar.gz";
-      sha256 = "0p7a6xaq7zxxq5vr5gizshnsbk2afm70apg97xwfdxiwyi201cjn";
-    };
-    buildInputs = with self; [ mock pytest ];
-    # No tests distributed
-    doCheck = false;
-    meta = {
-      description = "A Python utility / library to sort Python imports";
-      homepage = https://github.com/timothycrosley/isort;
-      license = licenses.mit;
-      maintainers = with maintainers; [ couchemar nand0p ];
-    };
-  };
+  isort = callPackage ../development/python-modules/isort {};
 
   jabberbot = callPackage ../development/python-modules/jabberbot {};
 


### PR DESCRIPTION
###### Motivation for this change

Update isort to the most recent version

Related to #35444
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

