### PR TITLE
grpc: 1.9.1 -> 1.10.0

### DIFF
--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, zlib, c-ares, pkgconfig, openssl, protobuf, gflags }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.1";
+  version = "1.10.0";
   name = "grpc-${version}";
   src = fetchurl {
     url = "https://github.com/grpc/grpc/archive/v${version}.tar.gz";
-    sha256 = "0h2w0dckxydngva9kl7dpilif8k9zi2ajnlanscr7s5kkza3dhps";
+    sha256 = "0wngrb44bpryrvrnx5y1ncrhi2097qla929wqjwvs0razbk3v9rr";
   };
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ zlib c-ares c-ares.cmake-config openssl protobuf gflags ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/check_epollexclusive -h` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/check_epollexclusive --help` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/check_epollexclusive help` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_hpack_tables -h` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_hpack_tables --help` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_hpack_tables help` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_legal_metadata_characters -h` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_legal_metadata_characters --help` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_legal_metadata_characters help` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_percent_encoding_tables -h` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_percent_encoding_tables --help` got 0 exit code
- ran `/nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0/bin/gen_percent_encoding_tables help` got 0 exit code
- found 1.10.0 with grep in /nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0
- found 1.10.0 in filename of file in /nix/store/f1darm5xs8ihd8bfkq1icsgcy2kz5cpa-grpc-1.10.0