### PR TITLE
kde-frameworks: 5.43 -> 5.44

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.43/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.44/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,627 +3,627 @@
 
 {
   attica = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/attica-5.43.0.tar.xz";
-      sha256 = "1vvf5d0dnfm69gahrhndy9jqxk7hkh5vj6z9pyprpl3zp5z1ki1a";
-      name = "attica-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/attica-5.44.0.tar.xz";
+      sha256 = "1ac2k3rc5dd5sc9n8qdb1d6jssjpag709sfsnvif1cvp0j8s2xj3";
+      name = "attica-5.44.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/baloo-5.43.0.tar.xz";
-      sha256 = "095z6w5qyq4z2hkdxq0vizfgv1v6g9w960wrh78b6bi1bf4ig2np";
-      name = "baloo-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/baloo-5.44.0.tar.xz";
+      sha256 = "0ybxl05njryk7zrdcwh4gbvxbn7n6xb51y2587d9bxiizasmbbiy";
+      name = "baloo-5.44.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/bluez-qt-5.43.0.tar.xz";
-      sha256 = "04bsrp0biyn7b630hywk82rwn8kl8c2rwh8iwhjz35b51jjqm2b5";
-      name = "bluez-qt-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/bluez-qt-5.44.0.tar.xz";
+      sha256 = "054zh3hc7wq13iks3nryzdns61wb56j2cvvfvsnv3yl9ni6i6wxv";
+      name = "bluez-qt-5.44.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/breeze-icons-5.43.0.tar.xz";
-      sha256 = "19yy6pcqjfbjxlkkf4g1hcgl3lv4m640sl26nblrydn9qyj5iniy";
-      name = "breeze-icons-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/breeze-icons-5.44.0.tar.xz";
+      sha256 = "05ndqmprwv4dd8aib3sjmvd5481znq4jg58cpk4id1xxq4dgx9gg";
+      name = "breeze-icons-5.44.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/extra-cmake-modules-5.43.0.tar.xz";
-      sha256 = "1zgzjh5q1ppgfzj4mhprgd4848iwjnzqsnilb0dk5rgdrvfsamsp";
-      name = "extra-cmake-modules-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/extra-cmake-modules-5.44.0.tar.xz";
+      sha256 = "121gwj54f7bns386wrw6rwqmwzsny93mb00sxxzf3ic8m6mw6wis";
+      name = "extra-cmake-modules-5.44.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/frameworkintegration-5.43.0.tar.xz";
-      sha256 = "0qjpk4lslpxqj5aisczm5kl201g4z3grgjhx38r1ih4hyp805vw0";
-      name = "frameworkintegration-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/frameworkintegration-5.44.0.tar.xz";
+      sha256 = "10rqabchldra16zb0ryynvjimc67di3r4b29fbn47wg4pwj0jn41";
+      name = "frameworkintegration-5.44.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kactivities-5.43.0.tar.xz";
-      sha256 = "0rmmyjfgz8ybvdgpbqndsn0gxizxpmwhvglnnl8ia1s4sna6sjby";
-      name = "kactivities-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kactivities-5.44.0.tar.xz";
+      sha256 = "1j5v03mgh0prql51hy468k2vhskg1gyddhjlb8qlyzyzqz1aj82c";
+      name = "kactivities-5.44.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kactivities-stats-5.43.0.tar.xz";
-      sha256 = "1rrn1dxsiyvyf3pa5fyxa0sfbamv5c6g95s4f144xwrx2b130rh1";
-      name = "kactivities-stats-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kactivities-stats-5.44.0.tar.xz";
+      sha256 = "1p1vznw8qxdasb82cvjc35wnhvfhjhapx3r451kl3ly4cbjf39fg";
+      name = "kactivities-stats-5.44.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kapidox-5.43.0.tar.xz";
-      sha256 = "0c358ply0qzg269vxyg6py6l8z5j8l4h6apqcynyql4dbbbm8941";
-      name = "kapidox-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kapidox-5.44.0.tar.xz";
+      sha256 = "0mn67ckxhsav70jk1wj5qci07qyy0291rm7q54qmcl6p7a7a0vj4";
+      name = "kapidox-5.44.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/karchive-5.43.0.tar.xz";
-      sha256 = "1f3pqhpdgn00ni05iflyydkmsf3vd403ma5f42zj00kh30l9lqqf";
-      name = "karchive-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/karchive-5.44.0.tar.xz";
+      sha256 = "00mvn9rsc4lb2kamfz2xzmm0a0s1m68ar65dcfrp0n2i8plxin5j";
+      name = "karchive-5.44.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kauth-5.43.0.tar.xz";
-      sha256 = "05w8vx45mrf32kzcyjmay1k9dw3j8axbrrp6infg0hhfsgk04w1f";
-      name = "kauth-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kauth-5.44.0.tar.xz";
+      sha256 = "1ph2jlbwx27g9awfvkvrynnfwyr8yqq4x7w4msn1clh8nz9c9n0k";
+      name = "kauth-5.44.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kbookmarks-5.43.0.tar.xz";
-      sha256 = "0i7rfahn32m6xpbwra5m5nnpgq8l56jm0ijsq6f80cx8ww3nkcq5";
-      name = "kbookmarks-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kbookmarks-5.44.0.tar.xz";
+      sha256 = "04wwg9s3i3nj7im0cscdzb3c78lqg96k7vyg9ziyn2cpqmj6gihr";
+      name = "kbookmarks-5.44.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kcmutils-5.43.0.tar.xz";
-      sha256 = "1dshx859k64yp00s5xx7z6x0wlawxyq41rg795nqizhk2s76agr2";
-      name = "kcmutils-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kcmutils-5.44.0.tar.xz";
+      sha256 = "1fddjg89az0gfcl9gf3r7rq7hw9j8k10mvlvzq31x89hn8h7kafs";
+      name = "kcmutils-5.44.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kcodecs-5.43.0.tar.xz";
-      sha256 = "0ncrzxvy2l324yvlzha9hkyp5qq75wfb9cbnxb5mygispxhrgh2v";
-      name = "kcodecs-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kcodecs-5.44.0.tar.xz";
+      sha256 = "15fv3f2akjz8n65rj6r2nd5zzc4wsz67zc80bp45kqynrb1jgcjk";
+      name = "kcodecs-5.44.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kcompletion-5.43.0.tar.xz";
-      sha256 = "065nzw26ps367lf3m1j6x95swk0f6grap71wjjv688gablcaz699";
-      name = "kcompletion-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kcompletion-5.44.0.tar.xz";
+      sha256 = "1fy2krnxxppax13jb82zsfxky9n01z28d3kw4jx58yw1b1jm9ha4";
+      name = "kcompletion-5.44.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kconfig-5.43.0.tar.xz";
-      sha256 = "1na1b2dsajl9b9rn2990fd8cqqaj2iwddrxjacbf0ib5mray1sr2";
-      name = "kconfig-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kconfig-5.44.0.tar.xz";
+      sha256 = "1vfl7jchlrw8hkf613nb9a4f0dxyppkc97506xsknxwf1z5v7cmm";
+      name = "kconfig-5.44.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kconfigwidgets-5.43.0.tar.xz";
-      sha256 = "1qxv8m614y0j687gwcsqqkwcdwsbbwc7ivwx6l9djll4r7r1d43w";
-      name = "kconfigwidgets-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kconfigwidgets-5.44.0.tar.xz";
+      sha256 = "15a7k8ai70a061gw91aps282v1f4sric0fhyw2fysfdfv6ry92rz";
+      name = "kconfigwidgets-5.44.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kcoreaddons-5.43.0.tar.xz";
-      sha256 = "10pgja1v2x5q6jyajld3yq116g1m90djnbf6p35i6n9ng65h0zy6";
-      name = "kcoreaddons-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kcoreaddons-5.44.0.tar.xz";
+      sha256 = "0lwxa326gap83qjw1dsj330qd3klgm6jwr7d77f7hyhm95d7pidl";
+      name = "kcoreaddons-5.44.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kcrash-5.43.0.tar.xz";
-      sha256 = "1hvfhr3s0igc1n37w5fxx0jivsgvcdvpa5iywnkk4g1r1l6snx1b";
-      name = "kcrash-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kcrash-5.44.0.tar.xz";
+      sha256 = "01dcj5cyqqn2jb6mjshjcf48jdjhmjhkqxbhhx07dy7r56r4sqp1";
+      name = "kcrash-5.44.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kdbusaddons-5.43.0.tar.xz";
-      sha256 = "1h4m6ra1cangvqyzmkxkh1fld4rlvxnzz8wny53drgbyrsq2xxv5";
-      name = "kdbusaddons-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kdbusaddons-5.44.0.tar.xz";
+      sha256 = "15b7nyivkrv7s2hdahsv27p8j6q80209ayqvi3dzlhzj2b5qqzkg";
+      name = "kdbusaddons-5.44.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kdeclarative-5.43.0.tar.xz";
-      sha256 = "0jbm2ih9hzpnfaqc867fvwr414q78f9jjk6yyf1cjgq8vx8rmjq1";
-      name = "kdeclarative-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kdeclarative-5.44.0.tar.xz";
+      sha256 = "0byggaxfkna0iqlhp970fx8kp926dc6m99xihvja1765525i1lj0";
+      name = "kdeclarative-5.44.0.tar.xz";
     };
   };
   kded = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kded-5.43.0.tar.xz";
