### PR TITLE
csound: 6.09.0 -> 6.10.0

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation rec {
   name = "csound-${version}";
-  version = "6.09.0";
+  version = "6.10.0";
 
   enableParallelBuilding = true;
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "csound";
     repo = "csound";
     rev = version;
-    sha256 = "1vfb0mab89psfwidadjrn5mbzq3bhjbyrrmyp98yp0xm6a8cssih";
+    sha256 = "1mak183y8bn097z9q3k7f1kwvawkngkc4ch9hv6gqhgfy1cjln8n";
   };
 
   cmakeFlags = [ "-DBUILD_CSOUND_AC=0" ] # fails to find Score.hpp


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/y5y28sldhyh69vy0xxy9y1zajzyzg4ln-csound-6.10.0/bin/csanalyze -h` got 0 exit code
- ran `/nix/store/y5y28sldhyh69vy0xxy9y1zajzyzg4ln-csound-6.10.0/bin/csanalyze --help` got 0 exit code
- ran `/nix/store/y5y28sldhyh69vy0xxy9y1zajzyzg4ln-csound-6.10.0/bin/csanalyze help` got 0 exit code
- ran `/nix/store/y5y28sldhyh69vy0xxy9y1zajzyzg4ln-csound-6.10.0/bin/csb64enc help` got 0 exit code
- ran `/nix/store/y5y28sldhyh69vy0xxy9y1zajzyzg4ln-csound-6.10.0/bin/makecsd help` got 0 exit code
- found 6.10.0 with grep in /nix/store/y5y28sldhyh69vy0xxy9y1zajzyzg4ln-csound-6.10.0
- found 6.10.0 in filename of file in /nix/store/y5y28sldhyh69vy0xxy9y1zajzyzg4ln-csound-6.10.0

cc @marcweber