### PR TITLE
drumstick: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "drumstick-${version}";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/drumstick/${version}/${name}.tar.bz2";
-    sha256 = "13pkfqrav30bbcddgf1imd7jk6lpqbxkz1qv31718pdl446jq7df";
+    sha256 = "0avwxr6n9ra7narxc5lmkhdqi8ix10gmif8rpd06wp4g9iv46xrn";
   };
 
   outputs = [ "out" "dev" "man" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpsmf -h` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpsmf --help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpsmf help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpsmf -V` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpsmf -v` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpsmf --version` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpsmf -h` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpsmf --help` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpwrk -h` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpwrk --help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpwrk help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpwrk -V` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpwrk -v` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpwrk --version` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpwrk -h` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpwrk --help` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpove -h` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpove --help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpove help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpove -V` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpove -v` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpove --version` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpove -h` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpove --help` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpmid -h` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpmid --help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpmid -V` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpmid -v` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpmid --version` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpmid -h` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-dumpmid --help` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-playsmf -h` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-playsmf --help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-playsmf help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-playsmf -V` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-playsmf -v` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-playsmf --version` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-playsmf -h` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-playsmf --help` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo -h` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo --help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo -V` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo -v` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo --version` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo version` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo -h` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo --help` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-sysinfo help` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-metronome -h` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-metronome --help` got 0 exit code
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-metronome -V` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-metronome -v` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-metronome --version` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-metronome -h` and found version 1.1.1
- ran `/nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1/bin/drumstick-metronome --help` and found version 1.1.1
- found 1.1.1 with grep in /nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1
- found 1.1.1 in filename of file in /nix/store/38x7gw88p7nwk586p5s5synjz2x1nral-drumstick-1.1.1

cc @solson