### PR TITLE
vale: init at 0.10.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2134,6 +2134,11 @@
     github = "markuskowa";
     name = "Markus Kowalewski";
   };
+  marsam = {
+    email = "marsam@users.noreply.github.com";
+    github = "marsam";
+    name = "Mario Rodas";
+  };
   martijnvermaat = {
     email = "martijn@vermaat.name";
     github = "martijnvermaat";

--- a/pkgs/tools/text/vale/default.nix
+++ b/pkgs/tools/text/vale/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "vale-${version}";
+  version = "0.10.1";
+  rev    = "${version}";
+
+  goPackagePath = "github.com/ValeLint/vale";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner  = "ValeLint";
+    repo   = "vale";
+    sha256 = "1iyc9mny3nb6j3allj3szkiygc2v3gi7l7syq9ifjrm1wknk8wrf";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Vale is an open source linter for prose";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/tools/text/vale/deps.nix
+++ b/pkgs/tools/text/vale/deps.nix
@@ -1,0 +1,275 @@
+
+  # file automatically generated from Gopkg.lock with https://github.com/nixcloud/dep2nix (golang dep)
+  [
+
+    {
+      goPackagePath  = "github.com/ValeLint/gospell";
+      fetch = {
+        type = "git";
+        url = "https://github.com/ValeLint/gospell";
+        rev =  "90dfc71015dfebd3a7274f1ad2756c1dbf09e250";
+        sha256 = "0i2ha76q2xja8r4j72kqiarnylrbk4l1b29632skgzib6k4fh4g1";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/client9/gospell";
+      fetch = {
+        type = "git";
+        url = "https://github.com/client9/gospell";
+        rev =  "90dfc71015dfebd3a7274f1ad2756c1dbf09e250";
+        sha256 = "0i2ha76q2xja8r4j72kqiarnylrbk4l1b29632skgzib6k4fh4g1";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/davecgh/go-spew";
+      fetch = {
+        type = "git";
+        url = "https://github.com/davecgh/go-spew";
+        rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+        sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/fatih/color";
+      fetch = {
+        type = "git";
+        url = "https://github.com/fatih/color";
+        rev =  "570b54cabe6b8eb0bc2dfce68d964677d63b5260";
+        sha256 = "1hw9hgkfzbzqjhy29pqpk20xggxaqjv45wx8yn69488mw5ph7khh";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/gobwas/glob";
+      fetch = {
+        type = "git";
+        url = "https://github.com/gobwas/glob";
+        rev =  "bea32b9cd2d6f55753d94a28e959b13f0244797a";
+        sha256 = "0dx0f293v1a0d8qi7ik5hdl26dapd8xm0hj9a9gc620vhj7khi9q";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/jdkato/prose";
+      fetch = {
+        type = "git";
+        url = "https://github.com/jdkato/prose";
+        rev =  "4d68d1b77f66e36b6897a79f59f434d558e5e0c2";
+        sha256 = "1g2wwj6azpcjy6j7pk4dqx868v3hrqwjg5d737p4441a55026prj";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/jdkato/regexp";
+      fetch = {
+        type = "git";
+        url = "https://github.com/jdkato/regexp";
+        rev =  "38ab2f7842bf2a539528aa7d0014b37421b886e1";
+        sha256 = "11z21z2h2l8vlh4nwkcn7vbfdcmdjk9sc90kn8ji1923i3s7p3bw";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/mattn/go-colorable";
+      fetch = {
+        type = "git";
+        url = "https://github.com/mattn/go-colorable";
+        rev =  "941b50ebc6efddf4c41c8e4537a5f68a4e686b24";
+        sha256 = "0dw492z5w0fzv1cxm3xx26n8qpqjaf2ybiwpmvimzyhv65n8nrf8";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/mattn/go-isatty";
+      fetch = {
+        type = "git";
+        url = "https://github.com/mattn/go-isatty";
+        rev =  "fc9e8d8ef48496124e79ae0df75490096eccf6fe";
+        sha256 = "1r5f9gkavkb1w6sr0qs5kj16706xirl3qnlq3hqpszkw9w27x65a";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/mattn/go-runewidth";
+      fetch = {
+        type = "git";
+        url = "https://github.com/mattn/go-runewidth";
+        rev =  "9e777a8366cce605130a531d2cd6363d07ad7317";
+        sha256 = "0vkrfrz3fzn5n6ix4k8s0cg0b448459sldq8bp4riavsxm932jzb";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/mitchellh/go-homedir";
+      fetch = {
+        type = "git";
+        url = "https://github.com/mitchellh/go-homedir";
+        rev =  "b8bc1bf767474819792c23f32d8286a45736f1c6";
+        sha256 = "13ry4lylalkh4g2vny9cxwvryslzyzwp9r92z0b10idhdq3wad1q";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/mitchellh/mapstructure";
+      fetch = {
+        type = "git";
+        url = "https://github.com/mitchellh/mapstructure";
+        rev =  "d0303fe809921458f417bcf828397a65db30a7e4";
+        sha256 = "1fjwi5ghc1ibyx93apz31n4hj6gcq1hzismpdfbg2qxwshyg0ya8";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/montanaflynn/stats";
+      fetch = {
+        type = "git";
+        url = "https://github.com/montanaflynn/stats";
+        rev =  "eeaced052adbcfeea372c749c281099ed7fdaa38";
+        sha256 = "0kamcla633692n81w0j0d423ws3qdds97r2c0i193ypsh9xknpq9";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/olekukonko/tablewriter";
+      fetch = {
+        type = "git";
+        url = "https://github.com/olekukonko/tablewriter";
+        rev =  "be5337e7b39e64e5f91445ce7e721888dbab7387";
+        sha256 = "04zg261i4bq29bc460nyx9r2j70mj0sbxlprn87ylk8y5j2m1d1w";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/pmezard/go-difflib";
+      fetch = {
+        type = "git";
+        url = "https://github.com/pmezard/go-difflib";
+        rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+        sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/remeh/sizedwaitgroup";
+      fetch = {
+        type = "git";
+        url = "https://github.com/remeh/sizedwaitgroup";
+        rev =  "4b44541c93591ee0e73747d6081e61bd8c58b5c7";
+        sha256 = "1kz7h8r09c95r3hc8bngznc4lrnkz2vm50lrl96cqxja0pw8jl92";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/russross/blackfriday";
+      fetch = {
+        type = "git";
+        url = "https://github.com/russross/blackfriday";
+        rev =  "0b647d0506a698cca42caca173e55559b12a69f2";
+        sha256 = "1bv6mvnrqrcrp5d45l5p07q855sval8l3jzw1cf2dajkpcpysqln";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/shogo82148/go-shuffle";
+      fetch = {
+        type = "git";
+        url = "https://github.com/shogo82148/go-shuffle";
+        rev =  "4789c7c401f229b3ae1673acbccca451480660cd";
+        sha256 = "1gaii1h51df8vr28ww5np8nhvfcy4plv0nja9b9h0cmcxa3jf1lp";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/shurcooL/sanitized_anchor_name";
+      fetch = {
+        type = "git";
+        url = "https://github.com/shurcooL/sanitized_anchor_name";
+        rev =  "541ff5ee47f1dddf6a5281af78307d921524bcb5";
+        sha256 = "1fslblamqkd0yrvl1kbq95hnnji78bq9m33nnxiqs7y9w32zylv5";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/stretchr/testify";
+      fetch = {
+        type = "git";
+        url = "https://github.com/stretchr/testify";
+        rev =  "69483b4bd14f5845b5a1e55bca19e954e827f1d0";
+        sha256 = "11lzrwkdzdd8yyag92akncc008h2f9d1bpc489mxiwp0jrmz4ivb";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/urfave/cli";
+      fetch = {
+        type = "git";
+        url = "https://github.com/urfave/cli";
+        rev =  "0bdeddeeb0f650497d603c4ad7b20cfe685682f6";
+        sha256 = "1ny63c7bfwfrsp7vfkvb4i0xhq4v7yxqnwxa52y4xlfxs4r6v6fg";
+      };
+    }
+
+    {
+      goPackagePath  = "github.com/xrash/smetrics";
+      fetch = {
+        type = "git";
+        url = "https://github.com/xrash/smetrics";
+        rev =  "a3153f7040e90324c58c6287535e26a0ac5c1cc1";
+        sha256 = "1phq5y6mcg741spq7snc6xsky1ybc7fllh2444sfr3p41sjq9hg6";
+      };
+    }
+
+    {
+      goPackagePath  = "golang.org/x/net";
+      fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/net";
+        rev =  "ab5485076ff3407ad2d02db054635913f017b0ed";
+        sha256 = "10805rk5rfgc3ivx35r9qmnps8hy3k3m57g0j6mz10w96k8i7pk7";
+      };
+    }
+
+    {
+      goPackagePath  = "golang.org/x/sys";
+      fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/sys";
+        rev =  "14ac33bf8474b62c65cae263af2e4d3b543cc699";
+        sha256 = "1453l5v5kizq142fiq3bg5hka7b0yvnf9fsq8y2ayj4bc9h5vqf3";
+      };
+    }
+
+    {
+      goPackagePath  = "gopkg.in/ini.v1";
+      fetch = {
+        type = "git";
+        url = "https://gopkg.in/ini.v1";
+        rev =  "d3de07a94d22b4a0972deb4b96d790c2c0ce8333";
+        sha256 = "1lpwqhcfhaa6aighd2lpjfswbb6aw5d5bsmyr0vqaqg6g5kz0ikg";
+      };
+    }
+
+    {
+      goPackagePath  = "gopkg.in/neurosnap/sentences.v1";
+      fetch = {
+        type = "git";
+        url = "https://gopkg.in/neurosnap/sentences.v1";
+        rev =  "a7f18ead1433a139742a8b42ce7a059cfb484d60";
+        sha256 = "1b64xv5anfbnq6354jaygxapwgkdhbszzi604b96sm682brwl0p7";
+      };
+    }
+
+    {
+      goPackagePath  = "gopkg.in/yaml.v2";
+      fetch = {
+        type = "git";
+        url = "https://gopkg.in/yaml.v2";
+        rev =  "25c4ec802a7d637f88d584ab26798e94ad14c13b";
+        sha256 = "053mknsl3xhjscmd552005xnwbfcg0z2iphvbvj3wi0w3pvmlw44";
+      };
+    }
+
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11635,6 +11635,8 @@ with pkgs;
     libva = libva-full; # needs libva-{x11,glx}
   };
 
+  vale = callPackage ../tools/text/vale { };
+
   vamp = callPackage ../development/libraries/audio/vamp { };
 
   vc = callPackage ../development/libraries/vc { };


### PR DESCRIPTION
###### Motivation for this change

Add [Vale](https://valelint.github.io/docs/) package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

