### PR TITLE
bitcoin-unlimited: fix build with boost 1.66

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-unlimited-const-comparators.patch
+++ b/pkgs/applications/altcoins/bitcoin-unlimited-const-comparators.patch
@@ -1,0 +1,38 @@
+--- a/src/txmempool.h
++++ b/src/txmempool.h
+@@ -204,7 +204,7 @@
+ class CompareTxMemPoolEntryByDescendantScore
+ {
+ public:
+-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
++    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+     {
+         bool fUseADescendants = UseDescendantScore(a);
+         bool fUseBDescendants = UseDescendantScore(b);
+@@ -226,7 +226,7 @@
+     }
+ 
+     // Calculate which score to use for an entry (avoiding division).
+-    bool UseDescendantScore(const CTxMemPoolEntry &a)
++    bool UseDescendantScore(const CTxMemPoolEntry &a) const
+     {
+         double f1 = (double)a.GetModifiedFee() * a.GetSizeWithDescendants();
+         double f2 = (double)a.GetModFeesWithDescendants() * a.GetTxSize();
+@@ -241,7 +241,7 @@
+ class CompareTxMemPoolEntryByScore
+ {
+ public:
+-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
++    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+     {
+         double f1 = (double)a.GetModifiedFee() * b.GetTxSize();
+         double f2 = (double)b.GetModifiedFee() * a.GetTxSize();
+@@ -255,7 +255,7 @@
+ class CompareTxMemPoolEntryByEntryTime
+ {
+ public:
+-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
++    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+     {
+         return a.GetTime() < b.GetTime();
+     }

--- a/pkgs/applications/altcoins/bitcoin-unlimited.nix
+++ b/pkgs/applications/altcoins/bitcoin-unlimited.nix
@@ -21,8 +21,13 @@ stdenv.mkDerivation rec {
                   miniupnpc utillinux protobuf libevent ]
                   ++ optionals withGui [ qt4 qrencode ];
 
+  patches = [
+    ./bitcoin-unlimited-const-comparators.patch
+  ];
+
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
                      ++ optionals withGui [ "--with-gui=qt4" ];
+  enableParallelBuilding = true;
 
   meta = {
     description = "Peer-to-peer electronic cash system (Unlimited client)";


### PR DESCRIPTION
Use part of fix for mainline bitcoin:
https://github.com/bitcoin/bitcoin/commit/1ec0c0a01c316146434642ab2f14a7367306dbec

Also enable parallel builds for speed.

###### Motivation for this change

It was failing in Hydra: [release-18.03/nixpkgs.altcoins.bitcoin-unlimited.x86_64-linux](https://hydra.nixos.org/job/nixos/release-18.03/nixpkgs.altcoins.bitcoin-unlimited.x86_64-linux)
/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

