### PR TITLE
taktuk: 3.7.5 -> 3.7.7

### DIFF
--- a/pkgs/applications/networking/cluster/taktuk/default.nix
+++ b/pkgs/applications/networking/cluster/taktuk/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, perl , openssh}:
 
 stdenv.mkDerivation rec {
-  version = "3.7.5";
+  version = "3.7.7";
   name = "taktuk-${version}";
 
   buildInputs = [ perl ];
 
   src = fetchurl {
     url = "https://gforge.inria.fr/frs/download.php/33412/${name}.tar.gz";
-    sha256 = "d96ef6c63d77f32339066f143ef7e0bc00041e10724254bf15787746ad1f1070";
+    sha256 = "0w0h3ynlcxvq2nzm8hkj20g0805ww3vkw53g0qwj7wvp7p3gcvnr";
   };
 
   preBuild = ''


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk -h` got 0 exit code
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk --help` got 0 exit code
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk help` got 0 exit code
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk -v` and found version 3.7.7
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk --version` and found version 3.7.7
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk version` and found version 3.7.7
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk -h` and found version 3.7.7
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk --help` and found version 3.7.7
- ran `/nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7/bin/taktuk help` and found version 3.7.7
- found 3.7.7 with grep in /nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7
- found 3.7.7 in filename of file in /nix/store/l4zd353icm418x6asy4123a3gcpy14cr-taktuk-3.7.7

cc @bzizou