-      sha256 = "1kfli2f4hxc9a0hk75kgln3x374y4av6hfajhncwyq37zd4wxq3r";
-      name = "kded-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kded-5.44.0.tar.xz";
+      sha256 = "04sdsz5frwff602ls3mqwijckl3kl64lanhhpmzxc33xdniff9as";
+      name = "kded-5.44.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/portingAids/kdelibs4support-5.43.0.tar.xz";
-      sha256 = "1rwk436vpny3sq12bjqwapjicc3inyrq6dn34a6mr6gjcd5p2mch";
-      name = "kdelibs4support-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/portingAids/kdelibs4support-5.44.0.tar.xz";
+      sha256 = "1cyxry09qnlbc2khaqjpb598f4rscg80dmjcqhlsn6b1375iqkjn";
+      name = "kdelibs4support-5.44.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kdesignerplugin-5.43.0.tar.xz";
-      sha256 = "0pk95vsgj67jw0qaalcrfvzkr9flxh6shkkmlaxclrz6yhnf9axz";
-      name = "kdesignerplugin-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kdesignerplugin-5.44.0.tar.xz";
+      sha256 = "1fh4nw8qh563yc2parqlbrjzx6avi4gi01jzclf4bxv78zs4957a";
+      name = "kdesignerplugin-5.44.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kdesu-5.43.0.tar.xz";
-      sha256 = "1mll18ms5zk7i4lpkj6qdcxwaf0h52h9mi47y882hzqkvvbnk4d6";
-      name = "kdesu-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kdesu-5.44.0.tar.xz";
+      sha256 = "1p6bk7cnngwqklvm6aj5xlna6c5r6rznfbvdn7zz5h3wpzs8pqz2";
+      name = "kdesu-5.44.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kdewebkit-5.43.0.tar.xz";
-      sha256 = "0yi7dv77flz7z1yjzlvrfvlybp7knz808hpfbr6hxgrp1gwi7h6b";
-      name = "kdewebkit-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kdewebkit-5.44.0.tar.xz";
+      sha256 = "07mr4x55pp6wvbgnkggwalrqx9z8y9q1mmn79jkyhf2q905ynsmj";
+      name = "kdewebkit-5.44.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kdnssd-5.43.0.tar.xz";
-      sha256 = "0d58aaii1r2x3nmw9s2hnk178sr54yvrqi22ry3xm3v7yvx9jr3b";
-      name = "kdnssd-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kdnssd-5.44.0.tar.xz";
+      sha256 = "18x43l7ni7jwfpch4hngiyz5w05z48q8wmhm38gz3jw09w9npgi4";
+      name = "kdnssd-5.44.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kdoctools-5.43.0.tar.xz";
-      sha256 = "1llif166p17ffjwsgvb0n9lq8ip3if0hqma9zm9jpghm5j21q1jh";
-      name = "kdoctools-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kdoctools-5.44.0.tar.xz";
+      sha256 = "146crn9arrbi6ha7p5p0x7zmwlz86my067rif0v7j48xmmz6h5i3";
+      name = "kdoctools-5.44.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kemoticons-5.43.0.tar.xz";
-      sha256 = "161n9xg82gxvl4a4by328llxz0x4w643vcxi88414zg1bm1z1cfb";
-      name = "kemoticons-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kemoticons-5.44.0.tar.xz";
+      sha256 = "1ggwyzs22907kxgapqi7md3ng1ry85gccyxbqvn638inxk299mla";
+      name = "kemoticons-5.44.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kfilemetadata-5.43.0.tar.xz";
-      sha256 = "1lxbj8fnaf6sybxgyq6h1qnic65l0mdhhxlw1djd16c7ih7ghrnq";
-      name = "kfilemetadata-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kfilemetadata-5.44.0.tar.xz";
+      sha256 = "0v8xdl0wgp67ykw5czxzvzsqzijg0qpkm5vjc9rnai7zaymxg7bg";
+      name = "kfilemetadata-5.44.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kglobalaccel-5.43.0.tar.xz";
-      sha256 = "00ygkszkklaz7k4hkshcb5gfynha8rncwvj7z9jvhd9chmwkiffc";
-      name = "kglobalaccel-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kglobalaccel-5.44.0.tar.xz";
+      sha256 = "16qhf6kb6q85p6y9zh72b4rz0ikmahvhyzmrx0jd1r044g4j81wn";
+      name = "kglobalaccel-5.44.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kguiaddons-5.43.0.tar.xz";
-      sha256 = "0z6sf4pr4ykhlzdckyfap2f41y2chrl2kwlrb4djflfxf7q2xcqr";
-      name = "kguiaddons-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kguiaddons-5.44.0.tar.xz";
+      sha256 = "1npl2ibk7ilsicmyvlnvf42lz6qjmqp4nl607a66ikxp3kvk3sdc";
+      name = "kguiaddons-5.44.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kholidays-5.43.0.tar.xz";
-      sha256 = "0zkjh7y0gdwakil6dj0z8yi2zzczzvdfhmnsd54s5yn0fvv37xbk";
-      name = "kholidays-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kholidays-5.44.0.tar.xz";
+      sha256 = "134zxnkclh16gh0qf2ak1pmhlxxwrcgzgmkn5wrynwraplf9b812";
+      name = "kholidays-5.44.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/portingAids/khtml-5.43.0.tar.xz";
-      sha256 = "034aycdi7i6pvwkwz632nzk3vp8040hlvmzpp38nsy4idl4klh46";
-      name = "khtml-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/portingAids/khtml-5.44.0.tar.xz";
+      sha256 = "1sph90cfwq0067a6ih8mx1bn715lvsspn6s9lijmm0ck9vbbixgp";
+      name = "khtml-5.44.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/ki18n-5.43.0.tar.xz";
-      sha256 = "1zspxv6z4a3rarrn9n38g7rp0gc48bl4kih91m3r2nkap83jb04a";
-      name = "ki18n-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/ki18n-5.44.0.tar.xz";
+      sha256 = "1rg24i8ks5mxryssq0zdig0q545zyj4svy9kb6r84qwag4vn7pcc";
+      name = "ki18n-5.44.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kiconthemes-5.43.0.tar.xz";
-      sha256 = "105c892d4np4lshmd5f5x74m1ib3fbmvwgjzf6j317mq261r3rsw";
-      name = "kiconthemes-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kiconthemes-5.44.0.tar.xz";
+      sha256 = "1xkrczqw332hr667qp9pwlkypcn9d6zkx51bmi4bg9xfgpg1pwz4";
+      name = "kiconthemes-5.44.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kidletime-5.43.0.tar.xz";
-      sha256 = "1jm2rdbzffnw0fv1pzfyz5lvzaa3x2pfp12zm9kl7skyj39z5vbj";
-      name = "kidletime-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kidletime-5.44.0.tar.xz";
+      sha256 = "1zf8rspn603hyz1rr3rkslnij7883f4ha0ls6v5phh19jdp9hcis";
+      name = "kidletime-5.44.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kimageformats-5.43.0.tar.xz";
-      sha256 = "1bn4rx5xx68m101n3ba774pd8qddaw3bwf2bc7zp7gi6d8bprh9i";
-      name = "kimageformats-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kimageformats-5.44.0.tar.xz";
+      sha256 = "1zpz3a4wghh348is2yyfs5qhhkg0261p5v2khxcgcy6vpblv1h1j";
+      name = "kimageformats-5.44.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kinit-5.43.0.tar.xz";
-      sha256 = "1jrzr4kv84rvf214wszd2zdnvlx2qxvr1ah9f564h23vvdrg79gd";
-      name = "kinit-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kinit-5.44.0.tar.xz";
+      sha256 = "1v3zmlmh3yg9333v7ha1xg3hp7ig2q8w7ixyzww5a5q4gxpzz9z5";
+      name = "kinit-5.44.0.tar.xz";
     };
   };
   kio = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kio-5.43.0.tar.xz";
