### PR TITLE
c-ares: 1.13.0 -> 1.14.0

### DIFF
--- a/pkgs/development/libraries/c-ares/default.nix
+++ b/pkgs/development/libraries/c-ares/default.nix
@@ -2,11 +2,11 @@
 
 let self =
 stdenv.mkDerivation rec {
-  name = "c-ares-1.13.0";
+  name = "c-ares-1.14.0";
 
   src = fetchurl {
     url = "http://c-ares.haxx.se/download/${name}.tar.gz";
-    sha256 = "19qxhv9aiw903fr808y77r6l9js0fq9m3gcaqckan9jan7qhixq3";
+    sha256 = "0vnwmbvymw677k780kpb6sb8i3szdp89rzy8mz1fwg1657yw3ls5";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.14.0 with grep in /nix/store/0azgccv236s0l92yfyxx7rbh8nci8g2z-c-ares-1.14.0
- found 1.14.0 in filename of file in /nix/store/0azgccv236s0l92yfyxx7rbh8nci8g2z-c-ares-1.14.0