### PR TITLE
spacefm: fix segfault by exporting shared-mime-info/share in XDG_DATA_DIRS

### DIFF
--- a/pkgs/applications/misc/spacefm/default.nix
+++ b/pkgs/applications/misc/spacefm/default.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
     ln -s /etc/spacefm/spacefm.conf $out/etc/spacefm/spacefm.conf
   '';
 
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
+  '';
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     gtk3 udev desktop-file-utils shared-mime-info intltool


### PR DESCRIPTION

###### Motivation for this change
Fixes #31797.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