-      sha256 = "1mbjld1kh5hhslfm4rx9nddghkcgrxbw2pf39c7niq0r1llx5v76";
-      name = "kio-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kio-5.44.0.tar.xz";
+      sha256 = "1dvif1779kh8d8yh6svmbs2yhvprzc38hchd4wb4l70hmzqcd3vs";
+      name = "kio-5.44.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kirigami2-5.43.0.tar.xz";
-      sha256 = "0vshabb1q5pjscw0g57l7lpaal69g1mdpf01w0yskmbiqnzzpjl0";
-      name = "kirigami2-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kirigami2-5.44.0.tar.xz";
+      sha256 = "1vvq3c2j9v07ngkm3c8hwvik80sfd7i20ga7hyx4i94spjcagj6h";
+      name = "kirigami2-5.44.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kitemmodels-5.43.0.tar.xz";
-      sha256 = "1yw7h7g0knlljizsf9cir196v22cqhlaazmrbm6jqz198g47sqdd";
-      name = "kitemmodels-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kitemmodels-5.44.0.tar.xz";
+      sha256 = "0m63i10nvgp86ajsd7aizah4g21dpwxrs2lvglv0kybhaykziwa8";
+      name = "kitemmodels-5.44.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kitemviews-5.43.0.tar.xz";
-      sha256 = "19w6xhhxr7w40baw6i6lfq0fd7bahxfzr7pj10mrwb5i6bcbsk1h";
-      name = "kitemviews-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kitemviews-5.44.0.tar.xz";
+      sha256 = "1vg99figpspm0p7ipbgf94j4xarcf2zicm3rijywxfcwcl0sr99h";
+      name = "kitemviews-5.44.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kjobwidgets-5.43.0.tar.xz";
-      sha256 = "1kri6z737abwsglh29bh4kckbf1ici8n162lcyvw8b3w91l4dyc6";
-      name = "kjobwidgets-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kjobwidgets-5.44.0.tar.xz";
+      sha256 = "1c26vdq8sqja95scqbvm0y2zhl1qx5aapkadi44vrjf54q4kgqrv";
+      name = "kjobwidgets-5.44.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/portingAids/kjs-5.43.0.tar.xz";
-      sha256 = "1jdqdy1kxarv6k31yd0k280jyfy7y3qwgd9c7is7aya1ns46nx59";
-      name = "kjs-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/portingAids/kjs-5.44.0.tar.xz";
+      sha256 = "1y350xgxip9qlwzanzlbyj4mb7i53msldv2wmacdp2di1hxn8ihy";
+      name = "kjs-5.44.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/portingAids/kjsembed-5.43.0.tar.xz";
-      sha256 = "11hcwwhkrl7sns4s36nxnp550n9xvky1rkrissm0mqh76309g6hy";
-      name = "kjsembed-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/portingAids/kjsembed-5.44.0.tar.xz";
+      sha256 = "0d71pnfx5fylxlpc0m08i1qasnrk0jvwmcv7zr7r8fnfagjl7gpk";
+      name = "kjsembed-5.44.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/portingAids/kmediaplayer-5.43.0.tar.xz";
-      sha256 = "1q1s5v3fqnmxx58ixgdhkhrgkrdxy8mq8hg4ll7l6038lgycfsxf";
-      name = "kmediaplayer-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/portingAids/kmediaplayer-5.44.0.tar.xz";
+      sha256 = "1nwpx2y8bl92m8yxk5c3sw7a0zm50hfpfrcicdqpv7nfs4n70anj";
+      name = "kmediaplayer-5.44.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/knewstuff-5.43.0.tar.xz";
-      sha256 = "1v3wzydi1jqb9an2bnxzfhwxhlb2lj8l735mdhym4859njj8x7w7";
-      name = "knewstuff-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/knewstuff-5.44.0.tar.xz";
+      sha256 = "1sd5780gpxidlc9g3dmd38ji5q5c1va49r604x5y739wjdrsgm0a";
+      name = "knewstuff-5.44.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/knotifications-5.43.0.tar.xz";
-      sha256 = "0kgn5h38z9xd5a210w989j3z0khs4l9ahf19lqfara1ziwl4gaiv";
-      name = "knotifications-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/knotifications-5.44.0.tar.xz";
+      sha256 = "137snmjix1jji1vn40vxsnigddz7xxlkkch1rag79f6dqjnswb76";
+      name = "knotifications-5.44.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/knotifyconfig-5.43.0.tar.xz";
-      sha256 = "0nrjxs263sp64h9pmrmr7fjkbpkalzr6crpyq0aqclciwfjpj326";
-      name = "knotifyconfig-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/knotifyconfig-5.44.0.tar.xz";
+      sha256 = "0122w5mklyr958284824qzxxp76hacnf8zgv58b9ihr5finc919z";
+      name = "knotifyconfig-5.44.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kpackage-5.43.0.tar.xz";
-      sha256 = "1nr7zkqp7zbvyrhc7iqznyqnfhmnqhhaqs30ig4gwsagq3x2a02b";
-      name = "kpackage-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kpackage-5.44.0.tar.xz";
+      sha256 = "1av8m9m7by0j128779rhws0pjc3hhi37cp311nks5sa5mmpbksmz";
+      name = "kpackage-5.44.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kparts-5.43.0.tar.xz";
-      sha256 = "09i2ds6xgkbm9k9nd9yj1p3qw9xl3a25lh97ln9c39ccx32i32wd";
-      name = "kparts-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kparts-5.44.0.tar.xz";
+      sha256 = "0bbf17y8nnd1gbhdnffhgj9xn1wjida6a7qgwi16k3zp4yjmpgac";
+      name = "kparts-5.44.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kpeople-5.43.0.tar.xz";
-      sha256 = "0xi6sxprqvmjc30cw1rfpryahid9dswql6b1wrdv5wsmci8k4xmq";
-      name = "kpeople-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kpeople-5.44.0.tar.xz";
+      sha256 = "0gp602c2wq2ipbsan84r11a14xqpzyfszhb4lw3qkd7y4dpha37i";
+      name = "kpeople-5.44.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kplotting-5.43.0.tar.xz";
-      sha256 = "0d5mf5xaysw837ninvdx1hfra8qjaxd9lcm28fyjfm506iq8v09f";
-      name = "kplotting-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kplotting-5.44.0.tar.xz";
+      sha256 = "0ccgpbccfrn4c4wri80zm8ni8390jnqywh4k1z5r68hzmr3l79xw";
+      name = "kplotting-5.44.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kpty-5.43.0.tar.xz";
-      sha256 = "09m02ramzk6jc9scnsvcm2sgnia2vmnnfgmjsddspc2kp1aj2km8";
-      name = "kpty-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kpty-5.44.0.tar.xz";
+      sha256 = "08jxq693mkwxr45696nz05f2zxa16finvacif330r6s03izvwfw0";
+      name = "kpty-5.44.0.tar.xz";
     };
   };
   kross = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/portingAids/kross-5.43.0.tar.xz";
