### PR TITLE
gramps: 4.2.6 -> 4.2.8

### DIFF
--- a/pkgs/applications/misc/gramps/default.nix
+++ b/pkgs/applications/misc/gramps/default.nix
@@ -7,7 +7,7 @@
 let
   inherit (pythonPackages) python buildPythonApplication;
 in buildPythonApplication rec {
-  version = "4.2.6";
+  version = "4.2.8";
   name = "gramps-${version}";
 
   buildInputs = [ intltool gtk3 ] 
@@ -22,7 +22,7 @@ in buildPythonApplication rec {
     owner = "gramps-project";
     repo = "gramps";
     rev = "v${version}";
-    sha256 = "0k0bx6msc2kvkg0nwa9v2mp3qy7lmnxjd97n6a1zdzlq8yzw29f1";
+    sha256 = "17y6rjvvcz7lwjck4f5nmhnn07i9k5vzk5dp1jk7j3ldxjagscsd";
   };
 
   pythonPath = with pythonPackages; [ bsddb3 PyICU pygobject3 pycairo ] ++ [ pango ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/gramps -h` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/gramps --help` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/gramps help` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/gramps -v` and found version 4.2.8
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/gramps --version` and found version 4.2.8
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/..gramps-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/..gramps-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/..gramps-wrapped-wrapped help` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/..gramps-wrapped-wrapped -v` and found version 4.2.8
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/..gramps-wrapped-wrapped --version` and found version 4.2.8
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/.gramps-wrapped -h` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/.gramps-wrapped --help` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/.gramps-wrapped help` got 0 exit code
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/.gramps-wrapped -v` and found version 4.2.8
- ran `/nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8/bin/.gramps-wrapped --version` and found version 4.2.8
- found 4.2.8 with grep in /nix/store/wpccn0mfc52ia42cx83v2q7irnvi99gg-gramps-4.2.8