### PR TITLE
qpdf: 7.1.1 -> 8.0.0

### DIFF
--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, libjpeg, zlib, perl }:
 
-let version = "7.1.1";
+let version = "8.0.0";
 in
 stdenv.mkDerivation rec {
   name = "qpdf-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/qpdf/qpdf/${version}/${name}.tar.gz";
-    sha256 = "1ypjxm74dhn9c4mj027zzkh0z4kpw9xiqwh3pjmmghm502hby3ca";
+    sha256 = "01a1d5wyrj1m35d68yj0cyqfjyrwhxq2yqwaw5an1d1p4aaid8gz";
   };
 
   nativeBuildInputs = [ perl ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/788zbmljyhaj8y93k7q5lqpah0c9pcz0-qpdf-8.0.0/bin/fix-qdf --version` and found version 8.0.0
- ran `/nix/store/788zbmljyhaj8y93k7q5lqpah0c9pcz0-qpdf-8.0.0/bin/qpdf --help` got 0 exit code
- ran `/nix/store/788zbmljyhaj8y93k7q5lqpah0c9pcz0-qpdf-8.0.0/bin/qpdf --version` and found version 8.0.0
- found 8.0.0 with grep in /nix/store/788zbmljyhaj8y93k7q5lqpah0c9pcz0-qpdf-8.0.0
- found 8.0.0 in filename of file in /nix/store/788zbmljyhaj8y93k7q5lqpah0c9pcz0-qpdf-8.0.0

cc @abbradar