### PR TITLE
kde-applications: 17.12.2 -> 17.12.3

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/17.12.2/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/applications/17.12.3/ -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1691 +3,1691 @@
 
 {
   akonadi = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadi-17.12.2.tar.xz";
-      sha256 = "03cz5jl5qywc39krjrzby7yxcrx4iaf94pkvzbkagx1c7bfgajkf";
-      name = "akonadi-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadi-17.12.3.tar.xz";
+      sha256 = "006cb98k3kxd51d0d07984aj4d0km0bn0v3rigpa3sw5s07w8dfi";
+      name = "akonadi-17.12.3.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadi-calendar-17.12.2.tar.xz";
-      sha256 = "1j2bs3ybl2lz3yr862kz4jnkiksawbyv96lsjvzgkalmri3y2jv9";
-      name = "akonadi-calendar-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadi-calendar-17.12.3.tar.xz";
+      sha256 = "0ffrnpwyjmvx80qziajdkihdzl5pyp0zbm8qg8wkcr8nxs3fgv6a";
+      name = "akonadi-calendar-17.12.3.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadi-calendar-tools-17.12.2.tar.xz";
-      sha256 = "0fh7zsf4ckmikqqwa3zqdd97i80s53r56bx8q0aj1dyxa5kzrid6";
-      name = "akonadi-calendar-tools-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadi-calendar-tools-17.12.3.tar.xz";
+      sha256 = "0836al499pd0bmwgaqzmbbmas3jmn44hv37y9k6j6ab71gpkjjy9";
+      name = "akonadi-calendar-tools-17.12.3.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadiconsole-17.12.2.tar.xz";
-      sha256 = "00w21nxbq9a9h1cs4wl0641hj82i3w63r9ab5hb9kw33gi9ijali";
-      name = "akonadiconsole-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadiconsole-17.12.3.tar.xz";
+      sha256 = "0xny4y5i03sj93dxaafnqiyczichjnzjrx1h4z13fn62flz8fn1b";
+      name = "akonadiconsole-17.12.3.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadi-contacts-17.12.2.tar.xz";
-      sha256 = "1v8082walg47bl8rj6zcp2br4wr0mhrw82l0aw41gmcwi2vr4pr7";
-      name = "akonadi-contacts-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadi-contacts-17.12.3.tar.xz";
+      sha256 = "0jbxyzvpp2lan8pi212adwflqx38paqvr661ia4zmdjnkhdvi95v";
+      name = "akonadi-contacts-17.12.3.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadi-import-wizard-17.12.2.tar.xz";
-      sha256 = "1yflksmvvysl3p3s37i0qc712cdzkzi501x74mk3c7sy1pw097g4";
-      name = "akonadi-import-wizard-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadi-import-wizard-17.12.3.tar.xz";
+      sha256 = "0knddbgirj55l24njak7s8ixg1v9i6g5nx6ijh6cnnbr2zl6aws4";
+      name = "akonadi-import-wizard-17.12.3.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadi-mime-17.12.2.tar.xz";
-      sha256 = "0xsm87nph967293ixwnh1450qwrn0ghfcw34444fj8f4ciwbv0iv";
-      name = "akonadi-mime-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadi-mime-17.12.3.tar.xz";
+      sha256 = "0n04x37palp2k6mq20p97k89qi2zfncaapn5pcf4372bzvzi9vj2";
+      name = "akonadi-mime-17.12.3.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadi-notes-17.12.2.tar.xz";
-      sha256 = "06ac7b1n3aaad7y1cbby44jaq748xnxfjd51c1jh0p257q22qj85";
-      name = "akonadi-notes-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadi-notes-17.12.3.tar.xz";
+      sha256 = "0lwnyl12a5sc3ijmahqy3prdzh9352rsqp2jpw2y58xpa2sx0w3g";
+      name = "akonadi-notes-17.12.3.tar.xz";
     };
   };
   akonadi-search = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akonadi-search-17.12.2.tar.xz";
-      sha256 = "0g03z7xcbl25ylrflgkycfgyvny5hr8i38flirw9jidwy5zf1pny";
-      name = "akonadi-search-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akonadi-search-17.12.3.tar.xz";
+      sha256 = "0npnbnras7lxs4r1g0v2nynpdni7wni7y9hy30k61lbif06ghm9x";
+      name = "akonadi-search-17.12.3.tar.xz";
     };
   };
   akregator = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/akregator-17.12.2.tar.xz";
-      sha256 = "19grppwmspn7x84ygxscch3ydr5i6nanshi1pk4wr5z34g8qcxrc";
-      name = "akregator-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/akregator-17.12.3.tar.xz";
+      sha256 = "0032jg05xwk29hpqscb5xfk7ipcpprhw8m28ksfx7v77fb025dsp";
+      name = "akregator-17.12.3.tar.xz";
     };
   };
   analitza = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/analitza-17.12.2.tar.xz";
-      sha256 = "128qcnzizcvrc1mknb5qdzricymxai2mxlrxb5h93cc14jwiivg1";
-      name = "analitza-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/analitza-17.12.3.tar.xz";
+      sha256 = "0xyr5s69768l0lp1qkp68jvny8mfh36q1xpz8msdhcn4513bw5sw";
+      name = "analitza-17.12.3.tar.xz";
     };
   };
   ark = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ark-17.12.2.tar.xz";
-      sha256 = "0xh60mf1ygyhcc06w8g4nnrhqyjf88ji3kf8d5vfpdijq8m6gg8b";
-      name = "ark-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ark-17.12.3.tar.xz";
+      sha256 = "0hjnzcn6ijpgqld7034gwzyl9m0i5nwac457f010ibzf0qp10gdi";
+      name = "ark-17.12.3.tar.xz";
     };
   };
   artikulate = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/artikulate-17.12.2.tar.xz";
-      sha256 = "0plc81c7sc47392x183q30x39ksjr1wnjhlwy0ixngj2q9nhi6nn";
-      name = "artikulate-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/artikulate-17.12.3.tar.xz";
+      sha256 = "0ynbq0m7rk4mm3khjsh0bl744g7m6l2cq9v2a4slg7n4dq8gr8zx";
+      name = "artikulate-17.12.3.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/audiocd-kio-17.12.2.tar.xz";
-      sha256 = "1n3n3ylwdm5yjv0hh43rmn3bn0q32xsbrl5wlbwgiijhpqd0ahkw";
-      name = "audiocd-kio-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/audiocd-kio-17.12.3.tar.xz";
+      sha256 = "0916igzdp1v9zafq5jwhwsfja5h9zsbqgwq97mnkmx9bnd4d2r26";
+      name = "audiocd-kio-17.12.3.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/baloo-widgets-17.12.2.tar.xz";
-      sha256 = "0pw153cy606dggkq2njk6fs5yp6a9jlkwpp7vckd9jl5s6pbsqd2";
-      name = "baloo-widgets-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/baloo-widgets-17.12.3.tar.xz";
+      sha256 = "1gn18raxqwjx09l54a4gaisxlv4i2vf7pnpv8fqfdk49wc06b58h";
+      name = "baloo-widgets-17.12.3.tar.xz";
     };
   };
   blinken = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/blinken-17.12.2.tar.xz";
-      sha256 = "008pmr3g553xd4mcdmby0fqzp8vk651dji3c8zkad94560xysm71";
-      name = "blinken-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/blinken-17.12.3.tar.xz";
+      sha256 = "0lda34yw7h867jzfqi071yw0g47916cmr145x1gz71nclg9sdgr0";
+      name = "blinken-17.12.3.tar.xz";
     };
   };
   bomber = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/bomber-17.12.2.tar.xz";
-      sha256 = "1rdxr7w2p3r1gviqsmshx6n07gzsc3ymz6drhqk3kacqwgnnr72y";
-      name = "bomber-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/bomber-17.12.3.tar.xz";
+      sha256 = "14iyn9901canzd4hpsb4xwxd67j01wn54asplvlizmwy3jhpfx9s";
+      name = "bomber-17.12.3.tar.xz";
     };
   };
   bovo = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/bovo-17.12.2.tar.xz";
-      sha256 = "0rhj0w7li1rsfjmrivr6g6z9ja408v59pk5rpci4344piaqglrqm";
-      name = "bovo-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/bovo-17.12.3.tar.xz";
+      sha256 = "15zaf8017zqfj4z0mlc321lvfnfhda8n648zlsxxap1lj6icr3s9";
+      name = "bovo-17.12.3.tar.xz";
     };
   };
   calendarsupport = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/calendarsupport-17.12.2.tar.xz";
-      sha256 = "0c6i8gqjdgc9s3mz351qjxwv6fsk3098i7ni6x4bhh5shg863vnr";
-      name = "calendarsupport-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/calendarsupport-17.12.3.tar.xz";
+      sha256 = "020ra0sbc8pmibff5ffyzhqwww8qdi1wlmn6h9qh0z2sjk9hrs84";
+      name = "calendarsupport-17.12.3.tar.xz";
     };
   };
   cantor = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/cantor-17.12.2.tar.xz";
-      sha256 = "1b055fcbpqs4fwwyj0pywv5y8pfpg3ha5382d4hhrpvpc8xwjn6c";
-      name = "cantor-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/cantor-17.12.3.tar.xz";
+      sha256 = "08jhbm54vv5s14ig2adw83fkk1r0p98aifhiq0sc4xga7gkx032w";
+      name = "cantor-17.12.3.tar.xz";
     };
   };
   cervisia = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/cervisia-17.12.2.tar.xz";
-      sha256 = "1iqkp7d3wkmi0wfxsx2k20qblkmk6m1ndh472bxn6vvfaii2dqmm";
-      name = "cervisia-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/cervisia-17.12.3.tar.xz";
+      sha256 = "04qvgpaa5mf9jmlqd60r1df3r9rscaqasfa9c39cfmahrnvm4yyr";
+      name = "cervisia-17.12.3.tar.xz";
     };
   };
   dolphin = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/dolphin-17.12.2.tar.xz";
-      sha256 = "1pmfix569996minfc8rrjdbfvybm1a5bnljk0gxybahlainxwjp4";
-      name = "dolphin-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/dolphin-17.12.3.tar.xz";
+      sha256 = "0fd4c7kwdvjpx7q9yb2razdlv6q7y74nkk99jg20jsng0px9dp20";
+      name = "dolphin-17.12.3.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/dolphin-plugins-17.12.2.tar.xz";
-      sha256 = "03637pxjf0kjbw831vvdj3lk3msvn6y3gkildsr1490v60cl2f2c";
-      name = "dolphin-plugins-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/dolphin-plugins-17.12.3.tar.xz";
+      sha256 = "0bdvwsl83bilm1jhgmcl0b8iyh4vbfg3imara2rmizfxl5g6jccf";
+      name = "dolphin-plugins-17.12.3.tar.xz";
     };
   };
   dragon = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/dragon-17.12.2.tar.xz";
-      sha256 = "03z263agwrkpqf1l3xpfmgxjzqs6icwxv22bp5shzlyiq5dvmq0d";
-      name = "dragon-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/dragon-17.12.3.tar.xz";
+      sha256 = "1j5li70fyz1ynykmxb63i2na3n964lsdkyilj1vhdzb55592b1s4";
+      name = "dragon-17.12.3.tar.xz";
     };
   };
   eventviews = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/eventviews-17.12.2.tar.xz";
-      sha256 = "1y1d8flzmi3mm15gc2q2925f1z17lcm5b8difd65z7rji4ra9rg6";
-      name = "eventviews-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/eventviews-17.12.3.tar.xz";
+      sha256 = "0v712sisa0bic6zbl7gb4jvh11wf7krsfpxffxgxc3i8zmvw9jfc";
+      name = "eventviews-17.12.3.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ffmpegthumbs-17.12.2.tar.xz";
-      sha256 = "098w62hvjqkq9iixbipg1wl0091d0fnb49jm874k4d68mpvlmmf2";
-      name = "ffmpegthumbs-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ffmpegthumbs-17.12.3.tar.xz";
+      sha256 = "18f2yxbfxrf4598xwzjd6fws35ipnvnsljv5jwy9lmq400iqpii5";
+      name = "ffmpegthumbs-17.12.3.tar.xz";
     };
   };
   filelight = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/filelight-17.12.2.tar.xz";
