### PR TITLE
nasc: init at 0.4.6

### DIFF
--- a/pkgs/applications/science/math/nasc/default.nix
+++ b/pkgs/applications/science/math/nasc/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, bash
+, gnused
+, fetchFromGitHub
+, gettext
+, pkgconfig
+, gtk3
+, granite
+, gnome3
+, cmake
+, ninja
+, vala
+, libqalculate
+, elementary-cmake-modules
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "nasc-${version}";
+  version = "0.4.6";
+
+  src = fetchFromGitHub {
+    owner = "parnold-x";
+    repo = "nasc";
+    rev = version;
+    sha256 = "01n4ldj5phrsv97vb04qvs9c1ip6v8wygx9llj704hly1il9fb54";
+  };
+
+  XDG_DATA_DIRS = stdenv.lib.concatStringsSep ":" [
+    "${granite}/share"
+    "${gnome3.libgee}/share"
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    wrapGAppsHook
+    vala
+    cmake
+    gettext
+  ];
+  buildInputs = [
+    libqalculate
+    gtk3
+    granite
+    gnome3.libgee
+    gnome3.libsoup
+    gnome3.gtksourceview
+  ];
+
+  prePatch = ''
+    substituteInPlace ./libqalculatenasc/libtool \
+      --replace "/bin/bash" "${bash}/bin/bash" \
+      --replace "/bin/sed" "${gnused}/bin/sed"
+    substituteInPlace ./libqalculatenasc/configure.inc \
+      --replace 'ac_default_path="/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/X11R6/bin"' 'ac_default_path=$PATH'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Do maths like a normal person";
+    longDescription = ''
+      It’s an app where you do maths like a normal person. It lets you
+      type whatever you want and smartly figures out what is math and
+      spits out an answer on the right pane. Then you can plug those
+      answers in to future equations and if that answer changes, so does
+      the equations it’s used in.
+    '';
+    homepage = https://github.com/parnold-x/nasc;
+    maintainers = with maintainers; [ samdroid-apps ];
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19553,6 +19553,8 @@ with pkgs;
 
   liblbfgs = callPackage ../development/libraries/science/math/liblbfgs { };
 
+  nasc = callPackage ../applications/science/math/nasc { };
+
   openblas = callPackage ../development/libraries/science/math/openblas { };
 
   # A version of OpenBLAS using 32-bit integers on all platforms for compatibility with


### PR DESCRIPTION
###### Motivation for this change

Adds this nice little qualculate interface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

