### PR TITLE
pythonPackages.asana: fix build

### DIFF
--- a/pkgs/development/python-modules/asana/default.nix
+++ b/pkgs/development/python-modules/asana/default.nix
@@ -1,5 +1,5 @@
-{ lib, buildPythonPackage, fetchPypi,
-  pytest, requests, requests_oauthlib, six
+{ lib, buildPythonPackage, pytest, requests, requests_oauthlib, six
+, fetchFromGitHub, responses, stdenv
 }:
 
 buildPythonPackage rec {
@@ -7,18 +7,14 @@ buildPythonPackage rec {
   version = "0.7.0";
   name = "${pname}-${version}";
 
-  meta = {
-    description = "Python client library for Asana";
-    homepage = https://github.com/asana/python-asana;
-    license = lib.licenses.mit;
+  src = fetchFromGitHub {
+    owner = "asana";
+    repo = "python-asana";
+    rev = "v${version}";
+    sha256 = "0786y3wxqxxhsb0kkpx4bfzif3dhvv3dmm6vnq58iyj94862kpxf";
   };
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a7ff4a78529257a5412e78cafd6b3025523364c0ab628d579f2771dd66b254bc";
-  };
-
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest responses ];
   propagatedBuildInputs = [ requests requests_oauthlib six ];
 
   patchPhase = ''
@@ -27,11 +23,13 @@ buildPythonPackage rec {
     sed -i "s/requests_oauthlib~=0.6.1/requests_oauthlib >=0.6.1/" setup.py
   '';
 
-  # ERROR: file not found: tests
-  doCheck = false; 
-
   checkPhase = ''
     py.test tests
   '';
 
+  meta = with stdenv.lib; {
+    description = "Python client library for Asana";
+    homepage = https://github.com/asana/python-asana;
+    license = licenses.mit;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Fetching sources from GitHub to have needed files like `LICENSE` and
tests available to provide safer builds.

See https://hydra.nixos.org/build/70676254/log
See ticket #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

