### PR TITLE
plasma5: 5.12.2 -> 5.12.3

### DIFF
--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.12.2/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.12.3/ -A '*.tar.xz' )

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -3,355 +3,355 @@
 
 {
   bluedevil = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/bluedevil-5.12.2.tar.xz";
-      sha256 = "11xwyawcfkxhdzcgj4nkj1vlp6zn53k9dl3c4llpj1z08jc2vdpj";
-      name = "bluedevil-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/bluedevil-5.12.3.tar.xz";
+      sha256 = "1vzdj2byxrsnxg1hkw8fhjnmxazypb8x6nplfi2wpjbm0inpv0gk";
+      name = "bluedevil-5.12.3.tar.xz";
     };
   };
   breeze = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/breeze-5.12.2.tar.xz";
-      sha256 = "1vx03wi4m6ly6sw7cznhzg96rkxbn2mxsn9719pra616axl6c00s";
-      name = "breeze-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/breeze-5.12.3.tar.xz";
+      sha256 = "0mknaxcgr51wbv43hhlplxmvi8k7xk73ns3ld86djj3mpa9cxfhw";
+      name = "breeze-5.12.3.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/breeze-grub-5.12.2.tar.xz";
-      sha256 = "1a76xbnrbd18cd6p0n94fixc7jmd8vdnzqbi9pbi3wj82cpp95xq";
-      name = "breeze-grub-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/breeze-grub-5.12.3.tar.xz";
+      sha256 = "1fh26sywr9cawywndw16zhdhs6pz9bfx0i9j0x1v7nbbnz0qam2b";
+      name = "breeze-grub-5.12.3.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/breeze-gtk-5.12.2.tar.xz";
-      sha256 = "1811r8gqhrdf5b4a1k94cid1whcd8g6h2mrms6qm40brzj8qn9w0";
-      name = "breeze-gtk-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/breeze-gtk-5.12.3.tar.xz";
+      sha256 = "0nw1d62fd74m9dsvnvy25bcd1y08fv3c51jnp06b3p1yljx8gw8x";
+      name = "breeze-gtk-5.12.3.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/breeze-plymouth-5.12.2.tar.xz";
-      sha256 = "1n96iysljakhhkw9wavhbvj29zlkkajgwpxs6v5ny4iifv9gn3cv";
-      name = "breeze-plymouth-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/breeze-plymouth-5.12.3.tar.xz";
+      sha256 = "15px5iw237lb27ms70w8vcm1kqf5k5wmyqkxqdd70x8aqrqzf9zn";
+      name = "breeze-plymouth-5.12.3.tar.xz";
     };
   };
   discover = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/discover-5.12.2.tar.xz";
-      sha256 = "1hkbannyrw1c6h45c8s669d4hg6irc991hjlg0mm31lnpa8lb51v";
-      name = "discover-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/discover-5.12.3.tar.xz";
+      sha256 = "132hbrnpr416yyzl8yh1d66j6j8h7paxw1lx2dm6fpyd0nf8zkdd";
+      name = "discover-5.12.3.tar.xz";
     };
   };
   drkonqi = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/drkonqi-5.12.2.tar.xz";