-      sha256 = "1ysh5rb9irgha62iw1yiw5f4fxanym9swgc8sd9cdlmkqm6km27m";
-      name = "filelight-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/filelight-17.12.3.tar.xz";
+      sha256 = "1k8vibkxv8m8f2q4hj3g4jvk96zkkd0wpxhag5jycla6v50q9anf";
+      name = "filelight-17.12.3.tar.xz";
     };
   };
   granatier = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/granatier-17.12.2.tar.xz";
-      sha256 = "1c86vh6jx991ig1n6n591r9va8rs029gd83m6y9appavi43aylkv";
-      name = "granatier-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/granatier-17.12.3.tar.xz";
+      sha256 = "1zysqf68d2zzhii587a3qdqqf1zhi2k3008f626r59a0yb2bdz9x";
+      name = "granatier-17.12.3.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/grantlee-editor-17.12.2.tar.xz";
-      sha256 = "1x4rn8liz083y8h3in743xrmk3caqcn75ba97f8ymaap0f48nly6";
-      name = "grantlee-editor-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/grantlee-editor-17.12.3.tar.xz";
+      sha256 = "03v4yrmbkpa6w8kq54iv0a6rx0q7zv1jmwka103iv89qf9d332j4";
+      name = "grantlee-editor-17.12.3.tar.xz";
     };
   };
   grantleetheme = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/grantleetheme-17.12.2.tar.xz";
-      sha256 = "0cpmd8glpjpg62h2qcngaks6adahfcbf9aikm9y4gwqbsmglqjkx";
-      name = "grantleetheme-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/grantleetheme-17.12.3.tar.xz";
+      sha256 = "0q6s5h236a61q015g9238jandibfhpw9yrx7s367qagk5wi4phsx";
+      name = "grantleetheme-17.12.3.tar.xz";
     };
   };
   gwenview = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/gwenview-17.12.2.tar.xz";
-      sha256 = "0cpv7wlbkm20vch1d4m49kxk02by9zh9lbdcli5p6bgp8mnvpxgr";
-      name = "gwenview-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/gwenview-17.12.3.tar.xz";
+      sha256 = "03gz5a4531xhmr0m5x7nzwzfr3j61xy8yw6pk06i6q7azbxxr1rr";
+      name = "gwenview-17.12.3.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/incidenceeditor-17.12.2.tar.xz";
-      sha256 = "1qlghzfc4lg69p5014f3zj6k0lgy57n0lg063b804nqy0378xra2";
-      name = "incidenceeditor-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/incidenceeditor-17.12.3.tar.xz";
+      sha256 = "19jl8mpabxm8gk7krpby1c0kcrss1nvxl5blpviy0m4ccq5jsbka";
+      name = "incidenceeditor-17.12.3.tar.xz";
     };
   };
   juk = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/juk-17.12.2.tar.xz";
-      sha256 = "1wa52sysy3hr7n5r59vb9qqnac73fcy2dc3zl51ba9da8lz8q0lj";
-      name = "juk-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/juk-17.12.3.tar.xz";
+      sha256 = "1zzzvwn3ahzwkd7gdavz6k72js2xh79wf1w06vfjx9h35j54smb6";
+      name = "juk-17.12.3.tar.xz";
     };
   };
   k3b = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/k3b-17.12.2.tar.xz";
-      sha256 = "0ryzchkk37yzihfhra5xh5sj2k46bdlspi9i2zfs63q3n32jyfww";
-      name = "k3b-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/k3b-17.12.3.tar.xz";
+      sha256 = "1i74c8x72qx36wl9vc7wcz5rpyd6410n3w8bas7hb5j4bfaapl3l";
+      name = "k3b-17.12.3.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kaccounts-integration-17.12.2.tar.xz";
-      sha256 = "14mipln6ppg88yipwvyc6ainj250ss6xynh9smxbji533wyg72c5";
-      name = "kaccounts-integration-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kaccounts-integration-17.12.3.tar.xz";
+      sha256 = "0c3jx2wr7qxkh5i3fmhsd1r0aqf133443nc7l7krymjzd54y6db9";
+      name = "kaccounts-integration-17.12.3.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kaccounts-providers-17.12.2.tar.xz";
-      sha256 = "1lapgxlgzymrdl8swn2prrlrmz5xgmkhmv7hx8fpxpc3cpfyvfsd";
-      name = "kaccounts-providers-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kaccounts-providers-17.12.3.tar.xz";
+      sha256 = "1h2asblaqmyhy4qfzcl7mxinfg0djghr9xrcvl2xyd85jkk428h5";
+      name = "kaccounts-providers-17.12.3.tar.xz";
     };
   };
   kaddressbook = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kaddressbook-17.12.2.tar.xz";
-      sha256 = "1b5a5ypmf0jr9si5cx01h52aql26v6cv16wzrrb6vhxqzksmwriw";
-      name = "kaddressbook-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kaddressbook-17.12.3.tar.xz";
+      sha256 = "1ys2hrpqpbwpml3arw076gng7ygdvvkwy489lnq7d345y79501bq";
+      name = "kaddressbook-17.12.3.tar.xz";
     };
   };
   kajongg = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kajongg-17.12.2.tar.xz";
-      sha256 = "15vnin2rg63c60injxqkx0jp5sy1hjmh5rys3qq40wy0bm41pwai";
-      name = "kajongg-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kajongg-17.12.3.tar.xz";
+      sha256 = "1p39qjj05p1zjlz9f49pvwzvlsa61h549r74ravj4xdl6fqvdgfa";
+      name = "kajongg-17.12.3.tar.xz";
     };
   };
   kalarm = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kalarm-17.12.2.tar.xz";
-      sha256 = "1vvayib91mh73kqc0linzqlwa1l9jlc2wsih80bzzglaaxbi4l7z";
-      name = "kalarm-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kalarm-17.12.3.tar.xz";
+      sha256 = "0n3cdj630q96rvljph3raz0f698pwrh2rx81xzsyp2lk917737h7";
+      name = "kalarm-17.12.3.tar.xz";
     };
   };
   kalarmcal = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kalarmcal-17.12.2.tar.xz";
-      sha256 = "04js601j477jwa5lhqdxq9gaacd7bf5ladgy3k64dwns5mx1j762";
-      name = "kalarmcal-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kalarmcal-17.12.3.tar.xz";
+      sha256 = "13bg69qsyzjaabghq6n33y211i5mz9pnnc26kqyhg87za526j7km";
+      name = "kalarmcal-17.12.3.tar.xz";
     };
   };
   kalgebra = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kalgebra-17.12.2.tar.xz";
-      sha256 = "10vfzwmz0l7yvmy8gjwcb3dnpqyfngj47knb5knvkibqzij6p4w4";
-      name = "kalgebra-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kalgebra-17.12.3.tar.xz";
+      sha256 = "1vm64azi46zgxg0kjg8ch7gxbb8wb3bafsfgxmv4x1hqy45crkv7";
+      name = "kalgebra-17.12.3.tar.xz";
     };
   };
   kalzium = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kalzium-17.12.2.tar.xz";
-      sha256 = "0rdq2cpq5mzl3qrj3ll1d0qixaiygl5x277wlr5fg9cngi51v58x";
-      name = "kalzium-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kalzium-17.12.3.tar.xz";
+      sha256 = "1zha7iy2wg8dyrajijnc3vy7wb0k4kli4q2xkv6ryc6klrp2910h";
+      name = "kalzium-17.12.3.tar.xz";
     };
   };
   kamera = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kamera-17.12.2.tar.xz";
-      sha256 = "070kvaij5chk8nkap9nm1rrilq3sc32q7ysnrld9bssbfi9m73v7";
-      name = "kamera-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kamera-17.12.3.tar.xz";
+      sha256 = "1xk2cclavzkjifzznd9kx4nq8dysmns2ni9w865s0vvl98z6jbg9";
+      name = "kamera-17.12.3.tar.xz";
     };
   };
   kanagram = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kanagram-17.12.2.tar.xz";
-      sha256 = "1300wg5k6x6s1wgmavywcwyqgv68xv0qv6hkqawvzsd61zfhxcr3";
-      name = "kanagram-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kanagram-17.12.3.tar.xz";
+      sha256 = "05dl248lvskh46mii5glvxpspf6gw1m4z2g6lpb9acafr8cqvz8k";
+      name = "kanagram-17.12.3.tar.xz";
     };
   };
   kapman = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kapman-17.12.2.tar.xz";
-      sha256 = "0njf1017dnf4xl801xinfgfmqqpjf3ifnpwchg35zm2qlrlwhmyi";
-      name = "kapman-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kapman-17.12.3.tar.xz";
+      sha256 = "04ngab85hsx4z9h45z32s1arahfzyxkyb4i9w6x51jmm3a7cnp4z";
+      name = "kapman-17.12.3.tar.xz";
     };
   };
   kapptemplate = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kapptemplate-17.12.2.tar.xz";
-      sha256 = "16p63zil3vaa5q2q01010gshn6a58kbmayks27kdgvsfdavgdh51";
-      name = "kapptemplate-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kapptemplate-17.12.3.tar.xz";
+      sha256 = "11v108jqmqp4xcmf6nz41fl7avmcpd26w4pdgfk70dzjwpzf1hl3";
+      name = "kapptemplate-17.12.3.tar.xz";
     };
   };
   kate = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kate-17.12.2.tar.xz";
-      sha256 = "1w3pswd3gpjpa55xy98yq39nck775mfv5i9lcvm8y15x1233rr6p";
-      name = "kate-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kate-17.12.3.tar.xz";
+      sha256 = "041ax9mvmgi9aj3759411bv1yj0a0v08djmwmn6kbvl8nv6a7dp5";
+      name = "kate-17.12.3.tar.xz";
     };
   };
   katomic = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/katomic-17.12.2.tar.xz";
-      sha256 = "0jhmszbq0rslwg8b8aq0vjynjlkg491di661k2b6yrsfqr4vmngw";
-      name = "katomic-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/katomic-17.12.3.tar.xz";
+      sha256 = "1ljc8h2ngsc3cqz58dal3kkn7ymwa23ikxhjakn0nsg07fbqkdjl";
+      name = "katomic-17.12.3.tar.xz";
     };
   };
   kblackbox = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kblackbox-17.12.2.tar.xz";
-      sha256 = "07bvmcfm3r4dj41dvsaba4rig2i9yilshrzl3wwprsjajmx4j6rf";
-      name = "kblackbox-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kblackbox-17.12.3.tar.xz";
+      sha256 = "1nc15k4rlpjb9p5y3g6jhi1j8nnwzxv4cymg7m7p356xr5k0m5qm";
+      name = "kblackbox-17.12.3.tar.xz";
     };
   };
   kblocks = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kblocks-17.12.2.tar.xz";
-      sha256 = "019h8rxv9p1ynby7bshr2yzrcn415magwlzmyrwvh5hzjjp0bmm9";
-      name = "kblocks-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kblocks-17.12.3.tar.xz";
+      sha256 = "04yyz71a4nr8g6fnb3mfsnlisnsw2c28z39w1hn54msmi32wyvi2";
+      name = "kblocks-17.12.3.tar.xz";
     };
   };
   kblog = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kblog-17.12.2.tar.xz";
-      sha256 = "1s2py5ll879zxcl6l7y2jryy1z29wljwm8hrgr52f8xr22vspbjc";
-      name = "kblog-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kblog-17.12.3.tar.xz";
+      sha256 = "0169m2h60iygy021j5w7fqww4ljal3gzffmj8f7arf6fin9myhwb";
+      name = "kblog-17.12.3.tar.xz";
     };
   };
   kbounce = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kbounce-17.12.2.tar.xz";
-      sha256 = "0rb9p8q0zwwfx70cxfcdbr9h3i8gag0da8nql6nnd37v2wcr4i82";
-      name = "kbounce-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kbounce-17.12.3.tar.xz";
+      sha256 = "0m0hvb8dv2z5s80c8i0ivkwnp9xaqprvgkgnrfmispj1splpzlvw";
+      name = "kbounce-17.12.3.tar.xz";
     };
   };
   kbreakout = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kbreakout-17.12.2.tar.xz";
-      sha256 = "1j9gfzgdjhfd4jz2x3qgbd4jwfix0m1qx5lnlbkbxnff5jkw68sh";
-      name = "kbreakout-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kbreakout-17.12.3.tar.xz";
+      sha256 = "04n01c36dbfq8khklc7jp2d80zxyhfy7v3x4dqpknnq22a8x8f6c";
+      name = "kbreakout-17.12.3.tar.xz";
     };
   };
   kbruch = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kbruch-17.12.2.tar.xz";
