### PR TITLE
pythonPackages.antlr4-python3-runtime: init at 4.7.1

### DIFF
--- a/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
@@ -1,0 +1,17 @@
+{buildPythonPackage, isPy3k, pkgs}:
+buildPythonPackage rec {
+  version = "4.7.1";
+  name = "antlr4-python3-runtime-${version}";
+  disabled = !isPy3k;
+
+  src = pkgs.fetchurl {
+    url = "mirror://pypi/a/antlr4-python3-runtime/${name}.tar.gz";
+    sha256 = "1lrzmagawmavyw1n1z0qarvs2jmbnbv0p89dah8g7klj8hnbf9hv";
+  };
+
+  meta = {
+    description = "Runtime for ANTLR";
+    homepage = "http://www.antlr.org/";
+    license = pkgs.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -539,6 +539,8 @@ in {
 
   amqplib = callPackage ../development/python-modules/amqplib {};
 
+  antlr4-python3-runtime = callPackage ../development/python-modules/antlr4-python3-runtime {};
+
   apipkg = callPackage ../development/python-modules/apipkg {};
 
   appdirs = callPackage ../development/python-modules/appdirs { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

