### PR TITLE
doc: mention symlinkJoin in multiple-outputs section

### DIFF
--- a/doc/multiple-output.xml
+++ b/doc/multiple-output.xml
@@ -101,6 +101,13 @@
    contain <varname>$outputBin</varname> and <varname>$outputLib</varname> are
    also added. (See <xref linkend="multiple-output-file-type-groups" />.)
   </para>
+
+  <para>
+   In some cases it may be desirable to combine different outputs under a
+   single store path. A function <literal>symlinkJoin</literal> can be used to
+   do this. (Note that it may negate some closure size benefits of using a
+   multiple-output package.)
+  </para>
  </section>
  <section>
   <title>Writing a split derivation</title>


### PR DESCRIPTION
###### Motivation for this change

Provide an additional exposure for ```symlinkJoin``` function by mentioning it in the documentation.

Fixes #36883

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
