### PR TITLE
pythonPackages.sphinxcontrib-navtree: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/sphinx-navtree/default.nix
+++ b/pkgs/development/python-modules/sphinx-navtree/default.nix
@@ -1,0 +1,18 @@
+{ lib, fetchPypi, buildPythonPackage, sphinx }:
+
+buildPythonPackage rec {
+  version = "0.3.0";
+  pname = "sphinx-navtree";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nqcsbqwr8ihk1fv534i0naag1qw04f7ibcgl2j8csvkh8q90b4p";
+  };
+
+  propagatedBuildInputs = [ sphinx ];
+
+  meta = {
+    description = "Navigation tree customization for Sphinx";
+    homepage = "https://github.com/bintoro/sphinx-navtree";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16324,16 +16324,7 @@ in {
     };
   });
 
-  sphinxcontrib-navtree = buildPythonPackage rec {
-    version = "0.3.0";
-    name = "sphinxcontrib-navtree-${version}";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/sphinx-navtree-0.3.0.tar.gz";
-      sha256 = "1nqcsbqwr8ihk1fv534i0naag1qw04f7ibcgl2j8csvkh8q90b4p";
-    };
-
-    propagatedBuildInputs = with self; [sphinx];
-  };
+  sphinx-navtree = callPackage ../development/python-modules/sphinx-navtree {};
 
   sphinxcontrib_newsfeed = buildPythonPackage (rec {
     name = "sphinxcontrib-newsfeed-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16324,6 +16324,17 @@ in {
     };
   });
 
+  sphinxcontrib-navtree = buildPythonPackage rec {
+    version = "0.3.0";
+    name = "sphinxcontrib-navtree-${version}";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/s/sphinx-navtree-0.3.0.tar.gz";
+      sha256 = "1nqcsbqwr8ihk1fv534i0naag1qw04f7ibcgl2j8csvkh8q90b4p";
+    };
+
+    propagatedBuildInputs = with self; [sphinx];
+  };
+
   sphinxcontrib_newsfeed = buildPythonPackage (rec {
     name = "sphinxcontrib-newsfeed-${version}";
     version = "0.1.4";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

