### PR TITLE
fcgiwrap: fix build with gcc7

### DIFF
--- a/pkgs/servers/fcgiwrap/default.nix
+++ b/pkgs/servers/fcgiwrap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, systemd, fcgi, autoreconfHook, pkgconfig }:
+{ stdenv, fetchurl, fetchpatch, systemd, fcgi, autoreconfHook, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "fcgiwrap-${version}";
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ systemd fcgi ];
+
+  patches = [
+    (fetchpatch {
+      url = https://sources.debian.org/data/main/f/fcgiwrap/1.1.0-10/debian/patches/declare_cgi_error_noreturn.patch;
+      sha256 = "07mc9jb0f2kzb4pvaxk0pxlb8fjmg42n9j3im548arqzbay2cfr8";
+    })
+  ];
 
   # systemd 230 no longer has libsystemd-daemon as a separate entity from libsystemd
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Fix build with gcc7.

 /cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

