### PR TITLE
kipi-plugins: 5.2.0 -> 5.8.0

### DIFF
--- a/pkgs/applications/graphics/kipi-plugins/default.nix
+++ b/pkgs/applications/graphics/kipi-plugins/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   name    = "kipi-plugins-${version}";
-  version = "5.2.0";
+  version = "5.8.0";
 
   src = fetchurl {
     url = "http://download.kde.org/stable/digikam/digikam-${version}.tar.xz";
-    sha256 = "0q4j7iv20cxgfsr14qwzx05wbp2zkgc7cg2pi7ibcnwba70ky96g";
+    sha256 = "0vhw15bjpp18vn8h8pm8d50ddlc3shw7m9pvmh0xaad27k648jhr";
   };
 
   prePatch = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 5.8.0 with grep in /nix/store/iran6x1779a5xbmb8ifs86lc708i6y18-kipi-plugins-5.8.0
- found 5.8.0 in filename of file in /nix/store/iran6x1779a5xbmb8ifs86lc708i6y18-kipi-plugins-5.8.0

cc @ttuegel