### PR TITLE
clingo: fix URL

### DIFF
--- a/pkgs/applications/science/logic/potassco/clingo.nix
+++ b/pkgs/applications/science/logic/potassco/clingo.nix
@@ -1,12 +1,13 @@
-{stdenv, fetchurl, cmake}:
+{ stdenv, fetchzip, cmake }:
+
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "clingo";
   version = "5.2.2";
 
-  src = fetchurl {
-    url = "https://github.com/potassco/clingo/releases/v${version}.tar.gz";
-    sha256 = "1kxzb385g8p9mqm1x9wvjrigifa09w6vj0wl7kradibm5qagh7ns";
+  src = fetchzip {
+    url = "https://github.com/potassco/clingo/archive/v${version}.tar.gz";
+    sha256 = "04rjwpna37gzm8vxr09z3z6ay8y8cxbjd8lga7xvqfpn2l178zjm";
   };
 
   buildInputs = [];
@@ -17,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "ASP system to ground and solve logic programs";
     license = stdenv.lib.licenses.mit;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     homepage = "https://potassco.org/";
     downloadPage = "https://github.com/potassco/clingo/releases/";
   };

--- a/pkgs/applications/science/logic/potassco/clingo.nix
+++ b/pkgs/applications/science/logic/potassco/clingo.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   buildInputs = [];
   nativeBuildInputs = [cmake];
 
+  cmakeFlags = [ "-DCLINGO_BUILD_WITH_PYTHON=OFF" ];
+
   meta = {
     inherit version;
     description = "ASP system to ground and solve logic programs";


### PR DESCRIPTION
###### Motivation for this change

Current URL is wrong. cc maintainer @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