-      sha256 = "0q95i474lgbl6phshbw7f89kik8hk9k8j8vpbzy3cchwn7dmg3p3";
-      name = "kbruch-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kbruch-17.12.3.tar.xz";
+      sha256 = "1m3cdifm13gyfkhnab3nmw762kvbz64fyfw8py7lqy7i023yg35r";
+      name = "kbruch-17.12.3.tar.xz";
     };
   };
   kcachegrind = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kcachegrind-17.12.2.tar.xz";
-      sha256 = "02nx8vqvl62vdm311r4akcckzl1w4c47phl3ybswygrakik7vf2a";
-      name = "kcachegrind-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kcachegrind-17.12.3.tar.xz";
+      sha256 = "1nsx813dsngf5agdw04cdrw3h8cj4g2na28i5anxbscn7fm715hd";
+      name = "kcachegrind-17.12.3.tar.xz";
     };
   };
   kcalc = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kcalc-17.12.2.tar.xz";
-      sha256 = "13h4c97qz8g7z4r5kb4js6sjzdgr3s4mabzr16qkwmmg4lwvzcp8";
-      name = "kcalc-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kcalc-17.12.3.tar.xz";
+      sha256 = "0w4rqkjsl24528bqkqansk985iq6nk78bm0pinagm1fqrarjqk8j";
+      name = "kcalc-17.12.3.tar.xz";
     };
   };
   kcalcore = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kcalcore-17.12.2.tar.xz";
-      sha256 = "06z7xd0a8pz75zx1l2hcban39rc6dmxhhwhgidfglkj3l2xzw927";
-      name = "kcalcore-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kcalcore-17.12.3.tar.xz";
+      sha256 = "125qdd3gp6bwm6lqc1ib4icv3sa8sd0n5fjbgwr4klx8xsxzr03z";
+      name = "kcalcore-17.12.3.tar.xz";
     };
   };
   kcalutils = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kcalutils-17.12.2.tar.xz";
-      sha256 = "11vp32f53by2gc7zv08zq0z591rw4srmmjmiafds8hvx76ry3dsl";
-      name = "kcalutils-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kcalutils-17.12.3.tar.xz";
+      sha256 = "1cag7pg9qd8w7xmvplkqr6p6pscnjzlzlin9fi6yjhhsq8bi2rxb";
+      name = "kcalutils-17.12.3.tar.xz";
     };
   };
   kcharselect = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kcharselect-17.12.2.tar.xz";
-      sha256 = "1gbr6gvp2vwgvns83pmg5idhwhixyw9yqyr6nn61qf43f97nkdiy";
-      name = "kcharselect-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kcharselect-17.12.3.tar.xz";
+      sha256 = "1chxa1nsczk525hvwyw6cbzdr73i21zw9jngp9c79frcnpb5hdi4";
+      name = "kcharselect-17.12.3.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kcolorchooser-17.12.2.tar.xz";
-      sha256 = "0jjzpm82jy9f4qf5sf5v24vk50y4qq2sj42zn057v0kwlpwzvrr9";
-      name = "kcolorchooser-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kcolorchooser-17.12.3.tar.xz";
+      sha256 = "1yf8bizxd65h9pzai51l7piw5p4rlcl2bmw3qf9s73xii9cxz8yl";
+      name = "kcolorchooser-17.12.3.tar.xz";
     };
   };
   kcontacts = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kcontacts-17.12.2.tar.xz";
-      sha256 = "0hg442jg0rb7fsy67fg44551c02gx3i7znwl6cgr9nzlxj5srhyq";
-      name = "kcontacts-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kcontacts-17.12.3.tar.xz";
+      sha256 = "08gzaznb6nazqcd5v755cs6fvxq4y1ywa7qbff7fb28sbkz6sdjl";
+      name = "kcontacts-17.12.3.tar.xz";
     };
   };
   kcron = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kcron-17.12.2.tar.xz";
-      sha256 = "1h1bkicvfbz7s0n36iw5pilqrv2vfzl3rwqx6r0wa10341sx8wc3";
-      name = "kcron-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kcron-17.12.3.tar.xz";
+      sha256 = "0kdd0kzx26jhwrz9ism9fc5gbf1fh0qsb6h3gmx524r40wzr45bf";
+      name = "kcron-17.12.3.tar.xz";
     };
   };
   kdav = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdav-17.12.2.tar.xz";
-      sha256 = "1jlw2l6jd2rhf7swl7bwlsphp1xddb0f9xzkpa6dxw4cimfz4r7l";
-      name = "kdav-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdav-17.12.3.tar.xz";
+      sha256 = "141a2fk3n18554qh8h00dnik33pf4jmvp1z94gbhscgkza1xdlx4";
+      name = "kdav-17.12.3.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdebugsettings-17.12.2.tar.xz";
-      sha256 = "1a9yy42x16maj60wh7x19248gp1x4diybj9k2gkmlf7hd8g82m4b";
-      name = "kdebugsettings-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdebugsettings-17.12.3.tar.xz";
+      sha256 = "0y71ay5b7fly5rbl7fii6glkhmdkrk6fxmyx5ick5jgjgnmzjkdr";
+      name = "kdebugsettings-17.12.3.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kde-dev-scripts-17.12.2.tar.xz";
-      sha256 = "181s9cf1kqx35w9cza40svgzbqvhz48f858r0rxvl6klzm7rrqmn";
-      name = "kde-dev-scripts-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kde-dev-scripts-17.12.3.tar.xz";
+      sha256 = "1mipi7fchmf6rmivlpbncx106axaw9hi9r1kd7ibn5jqz0raa554";
+      name = "kde-dev-scripts-17.12.3.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kde-dev-utils-17.12.2.tar.xz";
-      sha256 = "044w9az0jnc7lhlgyiqxsl5lgfzbnrfrdvsr2918idy2niif7cjq";
-      name = "kde-dev-utils-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kde-dev-utils-17.12.3.tar.xz";
+      sha256 = "05a8h9bdg81zlaf1zqk8vdqp1d2lkymdg82ppxvm2sxg00rrzgp6";
+      name = "kde-dev-utils-17.12.3.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdeedu-data-17.12.2.tar.xz";
-      sha256 = "1sdldx357ifv4sqwa8yrcjxyricb0kk21gvj9472bi28rcgyxqgv";
-      name = "kdeedu-data-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdeedu-data-17.12.3.tar.xz";
+      sha256 = "17xdhkaavz1b5f2iqw64b7891qc8l2i3f90zr2byw4j05gfm24wr";
+      name = "kdeedu-data-17.12.3.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdegraphics-mobipocket-17.12.2.tar.xz";
-      sha256 = "1jx5ir1q12s939m0nndhxwiarfr6r7ma79dy9fn5bbhdjgjqf7fq";
-      name = "kdegraphics-mobipocket-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdegraphics-mobipocket-17.12.3.tar.xz";
+      sha256 = "16l5s4ha93h7bvb07kx60674i0j1n26c16w8q3drl8jmkmmf2h4j";
+      name = "kdegraphics-mobipocket-17.12.3.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdegraphics-thumbnailers-17.12.2.tar.xz";
-      sha256 = "0d6cf2mhblxgnhv432x9rgk5k73fhpa20xajn6nfawxkmpkzngsy";
-      name = "kdegraphics-thumbnailers-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdegraphics-thumbnailers-17.12.3.tar.xz";
+      sha256 = "1xak3c76bwprmb0anjvw5p620lm9hxyn6dzw2vh1di899b1p60n4";
+      name = "kdegraphics-thumbnailers-17.12.3.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdenetwork-filesharing-17.12.2.tar.xz";
-      sha256 = "1ghdskmc0ynjb1a4qid9vjjcl8nmyqvr5x6aryzz9g1rmm6vv8l5";
-      name = "kdenetwork-filesharing-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdenetwork-filesharing-17.12.3.tar.xz";
+      sha256 = "0hkvmv0wiyhh4b036sdqx4f69ihxwl4m3mnmwc58va3cj5p32pyh";
+      name = "kdenetwork-filesharing-17.12.3.tar.xz";
     };
   };
   kdenlive = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdenlive-17.12.2.tar.xz";
-      sha256 = "1l2sv78wwfwrya486sm4iszkm1hsj473a5gpkgay66h4qb968w70";
-      name = "kdenlive-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdenlive-17.12.3.tar.xz";
+      sha256 = "0gjhiwjh5h727v4lcs3yy526sr4sr563acg9xc54q76hcl1qc7rp";
+      name = "kdenlive-17.12.3.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdepim-addons-17.12.2.tar.xz";
-      sha256 = "185qargpzlmphq5afzvw0pcmas8ska2cnnbv5rpicmg8q01ixnm7";
-      name = "kdepim-addons-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdepim-addons-17.12.3.tar.xz";
+      sha256 = "13562gn2jc049pfkq8kw2w5lnmh6s6z6r57p3rpjr880izw9707h";
+      name = "kdepim-addons-17.12.3.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdepim-apps-libs-17.12.2.tar.xz";
-      sha256 = "0zn620bv551lgl6sx9g4f8ncpv5hs231jbrzkiwqw6y74xw5qq7g";
-      name = "kdepim-apps-libs-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdepim-apps-libs-17.12.3.tar.xz";
+      sha256 = "178iq1kjynid2hfnlh5pbcq2z46rl55xfvvsnpbwbk80j81mpj24";
+      name = "kdepim-apps-libs-17.12.3.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdepim-runtime-17.12.2.tar.xz";
-      sha256 = "1z11ac0l4n80nybsnfk716c88ah2l7g1fsz5xmzvv6pcmhm2q94j";
-      name = "kdepim-runtime-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdepim-runtime-17.12.3.tar.xz";
+      sha256 = "1r30wp4n020hh83znv6889w3vm0flyn31b92pmrgvsxm8yzphgwn";
+      name = "kdepim-runtime-17.12.3.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdesdk-kioslaves-17.12.2.tar.xz";
-      sha256 = "09r7iqqvil2sjfzdnq64075gmm7wxd705j00qxfch99ja3nf4961";
-      name = "kdesdk-kioslaves-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdesdk-kioslaves-17.12.3.tar.xz";
+      sha256 = "022yp5glg3dxfm5lgv4095dimw9nwbdh559y2vvvlx06pyi0b1qa";
+      name = "kdesdk-kioslaves-17.12.3.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdesdk-thumbnailers-17.12.2.tar.xz";
-      sha256 = "1j8gqwcs65cfpaqvny29yqzsgjbjmxrafnf4ggc1bjaz2p63blni";
-      name = "kdesdk-thumbnailers-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdesdk-thumbnailers-17.12.3.tar.xz";
+      sha256 = "0qndm22x7f4w8nmai4zxrxmxkism25xh7cf8vfsihlpqj1qs7wci";
+      name = "kdesdk-thumbnailers-17.12.3.tar.xz";
     };
   };
   kdf = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdf-17.12.2.tar.xz";
-      sha256 = "07379lagrl7hhh05dixd4ldqiy9pwmw0yai8sgcbfi3kgcns9c6a";
-      name = "kdf-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdf-17.12.3.tar.xz";
+      sha256 = "18q0581jaqc6w2cbdq1crxgrn97p89ah205mv253pd58w9qc4xlp";
+      name = "kdf-17.12.3.tar.xz";
     };
   };
   kdialog = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdialog-17.12.2.tar.xz";
-      sha256 = "1pwicn5jsg3jwqqkrjhaxbcd9762k9fj4w51ahglby04c4cca38a";
-      name = "kdialog-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdialog-17.12.3.tar.xz";
+      sha256 = "1smz7q09ss963c9snsvb6biimn1d2c9yyx9lhxszfl9155cgd9x4";
+      name = "kdialog-17.12.3.tar.xz";
     };
   };
   kdiamond = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kdiamond-17.12.2.tar.xz";
