### PR TITLE
cadvisor: 0.28.3 -> 0.29.1

### DIFF
--- a/pkgs/servers/monitoring/cadvisor/default.nix
+++ b/pkgs/servers/monitoring/cadvisor/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cadvisor-${version}";
-  version = "0.28.3";
+  version = "0.29.1";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "cadvisor";
     rev = "v${version}";
-    sha256 = "1rdw09cbhs4il63lv1f92dw8pav9rjnkbrqx37lqij8x6xmv01gy";
+    sha256 = "132mpcp35cymm2zqig0yrvhnvgn72k7cmn6gla0v7r0yxfl879m3";
   };
 
   nativeBuildInputs = [ go ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.29.1 with grep in /nix/store/8zpvaz7imhsknld6d0qyykqw9b718lxi-cadvisor-0.29.1
- found 0.29.1 in filename of file in /nix/store/8zpvaz7imhsknld6d0qyykqw9b718lxi-cadvisor-0.29.1

cc @offlinehacker