### PR TITLE
folly: 2017.11.06.00 -> 2018.02.26.00

### DIFF
--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "folly-${version}";
-  version = "2017.11.06.00";
+  version = "2018.02.26.00";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "folly";
     rev = "v${version}";
-    sha256 = "11sn4gwqw94ygc2s4bzqy5k67v3rr20gy375brdcrl5rv0r2hhc0";
+    sha256 = "1pdb3nnly0x4x8yy1r13xgh9zhn34c9dq0b3nhxr8gwbzf643j1c";
   };
 
   nativeBuildInputs = [ autoreconfHook python pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2018.02.26.00 with grep in /nix/store/a1f6l0wcn1cw5v7ycmpdd21kmka3bxpg-folly-2018.02.26.00
- found 2018.02.26.00 in filename of file in /nix/store/a1f6l0wcn1cw5v7ycmpdd21kmka3bxpg-folly-2018.02.26.00

cc @abbradar