### PR TITLE
pythonPackages.pysdl2: init at 0.9.6

### DIFF
--- a/pkgs/development/python-modules/pysdl2/PySDL2-dll.patch
+++ b/pkgs/development/python-modules/pysdl2/PySDL2-dll.patch
@@ -1,0 +1,119 @@
+diff -ru PySDL2-0.9.6-old/sdl2/dll.py PySDL2-0.9.6/sdl2/dll.py
+--- PySDL2-0.9.6-old/sdl2/dll.py	2018-03-08 10:18:37.583471745 +0100
++++ PySDL2-0.9.6/sdl2/dll.py	2018-03-08 10:20:06.705517520 +0100
+@@ -45,29 +45,31 @@
+     """Function wrapper around the different DLL functions. Do not use or
+     instantiate this one directly from your user code.
+     """
+-    def __init__(self, libinfo, libnames, path=None):
+-        self._dll = None
+-        foundlibs = _findlib(libnames, path)
+-        dllmsg = "PYSDL2_DLL_PATH: %s" % (os.getenv("PYSDL2_DLL_PATH") or "unset")
+-        if len(foundlibs) == 0:
+-            raise RuntimeError("could not find any library for %s (%s)" %
+-                               (libinfo, dllmsg))
+-        for libfile in foundlibs:
+-            try:
+-                self._dll = CDLL(libfile)
+-                self._libfile = libfile
+-                break
+-            except Exception as exc:
+-                # Could not load the DLL, move to the next, but inform the user
+-                # about something weird going on - this may become noisy, but
+-                # is better than confusing the users with the RuntimeError below
+-                warnings.warn(repr(exc), DLLWarning)
+-        if self._dll is None:
+-            raise RuntimeError("found %s, but it's not usable for the library %s" %
+-                               (foundlibs, libinfo))
+-        if path is not None and sys.platform in ("win32",) and \
+-            path in self._libfile:
+-            os.environ["PATH"] = "%s;%s" % (path, os.environ["PATH"])
++    def __init__(self, libfile):
++        self._dll = CDLL(libfile)
++        self._libfile = libfile
++        # self._dll = None
++        # foundlibs = _findlib(libnames, path)
++        # dllmsg = "PYSDL2_DLL_PATH: %s" % (os.getenv("PYSDL2_DLL_PATH") or "unset")
++        # if len(foundlibs) == 0:
++        #     raise RuntimeError("could not find any library for %s (%s)" %
++        #                        (libinfo, dllmsg))
++        # for libfile in foundlibs:
++        #     try:
++        #         self._dll = CDLL(libfile)
++        #         self._libfile = libfile
++        #         break
++        #     except Exception as exc:
++        #         # Could not load the DLL, move to the next, but inform the user
++        #         # about something weird going on - this may become noisy, but
++        #         # is better than confusing the users with the RuntimeError below
++        #         warnings.warn(repr(exc), DLLWarning)
++        # if self._dll is None:
++        #     raise RuntimeError("found %s, but it's not usable for the library %s" %
++        #                        (foundlibs, libinfo))
++        # if path is not None and sys.platform in ("win32",) and \
++        #     path in self._libfile:
++        #     os.environ["PATH"] = "%s;%s" % (path, os.environ["PATH"])
+ 
+     def bind_function(self, funcname, args=None, returns=None, optfunc=None):
+         """Binds the passed argument and return value types to the specified
+@@ -110,7 +112,7 @@
+     return
+ 
+ try:
+-    dll = DLL("SDL2", ["SDL2", "SDL2-2.0"], os.getenv("PYSDL2_DLL_PATH"))
++    dll = DLL("SDL2")
+ except RuntimeError as exc:
+     raise ImportError(exc)
+ 
+diff -ru PySDL2-0.9.6-old/sdl2/sdlgfx.py PySDL2-0.9.6/sdl2/sdlgfx.py
+--- PySDL2-0.9.6-old/sdl2/sdlgfx.py	2018-03-08 10:18:37.585471769 +0100
++++ PySDL2-0.9.6/sdl2/sdlgfx.py	2018-03-08 10:20:06.705517520 +0100
+@@ -34,8 +34,7 @@
+            ]
+ 
+ try:
+-    dll = DLL("SDL2_gfx", ["SDL2_gfx", "SDL2_gfx-1.0"],
+-              os.getenv("PYSDL2_DLL_PATH"))
++    dll = DLL("SDL2_gfx")
+ except RuntimeError as exc:
+     raise ImportError(exc)
+ 
+diff -ru PySDL2-0.9.6-old/sdl2/sdlimage.py PySDL2-0.9.6/sdl2/sdlimage.py
+--- PySDL2-0.9.6-old/sdl2/sdlimage.py	2018-03-08 10:18:37.585471769 +0100
++++ PySDL2-0.9.6/sdl2/sdlimage.py	2018-03-08 10:20:06.705517520 +0100
+@@ -26,8 +26,7 @@
+            ]
+ 
+ try:
+-    dll = DLL("SDL2_image", ["SDL2_image", "SDL2_image-2.0"],
+-              os.getenv("PYSDL2_DLL_PATH"))
++    dll = DLL("SDL2_image")
+ except RuntimeError as exc:
+     raise ImportError(exc)
+ 
+diff -ru PySDL2-0.9.6-old/sdl2/sdlmixer.py PySDL2-0.9.6/sdl2/sdlmixer.py
+--- PySDL2-0.9.6-old/sdl2/sdlmixer.py	2018-03-08 10:18:37.585471769 +0100
++++ PySDL2-0.9.6/sdl2/sdlmixer.py	2018-03-08 10:20:27.415758478 +0100
+@@ -50,8 +50,7 @@
+           ]
+ 
+ try:
+-    dll = DLL("SDL2_mixer", ["SDL2_mixer", "SDL2_mixer-2.0"],
+-              os.getenv("PYSDL2_DLL_PATH"))
++    dll = DLL("SDL2_mixer")
+ except RuntimeError as exc:
+     raise ImportError(exc)
+ 
+diff -ru PySDL2-0.9.6-old/sdl2/sdlttf.py PySDL2-0.9.6/sdl2/sdlttf.py
+--- PySDL2-0.9.6-old/sdl2/sdlttf.py	2018-03-08 10:18:37.585471769 +0100
++++ PySDL2-0.9.6/sdl2/sdlttf.py	2018-03-08 10:20:06.705517520 +0100
+@@ -38,8 +38,7 @@
+           ]
+ 
+ try:
+-    dll = DLL("SDL2_ttf", ["SDL2_ttf", "SDL2_ttf-2.0"],
+-              os.getenv("PYSDL2_DLL_PATH"))
++    dll = DLL("SDL2_ttf")
+ except RuntimeError as exc:
+     raise ImportError(exc)
+ 

--- a/pkgs/development/python-modules/pysdl2/default.nix
+++ b/pkgs/development/python-modules/pysdl2/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchPypi, buildPythonPackage, fetchurl, SDL2, SDL2_ttf, SDL2_image, SDL2_gfx, SDL2_mixer, pyopengl }:
+
+buildPythonPackage rec {
+  pname = "PySDL2";
+  version = "0.9.6";
+  # The tests use OpenGL using find_library, which would have to be
+  # patched; also they seem to actually open X windows and test stuff
+  # like "screensaver disabling", which would have to be cleverly
+  # sandboxed. Disable for now.
+  doCheck = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08r1v9wdq8pzds4g3sng2xgh1hlzfs2z7qgy5a6b0xrs96swlamm";
+  };
+
+  # Deliberately not in propagated build inputs; users can decide
+  # which library they want to include.
+  buildInputs = [ SDL2_ttf SDL2_image SDL2_gfx SDL2_mixer ];
+  propagatedBuildInputs = [ SDL2 ];
+  patches = [ ./PySDL2-dll.patch ];
+  postPatch = ''
+    substituteInPlace sdl2/dll.py --replace \
+      "DLL(\"SDL2\")" "DLL('${SDL2}/lib/libSDL2${stdenv.hostPlatform.extensions.sharedLibrary}')"
+    substituteInPlace sdl2/sdlttf.py --replace \
+      "DLL(\"SDL2_ttf\")" "DLL('${SDL2_ttf}/lib/libSDL2_ttf${stdenv.hostPlatform.extensions.sharedLibrary}')"
+    substituteInPlace sdl2/sdlimage.py --replace \
+      "DLL(\"SDL2_image\")" "DLL('${SDL2_image}/lib/libSDL2_image${stdenv.hostPlatform.extensions.sharedLibrary}')"
+    substituteInPlace sdl2/sdlgfx.py --replace \
+     "DLL(\"SDL2_gfx\")" "DLL('${SDL2_gfx}/lib/libSDL2_gfx${stdenv.hostPlatform.extensions.sharedLibrary}')"
+    substituteInPlace sdl2/sdlmixer.py --replace \
+     "DLL(\"SDL2_mixer\")" "DLL('${SDL2_mixer}/lib/libSDL2_mixer${stdenv.hostPlatform.extensions.sharedLibrary}')"
+  '';
+
+  meta = {
+    description = "A wrapper around the SDL2 library and as such similar to the discontinued PySDL project";
+    homepage = https://github.com/marcusva/py-sdl2;
+    license = lib.licenses.publicDomain;
+    maintainers = with lib.maintainers; [ pmiddend ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18194,6 +18194,8 @@ EOF
   pyowm = callPackage ../development/python-modules/pyowm { };
 
   prometheus_client = callPackage ../development/python-modules/prometheus_client { };
+
+  pysdl2 = callPackage ../development/python-modules/pysdl2 { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

We have SDL2, but no Python support!

###### Things done

I commented out the whole `find_package` magic that Python (and PySDL2) does and replaced it by the hard-coded library paths. I hope that's nixpkgs policy.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

