### PR TITLE
git-radar: 0.5 -> 0.6

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-radar/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-radar/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "git-radar-${version}";
-  version = "0.5";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "michaeldfallen";
     repo = "git-radar";
     rev = "v${version}";
-    sha256 = "1915aqx8bfc4xmvhx2gfxv72p969a6rn436kii9w4yi38hibmqv9";
+    sha256 = "0c3zp8s4w7m4s71qgwk1jyfc8yzw34f2hi43x1w437ypgabwg81j";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.6 in filename of file in /nix/store/jps6rx12iqgxihhkg2gdi9k29nv1w2kz-git-radar-0.6

cc @kamilchm