### PR TITLE
qt-5.qtlocation: fix QTBUG-65654

### DIFF
--- a/pkgs/development/libraries/qt-5/5.10/default.nix
+++ b/pkgs/development/libraries/qt-5/5.10/default.nix
@@ -39,6 +39,7 @@ let
   patches = {
     qtbase = [ ./qtbase.patch ] ++ optional stdenv.isDarwin ./qtbase-darwin.patch;
     qtdeclarative = [ ./qtdeclarative.patch ];
+    qtlocation = optional stdenv.cc.isClang [ ./qtlocation.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];

--- a/pkgs/development/libraries/qt-5/5.10/qtlocation.patch
+++ b/pkgs/development/libraries/qt-5/5.10/qtlocation.patch
@@ -1,0 +1,13 @@
+diff --git a/src/3rdparty/mapbox-gl-native/deps/boost/1.62.0/include/boost/config.hpp b/src/3rdparty/mapbox-gl-native/deps/boost/1.62.0/include/boost/config.hpp
+index d49bb27..b61b29a 100644
+--- a/src/3rdparty/mapbox-gl-native/deps/boost/1.62.0/include/boost/config.hpp
++++ b/src/3rdparty/mapbox-gl-native/deps/boost/1.62.0/include/boost/config.hpp
+@@ -17,6 +17,8 @@
+ #ifndef BOOST_CONFIG_HPP
+ #define BOOST_CONFIG_HPP
+ 
++#define BOOST_NO_AUTO_PTR
++
+ // if we don't have a user config, then use the default location:
+ #if !defined(BOOST_USER_CONFIG) && !defined(BOOST_NO_USER_CONFIG)
+ #  define BOOST_USER_CONFIG <boost/config/user.hpp>

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -39,6 +39,7 @@ let
   patches = {
     qtbase = [ ./qtbase.patch ] ++ optional stdenv.isDarwin ./qtbase-darwin.patch;
     qtdeclarative = [ ./qtdeclarative.patch ];
+    qtlocation = optional stdenv.cc.isClang [ ./qtlocation.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];

--- a/pkgs/development/libraries/qt-5/5.9/qtlocation.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtlocation.patch
@@ -1,0 +1,13 @@
+diff --git a/src/3rdparty/mapbox-gl-native/deps/boost/1.62.0/include/boost/config.hpp b/src/3rdparty/mapbox-gl-native/deps/boost/1.62.0/include/boost/config.hpp
+index d49bb27..b61b29a 100644
+--- a/src/3rdparty/mapbox-gl-native/deps/boost/1.62.0/include/boost/config.hpp
++++ b/src/3rdparty/mapbox-gl-native/deps/boost/1.62.0/include/boost/config.hpp
+@@ -17,6 +17,8 @@
+ #ifndef BOOST_CONFIG_HPP
+ #define BOOST_CONFIG_HPP
+ 
++#define BOOST_NO_AUTO_PTR
++
+ // if we don't have a user config, then use the default location:
+ #if !defined(BOOST_USER_CONFIG) && !defined(BOOST_NO_USER_CONFIG)
+ #  define BOOST_USER_CONFIG <boost/config/user.hpp>


### PR DESCRIPTION
###### Motivation for this change

https://bugreports.qt.io/browse/QTBUG-65654
fixes build on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
