### PR TITLE
w_scan: 20161022 -> 20170107

### DIFF
--- a/pkgs/applications/video/w_scan/default.nix
+++ b/pkgs/applications/video/w_scan/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "w_scan-${version}";
-  version = "20161022";
+  version = "20170107";
 
   src = fetchurl {
     url = "http://wirbel.htpc-forum.de/w_scan/${name}.tar.bz2";
-    sha256 = "0y8dq2sm13xn2r2lrqf5pdhr9xcnbxbg1aw3iq1szds2idzsyxr0";
+    sha256 = "1zkgnj2sfvckix360wwk1v5s43g69snm45m0drnzyv7hgf5g7q1q";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/w28jzw0lnbqy9sdpm78lf4n282x05f74-w_scan-20170107/bin/w_scan -h` got 0 exit code
- ran `/nix/store/w28jzw0lnbqy9sdpm78lf4n282x05f74-w_scan-20170107/bin/w_scan --help` got 0 exit code
- ran `/nix/store/w28jzw0lnbqy9sdpm78lf4n282x05f74-w_scan-20170107/bin/w_scan -V` and found version 20170107
- ran `/nix/store/w28jzw0lnbqy9sdpm78lf4n282x05f74-w_scan-20170107/bin/w_scan -h` and found version 20170107
- ran `/nix/store/w28jzw0lnbqy9sdpm78lf4n282x05f74-w_scan-20170107/bin/w_scan --help` and found version 20170107
- found 20170107 in filename of file in /nix/store/w28jzw0lnbqy9sdpm78lf4n282x05f74-w_scan-20170107

cc @nico202 for review