### PR TITLE
pingus: fix build with gcc7

### DIFF
--- a/pkgs/games/pingus/default.nix
+++ b/pkgs/games/pingus/default.nix
@@ -1,5 +1,5 @@
-{stdenv, fetchurl, scons, SDL, SDL_image, boost, libpng, SDL_mixer, pkgconfig
-, libGLU_combined}:
+{stdenv, fetchurl, fetchpatch, scons, SDL, SDL_image, boost, libpng, SDL_mixer
+, pkgconfig, libGLU_combined}:
 let
   s = # Generated upstream information
   rec {
@@ -18,6 +18,13 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     inherit (s) url sha256;
   };
+  patches = [
+    # fix build with gcc7
+    (fetchpatch {
+      url = https://github.com/Pingus/pingus/commit/df6e2f445d3e2925a94d22faeb17be9444513e92.patch;
+      sha256 = "0nqyhznnnvpgfa6rfv8rapjfpw99b67n97jfqp9r3hpib1b3ja6p";
+    })
+  ];
   makeFlags = '' PREFIX="$(out)" '';
   meta = {
     inherit (s) version;


### PR DESCRIPTION
###### Motivation for this change

Fix build with gcc7.

/cc @7c6f434c 

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

