### PR TITLE
kore: fix build with gcc7

### DIFF
--- a/pkgs/development/web/kore/default.nix
+++ b/pkgs/development/web/kore/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
+  # added to fix build w/gcc7
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=pointer-compare" ];
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

didn't build because gcc7 is more picky with warnings.

/cc ZHF #36453 
/cc maintainer @johnmh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

