### PR TITLE
yate: patch shebangs in configure

### DIFF
--- a/pkgs/applications/misc/yate/default.nix
+++ b/pkgs/applications/misc/yate/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   preConfigure =
     ''
       sed -i 's@,/dev/null@@' configure
+      patchShebangs configure
     '';
 
   # --unresolved-symbols=ignore-in-shared-libs makes ld no longer find --library=yate? Why?

--- a/pkgs/applications/misc/yate/default.nix
+++ b/pkgs/applications/misc/yate/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     # OpenH323 and PWlib (licensed under MPL).
     license = ["GPL" "MPL"];
     maintainers = [ lib.maintainers.marcweber ];
-    platforms = lib.platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Avoid dependency on `/bin/sh`, otherwise the build may fail like so https://hydra.nixos.org/build/70734780/nixlog/2

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

