### PR TITLE
emby: 3.2.70.0 -> 3.3.0.0

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.2.70.0";
+  version = "3.3.0.0";
 
   src = fetchurl {
     url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "051mbzh1igcbda43n14aijbvhhh98rqw8i13f06xqsm67afrjjcv";
+    sha256 = "14nnrlwx8bghiz72lspxahwadhvnf8vs3bqbffnd5nrrv4shijhm";
   };
 
   buildInputs = with pkgs; [


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.3.0.0 with grep in /nix/store/nnp01d2wwym58qqvw6kigskycdqch47x-emby-3.3.0.0

cc @fadenb