### PR TITLE
gfan: 0.6 -> 0.6.2

### DIFF
--- a/pkgs/applications/science/math/gfan/default.nix
+++ b/pkgs/applications/science/math/gfan/default.nix
@@ -2,11 +2,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "gfan";
-  version = "0.6";
+  version = "0.6.2";
 
   src = fetchurl {
     url = "http://home.math.au.dk/jensen/software/gfan/gfan${version}.tar.gz";
-    sha256 = "02d6dvzfwy0lnidfgf98052jfqwy285nfm1h5nnx7jbgic1nnpgz";
+    sha256 = "02pihqb1lb76a0xbfwjzs1cd6ay3ldfxsm8dvsbl6qs3vkjxax56";
   };
 
   makeFlags = ''PREFIX=$(out) CC=cc CXX=c++ cddnoprefix=1'';


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/gdzrfmvi5x26is0hbv0yyg5s61cxm7dy-gfan-0.6.2/bin/gfan --help` got 0 exit code
- found 0.6.2 with grep in /nix/store/gdzrfmvi5x26is0hbv0yyg5s61cxm7dy-gfan-0.6.2
- found 0.6.2 in filename of file in /nix/store/gdzrfmvi5x26is0hbv0yyg5s61cxm7dy-gfan-0.6.2

cc @7c6f434c