### PR TITLE
gtkdatabox: 0.9.2.0 -> 0.9.3.0

### DIFF
--- a/pkgs/development/libraries/gtkdatabox/default.nix
+++ b/pkgs/development/libraries/gtkdatabox/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, gtk2 }:
 
 stdenv.mkDerivation rec {
-  name = "gtkdatabox-0.9.2.0";
+  name = "gtkdatabox-0.9.3.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/gtkdatabox/${name}.tar.gz";
-    sha256 = "0h20685bzw5j5h6mw8c6apbrbrd9w518c6xdhr55147px11nhnkl";
+    sha256 = "1wigd4bdlrz4pma2l2wd3z8sx7pqmsvq845nya5vma9ibi96nhhz";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.3.0 with grep in /nix/store/3axd91hc3vi45w0j8yw0qfgwip4cx9da-gtkdatabox-0.9.3.0
- found 0.9.3.0 in filename of file in /nix/store/3axd91hc3vi45w0j8yw0qfgwip4cx9da-gtkdatabox-0.9.3.0