### PR TITLE
gromacs: 4.6.7 -> 2018

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -8,11 +8,11 @@
 
 
 stdenv.mkDerivation {
-  name = "gromacs-4.6.7";
+  name = "gromacs-2018";
 
   src = fetchurl {
-    url = "ftp://ftp.gromacs.org/pub/gromacs/gromacs-4.6.7.tar.gz";
-    sha256 = "6afb1837e363192043de34b188ca3cf83db6bd189601f2001a1fc5b0b2a214d9";
+    url = "ftp://ftp.gromacs.org/pub/gromacs/gromacs-2018.tar.gz";
+    sha256 = "1sfh3wdrw07797xm86fq10r0024ym585yyrnhdh0qam596vx1dfy";
   };
 
   buildInputs = [cmake fftw]


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/GMXRC.bash -h` got 0 exit code
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/GMXRC.bash --help` got 0 exit code
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/GMXRC.bash help` got 0 exit code
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/GMXRC.zsh -h` got 0 exit code
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/GMXRC.zsh --help` got 0 exit code
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/GMXRC.zsh help` got 0 exit code
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/gmx -h` got 0 exit code
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/gmx help` got 0 exit code
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/gmx --version` and found version 2018
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/gmx -h` and found version 2018
- ran `/nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018/bin/gmx help` and found version 2018
- found 2018 with grep in /nix/store/i2ls9z094j6a3vqvq6gz4hyhl86dh31d-gromacs-2018