### PR TITLE
gsm: 1.0.14 -> 1.0.17

### DIFF
--- a/pkgs/development/libraries/gsm/default.nix
+++ b/pkgs/development/libraries/gsm/default.nix
@@ -9,11 +9,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "gsm-${version}";
-  version = "1.0.14";
+  version = "1.0.17";
 
   src = fetchurl {
     url = "http://www.quut.com/gsm/${name}.tar.gz";
-    sha256 = "0b1mx69jq88wva3wk0hi6fcl5a52qhnq2f9p3f3jdh5k61ma252q";
+    sha256 = "00bns0d4wwrvc60lj2w7wz4yk49q1f6rpdrwqzrxsha9d78mfnl5";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/cikcvld2cd32if9qgc3ilvvb7iksds3c-gsm-1.0.17/bin/toast -h` got 0 exit code
- ran `/nix/store/cikcvld2cd32if9qgc3ilvvb7iksds3c-gsm-1.0.17/bin/toast help` got 0 exit code
- ran `/nix/store/cikcvld2cd32if9qgc3ilvvb7iksds3c-gsm-1.0.17/bin/tcat -h` got 0 exit code
- ran `/nix/store/cikcvld2cd32if9qgc3ilvvb7iksds3c-gsm-1.0.17/bin/tcat help` got 0 exit code
- ran `/nix/store/cikcvld2cd32if9qgc3ilvvb7iksds3c-gsm-1.0.17/bin/untoast -h` got 0 exit code
- ran `/nix/store/cikcvld2cd32if9qgc3ilvvb7iksds3c-gsm-1.0.17/bin/untoast help` got 0 exit code
- found 1.0.17 with grep in /nix/store/cikcvld2cd32if9qgc3ilvvb7iksds3c-gsm-1.0.17
- found 1.0.17 in filename of file in /nix/store/cikcvld2cd32if9qgc3ilvvb7iksds3c-gsm-1.0.17

cc @codyopel @7c6f434c