### PR TITLE
prepare for a swtich to `libcardiacarrest`

### DIFF
--- a/pkgs/applications/audio/pamixer/default.nix
+++ b/pkgs/applications/audio/pamixer/default.nix
@@ -1,14 +1,21 @@
-{ stdenv, fetchurl, boost, libpulseaudio }:
+{ stdenv, fetchFromGitHub, fetchpatch, boost, libpulseaudio }:
 
 stdenv.mkDerivation rec {
-
   name = "pamixer-${version}";
   version = "1.3.1";
 
-  src = fetchurl {
-    url = "https://github.com/cdemoulins/pamixer/archive/${version}.tar.gz";
-    sha256 = "1lsvb4xk1dq762w9c0jn7xvj3v1lzppql9mj1b55fhzdypbrkm6x";
+  src = fetchFromGitHub {
+    owner = "cdemoulins";
+    repo = "pamixer";
+    rev = version;
+    sha256 = "15zs2x4hnrpxphqn542b6qqm4ymvhkvbcfyffy69d6cki51chzzw";
   };
+
+  # Remove after https://github.com/cdemoulins/pamixer/pull/16 gets fixed
+  patches = [(fetchpatch {
+    url = "https://github.com/oxij/pamixer/commit/dea1cd967aa837940e5c0b04ef7ebc47a7a93d63.patch";
+    sha256 = "0s77xmsiwywyyp6f4bjxg1sqdgms1k5fiy7na6ws0aswshfnzfjb";
+  })];
 
   buildInputs = [ boost libpulseaudio ];
 

--- a/pkgs/applications/networking/browsers/firefox/fix-pa-context-connect-retval.patch
+++ b/pkgs/applications/networking/browsers/firefox/fix-pa-context-connect-retval.patch
@@ -1,0 +1,26 @@
+Yep, it's a "return code was ignored" bug.
+diff --git a/media/libcubeb/src/cubeb_pulse.c b/media/libcubeb/src/cubeb_pulse.c
+index aaaaaaaaaaa..bbbbbbbbbbb 100644
+--- a/media/libcubeb/src/cubeb_pulse.c
++++ b/media/libcubeb/src/cubeb_pulse.c
+@@ -473,6 +473,8 @@
+ static int
+ pulse_context_init(cubeb * ctx)
+ {
++  int r;
++
+   if (ctx->context) {
+     assert(ctx->error == 1);
+     pulse_context_destroy(ctx);
+@@ -486,9 +488,9 @@
+   WRAP(pa_context_set_state_callback)(ctx->context, context_state_callback, ctx);
+ 
+   WRAP(pa_threaded_mainloop_lock)(ctx->mainloop);
+-  WRAP(pa_context_connect)(ctx->context, NULL, 0, NULL);
++  r = WRAP(pa_context_connect)(ctx->context, NULL, 0, NULL);
+ 
+-  if (wait_until_context_ready(ctx) != 0) {
++  if (r < 0 || wait_until_context_ready(ctx) != 0) {
+     WRAP(pa_threaded_mainloop_unlock)(ctx->mainloop);
+     pulse_context_destroy(ctx);
+     ctx->context = NULL;

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -93,15 +93,18 @@ rec {
         It will use your default Firefox profile if you're not careful
         even! Be careful!
 
-        It will clash with firefox binary if you install both. But its
-        not a problem since you should run browsers in separate
-        users/VMs anyway.
+        It will clash with firefox binary if you install both. But it
+        should not be a problem because you should run browsers in
+        separate users/VMs anyway.
 
         Create new profile by starting it as
 
         $ firefox -ProfileManager
 
         and then configure it to use your tor instance.
+
+        Or just use `tor-browser-bundle` package that packs this
+        `tor-browser` back into a sanely-built bundle.
       '';
       homepage = https://www.torproject.org/projects/torbrowser.html;
       platforms = lib.platforms.linux;

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -1,6 +1,18 @@
 { lib, callPackage, stdenv, overrideCC, gcc5, fetchurl, fetchFromGitHub, fetchpatch }:
 
-let common = opts: callPackage (import ./common.nix opts); in
+let
+
+  common = opts: callPackage (import ./common.nix opts);
+
+  nixpkgsPatches = [
+    ./env_var_for_system_dir.patch
+
+    # this one is actually an omnipresent bug
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1444519
+    ./fix-pa-context-connect-retval.patch
+  ];
+
+in
 
 rec {
 
@@ -12,9 +24,8 @@ rec {
       sha512 = "ff748780492fc66b3e44c7e7641f16206e4c09514224c62d37efac2c59877bdf428a3670bfb50407166d7b505d4e2ea020626fd776b87f6abb6bc5d2e54c773f";
     };
 
-    patches = [
+    patches = nixpkgsPatches ++ [
       ./no-buildconfig.patch
-      ./env_var_for_system_dir.patch
 
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1430274
       # Scheduled for firefox 59
@@ -49,8 +60,7 @@ rec {
       sha512 = "cf583df34272b7ff8841c3b093ca0819118f9c36d23c6f9b3135db298e84ca022934bcd189add6473922b199b47330c0ecf14c303ab4177c03dbf26e64476fa4";
     };
 
-    patches =
-      [ ./env_var_for_system_dir.patch ];
+    patches = nixpkgsPatches;
 
     meta = firefox.meta // {
       description = "A web browser built from Firefox Extended Support Release source tree";
@@ -127,8 +137,7 @@ in rec {
       sha256 = "169mjkr0bp80yv9nzza7kay7y2k03lpnx71h4ybcv9ygxgzdgax5";
     };
 
-    patches =
-      [ ./env_var_for_system_dir.patch ];
+    patches = nixpkgsPatches;
   } // commonAttrs) {};
 
   tor-browser-7-5 = common (rec {
@@ -145,8 +154,7 @@ in rec {
       sha256 = "0llbk7skh1n7yj137gv7rnxfasxsnvfjp4ss7h1fbdnw19yba115";
     };
 
-    patches =
-      [ ./env_var_for_system_dir.patch ];
+    patches = nixpkgsPatches;
   } // commonAttrs) {};
 
   tor-browser = tor-browser-7-5;

--- a/pkgs/misc/apulse/default.nix
+++ b/pkgs/misc/apulse/default.nix
@@ -1,14 +1,17 @@
-{ stdenv, fetchFromGitHub, alsaLib, cmake, pkgconfig, glib }:
+{ stdenv, fetchFromGitHub, alsaLib, cmake, pkgconfig, glib
+, tracingSupport ? true, logToStderr ? true }:
+
+let oz = x: if x then "1" else "0"; in
 
 stdenv.mkDerivation rec {
   name = "apulse-${version}";
-  version = "0.1.11";
+  version = "0.1.11.1";
 
   src = fetchFromGitHub {
     owner = "i-rinat";
     repo = "apulse";
-    rev = "v${version}";
-    sha256 = "16l278q0czca2794fj388ql6qn1zrw24a0p6k7bayrrf5h32fdzd";
+    rev = "602b3a02b4b459d4652a3a0a836fab6f892d4080";
+    sha256 = "0yk9vgb4aws8xnkhdhgpxp5c0rri8yq61yxk85j99j8ax806i3r8";
   };
 
   enableParallelBuilding = true;
@@ -16,6 +19,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [ alsaLib glib ];
+
+  cmakeFlags = [
+    "-DWITH_TRACE=${oz tracingSupport}"
+    "-DLOG_TO_STDERR=${oz logToStderr}"
+  ];
 
   meta = with stdenv.lib; {
     description = "PulseAudio emulation for ALSA";

--- a/pkgs/misc/apulse/pressureaudio.nix
+++ b/pkgs/misc/apulse/pressureaudio.nix
@@ -60,22 +60,22 @@ stdenv.mkDerivation {
   '';
 
   meta = apulse.meta // {
-    description = "libpulseaudio without any sound daemons over pure ALSA";
+    description = "libpulse without any sound daemons over pure ALSA";
     longDescription = ''
-      apulse (${apulse.meta.homepage}) implements most of libpulseaudio
+      apulse (${apulse.meta.homepage}) implements most of libpulse
       API over pure ALSA in 5% LOC of the original PulseAudio.
 
       But apulse is made to be used as a wrapper that substitutes its
       replacement libs into LD_LIBRARY_PATH. The problem with that is
-      that you still have to link against the original libpulseaudio.
+      that you still have to link against the original libpulse.
 
       pressureaudio (http://git.r-36.net/pressureaudio/) wraps apulse
-      with everything you need to replace libpulseaudio completely.
+      with everything you need to replace libpulse completely.
 
       This derivation is a reimplementation of pressureaudio in pure
       nix.
 
-      You can simply override libpulseaudio with this and most
+      You can simply override libpulse with this and most
       packages would just work.
     '';
   };

--- a/pkgs/misc/libcardiacarrest/default.nix
+++ b/pkgs/misc/libcardiacarrest/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, pkgconfig, glib, libpulseaudio }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "libcardiacarrest-${version}";
+  version = "11.0-6"; # <PA API version>-<version>
+
+  src = fetchFromGitHub {
+    owner = "oxij";
+    repo = "libcardiacarrest";
+    rev = "1220b37b3de75238fedee1a66ca703fe1c8c71c3";
+    sha256 = "0fkfiixjybac3rwcd26621hh5dw4f5gnmm230cr4g8fl0i2ikmrz";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ glib ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    moveToOutput $out/include $dev
+    moveToOutput $out/lib/pkgconfig $dev
+    moveToOutput $out/lib/cmake $dev
+  '';
+
+  meta = src.meta // {
+    description = "A trivial implementation of libpulse PulseAudio library API";
+    longDescription = ''
+      libcardiacarrest is a trivial implementation of libpulse
+      PulseAudio library API that unconditionally (but gracefully)
+      fails to connect to the PulseAudio daemon and does nothing else.
+
+      apulse and pressureaudio (which uses apulse internally) are an
+      inspiration for this but unlike those two projects
+      libcardiacarrest is not an emulation layer, all it does is it
+      gracefully fails to provide the requested PulseAudio service
+      hoping the application would try something else (e.g. ALSA or
+      JACK).
+    '';
+    license = libpulseaudio.meta.license; # "same as PA headers"
+    maintainers = [ maintainers.oxij ]; # also the author
+  };
+
+}

--- a/pkgs/tools/networking/vpnc/default.nix
+++ b/pkgs/tools/networking/vpnc/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "vpnc-0.5.3-post-r550";
   src = fetchsvn {
-    url = "http://svn.unix-ag.uni-kl.de/vpnc";
+    url = "https://svn.unix-ag.uni-kl.de/vpnc";
     rev = "550";
     sha256 = "0x4ckfv9lpykwmh28v1kyzz91y1j2v48fi8q5nsawrba4q0wlrls";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -502,6 +502,8 @@ with pkgs;
 
   libpressureaudio = callPackage ../misc/apulse/pressureaudio.nix { };
 
+  libcardiacarrest = callPackage ../misc/libcardiacarrest { };
+
   archivemount = callPackage ../tools/filesystems/archivemount { };
 
   arandr = callPackage ../tools/X11/arandr { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -498,12 +498,6 @@ with pkgs;
 
   aptly = callPackage ../tools/misc/aptly { };
 
-  apulse = callPackage ../misc/apulse { };
-
-  libpressureaudio = callPackage ../misc/apulse/pressureaudio.nix { };
-
-  libcardiacarrest = callPackage ../misc/libcardiacarrest { };
-
   archivemount = callPackage ../tools/filesystems/archivemount { };
 
   arandr = callPackage ../tools/X11/arandr { };
@@ -12392,10 +12386,7 @@ with pkgs;
 
   pshs = callPackage ../servers/http/pshs { };
 
-  libpulseaudio = callPackage ../servers/pulseaudio {
-    libOnly = true;
-    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
-  };
+  # PulseAudio daemons
 
   # Name is changed to prevent use in packages;
   # please use libpulseaudio instead.
@@ -12414,6 +12405,25 @@ with pkgs;
     zeroconfSupport = true;
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };
+
+  # libpulse implementations
+
+  libpulseaudio-vanilla = callPackage ../servers/pulseaudio {
+    libOnly = true;
+    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
+  };
+
+  apulse = callPackage ../misc/apulse { };
+
+  libpressureaudio = callPackage ../misc/apulse/pressureaudio.nix {
+    libpulseaudio = libpulseaudio-vanilla; # headers only
+  };
+
+  libcardiacarrest = callPackage ../misc/libcardiacarrest {
+    libpulseaudio = libpulseaudio-vanilla; # meta only
+  };
+
+  libpulseaudio = libpulseaudio-vanilla;
 
   tomcat_connectors = callPackage ../servers/http/apache-modules/tomcat-connectors { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10326,8 +10326,8 @@ with pkgs;
 
   libxmi = callPackage ../development/libraries/libxmi { };
 
-  libxml2 = callPackage ../development/libraries/libxml2 {
-  };
+  libxml2 = callPackage ../development/libraries/libxml2 { };
+
   libxml2Python = pkgs.buildEnv { # slightly hacky
     name = "libxml2+py-${self.libxml2.version}";
     paths = with libxml2; [ dev bin py ];


### PR DESCRIPTION
###### Motivation for this change

Side-effect of me building everything with `libcardiacarrest` instead of `libpulseaudio` (see #35374). This patchset continues adding new parts needed for the switch and fixing existing parts that would break after the switch. Also some OCD fixes.

This part should not cause a mass rebuild.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

