### PR TITLE
sasview: init at 4.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3015,6 +3015,11 @@
     github = "rongcuid";
     name = "Rongcui Dong";
   };
+  rprospero = {
+    email = "rprospero+nix@gmail.com";
+    github = "rprospero";
+    name = "Adam Washington";
+  };
   rszibele = {
     email = "richard@szibele.com";
     github = "rszibele";

--- a/pkgs/applications/science/misc/sasview/default.nix
+++ b/pkgs/applications/science/misc/sasview/default.nix
@@ -1,0 +1,51 @@
+{lib, fetchgit, gcc, python}:
+
+let
+  html5 = import ./myHtml5.nix {inherit python;};
+  xhtml2pdf = import ./xhtml2pdf.nix {inherit python html5;};
+in
+
+python.pkgs.buildPythonApplication rec {
+  name = "sasview-${version}";
+  version = "4.1.2";
+
+  propagatedBuildInputs = with python.pkgs; [
+    bumps
+    gcc
+    h5py
+    html5
+    libxslt
+    lxml
+    matplotlib
+    numpy
+    pyparsing
+    periodictable
+    pillow
+    pylint
+    pyopencl
+    pytest
+    reportlab
+    sasmodels
+    scipy
+    six
+    sphinx
+    unittest-xml-reporting
+    wxPython
+    xhtml2pdf];
+
+  src = fetchgit {
+    url = "https://github.com/SasView/sasview.git";
+    rev = "v${version}";
+    sha256 ="05la54wwzzlkhmj8vkr0bvzagyib6z6mgwqbddzjs5y1wd48vpcx";
+  };
+
+  patches = [./pyparsing-fix.patch ./local_config.patch];
+  sandbox = true;
+
+  meta = {
+    homepage = https://www.sasview.org;
+    description = "Fitting and data analysis for small angle scattering data";
+    maintainers = with lib.maintainers; [ rprospero ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/applications/science/misc/sasview/local_config.patch
+++ b/pkgs/applications/science/misc/sasview/local_config.patch
@@ -1,0 +1,10 @@
+--- a/src/sas/_config.py
++++ b/src/sas/_config.py
+@@ -70,2 +70,2 @@
+-        logger.critical("Error loading %s: %s", path, exc)
+-        sys.exit()
++        import sas.sasview.local_config
++        return sas.sasview.local_config
+-- 
+2.15.0
+

--- a/pkgs/applications/science/misc/sasview/myHtml5.nix
+++ b/pkgs/applications/science/misc/sasview/myHtml5.nix
@@ -1,0 +1,20 @@
+{python}:
+
+python.pkgs.buildPythonPackage (rec{
+  buildInputs = with python.pkgs; [ flake8 pytest pytest-expect mock ];
+  propagatedBuildInputs = with python.pkgs; [
+    six webencodings
+  ];
+
+  checkPhase = ''
+    py.test
+  '';
+  pname = "html5lib";
+  name = "html5lib-${version}";
+  version = "1.0b10";
+  src = python.pkgs.fetchPypi {
+    pname = "html5lib";
+    inherit version;
+    sha256 = "1yd068a5c00wd0ajq0hqimv7fd82lhrw0w3s01vbhy9bbd6xapqd";
+  };
+})

--- a/pkgs/applications/science/misc/sasview/pyparsing-fix.patch
+++ b/pkgs/applications/science/misc/sasview/pyparsing-fix.patch
@@ -1,0 +1,8 @@
+--- a/setup.py
++++ b/setup.py
+@@ -5,1 +5,1 @@
+-    'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing<2.0.0',
++    'bumps>=0.7.5.9', 'periodictable>=1.5.0',
+-- 
+2.15.0
+

--- a/pkgs/applications/science/misc/sasview/xhtml2pdf.nix
+++ b/pkgs/applications/science/misc/sasview/xhtml2pdf.nix
@@ -1,0 +1,15 @@
+{python, html5}:
+
+python.pkgs.buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "xhtml2pdf";
+  version = "0.2.1";
+
+  buildInputs = [html5];
+  propagatedBuildInputs = with python.pkgs; [httplib2 pillow pypdf2 reportlab html5];
+
+  src = python.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "1n9r8zdk9gc2x539fq60bhszmd421ipj8g78zmsn3njvma1az9k1";
+  };
+}

--- a/pkgs/development/python-modules/bumps/default.nix
+++ b/pkgs/development/python-modules/bumps/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, six}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "bumps";
+  version = "0.7.6";
+
+  propagatedBuildInputs = [six];
+
+  # Bumps does not provide its own tests.py, so the test
+  # always fails
+  doCheck = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ahzw8ls9wsz2ks668s15zskyykib52fhi07mg50hp7lw9avqb5k";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://www.reflectometry.org/danse/software.html;
+    description = "Data fitting with bayesian uncertainty analysis";
+    maintainers = with maintainers; [ rprospero ];
+    license = licenses.publicDomain;
+  };
+}

