### PR TITLE
caffe2: fix compilation on gcc7

### DIFF
--- a/pkgs/development/libraries/science/math/caffe2/default.nix
+++ b/pkgs/development/libraries/science/math/caffe2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, config, fetchFromGitHub
+{ stdenv, lib, config, fetchFromGitHub, fetchpatch
 , cmake
 , glog, google-gflags, gtest
 , protobuf, snappy
@@ -56,6 +56,8 @@ let
     };
     dst = "pybind11";
   };
+
+  ccVersion = (builtins.parseDrvName stdenv.cc.name).version;
 in
 
 stdenv.mkDerivation rec {
@@ -84,7 +86,9 @@ stdenv.mkDerivation rec {
   ;
   propagatedBuildInputs = [ numpy future six python-protobuf pydot ];
 
-  patches = lib.optional stdenv.cc.isClang [ ./update_clang_cvtsh_bugfix.patch ];
+  patches = lib.optional (stdenv.cc.isGNU && lib.versionAtLeast ccVersion "7.0.0") [
+    ./fix_compilation_on_gcc7.patch
+  ] ++ lib.optional stdenv.cc.isClang [ ./update_clang_cvtsh_bugfix.patch ];
 
   cmakeFlags = [ ''-DBUILD_TEST=OFF''
                  ''-DBUILD_PYTHON=ON''

--- a/pkgs/development/libraries/science/math/caffe2/fix_compilation_on_gcc7.patch
+++ b/pkgs/development/libraries/science/math/caffe2/fix_compilation_on_gcc7.patch
@@ -1,0 +1,46 @@
+diff --git a/caffe2/operators/recurrent_network_op.cc b/caffe2/operators/recurrent_network_op.cc
+index dd4fded..5995e8a 100644
+--- a/caffe2/operators/recurrent_network_op.cc
++++ b/caffe2/operators/recurrent_network_op.cc
+@@ -1,4 +1,4 @@
+-#include "recurrent_network_op.h"
++#include "caffe2/operators/recurrent_network_op.h"
+ #include "caffe2/core/workspace.h"
+ 
+ namespace caffe2 {
+diff --git a/caffe2/operators/recurrent_network_op.h b/caffe2/operators/recurrent_network_op.h
+index 55328e5..ea898bc 100644
+--- a/caffe2/operators/recurrent_network_op.h
++++ b/caffe2/operators/recurrent_network_op.h
+@@ -762,8 +762,8 @@ class AccumulateInputGradientOp : public Operator<Context> {
+   USE_OPERATOR_CONTEXT_FUNCTIONS;
+ 
+   bool RunOnDevice() override {
+-    const auto t =
+-        OperatorBase::Input<Tensor<CPUContext>>(0).template data<int32_t>()[0];
++    const auto& t0 = OperatorBase::Input<Tensor<CPUContext>>(0);
++    const auto t = t0.template data<int32_t>()[0];
+     auto& og = Input(1);
+     auto* g = Output(0);
+ 
+diff --git a/caffe2/queue/queue_ops.h b/caffe2/queue/queue_ops.h
+index f2c0a33..642343f 100644
+--- a/caffe2/queue/queue_ops.h
++++ b/caffe2/queue/queue_ops.h
+@@ -17,13 +17,10 @@ class CreateBlobsQueueOp final : public Operator<Context> {
+         name(operator_def.output().Get(0)) {}
+ 
+   bool RunOnDevice() override {
+-    const auto capacity =
+-        OperatorBase::template GetSingleArgument<int>("capacity", 1);
+-    const auto numBlobs =
+-        OperatorBase::template GetSingleArgument<int>("num_blobs", 1);
++    const auto capacity = GetSingleArgument("capacity", 1);
++    const auto numBlobs = GetSingleArgument("num_blobs", 1);
+     const auto enforceUniqueName =
+-        OperatorBase::template GetSingleArgument<int>(
+-            "enforce_unique_name", false);
++        GetSingleArgument("enforce_unique_name", false);
+     const auto fieldNames =
+         OperatorBase::template GetRepeatedArgument<std::string>("field_names");
+     CAFFE_ENFORCE_EQ(this->OutputSize(), 1);


### PR DESCRIPTION
###### Motivation for this change

Fixes hydra build failure https://hydra.nixos.org/build/69866586 .

The issue is discussed upstream in https://github.com/caffe2/caffe2/issues/805 and has been fixed on `master` by https://github.com/caffe2/caffe2/pull/1602 .
The change, however, has not been backported to `v0.8.1` nor can it be applied as-is, so we bundle a diff created by hand ( `fix_compilation_on_gcc7.patch` ).

edit: /cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

