### PR TITLE
nixos/network-interfaces: Fix 2 small typos

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -142,7 +142,7 @@ let
         default = { };
         example = { mtu = "1492"; window = "524288"; };
         description = ''
-          Other route options. See the symbol <literal>OPTION</literal>
+          Other route options. See the symbol <literal>OPTIONS</literal>
           in the <literal>ip-route(8)</literal> manual page for the details.
         '';
       };
@@ -191,7 +191,7 @@ let
       preferTempAddress = mkOption {
         type = types.bool;
         default = cfg.enableIPv6;
-        defaultText = literalExample "config.networking.enableIpv6";
+        defaultText = literalExample "config.networking.enableIPv6";
         description = ''
           When using SLAAC prefer a temporary (IPv6) address over the EUI-64
           address for originating connections. This is used to reduce tracking.


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