-      sha256 = "0dw9axkhp0cgw276cpfp4ddf5g9s2ccz6q43pk68fvphbz7m2wqm";
-      name = "drkonqi-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/drkonqi-5.12.3.tar.xz";
+      sha256 = "0vc5q9g9chwsbbg98mg0mnxcfva7dm9qgcpwxv5v0qdlddzm6m7m";
+      name = "drkonqi-5.12.3.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kactivitymanagerd-5.12.2.tar.xz";
-      sha256 = "1l6ar094y272fjxzj6qpapz4g5mfbf82z80zygmrs0cizpz1xv84";
-      name = "kactivitymanagerd-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kactivitymanagerd-5.12.3.tar.xz";
+      sha256 = "0fmr8n4s4qbfvrg0nmxl0rdl07rsy4l76idramn85rfbplv4nqr1";
+      name = "kactivitymanagerd-5.12.3.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kde-cli-tools-5.12.2.tar.xz";
-      sha256 = "1jd7r49i24psrx59n0djbbxbv8c3wchiabgrv4x4dq6nsqygh6vc";
-      name = "kde-cli-tools-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kde-cli-tools-5.12.3.tar.xz";
+      sha256 = "0d2mkrpy2pib0za75m2mg6pvkklbwizh14cqi3zabqi384fys1j3";
+      name = "kde-cli-tools-5.12.3.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kdecoration-5.12.2.tar.xz";
-      sha256 = "1whngfld0nlw3mbf70khvqiqqskfglnn3dzx5zg0l14xv0kips79";
-      name = "kdecoration-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kdecoration-5.12.3.tar.xz";
+      sha256 = "1xsjq8aw8r4yl5wpr0alihfaf6r146x4rz7p8k635n771b25ilsy";
+      name = "kdecoration-5.12.3.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kde-gtk-config-5.12.2.tar.xz";
-      sha256 = "1ncyj665hra8bj4nk2idpjq0lm72dr3r467ddx6k0n63arvfmxm4";
-      name = "kde-gtk-config-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kde-gtk-config-5.12.3.tar.xz";
+      sha256 = "0wsxz5v585srkn8qbb4b82ci1wgrpzg87krixzsxzd3k0wc0c71q";
+      name = "kde-gtk-config-5.12.3.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kdeplasma-addons-5.12.2.tar.xz";
-      sha256 = "00x0jd8jw77fh5qy5z9xldw3m27il9mamq0fl8f4vmny7y8hqg2k";
-      name = "kdeplasma-addons-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kdeplasma-addons-5.12.3.tar.xz";
+      sha256 = "06g61flgszaks5p9xrlnyjkdyfddyxrgv0vyf85h78wvydxca18p";
+      name = "kdeplasma-addons-5.12.3.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kgamma5-5.12.2.tar.xz";
-      sha256 = "1xhn8dw0595f48qbvj304agkg34y2pr0czvkpl1ahhzsndgjkxjs";
-      name = "kgamma5-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kgamma5-5.12.3.tar.xz";
+      sha256 = "0nvv4fg2hjxxmkjr1yrwsywgcm2y8w7xng928kisgaarf55dfmvm";
+      name = "kgamma5-5.12.3.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/khotkeys-5.12.2.tar.xz";
-      sha256 = "1hsnasx67vf0jdxnmlvhm86ykvjc89zbr8rdgr1ixq6iy543c1ry";
-      name = "khotkeys-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/khotkeys-5.12.3.tar.xz";
+      sha256 = "1sx3g6pk23lwpc7x2a90vakb4vlmr3lzmhy86iq07r0kbp6fz3wa";
+      name = "khotkeys-5.12.3.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kinfocenter-5.12.2.tar.xz";
-      sha256 = "0sagy72x94nv1zxvllkzgmln2j04bh8cib4fx3zsqfn572wncjqi";
-      name = "kinfocenter-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kinfocenter-5.12.3.tar.xz";
+      sha256 = "0l9mfxylcf9rmq3yih7gp43vxy8j9rfgniml831prax5kcqgk3yr";
+      name = "kinfocenter-5.12.3.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kmenuedit-5.12.2.tar.xz";
-      sha256 = "1ygwv1s9zgd6qh3gd7537dgjil8h3i21i5wwn99wynbifq0w6ikv";
-      name = "kmenuedit-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kmenuedit-5.12.3.tar.xz";
+      sha256 = "1x60z8g1lphsjmsrf6j3br0nx5ip6rk8f8g4r1xmbczgpnyzsqr4";
+      name = "kmenuedit-5.12.3.tar.xz";
     };
   };
   kscreen = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kscreen-5.12.2.tar.xz";