-      sha256 = "05px64msss6as0pbrpl6l4y2n97kayphxqhwfilgsj9yjmyhm46h";
-      name = "kross-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/portingAids/kross-5.44.0.tar.xz";
+      sha256 = "1gq2cg3gq40rqih0kflfxl2n5l7j4gli0w57xnfhc39xpkpd1cqv";
+      name = "kross-5.44.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/krunner-5.43.0.tar.xz";
-      sha256 = "1wiaaz7wc2ls0gxyyws7cw6gmphkzayhdz1xxsyn4bzrc1h3z7dw";
-      name = "krunner-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/krunner-5.44.0.tar.xz";
+      sha256 = "1zr3zm528p4agw8d7krm4drs8638gfmbnm011r9kcmpjadkv0ila";
+      name = "krunner-5.44.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kservice-5.43.0.tar.xz";
-      sha256 = "1mdxd8kxawlhrsnd9lrx6cx9p8gvvsr9mx2d1s0bi90kapfqyqi3";
-      name = "kservice-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kservice-5.44.0.tar.xz";
+      sha256 = "0gzp8sbf0mk7nhy1hz9m3fz97lkwijpxwf2l2ljz375ylf374iyk";
+      name = "kservice-5.44.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/ktexteditor-5.43.0.tar.xz";
-      sha256 = "1rhw1y0js2vjjp7c9f539lvqvci4nrgdicaypw3p5ndg8vsw2xag";
-      name = "ktexteditor-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/ktexteditor-5.44.0.tar.xz";
+      sha256 = "1g0v5sax3pfkvdcvyxyz81j3ainm0n1m7nc1rxh106iz8gs0z9cn";
+      name = "ktexteditor-5.44.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/ktextwidgets-5.43.0.tar.xz";
-      sha256 = "0h5bxf1a9mik2p2xhnm7nnr0r54s6zf4cby4qd8nlwl292dyf8gy";
-      name = "ktextwidgets-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/ktextwidgets-5.44.0.tar.xz";
+      sha256 = "1kxh39n9gzism99x1x7fpdqkppdpn7aaj6j3wp4a4y4hrn82bqwp";
+      name = "ktextwidgets-5.44.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kunitconversion-5.43.0.tar.xz";
-      sha256 = "14syfc9vybmaais740xmb79g7ffpyanwkb2blar88zm810dpshqd";
-      name = "kunitconversion-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kunitconversion-5.44.0.tar.xz";
+      sha256 = "1zr7m1wmyr9phg3lq11qm0l24kkc1zh6xc3x4hcrpv1yn458qxdl";
+      name = "kunitconversion-5.44.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kwallet-5.43.0.tar.xz";
-      sha256 = "01mxl06nbpgkp6dva1kvqcbhjahgjqkbql6rhwgdyhb4asabnsmj";
-      name = "kwallet-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kwallet-5.44.0.tar.xz";
+      sha256 = "01bah8rycjhgycd2bfkxj5jwfrwdbi2ba6bis79kbiaacl0q0qns";
+      name = "kwallet-5.44.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kwayland-5.43.0.tar.xz";
-      sha256 = "0glp9bnv53jjycwni0ywd7apr0jps3j0hpzs14y2v9bp4mwjgaji";
-      name = "kwayland-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kwayland-5.44.0.tar.xz";
+      sha256 = "1pq8gikwcq6p67whhfm653xq79cdwr48br5ydism06644ikc2nlk";
+      name = "kwayland-5.44.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kwidgetsaddons-5.43.0.tar.xz";
-      sha256 = "15x7k953jj6vqmb2bbw4wad2n10akkg4i5n0gmkj4fsaiag359sr";
-      name = "kwidgetsaddons-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kwidgetsaddons-5.44.0.tar.xz";
+      sha256 = "11yaqwqkmwvhn9phmsfgyfl229zcrikdi3hz2w7nk8ibraagn5pi";
+      name = "kwidgetsaddons-5.44.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kwindowsystem-5.43.0.tar.xz";
-      sha256 = "0zcrls3m9np2a9r5n7fry03ll6vrj36abjh2sajm531z657xmxjd";
-      name = "kwindowsystem-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kwindowsystem-5.44.0.tar.xz";
+      sha256 = "0qn02c0yq1ir7vb56jhlla8j7nm6yx725hxnw31b8i62k1i7nvqy";
+      name = "kwindowsystem-5.44.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kxmlgui-5.43.0.tar.xz";
-      sha256 = "1jncpyfvanyl02zx8zi2mmwbx86yaq9k7k40vh716dswbh2idzd3";
-      name = "kxmlgui-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kxmlgui-5.44.0.tar.xz";
+      sha256 = "1qr6j4cnndb14fdppc2mpbqgk1mkjfdxyl5pl7gjrwd8558brjg2";
+      name = "kxmlgui-5.44.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/kxmlrpcclient-5.43.0.tar.xz";
-      sha256 = "0c99wq7kqaqvafppcai47q8w9n21ncfmrc562cvhyqnx9qr9n5vn";
-      name = "kxmlrpcclient-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/kxmlrpcclient-5.44.0.tar.xz";
+      sha256 = "1r6mcwgagnskh8jiy2fyajgzqacw03d2qfk1fb3vv4lfwry4h2j3";
+      name = "kxmlrpcclient-5.44.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/modemmanager-qt-5.43.0.tar.xz";
-      sha256 = "16h8af046jlhn31dg1y3ajpniidkijf0wy0qa7z6bpqw01vj4l6w";
-      name = "modemmanager-qt-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/modemmanager-qt-5.44.0.tar.xz";
+      sha256 = "1dkbyn6y605i8xqwqvpxmspp0fh7zarc0h54k30rnvv1g9rs1dd4";
+      name = "modemmanager-qt-5.44.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/networkmanager-qt-5.43.0.tar.xz";
-      sha256 = "0pkm02bg201xcxyn2cbw1w3gag9ig4g5yz4wbd2db6qzvficmfqc";
-      name = "networkmanager-qt-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/networkmanager-qt-5.44.0.tar.xz";
+      sha256 = "0bhsminn31b8w1678im5zqixmyx1m5275szca9hh7wx6dl0sxhlw";
+      name = "networkmanager-qt-5.44.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/oxygen-icons5-5.43.0.tar.xz";
-      sha256 = "13c80jnc6h2z9bbwwzq1b8jsn80n4bs0zzr2xsbzsfbl5sw0hwpc";
-      name = "oxygen-icons5-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/oxygen-icons5-5.44.0.tar.xz";
+      sha256 = "0ymd9s26x2ryyw851y4yb2wl9f3syzfp0z08387h90jg6xk36si5";
+      name = "oxygen-icons5-5.44.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/plasma-framework-5.43.0.tar.xz";
-      sha256 = "1v7far0jz0b0rvx4jzqsq2pp1diny5c2qz67jyxnqlfgsba8y466";
-      name = "plasma-framework-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/plasma-framework-5.44.0.tar.xz";
+      sha256 = "1lfrmrgamizfkr9jmfmf3afis0z40r1chpk854pqfr4p27j4gdmz";
+      name = "plasma-framework-5.44.0.tar.xz";
     };
   };
   prison = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/prison-5.43.0.tar.xz";
