### PR TITLE
pgmanage 10.1.1

### DIFF
--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0kzdq3xl6wyclngq307544yk57vpm10wyklkbgzx649z3pls3kyw";
   };
 
+  patchPhase = ''
+    patchShebangs src/configure
+  '';
+
   buildInputs = [ postgresql openssl ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -2,17 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "pgmanage-${version}";
-  version = "10.1.0";
+  version = "10.1.1";
 
   src = fetchFromGitHub {
     owner  = "pgManage";
     repo   = "pgManage";
     rev    = "v${version}";
-    sha256 = "0kzdq3xl6wyclngq307544yk57vpm10wyklkbgzx649z3pls3kyw";
+    sha256 = "1gv96an1ff9amh16lf71wknshmxl3l4hsl3ga7wb106c10i14zzc";
   };
 
   patchPhase = ''
     patchShebangs src/configure
+  '';
+
+  configurePhase = ''
+    ./configure --prefix $out
   '';
 
   buildInputs = [ postgresql openssl ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/pgManage/pgManage/releases/tag/v10.1.1

###### Things done

Running the test suite:

```
nix-build nixos/release.nix -A tests.pgmanage.x86_64-linux
```

currently fails on some unrelated [assertion failure in <nixpkgs/pkgs/build-support/closure-info.nix>](https://github.com/NixOS/nixpkgs/blob/0d0021588015105696eb4981da7a835ec6b2e45b/pkgs/build-support/closure-info.nix#L11). When building with nix-2.0 using:

```
nix-shell -p nixStable2 --run 'nix-build nixos/release.nix -A tests.pgmanage.x86_64-linux'
```

I get a different error on the closure-info derivation:

```
building path(s) ‘/nix/store/sya4c8xzhsqbkj8by79b0f4w3sgxqvxi-closure-info’
/nix/store/aj9rz4k3xvg8q9fzqfnb0q123707zp0n-builder: line 1: .attrs.sh: No such file or directory
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

