### PR TITLE
cminpack: 1.3.4 -> 1.3.6

### DIFF
--- a/pkgs/development/libraries/cminpack/default.nix
+++ b/pkgs/development/libraries/cminpack/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "cminpack-1.3.4";
+  name = "cminpack-1.3.6";
   
   src = fetchurl {
     url = "http://devernay.free.fr/hacks/cminpack/${name}.tar.gz";
-    sha256 = "1jh3ymxfcy3ykh6gnvds5bbkf38aminvjgc8halck356vkvpnl9v";
+    sha256 = "17yh695aim508x1kn9zf6g13jxwk3pi3404h5ix4g5lc60hzs1rw";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.3.6 in filename of file in /nix/store/ch2n83jgh0mv5h7992gm4lf9lmxp59lp-cminpack-1.3.6