### PR TITLE
pythonPackages.discid: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -10,15 +10,17 @@ buildPythonPackage rec {
     sha256 = "78a3bf6c8377fdbe3d85e914a209ff97aa43e35605779639847b510ced31f7b9";
   };
 
-  patchPhase = ''
-    substituteInPlace discid/libdiscid.py \
-      --replace '_open_library(_LIB_NAME)' "_open_library('${libdiscid}/lib/libdiscid.so.0')"
-  '';
+  patchPhase =
+    let extension = stdenv.hostPlatform.extensions.sharedLibrary; in
+    ''
+      substituteInPlace discid/libdiscid.py \
+        --replace "_open_library(_LIB_NAME)" \
+                  "_open_library('${libdiscid}/lib/libdiscid${extension}')"
+    '';
 
   meta = with stdenv.lib; {
     description = "Python binding of libdiscid";
     homepage    = "https://python-discid.readthedocs.org/";
     license     = licenses.lgpl3Plus;
-    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