-      sha256 = "03m91x6rgh3wd8mim41d08x1c06ndg9vkciyl6nkj4iyflwwy0rp";
-      name = "kdiamond-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kdiamond-17.12.3.tar.xz";
+      sha256 = "1k4mlajxwpbn4y6dlkz5psxy6iqfjj5qif7i5sfn0c3gsgm76pxc";
+      name = "kdiamond-17.12.3.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/keditbookmarks-17.12.2.tar.xz";
-      sha256 = "1aqqd2lvdbqhnzz28axv9j84s7i7cxrs39zyaia7cwzbbgymkal1";
-      name = "keditbookmarks-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/keditbookmarks-17.12.3.tar.xz";
+      sha256 = "066ia9n648p53g4451zfn5nram821rlbjlnfi9ny9p0j4dl6wwya";
+      name = "keditbookmarks-17.12.3.tar.xz";
     };
   };
   kfind = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kfind-17.12.2.tar.xz";
-      sha256 = "0zxm5fjf6xzl871gjbs5nzp6h5j4qm47ygfq644jqbi9f3z2in74";
-      name = "kfind-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kfind-17.12.3.tar.xz";
+      sha256 = "1xf1sw422sg3ki1phy097lwma14drdnjbgc1m5rap3dg0za25c9s";
+      name = "kfind-17.12.3.tar.xz";
     };
   };
   kfloppy = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kfloppy-17.12.2.tar.xz";
-      sha256 = "0s25jbngh6zipxm16kffvwyd1ircnf0xjsh20lm08i9kh4jcicgq";
-      name = "kfloppy-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kfloppy-17.12.3.tar.xz";
+      sha256 = "0gjp2l5jm16v1v4xwzaandplabz6rjdiimcf3b0r5d9prbiwry3p";
+      name = "kfloppy-17.12.3.tar.xz";
     };
   };
   kfourinline = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kfourinline-17.12.2.tar.xz";
-      sha256 = "0cqlqab9sazhvvsdyvwzdzrjccvlbxwq2p1n6ki8g8i6707mx3hc";
-      name = "kfourinline-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kfourinline-17.12.3.tar.xz";
+      sha256 = "1l10fj1vhxj1d647mcxp7a2bbilrhs3sf7cwkr57vavfzsp7diyw";
+      name = "kfourinline-17.12.3.tar.xz";
     };
   };
   kgeography = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kgeography-17.12.2.tar.xz";
-      sha256 = "1mf5zr4cwnnrvsad4mq0mr6p3v38payajagc2whfl1lmcg82f2wl";
-      name = "kgeography-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kgeography-17.12.3.tar.xz";
+      sha256 = "1dl3k4zlchpdhvjb459wb44iyq30ngki6x198pyc23j15mjfdrih";
+      name = "kgeography-17.12.3.tar.xz";
     };
   };
   kget = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kget-17.12.2.tar.xz";
-      sha256 = "1fm5yzxxg7lihzgnl7207gfn9gz33ydk1axf8lmdhwwld14q25f9";
-      name = "kget-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kget-17.12.3.tar.xz";
+      sha256 = "1kaxvid76s8rx07hza56s83l785dxi5whhkqzkv132z2dm01yzww";
+      name = "kget-17.12.3.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kgoldrunner-17.12.2.tar.xz";
-      sha256 = "0dddzimh41xm6fvz1spl58gwff9vlx12h52kbfxdb2wz60zkg8wb";
-      name = "kgoldrunner-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kgoldrunner-17.12.3.tar.xz";
+      sha256 = "1ihj48kvr9xpw4rajiyq3kng1dn6l60dmii5pnyjmxlfs08apayx";
+      name = "kgoldrunner-17.12.3.tar.xz";
     };
   };
   kgpg = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kgpg-17.12.2.tar.xz";
-      sha256 = "0r604acqm255xqjqg4islk30g62f8p9mj6haqp0iyw82239hbkp0";
-      name = "kgpg-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kgpg-17.12.3.tar.xz";
+      sha256 = "19yacv7l6kynyznb8ixn3697h04mhh4fhx02n4frdy9pnzv94hyp";
+      name = "kgpg-17.12.3.tar.xz";
     };
   };
   khangman = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/khangman-17.12.2.tar.xz";
-      sha256 = "1wk0k4lbskgxrbv91032yg6n64ghir25128pphsy61m4v00jysg3";
-      name = "khangman-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/khangman-17.12.3.tar.xz";
+      sha256 = "0hnm499qs1l2yzfqxhmkyc5lp0qb5j29h1knap1vmv4qy0qnmnjk";
+      name = "khangman-17.12.3.tar.xz";
     };
   };
   khelpcenter = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/khelpcenter-17.12.2.tar.xz";
-      sha256 = "0871xxril7dllks46f4a31dkiwmgjc8ajm2jpn5hfm3g2cbawlsd";
-      name = "khelpcenter-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/khelpcenter-17.12.3.tar.xz";
+      sha256 = "0z5hrwqsi9ifraivz59nbq247x481hx90wiyfbls9lwv56y1zi7n";
+      name = "khelpcenter-17.12.3.tar.xz";
     };
   };
   kholidays = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kholidays-17.12.2.tar.xz";
-      sha256 = "0mn2bmjiy5k99g4yv0n61jklyp1105kmnvkf4ay28ha55zy95bbk";
-      name = "kholidays-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kholidays-17.12.3.tar.xz";
+      sha256 = "0w886443zzvpwqznnn7ymw5bxzdnigfz9j45qrl1qvdd6q8710di";
+      name = "kholidays-17.12.3.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kidentitymanagement-17.12.2.tar.xz";
-      sha256 = "1s5xjgbp7vdww8k59s8h2mypi1d94n4kkphkgiybdq2gxpfq73pb";
-      name = "kidentitymanagement-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kidentitymanagement-17.12.3.tar.xz";
+      sha256 = "0my4r8k8gadkda3z1myarrq4x72qz6wxsy6lj9rzkj4y549bm93y";
+      name = "kidentitymanagement-17.12.3.tar.xz";
     };
   };
   kig = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kig-17.12.2.tar.xz";
-      sha256 = "1cphrji1l3c32j8wdr88y40fzkr9s20q79hlk4c4rhzkym7jgzhp";
-      name = "kig-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kig-17.12.3.tar.xz";
+      sha256 = "0liv94y90bfd5pi003bd3jryc1dal5mwxhqy94c2n3ay8yz8kxid";
+      name = "kig-17.12.3.tar.xz";
     };
   };
   kigo = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kigo-17.12.2.tar.xz";
-      sha256 = "0xz8nmhgx8iadwmqkm6469vw8vn9n74mk2fhmciqn8xn66r11g9d";
-      name = "kigo-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kigo-17.12.3.tar.xz";
+      sha256 = "1z01w5zsbwn8h0mgr5liqagsmlppqclkjs4z5rdys75sxm142fzh";
+      name = "kigo-17.12.3.tar.xz";
     };
   };
   killbots = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/killbots-17.12.2.tar.xz";
-      sha256 = "140v8mwbkhv9fkqi0781mrk51fk00q5p1ad3p1rqgmhy0pzfvkg4";
-      name = "killbots-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/killbots-17.12.3.tar.xz";
+      sha256 = "14xgh9qhagq9c01xbv0n4g5b3q9r6qr0dsc5ilindr66psspx7an";
+      name = "killbots-17.12.3.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kimagemapeditor-17.12.2.tar.xz";
-      sha256 = "16wyb80al1vp3macr2lrkh0f1l42jzm126mv2l5gbhd5qiwj6yag";
-      name = "kimagemapeditor-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kimagemapeditor-17.12.3.tar.xz";
+      sha256 = "1s9929wb3lclbn85rk3zd0nai64mrwgqdqnkw2dys98snq12r3hn";
+      name = "kimagemapeditor-17.12.3.tar.xz";
     };
   };
   kimap = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kimap-17.12.2.tar.xz";
-      sha256 = "15nbnjckmqa4kka012lvaziimgnr6vs5k361sjhdykvrvk4fhz13";
-      name = "kimap-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kimap-17.12.3.tar.xz";
+      sha256 = "1prilnf01s73ml7542s7qh0ki9gqvgq7xqzxq2mz17k4d3irdvxw";
+      name = "kimap-17.12.3.tar.xz";
     };
   };
   kio-extras = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kio-extras-17.12.2.tar.xz";
-      sha256 = "0vc8wwx9cqs48hn1hf49fmz99xa4c8vhcqq58wmpq3bg62vfipyp";
-      name = "kio-extras-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kio-extras-17.12.3.tar.xz";
+      sha256 = "1ifi09hv5aqx62x1cjnsxxh7xji9m0mmk3gfn43la9vw4rhxzlks";
+      name = "kio-extras-17.12.3.tar.xz";
     };
   };
   kiriki = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kiriki-17.12.2.tar.xz";
-      sha256 = "1a427gja7y2s37a29jl1n4bx1xa2piqm7wwv7g7agaxm5j15qvx8";
-      name = "kiriki-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kiriki-17.12.3.tar.xz";
+      sha256 = "1zl8mq1ya3x67y1pj1ir98v5lbxwccwyni8i02wc7mbgmxbk6p9q";
+      name = "kiriki-17.12.3.tar.xz";
     };
   };
   kiten = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kiten-17.12.2.tar.xz";
-      sha256 = "0bcb65pcs3xv5pmr78zlxcbicxknvbf30h83i4f4qjxrq6iw8sf4";
-      name = "kiten-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kiten-17.12.3.tar.xz";
+      sha256 = "1p1s20ks3r2zfd7wig1j2lbxbf3ch9gbykw2cgadip4nyn9nyll5";
+      name = "kiten-17.12.3.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kjumpingcube-17.12.2.tar.xz";
-      sha256 = "0d2gdvjd0fxxdnpxfplw9gp69b1qx35w165srd79qcx17c2r7cdv";
-      name = "kjumpingcube-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kjumpingcube-17.12.3.tar.xz";
+      sha256 = "07fakw1nq3bickj05cvb39wyb02fpfph0ia1wfm8wf43rd34c76l";
+      name = "kjumpingcube-17.12.3.tar.xz";
     };
   };
   kldap = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kldap-17.12.2.tar.xz";
-      sha256 = "177xg8ng4636gnppf4jf0m2amadlrz0n9bdmc7f6xnijchmda2p4";
-      name = "kldap-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kldap-17.12.3.tar.xz";
+      sha256 = "02adfzjlvxjff33cpyihsf9z9zm7nvgmnipg9dmkpc0cwl25a8jy";
+      name = "kldap-17.12.3.tar.xz";
     };
   };
   kleopatra = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kleopatra-17.12.2.tar.xz";
-      sha256 = "04c1w1la826dwjam19m12jg8l5c8641l7ad6injrbig1kja819v4";
-      name = "kleopatra-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kleopatra-17.12.3.tar.xz";
+      sha256 = "1417j1jh7bs0020laaimpwmmng508k85kp24k923ad2v65i51agd";
+      name = "kleopatra-17.12.3.tar.xz";
     };
   };
   klettres = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/klettres-17.12.2.tar.xz";
-      sha256 = "16pi5r4s67j6pq5jjbyap7jrxxx5wrg7dr77391yk06s955rcfr1";
-      name = "klettres-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/klettres-17.12.3.tar.xz";
+      sha256 = "0npp2dkwi3g36scipdra5xj5lf0xga3l8h8pk6isx7l86xsv3ds0";
+      name = "klettres-17.12.3.tar.xz";
     };
   };
   klickety = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/klickety-17.12.2.tar.xz";
-      sha256 = "0rwmswrmwjizv9vw3bivh75wisy09icbykvwsi43zsapar9hs89l";
-      name = "klickety-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/klickety-17.12.3.tar.xz";
+      sha256 = "0f8gxqcfanxbqjqrq1j598nbis3djxxps61hdl1wd9xki1a86xy8";
+      name = "klickety-17.12.3.tar.xz";
     };
   };
   klines = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/klines-17.12.2.tar.xz";
-      sha256 = "0nl5w65m7c46hjh0hvd76x7zf5c9qlqxqn8b96dzgrab6s9f96wf";
-      name = "klines-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/klines-17.12.3.tar.xz";
+      sha256 = "0kp7c8qxkwgf13cwa7x5wik5w7snq6830zpah6lsk4ls5jw5mln0";
+      name = "klines-17.12.3.tar.xz";
     };
   };
   kmag = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmag-17.12.2.tar.xz";
-      sha256 = "0yxh4y5l6l528j2nz4wl0w8zmydayrgh1aracy1lymv65ww8qax2";
-      name = "kmag-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmag-17.12.3.tar.xz";
+      sha256 = "0n9dxf5mcz6rlfr91r6yd7sxfmshgdc8znxfbncd1a9j523vba3w";
+      name = "kmag-17.12.3.tar.xz";
     };
   };
   kmahjongg = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmahjongg-17.12.2.tar.xz";
