### PR TITLE
nixnote2: fix icon and version

### DIFF
--- a/pkgs/applications/misc/nixnote2/default.nix
+++ b/pkgs/applications/misc/nixnote2/default.nix
@@ -24,7 +24,13 @@ mkDerivation rec {
         --replace '#include <poppler-qt5.h>' '#include <poppler/qt5/poppler-qt5.h>'
     done
 
+    substituteInPlace help/about.html --replace '__VERSION__' '${version}'
+
     substituteInPlace nixnote.cpp --replace 'tidyProcess.start("tidy' 'tidyProcess.start("${html-tidy}/bin/tidy'
+  '';
+  
+  postInstal = ''
+    cp images/windowIcon.png $out/share/pixmaps/nixnote2.png
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
fixed missing icon and about-box's version

###### Things done

suggestion by @dtzWill 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

