### PR TITLE
uwsgi: 2.0.16 -> 2.0.17

### DIFF
--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -49,11 +49,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "uwsgi-${version}";
-  version = "2.0.16";
+  version = "2.0.17";
 
   src = fetchurl {
     url = "http://projects.unbit.it/downloads/${name}.tar.gz";
-    sha256 = "1x61vipgzhzb6flbbgl0hq96j9d330gh0kmwv8pwh6n57j7z84d9";
+    sha256 = "1wlbaairsmhp6bx5wv282q9pgh6w7w6yrb8vxjznfaxrinsfkhix";
   };
 
   nativeBuildInputs = [ python3 pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/22q44dlwa34xal0mggf9vqy1clsvad65-uwsgi-2.0.17/bin/uwsgi -h` got 0 exit code
- ran `/nix/store/22q44dlwa34xal0mggf9vqy1clsvad65-uwsgi-2.0.17/bin/uwsgi --help` got 0 exit code
- ran `/nix/store/22q44dlwa34xal0mggf9vqy1clsvad65-uwsgi-2.0.17/bin/uwsgi --version` and found version 2.0.17
- ran `/nix/store/22q44dlwa34xal0mggf9vqy1clsvad65-uwsgi-2.0.17/bin/uwsgi -h` and found version 2.0.17
- ran `/nix/store/22q44dlwa34xal0mggf9vqy1clsvad65-uwsgi-2.0.17/bin/uwsgi --help` and found version 2.0.17
- found 2.0.17 with grep in /nix/store/22q44dlwa34xal0mggf9vqy1clsvad65-uwsgi-2.0.17
- found 2.0.17 in filename of file in /nix/store/22q44dlwa34xal0mggf9vqy1clsvad65-uwsgi-2.0.17

cc @abbradar @schneefux for review