### PR TITLE
icoutils: 0.31.3 -> 0.32.2

### DIFF
--- a/pkgs/tools/graphics/icoutils/default.nix
+++ b/pkgs/tools/graphics/icoutils/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libpng, perl, perlPackages, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "icoutils-0.31.3";
+  name = "icoutils-0.32.2";
 
   src = fetchurl {
     url = "mirror://savannah/icoutils/${name}.tar.bz2";
-    sha256 = "d4651de8e3f9e28d24b5343a2b7564f49754e5fe7d211c5d4dd60dcd65c8a152";
+    sha256 = "1g8ihxw24gbiy189h36w16lbyfq7fn260qkbc85n9jqrvkxsz4p8";
   };
 
   buildInputs = [ makeWrapper libpng perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/extresso -h` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/extresso --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/extresso help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/extresso --version` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript -h` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript -V` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript -v` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript --version` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript version` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript help` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/icotool --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/icotool --version` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/icotool --help` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/wrestool --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/wrestool --version` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/wrestool --help` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped -h` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped -V` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped -v` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped --version` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped version` and found version 0.32.2
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped help` and found version 0.32.2
- found 0.32.2 with grep in /nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2
- found 0.32.2 in filename of file in /nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2