### PR TITLE
bcal: 1.7 -> 1.8

### DIFF
--- a/pkgs/applications/science/math/bcal/default.nix
+++ b/pkgs/applications/science/math/bcal/default.nix
@@ -4,30 +4,29 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "bcal-${version}";
-  version = "1.7";
+  version = "1.8";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "bcal";
     rev = "v${version}";
-    sha256 = "08cqp2jysvy743gmwpzkbqhybsb49n65r63z3if53m3y59qg4aw8";
+    sha256 = "0jdn46wzwq7yn3x6p1xyqarp52pcr0ghnfhkm7nyxv734g1abw7r";
   };
 
   nativeBuildInputs = [ python3Packages.pytest ];
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = true;
   checkPhase = ''
     python3 -m pytest test.py
   '';
 
-  makeFlags = [ "CC=cc" ];
   installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
   meta = {
     description = "Storage conversion and expression calculator";
     homepage = https://github.com/jarun/bcal;
     license = licenses.gpl3;
-    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+    platforms = [ "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
     maintainers = with maintainers; [ jfrankenau ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19945,9 +19945,7 @@ with pkgs;
 
   pcalc = callPackage ../applications/science/math/pcalc { };
 
-  bcal = callPackage ../applications/science/math/bcal {
-    stdenv = gccStdenv;
-  };
+  bcal = callPackage ../applications/science/math/bcal { };
 
   pspp = callPackage ../applications/science/math/pspp {
     inherit (gnome3) gtksourceview;


### PR DESCRIPTION
###### Motivation for this change

Update which fixes the build on Darwin and should now work on AArch64 as well.

The tests failed for a good reason on Darwin and should not have been disabled in  #36581. The issue has been resolved upstream with version 1.8.

See also #36454 for ZHF.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @matthewbauer
