### PR TITLE
sage: Mark as broken on non-86_64 platforms

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -224,7 +224,15 @@ stdenv.mkDerivation rec {
       Mission: Creating a viable free open source alternative to Magma, Maple, Mathematica and Matlab.
     '';
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.all;
+    # Sage *should* run on all platforms. However this package probably doesn't
+    # build on most of them. For example the aarch64 hydra build failed. I
+    # suspect thats because the x86_64 build uses some pre-generated make
+    # artefacts that have to be rebuilt on other platforms (but fail to do so).
+    # I don't currently have a non-x86_64 system with nix to test on. If you
+    # want to fix the build for another system and need help, feel free to
+    # contact me (timokau).
+    broken = stdenv.system != "x86_64-linux";
     maintainers = with stdenv.lib.maintainers; [ timokau ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Sage fails to build on aarch64. I'm not sure what the conventions around that are, but since upstream supports many more platforms than linux-x86_64 I used the `meta.broken` attribute instead of `meta.platforms`.

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

