### PR TITLE
iosevka: 1.14.0 -> 1.14.1

### DIFF
--- a/pkgs/data/fonts/iosevka/default.nix
+++ b/pkgs/data/fonts/iosevka/default.nix
@@ -26,13 +26,13 @@ in
 let pname = if set != null then "iosevka-${set}" else "iosevka"; in
 
 let
-  version = "1.14.0";
+  version = "1.14.1";
   name = "${pname}-${version}";
   src = fetchFromGitHub {
     owner = "be5invis";
     repo ="Iosevka";
     rev = "v${version}";
-    sha256 = "0mmdlrd9a0rhmmdqwkk6v7cdvbi23djr5kkiyv38llk11j3w0clp";
+    sha256 = "0m6kj1zfv9w6lyykhsfqdx2a951k8qa76licqikz5spm13n22z43";
   };
 in
 


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.14.1 with grep in /nix/store/96pxdcrjsqsw3wy79kqpjj1lwwndq62j-iosevka-1.14.1
- found 1.14.1 in filename of file in /nix/store/96pxdcrjsqsw3wy79kqpjj1lwwndq62j-iosevka-1.14.1

cc @cstrahan @jfrankenau @ttuegel