### PR TITLE
ghc841:  semi-automated updates

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -194,6 +194,24 @@ self: super: {
     };
   });
 
+  ## Upstreamed, awaiting a Hackage release
+  cabal2nix = (overrideCabal super.cabal2nix (drv: {
+    ##     Ambiguous occurrence ‘<>’
+    ##     It could refer to either ‘Prelude.<>’,
+    ##                              imported from ‘Prelude’ at src/Distribution/Nixpkgs/Haskell/Derivation.hs:6:8-46
+    src = pkgs.fetchFromGitHub {
+      owner  = "nixos";
+      repo   = "cabal2nix";
+      rev    = "32974fcc3d9b485bd35167d9ae90941a5b3d06df";
+      sha256 = "1racp49z5922rvrc62clslzdkxh4axj2i0k83w5y6w5chl83abyd";
+    };
+  })).override {
+    ##     • No instance for (Semigroup (List a))
+    ##         arising from the 'deriving' clause of a data type declaration
+    ##       Possible fix:
+    hpack = self.hpack;
+  };
+
   haskell-gi = overrideCabal super.haskell-gi (drv: {
     ## Setup: Encountered missing dependencies:
     ## haskell-gi-base ==0.20.*
@@ -557,13 +575,6 @@ self: super: {
        })
     ];
   });
