### PR TITLE
lkl: 2017-11-10 -> 2018-03-10

### DIFF
--- a/pkgs/applications/virtualization/lkl/default.nix
+++ b/pkgs/applications/virtualization/lkl/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, bc, python, fuse, libarchive }:
 
 stdenv.mkDerivation rec {
-  name = "lkl-2017-11-10";
-  rev  = "52a6a643c7d1dd3031c0cbec75e1ac7a999f3d57";
+  name = "lkl-2018-03-10";
+  rev  = "8772a4da6064444c5b70766b806fe272b0287c31";
 
   outputs = [ "dev" "lib" "out" ];
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     inherit rev;
     owner  = "lkl";
     repo   = "linux";
-    sha256 = "1i5ywrfxqpykjjalwh9g4rwd4s186cqk3j806d327a67xb2ivxnp";
+    sha256 = "1m6gh4zcx1q7rv05d0knjpk3ivk2b3kc0kwjndciadqc45kws4wh";
   };
 
   # Fix a /usr/bin/env reference in here that breaks sandboxed builds
@@ -27,7 +27,8 @@ stdenv.mkDerivation rec {
     sed -i $out/bin/lkl-hijack.sh \
         -e "s,LD_LIBRARY_PATH=.*,LD_LIBRARY_PATH=$lib/lib,"
 
-    cp tools/lkl/{cptofs,cpfromfs,fs2tar,lklfuse} $out/bin
+    cp tools/lkl/{cptofs,fs2tar,lklfuse} $out/bin
+    ln -s cptofs $out/bin/cpfromfs
     cp -r tools/lkl/include $dev/
     cp tools/lkl/liblkl*.{a,so} $lib/lib
   '';


### PR DESCRIPTION
Bump lkl version to latest that includes merge of Linux 4.15 and fix for
an issue where cptofs wasn't returning failure when image size was too
small and file copying failed with:

  error writing file: No space left on device

(see lkl/linux#427)

###### Motivation for this change

While fixing #36450 I've noticed that build was going on even when image was too small and cptofs was failing but was returning success status. My PR there has been merged, so let's use new version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

