### PR TITLE
rofi: add `theme` option

### DIFF
--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -5,10 +5,10 @@
 
 stdenv.mkDerivation rec {
   version = "1.5.1";
-  name = "rofi-${version}";
+  name = "rofi-unwrapped-${version}";
 
   src = fetchurl {
-    url = "https://github.com/DaveDavenport/rofi/releases/download/${version}/${name}.tar.gz";
+    url = "https://github.com/DaveDavenport/rofi/releases/download/${version}/rofi-${version}.tar.gz";
     sha256 = "1dc33zf33z38jcxb0lxpyd31waalpf6d4cd9z5f9m5qphdk1g679";
   };
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     description = "Window switcher, run dialog and dmenu replacement";
     homepage = https://davedavenport.github.io/rofi;
     license = licenses.mit;
-    maintainers = with maintainers; [ mbakke garbas ];
+    maintainers = with maintainers; [ mbakke garbas ma27 ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/applications/misc/rofi/wrapper.nix
+++ b/pkgs/applications/misc/rofi/wrapper.nix
@@ -1,0 +1,17 @@
+{ stdenv, rofi-unwrapped, makeWrapper, theme ? null, lib }:
+
+stdenv.mkDerivation {
+  name = "rofi-${rofi-unwrapped.version}";
+  buildInputs = [ makeWrapper ];
+  preferLocalBuild = true;
+  passthru = { unwrapped = rofi-unwrapped; };
+  buildCommand = ''
+    mkdir -p $out/bin
+    ln -s ${rofi-unwrapped}/bin/rofi $out/bin/rofi
+    ${lib.optionalString (theme != null) ''wrapProgram $out/bin/rofi --add-flags "-theme ${theme}"''}
+  '';
+
+  meta = rofi-unwrapped.meta // {
+    priority = (rofi-unwrapped.meta.priority or 0) - 1;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17497,7 +17497,8 @@ with pkgs;
 
   rkt = callPackage ../applications/virtualization/rkt { };
 
-  rofi = callPackage ../applications/misc/rofi { };
+  rofi-unwrapped = callPackage ../applications/misc/rofi { };
+  rofi = callPackage ../applications/misc/rofi/wrapper.nix { };
 
   rofi-pass = callPackage ../tools/security/pass/rofi-pass.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

This is helpful when defining a `*.rasi` theme for rofi using
`pkgs.writeText` rather than messing up the impure `~/.config`
directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

