### PR TITLE
sonarr: 2.0.0.5085 -> 2.0.0.5153

### DIFF
--- a/pkgs/servers/sonarr/default.nix
+++ b/pkgs/servers/sonarr/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "sonarr-${version}";
-  version = "2.0.0.5085";
+  version = "2.0.0.5153";
 
   src = fetchurl {
     url = "http://download.sonarr.tv/v2/master/mono/NzbDrone.master.${version}.mono.tar.gz";
-    sha256 = "1m6gdgsxk1d50kf4wnq6zyhbyf6rc0ma86l8m65am08xb0pihldz";
+    sha256 = "1zdsba5bpi87dhsa62qbpj55wbakl6w380pijs8qxn80bvapv3xy";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.0.0.5153 with grep in /nix/store/w0qkw2a73gnidkkr5ggvy1bm15w7fhn6-sonarr-2.0.0.5153
- found 2.0.0.5153 in filename of file in /nix/store/w0qkw2a73gnidkkr5ggvy1bm15w7fhn6-sonarr-2.0.0.5153

cc @fadenb