### PR TITLE
coursier: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "coursier-${version}";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchurl {
     url = "https://github.com/coursier/coursier/raw/v${version}/coursier";
-    sha256 = "1rn1vb33zfl9iy80fhqvi9ykdjxz029nah5yfr5xixcx9al0bai3";
+    sha256 = "0zjda6h4b79swn479r82xq0j67cfxnz9j6ng2zql675r6bqlaad9";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.0.2 with grep in /nix/store/3a4p6ixcs947hb9x2p6v8g53p3z9jymb-coursier-1.0.2
- found 1.0.2 in filename of file in /nix/store/3a4p6ixcs947hb9x2p6v8g53p3z9jymb-coursier-1.0.2

cc @adelbertc @nequissimus