### PR TITLE
libstrophe: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/development/libraries/libstrophe/default.nix
+++ b/pkgs/development/libraries/libstrophe/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libstrophe-${version}";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "strophe";
     repo = "libstrophe";
     rev = version;
-    sha256 = "099iv13c03y1dsn2ngdhfx2cnax0aj2gfh00w55hlzpvmjm8dsml";
+    sha256 = "1milna92h8wzxax8ll362zvb70091nmfks5lmd105vk0478zraca";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.2 with grep in /nix/store/gc20iqfsfjj6c9ikgz06k3rk3597h22q-libstrophe-0.9.2
- found 0.9.2 in filename of file in /nix/store/gc20iqfsfjj6c9ikgz06k3rk3597h22q-libstrophe-0.9.2

cc @devhell @flosse