### PR TITLE
pythonPackages.shapely: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/shapely/default.nix
+++ b/pkgs/development/python-modules/shapely/default.nix
@@ -30,10 +30,9 @@ buildPythonPackage rec {
     sed -i "s|free = load_dll('c').free|free = load_dll('c', fallbacks=['${stdenv.cc.libc}/lib/${libc}']).free|" shapely/geos.py
   '';
 
-  # tests/test_voctorized fails because the vectorized extension is not
-  # available in when running tests
+  # Disable the tests that improperly try to use the built extensions
   checkPhase = ''
-    py.test --ignore tests/test_vectorized.py
+    py.test -k 'not test_vectorized and not test_fallbacks' tests
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

