### PR TITLE
xpra: 2.1.3 -> 2.2.4

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -12,11 +12,11 @@ let
   inherit (python2Packages) python cython buildPythonApplication;
 in buildPythonApplication rec {
   name = "xpra-${version}";
-  version = "2.1.3";
+  version = "2.2.4";
 
   src = fetchurl {
     url = "http://xpra.org/src/${name}.tar.xz";
-    sha256 = "0r0l3p59q05fmvkp3jv8vmny2v8m1vyhqkg6b9r2qgxn1kcxx7rm";
+    sha256 = "0v8yflvisk94bfj0zg4ggdfwrig0f3ss9kjnws3zflsr33cb2hxy";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra -h` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra --help` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra --version` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra -h` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra --help` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/udev_product_version -h` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/udev_product_version --help` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/udev_product_version help` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra_launcher-wrapped -h` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra_launcher-wrapped --help` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra_launcher-wrapped --version` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra_launcher-wrapped -h` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra_launcher-wrapped --help` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra_launcher -h` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra_launcher --help` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra_launcher --version` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra_launcher -h` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/xpra_launcher --help` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/..xpra-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/..xpra-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/..xpra-wrapped-wrapped --version` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/..xpra-wrapped-wrapped -h` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/..xpra-wrapped-wrapped --help` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra-wrapped -h` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra-wrapped --help` got 0 exit code
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra-wrapped --version` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra-wrapped -h` and found version 2.2.4
- ran `/nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4/bin/.xpra-wrapped --help` and found version 2.2.4
- found 2.2.4 with grep in /nix/store/sdb561gabzb04az1f9wq6190prqzv618-xpra-2.2.4

cc @offlinehacker for review