### PR TITLE
postfix: 3.2.5 -> 3.3.0

### DIFF
--- a/pkgs/servers/mail/postfix/default.nix
+++ b/pkgs/servers/mail/postfix/default.nix
@@ -25,11 +25,11 @@ in stdenv.mkDerivation rec {
 
   name = "postfix-${version}";
 
-  version = "3.2.5";
+  version = "3.3.0";
 
   src = fetchurl {
     url = "ftp://ftp.cs.uu.nl/mirror/postfix/postfix-release/official/${name}.tar.gz";
-    sha256 = "0xpky04a5xnzbcizqj4y1gyxqjrzvpjlvk1g757wdrs678fq82vx";
+    sha256 = "0fggpbsc9jkrbaw9hy0zw9h32plmfvcv0x860pbih0g346byhhkr";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.3.0 with grep in /nix/store/8h882s0l773xiwgwf6flkig4yskagi3b-postfix-3.3.0
- found 3.3.0 in filename of file in /nix/store/8h882s0l773xiwgwf6flkig4yskagi3b-postfix-3.3.0

cc @rickynils