### PR TITLE
weston: fix typo in configure flag

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     "--enable-weston-launch"
     "--disable-setuid-install" # prevent install target to chown root weston-launch, which fails
   ] ++ stdenv.lib.optional (freerdp != null) "--enable-rdp-compositor"
-    ++ stdenv.lib.optional (vaapi != null) "--enabe-vaapi-recorder"
+    ++ stdenv.lib.optional (vaapi != null) "--enable-vaapi-recorder"
     ++ stdenv.lib.optionals (xwayland != null) [
         "--enable-xwayland"
         "--with-xserver-path=${xwayland.out}/bin/Xwayland"


### PR DESCRIPTION
###### Motivation for this change
Happened to search for "enabe" in nixpkgs and promptly found this typo in a configure flag. I haven't tested anything, [probably](https://xkcd.com/1172/) won't break anything though. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

