### PR TITLE
rocksdb: use split outputs

### DIFF
--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   name = "rocksdb-${version}";
   version = "5.10.3";
 
+  outputs = [ "dev" "out" "static" ];
+
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "rocksdb";
@@ -65,6 +67,8 @@ stdenv.mkDerivation rec {
     # Might eventually remove this when we are confident in the build process
     echo "BUILD CONFIGURATION FOR SANITY CHECKING"
     cat make_config.mk
+    mkdir -pv $static/lib/
+    mv -vi $out/lib/librocksdb.a $static/lib/
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

a 4.5mb static library was in `$out` along with 500kb of headers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