-
-  cabal2nix = super.cabal2nix.override {
-    ##     • No instance for (Semigroup (List a))
-    ##         arising from the 'deriving' clause of a data type declaration
-    ##       Possible fix:
-    hpack = self.hpack;
-  };
 
   deepseq-generics = overrideCabal super.deepseq-generics (drv: {
     ## Setup: Encountered missing dependencies:

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -644,6 +644,12 @@ self: super: {
     jailbreak       = true;
   });
 
+  protolude = overrideCabal super.protolude (drv: {
+    ## Setup: Encountered missing dependencies:
+    ## base >=4.6 && <4.11
+    jailbreak       = true;
+  });
+
   quickcheck-instances = overrideCabal super.quickcheck-instances (drv: {
     ## Setup: Encountered missing dependencies:
     ## base >=4.5 && <4.11

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -90,10 +90,19 @@ self: super: {
   hackage-db = super.hackage-db_2_0_1;
 
   ## Needs bump to a versioned attribute
-  ## Setup: Encountered missing dependencies:
-  ## base >=4.5 && <4.11
-  ## Older versions don't compile
-  haddock-library = super.haddock-library_1_5_0_1;
+  haddock-library = overrideCabal super.haddock-library_1_5_0_1 (drv: {
+    ## Setup: Encountered missing dependencies:
+    ## base >=4.5 && <4.11
+    ## Older versions don't compile
+    ##
+    ## Setup: Encountered missing dependencies:
+    ## QuickCheck ==2.11.*
+    doCheck         = false;
+    ## Running Haddock on library for haddock-library-1.5.0.1..
+    ## Setup: internal error when calculating transitive package dependencies.
+    ## Debug info: []
+    doHaddock       = false;
+  });
 
   ## Needs bump to a versioned attribute
   ##     • Could not deduce (Semigroup (ParseResult m))

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -56,6 +56,11 @@ self: super: {
   constraints = super.constraints_0_10;
 
   ## Needs bump to a versioned attribute
+  ## Setup: Encountered missing dependencies:
+  ## template-haskell >=2.5 && <2.13
+  deriving-compat = super.deriving-compat_0_4_1;
+
+  ## Needs bump to a versioned attribute
   ## Issue: https://github.com/sol/doctest/issues/189
   doctest = overrideCabal super.doctest_0_14_1 (drv: {
     ## Setup: Encountered missing dependencies:

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -258,6 +258,26 @@ self: super: {
     libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ network resolv ]);
   });
 
+  ## Upstreamed, awaiting a Hackage release
+  hackage-security = overrideCabal super.hackage-security (drv: {
+    ## Setup: Encountered missing dependencies:
+    ## Cabal >=1.14 && <1.26,
+    ## directory >=1.1.0.2 && <1.3,
+    ## time >=1.2 && <1.7
+    src = pkgs.fetchFromGitHub {
+      owner  = "haskell";
+      repo   = "hackage-security";
+      rev    = "21519f4f572b9547485285ebe44c152e1230fd76";
+      sha256 = "1ijwmps4pzyhsxfhc8mrnc3ldjvpisnmr457vvhgymwhdrr95k0z";
+    };
+    prePatch        = "cd hackage-security; ";
+    ## https://github.com/haskell/hackage-security/issues/211
+    jailbreak       = true;
+    ## error: while evaluating ‘overrideCabal’ at nixpkgs://pkgs/development/haskell-modules/lib.nix:37:24, called from /home/deepfire/nixpkgs/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix:217:22:
+    editedCabalFile = null;
+  });
+
+  ## Upstreamed, awaiting a Hackage release
   haskell-gi = overrideCabal super.haskell-gi (drv: {
     ## Setup: Encountered missing dependencies:
     ## haskell-gi-base ==0.20.*
@@ -626,11 +646,6 @@ self: super: {
          sha256 = "1dpdqsjmy9j9b6md5r9jyhbxnxjd51nmfb5in01j10iqzhj9j51k";
        })
     ];
-  });
-
-  hackage-security = overrideCabal super.hackage-security (drv: {
-    ## https://github.com/haskell/hackage-security/issues/211
-    jailbreak       = true;
   });
 
   haddock-library_1_5_0_1 = overrideCabal super.haddock-library_1_5_0_1 (drv: {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -648,6 +648,12 @@ self: super: {
     ];
   });
 
+  github = overrideCabal super.github (drv: {
+    ## Setup: Encountered missing dependencies:
+    ## base >=4.7 && <4.11
+    jailbreak       = true;
+  });
+
   haddock-library_1_5_0_1 = overrideCabal super.haddock-library_1_5_0_1 (drv: {
     ## Setup: Encountered missing dependencies:
     ## QuickCheck ==2.11.*

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -146,6 +146,16 @@ self: super: {
   lens = super.lens_4_16;
 
   ## Needs bump to a versioned attribute
+  regex-tdfa = overrideCabal super.regex-tdfa_1_2_3 (drv: {
+    ##     • No instance for (Semigroup (CharMap a))
+    ##         arising from the superclasses of an instance declaration
+    ##     • In the instance declaration for ‘Monoid (CharMap a)’
+    ##
+    ## error: while evaluating ‘overrideCabal’ at nixpkgs://pkgs/development/haskell-modules/lib.nix:37:24, called from /home/deepfire/nixpkgs/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix:188:16:
+    editedCabalFile = null;
+  });
+
+  ## Needs bump to a versioned attribute
   ## Setup: Encountered missing dependencies:
   ## doctest >=0.11.1 && <0.14
   semigroupoids = super.semigroupoids_5_2_2;
@@ -512,20 +522,6 @@ self: super: {
     ## prim-uniq -any,
     ## reflection -any,
     libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ data-default haskell-src-exts lens monad-control prim-uniq reflection split template-haskell unbounded-delays ]);
-  });
-
-  ## Unmerged.  PR: https://github.com/ChrisKuklewicz/regex-tdfa/pull/13
-  regex-tdfa = overrideCabal super.regex-tdfa (drv: {
-    ##     • No instance for (Semigroup (CharMap a))
-    ##         arising from the superclasses of an instance declaration
-    ##     • In the instance declaration for ‘Monoid (CharMap a)’
-    src = pkgs.fetchFromGitHub {
-      owner  = "bgamari";
-      repo   = "regex-tdfa";
-      rev    = "34f4593a520176a917b74b8c7fcbbfbd72fb8178";
-      sha256 = "1aiklvf08w1hx2jn9n3sm61mfvdx4fkabszkjliapih2yjpmi3hq";
-    };
-    jailbreak       = true;
   });
 
   ## Unmerged.  PR: https://github.com/bos/text-format/pull/21

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -96,6 +96,12 @@ self: super: {
   haddock-library = super.haddock-library_1_5_0_1;
 
   ## Needs bump to a versioned attribute
+  ##     • Could not deduce (Semigroup (ParseResult m))
+  ##         arising from the superclasses of an instance declaration
+  ##       from the context: Monoid m
+  haskell-src-exts = super.haskell-src-exts_1_20_2;
+
+  ## Needs bump to a versioned attribute
   hspec = overrideCabal super.hspec_2_4_8 (drv: {
     ## Setup: Encountered missing dependencies:
     ## hspec-core ==2.4.4, hspec-discover ==2.4.4
@@ -250,19 +256,6 @@ self: super: {
       sha256 = "1l3qm97gcjih695hhj80rbpnd72prnc81lg5y373yj8jk9f6ypbr";
     };
     prePatch        = "cd base; ";
-  });
-
-  ## Upstreamed, awaiting a Hackage release
-  haskell-src-exts = overrideCabal super.haskell-src-exts (drv: {
-    ##     • Could not deduce (Semigroup (ParseResult m))
-    ##         arising from the superclasses of an instance declaration
-    ##       from the context: Monoid m
-    src = pkgs.fetchFromGitHub {
-      owner  = "haskell-suite";
-      repo   = "haskell-src-exts";
-      rev    = "935f6f0915e89c314b686bdbdc6980c72335ba3c";
-      sha256 = "1v3c1bd5q07qncqfbikvs8h3r4dr500blm5xv3b4jqqv69f0iam9";
-    };
   });
 
   ## Upstreamed, awaiting a Hackage release

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -42,6 +42,11 @@ self: super: {
   unix = null;
   xhtml = null;
 
+  # https://github.com/bitemyapp/esqueleto/issues/77
+  esqueleto = markBrokenVersion "2.5.3" super.esqueleto;
+
+  # https://github.com/haskell-pkg-janitors/haskell-src/issues/5
+  haskell-src = markBrokenVersion "1.0.2.0" super.haskell-src;
   ## Shadowed:
 
   ## Needs bump to a versioned attribute
@@ -56,7 +61,8 @@ self: super: {
     ## Setup: Encountered missing dependencies:
     ## ghc >=7.0 && <8.4
     ##
-    ##        uncaught exception: IOException of type NoSuchThing (cabal: rawSystem: runInteractiveProcess: exec: does not exist (No such file or directory))
+    ## Setup: Encountered missing dependencies:
+    ## QuickCheck >=2.11.3
     doCheck         = false;
   });
 
@@ -78,12 +84,24 @@ self: super: {
   funcmp = super.funcmp_1_9;
 
   ## Needs bump to a versioned attribute
+  ## Setup: Encountered missing dependencies:
+  ## Cabal <2.2
+  ## Older versions don't compile.
+  hackage-db = super.hackage-db_2_0_1;
+
+  ## Needs bump to a versioned attribute
+  ## Setup: Encountered missing dependencies:
+  ## base >=4.5 && <4.11
+  ## Older versions don't compile
+  haddock-library = super.haddock-library_1_5_0_1;
+
+  ## Needs bump to a versioned attribute
   hspec = overrideCabal super.hspec_2_4_8 (drv: {
     ## Setup: Encountered missing dependencies:
     ## hspec-core ==2.4.4, hspec-discover ==2.4.4
     ##
-    ## error: while evaluating the attribute ‘buildInputs’ of the derivation ‘hspec-2.4.8’ at /home/deepfire/src/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:148:11:
-    ## while evaluating the attribute ‘buildInputs’ of the derivation ‘stringbuilder-0.5.1’ at /home/deepfire/src/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:148:11:
+    ## error: while evaluating the attribute ‘buildInputs’ of the derivation ‘hspec-2.4.8’ at nixpkgs://pkgs/stdenv/generic/make-derivation.nix:148:11:
+    ## while evaluating the attribute ‘buildInputs’ of the derivation ‘stringbuilder-0.5.1’ at nixpkgs://pkgs/stdenv/generic/make-derivation.nix:148:11:
     ## infinite recursion encountered, at undefined position
     ## test suite causes an infinite loop
     doCheck         = false;
@@ -91,14 +109,15 @@ self: super: {
 
   ## Needs bump to a versioned attribute
   hspec-core = overrideCabal super.hspec-core_2_4_8 (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## QuickCheck >=2.5.1 && <2.11
+    ##     • No instance for (Semigroup Summary)
+    ##         arising from the superclasses of an instance declaration
+    ##     • In the instance declaration for ‘Monoid Summary’
     ##
-    ## error: while evaluating the attribute ‘buildInputs’ of the derivation ‘hspec-core-2.4.8’ at /home/deepfire/src/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:148:11:
-    ## while evaluating the attribute ‘buildInputs’ of the derivation ‘silently-1.2.5’ at /home/deepfire/src/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:148:11:
-    ## while evaluating the attribute ‘buildInputs’ of the derivation ‘temporary-1.2.1.1’ at /home/deepfire/src/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:148:11:
-    ## while evaluating the attribute ‘buildInputs’ of the derivation ‘base-compat-0.9.3’ at /home/deepfire/src/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:148:11:
-    ## while evaluating the attribute ‘propagatedBuildInputs’ of the derivation ‘hspec-2.4.8’ at /home/deepfire/src/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:148:11:
+    ## error: while evaluating the attribute ‘buildInputs’ of the derivation ‘hspec-core-2.4.8’ at nixpkgs://pkgs/stdenv/generic/make-derivation.nix:148:11:
+    ## while evaluating the attribute ‘buildInputs’ of the derivation ‘silently-1.2.5’ at nixpkgs://pkgs/stdenv/generic/make-derivation.nix:148:11:
+    ## while evaluating the attribute ‘buildInputs’ of the derivation ‘temporary-1.2.1.1’ at nixpkgs://pkgs/stdenv/generic/make-derivation.nix:148:11:
+    ## while evaluating the attribute ‘buildInputs’ of the derivation ‘base-compat-0.9.3’ at nixpkgs://pkgs/stdenv/generic/make-derivation.nix:148:11:
+    ## while evaluating the attribute ‘propagatedBuildInputs’ of the derivation ‘hspec-2.4.8’ at nixpkgs://pkgs/stdenv/generic/make-derivation.nix:148:11:
     ## infinite recursion encountered, at undefined position
     doCheck         = false;
   });
@@ -107,6 +126,13 @@ self: super: {
   ## Setup: Encountered missing dependencies:
   ## hspec-discover ==2.4.8
   hspec-discover = super.hspec-discover_2_4_8;
+
+  ## Needs bump to a versioned attribute
+  HTTP = overrideCabal super.HTTP_4000_3_10 (drv: {
+    ##
+    ## https://github.com/haskell/HTTP/pull/114
+    doCheck         = false;
+  });
 
   ## Needs bump to a versioned attribute
   ## Setup: Encountered missing dependencies:
@@ -136,9 +162,8 @@ self: super: {
   turtle = super.turtle_1_5_4;
 
   ## Needs bump to a versioned attribute
-  ##     Module ‘Data.Semigroup’ does not export ‘Monoid(..)’
-  ##    |
-  ## 80 | import Data.Semigroup (Semigroup(..), Monoid(..))
+  ## Setup: Encountered missing dependencies:
+  ## base >=4 && <4.11
   unordered-containers = super.unordered-containers_0_2_9_0;
 
 
@@ -168,7 +193,7 @@ self: super: {
     };
     ## Setup: Encountered missing dependencies:
     ## th-abstraction >=0.2.2 && <1
-    libraryHaskellDepends = drv.libraryHaskellDepends ++ (with self; [ th-abstraction ]);
+    libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ th-abstraction ]);
   });
 
   ## Upstreamed, awaiting a Hackage release
@@ -187,7 +212,6 @@ self: super: {
   haskell-gi-base = overrideCabal super.haskell-gi-base (drv: {
     ## Setup: Encountered missing dependencies:
     ## haskell-gi-base ==0.21.*
-    ## cannot build derivation ‘/nix/store/qvnrni6j2sz8z26kmjz1hgxfxvggkvjl-gi-cairo-1.0.14.drv’: 1 dependencies couldn't be built
     src = pkgs.fetchFromGitHub {
       owner  = "haskell-gi";
       repo   = "haskell-gi";
@@ -323,6 +347,7 @@ self: super: {
   ## Unmerged
 
   ## Unmerged.  PR: https://github.com/lpsmith/blaze-builder/pull/10
+  ## Issue: https://github.com/lpsmith/blaze-builder/issues/12
   blaze-builder = overrideCabal super.blaze-builder (drv: {
     ##     • No instance for (Semigroup Poke)
     ##         arising from the superclasses of an instance declaration
@@ -333,7 +358,9 @@ self: super: {
       rev    = "b7195f160795a081adbb9013810d843f1ba5e062";
       sha256 = "1g351fdpsvn2lbqiy9bg2s0wwrdccb8q1zh7gvpsx5nnj24b1c00";
     };
-    jailbreak = true;   # https://github.com/lpsmith/blaze-builder/issues/12
+    ## Setup: Encountered missing dependencies:
+    ## base >=4 && <4.11
+    jailbreak       = true;
   });
 
   ## Unmerged.  PR: https://github.com/wrengr/bytestring-trie/pull/3
@@ -355,7 +382,7 @@ self: super: {
     doCheck         = false;
     ## Setup: Encountered missing dependencies:
     ## data-or ==1.0.*
-    libraryHaskellDepends = drv.libraryHaskellDepends ++ (with self; [ data-or ]);
+    libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ data-or ]);
   });
 
   ## Unmerged.  PR: https://github.com/gtk2hs/gtk2hs/pull/233
@@ -398,7 +425,7 @@ self: super: {
     };
     ## Setup: Encountered missing dependencies:
     ## http-client -any, http-client-tls -any, http-types -any
-    libraryHaskellDepends = drv.libraryHaskellDepends ++ (with self; [ http-client http-client-tls http-types ]);
+    libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ http-client http-client-tls http-types ]);
   });
 
   ## Unmerged.  PR: https://github.com/hanshoglund/monadplus/pull/3
@@ -427,7 +454,7 @@ self: super: {
     };
     ## haddock: internal error: internal: extractDecl (ClsInstD)
     ## CallStack (from HasCallStack):
-    ##   error, called at utils/haddock/haddock-api/src/Haddock/Interface/Create.hs:1058:16 in main:Haddock.Interface.Create
+    ##   error, called at utils/haddock/haddock-api/src/Haddock/Interface/Create.hs:1067:16 in main:Haddock.Interface.Create
     doHaddock       = false;
     ## Setup: Encountered missing dependencies:
     ## base >=4.7 && <4.11, bifunctors >=5.2 && <5.5
@@ -438,7 +465,7 @@ self: super: {
     ## monad-control -any,
     ## prim-uniq -any,
     ## reflection -any,
-    libraryHaskellDepends = drv.libraryHaskellDepends ++ (with self; [ data-default haskell-src-exts lens monad-control prim-uniq reflection split template-haskell unbounded-delays ]);
+    libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ data-default haskell-src-exts lens monad-control prim-uniq reflection split template-haskell unbounded-delays ]);
   });
 
   ## Unmerged.  PR: https://github.com/ChrisKuklewicz/regex-tdfa/pull/13
