### PR TITLE
docker-machine: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/applications/networking/cluster/docker-machine/default.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/default.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "machine-${version}";
-  version = "0.13.0";
+  version = "0.14.0";
 
   goPackagePath = "github.com/docker/machine";
 
@@ -11,7 +11,7 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "docker";
     repo = "machine";
-    sha256 = "1bqblgz2avrvp9xv6rlvgl0xh2ghpml3a00xhq3mmzkznayw6chq";
+    sha256 = "0hd5sklmvkhhpfn318hq9w0f7x14165h1l2mdn9iv4447z1iibff";
   };
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Update to latest `docker-machine` release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

