### PR TITLE
singularity: 2.4 -> 2.4.2

### DIFF
--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation rec {
   name = "singularity-${version}";
-  version = "2.4";
+  version = "2.4.2";
 
   enableParallelBuilding = true;
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     owner = "singularityware";
     repo = "singularity";
     rev = version;
-    sha256 = "1hi1ag1lb2x4djbz4x34wix83ymx0g9mzn2md6yrpiflc1d85rjz";
+    sha256 = "0cpa2yp82g9j64mgr90p75ddk85kbj1qi1r6hy0sz17grqdlaxl4";
   };
 
   nativeBuildInputs = [ autoreconfHook makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/64n6qi39xvh6jvi7qzpkfxpq1d57xw45-singularity-2.4.2/bin/singularity -h` got 0 exit code
- ran `/nix/store/64n6qi39xvh6jvi7qzpkfxpq1d57xw45-singularity-2.4.2/bin/singularity --help` got 0 exit code
- ran `/nix/store/64n6qi39xvh6jvi7qzpkfxpq1d57xw45-singularity-2.4.2/bin/singularity help` got 0 exit code
- ran `/nix/store/64n6qi39xvh6jvi7qzpkfxpq1d57xw45-singularity-2.4.2/bin/singularity -v` and found version 2.4.2
- ran `/nix/store/64n6qi39xvh6jvi7qzpkfxpq1d57xw45-singularity-2.4.2/bin/singularity --version` and found version 2.4.2
- found 2.4.2 with grep in /nix/store/64n6qi39xvh6jvi7qzpkfxpq1d57xw45-singularity-2.4.2
- found 2.4.2 in filename of file in /nix/store/64n6qi39xvh6jvi7qzpkfxpq1d57xw45-singularity-2.4.2

cc @jbedo