### PR TITLE
cni: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/applications/networking/cluster/cni/default.nix
+++ b/pkgs/applications/networking/cluster/cni/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cni-${version}";
-  version = "0.5.2";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "containernetworking";
     repo = "cni";
     rev = "v${version}";
-    sha256 = "0n2sc5xf1h0i54am80kj7imrvawddn0kxvgi65w0194dpmyrg5al";
+    sha256 = "00ajs2r5r2z3l0vqwxrcwhjfc9px12qbcv5vnvs2mdipvvls1y2y";
   };
 
   buildInputs = [ go ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.6.0 with grep in /nix/store/20rzgnqnxfx21j49wr48pd4p9wb0ai5z-cni-0.6.0
- found 0.6.0 in filename of file in /nix/store/20rzgnqnxfx21j49wr48pd4p9wb0ai5z-cni-0.6.0

cc @offlinehacker