-      sha256 = "018kj3xgl5wr3nhrasxmwvk6fh63fdwlz78z1rzyd78jx95wpaqc";
-      name = "prison-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/prison-5.44.0.tar.xz";
+      sha256 = "0glcifwjm50kn6fk3lvwpslmh4s6s8g5r7h208dw56n19yhpkrfm";
+      name = "prison-5.44.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/purpose-5.43.0.tar.xz";
-      sha256 = "1vk796f3w2arqaql16yy012211vxgz6awa8kg0p1zrxbid43x757";
-      name = "purpose-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/purpose-5.44.0.tar.xz";
+      sha256 = "1scc2vbb5ws70kvicaay634ghgp2c7xhm7d907b36jj9gvyp4d2f";
+      name = "purpose-5.44.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/qqc2-desktop-style-5.43.0.tar.xz";
-      sha256 = "0q6v1si1c8dlvq5f303dd4n1qqrn9kw0r51dl37px6rvy2n16d0w";
-      name = "qqc2-desktop-style-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/qqc2-desktop-style-5.44.0.tar.xz";
+      sha256 = "02s22xncpy988fbyjj17j5saamaf8q0sll4gd2s5xsswmalvnb51";
+      name = "qqc2-desktop-style-5.44.0.tar.xz";
     };
   };
   solid = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/solid-5.43.0.tar.xz";
