### PR TITLE
jshon: 20140712 -> 20160111.2

### DIFF
--- a/pkgs/development/tools/parsing/jshon/default.nix
+++ b/pkgs/development/tools/parsing/jshon/default.nix
@@ -1,10 +1,10 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, jansson }:
 
 stdenv.mkDerivation rec {
-  name = "jshon-20140712";
+  name = "jshon-20160111.2";
 
   rev = "a61d7f2f85f4627bc3facdf951746f0fd62334b7";
-  sha256 = "b0365e58553b9613a5636545c5bfd4ad05ab5024f192e1cb1d1824bae4e1a380";
+  sha256 = "1053w7jbl90q3p5y34pi4i8an1ddsjzwaib5cfji75ivamc5wdmh";
 
   src = fetchFromGitHub {
     inherit rev sha256;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/pdxydl7lg0pbpcmh2332yygbb7b4vbq2-jshon-20160111.2/bin/jshon help` got 0 exit code
- found 20160111.2 in filename of file in /nix/store/pdxydl7lg0pbpcmh2332yygbb7b4vbq2-jshon-20160111.2

cc @rushmorem