### PR TITLE
haskellPackages.cuda: Fixed broken dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -58,9 +58,8 @@ self: super: builtins.intersectAttrs super {
   # CUDA needs help finding the SDK headers and libraries.
   cuda = overrideCabal super.cuda (drv: {
     extraLibraries = (drv.extraLibraries or []) ++ [pkgs.linuxPackages.nvidia_x11];
-    configureFlags = (drv.configureFlags or []) ++
-      pkgs.lib.optional pkgs.stdenv.is64bit "--extra-lib-dirs=${pkgs.cudatoolkit}/lib64" ++ [
-      "--extra-lib-dirs=${pkgs.cudatoolkit}/lib"
+    configureFlags = (drv.configureFlags or []) ++ [
+      "--extra-lib-dirs=${pkgs.cudatoolkit.lib}/lib"
       "--extra-include-dirs=${pkgs.cudatoolkit}/include"
     ];
     preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
haskellPackages.cuda currently fails to build with the following error:
```
Found CUDA toolkit at:
/nix/store/yqrc7zq74rpa26155vdfr4j503sn9n3q-cudatoolkit-9.1.85.1
Storing parameters to cuda.buildinfo.generated
Using build information from 'cuda.buildinfo.generated'.
Provide a 'cuda.buildinfo' file to override this behaviour.
Setup: Missing dependency on a foreign library:
* Missing C library: cudart
This problem can usually be solved by installing the system package that
provides this library (you may need the "-dev" version). If the library is
already installed but in a non-standard location then you can use the flags
--extra-include-dirs= and --extra-lib-dirs= to specify where it is.
builder for ‘/nix/store/inin9v72pjmiy05r2z6yd4bwdql5ki68-cuda-0.9.0.1.drv’ failed with exit code 1
```
Inspecting the generated file and Nix store indicated that it was looking in the wrong directory for `libcudart.so`

###### Things done
* bumped it 0.9.0.1 -> 0.9.0.2, to take advantage of [this fix](https://github.com/tmcdonell/cuda/pull/53)
* changed lib dependency from `cudatoolkit` to `cudatoolkit.lib` (this fixes the error)
* cleaned up redundant specification of `lib64`, which is just a symlink to `lib`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

