### PR TITLE
opensubdiv: 3.3.0 -> 3.3.1

### DIFF
--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "opensubdiv-${version}";
-  version = "3.3.0";
+  version = "3.3.1";
 
   src = fetchFromGitHub {
     owner = "PixarAnimationStudios";
     repo = "OpenSubdiv";
     rev = "v${lib.replaceChars ["."] ["_"] version}";
-    sha256 = "0wpjwfik4q9s4r30hndhzmfyzv968mmg5lgng0123l07mn47d2yl";
+    sha256 = "1s96038yvf8wch5gv537iigqflxx7rh9wwn3wlrk8f9yfdwv1mk1";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.3.1 with grep in /nix/store/68xswr0fs8b098ww8l832z2gljmfgpwd-opensubdiv-3.3.1
- found 3.3.1 in filename of file in /nix/store/68xswr0fs8b098ww8l832z2gljmfgpwd-opensubdiv-3.3.1

cc @edolstra