### PR TITLE
bftpd: 4.4 -> 4.8

### DIFF
--- a/pkgs/servers/ftp/bftpd/default.nix
+++ b/pkgs/servers/ftp/bftpd/default.nix
@@ -2,11 +2,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "bftpd";
-  version = "4.4";
+  version = "4.8";
   # or fetchFromGitHub(owner,repo,rev) or fetchgit(rev)
   src = fetchurl {
     url = "mirror://sourceforge/project/${pname}/${pname}/${name}/${name}.tar.gz";
-    sha256 = "0hgpqwv7mj1yln8ps9bbcjhl5hvs02nxjfkk9nhkr6fysfyyn1dq";
+    sha256 = "1zlsajj6wjd9wcijzngmafhy2gr3sm5rphsr5n44rlmx1jdkk00c";
   };
   buildInputs = [];
   preConfigure = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/jl7d3l14s4p2f7r9mm9pij1ifpszkziv-bftpd-4.8/bin/bftpd -h` got 0 exit code
- ran `/nix/store/jl7d3l14s4p2f7r9mm9pij1ifpszkziv-bftpd-4.8/bin/bftpd --help` got 0 exit code
- ran `/nix/store/jl7d3l14s4p2f7r9mm9pij1ifpszkziv-bftpd-4.8/bin/bftpd -v` and found version 4.8
- ran `/nix/store/jl7d3l14s4p2f7r9mm9pij1ifpszkziv-bftpd-4.8/bin/bftpd --version` and found version 4.8
- ran `/nix/store/jl7d3l14s4p2f7r9mm9pij1ifpszkziv-bftpd-4.8/bin/bftpd -h` and found version 4.8
- ran `/nix/store/jl7d3l14s4p2f7r9mm9pij1ifpszkziv-bftpd-4.8/bin/bftpd --help` and found version 4.8
- found 4.8 with grep in /nix/store/jl7d3l14s4p2f7r9mm9pij1ifpszkziv-bftpd-4.8
- found 4.8 in filename of file in /nix/store/jl7d3l14s4p2f7r9mm9pij1ifpszkziv-bftpd-4.8

cc @7c6f434c