### PR TITLE
idrisPackages: fix errors

### DIFF
--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -50,8 +50,6 @@
 
     lightyear = callPackage ./lightyear.nix {};
 
-    optparse = callPackage ./optparse.nix {};
-
     wl-pprint = callPackage ./wl-pprint.nix {};
 
     specdris = callPackage ./specdris.nix {};

--- a/pkgs/development/idris-modules/wl-pprint.nix
+++ b/pkgs/development/idris-modules/wl-pprint.nix
@@ -6,7 +6,7 @@
 , idris
 }:
 build-idris-package {
-  pkName = "wl-pprint";
+  name = "wl-pprint";
   version = "2016-09-28";
 
   src = fetchFromGitHub {

--- a/pkgs/development/idris-modules/wl-pprint.nix
+++ b/pkgs/development/idris-modules/wl-pprint.nix
@@ -7,13 +7,13 @@
 }:
 build-idris-package {
   name = "wl-pprint";
-  version = "2016-09-28";
+  version = "2017-03-13";
 
   src = fetchFromGitHub {
     owner = "shayan-najd";
     repo = "wl-pprint";
-    rev = "4cc88a0865620a3b997863e4167d3b98e1a41b52";
-    sha256 = "1yxxh366k5njad75r0xci2q5c554cddvzgrwk43b0xn8rq0vm11x";
+    rev = "97590d1679b3db07bb430783988b4cba539e9947";
+    sha256 = "0ifp76cqg340jkkzanx69vg76qivv53vh1lzv9zkp5f49prkwl5d";
   };
 
   # The tests for this package fail. We should attempt to enable them when


### PR DESCRIPTION
###### Motivation for this change

- `idrisPackages` attrset could not be evaluated because of missing `optparse`
- `idrisPackages.wl-pprint` package definition was broken, preventing `idrisPackages` from being evaluated
- `idrisPackages.wl-pprint` was out of date and didn't build

I've successfully built all Idris packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

