### PR TITLE
xvkbd: 3.8 -> 3.9

### DIFF
--- a/pkgs/tools/X11/xvkbd/default.nix
+++ b/pkgs/tools/X11/xvkbd/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "xvkbd-${version}";
-  version = "3.8";
+  version = "3.9";
   src = fetchurl {
-    url = "http://t-sato.in.coocan.jp/xvkbd/xvkbd-3.8.tar.gz";
-    sha256 = "16r5wbb5za02ha0ilwswx37lrwa6j40px8c9gkpnmmpb5r7kv91c";
+    url = "http://t-sato.in.coocan.jp/xvkbd/xvkbd-3.9.tar.gz";
+    sha256 = "17csj6x5zm3g67izfwhagkal1rbqzpw09lqmmlyrjy3vzgfkf75q";
   };
 
   buildInputs = [ imake libXt libXaw libXtst xextproto libXi Xaw3d libXpm gccmakedep ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.9 with grep in /nix/store/254qz2nmlqkyzn1hv598i5y9spx50wji-xvkbd-3.9
- found 3.9 in filename of file in /nix/store/254qz2nmlqkyzn1hv598i5y9spx50wji-xvkbd-3.9

cc @bennofs for review