### PR TITLE
global: 6.5.7 -> 6.6.2

### DIFF
--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "global-${version}";
-  version = "6.5.7";
+  version = "6.6.2";
 
   src = fetchurl {
     url = "mirror://gnu/global/${name}.tar.gz";
-    sha256 = "0cnd7a7d1pl46yk15q6mnr9i9w3xi8pxgchw4ia9njgr4jjqzh6r";
+    sha256 = "0zvi5vxwiq0dy8mq2cgs64m8harxs0fvkmsnvi0ayb0w608lgij3";
   };
 
   nativeBuildInputs = [ libtool makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/gtags --help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/gtags --version` and found version 6.6.2
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/global --help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/global help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/global --version` and found version 6.6.2
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/gozilla --help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/gozilla --version` and found version 6.6.2
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/htags -h` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/htags --help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/htags help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/htags --version` and found version 6.6.2
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/gtags-cscope -h` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/gtags-cscope --help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/gtags-cscope -V` and found version 6.6.2
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/gtags-cscope --version` and found version 6.6.2
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/.gtags-wrapped --help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/.gtags-wrapped help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/.gtags-wrapped --version` and found version 6.6.2
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/.global-wrapped --help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/.global-wrapped help` got 0 exit code
- ran `/nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2/bin/.global-wrapped --version` and found version 6.6.2
- found 6.6.2 with grep in /nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2
- found 6.6.2 in filename of file in /nix/store/2flw25y597pyjl1hlnkpxm86crmps6cw-global-6.6.2

cc @pSub @peterhoeg