### PR TITLE
alot: move to own module

### DIFF
--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy3k
+, notmuch, urwid, urwidtrees, twisted, python_magic, configobj, pygpgme, mock, file, gpgme}:
+
+buildPythonPackage rec {
+  version = "0.5.1";
+  pname = "alot";
+
+  disabled = isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "pazz";
+    repo = pname;
+    rev = "version";
+    sha256 = "0ipkhc5wllfq78lg47aiq4qih0yjq8ad9xkrbgc88xk8pk9166i8";
+  };
+
+  postPatch = ''
+    substituteInPlace alot/defaults/alot.rc.spec \
+      --replace "themes_dir = string(default=None)" \
+                "themes_dir = string(default='$out/share/themes')"
+  '';
+
+  propagatedBuildInputs = [
+    notmuch
+    urwid
+    urwidtrees
+    twisted
+    python_magic
+    configobj
+    pygpgme
+    mock
+    file
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share
+    cp -r extra/themes $out/share
+    wrapProgram $out/bin/alot \
+      --prefix LD_LIBRARY_PATH : '${stdenv.lib.makeLibraryPath [ notmuch file gpgme ]}'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pazz/alot;
+    description = "Terminal MUA using notmuch mail";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ garbas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -468,50 +468,7 @@ in {
 
   python-sybase = callPackage ../development/python-modules/sybase {};
 
-  alot = buildPythonPackage rec {
-    rev = "0.5.1";
-    name = "alot-${rev}";
-
-    disabled = isPy3k;
-
-    src = pkgs.fetchFromGitHub {
-      owner = "pazz";
-      repo = "alot";
-      inherit rev;
-      sha256 = "0ipkhc5wllfq78lg47aiq4qih0yjq8ad9xkrbgc88xk8pk9166i8";
-    };
-
-    postPatch = ''
-      substituteInPlace alot/defaults/alot.rc.spec \
-        --replace "themes_dir = string(default=None)" \
-                  "themes_dir = string(default='$out/share/themes')"
-    '';
-
-    propagatedBuildInputs =
-      [ self.notmuch
-        self.urwid
-        self.urwidtrees
-        self.twisted
-        self.python_magic
-        self.configobj
-        self.pygpgme
-        self.mock
-      ];
-
-    postInstall = ''
-      mkdir -p $out/share
-      cp -r extra/themes $out/share
-      wrapProgram $out/bin/alot \
-        --prefix LD_LIBRARY_PATH : '${pkgs.lib.makeLibraryPath [ pkgs.notmuch pkgs.file pkgs.gpgme ]}'
-    '';
-
-    meta = {
-      homepage = https://github.com/pazz/alot;
-      description = "Terminal MUA using notmuch mail";
-      platforms = platforms.linux;
-      maintainers = with maintainers; [ garbas ];
-    };
-  };
+  alot = callPackage ../development/python-modules/alot {};
 
   anyjson = buildPythonPackage rec {
     name = "anyjson-0.3.3";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

