### PR TITLE
wxSVG: 1.5.11 -> 1.5.13

### DIFF
--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -7,11 +7,11 @@ stdenv.mkDerivation rec {
 
   name = "wxSVG-${version}";
   srcName = "wxsvg-${version}";
-  version = "1.5.11";
+  version = "1.5.13";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/wxsvg/wxsvg/${version}/${srcName}.tar.bz2";
-    sha256 = "0m3ff8mjiq4hvy8rmxyc9fkpf24xwxhvr3a6jmvr2q5zc41xhz7x";
+    sha256 = "029a1rayp4c480x8ayng13rcjk1j98ar0z6ggijrznkn8kgx8j2j";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.5.13 with grep in /nix/store/hcf1ibw1hvrwic1zagy3cvi1fc73rfgk-wxSVG-1.5.13
- found 1.5.13 in filename of file in /nix/store/hcf1ibw1hvrwic1zagy3cvi1fc73rfgk-wxSVG-1.5.13

cc @AndersonTorres for review