### PR TITLE
bitcoin-xt: 0.11G2 -> 0.11H

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-xt.nix
+++ b/pkgs/applications/altcoins/bitcoin-xt.nix
@@ -6,13 +6,13 @@ with stdenv.lib;
 stdenv.mkDerivation rec{
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-xt-" + version;
-  version = "0.11G2";
+  version = "0.11H";
 
   src = fetchFromGitHub {
     owner = "bitcoinxt";
     repo = "bitcoinxt";
     rev = "v${version}";
-    sha256 = "071rljvsabyc9j64v248qfb7zfqpfl84hpsnvlavin235zljq8qs";
+    sha256 = "1v43bynmidn2zdpky939km721x3ks91bzyh4200gji61qzsmyg62";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, boost155, openssl_1_1_0, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3 }:
+{ callPackage, boost155, boost165, openssl_1_1_0, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3 }:
 
 rec {
 
@@ -16,8 +16,8 @@ rec {
   bitcoin-classic  = libsForQt5.callPackage ./bitcoin-classic.nix { withGui = true; };
   bitcoind-classic = callPackage ./bitcoin-classic.nix { withGui = false; };
 
-  bitcoin-xt  = callPackage ./bitcoin-xt.nix { withGui = true; };
-  bitcoind-xt = callPackage ./bitcoin-xt.nix { withGui = false; };
+  bitcoin-xt  = callPackage ./bitcoin-xt.nix { boost = boost165; withGui = true; };
+  bitcoind-xt = callPackage ./bitcoin-xt.nix { boost = boost165; withGui = false; };
 
   btc1 = callPackage ./btc1.nix { withGui = true; };
   btc1d = callPackage ./btc1.nix { withGui = false; };


### PR DESCRIPTION
###### Motivation for this change

fix bitcoin-xt for 18.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

