### PR TITLE
unp: init at 2.0-pre7

### DIFF
--- a/pkgs/tools/archivers/unp/default.nix
+++ b/pkgs/tools/archivers/unp/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, pkgs, lib, fetchurl, makeWrapper, perl, unrar, unzip, gzip, file, extraBackends ? [] }:
+
+stdenv.mkDerivation rec {
+  name = "unp-${version}";
+  version = "2.0-pre7";
+
+  runtime_bins =  [ file unrar unzip gzip ] ++ extraBackends;
+  buildInputs = [ perl makeWrapper ] ++ runtime_bins;
+
+  src = fetchurl {
+    # url = "http://http.debian.net/debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2";
+    url = "mirror://debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2";
+    sha256 = "09w2sy7ivmylxf8blf0ywxicvb4pbl0xhrlbb3i9x9d56ll6ybbw";
+    name = "unp_2.0_pre7+nmu1.tar.bz2";
+  };
+
+  configurePhase = "true";
+  buildPhase = "true";
+  installPhase = ''
+  mkdir -p $out/bin
+  mkdir -p $out/share/man
+  cp unp $out/bin/
+  cp ucat $out/bin/
+  cp debian/unp.1 $out/share/man
+
+  wrapProgram $out/bin/unp \
+    --prefix PATH : ${lib.makeBinPath runtime_bins}
+  wrapProgram $out/bin/ucat \
+    --prefix PATH : ${lib.makeBinPath runtime_bins}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command line tool for unpacking archives easily";
+    homepage = https://packages.qa.debian.org/u/unp.html;
+    license = with licenses; [ gpl2 ];
+    maintainers = [ maintainers.timor ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5408,6 +5408,8 @@ with pkgs;
 
   unarj = callPackage ../tools/archivers/unarj { };
 
+  unp = callPackage ../tools/archivers/unp { };
+
   unshield = callPackage ../tools/archivers/unshield { };
 
   unzip = callPackage ../tools/archivers/unzip { };


### PR DESCRIPTION
###### Motivation for this change
Add useful unpacking tool.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

