### PR TITLE
user/group assertion to not exceed the 32/16 character limit

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -35,6 +35,7 @@ let
 
       name = mkOption {
         type = types.str;
+        apply = x: assert (builtins.stringLength x < 32 || abort "Username '${x}' is longer than 31 characters which is not allowed!"); x;
         description = ''
           The name of the user account. If undefined, the name of the
           attribute set will be used.
@@ -91,6 +92,7 @@ let
 
       group = mkOption {
         type = types.str;
+        apply = x: assert (builtins.stringLength x < 17 || abort "Group name '${x}' is longer than 16 characters which is not allowed!"); x;
         default = "nogroup";
         description = "The user's primary group.";
       };


### PR DESCRIPTION
###### Motivation for this change

With the previous implementation one can add a `user` or `group` which _is_ created by Nix but then fails to execute programs from `systemd`.

`man useradd` says: `Usernames may only be up to 32 characters long.`

The actual implementation says it is only 31 chars: https://github.com/systemd/systemd/blob/586fb20fd192d9f9cd2a850f50f67ccd797b6931/src/basic/user-util.c#L624

`man groupadd` says: `Groupnames may only be up to 16 characters long.`

So this simple `apply` check makes the user aware of this!

See also: https://github.com/nixcloud/nixcloud-webservices/issues/15
