### PR TITLE
github-release: 0.6.2 -> 0.7.2

### DIFF
--- a/pkgs/development/tools/github/github-release/default.nix
+++ b/pkgs/development/tools/github/github-release/default.nix
@@ -7,7 +7,7 @@ let
   metadata = assert linuxPredicate || bsdPredicate || darwinPredicate;
     if linuxPredicate then
       { arch = "linux-amd64";
-        sha256 = "0b3h0d0qsrjx99kcd2cf71xijh44wm5rpm2sr54snh3f7macj2p1";
+        sha256 = "0p0qj911nmmdj0r7wx3363gid8g4bm3my6mj3d6s4mwgh9lfisiz";
         archiveBinaryPath = "linux/amd64"; }
     else if bsdPredicate then
       { arch = "freebsd-amd64";
@@ -20,7 +20,7 @@ let
 in stdenv.mkDerivation rec {
   shortname = "github-release";
   name = "${shortname}-${version}";
-  version = "0.6.2";
+  version = "0.7.2";
 
   src = fetchurl {
     url = "https://github.com/aktau/github-release/releases/download/v${version}/${metadata.arch}-${shortname}.tar.bz2";


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/xs14bywjij7rdz2drjgfz17fxmlxgcqm-github-release-0.7.2/bin/github-release -h` got 0 exit code
- ran `/nix/store/xs14bywjij7rdz2drjgfz17fxmlxgcqm-github-release-0.7.2/bin/github-release --help` got 0 exit code
- ran `/nix/store/xs14bywjij7rdz2drjgfz17fxmlxgcqm-github-release-0.7.2/bin/github-release --version` and found version 0.7.2
- found 0.7.2 with grep in /nix/store/xs14bywjij7rdz2drjgfz17fxmlxgcqm-github-release-0.7.2
- found 0.7.2 in filename of file in /nix/store/xs14bywjij7rdz2drjgfz17fxmlxgcqm-github-release-0.7.2

cc @ardumont