### PR TITLE
nghttp2: 1.24.0 -> 1.31.0

### DIFF
--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -17,11 +17,11 @@ let inherit (stdenv.lib) optional; in
 
 stdenv.mkDerivation rec {
   name = "nghttp2-${version}";
-  version = "1.24.0";
+  version = "1.31.0";
 
   src = fetchurl {
     url = "https://github.com/nghttp2/nghttp2/releases/download/v${version}/nghttp2-${version}.tar.bz2";
-    sha256 = "18ys6p39yvm9wjjzhhlw35c9m8f5gf4dk9jbshibj19q4js1pnv9";
+    sha256 = "0d7ivd7agsrbpz8745d0c0hxjzx9pdj602p1bpnrsd7p393ydrln";
   };
 
   outputs = [ "bin" "out" "dev" "lib" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.dmypy-wrapped -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.dmypy-wrapped --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.dmypy-wrapped help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/dmypy -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/dmypy --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/dmypy help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.mypy-wrapped -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.mypy-wrapped --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/mypy -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/mypy --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.stubgen-wrapped -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.stubgen-wrapped --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/.stubgen-wrapped help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/stubgen -h` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/stubgen --help` got 0 exit code
- ran `/nix/store/ml19prlfk05s39z9252ppjs31ryjfn36-mypy-0.570/bin/stubgen help` got 0 exit code

cc @wkennington