### PR TITLE
openfst: 1.6.3 -> 1.6.6

### DIFF
--- a/pkgs/development/libraries/openfst/default.nix
+++ b/pkgs/development/libraries/openfst/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "openfst";
-  version = "1.6.3";
+  version = "1.6.6";
 
   src = fetchurl {
     url = "http://www.openfst.org/twiki/pub/FST/FstDownload/${name}.tar.gz";
-    sha256 = "5c28b6ccd017fc6ff94ebd0c73ed8ab37d48f563dab1c603856fb05bc9333d99";
+    sha256 = "1b13nzf9xh1iv0k8z7sdfs9ya2ykf0gzjiixpb1qn3bydck6ppdm";
   };
   meta = {
     description = "Library for working with finite-state transducers";


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/4yq76v4x9kkmwqmvrcxh89kh1lp96gg0-openfst-1.6.6/bin/fstcompile help` got 0 exit code
- found 1.6.6 with grep in /nix/store/4yq76v4x9kkmwqmvrcxh89kh1lp96gg0-openfst-1.6.6
- found 1.6.6 in filename of file in /nix/store/4yq76v4x9kkmwqmvrcxh89kh1lp96gg0-openfst-1.6.6

cc @dfordivam