### PR TITLE
[WIP] linux: Add options for deblobbed kernels

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -1,15 +1,19 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libre ? false, ... } @ args:
 
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.14.26";
+  version = "4.14.26" + (if libre then "-gnu" else "");
 
   # branchVersion needs to be x.y
   extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
 
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0n3ckh77n81jfgrivhxz17fm2l3mi5yicjg19sc7n0318b2nd94r";
+    url = if !libre
+          then "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz"
+          else "https://www.linux-libre.fsfla.org/pub/linux-libre/releases/${version}/linux-libre-${version}.tar.xz";
+    sha256 = if !libre
+             then "0n3ckh77n81jfgrivhxz17fm2l3mi5yicjg19sc7n0318b2nd94r"
+             else "1m2zr17wpasg5riysbaa4g5i492jzr93py2jm088ki818s4a9cm3";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.15.nix
@@ -1,9 +1,9 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libre ? false, ... } @ args:
 
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.15.9";
+  version = "4.15.9" + (if libre then "-gnu" else "");
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = concatStrings (intersperse "." (take 3 (splitString "." "${version}.0")));
@@ -12,7 +12,11 @@ buildLinux (args // rec {
   extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
 
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "14j4dpg1qx3bqw040lc6qkm544nz8qw5bpjnvz8ccw9f0jr1b86x";
+    url = if !libre
+          then "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz"
+          else "https://www.linux-libre.fsfla.org/pub/linux-libre/releases/${version}/linux-libre-${version}.tar.xz";
+    sha256 = if !libre
+             then "14j4dpg1qx3bqw040lc6qkm544nz8qw5bpjnvz8ccw9f0jr1b86x"
+             else "13lcard7i6w2c1cf9rfhvmq79xk4qp2p1c1920mfi69l20yvm572";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -1,11 +1,15 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libre ? false, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.4.121";
+  version = "4.4.121" + (if libre then "-gnu" else "");
   extraMeta.branch = "4.4";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0ad7djpbwapk126jddrnnq0a5a9mmhrr36qcnckc7388nml85a24";
+    url = if !libre
+          then "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz"
+          else "https://www.linux-libre.fsfla.org/pub/linux-libre/releases/${version}/linux-libre-${version}.tar.xz";
+    sha256 = if !libre
+             then "0ad7djpbwapk126jddrnnq0a5a9mmhrr36qcnckc7388nml85a24"
+             else "1d7djrhiib0ds9ssjkali6b5w6rzap4zgj5hf9jq1jmqpp54jkm4";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,11 +1,15 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libre ? false, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.9.87";
+  version = "4.9.87" + (if libre then "-gnu" else "");
   extraMeta.branch = "4.9";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "05y9wjmshd3pr3ymfpx80hjv5973i6l3zk1mpww7wnnwd6pzdjbs";
+    url = if !libre
+          then "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz"
+          else "https://www.linux-libre.fsfla.org/pub/linux-libre/releases/${version}/linux-libre-${version}.tar.xz";
+    sha256 = if !libre
+             then "05y9wjmshd3pr3ymfpx80hjv5973i6l3zk1mpww7wnnwd6pzdjbs"
+             else "1p8phvmxp04npzqzqcfmv8k9l5l65s7vpjcakdm0fxfkzvnswsp6";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13264,6 +13264,66 @@ with pkgs;
       ];
   };
 
+  linuxLibre_4_4 = callPackage ../os-specific/linux/kernel/linux-4.4.nix {
+    libre = true;
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.cpu-cgroup-v2."4.4"
+        kernelPatches.modinst_arg_list_too_long
+      ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
+  linuxLibre_4_9 = callPackage ../os-specific/linux/kernel/linux-4.9.nix {
+    libre = true;
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.cpu-cgroup-v2."4.9"
+        kernelPatches.modinst_arg_list_too_long
+      ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
+  linuxLibre_4_14 = callPackage ../os-specific/linux/kernel/linux-4.14.nix {
+    libre = true;
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
+        # when adding a new linux version
+        kernelPatches.cpu-cgroup-v2."4.11"
+        kernelPatches.modinst_arg_list_too_long
+      ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
+  linuxLibre_4_15 = callPackage ../os-specific/linux/kernel/linux-4.15.nix {
+    libre = true;
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
+        # when adding a new linux version
+        # kernelPatches.cpu-cgroup-v2."4.11"
+        kernelPatches.modinst_arg_list_too_long
+      ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
   linux_testing = callPackage ../os-specific/linux/kernel/linux-testing.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
@@ -13468,6 +13528,17 @@ with pkgs;
   linuxPackages_4_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_14);
   linuxPackages_4_15 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_15);
   # Don't forget to update linuxPackages_latest!
+
+  linuxLibrePackages = linuxLibrePackages_4_14;
+  linuxLibre = linuxLibrePackages.kernel;
+
+  linuxLibrePackages_latest = linuxLibrePackages_4_15;
+  linuxLibreLatest = linuxLibrePackages_4_15.kernel;
+
+  linuxLibrePackages_4_4 = recurseIntoAttrs (linuxPackagesFor pkgs.linuxLibre_4_4);
+  linuxLibrePackages_4_9 = recurseIntoAttrs (linuxPackagesFor pkgs.linuxLibre_4_9);
+  linuxLibrePackages_4_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linuxLibre_4_14);
+  linuxLibrePackages_4_15 = recurseIntoAttrs (linuxPackagesFor pkgs.linuxLibre_4_15);
 
   # Intentionally lacks recurseIntoAttrs, as -rc kernels will quite likely break out-of-tree modules and cause failed Hydra builds.
   linuxPackages_testing = linuxPackagesFor pkgs.linux_testing;


### PR DESCRIPTION
###### Motivation for this change

I prefer to run a deblobbed kernel for various reasons and I know I'm not the only one. This is fairly easy to do with `linuxPackages_custom` by just dropping in a custom tarball. But since this is so simple I figured it would be nice to add support so others interested in running a deblobbed kernel don't have to mess around with custom linux packages.

This is pretty much a rough draft as I am almost certain there is a better way to accomplish this. Any feedback or recommendations are welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

