### PR TITLE
pythonPackages.htmltreediff: fix build

### DIFF
--- a/pkgs/development/python-modules/htmltreediff/default.nix
+++ b/pkgs/development/python-modules/htmltreediff/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage, fetchFromGitHub, isPy3k, lxml, html5lib, nose, stdenv }:
+
+buildPythonPackage rec {
+  version = "v0.1.2";
+  pname = "htmltreediff";
+
+  disabled = isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "christian-oudard";
+    repo = pname;
+    rev = version;
+    sha256 = "16mqp2jyznrw1mgd3qzybq28h2k5wz7vmmz1m6xpgscazyjhvvd1";
+  };
+
+  propagatedBuildInputs = [ lxml html5lib ];
+
+  checkInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    description = " Structure-aware diff for html and xml documents";
+    homepage = https://github.com/christian-oudard/htmltreediff;
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20547,30 +20547,7 @@ EOF
     };
   };
 
-  htmltreediff = buildPythonPackage rec{
-    version = "0.1.2";
-    pname = "htmltreediff";
-    name = pname + "-${version}";
-
-    # Does not work with Py >= 3
-    disabled = !isPy27;
-
-    src = pkgs.fetchFromGitHub {
-      owner = "christian-oudard";
-      repo = pname;
-      rev = "v" + version;
-      sha256 = "16mqp2jyznrw1mgd3qzybq28h2k5wz7vmmz1m6xpgscazyjhvvd1";
-    };
-
-    propagatedBuildInputs = with self; [ lxml html5lib ];
-
-    meta = {
-      description = " Structure-aware diff for html and xml documents";
-      homepage = https://github.com/christian-oudard/htmltreediff;
-      license = licenses.bsdOriginal;
-      maintainers = with maintainers; [];
-    };
-  };
+  htmltreediff = callPackage ../development/python-modules/htmltreediff { };
 
   repeated_test = buildPythonPackage rec {
     name = "repeated_test-${version}";


### PR DESCRIPTION
###### Motivation for this change

- add `pythonPackages.nose` as `checkInput` to make the tests passing
- extract expression into its own file

See https://hydra.nixos.org/build/70680974/log
See ticket #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

