### PR TITLE
yarp: 2.3.68 -> 2.3.70.2

### DIFF
--- a/pkgs/applications/science/robotics/yarp/default.nix
+++ b/pkgs/applications/science/robotics/yarp/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   name = "yarp-${version}";
-  version = "2.3.68";
+  version = "2.3.70.2";
   src = fetchFromGitHub {
     owner = "robotology";
     repo = "yarp";
     rev = "v${version}";
-    sha256 = "1ksz2kv4v14fqgz3fsvvmdk2sikhnxr11jhhf7c2547x6jbzhda6";
+    sha256 = "0mphh899niy30xbjjwi9xpsliq8mladfldbbbjfngdrqfhiray1a";
   };
 
   buildInputs = [ cmake ace ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpidl_rosmsg -h` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpidl_rosmsg --help` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpidl_rosmsg help` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpserver --help` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarp help` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarp version` and found version 2.3.70.2
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarp-config --help` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarp-config --version` and found version 2.3.70.2
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpdev -h` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpdev --help` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpdev help` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpmanager-console --help` got 0 exit code
- ran `/nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2/bin/yarpdatadumper --help` got 0 exit code
- found 2.3.70.2 with grep in /nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2
- found 2.3.70.2 in filename of file in /nix/store/bp68k0rdxw13rxgy93lqlqmrmprz272g-yarp-2.3.70.2

cc @nico202 for review