### PR TITLE
bitcoin-abc: 0.16.0 -> 0.16.2

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-abc.nix
+++ b/pkgs/applications/altcoins/bitcoin-abc.nix
@@ -7,13 +7,13 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-abc-" + version;
-  version = "0.16.0";
+  version = "0.16.2";
 
   src = fetchFromGitHub {
     owner = "bitcoin-ABC";
     repo = "bitcoin-abc";
     rev = "v${version}";
-    sha256 = "0wwcgvd8zgl5qh6z1sa3kdv1lr9cwwbs9j2gaad5mqr9sfwbbxdh";
+    sha256 = "0d5npn4p321jqsbqjxkbv0ncvs2hp9vdp30np6n8n53f896cxl92";
   };
 
   patches = [ ./fix-bitcoin-qt-build.patch ];

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, boost155, openssl_1_1_0, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3 }:
+{ callPackage, boost155, boost165, openssl_1_1_0, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3 }:
 
 rec {
 
@@ -7,8 +7,8 @@ rec {
   bitcoin  = libsForQt5.callPackage ./bitcoin.nix { miniupnpc = miniupnpc_2; withGui = true; };
   bitcoind = callPackage ./bitcoin.nix { miniupnpc = miniupnpc_2; withGui = false; };
 
-  bitcoin-abc  = libsForQt5.callPackage ./bitcoin-abc.nix { withGui = true; };
-  bitcoind-abc = callPackage ./bitcoin-abc.nix { withGui = false; };
+  bitcoin-abc  = libsForQt5.callPackage ./bitcoin-abc.nix { boost = boost165; withGui = true; };
+  bitcoind-abc = callPackage ./bitcoin-abc.nix { boost = boost165; withGui = false; };
 
   bitcoin-unlimited  = callPackage ./bitcoin-unlimited.nix { withGui = true; };
   bitcoind-unlimited = callPackage ./bitcoin-unlimited.nix { withGui = false; };


### PR DESCRIPTION
###### Motivation for this change

fix bitcoin-abc for 18.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

