### PR TITLE
ansifilter: 2.4 -> 2.9

### DIFF
--- a/pkgs/tools/text/ansifilter/default.nix
+++ b/pkgs/tools/text/ansifilter/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ansifilter-${version}";
-  version = "2.4";
+  version = "2.9";
 
   src = fetchurl {
     url = "http://www.andre-simon.de/zip/ansifilter-${version}.tar.bz2";
-    sha256 = "c57cb878afa7191c7b7db3c086a344b4234df814aed632596619a4bda5941d48";
+    sha256 = "0fmwb8w1bpfxjwddal6cnhgmip26xqgcanpz2vp8jasklkcc1i7r";
 
   };
 


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/kws0dw1qp926cdc6msrndgq3iwp2l84a-ansifilter-2.9/bin/ansifilter -h` got 0 exit code
- ran `/nix/store/kws0dw1qp926cdc6msrndgq3iwp2l84a-ansifilter-2.9/bin/ansifilter --help` got 0 exit code
- ran `/nix/store/kws0dw1qp926cdc6msrndgq3iwp2l84a-ansifilter-2.9/bin/ansifilter help` got 0 exit code
- ran `/nix/store/kws0dw1qp926cdc6msrndgq3iwp2l84a-ansifilter-2.9/bin/ansifilter -V` and found version 2.9
- ran `/nix/store/kws0dw1qp926cdc6msrndgq3iwp2l84a-ansifilter-2.9/bin/ansifilter -v` and found version 2.9
- ran `/nix/store/kws0dw1qp926cdc6msrndgq3iwp2l84a-ansifilter-2.9/bin/ansifilter --version` and found version 2.9
- found 2.9 with grep in /nix/store/kws0dw1qp926cdc6msrndgq3iwp2l84a-ansifilter-2.9
- found 2.9 in filename of file in /nix/store/kws0dw1qp926cdc6msrndgq3iwp2l84a-ansifilter-2.9

cc @Adjective-Object 