### PR TITLE
vim-solidity: init at 2018-02-11

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -104,6 +104,7 @@ rec {
   repeat              = vim-repeat;
   rhubarb             = vim-rhubarb;
   signature           = vim-signature;
+  solidity            = vim-solidity;
   stylish-haskell     = vim-stylish-haskell;
   stylishHaskell      = stylish-haskell; # backwards compat, added 2014-10-18
   supertab            = Supertab;
@@ -2097,6 +2098,17 @@ rec {
       url = "https://github.com/tomasr/molokai";
       rev = "c67bdfcdb31415aa0ade7f8c003261700a885476";
       sha256 = "1piszjr5kyw43ac1f0jh9z88g824xknshrkchbys9qxlz7pd831s";
+    };
+    dependencies = [];
+
+  };
+
+  vim-solidity = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "vim-solidity-2018-02-11";
+    src = fetchgit {
+      url = "https://github.com/tomlion/vim-solidity";
+      rev = "46b87988e196abe646516932427253a838f7fff8";
+      sha256 = "0djqqxlh314n6yhn5m2min3nl435n4qcjgsyca7qbz4wvgmbwnlk";
     };
     dependencies = [];
 

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -168,6 +168,7 @@
 "github:thinca/vim-quickrun"
 "github:thinca/vim-themis"
 "github:tomasr/molokai"
+"github:tomlion/vim-solidity"
 "github:tpope/vim-dispatch"
 "github:tpope/vim-eunuch"
 "github:tpope/vim-repeat"


### PR DESCRIPTION
###### Motivation for this change
Add vim-solidity plugin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

