### PR TITLE
Remove some of the majorVersion pattern

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -8,10 +8,8 @@
 }:
 
 stdenv.mkDerivation rec{
-  majorVersion="2.18";
-  minorVersion="2";
-  version="${majorVersion}.${minorVersion}";
   name = "lilypond-${version}";
+  version="2.18.2";
 
   urwfonts = fetchsvn {
     url = "http://svn.ghostscript.com/ghostscript/tags/urw-fonts-1.0.7pre44";
@@ -19,7 +17,7 @@ stdenv.mkDerivation rec{
   };
 
   src = fetchurl {
-    url = "http://download.linuxaudio.org/lilypond/sources/v${majorVersion}/lilypond-${version}.tar.gz";
+    url = "http://download.linuxaudio.org/lilypond/sources/v${stdenv.lib.versions.major version}/lilypond-${version}.tar.gz";
     sha256 = "01xs9x2wjj7w9appaaqdhk15r1xvvdbz9qwahzhppfmhclvp779j";
   };
 

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -2,16 +2,13 @@
 , ncurses ? null, perl ? null, pam, systemd, minimal ? false }:
 
 let
-  version = lib.concatStringsSep "." ([ majorVersion ]
-    ++ lib.optional (patchVersion != "") patchVersion);
-  majorVersion = "2.31";
-  patchVersion = "1";
+  version = "2.31.1";
 
 in stdenv.mkDerivation rec {
   name = "util-linux-${version}";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/utils/util-linux/v${majorVersion}/${name}.tar.xz";
+    url = "mirror://kernel/linux/utils/util-linux/v${stdenv.lib.versions.major version}/${name}.tar.xz";
     sha256 = "04fzrnrr3pvqskvjn9f81y0knh0jvvqx4lmbz5pd4lfdm5pv2l8s";
   };
 

--- a/pkgs/servers/mail/pypolicyd-spf/default.nix
+++ b/pkgs/servers/mail/pypolicyd-spf/default.nix
@@ -2,11 +2,10 @@
 
 buildPythonApplication rec {
   name = "pypolicyd-spf-${version}";
-  majorVersion = "2.0";
-  version = "${majorVersion}.2";
+  version = "2.0.2";
 
   src = fetchurl {
-    url = "https://launchpad.net/pypolicyd-spf/${majorVersion}/${version}/+download/${name}.tar.gz";
+    url = "https://launchpad.net/pypolicyd-spf/${lib.versions.major version}/${version}/+download/${name}.tar.gz";
     sha256 = "1nm8y1jjgx6mxrbcxrbdnmkf8vglwp0wiw6jipzh641wb24gi76z";
   };
 

--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -4,18 +4,17 @@
 with stdenv.lib;
 
 let
-  majorVersion = "2.2";
-  minorVersion = ".0";
+  version = "2.2";
 
   binPath = makeBinPath [ coreutils gnugrep gnused lm_sensors net_snmp ];
 
 in stdenv.mkDerivation rec {
-  name = "monitoring-plugins-${majorVersion}${minorVersion}";
+  name = "monitoring-plugins-${version}";
 
   src = fetchFromGitHub {
     owner  = "monitoring-plugins";
     repo   = "monitoring-plugins";
-    rev    = "v${majorVersion}";
+    rev    = "v${version}";
     sha256 = "1pw7i6d2cnb5nxi2lbkwps2qzz04j9zd86fzpv9ka896b4aqrwv1";
   };
 

--- a/pkgs/tools/networking/gupnp-tools/default.nix
+++ b/pkgs/tools/networking/gupnp-tools/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "gupnp-tools-${version}";
-  majorVersion = "0.8";
-  version = "${majorVersion}.13";
+  version = "0.8.13";
+
   src = fetchurl {
-    url = "mirror://gnome/sources/gupnp-tools/${majorVersion}/gupnp-tools-${version}.tar.xz";
+    url = "mirror://gnome/sources/gupnp-tools/${stdenv.lib.versions.major version}/gupnp-tools-${version}.tar.xz";
     sha256 = "1vbr4iqi7nl7kq982agd3liw10gx67s95idd0pjy5h1jsnwyqgda";
   };
 


### PR DESCRIPTION
I'm trying to remove the majorVersion pattern from the repository, because it makes it harder to automatically update packages. These commits work toward that.

All these packages built for me on NixOS after the changes. Only `monitoring-plugins` actually changes, because it had the slightly wrong version.