### PR TITLE
xfe: 1.37 -> 1.42

### DIFF
--- a/pkgs/applications/misc/xfe/default.nix
+++ b/pkgs/applications/misc/xfe/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, fox, pkgconfig, gettext, xlibsWrapper, gcc, intltool, file, libpng }:
 
 stdenv.mkDerivation rec {
-  name = "xfe-1.37";
+  name = "xfe-1.42";
 
   src = fetchurl {
     url = "mirror://sourceforge/xfe/${name}.tar.gz";
-    sha256 = "1g9a0bpny2m7ixgxpqjh0wvh2x6d0lpj6682zn5dfqwan4j2xfsd";
+    sha256 = "1v1v0vcbnm30kpyd3rj8f56yh7lfnwy7nbs9785wi229b29fiqx1";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfe -h` got 0 exit code
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfe --help` got 0 exit code
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfe -v` and found version 1.42
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfe --version` and found version 1.42
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfp -h` got 0 exit code
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfp --help` got 0 exit code
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfp -v` and found version 1.42
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfp --version` and found version 1.42
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfw -h` got 0 exit code
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfw --help` got 0 exit code
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfw -v` and found version 1.42
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfw --version` and found version 1.42
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfi -h` got 0 exit code
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfi --help` got 0 exit code
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfi -v` and found version 1.42
- ran `/nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42/bin/xfi --version` and found version 1.42
- found 1.42 with grep in /nix/store/b2qafj27yc2v401kgykcwvqy0gg3jz82-xfe-1.42