### PR TITLE
sdcc: 3.6.0 -> 3.7.0

### DIFF
--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, bison, flex, boost, texinfo, gputils ? null }:
 
 stdenv.mkDerivation rec {
-  version = "3.6.0";
+  version = "3.7.0";
   name = "sdcc-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/sdcc/sdcc-src-${version}.tar.bz2";
-    sha256 = "0x53gh5yrrfjvlnkk29mjn8hq4v52alrsf7c8nsyzzq13sqwwpg8";
+    sha256 = "13llvx0j3v5qa7qd4fh7nix4j3alpd3ccprxvx163c4q8q4lfkc5";
   };
 
   # TODO: remove this comment when gputils != null is tested


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/as2gbmap -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/as2gbmap --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcdb -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcdb --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/s51 -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/s51 -v` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sz80 -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sz80 -v` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/stlcs -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/stlcs -v` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/shc08 -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/shc08 -v` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sstm8 -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sstm8 -v` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdar -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdar --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdar -h` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdar --help` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdranlib -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdranlib --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdranlib -h` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdranlib --help` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdobjcopy -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdobjcopy --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdobjcopy -h` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdobjcopy --help` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdnm -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdnm --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdnm -h` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdnm --help` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/packihx -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/packihx --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/makebin -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcpp --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcc -h` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcc --help` got 0 exit code
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcc -v` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcc --version` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcc -h` and found version 3.7.0
- ran `/nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0/bin/sdcc --help` and found version 3.7.0
- found 3.7.0 with grep in /nix/store/5xwjrizy4782acsnrjjfpypif8yjp41n-sdcc-3.7.0

cc @bjornfor