### PR TITLE
ssr: fix build

### DIFF
--- a/pkgs/applications/audio/soundscape-renderer/default.nix
+++ b/pkgs/applications/audio/soundscape-renderer/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
 
   # Without it doesn't find all of the boost libraries.
   BOOST_LIB_DIR="${boost}/lib";
+  # uses the deprecated get_generic_category() in boost_system
+  NIX_CFLAGS_COMPILE="-DBOOST_SYSTEM_ENABLE_DEPRECATED=1";
 
   LC_ALL = "en_US.UTF-8";
 


### PR DESCRIPTION

###### Motivation for this change

ZHF https://github.com/NixOS/nixpkgs/issues/36453
This fixes building ssr.
ssr uses the deprecated `get_generic_category()` from boost_system in ./configure
pass the flag enabling that to boost

cc @FRidh, maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


I tried to run the main executable, but I get 
```
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
```
I guess that it means that I don't use jack. I didn't try anything further.
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

