### PR TITLE
git-review: 1.25.0 -> 1.26.0

### DIFF
--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -2,7 +2,7 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "git-review-${version}";
-  version = "1.25.0";
+  version = "1.26.0";
 
   # Manually set version because prb wants to get it from the git
   # upstream repository (and we are installing from tarball instead)
@@ -14,7 +14,7 @@ pythonPackages.buildPythonApplication rec {
 
   src = fetchurl rec {
     url = "https://github.com/openstack-infra/git-review/archive/${version}.tar.gz";
-    sha256 = "aa594690ed586041a524d6e5ae76152cbd53d4f03a98b20b213d15cecbe128ce";
+    sha256 = "106nk6p7byf5vi68b2fvmwma5nk7qrv39nfj9p1bfxmb1gjdixhc";
   };
 
   propagatedBuildInputs = with pythonPackages; [ pbr requests setuptools ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/.git-review-wrapped -h` got 0 exit code
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/.git-review-wrapped --help` got 0 exit code
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/.git-review-wrapped --version` and found version 1.26.0
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/git-review -h` got 0 exit code
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/git-review --help` got 0 exit code
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/git-review --version` and found version 1.26.0
- found 1.26.0 with grep in /nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0
- found 1.26.0 in filename of file in /nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0