### PR TITLE
gmsh: 3.0.5 -> 3.0.6

### DIFF
--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, cmake, blas, liblapack, gfortran, gmm, fltk, libjpeg
 , zlib, libGLU_combined, libGLU, xorg }:
 
-let version = "3.0.5"; in
+let version = "3.0.6"; in
 
 stdenv.mkDerivation {
   name = "gmsh-${version}";
 
   src = fetchurl {
     url = "http://gmsh.info/src/gmsh-${version}-source.tgz";
-    sha256 = "ae39ed81178d94b76990b8c89b69a5ded8910fd8f7426b800044d00373d12a93";
+    sha256 = "0ywqhr0zmdhn8dvi6l8z1vkfycyv67fdrz6b95mb39np832bq04p";
   };
 
   # The original CMakeLists tries to use some version of the Lapack lib


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.0.6 with grep in /nix/store/ha4gl4kswiq7pz4chb1ba9ixb51rcdsn-gmsh-3.0.6
- found 3.0.6 in filename of file in /nix/store/ha4gl4kswiq7pz4chb1ba9ixb51rcdsn-gmsh-3.0.6