### PR TITLE
gibo: 1.0.4 -> 1.0.6

### DIFF
--- a/pkgs/tools/misc/gibo/default.nix
+++ b/pkgs/tools/misc/gibo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gibo-${version}";
-  version = "1.0.4";
+  version = "1.0.6";
 
   src = fetchFromGitHub {
     owner = "simonwhitaker";
     repo = "gibo";
     rev = version;
-    sha256 = "1vzchggxv660c1cj5v0hlmln7yda48wjy2cv0qwi619cmr5hwbgh";
+    sha256 = "07j3sv9ar9l074krajw8nfmsfmdp836irsbd053dbqk2v880gfm6";
   };
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.0.6 with grep in /nix/store/jk28x9x2szkp8cgfg3x7vmsrjhh4nabs-gibo-1.0.6
- found 1.0.6 in filename of file in /nix/store/jk28x9x2szkp8cgfg3x7vmsrjhh4nabs-gibo-1.0.6