### PR TITLE
librime: 1.2.9 -> 1.3.0

### DIFF
--- a/pkgs/data/misc/brise/default.nix
+++ b/pkgs/data/misc/brise/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     # Note that individual packages in this collection
     # may be released under different licenses
     license = licenses.gpl3;
-    platforms = platforms.all;
+    platforms = platforms.linux;
     maintainers = [ maintainers.sifmelcara ];
   };
 }

--- a/pkgs/development/libraries/librime/default.nix
+++ b/pkgs/development/libraries/librime/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "librime-${version}";
-  version = "1.2.9";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "rime";
     repo = "librime";
-    rev = "rime-${version}";
-    sha256 = "14jgnfm61ynm086x9v7wfmv2p14h0qp8lq4d2jqm21n821jsraj6";
+    rev = "${version}";
+    sha256 = "1sxxxliqjjsfblx9n6ijw9gx40xqw71v352b28aw51gg3k201v0j";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     description = "Rime Input Method Engine, the core library";
     license     = licenses.bsd3;
     maintainers = with maintainers; [ sifmelcara ];
-    platforms   = platforms.all;
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update the package.

Also disable builds on darwin. Does it even make sense to build input method frameworks on darwin?

(closes #36610 , which updates the package to 1.2.10)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

