### PR TITLE
picat: 1.9-4 -> 2.3

### DIFF
--- a/pkgs/development/compilers/picat/default.nix
+++ b/pkgs/development/compilers/picat/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation {
-  name = "picat-1.9-4";
+  name = "picat-2.3";
 
   src = fetchurl {
     url = http://picat-lang.org/download/picat19_src.tar.gz;
-    sha256 = "0wvl95gf4pjs93632g4wi0mw1glzzhjp9g4xg93ll2zxggbxibli";
+    sha256 = "1l5vzsscpp6nds6ksn57vjkkpzznl5xh7x6idjfn7pyh8jjhp50g";
   };
 
   ARCH = if stdenv.system == "i686-linux" then "linux32"


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/h0h3a0dk1zarzilxh7v60wz3xfkrz8gh-picat-2.3/bin/picat -h` got 0 exit code
- ran `/nix/store/h0h3a0dk1zarzilxh7v60wz3xfkrz8gh-picat-2.3/bin/picat --help` got 0 exit code
- found 2.3 with grep in /nix/store/h0h3a0dk1zarzilxh7v60wz3xfkrz8gh-picat-2.3
- found 2.3 in filename of file in /nix/store/h0h3a0dk1zarzilxh7v60wz3xfkrz8gh-picat-2.3

cc @earldouglas