### PR TITLE
hexcurse: fix build with gcc7

### DIFF
--- a/pkgs/applications/editors/hexcurse/default.nix
+++ b/pkgs/applications/editors/hexcurse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, ncurses }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, ncurses }:
 
 stdenv.mkDerivation rec {
   name = "hexcurse-${version}";
@@ -11,6 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "17ckkxfzbqvvfdnh10if4aqdcq98q3vl6dn1v6f4lhr4ifnyjdlk";
   };
   buildInputs = [ ncurses ];
+  patches = [
+    # gcc7 compat
+    (fetchpatch {
+      url = https://github.com/LonnyGomes/hexcurse/commit/d808cb7067d1df067f8b707fabbfaf9f8931484c.patch;
+      sha256 = "0h8345blmc401c6bivf0imn4cwii67264yrzxg821r46wrnfvyi2";
+    })
+    # gcc7 compat
+    (fetchpatch {
+      url = https://github.com/LonnyGomes/hexcurse/commit/716b5d58ac859cc240b8ccb9cbd79ace3e0593c1.patch;
+      sha256 = "0v6gbp6pjpmnzswlf6d97aywiy015g3kcmfrrkspsbb7lh1y3nix";
+    })
+  ];
   
   meta = with lib; {
     description = "ncurses-based console hexeditor written in C";


### PR DESCRIPTION
###### Motivation for this change

Fix build with gcc7.

/cc @cstrahan 

 /cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

