### PR TITLE
rename: fix build

### DIFF
--- a/pkgs/tools/misc/rename/default.nix
+++ b/pkgs/tools/misc/rename/default.nix
@@ -3,6 +3,7 @@
 buildPerlPackage rec {
   name = "rename-${version}";
   version = "1.9";
+  outputs = [ "out" ];
   src = fetchFromGitHub {
     owner = "pstray";
     repo = "rename";


### PR DESCRIPTION
###### Motivation for this change

build failed since there is no 'devdoc' output

/cc ZHF #36453 
/cc @mkgvt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

