### PR TITLE
wxhexeditor: 0.22 -> 0.24

### DIFF
--- a/pkgs/applications/editors/wxhexeditor/default.nix
+++ b/pkgs/applications/editors/wxhexeditor/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, wxGTK, autoconf, automake, libtool, python, gettext, bash }:
+{ stdenv, fetchFromGitHub, fetchpatch,
+wxGTK, autoconf, automake, libtool, python, gettext, bash }:
 
 stdenv.mkDerivation rec {
   name = "wxHexEditor-${version}";
@@ -19,6 +20,14 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace "/usr" "$out"
     substituteInPlace Makefile --replace "mhash; ./configure" "mhash; ./configure --prefix=$out"
   '';
+
+  patches = [
+    # https://github.com/EUA/wxHexEditor/issues/90
+    (fetchpatch {
+      url = https://github.com/EUA/wxHexEditor/commit/d0fa3ddc3e9dc9b05f90b650991ef134f74eed01.patch;
+      sha256 = "1wcb70hrnhq72frj89prcqylpqs74xrfz3kdfdkq84p5qfz9svyj";
+    })
+  ];
 
   buildPhase = ''
     make OPTFLAGS="-fopenmp"

--- a/pkgs/applications/editors/wxhexeditor/default.nix
+++ b/pkgs/applications/editors/wxhexeditor/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch,
-wxGTK, autoconf, automake, libtool, python, gettext, bash }:
+{ stdenv, fetchFromGitHub, fetchpatch, wxGTK, autoconf, automake, libtool, python, gettext, bash }:
 
 stdenv.mkDerivation rec {
   name = "wxHexEditor-${version}";

--- a/pkgs/applications/editors/wxhexeditor/default.nix
+++ b/pkgs/applications/editors/wxhexeditor/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, fetchurl, wxGTK, autoconf, automake, libtool, python, gettext, bash }:
+{ stdenv, fetchFromGitHub, wxGTK, autoconf, automake, libtool, python, gettext, bash }:
 
 stdenv.mkDerivation rec {
   name = "wxHexEditor-${version}";
-  version = "v0.22";
+  version = "v0.24";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/wxhexeditor/${name}-src.tar.bz2";
-    sha256 = "15ir038g4lyw1q5bsay974hvj0nkg2yd9kccwxz808cd45fp411w";
+  src = fetchFromGitHub {
+    repo = "wxHexEditor";
+    owner = "EUA";
+    rev = version;
+    sha256 = "08xnhaif8syv1fa0k6lc3jm7yg2k50b02lyds8w0jyzh4xi5crqj";
   };
 
   buildInputs = [ wxGTK autoconf automake libtool python gettext ];
 
-  patchPhase = ''
-    substituteInPlace Makefile --replace "/usr/local" "$out"
+  preConfigure = "patchShebangs .";
+
+  prePatch = ''
+    substituteInPlace Makefile --replace "/usr" "$out"
     substituteInPlace Makefile --replace "mhash; ./configure" "mhash; ./configure --prefix=$out"
-    substituteInPlace udis86/autogen.sh --replace "/bin/bash" "${bash}/bin/bash"
   '';
 
   buildPhase = ''
     make OPTFLAGS="-fopenmp"
-
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18184,7 +18184,9 @@ with pkgs;
 
   wtftw = callPackage ../applications/window-managers/wtftw {};
 
-  wxhexeditor = callPackage ../applications/editors/wxhexeditor { };
+  wxhexeditor = callPackage ../applications/editors/wxhexeditor {
+    wxGTK = wxGTK31;
+  };
 
   wxcam = callPackage ../applications/video/wxcam {
     inherit (gnome2) libglade;


### PR DESCRIPTION
###### Motivation for this change
ZHF: https://github.com/NixOS/nixpkgs/issues/36453

upgrading from wxGTK 2.8 to 3.1 fixes the build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

