### PR TITLE
paml: 4.9c -> 4.9g

### DIFF
--- a/pkgs/applications/science/biology/paml/default.nix
+++ b/pkgs/applications/science/biology/paml/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  version = "4.9c";
+  version = "4.9g";
   name = "paml-${version}";
   src = fetchurl {
     url = "http://abacus.gene.ucl.ac.uk/software/paml${version}.tgz";
-    sha256 = "18a1l47223l7jyjavm8a8la84q9k9kbxwmj7kz4z3pdx70qrl04j";
+    sha256 = "1kxkl47azkrsmdxiymnc76c2ccc514vlfnjvvm7lwch5l43j029h";
   };
 
   preBuild = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.9g in filename of file in /nix/store/70p59yxnlzhbj8ig1ax8lrrsdbcf37zp-paml-4.9g