### PR TITLE
git-secret: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-secret/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secret/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, git, gnupg }:
 
 let
-  version = "0.2.2";
+  version = "0.2.3";
   repo = "git-secret";
 
 in stdenv.mkDerivation {
@@ -11,7 +11,7 @@ in stdenv.mkDerivation {
     inherit repo;
     owner = "sobolevn";
     rev = "v${version}";
-    sha256 = "0vn9jibp97z7kc828wka1k0d7a9wx4skd6cnqy60kagfc00l0bzh";
+    sha256 = "1swgw91zzs9n582500a34cppyngrqrqrnl80d1vd7i93xx1lkmv6";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/5f9ki7kbirk84j77hfvs09dqlqdli79b-git-secret-0.2.3/bin/.git-secret-wrapped --version` and found version 0.2.3
- found 0.2.3 with grep in /nix/store/5f9ki7kbirk84j77hfvs09dqlqdli79b-git-secret-0.2.3
- found 0.2.3 in filename of file in /nix/store/5f9ki7kbirk84j77hfvs09dqlqdli79b-git-secret-0.2.3

cc @lo1tuma