### PR TITLE
overmind: init at 1.1.1

### DIFF
--- a/pkgs/tools/system/overmind/default.nix
+++ b/pkgs/tools/system/overmind/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, makeWrapper,
+  which, tmux }:
+
+buildGoPackage rec {
+  name = "overmind-${version}";
+  version = "1.1.1";
+
+  goPackagePath = "github.com/DarthSim/overmind";
+
+  src = fetchFromGitHub {
+    owner = "DarthSim";
+    repo = "overmind";
+    rev = "v${version}";
+    sha256 = "0gdsbm54ln07jv1kgg53fiavx18xxw4f21lfcdl74ijk6bx4jbzv";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram ''${!outputBin}/bin/overmind --prefix PATH : \
+      ${stdenv.lib.makeBinPath [ which tmux ]}
+  '';
+
+  meta = {
+    description = "Process manager for Procfile-based applications and tmux";
+    homepage = https://github.com/DarthSim/overmind;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4045,6 +4045,8 @@ with pkgs;
 
   otpw = callPackage ../os-specific/linux/otpw { };
 
+  overmind = callPackage ../tools/system/overmind {};
+
   owncloud = owncloud70;
 
   inherit (callPackages ../servers/owncloud { })


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

 - Does not fit CONTRIBUTING.md as `meta.maintainers` is not set. Is this necessary?
 - Placed in `tools/system`, to be a sibling of `foreman`, which serves a similar purpose.