### PR TITLE
shotcut: 17.11 -> 18.03

### DIFF
--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "shotcut-${version}";
-  version = "17.11";
+  version = "18.03";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "shotcut";
     rev = "v${version}";
-    sha256 = "1bw2cjpzycddxi9b21haiaslv0ikia85wwgkfm2xl2m15w5j8510";
+    sha256 = "0c8mi6hm0iwdnq30aizp9bbfx6vl1qcyp4h3clb2q8dkywijd08f";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 18.03 with grep in /nix/store/hpmghy84jrj0imp74fsw4p1k4d5h75iy-shotcut-18.03
- found 18.03 in filename of file in /nix/store/hpmghy84jrj0imp74fsw4p1k4d5h75iy-shotcut-18.03

cc @cillianderoiste