### PR TITLE
singularity: 2.4 -> 2.4.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -104,6 +104,7 @@
   ./programs/shadow.nix
   ./programs/shell.nix
   ./programs/spacefm.nix
+  ./programs/singularity.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
   ./programs/sysdig.nix

--- a/nixos/modules/programs/singularity.nix
+++ b/nixos/modules/programs/singularity.nix
@@ -1,0 +1,20 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  cfg = config.programs.singularity;
+in {
+  options.programs.singularity = {
+    enable = mkEnableOption "Singularity";
+  };
+
+  config = mkIf cfg.enable {
+      environment.systemPackages = [ pkgs.singularity ];
+      systemd.tmpfiles.rules = [ "d /var/singularity/mnt/session 0770 root root -"
+                                 "d /var/singularity/mnt/final 0770 root root -"
+                                 "d /var/singularity/mnt/overlay 0770 root root -"
+                                 "d /var/singularity/mnt/container 0770 root root -"
+                                 "d /var/singularity/mnt/source 0770 root root -"];
+  };
+
+}

--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation rec {
   name = "singularity-${version}";
-  version = "2.4";
+  version = "2.4.2";
 
   enableParallelBuilding = true;
 
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
     sed -i 's/-static//g' src/Makefile.am
     patchShebangs .
   '';
+
+  configureFlags = "--localstatedir=/var";
+  installFlags = "CONTAINER_MOUNTDIR=dummy CONTAINER_FINALDIR=dummy CONTAINER_OVERLAY=dummy SESSIONDIR=dummy";
 
   fixupPhase = ''
     patchShebangs $out
@@ -42,7 +45,7 @@ stdenv.mkDerivation rec {
     owner = "singularityware";
     repo = "singularity";
     rev = version;
-    sha256 = "1hi1ag1lb2x4djbz4x34wix83ymx0g9mzn2md6yrpiflc1d85rjz";
+    sha256 = "0cpa2yp82g9j64mgr90p75ddk85kbj1qi1r6hy0sz17grqdlaxl4";
   };
 
   nativeBuildInputs = [ autoreconfHook makeWrapper ];

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -96,6 +96,7 @@ rec {
             echo creating
             singularity image.create -s $((1 + size * 4 / 1024 + ${toString extraSpace})) $out
             echo importing
+            mkdir -p /var/singularity/mnt/container
             tar -c . | singularity image.import $out
           '');
 


### PR DESCRIPTION
###### Motivation for this change

Upgrades singularity. Ensures local state directory is /var instead of within the nix store. To ensure the /var/singularity/* directories exist, a small module has been added. This fixes the issue identified in #36691.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

