### PR TITLE
byobu: 5.121 -> 5.124

### DIFF
--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ncurses, python, perl, textual-window-manager }:
 
 stdenv.mkDerivation rec {
-  version = "5.121";
+  version = "5.124";
   name = "byobu-" + version;
 
   src = fetchurl {
     url = "https://launchpad.net/byobu/trunk/${version}/+download/byobu_${version}.orig.tar.gz";
-    sha256 = "0rbwb7kh0f458ad51grrhz56889g6xj1c29c838pi37cjdgl3wjx";
+    sha256 = "08pipvh2iwy5d4b1bnrh0vwlmm884cqzgsz6jx3ar4shp63i5jjf";
   };
 
   doCheck = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu -v` and found version 5.124
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu --version` and found version 5.124
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ctrl-a -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ctrl-a --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-disable -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-disable --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-disable help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-disable-prompt -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-disable-prompt --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-disable-prompt help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-enable -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-enable --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-enable help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-janitor -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-janitor --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-janitor help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-keybindings -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-keybindings --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-keybindings help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launch -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launch --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launch help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher -v` and found version 5.124
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher --version` and found version 5.124
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher-install -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher-install --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher-install help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher-uninstall -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher-uninstall --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-launcher-uninstall help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-select-profile -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-status -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-status --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-status help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-status-detail -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-status-detail --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-status-detail help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ugraph -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ugraph --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ugraph version` and found version 5.124
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ugraph -h` and found version 5.124
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ugraph --help` and found version 5.124
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ulevel -h` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ulevel --help` got 0 exit code
- ran `/nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124/bin/byobu-ulevel --help` and found version 5.124
- found 5.124 with grep in /nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124
- found 5.124 in filename of file in /nix/store/5vgygd2nxww9higxqnqy2cpjkpvi3jck-byobu-5.124

cc @qknight