### PR TITLE
python: Add Rtree library

### DIFF
--- a/pkgs/development/python-modules/Rtree/default.nix
+++ b/pkgs/development/python-modules/Rtree/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, libspatialindex, numpy }:
+
+buildPythonPackage rec {
+  pname = "Rtree";
+  version = "0.8.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0jc62jbcqqpjcwcly7l9zk25bg72mrxmjykpvfiscgln00qczfbc";
+  };
+
+  propagatedBuildInputs = [ libspatialindex ];
+
+  patchPhase = ''
+    substituteInPlace rtree/core.py --replace \
+      "find_library('spatialindex_c')" "'${libspatialindex}/lib/libspatialindex_c${stdenv.hostPlatform.extensions.sharedLibrary}'"
+  '';
+
+  # Tests appear to be broken due to mysterious memory unsafe issues. See #36760
+  doCheck = false;
+  checkInputs = [ numpy ];
+
+  meta = with stdenv.lib; {
+    description = "R-Tree spatial index for Python GIS";
+    homepage = https://toblerity.org/rtree/;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ bgamari ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14467,6 +14467,8 @@ in {
     };
   };
 
+  Rtree = callPackage ../development/python-modules/Rtree { inherit (pkgs) libspatialindex; };
+
   squaremap = buildPythonPackage rec {
     name = "squaremap-1.0.4";
     disabled = isPy3k;


### PR DESCRIPTION
###### Motivation for this change
This library is used by another package which I am working on packaging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

