### PR TITLE
qtkeychain: 0.7.0 -> 0.8.0, fix darwin build

### DIFF
--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -9,13 +9,13 @@ assert stdenv.isDarwin -> darwin != null;
 
 stdenv.mkDerivation rec {
   name = "qtkeychain-${if withQt5 then "qt5" else "qt4"}-${version}";
-  version = "0.8.0";
+  version = "0.8.0";            # verify after nix-build with `grep -R "set(PACKAGE_VERSION " result/`
 
   src = fetchFromGitHub {
     owner = "frankosterfeld";
     repo = "qtkeychain";
     rev = "v${version}";
-    sha256 = "04v6ymkw7qd1pf9lwijgqrl89w2hhsnqgz7dm4cdrh8i8dffpn52";
+    sha256 = "1r6qp9l2lp5jpc6ciklbg1swvvzcpc37rg9py46hk0wxy6klnm0b"; # v0.8.0
   };
 
   cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ]

--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -1,13 +1,15 @@
 { stdenv, fetchFromGitHub, cmake, qt4 ? null
 , withQt5 ? false, qtbase ? null, qttools ? null
+, darwin ? null
 }:
 
 assert withQt5 -> qtbase != null;
 assert withQt5 -> qttools != null;
+assert stdenv.isDarwin -> darwin != null;
 
 stdenv.mkDerivation rec {
   name = "qtkeychain-${if withQt5 then "qt5" else "qt4"}-${version}";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "frankosterfeld";
@@ -16,16 +18,26 @@ stdenv.mkDerivation rec {
     sha256 = "04v6ymkw7qd1pf9lwijgqrl89w2hhsnqgz7dm4cdrh8i8dffpn52";
   };
 
-  cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ];
+  cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ]
+    ++ stdenv.lib.optional stdenv.isDarwin [
+       # correctly detect the compiler
+       # for details see cmake --help-policy CMP0025
+       "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
+       ]
+   ;
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = if withQt5 then [ qtbase qttools ] else [ qt4 ];
+  buildInputs = if withQt5 then [ qtbase qttools ] else [ qt4 ]
+    ++ stdenv.lib.optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+         CoreFoundation Security
+    ])
+  ;
 
   meta = {
     description = "Platform-independent Qt API for storing passwords securely";
     homepage = https://github.com/frankosterfeld/qtkeychain;
     license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
The darwin build was failing for two reasons
  1) cmake incorrectly detected the compiler
  2) missing Frameworks

/cc ZHF #36454

Also related to #35444

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` this passes on NixOS but there are (still) failures on Darwin
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

