### PR TITLE
fflas-ffpack: 2.2.2 -> 2.3.2

### DIFF
--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -1,4 +1,7 @@
-{stdenv, fetchFromGitHub, autoreconfHook, givaro, pkgconfig, openblas, liblapack}:
+{ stdenv, fetchFromGitHub, autoreconfHook, givaro, pkgconfig, openblas, liblapack
+, gmpxx
+, optimize ? false # impure
+}:
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "fflas-ffpack";
@@ -9,9 +12,31 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1cqhassj2dny3gx0iywvmnpq8ca0d6m82xl5rz4mb8gaxr2kwddl";
   };
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  checkInputs = [
+    gmpxx
+  ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ] ++ stdenv.lib.optionals doCheck checkInputs;
   buildInputs = [ givaro (liblapack.override {shared = true;}) openblas];
-  configureFlags = "--with-blas-libs=-lopenblas --with-lapack-libs=-llapack";
+  configureFlags = [
+    "--with-blas-libs=-lopenblas"
+    "--with-lapack-libs=-llapack"
+  ] ++ stdenv.lib.optionals (!optimize) [
+    # disable SIMD instructions (which are enabled *when available* by default)
+    "--disable-sse"
+    "--disable-sse2"
+    "--disable-sse3"
+    "--disable-ssse3"
+    "--disable-sse41"
+    "--disable-sse42"
+    "--disable-avx"
+    "--disable-avx2"
+    "--disable-fma"
+    "--disable-fma4"
+  ];
+  doCheck = true;
   meta = {
     inherit version;
     description = ''Finite Field Linear Algebra Subroutines'';


### PR DESCRIPTION
###### Motivation for this change

fflas-ffpack was outdated.

This updates it, makes it more reproducible / less error-prone and enables checks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

