### PR TITLE
pythonPackages.mt-940: fix build

### DIFF
--- a/pkgs/development/python-modules/mt-940/default.nix
+++ b/pkgs/development/python-modules/mt-940/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage, stdenv, pytestrunner, pyyaml, pytest, enum34
+, pytestpep8, pytestflakes,fetchFromGitHub, isPy3k, lib, glibcLocales
+}:
+
+buildPythonPackage rec {
+  version = "v4.10.0";
+  pname = "mt940";
+
+  src = fetchFromGitHub {
+    owner = "WoLpH";
+    repo = pname;
+    rev = version;
+    sha256 = "1dsf2di8rr0iw2vaz6dppalby3y7i8x2bl0qjqvaiqacjxxvwj65";
+  };
+
+  patches = [
+    ./no-coverage.patch
+  ];
+
+  propagatedBuildInputs = [ pyyaml pytestrunner ]
+    ++ lib.optional (!isPy3k) enum34;
+
+  LC_ALL="en_US.UTF-8";
+
+  checkInputs = [ pytestpep8 pytestflakes pytest glibcLocales ];
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library to parse MT940 files and returns smart Python collections for statistics and manipulation";
+    homepage = "http://pythonhosted.org/mt-940/";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/mt-940/no-coverage.patch
+++ b/pkgs/development/python-modules/mt-940/no-coverage.patch
@@ -1,0 +1,26 @@
+diff --git a/pytest.ini b/pytest.ini
+index fef28f5..f366331 100644
+--- a/pytest.ini
++++ b/pytest.ini
+@@ -4,10 +4,6 @@ python_files =
+     tests/*.py
+ 
+ addopts =
+-    --cov mt940
+-    --cov-report term-missing
+-    --cov-report html
+-    --no-cov-on-fail
+     --doctest-modules
+     --pep8
+     --flakes
+diff --git a/tests/requirements.txt b/tests/requirements.txt
+index fc55572..e52cc28 100644
+--- a/tests/requirements.txt
++++ b/tests/requirements.txt
+@@ -3,6 +3,5 @@
+ -r ../docs/requirements.txt
+ pytest
+ pytest-cache
+-pytest-cover
+ pytest-flakes
+ pytest-pep8

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5535,24 +5535,7 @@ in {
     };
   };
 
-  mt-940 = buildPythonPackage rec {
-    version = "4.10.0";
-    name = "mt-940-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/m/mt-940/mt-940-${version}.tar.gz";
-      sha256 = "1gyqf1k2r2ml45x08bk69ws865yrpcph514mn4xvjz779mlgh67j";
-    };
-
-    buildInputs = with self; [ pytestrunner pyyaml pytest ];
-    doCheck = false; # Can't find data files
-
-    meta = {
-      description = "A library to parse MT940 files and returns smart Python collections for statistics and manipulation";
-      homepage = "http://pythonhosted.org/mt-940/";
-      license = licenses.bsd3;
-    };
-  };
+  mt-940 = callPackage ../development/python-modules/mt-940 { };
 
   mwlib = let
     pyparsing = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

- added missing `enum34` dependency
- enabled tests
- moved expression into its own file

See ticket #36453
See https://hydra.nixos.org/build/70677609/log

/cc @the-kenny

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

