### PR TITLE
redo-sh: 1.2.6 -> 2.0.3

### DIFF
--- a/pkgs/development/tools/build-managers/redo-sh/default.nix
+++ b/pkgs/development/tools/build-managers/redo-sh/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.6";
+  version = "2.0.3";
   name = "redo-sh-${version}";
 
   src = fetchurl {
     url = "http://news.dieweltistgarnichtso.net/bin/archives/redo-sh.tar.gz";
-    sha256 = "1cwrk4v22rb9410rzyb4py4ncg01n6850l80s74bk3sflbw974wp";
+    sha256 = "1ycx3hik7vnlbwxacn1dzr48fwsn2ials0sg6k9l3gcyrha5wf1n";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-dot -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-dot --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-dot help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange -V` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange -v` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange --version` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange version` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange -h` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange --help` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifchange help` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifcreate -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifcreate --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifcreate -V` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifcreate -v` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifcreate --version` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifcreate -h` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ifcreate --help` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood -V` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood -v` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood --version` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood version` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood -h` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood --help` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-ood help` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-sources -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-sources --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-sources help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-targets -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-targets --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/redo-targets help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-wrapped -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-wrapped --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-dot-wrapped -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-dot-wrapped --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-dot-wrapped help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped -V` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped -v` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped --version` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped version` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped -h` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped --help` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifchange-wrapped help` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifcreate-wrapped -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifcreate-wrapped --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifcreate-wrapped -V` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifcreate-wrapped -v` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifcreate-wrapped --version` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifcreate-wrapped -h` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-ifcreate-wrapped --help` and found version 2.0.3
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-sources-wrapped -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-sources-wrapped --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-sources-wrapped help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-targets-wrapped -h` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-targets-wrapped --help` got 0 exit code
- ran `/nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3/bin/.redo-targets-wrapped help` got 0 exit code
- found 2.0.3 with grep in /nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3
- found 2.0.3 in filename of file in /nix/store/2fsvjrj28vrwn7jymslg7ykmdi03p97z-redo-sh-2.0.3

cc @sternenseemann