### PR TITLE
pythonPackages.pkgconfig: 1.1.0 -> 1.3.1

### DIFF
--- a/pkgs/development/python-modules/pkgconfig/default.nix
+++ b/pkgs/development/python-modules/pkgconfig/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, nose, pkgconfig }:
+
+buildPythonPackage rec {
+  pname = "pkgconfig";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "107x2wmchlch8saixb488cgjz9n6inl38wi7nxkb942rbaapxiqb";
+  };
+
+  checkInputs = [ nose ];
+
+  propagatedBuildInputs = [ pkgconfig ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with lib; {
+    description = "Interface Python with pkg-config";
+    homepage = https://github.com/matze/pkgconfig;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12516,14 +12516,11 @@ in {
 
   pkgconfig = buildPythonPackage rec {
     name = "pkgconfig-${version}";
-    version = "1.1.0";
-
-    # pypy: SyntaxError: __future__ statements must appear at beginning of file
-    disabled = isPyPy;
+    version = "1.3.1";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/pkgconfig/${name}.tar.gz";
-      sha256 = "709daaf077aa2b33bedac12706373412c3683576a43013bbaa529fc2769d80df";
+      sha256 = "107x2wmchlch8saixb488cgjz9n6inl38wi7nxkb942rbaapxiqb";
     };
 
     buildInputs = with self; [ nose ];
@@ -12537,8 +12534,6 @@ in {
     };
 
     # nosetests needs to be run explicitly.
-    # Note that the distributed archive does not actually contain any tests.
-    # https://github.com/matze/pkgconfig/issues/9
     checkPhase = ''
       nosetests
     '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12514,30 +12514,8 @@ in {
     inherit (pkgs.xorg) libX11;
   };
 
-  pkgconfig = buildPythonPackage rec {
-    name = "pkgconfig-${version}";
-    version = "1.3.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pkgconfig/${name}.tar.gz";
-      sha256 = "107x2wmchlch8saixb488cgjz9n6inl38wi7nxkb942rbaapxiqb";
-    };
-
-    buildInputs = with self; [ nose ];
-
-    propagatedBuildInputs = with self; [pkgs.pkgconfig];
-
-    meta = {
-      description = "Interface Python with pkg-config";
-      homepage = https://github.com/matze/pkgconfig;
-      license = licenses.mit;
-    };
-
-    # nosetests needs to be run explicitly.
-    checkPhase = ''
-      nosetests
-    '';
-
+  pkgconfig = callPackage ../development/python-modules/pkgconfig {
+    inherit (pkgs) pkgconfig;
   };
 
   plumbum = callPackage ../development/python-modules/plumbum { };


### PR DESCRIPTION
###### Motivation for this change

The new version has a number of bugfixes and useful features. It also now includes the tests in the distribution.

It may cause breakage, though: 

> Version 1.2.0
> Released on November 30th 2016.
> 
> Potential break: switch from result set to list

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

