### PR TITLE
gitless: 0.8.5 -> 0.8.6

### DIFF
--- a/pkgs/applications/version-management/gitless/default.nix
+++ b/pkgs/applications/version-management/gitless/default.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub, pythonPackages, stdenv }:
 
 pythonPackages.buildPythonApplication rec {
-  ver = "0.8.5";
+  ver = "0.8.6";
   name = "gitless-${ver}";
 
   src = fetchFromGitHub {
     owner = "sdg-mit";
     repo = "gitless";
     rev = "v${ver}";
-    sha256 = "1v22i5lardswpqb6vxjgwra3ac8652qyajbijfj18vlkhajz78hq";
+    sha256 = "1q6y38f8ap6q1livvfy0pfnjr0l8b68hyhc9r5v87fmdyl7y7y8g";
   };
 
   propagatedBuildInputs = with pythonPackages; [ sh pygit2 clint ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/49m7aj5a77km9i0npzs0v4m821nmnhks-gitless-0.8.6/bin/.gl-wrapped -h` got 0 exit code
- ran `/nix/store/49m7aj5a77km9i0npzs0v4m821nmnhks-gitless-0.8.6/bin/.gl-wrapped --help` got 0 exit code
- ran `/nix/store/49m7aj5a77km9i0npzs0v4m821nmnhks-gitless-0.8.6/bin/.gl-wrapped --version` and found version 0.8.6
- ran `/nix/store/49m7aj5a77km9i0npzs0v4m821nmnhks-gitless-0.8.6/bin/gl -h` got 0 exit code
- ran `/nix/store/49m7aj5a77km9i0npzs0v4m821nmnhks-gitless-0.8.6/bin/gl --help` got 0 exit code
- ran `/nix/store/49m7aj5a77km9i0npzs0v4m821nmnhks-gitless-0.8.6/bin/gl --version` and found version 0.8.6
- found 0.8.6 with grep in /nix/store/49m7aj5a77km9i0npzs0v4m821nmnhks-gitless-0.8.6
- found 0.8.6 in filename of file in /nix/store/49m7aj5a77km9i0npzs0v4m821nmnhks-gitless-0.8.6

cc @cransom