### PR TITLE
gocr: 0.50 -> 0.51

### DIFF
--- a/pkgs/applications/graphics/gocr/default.nix
+++ b/pkgs/applications/graphics/gocr/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, tk }:
 
 stdenv.mkDerivation rec {
-  name = "gocr-0.50";
+  name = "gocr-0.51";
 
   src = fetchurl {
     url = "http://www-e.uni-magdeburg.de/jschulen/ocr/${name}.tar.gz";
-    sha256 = "1dgmcpapy7h68d53q2c5d0bpgzgfb2nw2blndnx9qhc7z12149mw";
+    sha256 = "14i6zi6q11h6d0qds2cpvgvhbxk5xaa027h8cd0wy1zblh7sxckf";
   };
 
   buildFlags = [ "all" "libs" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/6mm4a7nrr7ahv7wc47c137f28frhkrm5-gocr-0.51/bin/gocr --help` got 0 exit code
- ran `/nix/store/6mm4a7nrr7ahv7wc47c137f28frhkrm5-gocr-0.51/bin/gocr --help` and found version 0.51
- found 0.51 with grep in /nix/store/6mm4a7nrr7ahv7wc47c137f28frhkrm5-gocr-0.51
- found 0.51 in filename of file in /nix/store/6mm4a7nrr7ahv7wc47c137f28frhkrm5-gocr-0.51