### PR TITLE
libgroove: fix build

### DIFF
--- a/pkgs/development/libraries/libgroove/default.nix
+++ b/pkgs/development/libraries/libgroove/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1la9d9kig50mc74bxvhx6hzqv0nrci9aqdm4k2j4q0s1nlfgxipd";
   };
 
+  patches = [ ./no-warnings-as-errors.patch ];
+
   buildInputs = [ cmake libav SDL2 chromaprint libebur128 ];
 
   meta = with stdenv.lib; {
@@ -18,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/andrewrk/libgroove;
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = [ maintainers.andrewrk ];
+    maintainers = with maintainers; [ andrewrk ma27 ];
   };
 }

--- a/pkgs/development/libraries/libgroove/no-warnings-as-errors.patch
+++ b/pkgs/development/libraries/libgroove/no-warnings-as-errors.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a1e8541..6bc9c30 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -135,8 +135,8 @@ configure_file (
+   "${PROJECT_BINARY_DIR}/config.h"
+   )
+ 
+-set(LIB_CFLAGS "${C99_C_FLAGS} -pedantic -Werror -Wall -Werror=strict-prototypes -Werror=old-style-definition -Werror=missing-prototypes -D_REENTRANT -D_POSIX_C_SOURCE=200809L")
+-set(EXAMPLE_CFLAGS "${C99_C_FLAGS} -pedantic -Werror -Wall -g")
++set(LIB_CFLAGS "${C99_C_FLAGS} -pedantic -Wall -Werror=strict-prototypes -Werror=old-style-definition -Werror=missing-prototypes -D_REENTRANT -D_POSIX_C_SOURCE=200809L")
++set(EXAMPLE_CFLAGS "${C99_C_FLAGS} -pedantic -Wall -g")
+ set(EXAMPLE_INCLUDES "${PROJECT_SOURCE_DIR}")
+ 
+ add_library(groove SHARED ${LIBGROOVE_SOURCES} ${LIBGROOVE_HEADERS})


### PR DESCRIPTION
###### Motivation for this change

When compiling with GCC v7 and the `-Werror` flag several new warnings
caused the build to fail: https://hydra.nixos.org/build/70751457/nixlog/2

Note: I patched the CMake file manually as v4.3.0 is quite old, a v5 is
in progress, but isn't stable yet, so patching v4 seems to be the better
solution taking stability into account.

See tickets #31747 and #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

