### PR TITLE
gcc-arm-embedded-7: init at 7-2017-q4

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, ncurses5, python27 }:
+
+stdenv.mkDerivation rec {
+  name = "gcc-arm-embedded-${version}";
+  version = "7-2017-q4-major";
+  subdir = "7-2017q4";
+
+  platformString =
+    if stdenv.isLinux then "linux"
+    else if stdenv.isDarwin then "mac"
+    else throw "unsupported platform";
+
+  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-${platformString}.tar.bz2";
+
+  src =
+    if stdenv.isLinux then fetchurl { url=urlString; sha256="0slswspjsk3f130ikfhqmf704qq4ljg317m6x88142hkmvi2k84n"; }
+    else if stdenv.isDarwin then fetchurl { url=urlString; sha256="1jywgylr9f3idr9ll22hpiqmnfqivkj6f05nnl8ci485rz3pddw9"; }
+    else throw "unsupported platform";
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf $f > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python27 ]} "$f" || true
+    done
+  '';
+
+  meta = {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4/M7, Cortex-R4/R5/R7/R8)";
+    homepage = https://developer.arm.com/open-source/gnu-toolchain/gnu-rm;
+    license = with stdenv.lib.licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = with stdenv.lib.maintainers; [ vinymeuh ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6196,6 +6196,7 @@ with pkgs;
     ncurses = pkgsi686Linux.ncurses5;
   };
   gcc-arm-embedded-6 = callPackage ../development/compilers/gcc-arm-embedded/6 {};
+  gcc-arm-embedded-7 = callPackage ../development/compilers/gcc-arm-embedded/7 {};
   gcc-arm-embedded = gcc-arm-embedded-6;
 
   gforth = callPackage ../development/compilers/gforth {};


### PR DESCRIPTION
###### Motivation for this change

Add gcc-arm-embedded version 7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

