### PR TITLE
imlib2: 1.4.10 -> 1.5.0

### DIFF
--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -5,11 +5,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "imlib2-1.4.10";
+  name = "imlib2-1.5.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/enlightenment/${name}.tar.bz2";
-    sha256 = "0wm2q2xlkbm71k7mw2jyzbxgzylrkcj5yh6nq58w5gybhp98qs9z";
+    sha256 = "0kg28b5wp886hiy12v7abdybrvlymb7g3nvg0ysn2y8h883s5w8m";
   };
 
   buildInputs = [ libjpeg libtiff giflib libpng bzip2 freetype libid3tag ]


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/extresso -h` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/extresso --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/extresso help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript -h` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/genresscript help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/icotool --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/wrestool --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped -h` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped --help` got 0 exit code
- ran `/nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2/bin/.genresscript-wrapped help` got 0 exit code
- found 1.5.0 in filename of file in /nix/store/bkabiqznkhmpz32pnm7kpb7gnkrwjcl3-icoutils-0.32.2

cc @spwhitt