### PR TITLE
jfbview: mark as broken (upstream issue)

### DIFF
--- a/pkgs/os-specific/linux/jfbview/default.nix
+++ b/pkgs/os-specific/linux/jfbview/default.nix
@@ -64,5 +64,7 @@ stdenv.mkDerivation rec {
     homepage = https://seasonofcode.com/pages/jfbview.html;
     license = licenses.asl20;
     platforms = platforms.linux;
+    # incompatible with latest mupdf, see https://github.com/jichu4n/JFBView/issues/17
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

doesn't build, incompatible with current libmupdf: https://github.com/jichu4n/JFBView/issues/17
upstream repo appears rather inactive.

cc ZHF #36453 