-      sha256 = "0q62z23dml6rndgmkg6r09gsi0in8c4gbgv66dw47v02spsnp7v9";
-      name = "solid-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/solid-5.44.0.tar.xz";
+      sha256 = "08xw54m5srjr5n1h689hd05ld7ssimwvhlb9dlpxdavkag1vbqq1";
+      name = "solid-5.44.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/sonnet-5.43.0.tar.xz";
-      sha256 = "0i5vxaw124093fi7fi8gjyi08xgxpkpb68lrpsxqdikadvx6nwaa";
-      name = "sonnet-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/sonnet-5.44.0.tar.xz";
+      sha256 = "1dip8h9frxvzy39cjc205y2szdpczyh1fldlcpcq8ckjfk8pmgdm";
+      name = "sonnet-5.44.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/syntax-highlighting-5.43.0.tar.xz";
-      sha256 = "0a1xrpk3wavcq6d3cld33l05g5xlhz635vwcc6i1092gsgdns7k1";
-      name = "syntax-highlighting-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/syntax-highlighting-5.44.0.tar.xz";
+      sha256 = "10s5m1as9c1kln8mc7zf2m8zsqrf9rxfa2rzfyff1kki1icp65nm";
+      name = "syntax-highlighting-5.44.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.43.0";
+    version = "5.44.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.43/threadweaver-5.43.0.tar.xz";
-      sha256 = "0mmnf6lirvqwlrijpn5vqd8l9pk74dpsbr81y6kyfmx31mj36jjx";
-      name = "threadweaver-5.43.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.44/threadweaver-5.44.0.tar.xz";
+      sha256 = "135x9z1rzvlhx13nbkacmcj7g0z88rpv0c2vy8yybysfaspc1hzn";
+      name = "threadweaver-5.44.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I could not run `nox-review`as it always crash (the error was something with the garbage collector of nix) :(

@ttuegel @adisbladis @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

