### PR TITLE
gauge: 0.9.6 -> 0.9.7

### DIFF
--- a/pkgs/development/tools/gauge/default.nix
+++ b/pkgs/development/tools/gauge/default.nix
@@ -2,15 +2,16 @@
 
 buildGoPackage rec {
   name = "gauge-${version}";
-  version = "0.9.6";
+  version = "0.9.7";
 
   goPackagePath = "github.com/getgauge/gauge";
+  excludedPackages = ''\(build\|man\)'';
 
   src = fetchFromGitHub {
     owner = "getgauge";
     repo = "gauge";
     rev = "v${version}";
-    sha256 = "0p2bnrzgx616jbyr9h4h9azaq7ry63z4qkwgy0ivwrpmhfqfqwmh";
+    sha256 = "09afsi97yxlqwmrxvihravqvz17m7y402gbw4hvdk0iixa6jpq6a";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update to latest minor version of `gauge`. Also removes the unecessary binary from the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

