### PR TITLE
inadyn: 2.3 -> 2.3.1

### DIFF
--- a/pkgs/tools/networking/inadyn/default.nix
+++ b/pkgs/tools/networking/inadyn/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "inadyn-${version}";
-  version = "2.3";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "troglobit";
     repo = "inadyn";
     rev = "v${version}";
-    sha256 = "1nkrvd33mnj98m86g3xs27l88l2678qjzjhwpq1k9n8v9k255pd6";
+    sha256 = "0m2lkmvklhnggv1kim0rikq1gxxc984lsg4gpn8s6lzv6y0axbya";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1/bin/inadyn -h` got 0 exit code
- ran `/nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1/bin/inadyn --help` got 0 exit code
- ran `/nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1/bin/inadyn help` got 0 exit code
- ran `/nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1/bin/inadyn -V` and found version 2.3.1
- ran `/nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1/bin/inadyn -v` and found version 2.3.1
- ran `/nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1/bin/inadyn --version` and found version 2.3.1
- ran `/nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1/bin/inadyn -h` and found version 2.3.1
- ran `/nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1/bin/inadyn --help` and found version 2.3.1
- found 2.3.1 with grep in /nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1
- found 2.3.1 in filename of file in /nix/store/zl5vf4sncl2rbf1n2h52fg86rc53q3q3-inadyn-2.3.1

cc @viric