### PR TITLE
rapid-photo-downloader: init at 0.9.9

### DIFF
--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchurl, python3Packages
+, file, intltool, gobjectIntrospection, libgudev
+, udisks, glib, gnome3, gst_all_1, libnotify
+, exiv2, exiftool, qt5, gdk_pixbuf
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rapid-photo-downloader";
+  version = "0.9.9";
+
+  src = fetchurl {
+    url = "https://launchpad.net/rapid/pyqt/${version}/+download/${pname}-${version}.tar.gz";
+    sha256 = "193l55wdxwxmammyxwzp90sg0qw5r316443la3m9611sdpcmy8w3";
+  };
+
+  # Disable version check and fix install tests
+  postPatch = ''
+    substituteInPlace raphodo/constants.py \
+      --replace "disable_version_check = False" "disable_version_check = True"
+    substituteInPlace raphodo/rescan.py \
+      --replace "from preferences" "from raphodo.preferences"
+    substituteInPlace raphodo/copyfiles.py \
+      --replace "import problemnotification" "import raphodo.problemnotification"
+  '';
+
+  nativeBuildInputs = [ file intltool gobjectIntrospection ];
+
+  buildInputs = [
+    libgudev
+    udisks
+    glib
+    gnome3.gexiv2
+    gst_all_1.gstreamer
+    libnotify
+    exiv2
+    exiftool
+    qt5.qtimageformats
+    gdk_pixbuf
+  ] ++ (with python3Packages; [
+    pyqt5
+    pygobject3
+    gphoto2
+    pyzmq
+    tornado
+    psutil
+    pyxdg
+    arrow
+    dateutil
+    easygui
+    colour
+    pymediainfo
+    sortedcontainers
+    rawkit
+    requests
+    colorlog
+    pyprind
+  ]);
+
+  makeWrapperArgs = [
+    "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\""
+    "--set PYTHONPATH \"$PYTHONPATH\""
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Photo and video importer for cameras, phones, and memory cards";
+    homepage = http://www.damonlynch.net/rapid/;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/development/python-modules/easygui/default.nix
+++ b/pkgs/development/python-modules/easygui/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "easygui";
+  version = "0.98.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zmvmwgxyzvm83818skhn8b4wrci4kmnixaax8q3ia5cn7xrmj6v";
+  };
+
+  doCheck = false; # No tests available
+
+  meta = with stdenv.lib; {
+    description = "Very simple, very easy GUI programming in Python";
+    homepage = https://github.com/robertlugg/easygui;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/development/python-modules/gphoto2/default.nix
+++ b/pkgs/development/python-modules/gphoto2/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, pkgconfig
+, libgphoto2 }:
+
+buildPythonPackage rec {
+  pname = "gphoto2";
+  version = "1.8.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1806bdjc18qh0wyayxymgjnqqqlxs2iwvgk594anxw9y69hrxqni";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ libgphoto2 ];
+
+  doCheck = false; # No tests available
+
+  meta = with stdenv.lib; {
+    description = "Python interface to libgphoto2";
+    homepage = https://github.com/jim-easterbrook/python-gphoto2;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/development/python-modules/pymediainfo/default.nix
+++ b/pkgs/development/python-modules/pymediainfo/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, libmediainfo
+, setuptools_scm
+, pytest, glibcLocales }:
+
+buildPythonPackage rec {
+  pname = "pymediainfo";
+  version = "2.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1d0mxxycacimy46b08q44xyxkyji7rrs7viwc3wkpckhqs54q24x";
+  };
+
+  postPatch = ''
+    substituteInPlace pymediainfo/__init__.py \
+      --replace 'CDLL(library_file)' \
+                'CDLL("${libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}")' \
+      --replace 'CDLL("libmediainfo.0.dylib")' \
+                'CDLL("${libmediainfo}/lib/libmediainfo.0${stdenv.hostPlatform.extensions.sharedLibrary}")' \
+      --replace 'CDLL("libmediainfo.dylib")' \
+                'CDLL("${libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}")' \
+      --replace 'CDLL("libmediainfo.so.0")' \
+                'CDLL("${libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}.0")'
+  '';
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  checkInputs = [ glibcLocales pytest ];
+
+  checkPhase = ''
+    export LC_ALL=en_US.UTF-8
+    py.test -k 'not test_parse_url' tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python wrapper for the mediainfo library";
+    homepage = https://github.com/sbraz/pymediainfo;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/development/python-modules/pyprind/default.nix
+++ b/pkgs/development/python-modules/pyprind/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, psutil
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "PyPrind";
+  version = "2.11.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xg6m5hr33h9bdlrr42kc58jm2m87a9zsagy7n2m4n407d2snv64";
+  };
+
+  buildInputs = [ psutil ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python Progress Bar and Percent Indicator Utility";
+    homepage = https://github.com/rasbt/pyprind;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/development/python-modules/rawkit/default.nix
+++ b/pkgs/development/python-modules/rawkit/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, libraw
+, pytest, mock }:
+
+buildPythonPackage rec {
+  pname = "rawkit";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vrhrpr70i61y5q5ysk341x1539ff1q1k82g59zq69lv16s0f76s";
+  };
+
+  buildInputs = [ libraw ];
+
+  checkInputs = [ pytest mock ];
+
+  checkPhase = ''
+    py.test tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "CTypes based LibRaw bindings for Python";
+    homepage = https://rawkit.readthedocs.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17996,6 +17996,8 @@ with pkgs;
 
   rapcad = libsForQt5.callPackage ../applications/graphics/rapcad { boost = boost159; };
 