-      sha256 = "06skr41bs29q19dm6j79h0x1l2szbr6gz9kn6s47s23wmyjkqdqr";
-      name = "kmahjongg-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmahjongg-17.12.3.tar.xz";
+      sha256 = "0ai6jlny4fi69psiizix5adz3kga4plf70y322a3ybl8g9c44m1a";
+      name = "kmahjongg-17.12.3.tar.xz";
     };
   };
   kmail = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmail-17.12.2.tar.xz";
-      sha256 = "0kanmbb09x6cyswq7ws6cw7j117lqwqp3hvs9hipx7nyr38mhrlc";
-      name = "kmail-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmail-17.12.3.tar.xz";
+      sha256 = "02hjrk1c4mk3jrmyhn4ppar6vdlg51j79fqcjzfs1d8s4w0swwbs";
+      name = "kmail-17.12.3.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmail-account-wizard-17.12.2.tar.xz";
-      sha256 = "1l7szmbhxrqj93cqvpaywgyql319n1wmw8acnca1aym9l79pns0s";
-      name = "kmail-account-wizard-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmail-account-wizard-17.12.3.tar.xz";
+      sha256 = "1qdwqd763k5dq8mmwibnvgqjb7l6br9dqwxfsi7q8bhjxipijvdx";
+      name = "kmail-account-wizard-17.12.3.tar.xz";
     };
   };
   kmailtransport = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmailtransport-17.12.2.tar.xz";
-      sha256 = "1prrw61vz52wp8yb587xz1kd5rm6s6dry8i9zcs66aha5g7r0wj8";
-      name = "kmailtransport-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmailtransport-17.12.3.tar.xz";
+      sha256 = "131yy2xa61fi2dmrb3qapf589lf4s9v2rkk2js0bi1827yg097f0";
+      name = "kmailtransport-17.12.3.tar.xz";
     };
   };
   kmbox = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmbox-17.12.2.tar.xz";
-      sha256 = "0q6217br3cpdwns6hiw5klnvkwwx7sd8gbl003clf4wkfnxpgqsb";
-      name = "kmbox-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmbox-17.12.3.tar.xz";
+      sha256 = "15x9cdwcbwrjaj3rzphwmpayhy45j45pwj88sz0drqz3mwc55jgm";
+      name = "kmbox-17.12.3.tar.xz";
     };
   };
   kmime = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmime-17.12.2.tar.xz";
-      sha256 = "097xzsd7lld01iz1nziy8b9vv97xaz6vsl52d5809h0kxfpixw99";
-      name = "kmime-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmime-17.12.3.tar.xz";
+      sha256 = "0251szs8dcpnwhqk72c211mp7h0xhn0f8z21mdm6k94ij43da9cm";
+      name = "kmime-17.12.3.tar.xz";
     };
   };
   kmines = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmines-17.12.2.tar.xz";
-      sha256 = "00apcafaxh18rxk8d3r333mzjd0b6f7946kp6ffr1ps9c93mm3ab";
-      name = "kmines-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmines-17.12.3.tar.xz";
+      sha256 = "0r9rs97s92z5854xdampgp6igmppzp3mhaw9rscrdwvvq4xpsll9";
+      name = "kmines-17.12.3.tar.xz";
     };
   };
   kmix = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmix-17.12.2.tar.xz";
-      sha256 = "096dbmywdhgcjzvm473sm0vjrmgfmb19cjx82066ws8pvn9fybdj";
-      name = "kmix-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmix-17.12.3.tar.xz";
+      sha256 = "12fwimqr21hgwqscihaxwh1f39xm8k21f95f7b3gwwa5lbj0l9mp";
+      name = "kmix-17.12.3.tar.xz";
     };
   };
   kmousetool = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmousetool-17.12.2.tar.xz";
-      sha256 = "08kv4j6r18wrl7n4j7apffyj52w77l8rkksvmdzlfg2nk87vaafj";
-      name = "kmousetool-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmousetool-17.12.3.tar.xz";
+      sha256 = "0gbvzywnxbcb4iw7pgf70ljz0qd8xl8825srpp3fj7lv0kh9ni9z";
+      name = "kmousetool-17.12.3.tar.xz";
     };
   };
   kmouth = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmouth-17.12.2.tar.xz";
-      sha256 = "12kdrwz3mxwz9y4srq5jjrrn0wg3905qhg1qbj8p583gk1n03g20";
-      name = "kmouth-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmouth-17.12.3.tar.xz";
+      sha256 = "012lpy904n2isj8msxivgk0ssy56qajgjxn1hz2jy9jjyyi77f2n";
+      name = "kmouth-17.12.3.tar.xz";
     };
   };
   kmplot = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kmplot-17.12.2.tar.xz";
-      sha256 = "1pws8lajpjm4nfichd0949lmsn975ivxh2b001gsif3vvadmp48l";
-      name = "kmplot-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kmplot-17.12.3.tar.xz";
+      sha256 = "0plblgv243ymmcbpb8rs4clilwlsggn7219yqrh064lzbfblhxa9";
+      name = "kmplot-17.12.3.tar.xz";
     };
   };
   knavalbattle = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/knavalbattle-17.12.2.tar.xz";
-      sha256 = "0iil9kw7xhjq8ll93hcvcm9apigrys89nj7j2bpvs00208dcyv9c";
-      name = "knavalbattle-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/knavalbattle-17.12.3.tar.xz";
+      sha256 = "07z0h0h6fmd99x0kqjlwlkpxndypa2svdvmjv8vmwcdp45hik90f";
+      name = "knavalbattle-17.12.3.tar.xz";
     };
   };
   knetwalk = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/knetwalk-17.12.2.tar.xz";
-      sha256 = "0l98h7grhgddawbn9apm0zifxpdssdkp29cdrcyv025h72dhj5ih";
-      name = "knetwalk-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/knetwalk-17.12.3.tar.xz";
+      sha256 = "1iz819dsrdf5fck6qx0s4d0k7sz58pbxp5kk4aczszmvpnn2197k";
+      name = "knetwalk-17.12.3.tar.xz";
     };
   };
   knotes = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/knotes-17.12.2.tar.xz";
-      sha256 = "009mia832fxll0a5kl5n16zsy54jvvm9gr2zp4qy5xmimci48llj";
-      name = "knotes-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/knotes-17.12.3.tar.xz";
+      sha256 = "1iy6rmhlh7jgryxrwqrqaqaajfimdlqcw0x3yizbqalpw1k6f8m3";
+      name = "knotes-17.12.3.tar.xz";
     };
   };
   kolf = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kolf-17.12.2.tar.xz";
-      sha256 = "12zxqa88jsg4zf68ndw32gw7l6sjjzq6pkkj0a55wcwsdph59666";
-      name = "kolf-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kolf-17.12.3.tar.xz";
+      sha256 = "1zc1i36a302rpvv2lbfv8q8glh1brjk95mjkwxbplv8gmdbd71cj";
+      name = "kolf-17.12.3.tar.xz";
     };
   };
   kollision = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kollision-17.12.2.tar.xz";
-      sha256 = "1lzc0gih4lcw5dbrkkz0411al1xsjnqi1xzdwa2cijlka1py028g";
-      name = "kollision-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kollision-17.12.3.tar.xz";
+      sha256 = "019ibb9190k6qf07kgjy88lzyawvbh9hb7df96l96ilgssxxhnvz";
+      name = "kollision-17.12.3.tar.xz";
     };
   };
   kolourpaint = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kolourpaint-17.12.2.tar.xz";
-      sha256 = "0jd2r9jv0g1wrqvx7dwniv8an4miv3wjl3ym4rkczpdsjh3smc7c";
-      name = "kolourpaint-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kolourpaint-17.12.3.tar.xz";
+      sha256 = "15vd3ykixfkbwg3dk4plfpf72k2cknwpk6ip7rnw4h41r0rg838w";
+      name = "kolourpaint-17.12.3.tar.xz";
     };
   };
   kompare = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kompare-17.12.2.tar.xz";
-      sha256 = "0cww2zhvf97zya2wpmc9hyk1vp3za8r8xvxc0l4whcm33w0fwgc9";
-      name = "kompare-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kompare-17.12.3.tar.xz";
+      sha256 = "0kfrxwx2dnvbvy7ykm3dxm0873g2136jllakav8pxgf75z4iwryl";
+      name = "kompare-17.12.3.tar.xz";
     };
   };
   konqueror = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/konqueror-17.12.2.tar.xz";
-      sha256 = "08yyxkrc4rx8y166p8r871rs3b6gxq6fkrnfbg9j4n3387rpg64f";
-      name = "konqueror-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/konqueror-17.12.3.tar.xz";
+      sha256 = "0dhm22p4mx244pd2wnl7xxhkh4yc3dsl126ndmajj62i0si0y0hw";
+      name = "konqueror-17.12.3.tar.xz";
     };
   };
   konquest = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/konquest-17.12.2.tar.xz";
-      sha256 = "18c30b1z0jalkwcgdg6w5y4nl1j2iapp7588qk1zip3nfvgbdpky";
-      name = "konquest-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/konquest-17.12.3.tar.xz";
+      sha256 = "1jdwa4b9224x2m3r3v3sgk7796kvlayf7gjpsdvby0xggpihsqli";
+      name = "konquest-17.12.3.tar.xz";
     };
   };
   konsole = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/konsole-17.12.2.tar.xz";
-      sha256 = "1dbsmfqw0d1f0nhmhz61rhy6spcfvv54j7v05axjhh870wyfmrpc";
-      name = "konsole-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/konsole-17.12.3.tar.xz";
+      sha256 = "1g3c7wl10n5qhs5bnm1d92qsv7jh8gn3d1l0wivj29cn9b0rf2gs";
+      name = "konsole-17.12.3.tar.xz";
     };
   };
   kontact = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kontact-17.12.2.tar.xz";
-      sha256 = "0qn1iha7g6i85va7bvcagxjx3qk0g9lpaqikn2fvlz22sgv45a2q";
-      name = "kontact-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kontact-17.12.3.tar.xz";
+      sha256 = "0gik5h84mx3izdlml0sl1y68n7h9w8196h2l09lxnf10mmya3yas";
+      name = "kontact-17.12.3.tar.xz";
     };
   };
   kontactinterface = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kontactinterface-17.12.2.tar.xz";
-      sha256 = "044dys074cgahspx9h3bz8a807r5975b25pwjxwimr9vg4ln37d3";
-      name = "kontactinterface-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kontactinterface-17.12.3.tar.xz";
+      sha256 = "15nigzawl5rzd0s6l9xqv3sldah3wc9m6zd3avbsb3ydmi0f1hks";
+      name = "kontactinterface-17.12.3.tar.xz";
     };
   };
   korganizer = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/korganizer-17.12.2.tar.xz";
-      sha256 = "0ijw3dq0c21c11a4bhdpgd1ailamrhknim4bs4ix1fgriycwpz31";
-      name = "korganizer-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/korganizer-17.12.3.tar.xz";
+      sha256 = "0gplnra98ivhsqcrdy44ghak0h9x0fn481irqh2y11f8kjaf6z40";
+      name = "korganizer-17.12.3.tar.xz";
     };
   };
   kpat = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kpat-17.12.2.tar.xz";
-      sha256 = "1yy81rv29wfym74709hrz67ms6af408ni5dbnpwjniz86fx2jnxs";
-      name = "kpat-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kpat-17.12.3.tar.xz";
+      sha256 = "0nkqfnxrnik4ma7xrskqjsmcmbmxszyn9ckf3rql338d485h8awh";
+      name = "kpat-17.12.3.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kpimtextedit-17.12.2.tar.xz";
-      sha256 = "1bj3ccvccwg1x5px080w7c3adkjsl1z886bxdimdf84pdxj2fm65";
-      name = "kpimtextedit-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kpimtextedit-17.12.3.tar.xz";
+      sha256 = "0b6f1hsh3q183lkinaz9f94akaf1z2g1pb7sm83f6c4yjn9qfg9c";
+      name = "kpimtextedit-17.12.3.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kqtquickcharts-17.12.2.tar.xz";
-      sha256 = "05xsvc4ppncpjj0w5j7m5075ydxjnln8kjfd002c1m2a755brv5j";
-      name = "kqtquickcharts-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kqtquickcharts-17.12.3.tar.xz";
+      sha256 = "0gigdramz5kmjyzd7yff8j0c3sisblqy0xjc301hkhh7ss93r2d0";
+      name = "kqtquickcharts-17.12.3.tar.xz";
     };
   };
   krdc = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/krdc-17.12.2.tar.xz";
