### PR TITLE
squishyball: fix w/new ncurses

### DIFF
--- a/pkgs/applications/audio/squishyball/default.nix
+++ b/pkgs/applications/audio/squishyball/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flac libao libvorbis ncurses opusfile ];
 
+  NIX_CFLAGS_COMPILE = "-DNCURSES_INTERNALS";
+
   patches = [ ./gnu-screen.patch ];
 
   postInstall = ''


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/34477
https://bugs.debian.org/860334


Fixes build after ncurses update.

Backport to 18.03 please!
/cc ZHF #36453


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---