### PR TITLE
bleachbit: 1.12 -> 2.0

### DIFF
--- a/pkgs/applications/misc/bleachbit/default.nix
+++ b/pkgs/applications/misc/bleachbit/default.nix
@@ -1,13 +1,13 @@
 { stdenv, pythonPackages, fetchurl }:
 pythonPackages.buildPythonApplication rec {
   name = "bleachbit-${version}";
-  version = "1.12";
+  version = "2.0";
 
   namePrefix = "";
 
   src = fetchurl {
     url = "mirror://sourceforge/bleachbit/${name}.tar.bz2";
-    sha256 = "1x58n429q1c77nfpf2g3vyh6yq8wha69zfzmxf1rvjvcvvmqs62m";
+    sha256 = "0ps98zx4n13q92bq7ykqi6hj3i7brdqgm87i9gk6ibvljp1vxdz9";
   };
 
   buildInputs = [  pythonPackages.wrapPython ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/.bleachbit-wrapped -h` got 0 exit code
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/.bleachbit-wrapped --help` got 0 exit code
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/.bleachbit-wrapped help` got 0 exit code
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/.bleachbit-wrapped -v` and found version 2.0
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/.bleachbit-wrapped --version` and found version 2.0
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/bleachbit -h` got 0 exit code
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/bleachbit --help` got 0 exit code
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/bleachbit help` got 0 exit code
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/bleachbit -v` and found version 2.0
- ran `/nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0/bin/bleachbit --version` and found version 2.0
- found 2.0 with grep in /nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0
- found 2.0 in filename of file in /nix/store/3wdy7impkb43r97w6hqqmcrncqkh05j1-bleachbit-2.0

cc @leonardoce