### PR TITLE
freeswitch: 1.6.15 -> 1.6.19

### DIFF
--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -3,11 +3,11 @@
 , ldns, libedit, yasm, which, lua, libopus, libsndfile }:
 
 stdenv.mkDerivation rec {
-  name = "freeswitch-1.6.15";
+  name = "freeswitch-1.6.19";
 
   src = fetchurl {
     url = "http://files.freeswitch.org/freeswitch-releases/${name}.tar.bz2";
-    sha256 = "071g7229shr9srwzspx29fcx3ccj3rwakkydpc4vdf1q3lldd2ld";
+    sha256 = "019n16yyzk9yp6h7iwsg30h62zj5vqvigr5cl8pjik4106xzcjyr";
   };
   postPatch = ''
     patchShebangs     libs/libvpx/build/make/rtcd.pl


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/freeswitch -h` got 0 exit code
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/fs_cli -h` got 0 exit code
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/fs_cli --help` got 0 exit code
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/fs_cli -V` and found version 1.6.19
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/fs_cli -v` and found version 1.6.19
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/fs_cli --version` and found version 1.6.19
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/fs_cli -h` and found version 1.6.19
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/fs_cli --help` and found version 1.6.19
- ran `/nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19/bin/fsxs --help` got 0 exit code
- found 1.6.19 with grep in /nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19
- found 1.6.19 in filename of file in /nix/store/jpf73ild0rhyvsgngigp3ksb94nmf6pk-freeswitch-1.6.19

cc @viric