### PR TITLE
gettext: 0.19.8 -> 0.19.8.1

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gettext-${version}";
-  version = "0.19.8";
+  version = "0.19.8.1";
 
   src = fetchurl {
     url = "mirror://gnu/gettext/${name}.tar.gz";
-    sha256 = "13ylc6n3hsk919c7xl0yyibc3pfddzb53avdykn4hmk8g6yzd91x";
+    sha256 = "0hsw28f9q9xaggjlsdp2qmbp2rbd1mp0njzan2ld9kiqwkq2m57z";
   };
   patches = [ ./absolute-paths.diff ];
 


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/ngettext -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/ngettext --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/ngettext -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/ngettext --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/ngettext -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/ngettext --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/envsubst -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/envsubst --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/envsubst -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/envsubst --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/envsubst -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/envsubst --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcmp -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcmp --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcmp -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcmp --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcmp -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcmp --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfmt -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfmt --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfmt -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfmt --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfmt -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfmt --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgmerge -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgmerge --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgmerge -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgmerge --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgmerge -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgmerge --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgunfmt -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgunfmt --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgunfmt -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgunfmt --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgunfmt -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgunfmt --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/xgettext -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/xgettext --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/xgettext -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/xgettext --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/xgettext -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/xgettext --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgattrib -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgattrib --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgattrib -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgattrib --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgattrib -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgattrib --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcat -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcat --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcat -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcat --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcat -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcat --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcomm -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcomm --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcomm -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcomm --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcomm -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgcomm --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgconv -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgconv --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgconv -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgconv --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgconv -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgconv --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgen -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgen --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgen -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgen --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgen -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgen --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgexec -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgexec --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgexec -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgexec --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgexec -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgexec --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfilter -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfilter --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfilter -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfilter --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfilter -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msgfilter --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msggrep -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msggrep --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msggrep -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msggrep --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msggrep -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msggrep --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msginit -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msginit --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msginit -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msginit --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msginit -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msginit --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msguniq -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msguniq --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msguniq -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msguniq --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msguniq -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/msguniq --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/recode-sr-latin -h` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/recode-sr-latin --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/recode-sr-latin -V` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/recode-sr-latin --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/recode-sr-latin -h` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/recode-sr-latin --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext.sh --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext.sh --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettext.sh --help` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettextize --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/gettextize --version` and found version 0.19.8.1
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/autopoint --help` got 0 exit code
- ran `/nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1/bin/autopoint --version` and found version 0.19.8.1
- found 0.19.8.1 with grep in /nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1
- found 0.19.8.1 in filename of file in /nix/store/yvq13fsgfzy794h6a6fm4iqvg04l1ai4-gettext-0.19.8.1

cc @zimbatm @vrthra