### PR TITLE
tradcpp: 0.4 -> 0.5.2

### DIFF
--- a/pkgs/development/tools/tradcpp/default.nix
+++ b/pkgs/development/tools/tradcpp/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoconf }:
 
 stdenv.mkDerivation {
-  name = "tradcpp-0.4";
+  name = "tradcpp-0.5.2";
 
   src = fetchurl {
-    url = http://ftp.netbsd.org/pub/NetBSD/misc/dholland/tradcpp-0.4.tar.gz;
-    sha256 = "c60aa356945e0b6634bd449ead6a4fca0059d2ce3ae8044cf982140bbd54e688";
+    url = http://ftp.netbsd.org/pub/NetBSD/misc/dholland/tradcpp-0.5.2.tar.gz;
+    sha256 = "1h2bwxwc13rz3g2236l89hm47f72hn3m4h7wjir3j532kq0m68bc";
   };
 
   # tradcpp only comes with BSD-make Makefile; the patch adds configure support


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.5.2 with grep in /nix/store/s2kanna6c53sqm590xv8598j075j1ikb-tradcpp-0.5.2
- found 0.5.2 in filename of file in /nix/store/s2kanna6c53sqm590xv8598j075j1ikb-tradcpp-0.5.2