### PR TITLE
mypy: 0.560 -> 0.570

### DIFF
--- a/pkgs/development/tools/mypy/default.nix
+++ b/pkgs/development/tools/mypy/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonApplication rec {
   pname = "mypy";
-  version = "0.560";
+  version = "0.570";
 
   # Tests not included in pip package.
   doCheck = false;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1jja0xlwqajxzab8sabiycax8060zikg89dnl9a7lkqcrwprl35x";
+    sha256 = "09cz0h4d6xcdqlchw080nkjlwki3mgjrlvfnj5hxxwi3cgv9imw3";
   };
 
   propagatedBuildInputs = [ lxml typed-ast psutil ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.dmypy-wrapped -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.dmypy-wrapped --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.dmypy-wrapped help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/dmypy -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/dmypy --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/dmypy help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.mypy-wrapped -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.mypy-wrapped --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.mypy-wrapped -V` and found version 0.570
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.mypy-wrapped --version` and found version 0.570
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/mypy -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/mypy --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/mypy -V` and found version 0.570
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/mypy --version` and found version 0.570
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.stubgen-wrapped -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.stubgen-wrapped --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.stubgen-wrapped help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.stubgen-wrapped version` and found version 0.570
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.stubgen-wrapped help` and found version 0.570
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/stubgen -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/stubgen --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/stubgen help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/stubgen version` and found version 0.570
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/stubgen help` and found version 0.570
- found 0.570 with grep in /nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570

cc @martingms @lnl7