### PR TITLE
gdcm: 2.6.4 -> 2.8.4

### DIFF
--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, cmake, vtk }:
 
 stdenv.mkDerivation rec {
-  version = "2.6.4";
+  version = "2.8.4";
   name = "gdcm-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/gdcm/${name}.tar.bz2";
-    sha256 = "14bysjdldq7xb9k1ayskxijm08dy2n45v9bg379dqrcz1q5xq5mi";
+    sha256 = "1wjs9sfdi1v4bm750xl26mik5zyvmlk88jy2zf2jsm9y3qmcyfff";
   };
 
   dontUseCmakeBuildDir = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcm2vtk -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcm2vtk --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcm2vtk -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcm2vtk --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcm2vtk -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcm2vtk --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmviewer help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmdump -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmdump --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmdump help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmdump -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmdump --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmdump -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmdump --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmraw -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmraw --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmraw -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmraw --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmraw -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmraw --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscanner -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscanner --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscanner -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscanner --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscanner -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscanner --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmanon -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmanon --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmanon -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmanon --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmanon -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmanon --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmgendir -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmgendir --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmgendir -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmgendir --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmgendir -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmgendir --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmimg -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmimg --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmimg -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmimg --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmimg -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmimg --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmconv -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmconv --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmconv -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmconv --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmconv -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmconv --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmtar -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmtar --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmtar -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmtar --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmtar -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmtar --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcminfo -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcminfo --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcminfo help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcminfo -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcminfo --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcminfo -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcminfo --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscu -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscu --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscu -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscu --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscu -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmscu --help` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmpap3 -h` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmpap3 --help` got 0 exit code
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmpap3 -v` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmpap3 --version` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmpap3 -h` and found version 2.8.4
- ran `/nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4/bin/gdcmpap3 --help` and found version 2.8.4
- found 2.8.4 with grep in /nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4
- found 2.8.4 in filename of file in /nix/store/bqj3bkqyb9cz4lqffcbmd0k31lvx2wya-gdcm-2.8.4