### PR TITLE
libetpan: 1.6 -> 1.8

### DIFF
--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -1,6 +1,6 @@
 { autoconf, automake, fetchgit, libtool, stdenv, openssl }:
 
-let version = "1.6"; in
+let version = "1.8"; in
 
 stdenv.mkDerivation {
   name = "libetpan-${version}";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   src = fetchgit {
     url = "git://github.com/dinhviethoa/libetpan";
     rev = "refs/tags/" + version;
-    sha256 = "13hv49271rr9yj7ifxqqmc0jfy1f26llivhp22s5wigick7qjxky";
+    sha256 = "09xqy1n18qn63x7idfrpwm59lfkvb1p5vxkyksywvy4f6mn4pyxk";
   };
 
   buildInputs = [ autoconf automake libtool openssl ];

--- a/pkgs/development/libraries/mailcore2/default.nix
+++ b/pkgs/development/libraries/mailcore2/default.nix
@@ -5,13 +5,13 @@
 stdenv.mkDerivation rec {
   name = "mailcore2-${version}";
 
-  version = "0.5.1";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner  = "MailCore";
     repo   = "mailcore2";
     rev    = version;
-    sha256 = "1k0l59cdk8np4pff1my07dp7ivf3nchlhcpvm9xizp0my9rqgbxb";
+    sha256 = "1d0wmnkk9vnjqc28i79z3fwaaycdbprfspagik4mzdkgval5r5pm";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Version bump as package I'm building needs functions from the current version. and updated mailcore2 as it was needed to work with the more modern libetpan 
libetpan: 1.6-> 1.8
mailcore2: 0.5.1 -> 0.6.2
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

