### PR TITLE
google-play-music-desktop-player: 4.4.1 -> 4.5.0

### DIFF
--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "4.4.1";
+  version = "4.5.0";
 
   deps = [
     alsaLib
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v${version}/google-play-music-desktop-player_${version}_amd64.deb";
-    sha256 = "0jqgawgij6jxf3zy3glviqj6s34mq7d756syg2c7kk1gkqkwgdpw";
+    sha256 = "06h9g1yhd5q7gg8v55q143fr65frxg0khfgckr03gsaw0swin51q";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.5.0 with grep in /nix/store/9xvi5jsdbiphz2w704njd975xkv31y8g-google-play-music-desktop-player-4.5.0
- found 4.5.0 in filename of file in /nix/store/9xvi5jsdbiphz2w704njd975xkv31y8g-google-play-music-desktop-player-4.5.0

cc @SuprDewd