### PR TITLE
wyrd: fix build

### DIFF
--- a/pkgs/tools/misc/wyrd/default.nix
+++ b/pkgs/tools/misc/wyrd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, ncurses, remind, camlp4 }:
+{ stdenv, fetchurl, ocamlPackages, ncurses, remind }:
 
 stdenv.mkDerivation rec {
   version = "1.4.6";
@@ -9,7 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "0zlrg602q781q8dij62lwdprpfliyy9j1rqfqcz8p2wgndpivddj";
   };
 
-  buildInputs = [ ocaml ncurses remind camlp4 ];
+  NIX_CFLAGS_COMPILE = [ "-DNCURSES_INTERNALS=1" ];
+
+  preConfigure = ''
+    substituteInPlace curses/curses.ml --replace 'pp gcc' 'pp cc'
+  '';
+
+  buildInputs = [ ocamlPackages.ocaml ncurses remind ocamlPackages.camlp4 ];
 
   preferLocalBuild = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5500,7 +5500,7 @@ with pkgs;
 
   wv2 = callPackage ../tools/misc/wv2 { };
 
-  inherit (ocamlPackages) wyrd;
+  wyrd = callPackage ../tools/misc/wyrd { };
 
   x86info = callPackage ../os-specific/linux/x86info { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -969,10 +969,6 @@ let
 
     # Apps / from all-packages
 
-    wyrd = callPackage ../tools/misc/wyrd {
-      ncurses = pkgs.ncurses5;
-    };
-
     haxe = callPackage ../development/compilers/haxe { };
 
     ocamlnat = callPackage  ../development/ocaml-modules/ocamlnat { };


### PR DESCRIPTION
###### Motivation for this change

wyrd has been broken since 3d24ae9b4426bb8adfcb08de57be21fdf0a377f8. This fix is similar to 8afcfb2bb6681c56ecf21e056d91d6748d953997.

This should also fix the build on non-gcc stdenvs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

