### PR TITLE
linbox: init at 1.5.2

### DIFF
--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -1,0 +1,79 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, givaro
+, pkgconfig
+, openblas
+, liblapack
+, fflas-ffpack
+, gmpxx
+, optimize ? false # impure
+, withSage ? false # sage support
+}:
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "linbox";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "linbox-team";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "1wfivlwp30mzdy1697w7rzb8caajim50mc8h27k82yipn2qc5n4i";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    givaro
+    (liblapack.override {shared = true;})
+    openblas
+    gmpxx
+    fflas-ffpack
+  ];
+
+  configureFlags = [
+    "--with-blas-libs=-lopenblas"
+    "--with-lapack-libs=-llapack"
+    "--disable-optimization"
+  ] ++ stdenv.lib.optionals (!optimize) [
+    # disable SIMD instructions (which are enabled *when available* by default)
+    "--disable-sse"
+    "--disable-sse2"
+    "--disable-sse3"
+    "--disable-ssse3"
+    "--disable-sse41"
+    "--disable-sse42"
+    "--disable-avx"
+    "--disable-avx2"
+    "--disable-fma"
+    "--disable-fma4"
+  ] ++ stdenv.lib.optionals withSage [
+    "--enable-sage"
+  ];
+
+  patches = stdenv.lib.optionals withSage [
+    # https://trac.sagemath.org/ticket/24214#comment:39
+    # Will be resolved by
+    # https://github.com/linbox-team/linbox/issues/69
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/sagemath/sage/a843f48b7a4267e44895a3dfa892c89c85b85611/build/pkgs/linbox/patches/linbox_charpoly_fullCRA.patch";
+      sha256 = "16nxfzfknra3k2yk3xy0k8cq9rmnmsch3dnkb03kx15h0y0jmibk";
+    })
+  ];
+
+  doCheck = true;
+
+  meta = {
+    inherit version;
+    description = "C++ library for exact, high-performance linear algebra";
+    license = stdenv.lib.licenses.lgpl21Plus;
+    maintainers = [stdenv.lib.maintainers.timokau];
+    platforms = stdenv.lib.platforms.linux;
+    homepage = http://linalg.org/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8666,6 +8666,7 @@ with pkgs;
 
   fflas-ffpack = callPackage ../development/libraries/fflas-ffpack {};
   fflas-ffpack_1 = callPackage ../development/libraries/fflas-ffpack/1.nix {};
+  linbox = callPackage ../development/libraries/linbox {};
 
   ffmpeg_0_10 = callPackage ../development/libraries/ffmpeg/0.10.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
###### Motivation for this change

packaging linbox

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

