### PR TITLE
ngspice: 26 -> 27

### DIFF
--- a/pkgs/applications/science/electronics/ngspice/default.nix
+++ b/pkgs/applications/science/electronics/ngspice/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, readline, bison, flex, libX11, libICE, libXaw, libXext}:
 
 stdenv.mkDerivation {
-  name = "ngspice-26";
+  name = "ngspice-27";
 
   src = fetchurl {
-    url = "mirror://sourceforge/ngspice/ngspice-26.tar.gz";
-    sha256 = "51e230c8b720802d93747bc580c0a29d1fb530f3dd06f213b6a700ca9a4d0108";
+    url = "mirror://sourceforge/ngspice/ngspice-27.tar.gz";
+    sha256 = "15862npsy5sj56z5yd1qiv3y0fgicrzj7wwn8hbcy89fgbawf20c";
   };
 
   buildInputs = [ readline libX11 flex bison libICE libXaw libXext ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 27 with grep in /nix/store/73sh9hf5c9fjgh962pd1ac16kr8dvzxg-ngspice-27
- found 27 in filename of file in /nix/store/73sh9hf5c9fjgh962pd1ac16kr8dvzxg-ngspice-27

cc @viric @rongcuid