### PR TITLE
cppcheck: 1.80 -> 1.82

### DIFF
--- a/pkgs/development/tools/analysis/cppcheck/default.nix
+++ b/pkgs/development/tools/analysis/cppcheck/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "cppcheck";
-  version = "1.80";
+  version = "1.82";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${name}.tar.bz2";
-    sha256 = "1yx06yhkqlv9849ns7p97mj09gm9j7xc51q7yvzkk8ldvx4d4h88";
+    sha256 = "0kk9injrxbv4mmmjswrh1kidal6l0sdzbp40kv8vwf5aiv8jjaz0";
   };
 
   buildInputs = [ pcre ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/misra.py -h` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/misra.py --help` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/misra.py help` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/naming.py -h` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/naming.py --help` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/naming.py help` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/y2038.py -h` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/y2038.py --help` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/y2038.py help` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/cppcheck -h` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/cppcheck --help` got 0 exit code
- ran `/nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82/bin/cppcheck --version` and found version 1.82
- found 1.82 with grep in /nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82
- found 1.82 in filename of file in /nix/store/klfqwbh75zch4zzdbwdyvk9qhgf28sln-cppcheck-1.82

cc @joachifm