-      sha256 = "0m9ij015cs8qb1sbiysy27jrz070x9dkrbkrsqy3a2n9dkv7jjz0";
-      name = "krdc-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/krdc-17.12.3.tar.xz";
+      sha256 = "1flk8pvnr4kf273xzfxb7pcsam3mb056pbvmva1k864kbb6bzdps";
+      name = "krdc-17.12.3.tar.xz";
     };
   };
   kreversi = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kreversi-17.12.2.tar.xz";
-      sha256 = "1qx0lv85pn98wbaskk0ihg3zywwfj9p0l30jjq67my254qlbaqpk";
-      name = "kreversi-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kreversi-17.12.3.tar.xz";
+      sha256 = "1hmh80dpg25ay06dmd1g6a0a7zcd2di99s989msi85wzgk6vh0fg";
+      name = "kreversi-17.12.3.tar.xz";
     };
   };
   krfb = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/krfb-17.12.2.tar.xz";
-      sha256 = "1ggi0rmb0jx9pkqcvml5q6gxzzng5mdpyj8m9knknhmdx0y19k1b";
-      name = "krfb-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/krfb-17.12.3.tar.xz";
+      sha256 = "0anfcb1xsr638k3d3ljy9khbxf7v9sj5vbksyhfjrzsifj4m2skv";
+      name = "krfb-17.12.3.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kross-interpreters-17.12.2.tar.xz";
-      sha256 = "05fd5cbgh81qmffbkmn3zanlrdjdqcgyafcw4jxsfvqb556wdvzv";
-      name = "kross-interpreters-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kross-interpreters-17.12.3.tar.xz";
+      sha256 = "0v3ly21lc8riv4by87kjilab5zqd6wvwl92a983ybd5bivl1a98s";
+      name = "kross-interpreters-17.12.3.tar.xz";
     };
   };
   kruler = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kruler-17.12.2.tar.xz";
-      sha256 = "1j39vrd98p3bxa5kggmg3ccx4wrn8hvd100p0njkd54wagm9r2m7";
-      name = "kruler-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kruler-17.12.3.tar.xz";
+      sha256 = "0r12vwg9jsvg8bldrfdnmcygn6rkx9dp8r0948jhf662qs7a0jsa";
+      name = "kruler-17.12.3.tar.xz";
     };
   };
   kshisen = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kshisen-17.12.2.tar.xz";
-      sha256 = "02ihwa8zhaig97z14l3jx6c7swsm8aq5107n41h0z0lzf7sir47g";
-      name = "kshisen-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kshisen-17.12.3.tar.xz";
+      sha256 = "1an28mxgc1ic6acj3r59q9nnmq267fy6k48xzdxqdxhivs74bjx0";
+      name = "kshisen-17.12.3.tar.xz";
     };
   };
   ksirk = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ksirk-17.12.2.tar.xz";
-      sha256 = "049za390509m4gsmjybhidbq3p2qss47whwfmzcj6lpcxf0fsrja";
-      name = "ksirk-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ksirk-17.12.3.tar.xz";
+      sha256 = "07y300qk3jls8cscf0xxgq52gxmc4j5rkn2pxhxymm0yr07ip1xz";
+      name = "ksirk-17.12.3.tar.xz";
     };
   };
   ksmtp = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ksmtp-17.12.2.tar.xz";
-      sha256 = "0g6sjn5vkkwcdqjhpws86l5dhwilxrqqif50dndc2fyiak6x796n";
-      name = "ksmtp-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ksmtp-17.12.3.tar.xz";
+      sha256 = "1dws2jrizixi108mw1lgb7jz6dgs5xvvmj16bkf9x54rhvjb7r9b";
+      name = "ksmtp-17.12.3.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ksnakeduel-17.12.2.tar.xz";
-      sha256 = "1gqgw47im2sifxskhbgmg5rr6clvswcz81sinqffmjmpwgrabif7";
-      name = "ksnakeduel-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ksnakeduel-17.12.3.tar.xz";
+      sha256 = "0w4nw1pyznn4dkcqgf2d5c2r7z5xg5gc97whw1i67wqq9sbi98hy";
+      name = "ksnakeduel-17.12.3.tar.xz";
     };
   };
   kspaceduel = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kspaceduel-17.12.2.tar.xz";
-      sha256 = "13636n466yna04wga7f206gw1scnjr3w3x59hwi4mdr0sghz9a7i";
-      name = "kspaceduel-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kspaceduel-17.12.3.tar.xz";
+      sha256 = "13pqdb3f0zjnv71y93kha3wkq9kivl8g01sa5g9ydjmnxahzhqc6";
+      name = "kspaceduel-17.12.3.tar.xz";
     };
   };
   ksquares = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ksquares-17.12.2.tar.xz";
-      sha256 = "1csw9kns4b258k1hwcshw01bxbzfa1kclbd4w5fail1qp5xs7x7d";
-      name = "ksquares-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ksquares-17.12.3.tar.xz";
+      sha256 = "19cbmc2mnljlndijb11k9l67q2cmdd5yjsjwv61rawq25xwfh667";
+      name = "ksquares-17.12.3.tar.xz";
     };
   };
   ksudoku = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ksudoku-17.12.2.tar.xz";
-      sha256 = "0rwgzg0i8s4b7af2dhzccaklbg3rj0khyjsiawijw66p9gs9cczy";
-      name = "ksudoku-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ksudoku-17.12.3.tar.xz";
+      sha256 = "0c335klnzq4bf91c2iib3iqhx24nf264p86mypk2as2mbcr02j9n";
+      name = "ksudoku-17.12.3.tar.xz";
     };
   };
   ksystemlog = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ksystemlog-17.12.2.tar.xz";
-      sha256 = "1aw1m1kv3si3qqzhs5mdynmf2b8s2dpsjnb7h0c1l39kq7mbgc9i";
-      name = "ksystemlog-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ksystemlog-17.12.3.tar.xz";
+      sha256 = "0lnjdiwq3xlqi2lw0p9vj6fbqzmmqf0y6aivyxb7lbrjgjvh64lr";
+      name = "ksystemlog-17.12.3.tar.xz";
     };
   };
   kteatime = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kteatime-17.12.2.tar.xz";
-      sha256 = "13p1v7ic64rfff7md7f33xv9pl89sgjig35q78q31h5q42k6qzv9";
-      name = "kteatime-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kteatime-17.12.3.tar.xz";
+      sha256 = "0f7cf0p7cnmw6mpc3135wk9l2j63yfd2fz06vngnl0zdysf4iwfz";
+      name = "kteatime-17.12.3.tar.xz";
     };
   };
   ktimer = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktimer-17.12.2.tar.xz";
-      sha256 = "1263bsqz23064v7qnrz51nbbckld3d2vz80cm6z43vcis236bvh2";
-      name = "ktimer-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktimer-17.12.3.tar.xz";
+      sha256 = "1ghh3433wai87ifspvsvmjvamzminf9i73vbpf61ph5qgahx804x";
+      name = "ktimer-17.12.3.tar.xz";
     };
   };
   ktnef = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktnef-17.12.2.tar.xz";
-      sha256 = "05cj5lghqj8js0bd14w6kbpl29wslyh36yn57sdf5dfbgpnn9a7v";
-      name = "ktnef-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktnef-17.12.3.tar.xz";
+      sha256 = "13irgbcq6g363n65i92c2ciw35rxmq1x5hdlrdbidp718n44n84n";
+      name = "ktnef-17.12.3.tar.xz";
     };
   };
   ktouch = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktouch-17.12.2.tar.xz";
-      sha256 = "1jqc0i6n70vjy6ipgv4swnd8xp404d8frax6nfd4rv3gmn68l5q4";
-      name = "ktouch-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktouch-17.12.3.tar.xz";
+      sha256 = "04frgq9lyk51p66lv48pgk8b4f4jxh73fpr907dnwbsyqkg6l795";
+      name = "ktouch-17.12.3.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-accounts-kcm-17.12.2.tar.xz";
-      sha256 = "1qfq2sg2pzv2gkr87yb3r5j0xy0f1j56cxys8c1zijpglfy6a41z";
-      name = "ktp-accounts-kcm-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-accounts-kcm-17.12.3.tar.xz";
+      sha256 = "0fi3065yq38pn2x7r5a0fynbq7xyklbzvlp4gwr4bhg41fqm74hm";
+      name = "ktp-accounts-kcm-17.12.3.tar.xz";
     };
   };
   ktp-approver = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-approver-17.12.2.tar.xz";
-      sha256 = "0jhzazj42qigdbzjidpnkqlsndv3ias80ik033hzks6m22c20bz6";
-      name = "ktp-approver-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-approver-17.12.3.tar.xz";
+      sha256 = "06x1ycp5biapalf5yk0lh9wwda1mx5a4ssv1p3q9kb7f7v1i8wkp";
+      name = "ktp-approver-17.12.3.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-auth-handler-17.12.2.tar.xz";
-      sha256 = "0h81j79285k872wfyflabk6j4s3y7fi0nv41c9n6rnsdv91yvwpk";
-      name = "ktp-auth-handler-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-auth-handler-17.12.3.tar.xz";
+      sha256 = "03vha3rf7989wi47hn004g4m1lgi236in395yl4f2bl2h0qq1g21";
+      name = "ktp-auth-handler-17.12.3.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-call-ui-17.12.2.tar.xz";
-      sha256 = "1nh6a7gf3qp3vgw32rbh196ik5pzgad4z6lgrn59x36ssvcpmmd2";
-      name = "ktp-call-ui-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-call-ui-17.12.3.tar.xz";
+      sha256 = "0l85q8xykz0vj26yvcqcm3l6w84iada8hr32sn71151rv6palv0m";
+      name = "ktp-call-ui-17.12.3.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-common-internals-17.12.2.tar.xz";
-      sha256 = "18i311hnyd7lwvv6c08dk674w77q1sk3bggj5mp94r987507kns4";
-      name = "ktp-common-internals-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-common-internals-17.12.3.tar.xz";
+      sha256 = "0vzppfy2ik3j9aw2rzb272h8q57vv6z3pqycfwbsd4j751hccx80";
+      name = "ktp-common-internals-17.12.3.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-contact-list-17.12.2.tar.xz";
-      sha256 = "1fzw7mqk65ry16bpbrh9zp7rpcbdgjabcsw23xdz08dzl86gji24";
-      name = "ktp-contact-list-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-contact-list-17.12.3.tar.xz";
+      sha256 = "1clyfaabjjafmazw3gli10b00v0yb8m05bd6lwia7anslhs9pjfb";
+      name = "ktp-contact-list-17.12.3.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-contact-runner-17.12.2.tar.xz";
-      sha256 = "0qmwajxqhd2m2p9jnyqq5c8i1a02r8mc20limrikvg2m25cg8ii9";
-      name = "ktp-contact-runner-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-contact-runner-17.12.3.tar.xz";
+      sha256 = "0rj7l0dr0kqcijaxwq06chbmjb5xr12zcs02mjc08af5kc2girsq";
+      name = "ktp-contact-runner-17.12.3.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-desktop-applets-17.12.2.tar.xz";
-      sha256 = "02s5b2lgcsslr2zavijp457kngmdall03li9wlgg31kxyqwrycwc";
-      name = "ktp-desktop-applets-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-desktop-applets-17.12.3.tar.xz";
+      sha256 = "16n8gj6x9cbk9bbpdf8zchrjajpw0dh2n5vf2ngyhw59w3rlwisj";
+      name = "ktp-desktop-applets-17.12.3.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-filetransfer-handler-17.12.2.tar.xz";
-      sha256 = "1vc8w0aq16rfcwf48s3178y2qmz6r03bsdrgn2mkxscj8z4rv8j5";
-      name = "ktp-filetransfer-handler-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-filetransfer-handler-17.12.3.tar.xz";
+      sha256 = "1l2w39k9gmlnysphh4scc0krmxf0s9h1frj9blml9qfd8n92v5y8";
+      name = "ktp-filetransfer-handler-17.12.3.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-kded-module-17.12.2.tar.xz";
-      sha256 = "1is5l0ammvqqp4cz9hk9ra63rv5kphy58b1b1qh1vwdhbc74cdx6";
-      name = "ktp-kded-module-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-kded-module-17.12.3.tar.xz";
+      sha256 = "1752m9sr7mb7hgrbarr2vnllvd67n6c059i3k2ds4npajvcdszhp";
+      name = "ktp-kded-module-17.12.3.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-send-file-17.12.2.tar.xz";
-      sha256 = "13xq1slbr6qhjq135kxcxmv9lk5w68i6zkc47ffj76x40hdryh34";
-      name = "ktp-send-file-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-send-file-17.12.3.tar.xz";
+      sha256 = "02z13fy21v8yl3q164lw9265k3mw5mdhmr8f0dlpkx2x3mgdgjch";
+      name = "ktp-send-file-17.12.3.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktp-text-ui-17.12.2.tar.xz";
-      sha256 = "166ya2nggpljf591rvscd2gqbi8fbr2zq06v512clraawfzgbrqa";
-      name = "ktp-text-ui-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktp-text-ui-17.12.3.tar.xz";
+      sha256 = "0zhqhq7zq4xp44df77fms1jp14pfz1gdandblgcbyx55fqgkx38v";
+      name = "ktp-text-ui-17.12.3.tar.xz";
     };
   };
   ktuberling = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/ktuberling-17.12.2.tar.xz";
