### PR TITLE
ginac: 1.7.2 -> 1.7.4

### DIFF
--- a/pkgs/applications/science/math/ginac/default.nix
+++ b/pkgs/applications/science/math/ginac/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cln, pkgconfig, readline, gmp, python }:
 
 stdenv.mkDerivation rec {
-  name = "ginac-1.7.2";
+  name = "ginac-1.7.4";
 
   src = fetchurl {
     url    = "${meta.homepage}/${name}.tar.bz2";
-    sha256 = "1dyq47gc97jn1r5sy0klxs5b4lzhckyjqgsvwcs2a9ybqmhmpdr4";
+    sha256 = "1vvqv73yk9klbq0mz239zzw77rlp72qcvzci4j1v6rafvji1616n";
   };
 
   propagatedBuildInputs = [ cln ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/36kx0mbdfnf20mfrcicwgplcz0sibvpk-ginac-1.7.4/bin/viewgar -h` got 0 exit code
- ran `/nix/store/36kx0mbdfnf20mfrcicwgplcz0sibvpk-ginac-1.7.4/bin/viewgar --help` got 0 exit code
- ran `/nix/store/36kx0mbdfnf20mfrcicwgplcz0sibvpk-ginac-1.7.4/bin/viewgar help` got 0 exit code
- found 1.7.4 with grep in /nix/store/36kx0mbdfnf20mfrcicwgplcz0sibvpk-ginac-1.7.4
- found 1.7.4 in filename of file in /nix/store/36kx0mbdfnf20mfrcicwgplcz0sibvpk-ginac-1.7.4

cc @lovek323