### PR TITLE
notary: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/tools/security/notary/default.nix
+++ b/pkgs/tools/security/notary/default.nix
@@ -2,22 +2,22 @@
 
 buildGoPackage rec {
   name = "notary-${version}";
-  version = "0.5.1";
-  gitcommit = "9211198";
+  version = "0.6.0";
+  gitcommit = "34f53ad";
 
   src = fetchFromGitHub {
     owner = "theupdateframework";
     repo = "notary";
     rev = "v${version}";
-    sha256 = "0z9nsb1mrl0q5j02jkyzbc6xqsm83qzacsckypsxcrijhw935rs5";
+    sha256 = "0lg7ab2agkk3rnladcvpdzk8cnf3m49qfm4sanh7yjvlvlv1wm4a";
   };
 
   buildInputs = [ libtool ];
 
-  goPackagePath = "github.com/docker/notary";
+  goPackagePath = "github.com/theupdateframework/notary";
 
   buildPhase = ''
-    cd go/src/github.com/docker/notary
+    cd go/src/github.com/theupdateframework/notary
     make GITCOMMIT=${gitcommit} GITUNTRACKEDCHANGES= client
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Update `notary` to latest release. It's also now completely migrated to `github.com/theupdateframework/notary`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

