### PR TITLE
ecm: 6.4.4 -> 7.0.4

### DIFF
--- a/pkgs/applications/science/math/ecm/default.nix
+++ b/pkgs/applications/science/math/ecm/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "ecm";
-  version = "6.4.4";
+  version = "7.0.4";
   name = "${pname}-${version}";
 in
 
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
-    url = http://gforge.inria.fr/frs/download.php/file/32159/ecm-6.4.4.tar.gz;
-    sha256 = "0v5h2nicz9yx78c2d72plbhi30iq4nxbvphja1s9501db4aah4y8";
+    url = "http://gforge.inria.fr/frs/download.php/file/36224/ecm-${version}.tar.gz";
+    sha256 = "0hxs24c2m3mh0nq1zz63z3sb7dhy1rilg2s1igwwcb26x3pb7xqc";
   };
 
   # See https://trac.sagemath.org/ticket/19233


### PR DESCRIPTION
###### Motivation for this change

ecm was outdated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

