### PR TITLE
glpk: 4.64 -> 4.65

### DIFF
--- a/pkgs/development/libraries/glpk/default.nix
+++ b/pkgs/development/libraries/glpk/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "glpk-4.64";
+  name = "glpk-4.65";
 
   src = fetchurl {
     url = "mirror://gnu/glpk/${name}.tar.gz";
-    sha256 = "096cqgjc7vkq6wd8znhcxjbs1s2rym3qf753fqxrrq531vs6g4jk";
+    sha256 = "040sfaa9jclg2nqdh83w71sv9rc1sznpnfiripjdyr48cady50a2";
   };
 
   doCheck = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/ra315prmwpsflq6fwq5glpxq0zqa1v3y-glpk-4.65/bin/glpsol -h` got 0 exit code
- ran `/nix/store/ra315prmwpsflq6fwq5glpxq0zqa1v3y-glpk-4.65/bin/glpsol --help` got 0 exit code
- ran `/nix/store/ra315prmwpsflq6fwq5glpxq0zqa1v3y-glpk-4.65/bin/glpsol -v` and found version 4.65
- ran `/nix/store/ra315prmwpsflq6fwq5glpxq0zqa1v3y-glpk-4.65/bin/glpsol --version` and found version 4.65
- ran `/nix/store/ra315prmwpsflq6fwq5glpxq0zqa1v3y-glpk-4.65/bin/glpsol -h` and found version 4.65
- ran `/nix/store/ra315prmwpsflq6fwq5glpxq0zqa1v3y-glpk-4.65/bin/glpsol --help` and found version 4.65
- found 4.65 with grep in /nix/store/ra315prmwpsflq6fwq5glpxq0zqa1v3y-glpk-4.65
- found 4.65 in filename of file in /nix/store/ra315prmwpsflq6fwq5glpxq0zqa1v3y-glpk-4.65