### PR TITLE
torque: fix build with gcc7

### DIFF
--- a/pkgs/servers/computing/torque/default.nix
+++ b/pkgs/servers/computing/torque/default.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # added to fix build with gcc7
+  NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
+
   preConfigure = ''
    substituteInPlace ./configure \
      --replace '/usr/bin/file' '${file}/bin/file'


### PR DESCRIPTION
###### Motivation for this change

didnt't build with gcc7.

/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

