### PR TITLE
gifsicle: 1.90 -> 1.91

### DIFF
--- a/pkgs/tools/graphics/gifsicle/default.nix
+++ b/pkgs/tools/graphics/gifsicle/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "gifsicle-${version}";
-  version = "1.90";
+  version = "1.91";
 
   src = fetchurl {
     url = "http://www.lcdf.org/gifsicle/${name}.tar.gz";
-    sha256 = "0kc35g99fygzjj7qjcy87rdb8mbgmacr2mga9ihgln1dfnbb0wrd";
+    sha256 = "00586z1yz86qcblgmf16yly39n4lkjrscl52hvfxqk14m81fckha";
   };
 
   buildInputs = optional gifview [ xproto libXt libX11 ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91/bin/gifsicle -h` got 0 exit code
- ran `/nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91/bin/gifsicle --help` got 0 exit code
- ran `/nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91/bin/gifsicle --version` and found version 1.91
- ran `/nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91/bin/gifdiff -h` got 0 exit code
- ran `/nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91/bin/gifdiff --help` got 0 exit code
- ran `/nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91/bin/gifdiff -v` and found version 1.91
- ran `/nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91/bin/gifdiff --version` and found version 1.91
- found 1.91 with grep in /nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91
- found 1.91 in filename of file in /nix/store/7852k36z8l2vfsxm3ylgm0la1ggl9c8w-gifsicle-1.91

cc @fuuzetsu @zimbatm