### PR TITLE
freeorion: fix build

### DIFF
--- a/pkgs/games/freeorion/default.nix
+++ b/pkgs/games/freeorion/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, doxygen, graphviz, makeWrapper
-, boost, SDL2, python2, freetype, openal, libogg, libvorbis, zlib, libpng, libtiff, libjpeg, libGLU_combined, glew, libxslt }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, doxygen, graphviz, makeWrapper
+, boost, SDL2, python2, freetype, openal, libogg, libvorbis, zlib, libpng, libtiff
+, libjpeg, libGLU_combined, glew, libxslt
+}:
 
 stdenv.mkDerivation rec {
   version = "0.4.7.1";
@@ -19,6 +21,11 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   patches = [
+    # fix build with boost 1.66
+    (fetchpatch {
+      url = https://github.com/freeorion/freeorion/commit/c9b5b13fb81b1ed142dee0e843101c6b8832ca95.patch;
+      sha256 = "0agqhxk8462sgd230lmdzbrbrfd77zyy7a4g8hrf28zxza1nza94";
+    })
     ./fix_rpaths.patch
   ];
 


### PR DESCRIPTION
###### Motivation for this change

`boost::system::posix_error` is deprecated since v1.37, however the
default Boost version in NixOS is 1.66.
(see https://github.com/freeorion/freeorion/commit/c9b5b13fb81b1ed142dee0e843101c6b8832ca95)

The issue has been fixed on master, but isn't backported yet, so it
should be sufficient to manually include the patch in our build.

See ticket #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

