### PR TITLE
scriptcommunicator: init at 05.10

### DIFF
--- a/pkgs/tools/misc/scriptcommunicator/default.nix
+++ b/pkgs/tools/misc/scriptcommunicator/default.nix
@@ -1,0 +1,91 @@
+{ stdenv
+, fetchFromGitHub, qmake, pkgconfig
+, libpng, zlib, unzip
+, qtbase, qttools, qtserialport, qtscript, qtmultimedia
+, makeWrapper, makeDesktopItem
+}:
+
+let
+  pname = "scriptcommunicator";
+  version = "05.10";
+
+  desktopItem = makeDesktopItem {
+    name = "ScriptCommunicator";
+    exec = "${pname}";
+    icon = "$out/share/scriptcommunicator/images/main_32x32.png";
+    comment = "Scriptable data terminal"; 
+    desktopName = "ScriptCommunicator";
+    genericName = "Data Terminal";
+    categories = "Network;";
+  };
+
+in stdenv.mkDerivation rec {
+
+  inherit pname version;
+
+  nativeBuildInputs = [ unzip qmake makeWrapper ];
+  buildInputs = [  qtserialport qtscript qtmultimedia ];
+
+  # we want QtDesigner available to create UI
+  propagatedBuildInputs = [ qttools ]; 
+
+  src = fetchFromGitHub {
+    owner = "szieke";
+    repo = "ScriptCommunicator_serial-terminal";
+    rev = "Release_${stdenv.lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "0v6lh5di5pxkqklp3iyvdqmr7w66c7xdd1r8lkk43sh7w7jnbvc9";
+  };
+
+  sourceRoot = "source/ScriptCommunicator";
+
+  buildPhase = ''
+    cd DeleteFolder/DeleteFolder
+    qmake DeleteFolder.pro
+    make
+    cd ../..
+    
+    cd ScriptEditor
+    qmake ScriptEditor.pro
+    make
+    cd ..
+
+    qmake ScriptCommunicator.pro
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/scriptcommunicator,lib}
+
+    cp -a ScriptEditor/apiFiles exampleScripts images templates test $out/share/scriptcommunicator
+    cp ScriptEditor/ScriptEditor $out/share/scriptcommunicator/
+    cp DeleteFolder/DeleteFolder/DeleteFolder $out/share/scriptcommunicator/
+    cp ScriptCommunicator $out/share/scriptcommunicator/
+    cp documentation/Manual_ScriptCommunicator.pdf $out/share/scriptcommunicator/
+      
+    makeWrapper $out/share/scriptcommunicator/ScriptCommunicator $out/bin/scriptcommunicator \
+      --suffix PATH ':' "$out/share/scriptcommunicator"
+
+    # Install desktop file
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Scriptable data terminal which supports several interfaces";
+    longDescription = ''
+      In addition to the simple sending and receiving of data ScriptCommunicator
+      has a QtScript (similar to JavaScript) interface.
+      This script interface has following features:
+      - Scripts can send and receive data with the main interface.
+      - In addition to the main interface scripts can create and use own interfaces
+      (serial port (RS232, USB to serial), UDP, TCP client, TCP server, PCAN and SPI/I2C).
+      - Scripts can use their own GUI (GUI files which have been created with QtDesigner
+        (is included) or QtCreator).
+      - Multiple plot windows can be created by scripts (QCustomPlot from Emanuel Eichhammer is used)
+    '';
+    homepage = https://scriptcommunicator.sourceforge.io;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12779,6 +12779,8 @@ in
 
   sbc = callPackage ../development/libraries/sbc { };
 
+  scriptcommunicator = libsForQt5.callPackage ../tools/misc/scriptcommunicator { };
+
   schroedinger = callPackage ../development/libraries/schroedinger { };
 
   SDL = callPackage ../development/libraries/SDL ({


### PR DESCRIPTION
###### Motivation for this change

new

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

