### PR TITLE
calibre: 3.17.0 -> 3.18.0

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.17.0";
+  version = "3.18.0";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "1w6hw1s0d4daa4q2ykzhxdndiq61l8z7ls7rxh7k7p62ia0i5sxp";
+    sha256 = "0j9vq9gj7b1ka2ijljq16y1f2dynxir11m8sl97ck1xa5q3gbgp0";
   };
 
   patches = [


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-customize-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-customize-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-customize-wrapped_ help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-customize -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-customize --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-customize help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-debug-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-debug-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-debug -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-debug --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-server-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-server-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-server -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-server --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-smtp-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-smtp-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-smtp -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/calibre-smtp --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-convert-wrapped_ --version` and found version 3.18.0
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/ebook-convert --version` and found version 3.18.0
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-device-wrapped_ --version` and found version 3.18.0
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/ebook-device --version` and found version 3.18.0
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-meta-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-meta-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/ebook-meta -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/ebook-meta --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-polish-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-polish-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/ebook-polish -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/ebook-polish --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-viewer-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-viewer-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/ebook-viewer -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/ebook-viewer --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.fetch-ebook-metadata-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.fetch-ebook-metadata-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/fetch-ebook-metadata -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/fetch-ebook-metadata --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.lrf2lrs-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.lrf2lrs-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/lrf2lrs -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/lrf2lrs --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.lrfviewer-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.lrfviewer-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.lrfviewer-wrapped_ help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/lrfviewer -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/lrfviewer --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/lrfviewer help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.lrs2lrf-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.lrs2lrf-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/lrs2lrf -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/lrs2lrf --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.markdown-calibre-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.markdown-calibre-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/markdown-calibre -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/markdown-calibre --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.web2disk-wrapped_ -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.web2disk-wrapped_ --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.web2disk-wrapped_ help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/web2disk -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/web2disk --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/web2disk help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..calibre-customize-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..calibre-customize-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..calibre-customize-wrapped-wrapped help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-customize-wrapped -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-customize-wrapped --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-customize-wrapped help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..calibre-debug-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..calibre-debug-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-debug-wrapped -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-debug-wrapped --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..calibre-smtp-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..calibre-smtp-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-smtp-wrapped -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.calibre-smtp-wrapped --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..ebook-convert-wrapped-wrapped --version` and found version 3.18.0
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-convert-wrapped --version` and found version 3.18.0
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..ebook-device-wrapped-wrapped --version` and found version 3.18.0
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.ebook-device-wrapped --version` and found version 3.18.0
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..markdown-calibre-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/..markdown-calibre-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.markdown-calibre-wrapped -h` got 0 exit code
- ran `/nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0/bin/.markdown-calibre-wrapped --help` got 0 exit code
- found 3.18.0 with grep in /nix/store/zxxysqww8ws8d0d0zfcn8i1saaxb2var-calibre-3.18.0

cc @viric @domenkozar @pSub @AndersonTorres