@@ -452,7 +479,7 @@ self: super: {
       rev    = "34f4593a520176a917b74b8c7fcbbfbd72fb8178";
       sha256 = "1aiklvf08w1hx2jn9n3sm61mfvdx4fkabszkjliapih2yjpmi3hq";
     };
-    jailbreak = true;   # base >=4 && <4.11
+    jailbreak       = true;
   });
 
   ## Unmerged.  PR: https://github.com/vincenthz/hs-securemem/pull/12
@@ -575,6 +602,16 @@ self: super: {
     jailbreak       = true;
   });
 
+  boxes = overrideCabal super.boxes (drv: {
+    ## https://github.com/treeowl/boxes/issues/29
+    patches = (drv.patches or []) ++ [
+      (pkgs.fetchpatch
+       { url    = https://github.com/asr/boxes/commit/f03e16cb8677a9d85687c641fe27a87e6fd94d54.patch;
+         sha256 = "179vkn6jimiy64dwyam04x8v981l3pfrq3ig97600vnkns3v8i6a";
+       })
+    ];
+  });
+
   cabal2nix = super.cabal2nix.override {
     ##     • No instance for (Semigroup (List a))
     ##         arising from the 'deriving' clause of a data type declaration
@@ -595,10 +632,42 @@ self: super: {
     jailbreak       = true;
   });
 
