### PR TITLE
libsvm: 3.20 -> 3.22

### DIFF
--- a/pkgs/development/libraries/libsvm/default.nix
+++ b/pkgs/development/libraries/libsvm/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libsvm-${version}";
-  version = "3.20";
+  version = "3.22";
 
   src = fetchurl {
     url = "https://www.csie.ntu.edu.tw/~cjlin/libsvm/libsvm-${version}.tar.gz";
-    sha256 = "1gj5v5zp1qnsnv0iwxq0ikhf8262d3s5dq6syr6yqkglps0284hg";
+    sha256 = "0zd7s19y5vb7agczl6456bn45cj1y64739sslaskw1qk7dywd0bd";
   };
 
   buildPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/97a1nnpdah29fs3v274lnzk0hcyhncg3-libsvm-3.22/bin/svm-scale help` got 0 exit code
- ran `/nix/store/97a1nnpdah29fs3v274lnzk0hcyhncg3-libsvm-3.22/bin/svm-train help` got 0 exit code
- found 3.22 in filename of file in /nix/store/97a1nnpdah29fs3v274lnzk0hcyhncg3-libsvm-3.22

cc @spwhitt