### PR TITLE
givaro: 4.0.2 -> 4.0.4

### DIFF
--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -1,16 +1,34 @@
-{stdenv, fetchFromGitHub, automake, autoconf, libtool, autoreconfHook, gmpxx}:
+{ stdenv, fetchFromGitHub, automake, autoconf, libtool, autoreconfHook, gmpxx
+, optimize ? false # impure
+}:
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "givaro";
-  version = "4.0.2";
+  version = "4.0.4";
   src = fetchFromGitHub {
     owner = "linbox-team";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "04n1lyc823z3l1d7mnmqpc9z1pkn646szjchasbfkn74m7cb0qz7";
+    sha256 = "199p8wyj5i63jbnk7j8qbdbfp5rm2lpmcxyk3mdjy9bz7ygx3hhy";
   };
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [autoconf automake libtool gmpxx];
+  configureFlags = [
+    "--disable-optimization"
+  ] ++ stdenv.lib.optionals (!optimize) [
+    # disable SIMD instructions (which are enabled *when available* by default)
+    "--disable-sse"
+    "--disable-sse2"
+    "--disable-sse3"
+    "--disable-ssse3"
+    "--disable-sse41"
+    "--disable-sse42"
+    "--disable-avx"
+    "--disable-avx2"
+    "--disable-fma"
+    "--disable-fma4"
+  ];
+  doCheck = true;
   meta = {
     inherit version;
     description = ''A C++ library for arithmetic and algebraic computations'';


### PR DESCRIPTION
###### Motivation for this change

givaro was outdated.

This updates it, makes it more reproducible / less error-prone and enables checks. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

