### PR TITLE
help2man: 1.47.5 -> 1.47.6

### DIFF
--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -1,11 +1,11 @@
 { stdenv, hostPlatform, fetchurl, perl, gettext, LocaleGettext, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "help2man-1.47.5";
+  name = "help2man-1.47.6";
 
   src = fetchurl {
     url = "mirror://gnu/help2man/${name}.tar.xz";
-    sha256 = "1cb14kp380jzk1yi4i7x9d8qplc8c5mgcbgycgs9ggpx34jhp9kw";
+    sha256 = "0vz4dlrvy4vc6l7w0a7n668pfa0rdm73wr2gar58wqranyah46yr";
   };
 
   nativeBuildInputs = [ makeWrapper gettext LocaleGettext ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/3qw4v9wzqzk8kljaln8r0p7s0g8msyj2-help2man-1.47.6/bin/help2man --help` got 0 exit code
- ran `/nix/store/3qw4v9wzqzk8kljaln8r0p7s0g8msyj2-help2man-1.47.6/bin/help2man --version` and found version 1.47.6
- found 1.47.6 with grep in /nix/store/3qw4v9wzqzk8kljaln8r0p7s0g8msyj2-help2man-1.47.6
- found 1.47.6 in filename of file in /nix/store/3qw4v9wzqzk8kljaln8r0p7s0g8msyj2-help2man-1.47.6

cc @pSub