### PR TITLE
umockdev: 0.11 -> 0.11.1

### DIFF
--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "umockdev-${version}";
-  version = "0.11";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "martinpitt";
     repo = "umockdev";
     rev = version;
-    sha256 ="1gpk2f03nad4qv084hx7549d68cqc1xibxm0ncanafm5xjz1hp55";
+    sha256 ="0cmswac8m7zfvk6cb8k5iisqr7arnn1yhcmasri072yz0pmr6dr0";
   };
 
   buildInputs = [ glib systemd libgudev ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/cm17lsw2d83wwlh6hd7slh9amjlqrv7a-umockdev-0.11.1/bin/umockdev-run -h` got 0 exit code
- ran `/nix/store/cm17lsw2d83wwlh6hd7slh9amjlqrv7a-umockdev-0.11.1/bin/umockdev-run --help` got 0 exit code
- ran `/nix/store/cm17lsw2d83wwlh6hd7slh9amjlqrv7a-umockdev-0.11.1/bin/umockdev-run --version` and found version 0.11.1
- ran `/nix/store/cm17lsw2d83wwlh6hd7slh9amjlqrv7a-umockdev-0.11.1/bin/umockdev-record -h` got 0 exit code
- ran `/nix/store/cm17lsw2d83wwlh6hd7slh9amjlqrv7a-umockdev-0.11.1/bin/umockdev-record --help` got 0 exit code
- ran `/nix/store/cm17lsw2d83wwlh6hd7slh9amjlqrv7a-umockdev-0.11.1/bin/umockdev-record --version` and found version 0.11.1
- found 0.11.1 with grep in /nix/store/cm17lsw2d83wwlh6hd7slh9amjlqrv7a-umockdev-0.11.1
- found 0.11.1 in filename of file in /nix/store/cm17lsw2d83wwlh6hd7slh9amjlqrv7a-umockdev-0.11.1

cc @ndowens for review