### PR TITLE
gnubg: 1.04.000 -> 1.06.001

### DIFF
--- a/pkgs/games/gnubg/default.nix
+++ b/pkgs/games/gnubg/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, glib, python, gtk2, readline }:
 
-let version = "1.04.000"; in
+let version = "1.06.001"; in
 stdenv.mkDerivation {
   name = "gnubg-"+version;
 
   src = fetchurl {
     url = "http://gnubg.org/media/sources/gnubg-release-${version}-sources.tar.gz";
-    sha256 = "0gsfl6qbj529d1jg3bkyj9m7bvb566wd7pq5fslgg5yn6c6rbjk6";
+    sha256 = "0snz3j1bvr25ji7lg82bl2gm2s2x9lrpc7viw0hclgz0ql74cw7b";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/gnubg -h` got 0 exit code
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/gnubg --help` got 0 exit code
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/gnubg -v` and found version 1.06.001
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/gnubg --version` and found version 1.06.001
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/makebearoff -h` got 0 exit code
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/makebearoff --help` got 0 exit code
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/makehyper -h` got 0 exit code
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/makehyper --help` got 0 exit code
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/bearoffdump -h` got 0 exit code
- ran `/nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001/bin/bearoffdump --help` got 0 exit code
- found 1.06.001 with grep in /nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001
- found 1.06.001 in filename of file in /nix/store/6r487wa172j7yn39akgn0i1hjp2d8z4g-gnubg-1.06.001