### PR TITLE
groovy: 2.4.12 -> 2.4.14

### DIFF
--- a/pkgs/development/interpreters/groovy/default.nix
+++ b/pkgs/development/interpreters/groovy/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "groovy-${version}";
-  version = "2.4.12";
+  version = "2.4.14";
 
   src = fetchurl {
     url = "http://dl.bintray.com/groovy/maven/apache-groovy-binary-${version}.zip";
-    sha256 = "1dm7m221pqbgh3lp1q1nvv6qc0fpja3cgsd0mx3ghahcfsfa3fck";
+    sha256 = "0an5ddfajg8jwdi1zdkpcz1g8ij1iyp0xh7zck2bl84j3pi4dj7r";
   };
 
   buildInputs = [ unzip makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/grape -h` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/grape --help` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/grape help` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/grape -v` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/grape --version` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/java2groovy -h` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/java2groovy --help` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/java2groovy help` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovy -h` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovy --help` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovy -v` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovy --version` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovydoc --help` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovydoc --version` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovyc -h` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovyc --help` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovyc -v` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovyc --version` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovysh -h` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovysh --help` got 0 exit code
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovysh -V` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovysh --version` and found version 2.4.14
- ran `/nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14/bin/groovyConsole --help` got 0 exit code
- found 2.4.14 with grep in /nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14
- found 2.4.14 in filename of file in /nix/store/x26aa3454yhk91kncw7nnzl0pw4piwsy-groovy-2.4.14

cc @pSub