-      sha256 = "1scmaydn4fypjizfm7l71vszx725vgbgsg7hpnv2dgwqrf98kl9v";
-      name = "kscreen-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kscreen-5.12.3.tar.xz";
+      sha256 = "1azgvl7zx98a4jlqdb3w2h3951kg05l5lgz2bqfss5npm2kddis9";
+      name = "kscreen-5.12.3.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kscreenlocker-5.12.2.tar.xz";
-      sha256 = "0v8qyjkmaxq711dw1iw12j38aswfr4qccvzkm3qc1gvfjs1vl0gn";
-      name = "kscreenlocker-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kscreenlocker-5.12.3.tar.xz";
+      sha256 = "1incnja96342wdyqyayn4kyk5fhmyvg7r13pszcc9a5gx937n2dm";
+      name = "kscreenlocker-5.12.3.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/ksshaskpass-5.12.2.tar.xz";
-      sha256 = "1b70jbdm3c4agk66v5yvzvzdlwp0xn8lmxn3zyk1n280xgqr2z1m";
-      name = "ksshaskpass-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/ksshaskpass-5.12.3.tar.xz";
+      sha256 = "11wgb311pi1mxhy1xiylg5y3blyl234gcyfdn0xivmrgjn1kzg7h";
+      name = "ksshaskpass-5.12.3.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/ksysguard-5.12.2.tar.xz";
-      sha256 = "0k8ziqbvm8igczij3a26jyc0i7hwiqfv0072kywz76m9pfsd3lp7";
-      name = "ksysguard-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/ksysguard-5.12.3.tar.xz";
+      sha256 = "0w7yz7qwfz3hy0vg95rv09c4yzw7g90hm9a0jzz3prdm1sicsvbc";
+      name = "ksysguard-5.12.3.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kwallet-pam-5.12.2.tar.xz";
-      sha256 = "0xg01iianf0ygpjf971i3fln0gn44gw83gxhplwjv3q5dn79plrd";
-      name = "kwallet-pam-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kwallet-pam-5.12.3.tar.xz";
+      sha256 = "106dyl7w1b29351kzmgh5fjvy06yf6ab26x5p0aj7di2ymai9cqz";
+      name = "kwallet-pam-5.12.3.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kwayland-integration-5.12.2.tar.xz";
-      sha256 = "1s4vdsv8s72nplmk9395zfsp4fars14n2rkgqfp95b7ii76519nn";
-      name = "kwayland-integration-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kwayland-integration-5.12.3.tar.xz";
+      sha256 = "0cx1dnds4wr5fm2kbc7mlkpq82pzhq59jgij273lr6y656drxxdi";
+      name = "kwayland-integration-5.12.3.tar.xz";
     };
   };
   kwin = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kwin-5.12.2.tar.xz";
-      sha256 = "0lnyikmjsxjjbz7mrf421y1lw0vjqsri66dsjv2wldlbgifp94kw";
-      name = "kwin-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kwin-5.12.3.tar.xz";
+      sha256 = "0xsqiqnvk1gxrgik2cpqmzyl3q3ncr58r5p0xbyzqsybqz1jys71";
+      name = "kwin-5.12.3.tar.xz";
     };
   };
   kwrited = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/kwrited-5.12.2.tar.xz";
-      sha256 = "1n20g92h2hgcgp9qdxifp55acbkgh09chqz0p8qrj39vw5w5abv4";
-      name = "kwrited-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/kwrited-5.12.3.tar.xz";
+      sha256 = "1yhx94wdf19k2qaym7d89xj03rs6br2mk6z64nkw70d8i01vlax1";
+      name = "kwrited-5.12.3.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/libkscreen-5.12.2.tar.xz";
-      sha256 = "1hv180ac97m1i47c2bapv5bz149i8p55qyfxrka7fivhzszsa8x0";
-      name = "libkscreen-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/libkscreen-5.12.3.tar.xz";
+      sha256 = "09pg4fnzyklhgkgqrwqpc0kb4siiyz67mq2lyk5h50gmys4l48b4";
+      name = "libkscreen-5.12.3.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/libksysguard-5.12.2.tar.xz";
-      sha256 = "1nf847lwx88f8g0bknaxzn0q6cvs2xn1cz6ch7qrblg0a8v3ig19";
-      name = "libksysguard-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/libksysguard-5.12.3.tar.xz";
+      sha256 = "06lg3sd8h3wya9ss3cii9fsn4r4al2vqa0m0zb68s2l5340mcy7l";
+      name = "libksysguard-5.12.3.tar.xz";
     };
   };
   milou = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/milou-5.12.2.tar.xz";
