### PR TITLE
goaccess: 1.1.1 -> 1.2

### DIFF
--- a/pkgs/tools/misc/goaccess/default.nix
+++ b/pkgs/tools/misc/goaccess/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, geoipWithDatabase, ncurses, glib }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.1";
+  version = "1.2";
   name = "goaccess-${version}";
 
   src = fetchurl {
     url = "http://tar.goaccess.io/goaccess-${version}.tar.gz";
-    sha256 = "1lxnhvh4xhkgzdv0l2fiza2099phn9zs04p9cqfhhl5k6xq18wsc";
+    sha256 = "051lrprg9svl5ccc3sif8fl78vfpkrgjcxgi2wngqn7a81jzdabb";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/nify4rsvfsn7fbiq1c30060mr3386sz4-goaccess-1.2/bin/goaccess -V` and found version 1.2
- ran `/nix/store/nify4rsvfsn7fbiq1c30060mr3386sz4-goaccess-1.2/bin/goaccess --version` and found version 1.2
- found 1.2 with grep in /nix/store/nify4rsvfsn7fbiq1c30060mr3386sz4-goaccess-1.2
- found 1.2 in filename of file in /nix/store/nify4rsvfsn7fbiq1c30060mr3386sz4-goaccess-1.2

cc @ederoyd46 @garbas