### PR TITLE
beegfs: introduce patches for kernel 4.14

### DIFF
--- a/nixos/tests/beegfs.nix
+++ b/nixos/tests/beegfs.nix
@@ -28,6 +28,7 @@ let
       text = "ThisIsALousySecret";
       mode = "0600";
     };
+    nixpkgs.config.allowUnfree = true;
   };
 
 
@@ -62,6 +63,7 @@ let
         storeDir = "/data";
       };
     };
+    nixpkgs.config.allowUnfree = true;
   };
 
 in

--- a/pkgs/os-specific/linux/beegfs/kernel-module.nix
+++ b/pkgs/os-specific/linux/beegfs/kernel-module.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, which
+{ stdenv, fetchurl, fetchpatch, which
 , kmod, kernel
 } :
 
@@ -19,6 +19,19 @@ in stdenv.mkDerivation {
   buildInputs = kernel.moduleBuildDependencies;
 
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build/" ];
+
+  patches = [
+    # upstream patch for linux 4.14 compatibility
+    (fetchpatch {
+      url = https://git.beegfs.io/pub/v6-nightly/commit/c54ab7e0714a85bf245e71d8b6c4e15d021c3e37.diff;
+      sha256 = "1qzqnsvcl9km5z51vpsbvx5c9qrva4z09ka01nsjwxbr9mccmnx8";
+    })
+    # Fix a kernel oops during unmount introduced by 4.12
+    (fetchpatch {
+      url = https://git.beegfs.io/pub/v6-nightly/commit/0fe6a133f734183e4e21b9e8b4595593000791e7.diff;
+      sha256 = "1pf54jjvdk1a5i7hjyqcn63vy7mqyly2s74lxvcqsf14klzviqc0";
+    })
+  ];
 
   postPatch = ''
     patchShebangs ./
@@ -41,6 +54,6 @@ in stdenv.mkDerivation {
     platforms = [ "i686-linux" "x86_64-linux" ];
     license = licenses.gpl2;
     maintainers = with maintainers; [ markuskowa ];
-    broken = versionAtLeast kernel.version "4.14";
   };
 }
+


### PR DESCRIPTION
###### Motivation for this change
Add two upstream patches, which allow for the kernel module to be built with the most recent distribution kernel (4.14). This commit should also be picked for the 18.03 release.

To run the nixos tests I needed to add `allowUnfree=true` to machine defs in the test. Is this legitimate on nixpkgs?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

