### PR TITLE
jackett: 0.8.151 -> 0.8.716

### DIFF
--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "jackett-${version}";
-  version = "0.8.151";
+  version = "0.8.716";
 
   src = fetchurl {
     url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.Mono.tar.gz";
-    sha256 = "2df2b296b5b314ed035e8d370bf5708a8b5a23957353e2e1e0007ec08a2138a0";
+    sha256 = "0i770f4h06jf76977y3cp9l5n5csnb9wzpskndc7mgk0h02m7nrc";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/j1arij5hyi6b28sg3hf08k4s81nz26bz-jackett-0.8.716/bin/Jackett -v` and found version 0.8.716
- found 0.8.716 with grep in /nix/store/j1arij5hyi6b28sg3hf08k4s81nz26bz-jackett-0.8.716
- found 0.8.716 in filename of file in /nix/store/j1arij5hyi6b28sg3hf08k4s81nz26bz-jackett-0.8.716

cc @edwtjo