### PR TITLE
gmtp: 1.3.10 -> 1.3.11

### DIFF
--- a/pkgs/applications/misc/gmtp/default.nix
+++ b/pkgs/applications/misc/gmtp/default.nix
@@ -2,14 +2,14 @@
 , gsettings-desktop-schemas, wrapGAppsHook
 }:
 
-let version = "1.3.10"; in
+let version = "1.3.11"; in
 
 stdenv.mkDerivation {
   name = "gmtp-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/gmtp/gMTP-${version}/gmtp-${version}.tar.gz";
-    sha256 = "b21b9a8e66ae7bb09fc70ac7e317a0e32aff3917371a7241dea73c41db1dd13b";
+    sha256 = "04q6byyq002fhzkc2rkkahwh5b6272xakaj4m3vwm8la8jf0r0ss";
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.3.11 with grep in /nix/store/8lp6lwxfy7zq94jd2f26vgxc1zs0scfm-gmtp-1.3.11
- found 1.3.11 in filename of file in /nix/store/8lp6lwxfy7zq94jd2f26vgxc1zs0scfm-gmtp-1.3.11

cc @pbogdan