### PR TITLE
spideroak: 6.1.9 -> 7.0.1

### DIFF
--- a/pkgs/applications/networking/spideroak/default.nix
+++ b/pkgs/applications/networking/spideroak/default.nix
@@ -4,16 +4,16 @@
 }:
 
 let
-  arch = if stdenv.system == "x86_64-linux" then "x86_64"
-    else if stdenv.system == "i686-linux" then "i386"
+  arch = if stdenv.system == "x86_64-linux" then "x64"
+    else if stdenv.system == "i686-linux" then "x86"
     else throw "Spideroak client for: ${stdenv.system} not supported!";
 
   interpreter = if stdenv.system == "x86_64-linux" then "ld-linux-x86-64.so.2"
     else if stdenv.system == "i686-linux" then "ld-linux.so.2"
     else throw "Spideroak client for: ${stdenv.system} not supported!";
 
-  sha256 = if stdenv.system == "x86_64-linux" then "0k87rn4aj0v79rz9jvwspnwzmh031ih0y74ra88nc8kl8j6b6gjm"
-    else if stdenv.system == "i686-linux" then "1wbxfikj8f7rx26asswqrfp9vpk8w5941s21y1pnaff2gcac8m3z"
+  sha256 = if stdenv.system == "x86_64-linux" then "993e01986e3657d6fa979b8d0f45ac25b8223c18f75555016a9f92e651e91b1f"
+    else if stdenv.system == "i686-linux" then "d12c09c3a01bfa48bdecc8763bbf2c7f10b71cea5bcecc177dad031ba79bc83d"
     else throw "Spideroak client for: ${stdenv.system} not supported!";
 
   ldpath = stdenv.lib.makeLibraryPath [
@@ -21,14 +21,14 @@ let
     libX11 libXext libXrender zlib
   ];
 
-  version = "6.1.9";
+  version = "7.0.1";
 
 in stdenv.mkDerivation {
   name = "spideroak-${version}";
 
   src = fetchurl {
-    name = "spideroak-${version}-${arch}";
-    url = "https://spideroak.com/getbuild?platform=slackware&arch=${arch}&version=${version}";
+    name = "SpiderOakONE-${version}-slack_tar_${arch}.tgz";
+    url = "https://spideroak.com/release/spideroak/slack_tar_${arch}";
     inherit sha256;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
/cc @neilmayhew