### PR TITLE
terraform-provider-nixos: init at 0.0.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-provider-nixos/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-provider-nixos/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+buildGoPackage rec {
+  name = "terraform-provider-nixos-${version}";
+  version = "0.0.1";
+  goPackagePath = "github.com/tweag/terraform-provider-nixos";
+  src = fetchFromGitHub {
+    owner = "tweag";
+    repo = "terraform-provider-nixos";
+    sha256 = "00vz6qjq1pk39iqg4356b8g3c6slla9jifkv2knk46gc9q93q0lf";
+    rev = "v${version}";
+  };
+
+  # Terraform allow checking the provider versions, but this breaks
+  # if the versions are not provided via file paths.
+  postBuild = "mv go/bin/terraform-provider-nixos{,_v${version}}";
+
+  meta = with stdenv.lib; {
+    description = "Terraform plugin for outputting NixOS configuration files from Terraform resources.";
+    homepage = "https://github.com/tweag/terraform-provider-nixos";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ grahamc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20537,6 +20537,8 @@ with pkgs;
 
   terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};
 
+  terraform-provider-nixos = callPackage ../applications/networking/cluster/terraform-provider-nixos {};
+
   terraform-landscape = callPackage ../applications/networking/cluster/terraform-landscape {};
 
   terragrunt = callPackage ../applications/networking/cluster/terragrunt {};


### PR DESCRIPTION
###### Motivation for this change

Add terraform-provider-nixos, the initial version. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Use via

```nix
pkgs.terraform.withPlugins (p: [ pkgs.terraform-provider-nixos ])
```