### PR TITLE
libmysqlconnectorcpp: 1.1.7 -> 1.1.9

### DIFF
--- a/pkgs/development/libraries/libmysqlconnectorcpp/default.nix
+++ b/pkgs/development/libraries/libmysqlconnectorcpp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libmysqlconnectorcpp-${version}";
-  version = "1.1.7";
+  version = "1.1.9";
 
   src = fetchurl {
     url = "http://cdn.mysql.com/Downloads/Connector-C++/mysql-connector-c++-${version}.tar.gz";
-    sha256 = "0qy7kxz8h1zswr50ysyl2cc9gy0ip2j7ikl714m7lq3gsay3ydav";
+    sha256 = "1r6j17sy5816a2ld759iis2k6igc2w9p70y4nw9w3rd4d5x88c9y";
   };
 
   buildInputs = [ cmake boost mysql ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.1.9 with grep in /nix/store/vj6fm6qlsf14jlmlhwdyla240jqa6i4h-libmysqlconnectorcpp-1.1.9
- found 1.1.9 in filename of file in /nix/store/vj6fm6qlsf14jlmlhwdyla240jqa6i4h-libmysqlconnectorcpp-1.1.9