### PR TITLE
pythonPackages.gplaycli: 0.1.2 -> 3.21

### DIFF
--- a/pkgs/development/python-modules/gpapi/default.nix
+++ b/pkgs/development/python-modules/gpapi/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, requests, protobuf, pycryptodome }:
+
+buildPythonPackage rec {
+  version = "0.4.2";
+  pname = "gpapi";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "1fv2y3xbwn512fjxrdwgq6cz0xjd7mh54nq1f18wyz8w40vcznns";
+  };
+
+  propagatedBuildInputs = [ requests protobuf pycryptodome ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/NoMore201/googleplay-api;
+    license = licenses.gpl3;
+    description = "Google Play Unofficial Python API";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/development/python-modules/gplaycli/default.nix
+++ b/pkgs/development/python-modules/gplaycli/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage, stdenv, libffi, isPy3k, pyasn1, clint, ndg-httpsclient
+, protobuf, requests, args, gpapi, pyaxmlparser, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  version = "3.21";
+  name = "gplaycli-${version}";
+
+  src = fetchFromGitHub {
+    owner = "matlink";
+    repo = "gplaycli";
+    rev = version;
+    sha256 = "1r5nzi9yzswam0866gypjcvv3f1rw13jwx9s49chp8byxy1dyrs2";
+  };
+
+ disabled = !isPy3k;
+
+ propagatedBuildInputs = [ libffi pyasn1 clint ndg-httpsclient protobuf requests args gpapi pyaxmlparser ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/matlink/gplaycli;
+    description = "Google Play Downloader via Command line";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/development/python-modules/pyaxmlparser/default.nix
+++ b/pkgs/development/python-modules/pyaxmlparser/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, stdenv, lxml, click, fetchPypi }:
+
+buildPythonPackage rec {
+  version = "0.3.7";
+  pname = "pyaxmlparser";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1spwr28sc6fc3cqdx2j2zq38qx889hixl4ahhf1nphpmrl39ypxr";
+  };
+
+  propagatedBuildInputs = [ lxml click ];
+
+  meta = with stdenv.lib; {
+    description = "Python3 Parser for Android XML file and get Application Name without using Androguard";
+    homepage = https://github.com/appknox/pyaxmlparser;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -287,6 +287,8 @@ in {
 
   pyatspi = disabledIf (!isPy3k) (callPackage ../development/python-modules/pyatspi { });
 
+  pyaxmlparser = callPackage ../development/python-modules/pyaxmlparser { };
+
   pycairo = callPackage ../development/python-modules/pycairo { };
 
   pycangjie = disabledIf (!isPy3k) (callPackage ../development/python-modules/pycangjie { });
@@ -4807,33 +4809,8 @@ in {
 
   google-compute-engine = callPackage ../tools/virtualization/google-compute-engine { };
 
-  gplaycli = buildPythonPackage rec {
-    version = "0.1.2";
-    name = "gplaycli-${version}";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "matlink";
-      repo = "gplaycli";
-      rev = "${version}";
-      sha256 = "0yc09inzs3aggj0gw4irlhlzw5q562fsp0sks352y6z0vx31hcp3";
-    };
-
-   disabled = ! isPy27;
-
-   propagatedBuildInputs = with self; [ pkgs.libffi pyasn1 clint ndg-httpsclient protobuf requests args ];
-
-   preBuild = ''
-     substituteInPlace setup.py --replace "/etc" "$out/etc"
-     substituteInPlace gplaycli/gplaycli.py --replace "/etc" "$out/etc"
-   '';
-
-    meta = {
-      homepage = https://github.com/matlink/gplaycli;
-      description = "Google Play Downloader via Command line";
-      license = licenses.agpl3Plus;
-      maintainers = with maintainers; [ ];
-    };
-  };
+  gpapi = callPackage ../development/python-modules/gpapi { };
+  gplaycli = callPackage ../development/python-modules/gplaycli { };
 
   gpsoauth = buildPythonPackage rec {
     version = "0.2.0";


### PR DESCRIPTION
###### Motivation for this change

Fix the broken package: https://hydra.nixos.org/build/70687256/log

The newer version requires two new dependencies that have been added as
well:

- gpapi (Unofficial Python API for Google Play) at version 0.4.2
- pyaxmlparser (Parser for Android's XML handler) at version 0.3.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

