### PR TITLE
nix: Make `perl-bindings` an overridable derivation

### DIFF
--- a/pkgs/tools/package-management/nix/perl-bindings.nix
+++ b/pkgs/tools/package-management/nix/perl-bindings.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, nix, perl, pkgconfig, curl, libsodium
+, autoreconfHook, autoconf-archive, perlPackages
+}:
+
+stdenv.mkDerivation {
+  name = "nix-perl-" + nix.version;
+
+  inherit (nix) src;
+
+  postUnpack = "sourceRoot=$sourceRoot/perl";
+
+  nativeBuildInputs =
+    [ perl pkgconfig curl nix libsodium ]
+    ++ lib.optionals nix.fromGit [ autoreconfHook autoconf-archive ];
+
+  configureFlags =
+  [ "--with-dbi=${perlPackages.DBI}/${perl.libPrefix}"
+    "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}"
+  ];
+
+  preConfigure = "export NIX_STATE_DIR=$TMPDIR";
+
+  preBuild = "unset NIX_INDENT_MAKE";
+}


### PR DESCRIPTION
This change moves the `perl-bindings` derivation to its own file that can be trivially imported and instantiated with `callPackage`. Furthermore, `callPackage` uses `makeOverridable` which makes it trivial to override the derivation-producing function's intake arguments that `callPackage` fills in automatically for us.

###### Motivation for this change

The reason for this change is the difficulty in overriding the `nix` or `nixUnstable` derivations due to the fact that `perl-bindings` is added to the _result_ of the derivation (understandably so, adding it to the derivation would mean a circular dependency!)

This means that when we wish to override, say, `nixUnstable` we also have to extract `perl-bindings` from the old derivation but we're immediately struck by a problem: the `perl-bindings` derivation is produced by a function bound within a let-binding and defined without `makeOverridable`! So we would have to, very painfully, manually replace the instances of the `nix` dependency within the derivation using the _new and overridden_ `nixUnstable` derivation.

Using `callPackage` in this way is both idiomatic to `nixpkgs` and fixes this problem because it is now trivial to extract `perl-bindings` from the old nix derivation, override the arguments for `perl-bindings` to provide a `nix` argument that is the _new_ nix derivation, and re-inject it into the result of the _new_ nix derivation.

###### Impact

This change harms no hashes:

```shell
$ git checkout master
$ nix-instantiate --attr nix ./default.nix
/nix/store/j1mcknwhd12shfm668yic7spnwv5y7rh-nix-2.0.drv
```

... and the `nix` derivation from this branch has the same hash:

```shell
$ git checkout parnell/overridable-perl-bindings
$ nix-instantiate --attr nix ./default.nix
/nix/store/j1mcknwhd12shfm668yic7spnwv5y7rh-nix-2.0.drv
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
