### PR TITLE
cherrytree: 0.37.6 -> 0.38.4

### DIFF
--- a/pkgs/applications/misc/cherrytree/default.nix
+++ b/pkgs/applications/misc/cherrytree/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "cherrytree-${version}";
-  version = "0.37.6";
+  version = "0.38.4";
 
   src = fetchurl {
     url = "http://www.giuspen.com/software/${name}.tar.xz";
-    sha256 = "0x4cgsimpwh7wfbzbzw2f5ipxxjizpi4wa99s1cwizynfjr38y5s";
+    sha256 = "1zazyxkrli77wahn4c1z24qyz5bwlayl335f2kdxb44dicrx58g2";
   };
 
   buildInputs = with pythonPackages;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/z6xvmmp8nc09wcg5wmgdlvg0vmawm2vn-cherrytree-0.38.4/bin/.cherrytree-wrapped -h` got 0 exit code
- ran `/nix/store/z6xvmmp8nc09wcg5wmgdlvg0vmawm2vn-cherrytree-0.38.4/bin/.cherrytree-wrapped --help` got 0 exit code
- ran `/nix/store/z6xvmmp8nc09wcg5wmgdlvg0vmawm2vn-cherrytree-0.38.4/bin/cherrytree -h` got 0 exit code
- ran `/nix/store/z6xvmmp8nc09wcg5wmgdlvg0vmawm2vn-cherrytree-0.38.4/bin/cherrytree --help` got 0 exit code
- found 0.38.4 with grep in /nix/store/z6xvmmp8nc09wcg5wmgdlvg0vmawm2vn-cherrytree-0.38.4
- found 0.38.4 in filename of file in /nix/store/z6xvmmp8nc09wcg5wmgdlvg0vmawm2vn-cherrytree-0.38.4

cc @AndersonTorres