### PR TITLE
mosquitto: 1.4.14 -> 1.4.15

### DIFF
--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mosquitto";
-  version = "1.4.14";
+  version = "1.4.15";
 
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "http://mosquitto.org/files/source/mosquitto-${version}.tar.gz";
-    sha256 = "1la2577h7hcyj7lq26vizj0sh2zmi9m7nbxjp3aalayi66kiysqm";
+    sha256 = "10wsm1n4y61nz45zwk4zjhvrfd86r2cq33370m5wjkivb8j3wfvx";
   };
 
   buildInputs = [ openssl libuuid libwebsockets c-ares libuv ]


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.4.15 with grep in /nix/store/7nifpbj16dlhljb2jwbwxyv4wx1zwa1y-mosquitto-1.4.15
- found 1.4.15 in filename of file in /nix/store/7nifpbj16dlhljb2jwbwxyv4wx1zwa1y-mosquitto-1.4.15