### PR TITLE
focuswriter: 1.6.8 -> 1.6.10

### DIFF
--- a/pkgs/applications/editors/focuswriter/default.nix
+++ b/pkgs/applications/editors/focuswriter/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "focuswriter-${version}";
-  version = "1.6.8";
+  version = "1.6.10";
 
   src = fetchurl {
     url = "https://gottcode.org/focuswriter/focuswriter-${version}-src.tar.bz2";
-    sha256 = "1d2q99xa7dhdpqkipapzi1r1mvynf70s7sgdczd59kn0d8sr3map";
+    sha256 = "0hrbycy5lapdkaa2xm90j45sgsiqdnlk9wry41kxxpdln9msabxs";
   };
 
   nativeBuildInputs = [ pkgconfig qmake qttools ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.6.10 with grep in /nix/store/xj71q5kp9k5m2nsfydjhjra8axf3kdj8-focuswriter-1.6.10
- found 1.6.10 in filename of file in /nix/store/xj71q5kp9k5m2nsfydjhjra8axf3kdj8-focuswriter-1.6.10

cc @madjar