### PR TITLE
phrasendrescher: 1.0 -> 1.2.2b

### DIFF
--- a/pkgs/tools/security/phrasendrescher/default.nix
+++ b/pkgs/tools/security/phrasendrescher/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "phrasendrescher-${version}";
-  version = "1.0";
+  version = "1.2.2b";
 
   src = fetchurl {
     url = "http://leidecker.info/projects/phrasendrescher/${name}.tar.gz";
-    sha256 = "1r0j7ms3i324p6if9cg8i0q900zqfjpvfr8pwj181x8ascysbbf2";
+    sha256 = "0bkiy9dlc1rqicl7g5sbfhgqlyqms4s66lcawwhhbl9d60y72ghs";
   };
 
   buildInputs = [ openssl ];

--- a/pkgs/tools/security/phrasendrescher/default.nix
+++ b/pkgs/tools/security/phrasendrescher/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl }:
+{ stdenv, fetchurl, openssl, libssh2, gpgme }:
 
 stdenv.mkDerivation rec {
   name = "phrasendrescher-${version}";
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0bkiy9dlc1rqicl7g5sbfhgqlyqms4s66lcawwhhbl9d60y72ghs";
   };
 
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl libssh2 gpgme ];
+
+  configureFlags = "--with-plugins";
 
   meta = with stdenv.lib; {
     description = "Cracking tool that finds passphrases of SSH keys";


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/sifsd5n9sni7d35b32w3n8xm44yg56dd-phrasendrescher-1.2.2b/bin/pd -h` got 0 exit code
- ran `/nix/store/sifsd5n9sni7d35b32w3n8xm44yg56dd-phrasendrescher-1.2.2b/bin/pd -h` and found version 1.2.2b
- found 1.2.2b with grep in /nix/store/sifsd5n9sni7d35b32w3n8xm44yg56dd-phrasendrescher-1.2.2b
- found 1.2.2b in filename of file in /nix/store/sifsd5n9sni7d35b32w3n8xm44yg56dd-phrasendrescher-1.2.2b

cc @bjornfor