### PR TITLE
winswitch: 0.12.16 -> 0.12.23

### DIFF
--- a/pkgs/tools/X11/winswitch/default.nix
+++ b/pkgs/tools/X11/winswitch/default.nix
@@ -5,11 +5,11 @@ let
   base = pythonPackages.buildPythonApplication rec {
     name = "winswitch-${version}";
     namePrefix = "";
-    version = "0.12.16";
+    version = "0.12.23";
 
     src = fetchurl {
       url = "http://winswitch.org/src/${name}.src.tar.bz2";
-      sha256 = "0ix122d7rgzdkk70f2q3sd7a4pvyaqsyxkw93pc4zkcg1xh9z3y8";
+      sha256 = "1m0akjcdlsgng426rwvzlcl76kjm993icj0pggvha40cizig1yd9";
     };
 
     propagatedBuildInputs = with pythonPackages; [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.wcw-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.wcw-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.wcw-wrapped -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.wcw-wrapped --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_applet-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_applet-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_applet-wrapped help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_away-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_away-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_away-wrapped -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_away-wrapped --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_back-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_back-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_back-wrapped -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_back-wrapped --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_client-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_client-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_command_wrapper-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_command_wrapper-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_command_wrapper-wrapped -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_command_wrapper-wrapped --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_server-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_server-wrapped --version` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_server-wrapped --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_ssh_Xnest-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_ssh_Xnest-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_ssh_Xnest-wrapped help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_ssh_session-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_ssh_session-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_ssh_session-wrapped help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_socket-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_socket-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_socket-wrapped -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_socket-wrapped --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped -V` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped -v` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped --version` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped version` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/.winswitch_stdio_tcp-wrapped help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/wcw -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/wcw --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/wcw -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/wcw --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_applet -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_applet --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_applet help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_away -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_away --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_away -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_away --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_back -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_back --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_back -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_back --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_client -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_client --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_command_wrapper -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_command_wrapper --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_command_wrapper -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_command_wrapper --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_server --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_server --version` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_server --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_ssh_Xnest -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_ssh_Xnest --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_ssh_Xnest help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_ssh_session -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_ssh_session --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_ssh_session help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_socket -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_socket --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_socket -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_socket --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp -h` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp --help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp help` got 0 exit code
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp -V` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp -v` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp --version` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp version` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp -h` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp --help` and found version 0.12.23
- ran `/nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23/bin/winswitch_stdio_tcp help` and found version 0.12.23
- found 0.12.23 with grep in /nix/store/71f89z56xhgvh29an8nc7d5jl283968l-winswitch-0.12.23