### PR TITLE
os-prober: 1.73 -> 1.76

### DIFF
--- a/pkgs/tools/misc/os-prober/default.nix
+++ b/pkgs/tools/misc/os-prober/default.nix
@@ -11,11 +11,11 @@ ntfs3g ? null
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.73";
+  version = "1.76";
   name = "os-prober-${version}";
   src = fetchurl {
     url = "mirror://debian/pool/main/o/os-prober/os-prober_${version}.tar.xz";
-    sha256 = "1prssbwdgj5c33zhl3ldgaxk7lab9qvs4zhyrhag88wiivirb0sq";
+    sha256 = "1vb45i76bqivlghrq7m3n07qfmmq4wxrkplqx8gywj011rhq19fk";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/y8qy7xrvq4ji5hg5k5gv8v5f08m4ps1g-os-prober-1.76/bin/.linux-boot-prober-wrapped -h` got 0 exit code
- ran `/nix/store/y8qy7xrvq4ji5hg5k5gv8v5f08m4ps1g-os-prober-1.76/bin/.linux-boot-prober-wrapped --help` got 0 exit code
- ran `/nix/store/y8qy7xrvq4ji5hg5k5gv8v5f08m4ps1g-os-prober-1.76/bin/.linux-boot-prober-wrapped help` got 0 exit code
- ran `/nix/store/y8qy7xrvq4ji5hg5k5gv8v5f08m4ps1g-os-prober-1.76/bin/.os-prober-wrapped -h` got 0 exit code
- ran `/nix/store/y8qy7xrvq4ji5hg5k5gv8v5f08m4ps1g-os-prober-1.76/bin/.os-prober-wrapped --help` got 0 exit code
- ran `/nix/store/y8qy7xrvq4ji5hg5k5gv8v5f08m4ps1g-os-prober-1.76/bin/.os-prober-wrapped help` got 0 exit code
- found 1.76 with grep in /nix/store/y8qy7xrvq4ji5hg5k5gv8v5f08m4ps1g-os-prober-1.76
- found 1.76 in filename of file in /nix/store/y8qy7xrvq4ji5hg5k5gv8v5f08m4ps1g-os-prober-1.76