### PR TITLE
glibc: patch to fix building w/musl-based stdenv

### DIFF
--- a/pkgs/development/libraries/glibc/common-2.27.nix
+++ b/pkgs/development/libraries/glibc/common-2.27.nix
@@ -4,7 +4,7 @@
 { stdenv, lib
 , buildPlatform, hostPlatform
 , buildPackages
-, fetchurl, fetchpatch
+, fetchurl, fetchpatch ? null
 , linuxHeaders ? null
 , gd ? null, libpng ? null
 , bison

--- a/pkgs/development/libraries/glibc/common-2.27.nix
+++ b/pkgs/development/libraries/glibc/common-2.27.nix
@@ -4,7 +4,7 @@
 { stdenv, lib
 , buildPlatform, hostPlatform
 , buildPackages
-, fetchurl
+, fetchurl, fetchpatch
 , linuxHeaders ? null
 , gd ? null, libpng ? null
 , bison
@@ -78,7 +78,13 @@ stdenv.mkDerivation ({
        */
       ./allow-kernel-2.6.32.patch
     ]
-    ++ lib.optional stdenv.isx86_64 ./fix-x64-abi.patch;
+    ++ lib.optional stdenv.isx86_64 ./fix-x64-abi.patch
+    ++ lib.optional stdenv.hostPlatform.isMusl
+      (fetchpatch {
+        name = "fix-with-musl.patch";
+        url = "https://sourceware.org/bugzilla/attachment.cgi?id=10151&action=diff&collapsed=&headers=1&format=raw";
+        sha256 = "18kk534k6da5bkbsy1ivbi77iin76lsna168mfcbwv4ik5vpziq2";
+      });
 
   postPatch =
     ''

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -4,7 +4,7 @@
 { stdenv, lib
 , buildPlatform, hostPlatform
 , buildPackages
-, fetchurl
+, fetchurl, fetchpatch
 , linuxHeaders ? null
 , gd ? null, libpng ? null
 }:
@@ -88,7 +88,13 @@ stdenv.mkDerivation ({
        */
       ./allow-kernel-2.6.32.patch
     ]
-    ++ lib.optional stdenv.isx86_64 ./fix-x64-abi.patch;
+    ++ lib.optional stdenv.isx86_64 ./fix-x64-abi.patch
+    ++ lib.optional stdenv.hostPlatform.isMusl
+      (fetchpatch {
+        name = "fix-with-musl.patch";
+        url = "https://sourceware.org/bugzilla/attachment.cgi?id=10151&action=diff&collapsed=&headers=1&format=raw";
+        sha256 = "18kk534k6da5bkbsy1ivbi77iin76lsna168mfcbwv4ik5vpziq2";
+      });
 
   postPatch =
     # Needed for glibc to build with the gnumake 3.82

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -4,7 +4,7 @@
 { stdenv, lib
 , buildPlatform, hostPlatform
 , buildPackages
-, fetchurl, fetchpatch
+, fetchurl, fetchpatch ? null
 , linuxHeaders ? null
 , gd ? null, libpng ? null
 }:


### PR DESCRIPTION
See:
https://sourceware.org/bugzilla/show_bug.cgi?id=21604



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---