### PR TITLE
tamarin-prover: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/applications/science/logic/tamarin-prover/default.nix
+++ b/pkgs/applications/science/logic/tamarin-prover/default.nix
@@ -4,12 +4,12 @@
 }:
 
 let
-  version = "1.3.0";
+  version = "1.3.1";
   src = fetchFromGitHub {
     owner  = "tamarin-prover";
     repo   = "tamarin-prover";
-    rev    = "8e823691ad3325bce8921617b013735523d74557";
-    sha256 = "0rr2syl9xhv17bwky5p39mhn0bypr24h8pld1xidxv87vy7vk7nr";
+    rev    = "120c7e706f3e1d4646b233faf2bc9936834ed9d3";
+    sha256 = "064blwjjwnkycwgsrdn1xkjya976wndpz9h5pjmgjqqirinc8c5x";
   };
 
   # tamarin has its own dependencies, but they're kept inside the repo,


### PR DESCRIPTION
###### Motivation for this change
The development version of tamarin-prover is available in a new minor version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

