### PR TITLE
matio: 1.5.10 -> 1.5.11

### DIFF
--- a/pkgs/development/libraries/matio/default.nix
+++ b/pkgs/development/libraries/matio/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl }:
 stdenv.mkDerivation rec {
-  name = "matio-1.5.10";
+  name = "matio-1.5.11";
   src = fetchurl {
     url = "mirror://sourceforge/matio/${name}.tar.gz";
-    sha256 = "00dmg2f5k2xgakp7l0lganz122b1agazw5d899xci35xrqc9j821";
+    sha256 = "02ygr7bslzvn6mhxvapz57bh4d448xjf3ds82g1cvhn9al6fvk0c";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/252hdlnl6q9xajw71ydmpgi5nnybdc0n-matio-1.5.11/bin/matdump --help` got 0 exit code
- ran `/nix/store/252hdlnl6q9xajw71ydmpgi5nnybdc0n-matio-1.5.11/bin/matdump help` got 0 exit code
- ran `/nix/store/252hdlnl6q9xajw71ydmpgi5nnybdc0n-matio-1.5.11/bin/matdump -V` and found version 1.5.11
- ran `/nix/store/252hdlnl6q9xajw71ydmpgi5nnybdc0n-matio-1.5.11/bin/matdump --version` and found version 1.5.11
- found 1.5.11 with grep in /nix/store/252hdlnl6q9xajw71ydmpgi5nnybdc0n-matio-1.5.11
- found 1.5.11 in filename of file in /nix/store/252hdlnl6q9xajw71ydmpgi5nnybdc0n-matio-1.5.11

cc @vbgl