### PR TITLE
libinput-gestures: 2.32 -> 2.33

### DIFF
--- a/pkgs/tools/inputmethods/libinput-gestures/default.nix
+++ b/pkgs/tools/inputmethods/libinput-gestures/default.nix
@@ -5,14 +5,14 @@
 }:
 stdenv.mkDerivation rec {
   pname = "libinput-gestures";
-  version = "2.32";
+  version = "2.33";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "bulletmark";
     repo = "libinput-gestures";
     rev = version;
-    sha256 = "1by6sabx0s8sd9w5675gc26q7yccxnxxsjg4dqlb6nbs0vcg81s7";
+    sha256 = "0a4zq880da1rn0mxn1sq4cp6zkw4bfslr0vjczkbj4immjrj422j";
   };
   patches = [
     ./0001-hardcode-name.patch


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.33 with grep in /nix/store/axjjpwcbb3s56m0fk68y8w8vji56f2a5-libinput-gestures-2.33
- found 2.33 in filename of file in /nix/store/axjjpwcbb3s56m0fk68y8w8vji56f2a5-libinput-gestures-2.33

cc @teozkr