### PR TITLE
errbot: fix build

### DIFF
--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -13,9 +13,12 @@ pythonPackages.buildPythonApplication rec {
 
   LC_ALL = "en_US.utf8";
 
+  # restrictions on cryptography and pyOpenSSL are obsolete with python >=3.4 and broke build
   postPatch = ''
     substituteInPlace setup.py \
-      --replace dnspython3 dnspython
+      --replace dnspython3 dnspython \
+      --replace "cryptography<2.1.0" "cryptography" \
+      --replace "pyOpenSSL<17.3.0" "pyOpenSSL"
   '';
 
   # tests folder is not included in release


### PR DESCRIPTION
###### Motivation for this change

Build was broken due to version restrictions requiring older versions of cryptography and pyOpenSSL. These restrictions are not needed with python >= 3.4,  removed.

/cc ZHF #36453 
/cc maintainers @fpletz @globin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

