### PR TITLE
grml-zsh-config: 0.14.2 -> 0.14.3

### DIFF
--- a/pkgs/shells/grml-zsh-config/default.nix
+++ b/pkgs/shells/grml-zsh-config/default.nix
@@ -5,13 +5,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "grml-zsh-config-${version}";
-  version = "0.14.2";
+  version = "0.14.3";
 
   src = fetchFromGitHub {
     owner = "grml";
     repo = "grml-etc-core";
     rev = "v${version}";
-    sha256 = "1xvv2mnkfqa657w8y4q2zrchhindngdzij9fbalcg1gggz4zdwcm";
+    sha256 = "1akx6lwxnbcccddzw41rci8rb9n5vb6q2vpn5qr07f0grchyiifk";
   };
 
   buildInputs = [ zsh coreutils txt2tags ]


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.14.3 in filename of file in /nix/store/2z6cjbqfwc5h5rwz64c3pjd0a008yhp8-grml-zsh-config-0.14.3

cc @msteen @rvolosatovs