### PR TITLE
gzdoom: 3.1.0 -> 3.2.5

### DIFF
--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "gzdoom-${version}";
-  version = "3.1.0";
+  version = "3.2.5";
 
   src = fetchFromGitHub {
     owner = "coelckers";
     repo = "gzdoom";
     rev = "g${version}";
-    sha256 = "02287xvlk4a07ssm9y9h5vfsvdssshz13n5bbz13pfcani5d9flv";
+    sha256 = "1x4v3cv448wqx4cdhs28nxrv0lm2c2pd9i2hm92q9lg5yw8vv19q";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.2.5 with grep in /nix/store/m0ms0fpwwi306zq5as89r1kb40bhba8n-gzdoom-3.2.5
- found 3.2.5 in filename of file in /nix/store/m0ms0fpwwi306zq5as89r1kb40bhba8n-gzdoom-3.2.5

cc @Lassulus