### PR TITLE
cpp-gsl: treat sign-conversion as warning

### DIFF
--- a/pkgs/development/libraries/cpp-gsl/default.nix
+++ b/pkgs/development/libraries/cpp-gsl/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0h8py468bvxnydkjs352d7a9s8hk0ihc7msjkcnzj2d7nzp5nsc1";
   };
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=sign-conversion";
   nativeBuildInputs = [ cmake catch ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/cpp-gsl/default.nix
+++ b/pkgs/development/libraries/cpp-gsl/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "GSL-unstable";
-  version = "2018-03-06";
+  version = "2017-02-15";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/cpp-gsl/default.nix
+++ b/pkgs/development/libraries/cpp-gsl/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "GSL-unstable";
-  version = "2017-02-15";
+  version = "2018-03-06";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Fixes hydra build failure https://hydra.nixos.org/build/69860422 of upstream tests by treating C++ sign-conversion as warning.  (Presumably, the update of the default gcc from gcc6 to gcc7 have instroduced `-Werror=sign-conversion` to the default compiler options.)

Also, takes this opportunity to update to a recent version.

edit: /cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

