### PR TITLE
go-langserver: init at unstable-2018-03-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1720,6 +1720,11 @@
     github = "johnazoidberg";
     name = "Daniel Schäfer";
   };
+  johnchildren = {
+    email = "john.a.children@gmail.com";
+    github = "johnchildren";
+    name = "John Children";
+  };
   johnmh = {
     email = "johnmh@openblox.org";
     github = "johnmh";

--- a/pkgs/development/tools/go-langserver/default.nix
+++ b/pkgs/development/tools/go-langserver/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "go-langserver-${version}";
+  version = "unstable-2018-03-05";
+  rev = "5d7a5dd74738978d635f709669241f164c120ebd";
+
+  goPackagePath = "github.com/sourcegraph/go-langserver";
+  subPackages = [ "." ];
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "sourcegraph";
+    repo = "go-langserver";
+    sha256 = "0aih0akk3wk3332znkhr2bzxcc3parijq7n089mdahnf20k69xyz";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A Go language server protocol server";
+    homepage = https://github.com/sourcegraph/go-langserver;
+    license = licenses.mit;
+    maintainers = with maintainers; [ johnchildren ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13650,6 +13650,8 @@ with pkgs;
 
   gomodifytags = callPackage ../development/tools/gomodifytags { };
 
+  go-langserver = callPackage ../development/tools/go-langserver { };
+
   gotests = callPackage ../development/tools/gotests { };
 
   gogoclient = callPackage ../os-specific/linux/gogoclient { };


### PR DESCRIPTION
###### Motivation for this change

One of the listed implementations for language servers on: http://langserver.org/

Chose the latest unstable version as there has not been a release since 2016/11/29

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

