### PR TITLE
shairport-sync: 3.0.2 -> 3.1.7

### DIFF
--- a/pkgs/servers/shairport-sync/default.nix
+++ b/pkgs/servers/shairport-sync/default.nix
@@ -2,11 +2,11 @@
 , libdaemon, popt, pkgconfig, libconfig, libpulseaudio, soxr }:
 
 stdenv.mkDerivation rec {
-  version = "3.0.2";
+  version = "3.1.7";
   name = "shairport-sync-${version}";
 
   src = fetchFromGitHub {
-    sha256 = "1lpfl591lhk66a5jfp86j669iswjzj503x02hg9h3211vxv3h9pa";
+    sha256 = "1ip8vlyly190fhcd55am5xvqisvch8mnw50xwbm663dapdb1f8ys";
     rev = version;
     repo = "shairport-sync";
     owner = "mikebrady";


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.1.7 with grep in /nix/store/8r3k0r8vf0wfpj14443pm1k0jddlnii2-shairport-sync-3.1.7
- found 3.1.7 in filename of file in /nix/store/8r3k0r8vf0wfpj14443pm1k0jddlnii2-shairport-sync-3.1.7

cc @lnl7