### PR TITLE
pigz: 2.3.4 -> 2.4

### DIFF
--- a/pkgs/tools/compression/pigz/default.nix
+++ b/pkgs/tools/compression/pigz/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, zlib, utillinux }:
 
 let name = "pigz";
-    version = "2.3.4";
+    version = "2.4";
 in
 stdenv.mkDerivation {
   name = name + "-" + version;
 
   src = fetchurl {
     url = "http://www.zlib.net/${name}/${name}-${version}.tar.gz";
-    sha256 = "16lgbjzzfx0k4a1znsw8kq3lnkx17gw93zq2sn01sny11fj1y0vg";
+    sha256 = "0wsgw5vwl23jrnpsvd8v3xcp5k4waw5mk0164fynjhkv58i1dy54";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/j8izqqx03n8aqqab57sybxkv483xfz05-pigz-2.4/bin/pigz -h` got 0 exit code
- ran `/nix/store/j8izqqx03n8aqqab57sybxkv483xfz05-pigz-2.4/bin/pigz --help` got 0 exit code
- ran `/nix/store/j8izqqx03n8aqqab57sybxkv483xfz05-pigz-2.4/bin/pigz -V` and found version 2.4
- ran `/nix/store/j8izqqx03n8aqqab57sybxkv483xfz05-pigz-2.4/bin/pigz --version` and found version 2.4
- found 2.4 with grep in /nix/store/j8izqqx03n8aqqab57sybxkv483xfz05-pigz-2.4
- found 2.4 in filename of file in /nix/store/j8izqqx03n8aqqab57sybxkv483xfz05-pigz-2.4