### PR TITLE
darwin-frameworks: cleanup

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -14,7 +14,6 @@ with frameworks; with libs; {
   AppKitScripting         = [];
   AppleScriptKit          = [];
   AppleScriptObjC         = [];
-  AppleShareClientCore    = [ CoreServices ];
   AudioToolbox            = [ AudioUnit CoreAudio CF CoreMIDI ];
   AudioUnit               = [ Carbon CoreAudio CF ];
   AudioVideoBridging      = [ Foundation ];
@@ -84,12 +83,10 @@ with frameworks; with libs; {
   PCSC                    = [ CoreData ];
   PreferencePanes         = [];
   PubSub                  = [];
-  Python                  = [ ApplicationServices ];
   QTKit                   = [ CoreMediaIO CoreMedia MediaToolbox QuickTime VideoToolbox ];
   QuickLook               = [ ApplicationServices CF ];
   QuickTime               = [ ApplicationServices AudioUnit Carbon CoreAudio CoreServices OpenGL QuartzCore ];
   Ruby                    = [];
-  RubyCocoa               = [];
   SceneKit                = [];
   ScreenSaver             = [];
   Scripting               = [];
@@ -105,11 +102,9 @@ with frameworks; with libs; {
   SystemConfiguration     = [ CF Security ];
   TWAIN                   = [ Carbon ];
   Tcl                     = [];
-  Tk                      = [ ApplicationServices Carbon X11 ];
   VideoDecodeAcceleration = [ CF CoreVideo ];
   VideoToolbox            = [ CF CoreMedia CoreVideo ];
   WebKit                  = [ ApplicationServices Carbon JavaScriptCore OpenGL ];
-  X11                     = []; # used by Tk, should this exist?
 
   # Umbrellas
   Accelerate          = [ CoreWLAN IOBluetooth ];


### PR DESCRIPTION
###### Motivation for this change

None of these build because they don't exist in the 10.10 sdk anymore.

```
installing
cp: cannot stat '/nix/store/aihgjdf0jbhnhnflyaxasmfhb03nlj8l-MacOS_SDK-10.10/Library/Frameworks/Python.framework/Versions/2.7/Headers': No such file or directory
builder for '/nix/store/x3yvwipqjb3v9qb614i60inzim2mj719-apple-framework-Python.drv' failed with exit code 1
```

/cc @copumpkin 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
