### PR TITLE
chessx: 1.4.0 -> 1.4.6

### DIFF
--- a/pkgs/games/chessx/default.nix
+++ b/pkgs/games/chessx/default.nix
@@ -1,10 +1,10 @@
 { stdenv, pkgconfig, zlib, qtbase, qtsvg, qttools, qtmultimedia, qmake, fetchurl }:
 stdenv.mkDerivation rec {
   name = "chessx-${version}";
-  version = "1.4.0";
+  version = "1.4.6";
   src = fetchurl {
     url = "mirror://sourceforge/chessx/chessx-${version}.tgz";
-    sha256 = "1x10c9idj2qks8xk9dy7aw3alc5w7z1kvv6dnahs0428j0sp4a74";
+    sha256 = "1vb838byzmnyglm9mq3khh3kddb9g4g111cybxjzalxxlc81k5dd";
   };
   buildInputs = [
    qtbase


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.4.6 with grep in /nix/store/9cv1znh739dblr4avnhnp463v77yq9by-chessx-1.4.6
- found 1.4.6 in filename of file in /nix/store/9cv1znh739dblr4avnhnp463v77yq9by-chessx-1.4.6

cc @luispedro