### PR TITLE
pig: 0.14.0 -> 0.16.0

### DIFF
--- a/pkgs/applications/networking/cluster/pig/default.nix
+++ b/pkgs/applications/networking/cluster/pig/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
 
-  name = "pig-0.14.0";
+  name = "pig-0.16.0";
 
   src = fetchurl {
     url = "mirror://apache/pig/${name}/${name}.tar.gz";
-    sha256 = "183in34cj93ny3lhqyq76g9pjqgw1qlwakk5v6x847vrlkfndska";
+    sha256 = "0p79grz5islnq195lv7pqdxb5l3v4y0k0w63602827qs70zpr508";
 
   };
 


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/vfr6b50xzj4rj0xhl83vfqqq127lx79s-pig-0.16.0/bin/pig --help` got 0 exit code
- ran `/nix/store/vfr6b50xzj4rj0xhl83vfqqq127lx79s-pig-0.16.0/bin/pig --version` and found version 0.16.0
- ran `/nix/store/vfr6b50xzj4rj0xhl83vfqqq127lx79s-pig-0.16.0/bin/pig -h` and found version 0.16.0
- found 0.16.0 with grep in /nix/store/vfr6b50xzj4rj0xhl83vfqqq127lx79s-pig-0.16.0

cc @svenkeidel