### PR TITLE
qtlocation: fix darwin build

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtlocation.nix
@@ -1,4 +1,4 @@
-{ qtModule, qtbase, qtmultimedia }:
+{ stdenv, qtModule, qtbase, qtmultimedia }:
 
 qtModule {
   name = "qtlocation";
@@ -6,4 +6,11 @@ qtModule {
   outputs = [ "bin" "out" "dev" ];
   # Linking with -lclipper fails with parallel build enabled
   enableParallelBuilding = false;
+  qmakeFlags = stdenv.lib.optional stdenv.isDarwin [
+     # boost uses std::auto_ptr which has been disabled in clang with libcxx
+     # This flag re-enables this feature
+     # https://libcxx.llvm.org/docs/UsingLibcxx.html#c-17-specific-configuration-macros
+     "QMAKE_CXXFLAGS+=-D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR"
+  ];
+
 }


### PR DESCRIPTION
A dependency (boost) makes use of `std::auto_ptr`, which is no longer
supported in C++17 in Clang. This change re-enables `std::auto_ptr`
capabilities.

/cc ZHF #36454

This is a dependency for `nextcloud-client` (#36788) and `owncloud-client`.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` No change on Linux. On Darwin some still have build failures.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

