### PR TITLE
beegfs: 6.17 -> 6.18

### DIFF
--- a/pkgs/os-specific/linux/beegfs/default.nix
+++ b/pkgs/os-specific/linux/beegfs/default.nix
@@ -5,7 +5,7 @@
 } :
 
 let
-  version = "6.17";
+  version = "6.18";
 
   subdirs = [
     "beeond_thirdparty/build"
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://git.beegfs.com/pub/v6/repository/archive.tar.bz2?ref=${version}";
-    sha256 = "10xs7gzdmlg23k6zn1b7jij3lljn7rr1j6h476hq4lbg981qk3n3";
+    sha256 = "1g874qyxh4v53ah3lzchrqi0jci7wngr54q3f4d9q0kzvvifripn";
   };
 
   nativeBuildInputs = [ which unzip pkgconfig cppunit openjdk ant perl ];

--- a/pkgs/os-specific/linux/beegfs/kernel-module.nix
+++ b/pkgs/os-specific/linux/beegfs/kernel-module.nix
@@ -3,13 +3,13 @@
 } :
 
 let
-  version = "6.17";
+  version = "6.18";
 in stdenv.mkDerivation {
   name = "beegfs-module-${version}-${kernel.version}";
 
   src = fetchurl {
     url = "https://git.beegfs.com/pub/v6/repository/archive.tar.bz2?ref=${version}";
-    sha256 = "10xs7gzdmlg23k6zn1b7jij3lljn7rr1j6h476hq4lbg981qk3n3";
+    sha256 = "1g874qyxh4v53ah3lzchrqi0jci7wngr54q3f4d9q0kzvvifripn";
   };
 
   hardeningDisable = [ "fortify" "pic" "stackprotector" ];
@@ -41,6 +41,5 @@ in stdenv.mkDerivation {
     platforms = [ "i686-linux" "x86_64-linux" ];
     license = licenses.gpl2;
     maintainers = with maintainers; [ markuskowa ];
-    broken = versionAtLeast kernel.version "4.14";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Minor version update. Contains bug fixes and support for linux kernel 4.14.
I suggest to cherry pick this commit also for nixos 18.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  nixos/test/beegfs.nix completes (with additional `nixpkgs.config.allowUnfree = true`)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

