### PR TITLE
stupidterm: 2017-03-15 -> 2018-03-10

### DIFF
--- a/pkgs/applications/misc/stupidterm/default.nix
+++ b/pkgs/applications/misc/stupidterm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, vte, gtk }:
 
 stdenv.mkDerivation rec {
-  name = "stupidterm-2017-03-15";
+  name = "stupidterm-2018-03-10";
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "esmil";
     repo = "stupidterm";
-    rev = "752316a783f52317ffd9f05d32e208dbcafc5ba6";
-    sha256 = "1d8fyhr9sgpxgkwzkyiws0kvhmqfwwyycvcr1qf2wjldiax222lv";
+    rev = "0463519a96c9e4f9ce9fdc99d8e776499346ccba";
+    sha256 = "1vbk53xyjn33myb3fix6y7sxb1x3rndrkk5l9qa60qaw2ivkr965";
   };
 
   makeFlags = "PKGCONFIG=${pkgconfig}/bin/pkg-config binary=stupidterm";


### PR DESCRIPTION
###### Motivation for this change
Fix transparency issues in GnomeShell/Mutter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

