### PR TITLE
[Request For Testing] pkgs: libpulseaudio -> libcardiacarrest; nixos: override when running PA daemon

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -228,6 +228,9 @@ in {
           source = writeText "libao.conf" "default_driver=pulse"; }
       ];
 
+      environment.sessionVariables.LD_LIBRARY_PATH =
+        [ "${getLib overriddenPackage}/lib" ];
+
       # Allow PulseAudio to get realtime priority using rtkit.
       security.rtkit.enable = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12423,7 +12423,21 @@ with pkgs;
     libpulseaudio = libpulseaudio-vanilla; # meta only
   };
 
-  libpulseaudio = libpulseaudio-vanilla;
+  # See `longDescription` of `libcardiacarrest`. We use
+  # `libcardiacarrest` as our default `libpulse` implementation, NixOS
+  # then overrides it at run-time with `libpulseaudio-vanilla` via
+  # `LD_LIBRARY_PATH` when the user enables the daemon service.
+  #
+  # This way
+  # - users that don't run PulseAudio daemon benefit from smaller
+  #   closure sizes,
+  # - users that don't run PulseAudio daemon and don't want to even
+  #   link against `libpulseaudio-vanilla` for ethical, religious,
+  #   and/or security reasons don't need to make any overrides and
+  #   benefit from hydra cache,
+  # - while users that do run PulseAudio daemon don't really notice
+  #   anything.
+  libpulseaudio = libcardiacarrest;
 
   tomcat_connectors = callPackage ../servers/http/apache-modules/tomcat-connectors { };
 


### PR DESCRIPTION
###### What?

`libcardiacarrest` (https://github.com/oxij/libcardiacarrest) is a trivial implementation of `libpulse*` PulseAudio library API that unconditionally (but gracefully) fails to connect to the PulseAudio daemon and does **nothing** else. See https://github.com/oxij/libcardiacarrest/blob/master/README.org for more info.

With this we switch to linking against `libcardiacarrest` instead of the vanilla `libpulseaudio` by default. NixOS then overrides this with the vanilla `libpulseaudio` via `LD_LIBRARY_PATH` when user enables the daemon service.

###### Motivation

- If you do run PulseAudio daemon you shouldn't notice anything (except, maybe, for one of the Cons below until things will get fixed there).

Pros:

- Smaller closure size when not using PulseAudio, much smaller closure size when not running either of PulseAudio, SystemD.
- You can't statically link against `libcardiacarrest` by accident, unlike the vanilla `libpulseaudio` (SDL did this before, see #36377).
- Hence, `libpulseaudio` is no longer an ethical and security liability (see https://github.com/oxij/libcardiacarrest/blob/master/README.org for the case against `libpulseaudio`).
- Since it's a different implementation, it makes some buggy software crash sometimes. Which is good.

Cons:

- Since it's a different implementation, it makes some buggy software crash sometimes. Which can be inconvenient. But it will print helpful tracing messages when it does so. Also overriding this with the vanilla `libpulseaudio` on app-by-app basis for a temporary workaround is pretty trivial.
- Apps than override `LD_LIBRARY_PATH` instead of appending into it will need fixing when running with PulseAudio daemon. Or we can do something like #31263 (but, hopefully, a bit better). Or you can just override the broken app with the vanilla `libpulseaudio` and forget about it.

###### Related things

This is a better version of what I wanted to have with #35374 which did the same with `libpressureaudio`. The problem with linking against `libpressureaudio` by default is that many apps just start using `apulse` emulation of PA API and completely ignore native ALSA. This hurts performance, ignores cool things you can do with your `asound.conf`, and puts pressure on `apulse` to emulate more of the PA API, which could eventually turn `apulse` into a monster `libpulseaudio` already is. `libcardiacarrest` is tiny (even by comparison to `apulse`, not just to `libpulseaudio`), all it does is it reports to the caller that PulseAudio daemon is unavailable, all the apps I tested then just switch to other output plugins like ALSA or JACK. This closes #35374.

###### What I did

- I built a lot (~60% of nixpkgs and counting) of things with this and everything that built before seems to build now.
- I'm running several machines with minimalistic DEs on top of this for a week and everything is perfect.
- I'm running a machine with Xfce DE on top of this, and everything is perfect, but I used it maybe a couple of hours this week, so it may have issues I didn't encounter.
- I tried running KDE with this, everything seems to be perfect, but I'm not a KDE user, so who knows.
- I tried building Gnome3, but it failed even before applying this patch, so, meh.

###### What I want you to do

- Running with the actual PulseAudio daemon. I have a report that it works with one of the previous versions of this branch, but I'm not running PulseAudio myself.
- Building everything you use against this. Maybe something breaks. Can I have a hydra job for this?
- Run everything you use under this. Maybe something crashes.

###### Merge plan

After somebody else can confirm that running with PulseAudio daemon works, I think, in principle, you can merge this immediately because I'm pretty sure it doesn't break anything sufficiently common and overriding with the vanilla `libpulseaudio` on app-by-app basis for uncommon things (while things get fixed, or just forever) is trivial.

You could keep it here for a week or two anyway so that people could test it, but the practice shows that people don't test Nixpkgs PRs until they get into `master`, so, inevitably, there are going to be surprises. I'd like this to get into `master` ASAP to be over the surprises ASAP.

Hydra job would be nice, though.

So. Study this branch. Study the source of `libcardiacarrest`. Confirm I'm not doing anything stupid or evil. Try this with PulseAudio daemon. Merge.