### PR TITLE
librime: 1.2.9 -> 1.2.10

### DIFF
--- a/pkgs/development/libraries/librime/default.nix
+++ b/pkgs/development/libraries/librime/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "librime-${version}";
-  version = "1.2.9";
+  version = "1.2.10";
 
   src = fetchFromGitHub {
     owner = "rime";
     repo = "librime";
     rev = "rime-${version}";
-    sha256 = "14jgnfm61ynm086x9v7wfmv2p14h0qp8lq4d2jqm21n821jsraj6";
+    sha256 = "1dah5clq3x8lrr2fyacyj4s4kicqaah2q6qm93l1621nm5qj3k1j";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.2.10 with grep in /nix/store/i14qrs2nf387q4b0pcxw0jdn2fjvd2nd-librime-1.2.10
- found 1.2.10 in filename of file in /nix/store/i14qrs2nf387q4b0pcxw0jdn2fjvd2nd-librime-1.2.10

cc @sifmelcara