### PR TITLE
dateutils: 0.4.2 -> 0.4.3

### DIFF
--- a/pkgs/tools/misc/dateutils/default.nix
+++ b/pkgs/tools/misc/dateutils/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.2";
+  version = "0.4.3";
   name = "dateutils-${version}";
 
   src = fetchurl {
     url = "https://bitbucket.org/hroptatyr/dateutils/downloads/${name}.tar.xz";
-    sha256 = "0sxl5rz9rw02dfn5mdww378hjgnnbxavs52viyfyx620b29finpc";
+    sha256 = "06lgqp2cyvmh09j04lm3g6ml7yxn1x92rjzgnwzq4my95c37kmdh";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/strptime -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/strptime --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/strptime -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/strptime --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateadd -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateadd --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateadd -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateadd --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateconv -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateconv --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateconv -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateconv --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datediff -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datediff --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datediff -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datediff --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dategrep -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dategrep --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dategrep -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dategrep --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateround -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateround --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateround -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateround --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateseq -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateseq --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateseq -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/dateseq --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datesort -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datesort --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datesort help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datesort -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datesort --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datetest -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datetest --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datetest -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datetest --version` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datezone -h` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datezone --help` got 0 exit code
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datezone -V` and found version 0.4.3
- ran `/nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3/bin/datezone --version` and found version 0.4.3
- found 0.4.3 with grep in /nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3
- found 0.4.3 in filename of file in /nix/store/2nrrhpq3w9cxjrxzpi6w3czfzn0lmbsi-dateutils-0.4.3

cc @paperdigits