### PR TITLE
bibutils: 5.6 -> 6.2

### DIFF
--- a/pkgs/tools/misc/bibutils/default.nix
+++ b/pkgs/tools/misc/bibutils/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "bibutils-${version}";
-  version = "5.6";
+  version = "6.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/bibutils/bibutils_${version}_src.tgz";
-    sha256 = "08vlaf1rs881v61hb0dnab5brbpbwbv2hqlxmw0yaycknqwbmiwz";
+    sha256 = "07wgzk01kfdrjl6g3qlxg9qbi3kyrxxmxyy49qmcfq24fpmf9mrr";
   };
 
   configureFlags = [ "--dynamic" "--install-dir" "$(out)/bin" "--install-lib" "$(out)/lib" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/bib2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/bib2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/bib2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/bib2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/bib2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/bib2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/biblatex2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/biblatex2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/biblatex2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/biblatex2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/biblatex2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/biblatex2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/copac2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/copac2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/copac2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/copac2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/copac2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/copac2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/end2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/end2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/end2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/end2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/end2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/end2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/endx2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/endx2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/endx2xml help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/endx2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/endx2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/endx2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/endx2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/isi2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/isi2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/isi2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/isi2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/isi2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/isi2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/med2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/med2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/med2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/med2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/med2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/med2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/nbib2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/nbib2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/nbib2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/nbib2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/nbib2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/nbib2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ris2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ris2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ris2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ris2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ris2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ris2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ebi2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ebi2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ebi2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ebi2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ebi2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/ebi2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/wordbib2xml -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/wordbib2xml --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/wordbib2xml -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/wordbib2xml --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/wordbib2xml -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/wordbib2xml --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ads -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ads --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ads -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ads --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ads -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ads --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2bib -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2bib --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2bib -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2bib --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2bib -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2bib --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2end -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2end --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2end -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2end --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2end -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2end --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2isi -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2isi --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2isi -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2isi --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2isi -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2isi --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ris -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ris --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ris -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ris --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ris -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2ris --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2wordbib -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2wordbib --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2wordbib -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2wordbib --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2wordbib -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/xml2wordbib --help` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/modsclean -h` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/modsclean --help` got 0 exit code
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/modsclean -v` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/modsclean --version` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/modsclean -h` and found version 6.2
- ran `/nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2/bin/modsclean --help` and found version 6.2
- found 6.2 with grep in /nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2
- found 6.2 in filename of file in /nix/store/9ara0dz7v6alr1rxwqi3ikxd45xzsk8s-bibutils-6.2

cc @garrison