### PR TITLE
prometheus: add 2.1.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -1,42 +1,56 @@
 { stdenv, go, buildGoPackage, fetchFromGitHub }:
 
-buildGoPackage rec {
-  name = "prometheus-${version}";
-  version = "1.8.1";
-  rev = "v${version}";
-
+let
   goPackagePath = "github.com/prometheus/prometheus";
 
-  src = fetchFromGitHub {
-    inherit rev;
-    owner = "prometheus";
-    repo = "prometheus";
+  generic = { version, sha256, ... }@attrs:
+    let attrs' = builtins.removeAttrs attrs ["version" "sha256"]; in
+      buildGoPackage ({
+        name = "prometheus-${version}";
+
+        inherit goPackagePath;
+
+        src = fetchFromGitHub {
+          rev = "v${version}";
+          owner = "prometheus";
+          repo = "prometheus";
+          inherit sha256;
+        };
+
+        docheck = true;
+
+        buildFlagsArray = let t = "${goPackagePath}/version"; in ''
+          -ldflags=
+             -X ${t}.Version=${version}
+             -X ${t}.Revision=unknown
+             -X ${t}.Branch=unknown
+             -X ${t}.BuildUser=nix@nixpkgs
+             -X ${t}.BuildDate=unknown
+             -X ${t}.GoVersion=${stdenv.lib.getVersion go}
+        '';
+
+        preInstall = ''
+          mkdir -p "$bin/share/doc/prometheus" "$bin/etc/prometheus"
+          cp -a $src/documentation/* $bin/share/doc/prometheus
+          cp -a $src/console_libraries $src/consoles $bin/etc/prometheus
+        '';
+
+        meta = with stdenv.lib; {
+          description = "Service monitoring system and time series database";
+          homepage = https://prometheus.io;
+          license = licenses.asl20;
+          maintainers = with maintainers; [ benley fpletz ];
+          platforms = platforms.unix;
+        };
+    } // attrs');
+in rec {
+  prometheus_1 = generic {
+    version = "1.8.1";
     sha256 = "07xvpjhhxc0r73qfmkvf94zhv19zv76privw6blg35k5nxcnj7j4";
   };
 
-  docheck = true;
-
-  buildFlagsArray = let t = "${goPackagePath}/version"; in ''
-    -ldflags=
-       -X ${t}.Version=${version}
-       -X ${t}.Revision=unknown
-       -X ${t}.Branch=unknown
-       -X ${t}.BuildUser=nix@nixpkgs
-       -X ${t}.BuildDate=unknown
-       -X ${t}.GoVersion=${stdenv.lib.getVersion go}
-  '';
-
-  preInstall = ''
-    mkdir -p "$bin/share/doc/prometheus" "$bin/etc/prometheus"
-    cp -a $src/documentation/* $bin/share/doc/prometheus
-    cp -a $src/console_libraries $src/consoles $bin/etc/prometheus
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Service monitoring system and time series database";
-    homepage = https://prometheus.io;
-    license = licenses.asl20;
-    maintainers = with maintainers; [ benley fpletz ];
-    platforms = platforms.unix;
+  prometheus_2 = generic {
+    version = "2.1.0";
+    sha256 = "01pbqfp43qrqcgyidyg2lw9jnjdrv140vnmqmm49z0vhlkxkwlvw";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12587,8 +12587,13 @@ with pkgs;
 
   postgresql_jdbc = callPackage ../servers/sql/postgresql/jdbc { };
 
+  inherit (callPackage ../servers/monitoring/prometheus {})
+      prometheus_1
+      prometheus_2
+      ;
+
   prom2json = callPackage ../servers/monitoring/prometheus/prom2json.nix { };
-  prometheus = callPackage ../servers/monitoring/prometheus { };
+  prometheus = prometheus_1;
   prometheus-alertmanager = callPackage ../servers/monitoring/prometheus/alertmanager.nix { };
   prometheus-bind-exporter = callPackage ../servers/monitoring/prometheus/bind-exporter.nix { };
   prometheus-blackbox-exporter = callPackage ../servers/monitoring/prometheus/blackbox-exporter.nix { };


### PR DESCRIPTION
###### Motivation for this change
Make Prometheus 2 available as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

