### PR TITLE
grails: 3.3.0 -> 3.3.2

### DIFF
--- a/pkgs/development/web/grails/default.nix
+++ b/pkgs/development/web/grails/default.nix
@@ -11,11 +11,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "grails-${version}";
-  version = "3.3.0";
+  version = "3.3.2";
 
   src = fetchurl {
     url = "https://github.com/grails/grails-core/releases/download/v${version}/grails-${version}.zip";
-    sha256 = "0lk9ll0x9w2akmlwkams9pxyafmgjmsr3fa45gx1r16nx563qxsg";
+    sha256 = "0rr1q84zgr8xvy40w0wq9ai9gilyn6by4j6av02aszjxciqblvzd";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.3.2 with grep in /nix/store/j3w2l8kqw37ndh3x7chkzw0mgryly4py-grails-3.3.2

cc @bjornfor