### PR TITLE
cairo: 1.14.10 -> 1.14.12

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -12,11 +12,11 @@ assert glSupport -> mesa_noglu != null;
 let inherit (stdenv.lib) optional optionals; in
 
 stdenv.mkDerivation rec {
-  name = "cairo-1.14.10";
+  name = "cairo-1.14.12";
 
   src = fetchurl {
     url = "http://cairographics.org/releases/${name}.tar.xz";
-    sha256 = "02banr0wxckq62nbhc3mqidfdh2q956i2r7w2hd9bjgjb238g1vy";
+    sha256 = "05mzyxkvsfc1annjw2dja8vka01ampp9pp93lg09j8hba06g144c";
   };
 
   patches = [


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.14.12 with grep in /nix/store/bcgqq41zr4h4yp3ypasz5yj2ng92l1xq-cairo-1.14.12
- found 1.14.12 in filename of file in /nix/store/bcgqq41zr4h4yp3ypasz5yj2ng92l1xq-cairo-1.14.12