### PR TITLE
spin: 6.4.7 -> 6.4.8

### DIFF
--- a/pkgs/development/tools/analysis/spin/default.nix
+++ b/pkgs/development/tools/analysis/spin/default.nix
@@ -7,12 +7,12 @@ let
 
 in stdenv.mkDerivation rec {
   name = "spin-${version}";
-  version = "6.4.7";
+  version = "6.4.8";
   url-version = stdenv.lib.replaceChars ["."] [""] version;
 
   src = fetchurl {
     url = "http://spinroot.com/spin/Src/spin${url-version}.tar.gz";
-    sha256 = "17m2xaag0jns8hsa4466zxq35ylg9fnzynzvjjmx4ympbiil6mqv";
+    sha256 = "1rvamdsf0igzpndlr4ck7004jw9x1bg4xyf78zh5k9sp848vnd80";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/12jh28iy7m99x5gysgy5m6qzz3yps25z-spin-6.4.8/bin/spin -V` and found version 6.4.8
- ran `/nix/store/12jh28iy7m99x5gysgy5m6qzz3yps25z-spin-6.4.8/bin/.spin-wrapped -V` and found version 6.4.8
- found 6.4.8 with grep in /nix/store/12jh28iy7m99x5gysgy5m6qzz3yps25z-spin-6.4.8
- found 6.4.8 in filename of file in /nix/store/12jh28iy7m99x5gysgy5m6qzz3yps25z-spin-6.4.8

cc @pSub