### PR TITLE
gssdp: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/libraries/gssdp/default.nix
+++ b/pkgs/development/libraries/gssdp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gssdp-${version}";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gssdp/1.0/${name}.tar.xz";
-    sha256 = "1qfj4gir1qf6v86z70ryzmjb75ns30q6zi5p89vhd3621gs6f7b0";
+    sha256 = "1p1m2m3ndzr2whipqw4vfb6s6ia0g7rnzzc4pnq8b8g1qw4prqd1";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.0.2 with grep in /nix/store/dyf9dj8j9nlhh3kv4zvg6aj85hw5k42n-gssdp-1.0.2
- found 1.0.2 in filename of file in /nix/store/dyf9dj8j9nlhh3kv4zvg6aj85hw5k42n-gssdp-1.0.2