### PR TITLE
perlPackages.PkgConfig: init at 0.19026

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11226,6 +11226,19 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  PkgConfig = buildPerlPackage rec {
+    name = "PkgConfig-0.19026";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/PkgConfig-0.19026.tar.gz";
+      sha256 = "0b4jgsxs85r04dxb8mv9ypd1wdjigr5ryxzsq823xncxs8sfkdjw";
+    };
+    meta = {
+      maintainers = [ maintainers.limeytexan ];
+      description = "Pure-Perl Core-Only replacement for pkg-config";
+      license = stdenv.lib.licenses.free; # Same as Perl
+    };
+  };
+
   Plack = buildPerlPackage rec {
     name = "Plack-1.0039";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
Add PkgConfig module from CPAN.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

