### PR TITLE
xenPackages: deprecate Xen 4.5, security support ended

### DIFF
--- a/pkgs/applications/virtualization/xen/4.5.nix
+++ b/pkgs/applications/virtualization/xen/4.5.nix
@@ -39,6 +39,10 @@ in
 callPackage (import ./generic.nix (rec {
   version = "4.5.5";
 
+  meta = {
+    knownVulnerabilities = [ "Security support ended in January 2018" ];
+  };
+
   src = fetchurl {
     url = "https://downloads.xenproject.org/release/xen/${version}/xen-${version}.tar.gz";
     sha256 = "1y74ms4yc3znf8jc3fgyq94va2y0pf7jh8m9pfqnpgklywqnw8g2";

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -221,6 +221,7 @@ stdenv.mkDerivation (rec {
     done
   '';
 
+  # TODO(@oxij): Stop referencing args here
   meta = {
     homepage = http://www.xen.org/;
     description = "Xen hypervisor and related components"
@@ -231,5 +232,5 @@ stdenv.mkDerivation (rec {
                     + withXenfiles (name: x: ''* ${name}: ${x.meta.description or "(No description)"}.'');
     platforms = [ "x86_64-linux" ];
     maintainers = with stdenv.lib.maintainers; [ eelco tstrobel oxij ];
-  };
+  } // (config.meta or {});
 } // removeAttrs config [ "xenfiles" "buildInputs" "patches" "postPatch" "meta" ])

--- a/pkgs/applications/virtualization/xen/packages.nix
+++ b/pkgs/applications/virtualization/xen/packages.nix
@@ -2,7 +2,7 @@
 , stdenv, overrideCC, gcc49
 }:
 
-# TODO on new Xen version: generalize this to generate [vanilla slim
+# TODO(@oxij) on new Xen version: generalize this to generate [vanilla slim
 # light] for each ./<version>.nix.
 
 rec {
@@ -149,8 +149,8 @@ rec {
     };
   };
 
-  xen-vanilla = xen_4_5-vanilla;
-  xen-slim = xen_4_5-slim;
-  xen-light = xen_4_5-light;
+  xen-vanilla = xen_4_8-vanilla;
+  xen-slim = xen_4_8-slim;
+  xen-light = xen_4_8-light;
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18353,9 +18353,10 @@ with pkgs;
 
   xenPackages = recurseIntoAttrs (callPackage ../applications/virtualization/xen/packages.nix {});
 
-  xen = xenPackages.xen_4_5-vanilla;
-  xen-slim = xenPackages.xen_4_5-slim;
-  xen-light = xenPackages.xen_4_5-light;
+  xen = xenPackages.xen-vanilla;
+  xen-slim = xenPackages.xen-slim;
+  xen-light = xenPackages.xen-light;
+
   xen_4_8 = xenPackages.xen_4_8-vanilla;
   xen_4_8-slim = xenPackages.xen_4_8-slim;
   xen_4_8-light = xenPackages.xen_4_8-light;


### PR DESCRIPTION
###### Motivation for this change

The title. Closes  #36436.

###### Things done

- [X] It builds.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