-      sha256 = "05h47my9f167gi811nzpdn6sdn0k7bdbr582rrm6j1gpjgay2d16";
-      name = "ktuberling-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/ktuberling-17.12.3.tar.xz";
+      sha256 = "1rqn9fzniyz3nnrjk6qjpbcs7m0gfnl2m671dgj87pwfsddicyr4";
+      name = "ktuberling-17.12.3.tar.xz";
     };
   };
   kturtle = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kturtle-17.12.2.tar.xz";
-      sha256 = "0xk3dpnld7f58b9p1hgcv6afvay1yhcm285jq22qa29wi2ckhk6m";
-      name = "kturtle-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kturtle-17.12.3.tar.xz";
+      sha256 = "1m7pppqy1c6kscy95hx284p0iinx00iafpihii8hl4bvvam2sws8";
+      name = "kturtle-17.12.3.tar.xz";
     };
   };
   kubrick = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kubrick-17.12.2.tar.xz";
-      sha256 = "0f5b3z91w4g8kl11wv43xn7n92dcfpmga51nw20wk4vsfmrwgpc9";
-      name = "kubrick-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kubrick-17.12.3.tar.xz";
+      sha256 = "0ls51xvkvxpr6pzpj67jmfbcwx7wrc9lyb149y59bmfbckc1cimp";
+      name = "kubrick-17.12.3.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kwalletmanager-17.12.2.tar.xz";
-      sha256 = "0aqdlm87hxw8d28jr9hhvpjcjs939595vxhg8p5bw5dzanj48zkv";
-      name = "kwalletmanager-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kwalletmanager-17.12.3.tar.xz";
+      sha256 = "1lwslsx15ymyssnwl9yam26j3m5153sjyc4cvv5sxflk5wghaad1";
+      name = "kwalletmanager-17.12.3.tar.xz";
     };
   };
   kwave = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kwave-17.12.2.tar.xz";
-      sha256 = "1l5mdy1qdzw3lmrmvylcjj4wc9xg6brcd7qd20fsanzfv7w8if6k";
-      name = "kwave-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kwave-17.12.3.tar.xz";
+      sha256 = "1wqhjdjc1cf1zjbgpxmiw60bxlxld7mikv1lkph750wygjkmnrng";
+      name = "kwave-17.12.3.tar.xz";
     };
   };
   kwordquiz = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/kwordquiz-17.12.2.tar.xz";
-      sha256 = "175cf0qvw7qiifbqbgsg036n125gqpbpw7v1qq81hfg8nl0zpy2h";
-      name = "kwordquiz-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/kwordquiz-17.12.3.tar.xz";
+      sha256 = "1w1z5hjg36jyzl247ff1xk4xhr49qhnkmcxhnyp8fsj5hq9in6xx";
+      name = "kwordquiz-17.12.3.tar.xz";
     };
   };
   libgravatar = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libgravatar-17.12.2.tar.xz";
-      sha256 = "1vps67mbjh31y7q19wr1km0n35drimc7gi4xyhfx17l8k87nrx7a";
-      name = "libgravatar-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libgravatar-17.12.3.tar.xz";
+      sha256 = "1862yzcmk1w9y1k83hkh749mhk9hlba7hdlsbbj8hmf3jb7hrczm";
+      name = "libgravatar-17.12.3.tar.xz";
     };
   };
   libkcddb = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkcddb-17.12.2.tar.xz";
-      sha256 = "1hqrpnfy5gzknvvcfmbp2axx4qbk0qkl47rmhr8gmpdvlkh33cny";
-      name = "libkcddb-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkcddb-17.12.3.tar.xz";
+      sha256 = "1qwizxb8y35qddiqvf0469gnjid2bc80dfnv4qixxs3ba094c2pi";
+      name = "libkcddb-17.12.3.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkcompactdisc-17.12.2.tar.xz";
-      sha256 = "12dcyxjr6b6i8zfk3i17ah0kc3x0d9ixy65wj3zw1gf4mmdzgpbk";
-      name = "libkcompactdisc-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkcompactdisc-17.12.3.tar.xz";
+      sha256 = "1brz12j45vfb4xixr3lhn9fs1hbf723kc46psdg24yghfmx5j28v";
+      name = "libkcompactdisc-17.12.3.tar.xz";
     };
   };
   libkdcraw = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkdcraw-17.12.2.tar.xz";
-      sha256 = "1qfzyy4952b2lc3619bbzqffvrphqsq16z89bxb4pn1ad796zn62";
-      name = "libkdcraw-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkdcraw-17.12.3.tar.xz";
+      sha256 = "11p25ldv3ry4khb52mfay85wlfbrsvk6f52yx8shzvbzxyzxf0nc";
+      name = "libkdcraw-17.12.3.tar.xz";
     };
   };
   libkdegames = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkdegames-17.12.2.tar.xz";
-      sha256 = "1v3a9240crfpjdwpbz0bdwv06572s99h80l53vf3zwmqw5yk05z4";
-      name = "libkdegames-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkdegames-17.12.3.tar.xz";
+      sha256 = "1kh1wpdajzd1i3j0kr79npzq4w41gisn27k8v26dq1wy727vy4kd";
+      name = "libkdegames-17.12.3.tar.xz";
     };
   };
   libkdepim = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkdepim-17.12.2.tar.xz";
-      sha256 = "069x28ia6d95rm1g3mr339v7rdvlmiz20y4kddp2acja53b0sagg";
-      name = "libkdepim-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkdepim-17.12.3.tar.xz";
+      sha256 = "0zz86mnz73jj78gdfh0s19wfypb0xwxsvjcijbkr340diri5862q";
+      name = "libkdepim-17.12.3.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkeduvocdocument-17.12.2.tar.xz";
-      sha256 = "1g4zldr9ys7ddxqfkkhlyqgq623q303011ifaraid5zpiql092qd";
-      name = "libkeduvocdocument-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkeduvocdocument-17.12.3.tar.xz";
+      sha256 = "0yqilmf61izbh44rsmspslnikawikxsq8nk8a4lvq9206yy6h11v";
+      name = "libkeduvocdocument-17.12.3.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkexiv2-17.12.2.tar.xz";
-      sha256 = "0jr9wpnl80xala60yz4zd5j9nd1bv56y688fldr5dxx25ljavn24";
-      name = "libkexiv2-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkexiv2-17.12.3.tar.xz";
+      sha256 = "1xzrq9dn4x8afsf21sxqbsz1sk2vzp2g1ri5d5rz4vd1gj0sk3lg";
+      name = "libkexiv2-17.12.3.tar.xz";
     };
   };
   libkgapi = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkgapi-17.12.2.tar.xz";
-      sha256 = "1vki4sxb7dzg202waqqyvjwsx8yhx8cfp2wk4b6p81hfaq8a1syd";
-      name = "libkgapi-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkgapi-17.12.3.tar.xz";
+      sha256 = "015g1l4fkc5j403f0hak03iz2qi62gx4wlldm59hi1vgqq1xfp1y";
+      name = "libkgapi-17.12.3.tar.xz";
     };
   };
   libkgeomap = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkgeomap-17.12.2.tar.xz";
-      sha256 = "1spq6g56ih6wlc2qasf3fkpkn7m4gsbn14p6ja60cr1gvf4p9j79";
-      name = "libkgeomap-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkgeomap-17.12.3.tar.xz";
+      sha256 = "1064yl3whr8g9qyirpgzvag2z4lal4qyljvlapfq3mpa3jxpcwdi";
+      name = "libkgeomap-17.12.3.tar.xz";
     };
   };
   libkipi = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkipi-17.12.2.tar.xz";
-      sha256 = "180yg24iqh02nkcv7jbvm10lr7z7qagapjh8zarpmh6r2s3c0nh5";
-      name = "libkipi-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkipi-17.12.3.tar.xz";
+      sha256 = "0qqvrg1nvzcrxjvm1grxzm0vk7s9j1kzf73dk41cmvgwv9wirlgq";
+      name = "libkipi-17.12.3.tar.xz";
     };
   };
   libkleo = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkleo-17.12.2.tar.xz";
-      sha256 = "00nlspwnh9nvxarm34y9hdis3af2zkjf2flla4qwks5nhl7fgi8g";
-      name = "libkleo-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkleo-17.12.3.tar.xz";
+      sha256 = "0pp72ba58vwl1m9i72gdghbk3r5sa0pm8y7q9hz4a5qv919iny2k";
+      name = "libkleo-17.12.3.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkmahjongg-17.12.2.tar.xz";
-      sha256 = "0l8krpiyzlsn9awp8za10n9qhbac8nf98jiz7dxzn4qpniv45px5";
-      name = "libkmahjongg-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkmahjongg-17.12.3.tar.xz";
+      sha256 = "10j9r8mb5x90zv91m32q0in2brqcwl3h7kv7lr6dqhd6jjmrx4gd";
+      name = "libkmahjongg-17.12.3.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libkomparediff2-17.12.2.tar.xz";
-      sha256 = "07is7vn9wrivxpyd4s19371ffylj2x3s5zi14y8zr778nq68wrzq";
-      name = "libkomparediff2-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libkomparediff2-17.12.3.tar.xz";
+      sha256 = "0w6p8lvm2rn7y4qz0x3s87lwh1758xnyhwkkkng55n8v9rpjjw7l";
+      name = "libkomparediff2-17.12.3.tar.xz";
     };
   };
   libksane = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libksane-17.12.2.tar.xz";
-      sha256 = "01d182hnrj6n8qmh85pkwmjdyhfy0n946zp40r9r6avh9ajrx5nd";
-      name = "libksane-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libksane-17.12.3.tar.xz";
+      sha256 = "1rnxywpljiw4fb6djlm486z98l5f7vlwca0i0q99rj17gkxlddk2";
+      name = "libksane-17.12.3.tar.xz";
     };
   };
   libksieve = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/libksieve-17.12.2.tar.xz";
-      sha256 = "1nfy96ykaxdm5h67bhykgdcmlidsjgvbsf52qs5f7j7iyl3w4nhr";
-      name = "libksieve-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/libksieve-17.12.3.tar.xz";
+      sha256 = "1cp1bfw2xd5fsnw5z061vfg8wbvv1bqk2lvcyvxgvm1im7892433";
+      name = "libksieve-17.12.3.tar.xz";
     };
   };
   lokalize = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/lokalize-17.12.2.tar.xz";
-      sha256 = "18nama2dafhp5v1lvxibm92cxwdldkxs778s948qnb7xh65mxvsb";
-      name = "lokalize-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/lokalize-17.12.3.tar.xz";
+      sha256 = "0n5f7myv45446kfpcaw7y278xsjxq5hnamfhc20h24m9pflp7bp9";
+      name = "lokalize-17.12.3.tar.xz";
     };
   };
   lskat = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/lskat-17.12.2.tar.xz";
