### PR TITLE
darling-dmg: fix build with gcc7

### DIFF
--- a/pkgs/tools/filesystems/darling-dmg/default.nix
+++ b/pkgs/tools/filesystems/darling-dmg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, fuse, zlib, bzip2, openssl, libxml2, icu } :
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, fuse, zlib, bzip2, openssl, libxml2, icu } :
 
 stdenv.mkDerivation rec {
   name = "darling-dmg-${version}";
@@ -10,6 +10,13 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0x285p16zfnp0p6injw1frc8krif748sfgxhdd7gb75kz0dfbkrk";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/darlinghq/darling-dmg/commit/cbb0092264b5c5cf3e92d6c2de23f02d859ebf44.patch";
+    sha256 = "05fhgn5c09f1rva6bvbq16nhlkblrhscbf69k04ajwdh7y98sw39";
+     })
+  ];
 
   buildInputs = [ cmake fuse openssl zlib bzip2 libxml2 icu ];
 


### PR DESCRIPTION
###### Motivation for this change

didn't build with gcc7

/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

