### PR TITLE
easyloggingpp: 9.96.0 -> 9.96.1

### DIFF
--- a/pkgs/development/libraries/easyloggingpp/default.nix
+++ b/pkgs/development/libraries/easyloggingpp/default.nix
@@ -4,12 +4,12 @@
 { stdenv, fetchFromGitHub, cmake, gtest }:
 stdenv.mkDerivation rec {
   name = "easyloggingpp-${version}";
-  version = "9.96.0";
+  version = "9.96.1";
   src = fetchFromGitHub {
     owner = "muflihun";
     repo = "easyloggingpp";
     rev = "v${version}";
-    sha256 = "134arh13rksfsxa80h6xw104458ihzp1mpblz5sprx5gxkq7yqfv";
+    sha256 = "1x5wwm62l1231sgxfwx8mj7fc8452j3f509jyxa9wd2krkpvqxmy";
   };
 
   nativeBuildInputs = [cmake];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 9.96.1 with grep in /nix/store/ha2fl2l2j3p9lcn6scxn1n50f1vsb5k6-easyloggingpp-9.96.1
- found 9.96.1 in filename of file in /nix/store/ha2fl2l2j3p9lcn6scxn1n50f1vsb5k6-easyloggingpp-9.96.1

cc @acowley