### PR TITLE
sambaMaster: 4.8.0_2018-01-25 -> 2018-03-09

### DIFF
--- a/pkgs/servers/samba/master.nix
+++ b/pkgs/servers/samba/master.nix
@@ -4,14 +4,14 @@
 } :
 
   (samba4.overrideAttrs(oldAttrs: rec {
-    name = "samba-master${version}";
-    version = "4.8.0_2018-01-25";
+    name = "samba-unstable-${version}";
+    version = "2018-03-09";
 
     src = fetchFromGitHub {
       owner = "samba-team";
       repo = "samba";
-      rev = "849169a7b6ed0beb78bbddf25537521c1ed2f8e1";
-      sha256 = "1535w787cy1x5ia9arjrg6hhf926wi8wm9qj0k0jgydy3600zpbv";
+      rev = "9e954bcbf43d67a18ee55f84cda0b09028f96b92";
+      sha256 = "07j1pwm4kax6pq21gq9gpmp7dhj5afdyvkhgyl3yz334mb41q11g";
     };
 
     # Remove unnecessary install flags, same as <4.8 patch


### PR DESCRIPTION
###### Motivation for this change
Bring sambaMaster up to 4.8-rc4 to enable testing for 4.8 stable release. Samba test ran by overriding samba with sambaMaster, which passed.

Not sure if the <ver>_<date> is the preferred naming scheme for evergreen packages... Let me know if a different style is preferred.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

