### PR TITLE
gperftools: 2.6.1 -> 2.6.3

### DIFF
--- a/pkgs/development/libraries/gperftools/default.nix
+++ b/pkgs/development/libraries/gperftools/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libunwind }:
 
 stdenv.mkDerivation rec {
-  name = "gperftools-2.6.1";
+  name = "gperftools-2.6.3";
 
   src = fetchurl {
     url = "https://github.com/gperftools/gperftools/releases/download/${name}/${name}.tar.gz";
-    sha256 = "10cxd6s5pkm2d934gh47hrn9xcrw4qlc9yr7s99z4a508bmngd1q";
+    sha256 = "17zfivp6n00rlqbrx6q6h71y2f815nvlzysff1ihgk4mxpv2yjri";
   };
 
   buildInputs = stdenv.lib.optional stdenv.isLinux libunwind;

--- a/pkgs/development/libraries/gperftools/default.nix
+++ b/pkgs/development/libraries/gperftools/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
     substituteInPlace libtool --replace stdc++ c++
   '';
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optional stdenv.isDarwin "-D_XOPEN_SOURCE";
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionals stdenv.isDarwin [
+    "-D_XOPEN_SOURCE" "-Wno-aligned-allocation-unavailable"
+  ];
 
   # some packages want to link to the static tcmalloc_minimal
   # to drop the runtime dependency on gperftools


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/ba54ymdab4y2jcxwbmn71sm698cy1wik-gperftools-2.6.3/bin/pprof --help` got 0 exit code
- ran `/nix/store/ba54ymdab4y2jcxwbmn71sm698cy1wik-gperftools-2.6.3/bin/pprof --help` and found version 2.6.3
- found 2.6.3 with grep in /nix/store/ba54ymdab4y2jcxwbmn71sm698cy1wik-gperftools-2.6.3
- found 2.6.3 in filename of file in /nix/store/ba54ymdab4y2jcxwbmn71sm698cy1wik-gperftools-2.6.3

cc @vcunat @wkennington