### PR TITLE
iwd: 2017-12-14 -> 0.1

### DIFF
--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -26,7 +26,7 @@ in {
       wants = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      serviceConfig.ExecStart = "${pkgs.iwd}/bin/iwd";
+      serviceConfig.ExecStart = "${pkgs.iwd}/libexec/iwd";
     };
   };
 

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -3,16 +3,17 @@
 let
   ell = fetchgit {
      url = https://git.kernel.org/pub/scm/libs/ell/ell.git;
-     rev = "8192131685be0f27d6f51b14b78ef93fa7f3c692";
-     sha256 = "1k74qz3w0l4zq8llrxc4p62xy0c0n33f260vy3d14wx5rhvf0544";
+     rev = "0.4";
+     sha256 = "0l203n1jnqa2mcifir8ydxhcvbiwlvk89ailm0lida83l9vdlwpv";
   };
 in stdenv.mkDerivation rec {
-  name = "iwd-unstable-2017-12-14";
+  name = "iwd-${version}";
+  version = "0.1";
 
   src = fetchgit {
     url = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
-    rev = "cf3372235c4592ca7366b27548abc4e89a982414";
-    sha256 = "0dg28j919w1v8sqr6jdj12c233rsjzd2jzkcpag1hx2h3g35hnlz";
+    rev = version;
+    sha256 = "1f8c6xvcvqw8z78mskynd2fkghggcl7vfz8vxzvpx0fkqcprn5n0";
   };
 
   nativeBuildInputs = [
@@ -24,7 +25,7 @@ in stdenv.mkDerivation rec {
     readline
     python3Packages.python
   ];
-  
+
   pythonPath = [
     python3Packages.dbus-python
     python3Packages.pygobject3
@@ -33,7 +34,8 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configureFlags = [
-    "--with-dbusconfdir=$(out)/etc/"
+    "--with-dbus-datadir=$(out)/etc/"
+    "--disable-systemd-service"
   ];
 
   postUnpack = ''


### PR DESCRIPTION
[wireless/iwd.git — build: Don't provide iwd/main.conf during make install](https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/?id=0cf589e13d10ef5a6b893b4e4a6f48e7dd169777)
[wireless/iwd.git — build: Add support for installing systemd service unit](https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/?id=c31244ddecb91144276dafb366d9dca350f97eba)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Mic92 