### PR TITLE
bonfire: fix build

### DIFF
--- a/pkgs/tools/misc/bonfire/default.nix
+++ b/pkgs/tools/misc/bonfire/default.nix
@@ -20,7 +20,7 @@ buildPythonApplication rec {
     # https://github.com/blue-yonder/bonfire/pull/24
     substituteInPlace requirements.txt \
       --replace "arrow>=0.5.4,<0.8" "arrow>=0.5.4,<0.13" \
-      --replace "keyring>=9,<10"    "keyring>=9,<11"
+      --replace "keyring>=9,<10"    "keyring>=9,<=11"
     # pip fails when encountering the git hash for the package version
     substituteInPlace setup.py \
       --replace "version=version," "version='${version}',"


### PR DESCRIPTION
###### Motivation for this change

The requirement's constraint for `pythonPackages.keyring` didn't allow
keyring v11. However it has been bumped in 93a16a2ace93fd96866d98181a07a8c5a779acce
by @FRidh.

Current failure: https://nix-cache.s3.amazonaws.com/log/2nw5adfx86jwiax32mn11kqpc35xwhsh-bonfire-unstable-2017-01-19.drv
See ticket #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

