### PR TITLE
argyllcms: 1.8.3 -> 2.0.0

### DIFF
--- a/pkgs/tools/graphics/argyllcms/default.nix
+++ b/pkgs/tools/graphics/argyllcms/default.nix
@@ -2,7 +2,7 @@
 , libXrender, libXext, libtiff, libjpeg, libpng, libXScrnSaver, writeText
 , libXdmcp, libXau, lib, openssl, zlib }:
 let
-  version = "1.8.3";
+  version = "2.0.0";
  in
 stdenv.mkDerivation rec {
   name = "argyllcms-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     # Kind of flacky URL, it was reaturning 406 and inconsistent binaries for a
     # while on me. It might be good to find a mirror
     url = "http://www.argyllcms.com/Argyll_V${version}_src.zip";
-    sha256 = "00ggh47qzb3xyl8rnppwxa6j113lr38aiwvsfyxwgs51aqmvq7bd";
+    sha256 = "1583hspas7rw5xwrs1rb4yn1yl34wh6lfik6xyszpfv39a2axdxx";
 
     # The argyllcms web server doesn't like curl ...
     curlOpts = "--user-agent 'Mozilla/5.0'";


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/hh6cqaai79dsh200g3c581iaq52yi580-argyllcms-2.0.0/bin/synthcal help` got 0 exit code
- found 2.0.0 with grep in /nix/store/hh6cqaai79dsh200g3c581iaq52yi580-argyllcms-2.0.0
- found 2.0.0 in filename of file in /nix/store/hh6cqaai79dsh200g3c581iaq52yi580-argyllcms-2.0.0

cc @rickynils