-      sha256 = "1sick71qd04shs34nlsplln3zpgvrbal4jlklm4k094w487fvcc8";
-      name = "milou-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/milou-5.12.3.tar.xz";
+      sha256 = "0ywa8yvblc07mzmrzhrmsgdygzxdq6c3nnd7ayw68iil8886r7wq";
+      name = "milou-5.12.3.tar.xz";
     };
   };
   oxygen = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/oxygen-5.12.2.tar.xz";
-      sha256 = "03g0pwk5n6idgrrm0g4hfvyls7h8by6lz6rp7h1i9ibpaph3czmy";
-      name = "oxygen-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/oxygen-5.12.3.tar.xz";
+      sha256 = "1fcp3swa7b8qk2zzvs9nxjp0100hgpxc4av39rvvw0d2m647k856";
+      name = "oxygen-5.12.3.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-desktop-5.12.2.tar.xz";
-      sha256 = "0wymhk1wzvx3ihq7gn4zkisp5x1n5m62fk1vmg5il75hn69qw4g5";
-      name = "plasma-desktop-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-desktop-5.12.3.tar.xz";
+      sha256 = "1mz20r7cc7mn1ay7dkz6sikhadnk2dsxf5y6ijlpan7mp3ljlsq8";
+      name = "plasma-desktop-5.12.3.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-integration-5.12.2.tar.xz";
-      sha256 = "0hyxn51vjdbkw9kj5nqp7lr1myjpnlp5ri01jwg43v5h44mq6k08";
-      name = "plasma-integration-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-integration-5.12.3.tar.xz";
+      sha256 = "0q9kgfsa530qkjari4zw6bxrk7127v6gpirs76phw9lphpqbvgww";
+      name = "plasma-integration-5.12.3.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-nm-5.12.2.tar.xz";
-      sha256 = "0wlp0wqbcbnmclfvhii50sds1ij4la3wni9987xym7qrc8bxm43x";
-      name = "plasma-nm-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-nm-5.12.3.tar.xz";
+      sha256 = "143xma5i5qpfzg727pixvjgwcczj6zi0jwyibd05qmpbcyy09c9w";
+      name = "plasma-nm-5.12.3.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-pa-5.12.2.tar.xz";
-      sha256 = "119gcgx8rrihhmxzfp7wj3v8q4vwzk989w9qn5b2y72vyvllbln7";
-      name = "plasma-pa-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-pa-5.12.3.tar.xz";
+      sha256 = "0jlx07isw63nw2dfvn4sbv8j0az8bw62j7wp2mhxnwn5g6afci2l";
+      name = "plasma-pa-5.12.3.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-sdk-5.12.2.tar.xz";
-      sha256 = "0as3718rkcal8va6w1ip2prsvrp6b218r33hmhdkdbbshnx40csv";
-      name = "plasma-sdk-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-sdk-5.12.3.tar.xz";
+      sha256 = "0hla9vi4yp79fmv06w89974fxzsfxnxfad4iyhpqpsrp3g004qli";
+      name = "plasma-sdk-5.12.3.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-tests-5.12.2.tar.xz";
-      sha256 = "1336kj277hrbgi5dx6z19dp8fgxhifnapd0jas4lq8z06gn6dh40";
-      name = "plasma-tests-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-tests-5.12.3.tar.xz";
+      sha256 = "1025prmvwlx5id14243m14hmz626nbpzn98q25i1nagmj2whw4w7";
+      name = "plasma-tests-5.12.3.tar.xz";
     };
   };
   plasma-vault = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-vault-5.12.2.tar.xz";
