### PR TITLE
gtkwave: 3.3.86 -> 3.3.87

### DIFF
--- a/pkgs/applications/science/electronics/gtkwave/default.nix
+++ b/pkgs/applications/science/electronics/gtkwave/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gtkwave-${version}";
-  version = "3.3.86";
+  version = "3.3.87";
 
   src = fetchurl {
     url    = "mirror://sourceforge/gtkwave/${name}.tar.gz";
-    sha256 = "1l1hikhhk7drkbpdmj9qg7c3lj1b86z7f5rnwagrql8bss2j80fx";
+    sha256 = "0yjvxvqdl276wv0y55bqxwna6lwc99hy6dkfiy6bij3nd1qm5rf6";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/evcd2vcd -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/evcd2vcd --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/evcd2vcd help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/evcd2vcd -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/evcd2vcd -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/evcd2vcd --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/evcd2vcd -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/evcd2vcd --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fst2vcd -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fst2vcd --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fst2vcd -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fst2vcd -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fst2vcd --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fst2vcd -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fst2vcd --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2fst help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fstminer -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fstminer --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fstminer -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fstminer -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fstminer --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fstminer -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/fstminer --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2miner -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2miner --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2miner -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2miner -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2miner --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2miner -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2miner --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2vcd -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2vcd --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2vcd -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2vcd -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2vcd --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2vcd -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/lxt2vcd --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/shmidcat -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/shmidcat --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2lxt2 help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vcd2vzt help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vzt2vcd -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vzt2vcd --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vzt2vcd -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vzt2vcd -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vzt2vcd --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vzt2vcd -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vzt2vcd --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vztminer -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vztminer --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vztminer -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vztminer -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vztminer --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vztminer -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vztminer --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave -V` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave -v` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave --version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave version` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave -h` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave --help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/gtkwave help` and found version 3.3.87
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vermin -h` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vermin --help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vermin help` got 0 exit code
- ran `/nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87/bin/vermin -h` and found version 3.3.87
- found 3.3.87 with grep in /nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87
- found 3.3.87 in filename of file in /nix/store/4zxs7f77kc86xgy6k86cb8471l2kndax-gtkwave-3.3.87

cc @thoughtpolice @viric