### PR TITLE
bwidget: 1.9.10 -> 1.9.12

### DIFF
--- a/pkgs/development/libraries/bwidget/default.nix
+++ b/pkgs/development/libraries/bwidget/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "bwidget-${version}";
-  version = "1.9.10";
+  version = "1.9.12";
 
   src = fetchurl {
     url = "mirror://sourceforge/tcllib/bwidget-${version}.tar.gz";
-    sha256 = "025lmriaq4qqy99lh826wx2cnqqgxn7srz4m3q06bl6r9ch15hr6";
+    sha256 = "0qrj8k4zzrnhwgdn5dpa6j0q5j739myhwn60ssnqrzq77sljss1g";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.9.12 with grep in /nix/store/5rrcmy0g4sj5q2yhxxyczgddnjhgjfxm-bwidget-1.9.12
- found 1.9.12 in filename of file in /nix/store/5rrcmy0g4sj5q2yhxxyczgddnjhgjfxm-bwidget-1.9.12
