### PR TITLE
bundler: 1.14.6 -> 1.16.1

### DIFF
--- a/pkgs/development/ruby-modules/bundler/default.nix
+++ b/pkgs/development/ruby-modules/bundler/default.nix
@@ -4,8 +4,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "bundler";
-  version = "1.14.6";
-  source.sha256 = "0h3x2csvlz99v2ryj1w72vn6kixf7rl35lhdryvh7s49brnj0cgl";
+  version = "1.16.1";
+  source.sha256 = "1s2nq4qnffxg3kwrk7cnwxcvfihlhxm9absl2l6d3qckf3sy1f22";
   dontPatchShebangs = true;
 
   postFixup = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/fbbvzgri8gmzq1s5q68f6xh87771rhf4-bundler-1.16.1/bin/bundle -h` got 0 exit code
- ran `/nix/store/fbbvzgri8gmzq1s5q68f6xh87771rhf4-bundler-1.16.1/bin/bundle --help` got 0 exit code
- ran `/nix/store/fbbvzgri8gmzq1s5q68f6xh87771rhf4-bundler-1.16.1/bin/bundle help` got 0 exit code
- ran `/nix/store/fbbvzgri8gmzq1s5q68f6xh87771rhf4-bundler-1.16.1/bin/bundle -v` and found version 1.16.1
- ran `/nix/store/fbbvzgri8gmzq1s5q68f6xh87771rhf4-bundler-1.16.1/bin/bundle --version` and found version 1.16.1
- ran `/nix/store/fbbvzgri8gmzq1s5q68f6xh87771rhf4-bundler-1.16.1/bin/bundle version` and found version 1.16.1
- found 1.16.1 with grep in /nix/store/fbbvzgri8gmzq1s5q68f6xh87771rhf4-bundler-1.16.1
- found 1.16.1 in filename of file in /nix/store/fbbvzgri8gmzq1s5q68f6xh87771rhf4-bundler-1.16.1