### PR TITLE
[WIP] nixos/zfs: Don't force import by default

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -108,7 +108,7 @@ in
 
       forceImportRoot = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Forcibly import the ZFS root pool(s) during early boot.
 
@@ -126,7 +126,7 @@ in
 
       forceImportAll = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Forcibly import all ZFS pool(s).
 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/commit/12e77fdc3f6f for reasoning of the previous default enabling of these
options. It is quiet a bit later now and `networking.hostId` being set has
been enforced since https://github.com/NixOS/nixpkgs/commit/e9affb4274a4 in 2014.

This should be properly tested by multiple people before merged. If you have tested this on your zfs setup please make a comment. Edit: And if you have set those options to false already, drop a comment as well.

Edit: Make sure to reboot after setting these to properly test it!

```nix
{
  boot.zfs.forceImportRoot = false;
  boot.zfs.forceImportAll = false;
}
```

###### Motivation for this change
See https://github.com/NixOS/nixpkgs/commit/12e77fdc3f6f

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

