### PR TITLE
fping: 3.16 -> 4.0

### DIFF
--- a/pkgs/tools/networking/fping/default.nix
+++ b/pkgs/tools/networking/fping/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "fping-3.16";
+  name = "fping-4.0";
 
   src = fetchurl {
     url = "http://www.fping.org/dist/${name}.tar.gz";
-    sha256 = "2f753094e4df3cdb1d99be1687c0fb7d2f14c0d526ebf03158c8c5519bc78f54";
+    sha256 = "1kp81wchi79l8z8rrj602fpjrd8bi84y3i7fsaclzlwap5943sv7";
   };
 
   configureFlags = [ "--enable-ipv6" "--enable-ipv4" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.0 with grep in /nix/store/mcwq9l7zxi30ksdmlfj5vlcw98dv08ny-fping-4.0
- found 4.0 in filename of file in /nix/store/mcwq9l7zxi30ksdmlfj5vlcw98dv08ny-fping-4.0

cc @the-kenny