### PR TITLE
syncplay: 1.5.0 -> 1.5.2

### DIFF
--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -2,13 +2,13 @@
 
 python2Packages.buildPythonApplication rec {
   name = "syncplay-${version}";
-  version = "1.5.0";
+  version = "1.5.2";
 
   format = "other";
 
   src = fetchurl {
-    url = https://github.com/Syncplay/syncplay/archive/v1.5.0.tar.gz;
-    sha256 = "762e6318588e14aa02b1340baa18510e7de87771c62ca5b44d985b6d1289964d";
+    url = https://github.com/Syncplay/syncplay/archive/v1.5.2.tar.gz;
+    sha256 = "0a7lqq3y53ag5hzkkjpz61gfmglf3w1kpvyynhq2514fn9rnwsla";
   };
 
   propagatedBuildInputs = with python2Packages; [ pyside twisted ];


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/.syncplay-wrapped -h` got 0 exit code
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/.syncplay-wrapped --help` got 0 exit code
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/.syncplay-wrapped -v` and found version 1.5.2
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/.syncplay-wrapped --version` and found version 1.5.2
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/syncplay -h` got 0 exit code
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/syncplay --help` got 0 exit code
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/syncplay -v` and found version 1.5.2
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/syncplay --version` and found version 1.5.2
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/.syncplay-server-wrapped -h` got 0 exit code
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/.syncplay-server-wrapped --help` got 0 exit code
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/syncplay-server -h` got 0 exit code
- ran `/nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2/bin/syncplay-server --help` got 0 exit code
- found 1.5.2 with grep in /nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2
- found 1.5.2 in filename of file in /nix/store/s02mpddajsz1q5h5r8mvmyd31np2ha26-syncplay-1.5.2

cc @enzime