### PR TITLE
openlibm: 0.5.4 -> 0.5.5

### DIFF
--- a/pkgs/development/libraries/science/math/openlibm/default.nix
+++ b/pkgs/development/libraries/science/math/openlibm/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "openlibm-${version}";
-  version = "0.5.4";
+  version = "0.5.5";
   src = fetchurl {
     url = "https://github.com/JuliaLang/openlibm/archive/v${version}.tar.gz";
-    sha256 = "0cwqqqlblj3kzp9aq1wnpfs1fl0qd1wp1xzm5shb09w06i4rh9nn";
+    sha256 = "1z8cj5q8ca8kmrakwkpjxf8svi81waw0c568cx8v8pv9kvswbp07";
   };
 
   makeFlags = [ "prefix=$(out)" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.5.5 with grep in /nix/store/im5hsldagl6la2yf5s8rsnv2w57mb76m-openlibm-0.5.5
- found 0.5.5 in filename of file in /nix/store/im5hsldagl6la2yf5s8rsnv2w57mb76m-openlibm-0.5.5

cc @ttuegel