### PR TITLE
google-compute-engine: 20170914 -> 20180129

### DIFF
--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonApplication rec {
   name = "google-compute-engine-${version}";
-  version = "20170914";
+  version = "20180129";
   namePrefix = "";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "compute-image-packages";
     rev = version;
-    sha256 = "0hlzcrf6yhzan25f4wzy1vbncak9whhqzrzza026ly3sq0smmjpg";
+    sha256 = "0380fnr64109hv8l1f3sgdg8a5mf020axj7jh8y25xq6wzkjm20c";
   };
 
   postPatch = ''

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -52,5 +52,6 @@ buildPythonApplication rec {
     homepage = "https://github.com/GoogleCloudPlatform/compute-image-packages";
     license = licenses.asl20;
     maintainers = with maintainers; [ zimbatm ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/optimize_local_ssd -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/optimize_local_ssd --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/optimize_local_ssd help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue -V` and found version 20180129
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue -v` and found version 20180129
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue --version` and found version 20180129
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue version` and found version 20180129
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue -h` and found version 20180129
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue --help` and found version 20180129
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/set_multiqueue help` and found version 20180129
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_accounts_daemon-wrapped -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_accounts_daemon-wrapped --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_accounts_daemon -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_accounts_daemon --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_instance_setup-wrapped -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_instance_setup-wrapped --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_instance_setup -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_instance_setup --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_network_setup-wrapped -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_network_setup-wrapped --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_network_setup -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_network_setup --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_ip_forwarding_daemon-wrapped -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_ip_forwarding_daemon-wrapped --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_ip_forwarding_daemon-wrapped help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_ip_forwarding_daemon -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_ip_forwarding_daemon --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_ip_forwarding_daemon help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_clock_skew_daemon-wrapped -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_clock_skew_daemon-wrapped --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_clock_skew_daemon-wrapped help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_clock_skew_daemon -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_clock_skew_daemon --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_clock_skew_daemon help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_metadata_script_runner-wrapped -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/.google_metadata_script_runner-wrapped --help` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_metadata_script_runner -h` got 0 exit code
- ran `/nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129/bin/google_metadata_script_runner --help` got 0 exit code
- found 20180129 with grep in /nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129
- found 20180129 in filename of file in /nix/store/xxf54yjdmhkmsy5h0rrh985lygpi3sjv-google-compute-engine-20180129

cc @zimbatm