### PR TITLE
oneko: 1.2.5 -> 2.0b

### DIFF
--- a/pkgs/applications/misc/oneko/default.nix
+++ b/pkgs/applications/misc/oneko/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   version = "1.2.sakura.5";
-  vname = "1.2.5";
+  vname = "2.0b";
   name = "oneko-${vname}";
   src = fetchurl {
     url = "http://www.daidouji.com/oneko/distfiles/oneko-${version}.tar.gz";
-    sha256 = "2c2e05f1241e9b76f54475b5577cd4fb6670de058218d04a741a04ebd4a2b22f";
+    sha256 = "0bxjlbafn10sfi5d06420pg70rpvsiy5gdbm8kspd6qy4kqhabic";
   };
   buildInputs = [ xorg.imake xorg.gccmakedep x11 ];
   


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/pilvgigv4bhwcn6viy3cl9w6gl8kmcsy-oneko-2.0b/bin/oneko -h` got 0 exit code
- ran `/nix/store/pilvgigv4bhwcn6viy3cl9w6gl8kmcsy-oneko-2.0b/bin/oneko -h` and found version 2.0b
- found 2.0b in filename of file in /nix/store/pilvgigv4bhwcn6viy3cl9w6gl8kmcsy-oneko-2.0b

cc @xaverdh