### PR TITLE
checkstyle: 6.19 -> 8.8

### DIFF
--- a/pkgs/development/tools/analysis/checkstyle/default.nix
+++ b/pkgs/development/tools/analysis/checkstyle/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "6.19";
+  version = "8.8";
   name = "checkstyle-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/checkstyle/${name}-bin.tar.gz";
-    sha256 = "0x899i5yamwyhv7wgii80fv5hl8bdq0b8wlx1f789l85ik8rjwk9";
+    sha256 = "0yawd6mbz6cqj0qlrh01vy33p30f4s3pfrvsxwg5l11p416zzrz4";
   };
 
   installPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 8.8 with grep in /nix/store/09g6vrj90r6lbwj2hwb319sgd3ppp14k-checkstyle-8.8
- found 8.8 in filename of file in /nix/store/09g6vrj90r6lbwj2hwb319sgd3ppp14k-checkstyle-8.8

cc @pSub