### PR TITLE
gource: 0.47 -> 0.48

### DIFF
--- a/pkgs/applications/version-management/gource/default.nix
+++ b/pkgs/applications/version-management/gource/default.nix
@@ -3,12 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.47";
+  version = "0.48";
   name = "gource-${version}";
 
   src = fetchurl {
     url = "https://github.com/acaudwell/Gource/releases/download/${name}/${name}.tar.gz";
-    sha256 = "1llqwdnfa1pff8bxk27qsqff1fcg0a9kfdib0rn7p28vl21n1cgj";
+    sha256 = "04qxcm05qiyr9rg2kv6abfy7kkzqr8ziw4iyp1d14lniv93m61dp";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/gyy4z4wamcdzymm7q4a6j1dljxcad7w2-gource-0.48/bin/gource -h` got 0 exit code
- ran `/nix/store/gyy4z4wamcdzymm7q4a6j1dljxcad7w2-gource-0.48/bin/gource --help` got 0 exit code
- ran `/nix/store/gyy4z4wamcdzymm7q4a6j1dljxcad7w2-gource-0.48/bin/gource -h` and found version 0.48
- ran `/nix/store/gyy4z4wamcdzymm7q4a6j1dljxcad7w2-gource-0.48/bin/gource --help` and found version 0.48
- found 0.48 with grep in /nix/store/gyy4z4wamcdzymm7q4a6j1dljxcad7w2-gource-0.48
- found 0.48 in filename of file in /nix/store/gyy4z4wamcdzymm7q4a6j1dljxcad7w2-gource-0.48

cc @pSub