-      sha256 = "1hkdaxlr00s00ax0xm2zmfk9pwl4nrs1x2dna248s6dd06cjmapk";
-      name = "plasma-vault-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-vault-5.12.3.tar.xz";
+      sha256 = "0a9cqfvxjzcgka786s9arz3zahl2qpj6qkh5vdxpf6akvcffw70h";
+      name = "plasma-vault-5.12.3.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-workspace-5.12.2.tar.xz";
-      sha256 = "1v4xaviby76c833gx02s1bf0hk9smv4m2s8sp75yxirh2xv4azid";
-      name = "plasma-workspace-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-workspace-5.12.3.tar.xz";
+      sha256 = "0br36qyd7w7cgd6fzw1iai06mfzyvsf94qyip008h68j92wznfcy";
+      name = "plasma-workspace-5.12.3.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plasma-workspace-wallpapers-5.12.2.tar.xz";
-      sha256 = "1x6qi0cpr461vc7gn4fzz9dh9wfwz6hcgb8dsz82wdxpwssck7i7";
-      name = "plasma-workspace-wallpapers-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plasma-workspace-wallpapers-5.12.3.tar.xz";
+      sha256 = "0gmpf0d7dzpnmm9lzgjqmr201mjkvjwbf0qlg5n87w7j9j4c580v";
+      name = "plasma-workspace-wallpapers-5.12.3.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/plymouth-kcm-5.12.2.tar.xz";
-      sha256 = "11kaprbcsd7j1kamsr9m9c27rj1ry8gxp1m6r1ibf9agimsmdfcb";
-      name = "plymouth-kcm-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/plymouth-kcm-5.12.3.tar.xz";
+      sha256 = "1zqmlmzrxmvm49mj33wj51q83j15rq8a6v3xmv7fr55gsfh9hmpk";
+      name = "plymouth-kcm-5.12.3.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.12.2";
+    version = "1-5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/polkit-kde-agent-1-5.12.2.tar.xz";
-      sha256 = "176wb8sh9r4f1ij604x52w4q5nbhmnqwxid3w107cqwpydnh0dm9";
-      name = "polkit-kde-agent-1-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/polkit-kde-agent-1-5.12.3.tar.xz";
+      sha256 = "0kb2ijjfqncrw02lrkh6jw2g2rps7aqs7v20gjdam9sacmnwy5j0";
+      name = "polkit-kde-agent-1-5.12.3.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/powerdevil-5.12.2.tar.xz";
-      sha256 = "0b9m3jm0ar84b2ln1ml5lk26nryrrlis7kj46whzqicwpdi7dpxw";
-      name = "powerdevil-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/powerdevil-5.12.3.tar.xz";
+      sha256 = "1xj6d4b3iam0xpv27506k11qyh9bwafq4vlwah6bla944cvza484";
+      name = "powerdevil-5.12.3.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/sddm-kcm-5.12.2.tar.xz";
-      sha256 = "0nh8kviqn43zh6kdqzfcqksp48k1brd8bg4kni2cbmzif6md3ay3";
-      name = "sddm-kcm-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/sddm-kcm-5.12.3.tar.xz";
+      sha256 = "1fd3ski6pnz6lba2zwvwqnxrszsn5505gnxbs15wc7zk6avf2hp2";
+      name = "sddm-kcm-5.12.3.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/systemsettings-5.12.2.tar.xz";
-      sha256 = "06cfxydpcnzi5g6ipi7sgiswgrzhnksgyhsp56zgqdswbilanp4n";
-      name = "systemsettings-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/systemsettings-5.12.3.tar.xz";
+      sha256 = "05l3yl27577567apmbiw884qkbrlgjzwz93s26va76apqn71vali";
+      name = "systemsettings-5.12.3.tar.xz";
     };
   };
   user-manager = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/user-manager-5.12.2.tar.xz";
-      sha256 = "047bssxfs8z1lhg25f263fq05w6m22mdk5i16ji5i11n26v8hdwa";
-      name = "user-manager-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/user-manager-5.12.3.tar.xz";
+      sha256 = "11glncc24qna9v6mjz7rgv18nrx90bhmfamlf07n3fziz9fmxvkh";
+      name = "user-manager-5.12.3.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.12.2";
+    version = "5.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.12.2/xdg-desktop-portal-kde-5.12.2.tar.xz";
-      sha256 = "1gr07p281icc2v7cv3n6rzi1c70ddkwiw12n9klk3sxprjxmc0pm";
-      name = "xdg-desktop-portal-kde-5.12.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.12.3/xdg-desktop-portal-kde-5.12.3.tar.xz";
+      sha256 = "0swy8kcczvs2ariyjrkln6mvc0xqrjznpkhw5gzyh61v3hpddgk9";
+      name = "xdg-desktop-portal-kde-5.12.3.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I could not run `nox-review`as it always crash (the error was something with the garbage collector of nix) :(

@ttuegel @adisbladis @peterhoeg 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

