### PR TITLE
baresip: 0.5.6 -> 0.5.8

### DIFF
--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -4,11 +4,11 @@
 , gsm, speex, portaudio, spandsp, libuuid, ccache, libvpx
 }:
 stdenv.mkDerivation rec {
-  version = "0.5.6";
+  version = "0.5.8";
   name = "baresip-${version}";
   src=fetchurl {
     url = "http://www.creytiv.com/pub/baresip-${version}.tar.gz";
-    sha256 = "036hvl652zndqj3kmkv8z9pv7r4d1jxq8b7rg8jf0hh82vpyz38l";
+    sha256 = "0qk6y83mm7cz4j66d7zy72l7890k7ifqnqbqnjd3bjfn1yjivwfr";
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [zlib openssl libre librem


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.5.8 with grep in /nix/store/v1xv4aj5wq1mw5mdml2hwh4qd5bfdcim-baresip-0.5.8
- found 0.5.8 in filename of file in /nix/store/v1xv4aj5wq1mw5mdml2hwh4qd5bfdcim-baresip-0.5.8

cc @7c6f434c