### PR TITLE
p4v: init at 2017.3.1601999

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2516,6 +2516,11 @@
     github = "ninjatrappeur";
     name = "Félix Baylac-Jacqué";
   };
+  nioncode = {
+    email = "nioncode+github@gmail.com";
+    github = "nioncode";
+    name = "Nicolas Schneider";
+  };
   nipav = {
     email = "niko.pavlinek@gmail.com";
     github = "nipav";

--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib/p4v
     cp -r lib/p4v/P4VResources $out/lib/p4v
 
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/p4merge.bin
-
     for f in $out/bin/*.bin ; do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $f
+
       wrapProgram $f \
         --suffix LD_LIBRARY_PATH : ${ldLibraryPath} \
         --suffix QT_XKB_CONFIG_ROOT : ${xkeyboard_config}/share/X11/xkb \

--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, lib, qtbase, qtmultimedia, qtscript, qtsensors, qtwebkit, openssl, xkeyboard_config, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "p4v-${version}";
+  version = "2017.3.1601999";
+
+  src = fetchurl {
+    url = "http://cdist2.perforce.com/perforce/r17.3/bin.linux26x86_64/p4v.tgz";
+    sha256 = "f317607f1bc8877db01ff020b8b0857c2d0f8600474d152749264aea0be66b21";
+  };
+
+  dontBuild = true;
+  nativeBuildInputs = [makeWrapper];
+
+  ldLibraryPath = lib.makeLibraryPath [
+      stdenv.cc.cc.lib
+      qtbase
+      qtmultimedia
+      qtscript
+      qtsensors
+      qtwebkit
+      openssl
+  ];
+
+  installPhase = ''
+    mkdir $out
+    cp -r bin $out
+    mkdir -p $out/lib/p4v
+    cp -r lib/p4v/P4VResources $out/lib/p4v
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/p4merge.bin
+
+    for f in $out/bin/*.bin ; do
+      wrapProgram $f \
+        --suffix LD_LIBRARY_PATH : ${ldLibraryPath} \
+        --suffix QT_XKB_CONFIG_ROOT : ${xkeyboard_config}/share/X11/xkb \
+        --suffix QT_PLUGIN_PATH : ${qtbase.bin}/${qtbase.qtPluginPrefix}
+    done
+  '';
+
+  meta = {
+    description = "Perforce Visual Client";
+    homepage = http://www.perforce.com;
+    license = stdenv.lib.licenses.unfreeRedistributable;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ stdenv.lib.maintainers.nioncode ];
+  };
+}

--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2017.3.1601999";
 
   src = fetchurl {
-    url = "http://cdist2.perforce.com/perforce/r17.3/bin.linux26x86_64/p4v.tgz";
+    url = "https://cdist2.perforce.com/perforce/r17.3/bin.linux26x86_64/p4v.tgz";
     sha256 = "f317607f1bc8877db01ff020b8b0857c2d0f8600474d152749264aea0be66b21";
   };
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Perforce Visual Client";
-    homepage = http://www.perforce.com;
+    homepage = https://www.perforce.com;
     license = stdenv.lib.licenses.unfreeRedistributable;
     platforms = [ "x86_64-linux" ];
     maintainers = [ stdenv.lib.maintainers.nioncode ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16736,6 +16736,8 @@ with pkgs;
 
   ostinato = callPackage ../applications/networking/ostinato { };
 
+  p4v = libsForQt5.callPackage ../applications/version-management/p4v { };
+
   panamax_api = callPackage ../applications/networking/cluster/panamax/api { };
   panamax_ui = callPackage ../applications/networking/cluster/panamax/ui { };
 


### PR DESCRIPTION
###### Motivation for this change
Package the Perforce Visual Client for nix.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

