### PR TITLE
f3: 6.0-2016.11.16-unstable -> 7.0

### DIFF
--- a/pkgs/tools/filesystems/f3/default.nix
+++ b/pkgs/tools/filesystems/f3/default.nix
@@ -1,27 +1,26 @@
 { stdenv, fetchFromGitHub
 , parted, udev
 }:
-let
-  version = "6.0-2016.11.16-unstable";
-in
+
 stdenv.mkDerivation rec {
-  name = "f3-${version}";
+  name = "${pname}-${version}";
+  pname = "f3";
+  version = "7.0";
 
   enableParallelBuilding = true;
 
   src = fetchFromGitHub {
     owner = "AltraMayor";
-    repo = "f3";
-    rev = "eabf001f69a788e64912bc9e812c118a324077d5";
-    sha256 = "0ypqyqwqiy3ynssdd9gamk1jxywg6avb45ndlzhv3wxh2qcframm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "195j2zd747ffbsl8p5rf7dyn1j5n05zfqy1s9fm4y6lz8yc1nr17";
   };
 
   buildInputs = [ parted udev ];
 
   patchPhase = "sed -i 's/-oroot -groot//' Makefile";
 
-  buildFlags   = [ "CFLAGS=-fgnu89-inline"  # HACK for weird gcc incompatibility with -O2
-                   "all"                    # f3read, f3write
+  buildFlags   = [ "all"                    # f3read, f3write
                    "extra"                  # f3brew, f3fix, f3probe
                  ];
 


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @makefu @elitak
