### PR TITLE
WIP: pythonPackages.macfsevents: init at 0.8.1

### DIFF
--- a/pkgs/development/python-modules/macfsevents/default.nix
+++ b/pkgs/development/python-modules/macfsevents/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, darwin }:
+
+buildPythonPackage rec {
+  pname = "MacFSEvents";
+  version = "0.8.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "041yhfgl82p68q9fsixh8b6jl1ns7bvq8zd85dkdwlb06mmvc90k";
+  };
+  buildInputs = with darwin.apple_sdk.frameworks; [
+    darwin.cf-private
+    CoreServices
+  ];
+
+  meta = {
+    description = "A python interface to file system observation primitives in Mac OS X";
+    homepage = https://github.com/malthe/macfsevents;
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
+    platforms = stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9519,6 +9519,8 @@ in {
 
   python_magic = callPackage ../development/python-modules/python-magic { };
 
+  macfsevents = callPackage ../development/python-modules/macfsevents { };
+
   magic = buildPythonPackage rec {
     name = "${pkgs.file.name}";
 


### PR DESCRIPTION
###### Motivation for this change
This adds `macfsevents` in order to fix #32087. This new package is required to fix `pynotify` on darwin.
### Caveat
As of now this is still WIP, because during the checkPhase, I get a segmentation fault:
```
test_existing_directories_are_not_reported (tests.FileObservationTestCase) ... /nix/store/0igxxngigjgfkgg3cw547n92b8bpg6b1-stdenv-darwin/setup: line 1230: 45926 Segmentation fault: 11  /nix/store/4llw0i5jbb7p5n0r58w9z0azqgx5wk09-python-2.7.14/bin/python2.7 nix_run_setup test
```
Maybe someone could give me some pointers on how to proceed.
I guess this has something to do with the darwin headers on nixpkgs not actually matching the kernel version.  (I'm on OS 10.11.6)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

