### PR TITLE
pipelight: 0.2.8 -> 0.2.8.2

### DIFF
--- a/pkgs/tools/misc/pipelight/default.nix
+++ b/pkgs/tools/misc/pipelight/default.nix
@@ -9,13 +9,13 @@ let
 
 in stdenv.mkDerivation rec {
 
-  version = "0.2.8";
+  version = "0.2.8.2";
 
   name = "pipelight-${version}";
 
   src = fetchurl {
     url = "https://bitbucket.org/mmueller2012/pipelight/get/v${version}.tar.gz";
-    sha256 = "1i440rf22fmd2w86dlm1mpi3nb7410rfczc0yldnhgsvp5p3sm5f";
+    sha256 = "1kyy6knkr42k34rs661r0f5sf6l1s2jdbphdg89n73ynijqmzjhk";
   };
 
   buildInputs = [ wine_custom libX11 libGLU_combined curl ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/x1h0gya1nb2kxbvkcr8sivskx2kzycdr-pipelight-0.2.8.2/bin/pipelight-plugin --help` got 0 exit code
- ran `/nix/store/x1h0gya1nb2kxbvkcr8sivskx2kzycdr-pipelight-0.2.8.2/bin/pipelight-plugin --version` and found version 0.2.8.2
- found 0.2.8.2 with grep in /nix/store/x1h0gya1nb2kxbvkcr8sivskx2kzycdr-pipelight-0.2.8.2
- found 0.2.8.2 in filename of file in /nix/store/x1h0gya1nb2kxbvkcr8sivskx2kzycdr-pipelight-0.2.8.2

cc @svenkeidel