### PR TITLE
qutebrowser: 1.1.1 -> 1.1.2

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -29,13 +29,13 @@ let
 in python3Packages.buildPythonApplication rec {
   name = "qutebrowser-${version}${versionPostfix}";
   namePrefix = "";
-  version = "1.1.1";
+  version = "1.1.2";
   versionPostfix = "";
 
   # the release tarballs are different from the git checkout!
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "09fa77rg1yrl8cksavxmgm9z2246s4d8wjbkl5jm1gsam345f7mz";
+    sha256 = "1ys8hxz8r0zgjj0wbf171l82vhk4gymgiirxv6mivh9fl4qami6r";
   };
 
   # Needs tox


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/sfhq3qa79iwlwifd5pfnsy4n03cwnn88-qutebrowser-1.1.2/bin/qutebrowser -h` got 0 exit code
- ran `/nix/store/sfhq3qa79iwlwifd5pfnsy4n03cwnn88-qutebrowser-1.1.2/bin/qutebrowser --help` got 0 exit code
- ran `/nix/store/sfhq3qa79iwlwifd5pfnsy4n03cwnn88-qutebrowser-1.1.2/bin/..qutebrowser-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/sfhq3qa79iwlwifd5pfnsy4n03cwnn88-qutebrowser-1.1.2/bin/..qutebrowser-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/sfhq3qa79iwlwifd5pfnsy4n03cwnn88-qutebrowser-1.1.2/bin/.qutebrowser-wrapped -h` got 0 exit code
- ran `/nix/store/sfhq3qa79iwlwifd5pfnsy4n03cwnn88-qutebrowser-1.1.2/bin/.qutebrowser-wrapped --help` got 0 exit code
- found 1.1.2 with grep in /nix/store/sfhq3qa79iwlwifd5pfnsy4n03cwnn88-qutebrowser-1.1.2
- found 1.1.2 in filename of file in /nix/store/sfhq3qa79iwlwifd5pfnsy4n03cwnn88-qutebrowser-1.1.2

cc @jagajaga