### PR TITLE
mpfr: 3.1.6 -> 4.0.1

### DIFF
--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "mpfr-3.1.6";
+  name = "mpfr-4.0.1";
 
   src = fetchurl {
     url = "mirror://gnu/mpfr/${name}.tar.xz";
-    sha256 = "0l598h9klpgkz2bp0rxiqb90mkqh9f2f81n5rpy191j00hdaqqks";
+    sha256 = "0vp1lrc08gcmwdaqck6bpzllkrykvp06vz5gnqpyw0v3h9h4m1v7";
   };
 
   outputs = [ "out" "dev" "doc" "info" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.0.1 with grep in /nix/store/gpsg0bpw02hpc8hddjnirpnvsp7n4ak8-mpfr-4.0.1
- found 4.0.1 in filename of file in /nix/store/gpsg0bpw02hpc8hddjnirpnvsp7n4ak8-mpfr-4.0.1