### PR TITLE
mpg123: 1.25.8 -> 1.25.10

### DIFF
--- a/pkgs/applications/audio/mpg123/default.nix
+++ b/pkgs/applications/audio/mpg123/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "mpg123-1.25.8";
+  name = "mpg123-1.25.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/mpg123/${name}.tar.bz2";
-    sha256 = "16s9z1xc5kv1p90g42vsr9m4gq3dwjsmrj873x4i8601mvpm3nkr";
+    sha256 = "08vhp8lz7d9ybhxcmkq3adwfryhivfvp0745k4r9kgz4wap3f4vc";
   };
 
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin) alsaLib;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123 --help` got 0 exit code
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123 --version` and found version 1.25.10
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123 --help` and found version 1.25.10
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/out123 --help` got 0 exit code
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/out123 --version` and found version 1.25.10
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/out123 --help` and found version 1.25.10
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-id3dump -h` got 0 exit code
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-id3dump --help` got 0 exit code
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-id3dump help` got 0 exit code
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-id3dump -h` and found version 1.25.10
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-id3dump --help` and found version 1.25.10
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-strip -h` got 0 exit code
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-strip --help` got 0 exit code
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-strip -h` and found version 1.25.10
- ran `/nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10/bin/mpg123-strip --help` and found version 1.25.10
- found 1.25.10 with grep in /nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10
- found 1.25.10 in filename of file in /nix/store/1jxjkns1jaykmbi0ci3rrvbk5ag2ldrf-mpg123-1.25.10

cc @ftrvxmtrx