### PR TITLE
x265: 2.6 -> 2.7

### DIFF
--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -16,14 +16,14 @@ in
 
 stdenv.mkDerivation rec {
   name = "x265-${version}";
-  version = "2.6";
+  version = "2.7";
 
   src = fetchurl {
     urls = [
       "http://get.videolan.org/x265/x265_${version}.tar.gz"
       "https://github.com/videolan/x265/archive/${version}.tar.gz"
     ];
-    sha256 = "1gyd94jkwdii9308m07nymsbxrmrcl81c0j8i10zhslr2mj07w0v";
+    sha256 = "18llni1m8kfvdwy5bp950z6gyd0nijmvi3hzd6gd8vpy5yk5zrym";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/55ya7ybd3v04zyss7zc2dib0bk6xacxw-x265-2.7/bin/x265 -V` and found version 2.7
- ran `/nix/store/55ya7ybd3v04zyss7zc2dib0bk6xacxw-x265-2.7/bin/x265 --version` and found version 2.7
- found 2.7 with grep in /nix/store/55ya7ybd3v04zyss7zc2dib0bk6xacxw-x265-2.7
- found 2.7 in filename of file in /nix/store/55ya7ybd3v04zyss7zc2dib0bk6xacxw-x265-2.7

cc @codyopel for review