### PR TITLE
discount: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/tools/text/discount/default.nix
+++ b/pkgs/tools/text/discount/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  version = "2.2.2";
+  version = "2.2.3";
   name = "discount-${version}";
 
   src = fetchurl {
     url = "http://www.pell.portland.or.us/~orc/Code/discount/discount-${version}.tar.bz2";
-    sha256 = "0r4gjyk1ngx47zhb25q0gkjm3bz2m5x8ngrk6rim3y1y3rricygc";
+    sha256 = "17797xiaq0kk152pj4rvd9grg4i518x3glnwg1lgl8rry3dbrzx8";
   };
 
   patches = ./fix-configure-path.patch;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/rq0ny7n6qfg7sgjqa5ki2ds6v3gzjwil-discount-2.2.3/bin/markdown help` got 0 exit code
- ran `/nix/store/rq0ny7n6qfg7sgjqa5ki2ds6v3gzjwil-discount-2.2.3/bin/markdown -V` and found version 2.2.3
- ran `/nix/store/rq0ny7n6qfg7sgjqa5ki2ds6v3gzjwil-discount-2.2.3/bin/markdown --version` and found version 2.2.3
- found 2.2.3 with grep in /nix/store/rq0ny7n6qfg7sgjqa5ki2ds6v3gzjwil-discount-2.2.3
- found 2.2.3 in filename of file in /nix/store/rq0ny7n6qfg7sgjqa5ki2ds6v3gzjwil-discount-2.2.3

cc @VShell @ndowens