### PR TITLE
obs-studio: 21.0.2 -> 21.0.3

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -29,13 +29,13 @@ let
   optional = stdenv.lib.optional;
 in stdenv.mkDerivation rec {
   name = "obs-studio-${version}";
-  version = "21.0.2";
+  version = "21.0.3";
 
   src = fetchFromGitHub {
     owner = "jp9000";
     repo = "obs-studio";
     rev = "${version}";
-    sha256 = "1yyvxqzxy9dz6rmjcrdn90nfaff4f38mfz2gsq535cr59sg3f8jc";
+    sha256 = "1mrihhzlsc66w5lr1lcm8c8jg6z0iwmmckr3pk3gk92z4s55969q";
   };
 
   patches = [ ./find-xcb.patch ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/f600v8k119a2l3hscik6xsbsvz3w4jx8-obs-studio-21.0.3/bin/obs -h` got 0 exit code
- ran `/nix/store/f600v8k119a2l3hscik6xsbsvz3w4jx8-obs-studio-21.0.3/bin/obs --help` got 0 exit code
- ran `/nix/store/f600v8k119a2l3hscik6xsbsvz3w4jx8-obs-studio-21.0.3/bin/.obs-wrapped -h` got 0 exit code
- ran `/nix/store/f600v8k119a2l3hscik6xsbsvz3w4jx8-obs-studio-21.0.3/bin/.obs-wrapped --help` got 0 exit code
- found 21.0.3 with grep in /nix/store/f600v8k119a2l3hscik6xsbsvz3w4jx8-obs-studio-21.0.3

cc @jb55 @MP2E