### PR TITLE
libdigidocpp: 3.12.0.1317 -> 3.13.3.1365

### DIFF
--- a/pkgs/development/libraries/libdigidocpp/default.nix
+++ b/pkgs/development/libraries/libdigidocpp/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
 
-  version = "3.12.0.1317";
+  version = "3.13.3.1365";
   name = "libdigidocpp-${version}";
 
   src = fetchurl {
-    url = "https://installer.id.ee/media/ubuntu/pool/main/libd/libdigidocpp/libdigidocpp_3.12.0.1317.orig.tar.xz";
-    sha256 = "8059e1dbab99f062d070b9da0b1334b7226f1ab9badcd7fddea3100519d1f9a9";
+    url = "https://installer.id.ee/media/ubuntu/pool/main/libd/libdigidocpp/libdigidocpp_3.13.3.1365.orig.tar.xz";
+    sha256 = "1xmvjh5xzspm6ja8hz6bzblwly7yn2jni2m6kx8ny9g65zjrj2iw";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.13.3.1365 with grep in /nix/store/bh5cizakj0dkmmwqqg4bvmhyvqd8x28n-libdigidocpp-3.13.3.1365
- found 3.13.3.1365 in filename of file in /nix/store/bh5cizakj0dkmmwqqg4bvmhyvqd8x28n-libdigidocpp-3.13.3.1365

cc @jagajaga