### PR TITLE
Add platforms attribute to umockdev

### DIFF
--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     description = "Mock hardware devices for creating unit tests";
     license = licenses.lgpl2;
     maintainers = [ maintainers.ndowens ];
+    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
See #36707 to observe that the build fails. It depends on linux specific packages such as systemd.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

