### PR TITLE
parallel: 20180122 -> 20180222

### DIFF
--- a/pkgs/tools/misc/parallel/default.nix
+++ b/pkgs/tools/misc/parallel/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, perl, makeWrapper, procps }:
 
 stdenv.mkDerivation rec {
-  name = "parallel-20180122";
+  name = "parallel-20180222";
 
   src = fetchurl {
     url = "mirror://gnu/parallel/${name}.tar.bz2";
-    sha256 = "1wkbppb4mc56grl6jsp803sf0hm7mg5ff7qmxalp7sd0vxqw41p9";
+    sha256 = "1bwx1rcrqz04d8fajlllhrfkjqxg0mfvsd86wf6p067gmgdrf6g8";
   };
 
   nativeBuildInputs = [ makeWrapper perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parallel -h` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parallel --help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parallel -V` and found version 20180222
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parallel --version` and found version 20180222
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/sql -V` and found version 20180222
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/sql --version` and found version 20180222
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/niceload -h` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/niceload --help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/niceload -V` and found version 20180222
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/niceload --version` and found version 20180222
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parcat -h` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parcat --help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parcat help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parset -h` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parset --help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/parset help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel -h` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel --help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel.bash -h` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel.bash --help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel.bash help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel.sh -h` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel.sh --help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/env_parallel.sh help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/.parallel-wrapped -h` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/.parallel-wrapped --help` got 0 exit code
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/.parallel-wrapped -V` and found version 20180222
- ran `/nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222/bin/.parallel-wrapped --version` and found version 20180222
- found 20180222 with grep in /nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222
- found 20180222 in filename of file in /nix/store/yianx0n1hidxg0x1wkra3h6bi4gir88l-parallel-20180222

cc @pSub @vrthra