### PR TITLE
fldigi: 3.23.15 -> 4.0.16

### DIFF
--- a/pkgs/applications/audio/fldigi/default.nix
+++ b/pkgs/applications/audio/fldigi/default.nix
@@ -2,13 +2,13 @@
   libsamplerate, libpulseaudio, libXinerama, gettext, pkgconfig, alsaLib }:
 
 stdenv.mkDerivation rec {
-  version = "3.23.15";
+  version = "4.0.16";
   pname = "fldigi";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${name}.tar.gz";
-    sha256 = "1nxafk99fr6yb09cq3vdpzjcd85mnjwwl8rzccx21kla1ysihl5m";
+    sha256 = "1gcahm1lv3yfscaxanrx6q7dydxjznw98vdc0f8zgdb15na3f0g7";
   };
 
   buildInputs = [ libXinerama gettext hamlib fltk13 libjpeg libpng portaudio


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/vxx260nm7dk471pgh1090pp9xlm53hbs-fldigi-4.0.16/bin/fldigi --help` got 0 exit code
- ran `/nix/store/vxx260nm7dk471pgh1090pp9xlm53hbs-fldigi-4.0.16/bin/fldigi --version` and found version 4.0.16
- ran `/nix/store/vxx260nm7dk471pgh1090pp9xlm53hbs-fldigi-4.0.16/bin/flarq --help` got 0 exit code
- found 4.0.16 with grep in /nix/store/vxx260nm7dk471pgh1090pp9xlm53hbs-fldigi-4.0.16
- found 4.0.16 in filename of file in /nix/store/vxx260nm7dk471pgh1090pp9xlm53hbs-fldigi-4.0.16

cc @relrod @ftrvxmtrx