### PR TITLE
snpeff: 4.3t -> 4.3q

### DIFF
--- a/pkgs/applications/science/biology/snpeff/default.nix
+++ b/pkgs/applications/science/biology/snpeff/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "snpeff-${version}";
-  version = "4.3t";
+  version = "4.3q";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/snpeff/snpEff_v4_3t_core.zip";
-    sha256 = "0i12mv93bfv8xjwc3rs2x73d6hkvi7kgbbbx3ry984l3ly4p6nnm";
+    url = "mirror://sourceforge/project/snpeff/snpEff_v4_3q_core.zip";
+    sha256 = "0sxz8zy8wrzcy01hyb1cirwbxqyjw30a2x3q6p4l7zmw2szi7mn1";
   };
 
   buildInputs = [ unzip jre makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Update snpeff to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