+  rapid-photo-downloader = libsForQt5.callPackage ../applications/graphics/rapid-photo-downloader { };
+
   rapidsvn = callPackage ../applications/version-management/rapidsvn { };
 
   ratmen = callPackage ../tools/X11/ratmen {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4091,6 +4091,8 @@ in {
     };
   };
 
+  pyprind = callPackage ../development/python-modules/pyprind { };
+
   python-axolotl = callPackage ../development/python-modules/python-axolotl { };
 
   python-axolotl-curve25519 = callPackage ../development/python-modules/python-axolotl-curve25519 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4280,6 +4280,8 @@ in {
 
   raven = callPackage ../development/python-modules/raven { };
 
+  rawkit = callPackage ../development/python-modules/rawkit { };
+
   rethinkdb = buildPythonPackage rec {
     name = "rethinkdb-${version}";
     version = "2.3.0.post6";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6263,6 +6263,10 @@ in {
 
   gpgme = toPythonModule (pkgs.gpgme.override { withPython=true; });
 
+  gphoto2 = callPackage ../development/python-modules/gphoto2 {
+    inherit (pkgs) pkgconfig;
+  };
+
   grammalecte = callPackage ../development/python-modules/grammalecte { };
 
   greenlet = callPackage ../development/python-modules/greenlet { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2272,6 +2272,8 @@ in {
 
   easydict = callPackage ../development/python-modules/easydict { };
 
+  easygui = callPackage ../development/python-modules/easygui { };
+
   EasyProcess = callPackage ../development/python-modules/easyprocess { };
 
   easy-thumbnails = callPackage ../development/python-modules/easy-thumbnails { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4025,6 +4025,8 @@ in {
 
   pylama = callPackage ../development/python-modules/pylama { };
 
+  pymediainfo = callPackage ../development/python-modules/pymediainfo { };
+
   pyphen = callPackage ../development/python-modules/pyphen {};
 
   pypoppler = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Rapid Photo Downloader is a quick and simple to use photo importer.

###### Things done

Add a few python packages needed for `rapid-photo-downloader`.

Currently, `libgudev` is manually overridden for `rapid-photo-downloader` to be built with `gobjectIntrospection`. It's probably better to wait for #35335 to be merged.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
