### PR TITLE
libtar, languagemachines: fix darwin build

### DIFF
--- a/pkgs/development/libraries/languagemachines/frog.nix
+++ b/pkgs/development/libraries/languagemachines/frog.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, automake, autoconf, libtool, pkgconfig, autoconf-archive
+, automake, autoconf, bzip2, libtar, libtool, pkgconfig, autoconf-archive
 , libxml2, icu
 , languageMachines
 }:
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchurl { inherit (release) url sha256;
                    name = "frog-${release.version}.tar.gz"; };
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ automake autoconf libtool autoconf-archive
+  buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
                   libxml2 icu
                   languageMachines.ticcutils
                   languageMachines.timbl

--- a/pkgs/development/libraries/languagemachines/libfolia.nix
+++ b/pkgs/development/libraries/languagemachines/libfolia.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , automake, autoconf, libtool, pkgconfig, autoconf-archive
-, libxml2, icu
+, libxml2, icu, bzip2, libtar
 , languageMachines }:
 
 let
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   src = fetchurl { inherit (release) url sha256;
                    name = "libfolia-${release.version}.tar.gz"; };
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ automake autoconf libtool autoconf-archive libxml2 icu languageMachines.ticcutils ];
+  buildInputs = [ automake autoconf bzip2 libtool autoconf-archive libtar libxml2 icu languageMachines.ticcutils ];
   preConfigure = "sh bootstrap.sh";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/languagemachines/mbt.nix
+++ b/pkgs/development/libraries/languagemachines/mbt.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, automake, autoconf, libtool, pkgconfig, autoconf-archive
+, automake, autoconf, bzip2, libtar, libtool, pkgconfig, autoconf-archive
 , libxml2
 , languageMachines
 }:
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchurl { inherit (release) url sha256;
                    name = "mbt-${release.version}.tar.gz"; };
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ automake autoconf libtool autoconf-archive
+  buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
                   libxml2
                   languageMachines.ticcutils
                   languageMachines.timbl

--- a/pkgs/development/libraries/languagemachines/timbl.nix
+++ b/pkgs/development/libraries/languagemachines/timbl.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , automake, autoconf, libtool, pkgconfig, autoconf-archive
-, libxml2
+, libxml2, bzip2, libtar
 , languageMachines
 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchurl { inherit (release) url sha256;
                    name = "timbl-${release.version}.tar.gz"; };
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ automake autoconf libtool autoconf-archive
+  buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
                   libxml2
                   languageMachines.ticcutils
                 ];

--- a/pkgs/development/libraries/languagemachines/timblserver.nix
+++ b/pkgs/development/libraries/languagemachines/timblserver.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, automake, autoconf, libtool, pkgconfig, autoconf-archive
+, automake, autoconf, bzip2, libtar, libtool, pkgconfig, autoconf-archive
 , libxml2
 , languageMachines
 }:
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchurl { inherit (release) url sha256;
                    name = "timblserver-${release.version}.tar.gz"; };
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ automake autoconf libtool autoconf-archive
+  buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
                   libxml2
                   languageMachines.ticcutils
                   languageMachines.timbl

--- a/pkgs/development/libraries/languagemachines/ucto.nix
+++ b/pkgs/development/libraries/languagemachines/ucto.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , automake, autoconf, libtool, pkgconfig, autoconf-archive
-, libxml2, icu
+, libxml2, icu, bzip2, libtar
 , languageMachines
 }:
 
@@ -14,8 +14,8 @@ stdenv.mkDerivation {
   src = fetchurl { inherit (release) url sha256;
                    name = "ucto-${release.version}.tar.gz"; };
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ automake autoconf libtool autoconf-archive
-                  icu libxml2
+  buildInputs = [ automake autoconf bzip2 libtool autoconf-archive
+                  icu libtar libxml2
                   languageMachines.ticcutils
                   languageMachines.libfolia
                   languageMachines.uctodata

--- a/pkgs/development/libraries/libtar/default.nix
+++ b/pkgs/development/libraries/libtar/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "C library for manipulating POSIX tar files";
     homepage = http://www.feep.net/libtar/;
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
/cc ZHF #36454

Fixing libtar propagated to languagemachines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (spot-checked a couple)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

