### PR TITLE
SDL: propagate X11 libs even when building statically against them on Darwin

### DIFF
--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   propagatedBuildInputs = [ ]
-    ++ optionals (x11Support && !stdenv.isDarwin) [ libXext libICE libXrandr ]
+    ++ optionals x11Support [ libXext libICE libXrandr ]
     ++ optional stdenv.isLinux libcap
     ++ optionals openglSupport [ libGL libGLU ]
     ++ optional alsaSupport alsaLib
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin Cocoa;
 
   buildInputs = [ libiconv ]
-    ++ optionals (x11Support && stdenv.isDarwin) [ libXext libICE libXrandr ]
     ++ optional (!hostPlatform.isMinGW) audiofile
     ++ optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreServices Kernel OpenGL ];
 


### PR DESCRIPTION
Packages like SDL_image, SDL_mixer, SDL_net, SDL_ttf depend on this.

This reverts a piece of 19130ebc5d05cc7720335c92d68a4fd1faf28dc0.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/commit/19130ebc5d05cc7720335c92d68a4fd1faf28dc0#commitcomment-27987219, search "SDL" in https://hydra.nixos.org/jobset/nixpkgs/trunk#tabs-jobs.

###### Things done

- [X] It evaluates.
- [X] Nothing changes on Linux.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Please run ofborg `build SDL SDL_image SDL_mixer SDL_net SDL_ttf` on darwin.

---

