### PR TITLE
chromedriver: 2.35 -> 2.36

### DIFF
--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -6,7 +6,7 @@ let
   allSpecs = {
     "x86_64-linux" = {
       system = "linux64";
-      sha256 = "13iyz6579yw4fk9dr4nf2pdj55v1iflj8yf9a4zz7qw5996d5yk7";
+      sha256 = "1m119kbsr6gm8a37q92rflp5mp3fjzw8cy4r5j4bnihkai7khq94";
     };
 
     "x86_64-darwin" = {
@@ -28,7 +28,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "chromedriver-${version}";
-  version = "2.35";
+  version = "2.36";
 
   src = fetchurl {
     url = "http://chromedriver.storage.googleapis.com/${version}/chromedriver_${spec.system}.zip";


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/in6njcawrv5bjk2j6p5bwdj0qrygsrk7-chromedriver-2.36/bin/chromedriver -h` got 0 exit code
- ran `/nix/store/in6njcawrv5bjk2j6p5bwdj0qrygsrk7-chromedriver-2.36/bin/chromedriver --help` got 0 exit code
- ran `/nix/store/in6njcawrv5bjk2j6p5bwdj0qrygsrk7-chromedriver-2.36/bin/chromedriver -v` and found version 2.36
- ran `/nix/store/in6njcawrv5bjk2j6p5bwdj0qrygsrk7-chromedriver-2.36/bin/chromedriver --version` and found version 2.36
- ran `/nix/store/in6njcawrv5bjk2j6p5bwdj0qrygsrk7-chromedriver-2.36/bin/chromedriver -h` and found version 2.36
- ran `/nix/store/in6njcawrv5bjk2j6p5bwdj0qrygsrk7-chromedriver-2.36/bin/chromedriver --help` and found version 2.36
- found 2.36 with grep in /nix/store/in6njcawrv5bjk2j6p5bwdj0qrygsrk7-chromedriver-2.36
- found 2.36 in filename of file in /nix/store/in6njcawrv5bjk2j6p5bwdj0qrygsrk7-chromedriver-2.36

cc @cillianderoiste