### PR TITLE
gmic: 1.7.9 -> 2.2.0

### DIFF
--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gmic-${version}";
-  version = "1.7.9";
+  version = "2.2.0";
 
   src = fetchurl {
     url = "http://gmic.eu/files/source/gmic_${version}.tar.gz";
-    sha256 = "0cvi5kmcrrg5pm774ligyy33fasgsfp3mr6ingjzd99rn4710bqm";
+    sha256 = "0yvb9iwwmjxvck2in3ymqszaddz502v2ryk50qs0wskhbhdh96c7";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/akcdj31wk383lglx9afg3vyyilvfmbnb-gmic-2.2.0/bin/gmic --version` and found version 2.2.0
- ran `/nix/store/akcdj31wk383lglx9afg3vyyilvfmbnb-gmic-2.2.0/bin/gmic version` and found version 2.2.0
- found 2.2.0 in filename of file in /nix/store/akcdj31wk383lglx9afg3vyyilvfmbnb-gmic-2.2.0