### PR TITLE
pythonPackages.regex: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/regex/default.nix
+++ b/pkgs/development/python-modules/regex/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
 }:
 
 
@@ -13,11 +14,15 @@ buildPythonPackage rec {
     sha256 = "2353c0e983c4029caf32016f1dddef623c3117ac282a818468c6d2f5d541698d";
   };
 
+  postCheck = ''
+    echo "We now run tests ourselves, since the setuptools installer doesn't."
+    ${python.interpreter} -c 'import test_regex; test_regex.test_main();'
+  '';
+
   meta = {
     description = "Alternative regular expression module, to replace re";
     homepage = https://bitbucket.org/mrabarnett/mrab-regex;
     license = lib.licenses.psfl;
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ abbradar ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)
The package works fine on darwin. We run some tests to prove this.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

