### PR TITLE
houdini 16.0.671->16.5.405

### DIFF
--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -29,11 +29,11 @@ let
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
-  version = "16.0.671";
+  version = "16.5.405";
   name = "houdini-runtime-${version}";
   src = requireFile rec {
     name = "houdini-${version}-linux_x86_64_gcc4.8.tar.gz";
-    sha256 = "1d3c1a1128szlgaf3ilw5y20plz5azwp37v0ljawgm80y64hq15r";
+    sha256 = "14i0kzv881jqd5z9jshri1fxxi3pkxdmi5l4p2b51c9i3apsxmw6";
     message = ''
       This nix expression requires that ${name} is already part of the store.
       Download it from https://sidefx.com and add it to the nix store with:


### PR DESCRIPTION
###### Motivation for this change

Bump nixpkgs version to match new release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

