### PR TITLE
cmst: 2017.09.19 -> 2018.01.06

### DIFF
--- a/pkgs/tools/networking/cmst/default.nix
+++ b/pkgs/tools/networking/cmst/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cmst-${version}";
-  version = "2017.09.19";
+  version = "2018.01.06";
 
   src = fetchFromGitHub {
     repo = "cmst";
     owner = "andrew-bibb";
     rev = name;
-    sha256 = "14inss0mr9i4q6vfqqfxbjgpjaclp1kh60qlm5xv4cwnvi395rc7";
+    sha256 = "1a3v7z75ghziymdj2w8603ql9nfac5q224ylfsqfxcqxw4bdip4r";
   };
 
   nativeBuildInputs = [ qmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2018.01.06 with grep in /nix/store/va2g67lavq3xhp2154dlgz95p4438ccx-cmst-2018.01.06
- found 2018.01.06 in filename of file in /nix/store/va2g67lavq3xhp2154dlgz95p4438ccx-cmst-2018.01.06

cc @matejc