### PR TITLE
tini: 0.16.1 -> 0.17.0

### DIFF
--- a/pkgs/applications/virtualization/tini/default.nix
+++ b/pkgs/applications/virtualization/tini/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, glibc }:
 
 stdenv.mkDerivation rec {
-  version = "0.16.1";
+  version = "0.17.0";
   name = "tini-${version}";
 
   src = fetchFromGitHub {
     owner = "krallin";
     repo = "tini";
     rev = "v${version}";
-    sha256 ="1abvjwjk7xhsbx60niy4ykcj3xvrxcl6zx8z1v827jsn47wzpikp";
+    sha256 ="0y16xk89811a6g2srg63jv5b2221dirzrhha7mj056a6jq5ql2f0";
   };
 
   patchPhase = "sed -i /tini-static/d CMakeLists.txt";


### PR DESCRIPTION
Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/p41wb0fqnvn4bx6jjs7hs98xlrzp8s79-tini-0.17.0/bin/tini -h` got 0 exit code
- ran `/nix/store/p41wb0fqnvn4bx6jjs7hs98xlrzp8s79-tini-0.17.0/bin/tini --version` and found version 0.17.0
- ran `/nix/store/p41wb0fqnvn4bx6jjs7hs98xlrzp8s79-tini-0.17.0/bin/tini -h` and found version 0.17.0
- found 0.17.0 with grep in /nix/store/p41wb0fqnvn4bx6jjs7hs98xlrzp8s79-tini-0.17.0
- found 0.17.0 in filename of file in /nix/store/p41wb0fqnvn4bx6jjs7hs98xlrzp8s79-tini-0.17.0