### PR TITLE
apktool: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/development/tools/apktool/default.nix
+++ b/pkgs/development/tools/apktool/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "apktool-${version}";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = fetchurl {
     urls = [
       "https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${version}.jar"
       "https://github.com/iBotPeaches/Apktool/releases/download/v${version}/apktool_${version}.jar"
     ];
-    sha256 = "b724c158ec99dbad723024e259fd73e5135c40d652a3c599cec6ade9264a568e";
+    sha256 = "01xj2hivwwp3msvv0psxyxrzg95vj2ny56l3n90glhwznn7l60ai";
   };
 
   phases = [ "installPhase" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool -h` got 0 exit code
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool --help` got 0 exit code
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool help` got 0 exit code
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool -V` and found version 2.3.1
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool -v` and found version 2.3.1
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool --version` and found version 2.3.1
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool version` and found version 2.3.1
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool -h` and found version 2.3.1
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool --help` and found version 2.3.1
- ran `/nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1/bin/apktool help` and found version 2.3.1
- found 2.3.1 with grep in /nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1
- found 2.3.1 in filename of file in /nix/store/h8i3bh2ka65cj2ddfmvq2fv7wldsprk4-apktool-2.3.1

cc @offlinehacker 