-      sha256 = "0a4gch1krd7xpvxkscy7prsfb72dcg78alk4vz2z70nfn11zrzv3";
-      name = "lskat-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/lskat-17.12.3.tar.xz";
+      sha256 = "0n4kma0llqbgzcqsm7rb5rjidn8wlal9ay26041mic9hk51s3bm0";
+      name = "lskat-17.12.3.tar.xz";
     };
   };
   mailcommon = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/mailcommon-17.12.2.tar.xz";
-      sha256 = "0ikmbg91f4p7d4qb7nx05n5mlbmmcdwzgw0xvdsib7vkj5cfrxp2";
-      name = "mailcommon-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/mailcommon-17.12.3.tar.xz";
+      sha256 = "17m54i4a9kn8lmpj3b42q2q9gqrympl9z2lgbhsacmak9aqrv94f";
+      name = "mailcommon-17.12.3.tar.xz";
     };
   };
   mailimporter = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/mailimporter-17.12.2.tar.xz";
-      sha256 = "1p4dc7xwk6wx1j6xk3h5w5cnzm665pzrmc70v8l5898025i94ml5";
-      name = "mailimporter-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/mailimporter-17.12.3.tar.xz";
+      sha256 = "1q93lc98ak5kzz762ih906g0jj0vnib97x39sqq4awspy4a825pc";
+      name = "mailimporter-17.12.3.tar.xz";
     };
   };
   marble = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/marble-17.12.2.tar.xz";
-      sha256 = "1y6wbh571g2d8gzg9pwdbsc4a4bl67fmvnkf65acs182zfc2x7jy";
-      name = "marble-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/marble-17.12.3.tar.xz";
+      sha256 = "1pgqnvdmx7s33m2wyz73lwlpbjh9qfc3aqk532lznz3ncc54n07i";
+      name = "marble-17.12.3.tar.xz";
     };
   };
   mbox-importer = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/mbox-importer-17.12.2.tar.xz";
-      sha256 = "0f1zvp31m6i20jd7xi9hxks8759mvbsj57r2nciwhc47r3m9wi3l";
-      name = "mbox-importer-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/mbox-importer-17.12.3.tar.xz";
+      sha256 = "16gkjgqjh91kx2rgjz4idm888q6fxycqdmwy6bmks825260426rp";
+      name = "mbox-importer-17.12.3.tar.xz";
     };
   };
   messagelib = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/messagelib-17.12.2.tar.xz";
-      sha256 = "17fayacl3m7p0w0rf724fhdm287dz8n03pyliapsxybldgp2rlaz";
-      name = "messagelib-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/messagelib-17.12.3.tar.xz";
+      sha256 = "1pmdzyd8jka9wrflzv7lrr03nqf4r4vli2imhmg5hhjknn2b0ald";
+      name = "messagelib-17.12.3.tar.xz";
     };
   };
   minuet = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/minuet-17.12.2.tar.xz";
-      sha256 = "17gwnh0bd2a7fvxbjhwadh0gvb0zly71lwv8znkb18dwsyd38v3r";
-      name = "minuet-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/minuet-17.12.3.tar.xz";
+      sha256 = "1ahrcpkbs49kyhq0l5fcacn49pqfczy1b9zvydxmld5kxlpz7w8b";
+      name = "minuet-17.12.3.tar.xz";
     };
   };
   okteta = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/okteta-17.12.2.tar.xz";
-      sha256 = "1k4b2m5pvrv1zxvm6pwmkl0ahh0ynkssa8z1v51a3hxlvw593b4d";
-      name = "okteta-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/okteta-17.12.3.tar.xz";
+      sha256 = "03wsv83l1cay2dpcsksad124wzan7kh8zxdw1h0yicn398kdbck4";
+      name = "okteta-17.12.3.tar.xz";
     };
   };
   okular = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/okular-17.12.2.tar.xz";
-      sha256 = "10rkrwp3rwccvqsw7njcmggw3jkj84fb90vkvqp8k2lmhnrz1ypx";
-      name = "okular-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/okular-17.12.3.tar.xz";
+      sha256 = "0786kr75ly0h2jwabhzz3fc15swn8n90g1w3l27kphch5nf584ha";
+      name = "okular-17.12.3.tar.xz";
     };
   };
   palapeli = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/palapeli-17.12.2.tar.xz";
-      sha256 = "0j9b4a6x3bp9bki2p79ksn86l16niixa2x8xx24vdnd9y71lp2yb";
-      name = "palapeli-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/palapeli-17.12.3.tar.xz";
+      sha256 = "11kjj85axc7l1l1ip0gcf5p7f7g9rfwyn476wz25prsr2g2ijgln";
+      name = "palapeli-17.12.3.tar.xz";
     };
   };
   parley = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/parley-17.12.2.tar.xz";
-      sha256 = "0kqvj1gwsv9kdac0zsv6cda34h8qx8xr43mgwk343c8pcwm1r2r5";
-      name = "parley-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/parley-17.12.3.tar.xz";
+      sha256 = "0swb7371vz9cxr2588hgcdxa5bmdb9n7h1yvmw28fbzgz98ax7g6";
+      name = "parley-17.12.3.tar.xz";
     };
   };
   picmi = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/picmi-17.12.2.tar.xz";
-      sha256 = "0ry4vvspa2mdvxrxvbqihkdh7qvsxhl9v7i07ycx3qs7sybf1rx4";
-      name = "picmi-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/picmi-17.12.3.tar.xz";
+      sha256 = "04cza4rvgzzvrzzw27n74k7kiwm7amcg12k97fr1rvlpd5irh2vn";
+      name = "picmi-17.12.3.tar.xz";
     };
   };
   pimcommon = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/pimcommon-17.12.2.tar.xz";
-      sha256 = "0frgn2shd2qzf4rbix9k4psy81b2yzsyy0sisy0ngc68gk5mdj8a";
-      name = "pimcommon-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/pimcommon-17.12.3.tar.xz";
+      sha256 = "1yav8flw6rf5qdwgys3zkmijp81p56hwn6cd71ckfzdrjm11kikq";
+      name = "pimcommon-17.12.3.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/pim-data-exporter-17.12.2.tar.xz";
-      sha256 = "1fbpz4sw4gn01yc7vzlj9v15wp3b6acbcd6xs9nsp3bfpb9mqd16";
-      name = "pim-data-exporter-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/pim-data-exporter-17.12.3.tar.xz";
+      sha256 = "0j5ynb0y602lnl571i247dbxna7xjqfphl7bcfqmg09ipjhxvk5b";
+      name = "pim-data-exporter-17.12.3.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/pim-sieve-editor-17.12.2.tar.xz";
-      sha256 = "1jwjgywqp23c17g08c18ajbl2dzq3h9vm94bmbjcan64isd03jr4";
-      name = "pim-sieve-editor-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/pim-sieve-editor-17.12.3.tar.xz";
+      sha256 = "0bkd5qsrabwg5imnif8z0hvhsk00a2n23238f9y14g963bhyw4pp";
+      name = "pim-sieve-editor-17.12.3.tar.xz";
     };
   };
   poxml = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/poxml-17.12.2.tar.xz";
-      sha256 = "0amb095qjv8d22ny86rs6wj280b2ag2zpk7bzs5834m75wlmpg6w";
-      name = "poxml-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/poxml-17.12.3.tar.xz";
+      sha256 = "0r8wm2x13ayb3mi69c35plvwzw7r9525idk3indsxc0rhv5qkhfp";
+      name = "poxml-17.12.3.tar.xz";
     };
   };
   print-manager = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/print-manager-17.12.2.tar.xz";
-      sha256 = "0sz7xqcjc5ddxkc7gbl1h673ywp3ffhmx985jzpd296n6sjppc2v";
-      name = "print-manager-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/print-manager-17.12.3.tar.xz";
+      sha256 = "0w1snq5ca7hza3x4gp17skia6g8yvarn9g3qacfwp13vad4v8zj7";
+      name = "print-manager-17.12.3.tar.xz";
     };
   };
   rocs = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/rocs-17.12.2.tar.xz";
-      sha256 = "08flyrla2kqkdc94hd8w2inzmnmzvczcgwl9hzqxxzf3fsjnnfdl";
-      name = "rocs-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/rocs-17.12.3.tar.xz";
+      sha256 = "1dfg0klvix2mgnvw3dkh13694iac5jf0jk8rm9ssxcaljvix7h46";
+      name = "rocs-17.12.3.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/signon-kwallet-extension-17.12.2.tar.xz";
-      sha256 = "06l1mynl7wp1r3gmy5919dm0p19p23harsh6qwdvbi9lffy7ascp";
-      name = "signon-kwallet-extension-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/signon-kwallet-extension-17.12.3.tar.xz";
+      sha256 = "0r9whz7p6v9wgbycdxzgxfm1ngxhjk4dzir5k5fqvmb6wrg05v4m";
+      name = "signon-kwallet-extension-17.12.3.tar.xz";
     };
   };
   spectacle = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/spectacle-17.12.2.tar.xz";
-      sha256 = "0qhhnpdk4rqzpg3npj183nl7k1n4mvhcb97hydwaq51yh51r4gvj";
-      name = "spectacle-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/spectacle-17.12.3.tar.xz";
+      sha256 = "12g976ys2ga88n0a45zqkai28bmxw0vxy2qlgdmx7mxvkpwlccyr";
+      name = "spectacle-17.12.3.tar.xz";
     };
   };
   step = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/step-17.12.2.tar.xz";
-      sha256 = "1n9gd2sq2lvfmgvjdb8yn5g25j58jcb24qh8l41k1y0hgcbaxly7";
-      name = "step-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/step-17.12.3.tar.xz";
+      sha256 = "161r0abz18s32xpn8x2j5diwb6p4hggvlnv7p9yk1z3qm3fyj46v";
+      name = "step-17.12.3.tar.xz";
     };
   };
   svgpart = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/svgpart-17.12.2.tar.xz";
-      sha256 = "1d7yrpnxc3sm3381fd9m3fiipi664vl8cz2li8dlw2y4pbgpx28g";
-      name = "svgpart-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/svgpart-17.12.3.tar.xz";
+      sha256 = "1rcfdkpinqdbz7js7p9h0lxmnvln4y95af1icq2871w7mg4fzsf5";
+      name = "svgpart-17.12.3.tar.xz";
     };
   };
   sweeper = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/sweeper-17.12.2.tar.xz";
-      sha256 = "1qi4kfd4p8xnykv3zn3sqkx4b605mwbnr6m9l6cr0v26c01yjq3k";
-      name = "sweeper-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/sweeper-17.12.3.tar.xz";
+      sha256 = "1pwjv4knj0by0sn8j788cxg3sl3vm0gql49yv47bansrvs458n4x";
+      name = "sweeper-17.12.3.tar.xz";
     };
   };
   syndication = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/syndication-17.12.2.tar.xz";
-      sha256 = "1hcdk0apdrppfrjyfjm4cn0iyb1yrf7zq2wb2ipmxzca1hfgw4c0";
-      name = "syndication-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/syndication-17.12.3.tar.xz";
+      sha256 = "1bq220ir09sszj31xi8sk116k9xkhkmnmahigc73qc3hvgq0x808";
+      name = "syndication-17.12.3.tar.xz";
     };
   };
   umbrello = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/umbrello-17.12.2.tar.xz";
-      sha256 = "1sm0drfsyyslls5n66mvjy2knbwykws34g74c6rn1mmmdpyp7b94";
-      name = "umbrello-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/umbrello-17.12.3.tar.xz";
+      sha256 = "0j3qwisq9aqvgpqx54jd4idspbgvl72xffb8qn3wwyky9jpnmhr0";
+      name = "umbrello-17.12.3.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "17.12.2";
+    version = "17.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/17.12.2/src/zeroconf-ioslave-17.12.2.tar.xz";
-      sha256 = "09p55dmrsi8jyvs793ya2xzfbhm6f6gwg8ldri15v9n3if7crpzx";
-      name = "zeroconf-ioslave-17.12.2.tar.xz";
+      url = "${mirror}/stable/applications/17.12.3/src/zeroconf-ioslave-17.12.3.tar.xz";
+      sha256 = "1glhci1vivkx3nvk6zwf2z09dii81vr5lcp3xf0aafl4p1vlxi3i";
+      name = "zeroconf-ioslave-17.12.3.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I could not run `nox-review`as it always crash (the error was something with the garbage collector of nix) :(

@ttuegel @adisbladis @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

