### PR TITLE
gtk-doc: 1.25 -> 1.27

### DIFF
--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gtk-doc-${version}";
-  version = "1.25";
+  version = "1.27";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk-doc/${version}/${name}.tar.xz";
-    sha256 = "0hpxcij9xx9ny3gs9p0iz4r8zslw8wqymbyababiyl7603a6x90y";
+    sha256 = "0vwsdl61nvnmqswlz5j9m4hg7qirhazwcikcnqf9nx0c13vx6sz2";
   };
 
   patches = [


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/6i54qzjbf3645yavr53qbvm12ddr9y7b-gtk-doc-1.27/bin/gtkdoc-depscan -h` got 0 exit code
- ran `/nix/store/6i54qzjbf3645yavr53qbvm12ddr9y7b-gtk-doc-1.27/bin/gtkdoc-depscan --help` got 0 exit code
- ran `/nix/store/6i54qzjbf3645yavr53qbvm12ddr9y7b-gtk-doc-1.27/bin/gtkdoc-depscan --version` and found version 1.27
- ran `/nix/store/6i54qzjbf3645yavr53qbvm12ddr9y7b-gtk-doc-1.27/bin/gtkdocize --help` got 0 exit code
- ran `/nix/store/6i54qzjbf3645yavr53qbvm12ddr9y7b-gtk-doc-1.27/bin/gtkdocize --version` and found version 1.27
- found 1.27 with grep in /nix/store/6i54qzjbf3645yavr53qbvm12ddr9y7b-gtk-doc-1.27
- found 1.27 in filename of file in /nix/store/6i54qzjbf3645yavr53qbvm12ddr9y7b-gtk-doc-1.27

cc @pSub