### PR TITLE
openvpn: 2.4.4 -> 2.4.5

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -10,11 +10,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "openvpn-${version}";
-  version = "2.4.4";
+  version = "2.4.5";
 
   src = fetchurl {
     url = "http://swupdate.openvpn.net/community/releases/${name}.tar.xz";
-    sha256 = "102an395nv8l7qfx3syydzhmd9xfbycd6gvwy0h2kjz8w67ipkcn";
+    sha256 = "17njq59hsraqyxrbhkrxr7dvx0p066s3pn8w1mi0yd9jldis7h23";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.4.5 with grep in /nix/store/a2wdxd4c08b1gilnj2mcvkmvpnqxw942-openvpn-2.4.5
- found 2.4.5 in filename of file in /nix/store/a2wdxd4c08b1gilnj2mcvkmvpnqxw942-openvpn-2.4.5

cc @viric