### PR TITLE
softhsm: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/tools/security/softhsm/default.nix
+++ b/pkgs/tools/security/softhsm/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   name = "softhsm-${version}";
-  version = "2.3.0";
+  version = "2.4.0";
 
   src = fetchurl {
     url = "https://dist.opendnssec.org/source/${name}.tar.gz";
-    sha256 = "09y1ladg7j0j5n780b1hdzwd2g2b5j5c54pfs7bzjviskb409mjy";
+    sha256 = "01ysfmq0pzr3g9laq40xwq8vg8w135d4m8n05mr1bkdavqmw3ai6";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-keyconv -h` got 0 exit code
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-keyconv --help` got 0 exit code
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-keyconv -V` and found version 2.4.0
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-keyconv -v` and found version 2.4.0
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-keyconv --version` and found version 2.4.0
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-util -h` got 0 exit code
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-util --help` got 0 exit code
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-util -V` and found version 2.4.0
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-util -v` and found version 2.4.0
- ran `/nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0/bin/softhsm2-util --version` and found version 2.4.0
- found 2.4.0 with grep in /nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0
- found 2.4.0 in filename of file in /nix/store/cs5ycqjsa2lklgx5slaja3gshxf2g7r5-softhsm-2.4.0

cc @leenaars