### PR TITLE
pythonPackages.robotframework: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/robotframework/default.nix
+++ b/pkgs/development/python-modules/robotframework/default.nix
@@ -15,7 +15,6 @@ buildPythonPackage rec {
     description = "Generic test automation framework";
     homepage = http://robotframework.org/;
     license = licenses.asl20;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)
The package works fine on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

