### PR TITLE
libzdb: 3.0 -> 3.1

### DIFF
--- a/pkgs/development/libraries/libzdb/default.nix
+++ b/pkgs/development/libraries/libzdb/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec
 {
-  version = "3.0";
+  version = "3.1";
   name = "libzdb-${version}";
 
   src = fetchurl
   {
     url = "http://www.tildeslash.com/libzdb/dist/libzdb-${version}.tar.gz";
-    sha256 = "e334bcb9ca1410e863634a164e3b1b5784018eb6e90b6c2b527780fc29a123c8";
+    sha256 = "1596njvy518x7vsvsykmnk1ky82x8jxd6nmmp551y6hxn2qsn08g";
   };
 
   buildInputs = [ sqlite ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.1 with grep in /nix/store/zpsvgnphvh4h494h5ivifrvrb5fjzj0w-libzdb-3.1
- found 3.1 in filename of file in /nix/store/zpsvgnphvh4h494h5ivifrvrb5fjzj0w-libzdb-3.1

cc @MoritzMaxeiner