--- a/pkgs/development/python-modules/sasmodels/default.nix
+++ b/pkgs/development/python-modules/sasmodels/default.nix
@@ -1,0 +1,23 @@
+{fetchgit, licenses, buildPythonPackage, pytest, numpy, scipy, matplotlib, docutils}:
+
+buildPythonPackage rec {
+  name = "sasmodels-${version}";
+  version = "0.96";
+
+  propagatedBuildInputs = [docutils matplotlib numpy pytest scipy];
+
+  preCheck = ''export HOME=$(mktemp -d)'';
+
+  src = fetchgit {
+    url = "https://github.com/SasView/sasmodels.git";
+    rev = "v${version}";
+    sha256 = "11qaaqdc23qzb75zs48fkypksmcb332vl0pkjqr5bijxxymgm7nw";
+  };
+
+  meta = {
+    description = "Library of small angle scattering models";
+    homepage = http://sasview.org;
+    license = licenses.bsd3;
+    maintainers = with lib.maintainers; [ rprospero ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4633,6 +4633,8 @@ with pkgs;
 
   samplicator = callPackage ../tools/networking/samplicator { };
 
+  sasview = callPackage ../applications/science/misc/sasview {};
+
   scanbd = callPackage ../tools/graphics/scanbd { };
 
   screen = callPackage ../tools/misc/screen {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1321,6 +1321,8 @@ in {
     enablePython = true;
   });
 
+  bumps = callPackage ../development/python-modules/bumps {};
+
   buttersink = buildPythonPackage rec {
     name = "buttersink-0.6.8";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15321,6 +15321,10 @@ in {
 
   sampledata = callPackage ../development/python-modules/sampledata { };
 
+  sasmodels = callPackage ../development/python-modules/sasmodels {
+    inherit licenses;
+  };
+
   scapy = callPackage ../development/python-modules/scapy { };
 
   scipy = callPackage ../development/python-modules/scipy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12276,6 +12276,26 @@ in {
     };
   };
 
+  periodictable = buildPythonPackage rec{
+    name = "${pname}-${version}";
+    pname = "periodictable";
+    version = "1.5.0";
+
+    propagatedBuildInputs = with self; [numpy pyparsing];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1cjk6aqcz41nxm4fpriz01vqdafd6g57cjk0wh1iklk5cx6c085h";
+    };
+
+    meta = {
+      homepage = http://www.reflectometry.org/danse/software.html;
+      description = "an extensible periodic table of the elements prepopulated with data important to neutron and x-ray scattering experiments";
+      license = licenses.publicDomain;
+      maintainers = with maintainers; [ rprospero ];
+    };
+  };
+
   pg8000 = buildPythonPackage rec {
     name = "pg8000-1.10.1";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17349,6 +17349,29 @@ in {
     };
   };
 
+  unittest-xml-reporting = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "unittest-xml-reporting";
+    version = "2.1.1";
+
+    propagatedBuildInputs = with self; [six];
+
+    # The tarball from Pypi doesn't actually contain the unit tests
+    doCheck = false;
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1jwkqx5gfphkymp3xwqvlb94ng22gpbqh36vbbnsrpk1a0mammm6";
+    };
+    meta = with stdenv.lib; {
+      homepage = https://github.com/xmlrunner/unittest-xml-reporting/tree/master/;
+      description = "A unittest runner that can save test results to XML files";
+      license = licenses.bsd2;
+      maintainers = with maintainers; [ rprospero ];
+    };
+  };
+
+
   uritemplate_py = buildPythonPackage rec {
     name = "uritemplate.py-${version}";
     version = "0.3.0";


### PR DESCRIPTION
###### Motivation for this change

[Sasview](https://www.sasview.org) is a data fitting and analysis package for small angle scattering data.  This PR adds both SasView and the python libraries that it depends upon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

