### PR TITLE
glbinding: init at 2.1.4

### DIFF
--- a/pkgs/development/libraries/glbinding/default.nix
+++ b/pkgs/development/libraries/glbinding/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, cmake, libGLU, xlibsWrapper }:
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "glbinding";
+  version = "2.1.4";
+
+  src = fetchFromGitHub {
+    owner = "cginternals";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1yic3p2iqzxc7wrjnqclx7vcaaqx5fiysq9rqbi6v390jqkg3zlz";
+  };
+
+  buildInputs = [ cmake libGLU xlibsWrapper ];
+
+  meta.description = with stdenv.lib; {
+    homepage = https://github.com/cginternals/glbinding/;
+    description = "A C++ binding for the OpenGL API, generated using the gl.xml specification";
+    license = licenses.mit;
+    maintainers = [ maintainers.mt-caret ];
+  };
+}

--- a/pkgs/development/libraries/glbinding/default.nix
+++ b/pkgs/development/libraries/glbinding/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake libGLU xlibsWrapper ];
 
-  meta.description = with stdenv.lib; {
+  meta = with stdenv.lib; {
     homepage = https://github.com/cginternals/glbinding/;
     description = "A C++ binding for the OpenGL API, generated using the gl.xml specification";
     license = licenses.mit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8866,6 +8866,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  glbinding = callPackage ../development/libraries/glbinding { };
+
   gle = callPackage ../development/libraries/gle { };
 
   glew = callPackage ../development/libraries/glew { };


### PR DESCRIPTION
###### Motivation for this change

"A C++ binding for the OpenGL API, generated using the gl.xml specification".
One of the dependencies for ArrayFire.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

