### PR TITLE
valum: 0.3.14 -> 0.3.15

### DIFF
--- a/pkgs/development/web/valum/default.nix
+++ b/pkgs/development/web/valum/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "valum-${version}";
-  version = "0.3.14";
+  version = "0.3.15";
 
   src = fetchFromGitHub {
     owner = "valum-framework";
     repo = "valum";
     rev = "v${version}";
-    sha256 = "1w1mipczcfmrrxg369wvrj3wvf76rqn8rrkxbq88aial1bi23kd3";
+    sha256 = "1wk23aq5lxsqns58s4g9jrwx6wrk7k9hq9rg8jcs42rxn2pckaxw";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.3.15 with grep in /nix/store/7w47g1l0qg7bzc1rrmllxxinjyg7zg5c-valum-0.3.15
- found 0.3.15 in filename of file in /nix/store/7w47g1l0qg7bzc1rrmllxxinjyg7zg5c-valum-0.3.15

cc @lethalman for review