### PR TITLE
libdwarf: 20170709 -> 20180129

### DIFF
--- a/pkgs/development/libraries/libdwarf/default.nix
+++ b/pkgs/development/libraries/libdwarf/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, libelf }:
 
 let
-  version = "20170709";
+  version = "20180129";
   src = fetchurl {
     url = "http://www.prevanders.net/libdwarf-${version}.tar.gz";
     sha512 = "afff6716ef1af5d8aae2b887f36b9a6547fb576770bc6f630b82725ed1e59cbd"


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 20180129 in filename of file in /nix/store/42rw668b8h1zk4dvwlbdrknaf7vadlk5-libdwarf-20180129