### PR TITLE
cdrtools: 3.02a06 -> 3.01

### DIFF
--- a/pkgs/applications/misc/cdrtools/default.nix
+++ b/pkgs/applications/misc/cdrtools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cdrtools-${version}";
-  version = "3.02a06";
+  version = "3.01";
 
   src = fetchurl {
     url = "mirror://sourceforge/cdrtools/${name}.tar.bz2";
-    sha256 = "1cayhfbhj5g2vgmkmq5scr23k0ka5fsn0dhn0n9yllj386csnygd";
+    sha256 = "03w6ypsmwwy4d7vh6zgwpc60v541vc5ywp8bdb758hbc4yv2wa7d";
   };
 
   patches = [ ./fix-paths.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/btcflash -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/btcflash --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/cdda2wav --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/cdrecord --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/cdrecord --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/mkisofs --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/mkisofs help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/mkisofs --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/mkisofs version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/mkisofs help` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/devdump -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/devdump --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/devdump --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isodump -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isodump --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isodump --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isoinfo -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isoinfo --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isoinfo --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isovfy -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isovfy --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isovfy --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isodebug -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isodebug --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/isodebug --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/readcd -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/readcd --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/readcd --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/scgcheck -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/scgcheck --help` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/scgcheck --version` and found version 3.01
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/scgskeleton -h` got 0 exit code
- ran `/nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01/bin/scgskeleton --help` got 0 exit code
- found 3.01 with grep in /nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01
- found 3.01 in filename of file in /nix/store/d7l7g8h8jdpknng4jxrn712fyp3f7dnr-cdrtools-3.01