### PR TITLE
adds tmuxPlugins

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1,0 +1,224 @@
+{ fetchgit, stdenv, pkgs }:
+
+let
+  rtpPath = "share/tmux-plugins";
+
+  addRtp = path: pluginName: attrs: derivation:
+    derivation // { rtp = "${derivation}/${path}/${builtins.replaceStrings ["-"] ["_"] pluginName}.tmux"; } // {
+      overrideAttrs = f: buildTmuxPlugin (attrs // f attrs);
+    };
+
+  buildTmuxPlugin = a@{
+    pluginName,
+    namePrefix ? "tmuxplugin-",
+    src,
+    unpackPhase ? "",
+    configurePhase ? "",
+    buildPhase ? "",
+    addonInfo ? null,
+    preInstall ? "",
+    postInstall ? "",
+    path ? (builtins.parseDrvName pluginName).name,
+    dependencies ? [],
+    ...
+  }:
+    addRtp "${rtpPath}/${path}" pluginName a (stdenv.mkDerivation (a // {
+      name = namePrefix + pluginName;
+
+      inherit pluginName unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
+
+      installPhase = ''
+        runHook preInstall
+
+        target=$out/${rtpPath}/${path}
+        mkdir -p $out/${rtpPath}
+        cp -r . $target
+        if [ -n "$addonInfo" ]; then
+          echo "$addonInfo" > $target/addon-info.json
+        fi
+
+        runHook postInstall
+      '';
+
+      dependencies = [ pkgs.bash ] ++ dependencies;
+    }));
+
+  buildTmuxPluginFrom2Nix = a: buildTmuxPlugin ({
+    buildPhase = ":";
+    configurePhase =":";
+  } // a);
+
+in rec {
+
+  battery = buildTmuxPluginFrom2Nix {
+    pluginName = "battery";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-battery";
+      rev = "09be78c35ee84f858f724442b94ad045ade23eb0";
+      sha256 = "0gm6qiay0k5b3yzrabfmh4inyh9r6rfhja2l3r4cixcvc8sgvh8l";
+    };
+  };
+
+  continuum = buildTmuxPluginFrom2Nix {
+    pluginName = "continuum";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-continuum";
+      rev = "90f4a00c41de094864dd4e29231253bcd80d4409";
+      sha256 = "1hviqz62mnq5h4vgcy9bl5004q18yz5b90bnih0ibsna877x3nbc";
+    };
+    dependencies = [ resurrect ];
+  };
+
+  copycat = buildTmuxPluginFrom2Nix {
+    pluginName = "copycat";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-copycat";
+      rev = "6f9b9cd2d93872cef60e3ea7f7ae89598569ed25";
+      sha256 = "12dgn5wnzrhd6sqa64w875ld3lrrny8xvdq6b6lzxyain9q49mrf";
+    };
+  };
+
+  cpu = buildTmuxPluginFrom2Nix {
+    pluginName = "cpu";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-cpu";
+      rev = "12f7a74e25bf59701456e2c0d98b39bb19ec7039";
+      sha256 = "0qxn8ngg297980lj6w8ih2m8m8bxxdbcz5hsjmlia92h5rdkm5kl";
+    };
+  };
+
+  fpp = buildTmuxPluginFrom2Nix {
+    pluginName = "fpp";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-fpp";
+      rev = "ca125d5a9c80bb156ac114ac3f3d5951a795c80e";
+      sha256 = "1b89s6mfzifi7s5iwf22w7niddpq28w48nmqqy00dv38z4yga5ws";
+    };
+    postInstall = ''
+      sed -i -e 's|fpp |${pkgs.fpp}/bin/fpp |g' $target/fpp.tmux
+    '';
+    dependencies = [ pkgs.fpp ];
+  };
+
+  logging = buildTmuxPluginFrom2Nix {
+    pluginName = "logging";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-logging";
+      rev = "b2706119cd587230beae02980d3d7fa2d5afebe9";
+      sha256 = "1w1ymscfbz87lypaxgjdva1rg7jw2jyf7nnfgyngghw9m1l2xk2c";
+    };
+  };
+
+  net-speed = buildTmuxPluginFrom2Nix {
+    pluginName = "net-speed";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-net-speed";
+      rev = "536d2bdd053a3bdfcc5cf7680c0dba76127c95ca";
+      sha256 = "1bly5f40dgiym378jkfwm7qag9xl6qvziqiqnj65yblqd5py325z";
+    };
+  };
+
+  maildir-counter = buildTmuxPluginFrom2Nix {
+    pluginName = "maildir-counter";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-maildir-counter";
+      rev = "9415f0207e71e37cbd870c9443426dbea6da78b9";
+      sha256 = "0dwvqhiv9bjwr01hsi5c57n55jyv5ha5m5q1aqgglf4wyhbnfms4";
+    };
+  };
+
+  online-status = buildTmuxPluginFrom2Nix {
+    pluginName = "online-status";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-online-status";
+      rev = "ea86704ced8a20f4a431116aa43f57edcf5a6312";
+      sha256 = "1hy3vg8v2sir865ylpm2r4ip1zgd4wlrf24jbwh16m23qdcvc19r";
+    };
+  };
+
+  open = buildTmuxPluginFrom2Nix {
+    pluginName = "open";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-open";
+      rev = "f99d3189c445188eae5fa9bfeabc95df16deca92";
+      sha256 = "13q3zd5jv7akkjjwhgimmfylrvalxdn54fnpfb14g6xam6h8808m";
+    };
+  };
+
+  pain-control = buildTmuxPluginFrom2Nix {
+    pluginName = "pain-control";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-pain-control";
+      rev = "731667692da46d51a6a9dffb4c43384a5d68ff28";
+      sha256 = "1ihpl5wgjmhfgcrasgnydd7vpsar865sx2whra19gpfm4bglmdzl";
+    };
+  };
+
+  prefix-highlight = buildTmuxPluginFrom2Nix {
+    pluginName = "prefix-highlight";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-prefix-highlight";
+      rev = "34f7125ae46e5123bedad03e08027332d1186186";
+      sha256 = "16z8sm8pifg1m9lmv0z50fb0ws9mk5zqs7a1ddl2bfwkqi7yc0c0";
+    };
+  };
+
+  resurrect = buildTmuxPluginFrom2Nix {
+    pluginName = "resurrect";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-resurrect";
+      rev = "7c77c70483b818d331e46c4cf64c716ded09a152";
+      sha256 = "08gjxwdmfy16xpgi87rp9dj5338imqsy392pixf7xcnr05413ap1";
+    };
+  };
+
+  sensible = buildTmuxPluginFrom2Nix {
+    pluginName = "sensible";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-sensible";
+      rev = "e91b178ff832b7bcbbf4d99d9f467f63fd1b76b5";
+      sha256 = "1z8dfbwblrbmb8sgb0k8h1q0dvfdz7gw57las8nwd5gj6ss1jyvx";
+    };
+  };
+
+  sessionist = buildTmuxPluginFrom2Nix {
+    pluginName = "sessionist";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-sessionist";
+      rev = "09ec86be38eae98ffc27bd0dde605ed10ae0dc89";
+      sha256 = "030q2mmj8akbc26jnqn8n7fckg1025p0ildx4wr401b6p1snnlw4";
+    };
+  };
+
+  sidebar = buildTmuxPluginFrom2Nix {
+    pluginName = "sidebar";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-sidebar";
+      rev = "23014524cab53f8d36373983500fe05a527a444d";
+      sha256 = "1w363587isdip1r81h0vkp5163lpa83lvasg8l04h43sbip2y6i8";
+    };
+  };
+
+  urlview = buildTmuxPluginFrom2Nix {
+    pluginName = "urlview";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-urlview";
+      rev = "b84c876cffdd22990b4ab51247e795cbd7813d53";
+      sha256 = "1jp4jq57cn116b3i34v6yy69izd8s6mp2ijr260cw86g0470k0fn";
+    };
+    postInstall = ''
+      sed -i -e '14,20{s|urlview|${pkgs.urlview}/bin/urlview|g}' $target/urlview.tmux
+    '';
+    dependencies = [ pkgs.urlview ];
+  };
+
+  yank = buildTmuxPluginFrom2Nix {
+    pluginName = "yank";
+    src = fetchgit {
+      url = "https://github.com/tmux-plugins/tmux-yank";
+      rev = "feb9611b7d1c323ca54cd8a5111a53e3e8265b59";
+      sha256 = "1ywbm09jfh6cm2m6gracmdc3pp5p2dwraalbhfaafqaydjr22qc3";
+    };
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5021,6 +5021,8 @@ with pkgs;
 
   tmuxinator = callPackage ../tools/misc/tmuxinator { };
 
+  tmuxPlugins = recurseIntoAttrs (callPackage ../misc/tmux-plugins { });
+
   tmsu = callPackage ../tools/filesystems/tmsu { };
 
   toilet = callPackage ../tools/misc/toilet { };


### PR DESCRIPTION
###### Motivation for this change

Similar as the plugins for vim, but now for tmux.

How to use:
They can be loaded by installing the pkg, as well as adding a line in the tmux config like this:
```
run-shell ${tmuxPlugins.sessionist.rtp}
```
or, if you have a set of plugins (e.g.: `plugins = with tmuxPlugins; [ sessionist yank ];`):
```
${lib.concatStrings (map (x: "run-shell ${x.rtp}\n") plugins)}
```
I plan on adding the latter in the tmux modules for both `nixos` and `nix-darwin` once this gets merged in follow-up PRs.

ps: I didn't add myself to the contributor/maintainer list yet. I'm not sure when that becomes needed or appropriate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

