### PR TITLE
graylog: 2.4.1 -> 2.4.3

### DIFF
--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.1";
+  version = "2.4.3";
   name = "graylog-${version}";
 
   src = fetchurl {
     url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-    sha256 = "1dps1vvv8b154ayamhjxdgiq101qs4w0nk79j3zb41pdyn2fji4j";
+    sha256 = "0kwgg9m9sqzl4y2ri69fpi7w9961psbmfdq3avjsbgbs60ly1hn6";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl -h` got 0 exit code
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl --help` got 0 exit code
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl help` got 0 exit code
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl -V` and found version 2.4.3
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl -v` and found version 2.4.3
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl --version` and found version 2.4.3
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl version` and found version 2.4.3
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl -h` and found version 2.4.3
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl --help` and found version 2.4.3
- ran `/nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3/bin/graylogctl help` and found version 2.4.3
- found 2.4.3 with grep in /nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3
- found 2.4.3 in filename of file in /nix/store/qyrv15995w1pl2vmf1i720ii4s9gb3x3-graylog-2.4.3

cc @fadenb