### PR TITLE
wyrd: fix build error with ncurses-6.0-abi5-compat

### DIFF
--- a/pkgs/tools/misc/wyrd/default.nix
+++ b/pkgs/tools/misc/wyrd/default.nix
@@ -11,6 +11,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml ncurses remind camlp4 ];
 
+  # needed for configure phase to succeed
+  CPPFLAGS = "-DNCURSES_INTERNALS";
+
   preferLocalBuild = true;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

fix build error caused by ncurses 5.0 -> 6.0-abi5-compat

/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

