### PR TITLE
doit: 0.30.3 -> 0.31.0

### DIFF
--- a/pkgs/development/tools/build-managers/doit/default.nix
+++ b/pkgs/development/tools/build-managers/doit/default.nix
@@ -3,14 +3,14 @@
 let
 
   name = "doit";
-  version = "0.30.3";
+  version = "0.31.0";
 
 in python3Packages.buildPythonApplication {
   name = "${name}-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/d/${name}/${name}-${version}.tar.gz";
-    sha256 = "1fcsslc3mc4bszq5xdqbxv37720s1s31d6pbfwc2iyxk1x2wi219";
+    sha256 = "0v1yr04bfqnz3sp261np3zhf0y1b3a1daxc83iq308lscf39fdgx";
   };
 
   buildInputs = with python3Packages; [ mock pytest ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/y6r8fjncv9axs205hmi0vjv8rb2s4i6v-doit-0.31.0/bin/.doit-wrapped --help` got 0 exit code
- ran `/nix/store/y6r8fjncv9axs205hmi0vjv8rb2s4i6v-doit-0.31.0/bin/.doit-wrapped help` got 0 exit code
- ran `/nix/store/y6r8fjncv9axs205hmi0vjv8rb2s4i6v-doit-0.31.0/bin/.doit-wrapped --version` and found version 0.31.0
- ran `/nix/store/y6r8fjncv9axs205hmi0vjv8rb2s4i6v-doit-0.31.0/bin/doit --help` got 0 exit code
- ran `/nix/store/y6r8fjncv9axs205hmi0vjv8rb2s4i6v-doit-0.31.0/bin/doit help` got 0 exit code
- ran `/nix/store/y6r8fjncv9axs205hmi0vjv8rb2s4i6v-doit-0.31.0/bin/doit --version` and found version 0.31.0
- found 0.31.0 with grep in /nix/store/y6r8fjncv9axs205hmi0vjv8rb2s4i6v-doit-0.31.0
- found 0.31.0 in filename of file in /nix/store/y6r8fjncv9axs205hmi0vjv8rb2s4i6v-doit-0.31.0