+  ## Issue: https://github.com/jgm/doctemplates/issues/2
+  doctemplates = overrideCabal super.doctemplates (drv: {
+    patches = (drv.patches or []) ++ [
+      (pkgs.fetchpatch
+       { url    = https://github.com/jgm/doctemplates/commit/3f8bb8feb19ed86b881bc09d963026db9d98df21.patch;
+         sha256 = "0xmjljh8c90qlzp6wn39iy23pj2j0d4m4r1hxs22zps6qdwk5s6d";
+       })
+    ];
+  });
+
   exception-transformers = overrideCabal super.exception-transformers (drv: {
     ## Setup: Encountered missing dependencies:
     ## HUnit >=1.2 && <1.6
     jailbreak       = true;
+  });
+
+  GenericPretty = overrideCabal super.GenericPretty (drv: {
+    ## https://github.com/RazvanRanca/GenericPretty/issues/2
+    patches = (drv.patches or []) ++ [
+      (pkgs.fetchpatch
+       { url    = https://github.com/RazvanRanca/GenericPretty/pull/3.patch;
+         sha256 = "1dpdqsjmy9j9b6md5r9jyhbxnxjd51nmfb5in01j10iqzhj9j51k";
+       })
+    ];
+  });
+
+  hackage-security = overrideCabal super.hackage-security (drv: {
+    ## https://github.com/haskell/hackage-security/issues/211
+    jailbreak       = true;
+  });
+
+  haddock-library_1_5_0_1 = overrideCabal super.haddock-library_1_5_0_1 (drv: {
+    ## Setup: Encountered missing dependencies:
+    ## QuickCheck ==2.11.*
+    doCheck         = false;
+    doHaddock       = false;
   });
 
   hashable = overrideCabal super.hashable (drv: {
@@ -700,6 +769,16 @@ self: super: {
     doCheck         = false;
   });
 
+  setlocale = overrideCabal super.setlocale (drv: {
+    ## https://bitbucket.org/IchUndNichtDu/haskell-setlocale/issues/1/please-allow-base-412-from-ghc-841
+    jailbreak       = true;
+  });
+
+  stylish-cabal = overrideCabal super.stylish-cabal (drv: {
+    ## https://github.com/pikajude/stylish-cabal/issues/6
+    doHaddock       = false;
+  });
+
   tasty-expected-failure = overrideCabal super.tasty-expected-failure (drv: {
     ## Setup: Encountered missing dependencies:
     ## base >=4.5 && <4.11
@@ -727,17 +806,18 @@ self: super: {
     ##        uncaught exception: ErrorCall (Data.Text.Array.new: size overflow
     ##        CallStack (from HasCallStack):
     ##          error, called at libraries/text/Data/Text/Array.hs:132:20 in text-1.2.3.0:Data.Text.Array)
-    ## Randomized with seed 2114194349
-    ## Finished in 0.0017 seconds
+    ## Randomized with seed 1899912238
+    ## Finished in 0.0027 seconds
     doCheck         = false;
     ## Setup: Encountered missing dependencies:
     ## extra >=1.4.10 && <1.5, lens ==4.14.*
     jailbreak       = true;
   });
 
-  these = overrideCabal super.these (drv: {
+  ## Issue: https://github.com/phadej/tree-diff/issues/15
+  tree-diff = overrideCabal super.tree-diff (drv: {
     ## Setup: Encountered missing dependencies:
-    ## base >=4.5 && <4.11
+    ## base >=4.7 && <4.11
     jailbreak       = true;
   });
 
@@ -757,53 +837,5 @@ self: super: {
     ## base >=4.8 && <4.11
     jailbreak       = true;
   });
-
-  # https://github.com/haskell/HTTP/pull/114
-  HTTP = self.HTTP_4000_3_10;
-  HTTP_4000_3_10 = dontCheck super.HTTP_4000_3_10;
-
-  # Older versions don't compile.
-  haddock-library = self.haddock-library_1_5_0_1;
-  haddock-library_1_5_0_1 = dontHaddock (dontCheck super.haddock-library_1_5_0_1);
-
-  # https://github.com/phadej/tree-diff/issues/15
-  tree-diff = doJailbreak super.tree-diff;
-
-  # https://github.com/jgm/doctemplates/issues/2
-  doctemplates = appendPatch super.doctemplates (pkgs.fetchpatch
-    { url = https://github.com/jgm/doctemplates/commit/3f8bb8feb19ed86b881bc09d963026db9d98df21.patch;
-      sha256 = "0xmjljh8c90qlzp6wn39iy23pj2j0d4m4r1hxs22zps6qdwk5s6d";
-    });
-
-  # https://github.com/bitemyapp/esqueleto/issues/77
-  esqueleto = markBrokenVersion "2.5.3" super.esqueleto;
-
-  # https://github.com/haskell-pkg-janitors/haskell-src/issues/5
-  haskell-src = markBrokenVersion "1.0.2.0" super.haskell-src;
-
-  # Older versions don't compile.
-  hackage-db = super.hackage-db_2_0_1;
-
-  # https://github.com/RazvanRanca/GenericPretty/issues/2
-  GenericPretty = appendPatch super.GenericPretty (pkgs.fetchpatch
-    { url = https://github.com/RazvanRanca/GenericPretty/pull/3.patch;
-      sha256 = "1dpdqsjmy9j9b6md5r9jyhbxnxjd51nmfb5in01j10iqzhj9j51k";
-    }
-  );
-
-  # https://github.com/haskell/hackage-security/issues/211
-  hackage-security = doJailbreak super.hackage-security;
-
-  # https://github.com/pikajude/stylish-cabal/issues/6
-  stylish-cabal = dontHaddock super.stylish-cabal;
-
-  # https://github.com/treeowl/boxes/issues/29
-  boxes = appendPatch super.boxes (pkgs.fetchpatch
-    { url = https://github.com/asr/boxes/commit/f03e16cb8677a9d85687c641fe27a87e6fd94d54.patch;
-      sha256 = "179vkn6jimiy64dwyam04x8v981l3pfrq3ig97600vnkns3v8i6a";
-    });
-
-  # https://bitbucket.org/IchUndNichtDu/haskell-setlocale/issues/1/please-allow-base-412-from-ghc-841
-  setlocale = doJailbreak super.setlocale;
 
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -182,6 +182,18 @@ self: super: {
   ## Upstreamed
 
   ## Upstreamed, awaiting a Hackage release
+  bv = overrideCabal super.bv (drv: {
+    ##     • No instance for (GHC.Base.Semigroup BV)
+    ##         arising from the superclasses of an instance declaration
+    ##     • In the instance declaration for ‘Monoid BV’
+    src = pkgs.fetchFromGitHub {
+      owner  = "iagoabal";
+      repo   = "haskell-bv";
+      rev    = "92932a75719020d6a8ac55c455e5c03a4304043f";
+      sha256 = "0fi4v9mpw5y9q1pm7lqhm2zazfyy921wpaa28125misix0frasfw";
+    };
+  });
+
   haskell-gi = overrideCabal super.haskell-gi (drv: {
     ## Setup: Encountered missing dependencies:
     ## haskell-gi-base ==0.20.*

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -662,6 +662,12 @@ self: super: {
     jailbreak       = true;
   });
 
+  resolv = overrideCabal super.resolv (drv: {
+    ## Setup: Encountered missing dependencies:
+    ## tasty >=0.11.2 && <0.12
+    doCheck         = false;
+  });
+
   setlocale = overrideCabal super.setlocale (drv: {
     ## https://bitbucket.org/IchUndNichtDu/haskell-setlocale/issues/1/please-allow-base-412-from-ghc-841
     jailbreak       = true;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -482,19 +482,6 @@ self: super: {
     jailbreak       = true;
   });
 
-  ## Unmerged.  PR: https://github.com/vincenthz/hs-securemem/pull/12
-  securemem = overrideCabal super.securemem (drv: {
-    ##     • No instance for (Semigroup SecureMem)
-    ##         arising from the superclasses of an instance declaration
-    ##     • In the instance declaration for ‘Monoid SecureMem’
-    src = pkgs.fetchFromGitHub {
-      owner  = "shlevy";
-      repo   = "hs-securemem";
-      rev    = "6168d90b00bfc6a559d3b9160732343644ef60fb";
-      sha256 = "06dhx1z44j5gshpdlsb4aryr3g4was3x4c2sgv1px8j57zrvlypx";
-    };
-  });
-
   ## Unmerged.  PR: https://github.com/bos/text-format/pull/21
   text-format = overrideCabal super.text-format (drv: {
     ##     • No instance for (Semigroup Format)
@@ -505,32 +492,6 @@ self: super: {
       repo   = "text-format";
       rev    = "a1cda87c222d422816f956c7272e752ea12dbe19";
       sha256 = "0lyrx4l57v15rvazrmw0nfka9iyxs4wyaasjj9y1525va9s1z4fr";
-    };
-  });
-
-  ## Unmerged.  PR: https://github.com/vincenthz/hs-tls/pull/270
-  tls = overrideCabal super.tls (drv: {
-    ##     • No instance for (Semigroup Credentials)
-    ##         arising from the superclasses of an instance declaration
-    ##     • In the instance declaration for ‘Monoid Credentials’
-    src = pkgs.fetchFromGitHub {
-      owner  = "ocheron";
-      repo   = "hs-tls";
-      rev    = "763656fbc6c2edabb43fc63d8717960f4b26e6e7";
-      sha256 = "0v7f9b78w6prkbscdx5ggjixll9z1zfqzm5x0ap4wvynnflkspqb";
-    };
-    prePatch        = "cd core; ";
-  });
-
-  ## Unmerged.  PR: https://github.com/Soostone/uri-bytestring/pull/0
-  uri-bytestring = overrideCabal super.uri-bytestring (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## template-haskell >=2.9 && <2.13
-    src = pkgs.fetchFromGitHub {
-      owner  = "koenigmaximilian";
-      repo   = "uri-bytestring";
-      rev    = "105d5855bbf9c78d1e48394677b42a058e242fc9";
-      sha256 = "144hr12k0d61zpgxv62vwlzy6bfs01fqh7qr4qsbv457sznmbb9d";
     };
   });
 
@@ -547,34 +508,6 @@ self: super: {
     };
   });
 
-  ## Unmerged.  PR: https://github.com/vincenthz/hs-certificate/pull/89
-  x509 = overrideCabal super.x509 (drv: {
-    ##     • No instance for (Semigroup DistinguishedName)
-    ##         arising from the superclasses of an instance declaration
-    ##     • In the instance declaration for ‘Monoid DistinguishedName’
-    src = pkgs.fetchFromGitHub {
-      owner  = "bgamari";
-      repo   = "hs-certificate";
-      rev    = "2c5f54ba69c8a0531d10f9b37542bf958ede54c9";
-      sha256 = "1fakr9gqz8k62rnjdsslfavbqrhn92jq9mahyc91f9zhisxp5kdf";
-    };
-    prePatch        = "cd x509; ";
-  });
-
-  ## Unmerged.  PR: https://github.com/vincenthz/hs-certificate/pull/89
-  x509-store = overrideCabal super.x509-store (drv: {
-    ##     • No instance for (Semigroup CertificateStore)
-    ##         arising from the superclasses of an instance declaration
-    ##     • In the instance declaration for ‘Monoid CertificateStore’
-    src = pkgs.fetchFromGitHub {
-      owner  = "bgamari";
-      repo   = "hs-certificate";
-      rev    = "2c5f54ba69c8a0531d10f9b37542bf958ede54c9";
-      sha256 = "1fakr9gqz8k62rnjdsslfavbqrhn92jq9mahyc91f9zhisxp5kdf";
-    };
-    prePatch        = "cd x509-store; ";
-  });
-
 
   ## Non-code, configuration-only change
 
@@ -587,12 +520,6 @@ self: super: {
   async = overrideCabal super.async (drv: {
     ## Setup: Encountered missing dependencies:
     ## base >=4.3 && <4.11
-    jailbreak       = true;
-  });
-
-  bifunctors = overrideCabal super.bifunctors (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## template-haskell >=2.4 && <2.13
     jailbreak       = true;
   });
 
@@ -618,12 +545,6 @@ self: super: {
     ##       Possible fix:
     hpack = self.hpack;
   };
-
-  cabal-doctest = overrideCabal super.cabal-doctest (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## Cabal >=1.10 && <2.1, base >=4.3 && <4.11
-    jailbreak       = true;
-  });
 
   deepseq-generics = overrideCabal super.deepseq-generics (drv: {
     ## Setup: Encountered missing dependencies:
@@ -688,13 +609,6 @@ self: super: {
     jailbreak       = true;
   });
 
-  here = overrideCabal super.here (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## base >=4.5 && <4.11
-    ## https://github.com/tmhedberg/here/pull/22
-    jailbreak       = true;
-  });
-
   hnix = overrideCabal super.hnix (drv: {
     ## Setup: Encountered missing dependencies:
     ## deriving-compat ==0.3.*
@@ -739,12 +653,6 @@ self: super: {
     jailbreak       = true;
   });
 
-  megaparsec = overrideCabal super.megaparsec (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## QuickCheck >=2.7 && <2.11
-    doCheck         = false;
-  });
-
   newtype-generics = overrideCabal super.newtype-generics (drv: {
     ## Setup: Encountered missing dependencies:
     ## base >=4.6 && <4.11
@@ -761,12 +669,6 @@ self: super: {
     ## Setup: Encountered missing dependencies:
     ## base >=4.8 && <4.11
     jailbreak       = true;
-  });
-
-  scientific = overrideCabal super.scientific (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## QuickCheck >=2.5 && <2.11
-    doCheck         = false;
   });
 
   setlocale = overrideCabal super.setlocale (drv: {
@@ -791,13 +693,6 @@ self: super: {
     jailbreak       = true;
   });
 
-  ## Issue: https://github.com/haskell/test-framework/issues/35
-  test-framework-quickcheck2 = overrideCabal super.test-framework-quickcheck2 (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## QuickCheck >=2.4 && <2.11
-    jailbreak       = true;
-  });
-
   ## Issue: https://github.com/ChrisPenner/rasa/issues/54
   text-lens = overrideCabal super.text-lens (drv: {
     ## Failures:
@@ -818,12 +713,6 @@ self: super: {
   tree-diff = overrideCabal super.tree-diff (drv: {
     ## Setup: Encountered missing dependencies:
     ## base >=4.7 && <4.11
-    jailbreak       = true;
-  });
-
-  unliftio-core = overrideCabal super.unliftio-core (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## base >=4.5 && <4.11
     jailbreak       = true;
   });
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -370,6 +370,28 @@ self: super: {
     libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ data-or ]);
   });
 
+  ## Unmerged.  PR: https://github.com/dhall-lang/dhall-haskell/pull/321
+  dhall = overrideCabal super.dhall (drv: {
+    ##     • No instance for (Semigroup (Parser Builder))
+    ##         arising from a use of ‘<>’
+    ##       There are instances for similar types:
+    src = pkgs.fetchFromGitHub {
+      owner  = "deepfire";
+      repo   = "dhall-haskell";
+      rev    = "38f3d8c861e137da6d8ac8eab88aec1c359efcac";
+      sha256 = "1pya7lhdjsygk622k1g3whj0a7jqwyym26ikxbn1anxypnb0n2wy";
+    };
+    ## Setup: Encountered missing dependencies:
+    ## prettyprinter >=1.2.0.1 && <1.3
+    jailbreak       = true;
+    ## Setup: Encountered missing dependencies:
+    ## insert-ordered-containers -any,
+    ## lens-family-core -any,
+    ## prettyprinter-ansi-terminal -any,
+    ## repline -any
+    libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ insert-ordered-containers lens-family-core prettyprinter prettyprinter-ansi-terminal repline ]);
+  });
+
   ## Unmerged.  PR: https://github.com/gtk2hs/gtk2hs/pull/233
   gtk2hs-buildtools = overrideCabal super.gtk2hs-buildtools (drv: {
     ## Setup: Encountered missing dependencies:

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -212,6 +212,22 @@ self: super: {
     hpack = self.hpack;
   };
 
+  ## Upstreamed, awaiting a Hackage release
+  cabal-install = overrideCabal super.cabal-install (drv: {
+    ## Setup: Encountered missing dependencies:
+    ## Cabal >=2.0.1.0 && <2.1, base >=4.5 && <4.11
+    src = pkgs.fetchFromGitHub {
+      owner  = "haskell";
+      repo   = "cabal";
+      rev    = "728ad1a1e066da453ae13ee479629c00d8c2f32d";
+      sha256 = "0943xpva0fjlx8fanqvb6bg7myim2pki7q8hz3q0ijnf73bgzf7p";
+    };
+    prePatch        = "cd cabal-install; ";
+    ## Setup: Encountered missing dependencies:
+    ## network >=2.4 && <2.6, resolv >=0.1.1 && <0.2
+    libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ network resolv ]);
+  });
+
   haskell-gi = overrideCabal super.haskell-gi (drv: {
     ## Setup: Encountered missing dependencies:
     ## haskell-gi-base ==0.20.*

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -182,21 +182,6 @@ self: super: {
   ## Upstreamed
 
   ## Upstreamed, awaiting a Hackage release
-  deriving-compat = overrideCabal super.deriving-compat (drv: {
-    ## Setup: Encountered missing dependencies:
-    ## template-haskell >=2.5 && <2.13
-    src = pkgs.fetchFromGitHub {
-      owner  = "haskell-compat";
-      repo   = "deriving-compat";
-      rev    = "e592c6f8af53866dcf6f5700175a3b02bb4f77d3";
-      sha256 = "0h4qadk7fmz5v3lbdsxfbf3ha81f73xn7v0s6wia16ika5yvfggs";
-    };
-    ## Setup: Encountered missing dependencies:
-    ## th-abstraction >=0.2.2 && <1
-    libraryHaskellDepends = (drv.libraryHaskellDepends or []) ++ (with self; [ th-abstraction ]);
-  });
-
-  ## Upstreamed, awaiting a Hackage release
   haskell-gi = overrideCabal super.haskell-gi (drv: {
     ## Setup: Encountered missing dependencies:
     ## haskell-gi-base ==0.20.*


### PR DESCRIPTION
- interned the manual changes to the GHC 8.4 package set (except the `markBroken` things, which are maintained as plaintext)
- dropped stale overrides
- new fixes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

