### PR TITLE
calc: 2.12.6.3 -> 2.12.6.6

### DIFF
--- a/pkgs/applications/science/math/calc/default.nix
+++ b/pkgs/applications/science/math/calc/default.nix
@@ -12,11 +12,11 @@ in
 stdenv.mkDerivation rec {
 
   name = "calc-${version}";
-  version = "2.12.6.3";
+  version = "2.12.6.6";
 
   src = fetchurl {
     url = "https://github.com/lcn2/calc/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "01m20s5zs74zyb23x6zg6i13gc30a2ay2iz1rdbkxram01cblzky";
+    sha256 = "03sg1xhin6qsrz82scf96mmzw8lz1yj68rhj4p4npp4s0fawc9d5";
   };
 
   buildInputs = [ makeWrapper readline ncurses utillinux ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere -V` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere -v` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere --version` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere version` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere -h` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere --help` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/4dsphere help` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/fproduct -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/fproduct --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/fproduct help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/mersenne -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/mersenne --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/mersenne help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/piforever -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/piforever -v` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/plus -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/plus --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/plus help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/plus -v` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/plus --version` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/plus version` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/plus --help` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/plus help` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/powerterm -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/powerterm --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/powerterm help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/simple -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/simple --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/simple help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/simple -v` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/square -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/square --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/square help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/cscript/square -v` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/calc -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/calc --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/calc help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/calc -v` and found version 2.12.6.6
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/.calc-wrapped -h` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/.calc-wrapped --help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/.calc-wrapped help` got 0 exit code
- ran `/nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6/bin/.calc-wrapped -v` and found version 2.12.6.6
- found 2.12.6.6 with grep in /nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6
- found 2.12.6.6 in filename of file in /nix/store/mdjaq6pgxp9qrfg9s7iaavj2rsvjqh9q-calc-2.12.6.6

cc