### PR TITLE
treewide: Prepare for #34444

### DIFF
--- a/pkgs/applications/misc/robo3t/default.nix
+++ b/pkgs/applications/misc/robo3t/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/icons
     cp ${icon} $out/share/icons/robomongo.png
 
-    patchelf --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 $BASEDIR/bin/robo3t
+    patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 $BASEDIR/bin/robo3t
 
     mkdir $out/bin
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = https://robomongo.org/;
     description = "Query GUI for mongodb";
-    platforms = stdenv.lib.intersectLists stdenv.lib.platforms.linux stdenv.lib.platforms.x86_64;
+    platforms = [ "x86_64-linux" ];
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.eperuffo ];
   };

--- a/pkgs/applications/networking/instant-messengers/pond/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pond/default.nix
@@ -2,7 +2,6 @@
   fetchgit, fetchhg, fetchbzr, fetchsvn }:
 
 let
-  isx86_64 = stdenv.lib.any (n: n == stdenv.system) stdenv.lib.platforms.x86_64;
   gui = true; # Might be implemented with nixpkgs config.
 in
 buildGoPackage rec {
@@ -22,11 +21,11 @@ buildGoPackage rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ trousers gtk3 gtkspell3 ]
-    ++ stdenv.lib.optional isx86_64 dclxvi
+    ++ stdenv.lib.optional stdenv.hostPlatform.isx86_64 dclxvi
     ++ stdenv.lib.optionals gui [ wrapGAppsHook ];
   buildFlags = stdenv.lib.optionalString (!gui) "-tags nogui";
   excludedPackages = "\\(appengine\\|bn256cgo\\)";
-  postPatch = stdenv.lib.optionalString isx86_64 ''
+  postPatch = stdenv.lib.optionalString stdenv.hostPlatform.isx86_64 ''
     grep -r 'bn256' | awk -F: '{print $1}' | xargs sed -i \
       -e "s,golang.org/x/crypto/bn256,github.com/agl/pond/bn256cgo,g" \
       -e "s,bn256\.,bn256cgo.,g"

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -30,7 +30,6 @@ assert withGtk3 -> dconf != null;
 assert withGtk3 -> gtk3 != null;
 
 let
-  system-x86_64 = lib.elem stdenv.system lib.platforms.x86_64;
   compareVersion = v: builtins.compareVersions version v;
 in
 
@@ -258,7 +257,7 @@ stdenv.mkDerivation {
       "-no-warnings-are-errors"
     ]
     ++ (
-      if (!system-x86_64)
+      if (!stdenv.hostPlatform.isx86_64)
       then [ "-no-sse2" ]
       else lib.optional (compareVersion "5.9.0" >= 0) [ "-sse2" ]
     )

--- a/pkgs/development/libraries/wiredtiger/default.nix
+++ b/pkgs/development/libraries/wiredtiger/default.nix
@@ -15,7 +15,7 @@ let
   mkWith = mkFlag "with-" "without-";
   mkOther = mkFlag "" "" true;
 
-  shouldUsePkg = pkg: if pkg != null && any (x: x == stdenv.system) pkg.meta.platforms then pkg else null;
+  shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
 
   optLz4 = shouldUsePkg lz4;
   optSnappy = shouldUsePkg snappy;

--- a/pkgs/development/pharo/vm/build-vm-legacy.nix
+++ b/pkgs/development/pharo/vm/build-vm-legacy.nix
@@ -70,9 +70,9 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.lukego ];
     # Pharo VM sources are packaged separately for darwin (OS X)
-    platforms = with stdenv.lib;
-                  intersectLists
-                    platforms.mesaPlatforms
-                    (subtractLists platforms.darwin platforms.unix);
+    platforms = stdenv.lib.filter
+      (system: with stdenv.lib.systems.elaborate { inherit system; };
+         isUnix && !isDarwin)
+      stdenv.lib.platforms.mesaPlatforms;
   };
 }

--- a/pkgs/development/pharo/wrapper/default.nix
+++ b/pkgs/development/pharo/wrapper/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "pharo";
-  src = ./.;
+  src = ./pharo-vm.sh;
   inherit cog32 spur32 spur64 file;
   magic = ./magic;
   desktopItem = makeDesktopItem {
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
     categories = "Development;";
     mimeType = "application/x-pharo-image";
   };
+  unpackPhase = ''
+    cp $src ./pharo-vm.sh
+    sourceRoot=$PWD
+  '';
   buildPhase = ''
     substituteAllInPlace ./pharo-vm.sh
   '';
