### PR TITLE
hsqldb: 1.8.0.9 -> 2.4.0

### DIFF
--- a/pkgs/development/libraries/java/hsqldb/default.nix
+++ b/pkgs/development/libraries/java/hsqldb/default.nix
@@ -2,12 +2,12 @@
 }:
 
 stdenv.mkDerivation {
-  name = "hsqldb-1.8.0.9";
+  name = "hsqldb-2.4.0";
   builder = ./builder.sh;
 
   src = fetchurl {
     url = mirror://sourceforge/hsqldb/hsqldb_1_8_0_9.zip;
-    sha256 = "e98d1d8bca15059f4ef4f0d3dde2d75778a5e1bbe8bc12abd4ec2cac39d5adec";
+    sha256 = "1v5dslwsqb7csjmi5g78pghsay2pszidvlzhyi79y18mra5iv3g9";
   };
 
   buildInputs = [ unzip


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.4.0 with grep in /nix/store/4179pxpwkjn7xk7rj0g538zjhsx9xzy1-hsqldb-2.4.0