### PR TITLE
openldap: Fix test

### DIFF
--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -28,8 +28,8 @@ import ./make-test.nix {
   };
 
   testScript = ''
-    $machine->succeed('systemctl status openldap.service');
     $machine->waitForUnit('openldap.service');
+    $machine->succeed('systemctl status openldap.service');
     $machine->succeed('ldapsearch -LLL -D "cn=root,dc=example" -w notapassword -b "dc=example"');
   '';
 }


### PR DESCRIPTION
Fixing OpenLDAP test

The timings were just unfortunate, `systemctl status` returns 3, not 0, during service startup.