### PR TITLE
conan: Fix build

### DIFF
--- a/pkgs/development/python-modules/distro/11.nix
+++ b/pkgs/development/python-modules/distro/11.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchPypi, buildPythonPackage, pytest, pytestcov, tox }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "distro";
+  version = "1.1.0";
+
+  buildInputs = [ pytest pytestcov tox];
+
+  checkPhase = ''
+    touch tox.ini
+    tox
+  '';
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vn1db2akw98ybnpns92qi11v94hydwp130s8753k6ikby95883j";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/nir0s/distro;
+    description = "Linux Distribution - a Linux OS platform information API.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nand0p ];
+  };
+}

--- a/pkgs/development/python-modules/node-semver/2.nix
+++ b/pkgs/development/python-modules/node-semver/2.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchPypi, buildPythonPackage, pytest, tox }:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  version = "0.2.0";
+  pname = "node-semver";
+
+  buildInputs = [ pytest tox ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1080pdxrvnkr8i7b7bk0dfx6cwrkkzzfaranl7207q6rdybzqay3";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/podhmo/python-semver;
+    description = "A port of node-semver";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -1,26 +1,28 @@
 { lib, buildPythonApplication, fetchPypi
 , requests, fasteners, pyyaml, pyjwt, colorama, patch
-, bottle, pluginbase, six, distro, pylint, node-semver
+, bottle, pluginbase, six, distro11, pylint, node-semver2
 , future, pygments, mccabe
+, fetchpatch
 }:
 
 buildPythonApplication rec {
-  version = "0.28.1";
+  version = "1.1.1";
   pname = "conan";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0zf564iqh0099yd779f9fgk21qyp87d7cmgfj34hmncf8y3qh32a";
+    sha256 = "1k1r401bc9fgmhd5n5f29mjcn346r3zdrm7p28nwpr2r2p3fslrl";
   };
 
   propagatedBuildInputs = [
     requests fasteners pyyaml pyjwt colorama patch
-    bottle pluginbase six distro pylint node-semver
+    bottle pluginbase six distro11 pylint node-semver2
     future pygments mccabe
   ];
 
   # enable tests once all of these pythonPackages available:
   # [ nose nose_parameterized mock webtest codecov ]
+  # update 2018-03-11: only nose_parameterized is missing
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21051,7 +21051,11 @@ EOF
 
   node-semver = callPackage ../development/python-modules/node-semver { };
 
+  node-semver2 = callPackage ../development/python-modules/node-semver/2.nix { };
+
   distro = callPackage ../development/python-modules/distro { };
+
+  distro11 = callPackage ../development/python-modules/distro/11.nix { };
 
   bz2file =  callPackage ../development/python-modules/bz2file { };
 


### PR DESCRIPTION
conan has very strict requirements on the versions of its dependencies.
This patch adds downgraded versinos of node-semver and distro to
statisfy these requirements.

###### Motivation for this change

/cc ZHF #36453 (please backport)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

