### PR TITLE
sbcl: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   name    = "sbcl-${version}";
-  version = "1.4.4";
+  version = "1.4.5";
 
   src = fetchurl {
     url    = "mirror://sourceforge/project/sbcl/sbcl/${version}/${name}-source.tar.bz2";
-    sha256 = "1k6v5b8qv7vyxvh8asx6phf2hbapx5pp5p5j47hgnq123fwnh4fa";
+    sha256 = "0h65i8yjnm3aak0ydq177qlygrjcg0chdzxwfxzlagkzs7zjw6cn";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/60dxbmafhmx26c0nmbpqj182innp8hqg-sbcl-1.4.5/bin/sbcl --help` got 0 exit code
- ran `/nix/store/60dxbmafhmx26c0nmbpqj182innp8hqg-sbcl-1.4.5/bin/sbcl --version` and found version 1.4.5
- found 1.4.5 with grep in /nix/store/60dxbmafhmx26c0nmbpqj182innp8hqg-sbcl-1.4.5
- found 1.4.5 in filename of file in /nix/store/60dxbmafhmx26c0nmbpqj182innp8hqg-sbcl-1.4.5

cc @7c6f434c @tohl