### PR TITLE
libf2c: 20100903 -> 20130927

### DIFF
--- a/pkgs/development/libraries/libf2c/default.nix
+++ b/pkgs/development/libraries/libf2c/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  name = "libf2c-20100903";
+  name = "libf2c-20130927";
 
   src = fetchurl {
     url = http://www.netlib.org/f2c/libf2c.zip;
-    sha256 = "1mcp1lh7gay7hm186dr0wvwd2bc05xydhnc1qy3dqs4n3r102g7i";
+    sha256 = "1q78y8j8xpl8zdzdxmn5ablss56hi5a7vz3idam9l2nfx5q40h6a";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 20130927 in filename of file in /nix/store/6vvrb5gv988h40kyb2w6ag8nbd77r0wa-libf2c-20130927