### PR TITLE
gnome3.gnome-color-manager: init at 3.26.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, itstool, desktop-file-utils, gnome3, glib, gtk3, libexif, libtiff, colord, colord-gtk, libcanberra-gtk3, lcms2, vte, exiv2 }:
+
+let
+  pname = "gnome-color-manager";
+  version = "3.26.0";
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
+    sha256 = "1kbi46vk0qf0gxiwm4yhsx8931r7c9cg0c4244j8ncr0hph008b5";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig gettext itstool desktop-file-utils ];
+  buildInputs = [ glib gtk3 libexif libtiff colord colord-gtk libcanberra-gtk3 lcms2 vte exiv2 ];
+
+  patches = [
+    # https://bugzilla.gnome.org/show_bug.cgi?id=791158
+    (fetchurl {
+      url = https://bugzilla.gnome.org/attachment.cgi?id=364865;
+      sha256 = "1zh1aql6rwzfhy2xbdw0jqgzrl9l6wf0jcbdkjd67ykbmynh2cmv";
+    })
+  ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "A set of graphical utilities for color management to be used in the GNOME desktop";
+    license = licenses.gpl2Plus;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -1,26 +1,21 @@
-{ fetchurl, stdenv, pkgconfig, gnome3, ibus, intltool, upower, wrapGAppsHook
+{ fetchurl, stdenv, substituteAll, pkgconfig, gnome3, ibus, intltool, upower, wrapGAppsHook
 , libcanberra-gtk3, accountsservice, libpwquality, libpulseaudio
-, gdk_pixbuf, librsvg, libnotify, libgudev
+, gdk_pixbuf, librsvg, libnotify, libgudev, gnome-color-manager
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
-, cracklib, libkrb5, networkmanagerapplet, networkmanager
-, libwacom, samba, shared-mime-info, tzdata, libtool
+, cracklib, libkrb5, networkmanagerapplet, networkmanager, glibc
+, libwacom, samba, shared-mime-info, tzdata, libtool, libgnomekbd
 , docbook_xsl, docbook_xsl_ns, modemmanager, clutter, clutter-gtk
 , fontconfig, sound-theme-freedesktop, grilo }:
 
-stdenv.mkDerivation rec {
-  name = "gnome-control-center-${version}";
+let
   version = "3.26.2";
+in stdenv.mkDerivation rec {
+  name = "gnome-control-center-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${gnome3.versionBranch version}/${name}.tar.xz";
     sha256 = "07aed27d6317f2cad137daa6d94a37ad02c32b958dcd30c8f07d0319abfb04c5";
   };
-
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "gnome-control-center"; attrPath = "gnome3.gnome-control-center"; };
-  };
-
-  propagatedUserEnvPkgs = [ gnome3.gnome-themes-standard ];
 
   nativeBuildInputs = [
     pkgconfig intltool wrapGAppsHook libtool libxslt docbook_xsl docbook_xsl_ns
@@ -37,15 +32,13 @@ stdenv.mkDerivation rec {
     networkmanager modemmanager gnome-bluetooth tracker
   ];
 
-  preBuild = ''
-    substituteInPlace panels/datetime/tz.h --replace "/usr/share/zoneinfo/zone.tab" "${tzdata}/share/zoneinfo/zone.tab"
-
-    substituteInPlace panels/region/cc-region-panel.c --replace "gkbd-keyboard-display" "${gnome3.libgnomekbd}/bin/gkbd-keyboard-display"
-
-    # hack to make test-endianess happy
-    mkdir -p $out/share/locale
-    substituteInPlace panels/datetime/test-endianess.c --replace "/usr/share/locale/" "$out/share/locale/"
-  '';
+  patches = [
+    (substituteAll {
+      src = ./paths.patch;
+      gcm = gnome-color-manager;
+      inherit glibc libgnomekbd tzdata;
+    })
+  ];
 
   preFixup = ''
     gappsWrapperArgs+=(
@@ -58,6 +51,13 @@ stdenv.mkDerivation rec {
       substituteInPlace $i --replace "gnome-control-center" "$out/bin/gnome-control-center"
     done
   '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "gnome-control-center";
+      attrPath = "gnome3.gnome-control-center";
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Utilities to configure the GNOME desktop";

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/paths.patch
@@ -1,0 +1,82 @@
+--- a/panels/color/cc-color-panel.c
++++ b/panels/color/cc-color-panel.c
+@@ -634,7 +634,7 @@
+ 
+   /* run with modal set */
+   argv = g_ptr_array_new_with_free_func (g_free);
+-  g_ptr_array_add (argv, g_build_filename (BINDIR, "gcm-calibrate", NULL));
++  g_ptr_array_add (argv, g_build_filename ("@gcm@", "bin", "gcm-calibrate", NULL));
+   g_ptr_array_add (argv, g_strdup ("--device"));
+   g_ptr_array_add (argv, g_strdup (cd_device_get_id (priv->current_device)));
+   g_ptr_array_add (argv, g_strdup ("--parent-window"));
+@@ -1136,7 +1136,7 @@
+ 
+   /* open up gcm-viewer as a info pane */
+   argv = g_ptr_array_new_with_free_func (g_free);
+-  g_ptr_array_add (argv, g_build_filename (BINDIR, "gcm-viewer", NULL));
++  g_ptr_array_add (argv, g_build_filename ("@gcm@", "bin", "gcm-viewer", NULL));
+   g_ptr_array_add (argv, g_strdup ("--profile"));
+   g_ptr_array_add (argv, g_strdup (cd_profile_get_id (profile)));
+   g_ptr_array_add (argv, g_strdup ("--parent-window"));
+@@ -1406,7 +1406,6 @@
+ gcm_prefs_profile_clicked (CcColorPanel *prefs, CdProfile *profile, CdDevice *device)
+ {
+   GtkWidget *widget;
+-  gchar *s;
+   CcColorPanelPrivate *priv = prefs->priv;
+ 
+   /* get profile */
+@@ -1416,11 +1415,9 @@
+   /* allow getting profile info */
+   widget = GTK_WIDGET (gtk_builder_get_object (priv->builder,
+                "toolbutton_profile_view"));
+-  if (cd_profile_get_filename (profile) != NULL &&
+-      (s = g_find_program_in_path ("gcm-viewer")) != NULL)
++  if (cd_profile_get_filename (profile) != NULL)
+     {
+       gtk_widget_set_sensitive (widget, TRUE);
+-      g_free (s);
+     }
+   else
+       gtk_widget_set_sensitive (widget, FALSE);
+--- a/panels/datetime/test-endianess.c
++++ b/panels/datetime/test-endianess.c
+@@ -26,7 +26,7 @@
+ 	GDir *dir;
+ 	const char *name;
+ 
+-	dir = g_dir_open ("/usr/share/i18n/locales/", 0, NULL);
++	dir = g_dir_open ("@glibc@/share/i18n/locales/", 0, NULL);
+ 	if (dir == NULL) {
+ 		/* Try with /usr/share/locale/
+ 		 * https://bugzilla.gnome.org/show_bug.cgi?id=646780 */
+--- a/panels/datetime/tz.h
++++ b/panels/datetime/tz.h
+@@ -27,11 +27,7 @@
+ 
+ #include <glib.h>
+ 
+-#ifndef __sun
+-#  define TZ_DATA_FILE "/usr/share/zoneinfo/zone.tab"
+-#else
+-#  define TZ_DATA_FILE "/usr/share/lib/zoneinfo/tab/zone_sun.tab"
+-#endif
++#define TZ_DATA_FILE "@tzdata@/share/zoneinfo/zone.tab"
+ 
+ typedef struct _TzDB TzDB;
+ typedef struct _TzLocation TzLocation;
+--- a/panels/region/cc-region-panel.c
++++ b/panels/region/cc-region-panel.c
+@@ -1388,10 +1388,10 @@
+         }
+ 
+         if (variant && variant[0])
+-                commandline = g_strdup_printf ("gkbd-keyboard-display -l \"%s\t%s\"",
++                commandline = g_strdup_printf ("@libgnomekbd@/bin/gkbd-keyboard-display -l \"%s\t%s\"",
+                                                layout, variant);
+         else
+-                commandline = g_strdup_printf ("gkbd-keyboard-display -l %s",
++                commandline = g_strdup_printf ("@libgnomekbd@/bin/gkbd-keyboard-display -l %s",
+                                                layout);
+ 
+         g_spawn_command_line_async (commandline, NULL);

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -110,6 +110,8 @@ let
 
   gnome-bluetooth = callPackage ./core/gnome-bluetooth { };
 
+  gnome-color-manager = callPackage ./core/gnome-color-manager { };
+
   gnome-contacts = callPackage ./core/gnome-contacts { };
 
   gnome-control-center = callPackage ./core/gnome-control-center { };


### PR DESCRIPTION
###### Motivation for this change
From https://github.com/NixOS/nixpkgs/issues/247

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

