### PR TITLE
pythonPackages.construct: Fix darwin build

### DIFF
--- a/pkgs/development/python-modules/construct/default.nix
+++ b/pkgs/development/python-modules/construct/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, six, pythonOlder }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, six, pytest, pythonOlder }:
 
 buildPythonPackage rec {
   pname = "construct";
@@ -14,15 +14,16 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six ];
 
-  # Tests fail with the following error on Python 3.5+
-  # TypeError: not all arguments converted during string formatting
-  doCheck = pythonOlder "3.5";
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test -k 'not test_numpy' tests
+  '';
 
   meta = with stdenv.lib; {
     description = "Powerful declarative parser (and builder) for binary data";
     homepage = http://construct.readthedocs.org/;
     license = licenses.mit;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)
The package runs fine on darwin. Using pytest as a test runner also
resolves the checkPhase issue on Python 3.5+.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

