### PR TITLE
wcslib: 5.15 -> 5.18

### DIFF
--- a/pkgs/development/libraries/wcslib/default.nix
+++ b/pkgs/development/libraries/wcslib/default.nix
@@ -1,14 +1,14 @@
 { fetchurl,  stdenv, flex }:
 
 stdenv.mkDerivation rec {
-  version = "5.15";
+  version = "5.18";
   name = "wcslib-${version}";
 
   buildInputs = [ flex ];
 
   src = fetchurl {
     url = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/${name}.tar.bz2";
-    sha256 ="1s2nig327g4bimd9xshlk11ww09a7mrjmsbpdcd8smsmn2kl1glb";
+    sha256 ="16jh568k99c9p0y3qzcgps2rii933x9wlay7q1xm0lr59zqzp4xn";
   };
 
   prePatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 5.18 with grep in /nix/store/pr88acrgc8w11q3p8407w7v0kwd2asq8-wcslib-5.18
- found 5.18 in filename of file in /nix/store/pr88acrgc8w11q3p8407w7v0kwd2asq8-wcslib-5.18