### PR TITLE
hivex: 1.3.14 -> 1.3.15

### DIFF
--- a/pkgs/development/libraries/hivex/default.nix
+++ b/pkgs/development/libraries/hivex/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "hivex-${version}";
-  version = "1.3.14";
+  version = "1.3.15";
 
   src = fetchurl {
     url = "http://libguestfs.org/download/hivex/${name}.tar.gz";
-    sha256 = "0aqv28prjcmc66znw0wgaxjijg5mjm44bgn1iil8a4dlbsgv4p7b";
+    sha256 = "02vzipzrp1gr87rn7mkhyzr4zdjkp2dzcvvb223x7i0ch8ci7r4c";
   };
 
   patches = [ ./hivex-syms.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.3.15 with grep in /nix/store/i73ksxx7rd6dfwiasx7xacm4pvskprpv-hivex-1.3.15
- found 1.3.15 in filename of file in /nix/store/i73ksxx7rd6dfwiasx7xacm4pvskprpv-hivex-1.3.15

cc @offlinehacker