### PR TITLE
urlscan: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/applications/misc/urlscan/default.nix
+++ b/pkgs/applications/misc/urlscan/default.nix
@@ -1,20 +1,23 @@
 { stdenv, python3Packages, fetchFromGitHub }:
 
 python3Packages.buildPythonApplication rec {
-  name = "urlscan-${version}";
-  version = "0.8.6";
+  pname = "urlscan";
+  version = "0.8.7";
 
   src = fetchFromGitHub {
     owner = "firecat53";
-    repo = "urlscan";
+    repo = pname;
     rev = version;
-    sha256 = "1v26fni64n0lbv37m35plh2bsrvhpb4ibgmg2mv05qfc3df721s5";
+    sha256 = "1jxjcq869jimsq1ihk2fbjhp5lj7yga0hbp0msskxyz92afl1kz8";
   };
 
   propagatedBuildInputs = [ python3Packages.urwid ];
 
+  doCheck = false; # No tests available
+
   meta = with stdenv.lib; {
     description = "Mutt and terminal url selector (similar to urlview)";
+    homepage = https://github.com/firecat53/urlscan;
     license = licenses.gpl2;
     maintainers = with maintainers; [ dpaetzel jfrankenau ];
   };


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @dpaetzel