@@ -49,10 +53,10 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.lukego ];
     # Pharo VM sources are packaged separately for darwin (OS X)
-    platforms = with stdenv.lib;
-                  intersectLists
-                    platforms.mesaPlatforms
-                    (subtractLists platforms.darwin platforms.unix);
+    platforms = stdenv.lib.filter
+      (system: with stdenv.lib.systems.elaborate { inherit system; };
+         isUnix && !isDarwin)
+      stdenv.lib.platforms.mesaPlatforms;
   };
 }
 

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -2,11 +2,11 @@
 
 let
   platform =
-    if lib.elem stdenv.system lib.platforms.unix then "unix"
+    if stdenv.hostPlatform.isUnix then "unix"
     else throw "Unknown platform for NetHack: ${stdenv.system}";
   unixHint =
-    if stdenv.isLinux then "linux"
-    else if stdenv.isDarwin then "macosx10.10"
+    /**/ if stdenv.hostPlatform.isLinux  then "linux"
+    else if stdenv.hostPlatform.isDarwin then "macosx10.10"
     # We probably want something different for Darwin
     else "unix";
   userDir = "~/.config/nethack";

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -15,7 +15,7 @@
 with stdenv.lib;
 let
   inherit (python2Packages) python dbus-python;
-  shouldUsePkg = pkg: if pkg != null && stdenv.lib.any (x: x == stdenv.system) pkg.meta.platforms then pkg else null;
+  shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
 
   libOnly = prefix == "lib";
 

--- a/pkgs/misc/jackaudio/jack1.nix
+++ b/pkgs/misc/jackaudio/jack1.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  shouldUsePkg = pkg: if pkg != null && stdenv.lib.any (x: x == stdenv.system) pkg.meta.platforms then pkg else null;
+  shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
 
   optAlsaLib = shouldUsePkg alsaLib;
   optDb = shouldUsePkg db;

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -11,7 +11,7 @@
 
 let
 
-  shouldUsePkg = pkg: if pkg != null && stdenv.lib.any (x: x == stdenv.system) pkg.meta.platforms then pkg else null;
+  shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
 
   libOnly = prefix == "lib";
 

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
     "--with-mail_ssl_module"
   ]
     ++ optional (gd != null) "--with-http_image_filter_module"
-    ++ optional (elem stdenv.system (with platforms; linux ++ freebsd)) "--with-file-aio"
+    ++ optional (with stdenv.hostPlatform; isLinux || isFreeBSD) "--with-file-aio"
     ++ map (mod: "--add-module=${mod.src}") modules;
 
   NIX_CFLAGS_COMPILE = [ "-I${libxml2.dev}/include/libxml2" ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";

--- a/pkgs/servers/shishi/default.nix
+++ b/pkgs/servers/shishi/default.nix
@@ -14,7 +14,7 @@ let
   mkWith = mkFlag "with-" "without-";
   mkOther = mkFlag "" "" true;
 
-  shouldUsePkg = pkg: if pkg != null && stdenv.lib.any (x: x == stdenv.system) pkg.meta.platforms then pkg else null;
+  shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
 
   optPam = shouldUsePkg pam;
   optLibidn = shouldUsePkg libidn;

--- a/pkgs/tools/cd-dvd/dvdisaster/default.nix
+++ b/pkgs/tools/cd-dvd/dvdisaster/default.nix
@@ -33,8 +33,7 @@ stdenv.mkDerivation rec {
     "--docdir=share/doc"
     "--with-nls=yes"
     "--with-embedded-src-path=no"
-  ] ++ stdenv.lib.optional (builtins.elem stdenv.system
-      stdenv.lib.platforms.x86_64) "--with-sse2=yes";
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isx86_64) "--with-sse2=yes";
 
   # fatal error: inlined-icons.h: No such file or directory
   enableParallelBuilding = false;

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -37,8 +37,7 @@ with stdenv.lib;
 let
 
   shouldUsePkg = pkg_: let pkg = (builtins.tryEval pkg_).value;
-    in if lib.any (x: x == system) (pkg.meta.platforms or [])
-      then pkg else null;
+    in if pkg.meta.available or false then pkg else null;
 
   optYasm = shouldUsePkg yasm;
   optFcgi = shouldUsePkg fcgi;


### PR DESCRIPTION
###### Motivation for this change

#34444 changes the `meta.platform` interface slightly. This PR fixes/improves a few misc packages so that that one doesn't change anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

