### PR TITLE
bareos: 15.2.4 -> 17.2.5

### DIFF
--- a/pkgs/tools/backup/bareos/default.nix
+++ b/pkgs/tools/backup/bareos/default.nix
@@ -12,14 +12,14 @@ let
 in
 stdenv.mkDerivation rec {
   name = "bareos-${version}";
-  version = "15.2.4";
+  version = "17.2.5";
 
   src = fetchFromGitHub {
     owner = "bareos";
     repo = "bareos";
     rev = "Release/${version}";
     name = "${name}-src";
-    sha256 = "02k6wmr2n12dc6vwda8xczmbqidg6fs8nfg9n2cwwpm3k1a21qnd";
+    sha256 = "1mgh25lhd05m26sq1sj5ir2b4n7560x93ib25cvf9vmmypm1c7pn";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bpluginfo -h` got 0 exit code
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bpluginfo --help` got 0 exit code
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bpluginfo -V` and found version 17.2.5
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bpluginfo --version` and found version 17.2.5
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bpluginfo -h` and found version 17.2.5
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bpluginfo --help` and found version 17.2.5
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bscrypto -h` got 0 exit code
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bscrypto --help` got 0 exit code
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bscrypto help` got 0 exit code
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bscrypto -V` and found version 17.2.5
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bscrypto --version` and found version 17.2.5
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bscrypto -h` and found version 17.2.5
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/bscrypto --help` and found version 17.2.5
- ran `/nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5/bin/testls help` got 0 exit code
- found 17.2.5 with grep in /nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5
- found 17.2.5 in filename of file in /nix/store/ayjbl5v8ng7fdzcjv93c7n5lax2q03hm-bareos-17.2.5

cc @wkennington