### PR TITLE
ocamlPackages.sawja: 1.5.2 -> 1.5.3

### DIFF
--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -4,7 +4,7 @@ assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
 
 let
   pname = "sawja";
-  version = "1.5.2";
+  version = "1.5.3";
   webpage = "http://sawja.inria.fr/";
 in
 stdenv.mkDerivation rec {
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
   src = fetchurl {
-    url = https://gforge.inria.fr/frs/download.php/file/36093/sawja-1.5.2.tar.bz2;
-    sha256 = "12046arkxiy4gf1s17hyc0yzydjzpzwqxn13sbkbxl8xzvmankx4";
+    url = https://gforge.inria.fr/frs/download.php/file/37403/sawja-1.5.3.tar.bz2;
+    sha256 = "17vfknr126vfhpmr14j75sg8r47xz7pw7fba4nsdw3k7rq43vcn2";
   };
 
   buildInputs = [ which perl ocaml findlib camlp4 ];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

