### PR TITLE
xfce: do not use old names

### DIFF
--- a/pkgs/applications/window-managers/xmonad-log-applet/default.nix
+++ b/pkgs/applications/window-managers/xmonad-log-applet/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, glib, dbus-glib
 , desktopSupport
 , gtk2, gnome2_panel, GConf2
-, libxfce4util, xfce4panel
+, libxfce4util, xfce4-panel
 }:
 
 assert desktopSupport == "gnome2" || desktopSupport == "gnome3" || desktopSupport == "xfce4";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
               ++ optionals (desktopSupport == "gnome2") [ gtk2 gnome2_panel GConf2 ]
               # TODO: no idea where to find libpanelapplet-4.0
               ++ optionals (desktopSupport == "gnome3") [ ]
-              ++ optionals (desktopSupport == "xfce4") [ gtk2 libxfce4util xfce4panel ]
+              ++ optionals (desktopSupport == "xfce4") [ gtk2 libxfce4util xfce4-panel ]
               ;
   
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/desktops/xfce/applications/orage.nix
+++ b/pkgs/desktops/xfce/applications/orage.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool bison flex ];
   
   buildInputs = [ gtk libical dbus-glib libnotify popt xfce.libxfce4util
-    xfce.xfce4panel ];
+    xfce.xfce4-panel ];
 
   preFixup = "rm $out/share/icons/hicolor/icon-theme.cache ";
 

--- a/pkgs/desktops/xfce/applications/xfce4-mixer.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-mixer.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool, makeWrapper
 , glib, gstreamer, gst-plugins-base, gtk
-, libxfce4util, libxfce4ui, xfce4panel, xfconf, libunique ? null
+, libxfce4util, libxfce4ui, xfce4-panel, xfconf, libunique ? null
 , pulseaudioSupport ? false, gst-plugins-good
 }:
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ pkgconfig intltool glib gstreamer gtk
-      libxfce4util libxfce4ui xfce4panel xfconf libunique makeWrapper
+      libxfce4util libxfce4ui xfce4-panel xfconf libunique makeWrapper
     ] ++ gst_plugins;
 
   postInstall =

--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, xfce4panel, libxfce4util, gtk, libsoup
+{ stdenv, fetchurl, pkgconfig, intltool, xfce4-panel, libxfce4util, gtk, libsoup
 , makeWrapper, glib-networking, exo, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    xfce4panel libxfce4util gtk libsoup exo hicolor-icon-theme glib-networking
+    xfce4-panel libxfce4util gtk libsoup exo hicolor-icon-theme glib-networking
   ];
 
   meta = {

--- a/pkgs/desktops/xfce/core/thunar-build.nix
+++ b/pkgs/desktops/xfce/core/thunar-build.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool
 , gtk, dbus-glib, libstartup_notification, libnotify, libexif, pcre, udev
-, exo, libxfce4util, xfconf, xfce4panel, wrapGAppsHook
+, exo, libxfce4util, xfconf, xfce4-panel, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     intltool
     gtk dbus-glib libstartup_notification libnotify libexif pcre udev
-    exo libxfce4util xfconf xfce4panel
+    exo libxfce4util xfconf xfce4-panel
   ];
   # TODO: optionality?
 

--- a/pkgs/desktops/xfce/core/thunar.nix
+++ b/pkgs/desktops/xfce/core/thunar.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildEnv, runCommand, makeWrapper, lndir, thunar-build
+{ stdenv, buildEnv, runCommand, makeWrapper, lndir, thunar-bare
 , thunarPlugins ? []
 }:
 
@@ -6,7 +6,7 @@ with stdenv.lib;
 
 let
 
-  build = thunar-build;
+  build = thunar-bare;
 
   replaceLnExeListWithWrapped = exeDir: exeNameList: mkWrapArgs: ''
     exeDir="${exeDir}"
@@ -50,7 +50,7 @@ runCommand name {
 } 
 (let
   buildWithPlugins = buildEnv {
-    name = "thunar-build-with-plugins";
+    name = "thunar-bare-with-plugins";
     paths = [ build ] ++ thunarPlugins;
   };
 

--- a/pkgs/desktops/xfce/core/xfce4-panel.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk, libxfce4util, libxfce4ui
 , libxfce4ui_gtk3, libwnck, exo, garcon, xfconf, libstartup_notification
-, makeWrapper, xfce4mixer, hicolor-icon-theme
+, makeWrapper, xfce4-mixer, hicolor-icon-theme
 , withGtk3 ? false, gtk3, gettext, glib-networking
 }:
 let
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig intltool gtk libxfce4util exo libwnck
       garcon xfconf libstartup_notification makeWrapper hicolor-icon-theme
-    ] ++ xfce4mixer.gst_plugins
+    ] ++ xfce4-mixer.gst_plugins
       ++ optional withGtk3 gtk3;
 
   propagatedBuildInputs = [ (if withGtk3 then libxfce4ui_gtk3 else libxfce4ui) ];

--- a/pkgs/desktops/xfce/core/xfce4-power-manager.nix
+++ b/pkgs/desktops/xfce/core/xfce4-power-manager.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, pkgconfig, intltool, glib, gtk, dbus-glib, upower, xfconf
-, libxfce4ui, libxfce4util, libnotify, xfce4panel, hicolor-icon-theme
+, libxfce4ui, libxfce4util, libnotify, xfce4-panel, hicolor-icon-theme
 , withGtk3 ? false, gtk3, libxfce4ui_gtk3, xfce4panel_gtk3 }:
 let
   p_name  = "xfce4-power-manager";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     ] ++
     (if withGtk3
     then [ gtk3 libxfce4ui_gtk3 xfce4panel_gtk3 ]
-    else [ gtk  libxfce4ui      xfce4panel      ]);
+    else [ gtk  libxfce4ui      xfce4-panel      ]);
 
   postPatch = lib.optionalString withGtk3 ''
     substituteInPlace configure --replace gio-2.0 gio-unix-2.0

--- a/pkgs/desktops/xfce/core/xfce4-session.nix
+++ b/pkgs/desktops/xfce/core/xfce4-session.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gtk, polkit
-, libxfce4util, libxfce4ui, xfce4panel, libwnck, dbus-glib, xfconf, libglade, xorg
+, libxfce4util, libxfce4ui, xfce4-panel, libwnck, dbus-glib, xfconf, libglade, xorg
 , hicolor-icon-theme
 }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ pkgconfig intltool gtk libxfce4util libxfce4ui libwnck dbus-glib
-      xfconf xfce4panel libglade xorg.iceauth xorg.libSM
+      xfconf xfce4-panel libglade xorg.iceauth xorg.libSM
       polkit hicolor-icon-theme
     ]; #TODO: upower-glib, gconf (assistive?), gnome keyring
 

--- a/pkgs/desktops/xfce/core/xfdesktop.nix
+++ b/pkgs/desktops/xfce/core/xfdesktop.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gtk, libxfce4util, libxfce4ui
-, libwnck, xfconf, libglade, xfce4panel, thunar, exo, garcon, libnotify
+, libwnck, xfconf, libglade, xfce4-panel, thunar, exo, garcon, libnotify
 , hicolor-icon-theme }:
 let
   p_name  = "xfdesktop";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig intltool gtk libxfce4util libxfce4ui libwnck xfconf
-    libglade xfce4panel thunar exo garcon libnotify hicolor-icon-theme
+    libglade xfce4-panel thunar exo garcon libnotify hicolor-icon-theme
   ];
 
   patches = [(fetchpatch {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-battery-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-battery-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
   preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-clipman-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-clipman-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, exo, libXtst, xproto, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, exo, libXtst, xproto, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool glib exo libXtst xproto libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool glib exo libXtst xproto libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
   preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-cpufreq-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-cpufreq-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
-  buildInputs = [ libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, exo, libXtst, xproto, libxfce4util, xfce4panel, libxfce4ui, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, exo, libXtst, xproto, libxfce4util, xfce4-panel, libxfce4ui, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool glib exo libXtst xproto libxfce4util libxfce4ui xfce4panel xfconf gtk ];
+  buildInputs = [ intltool glib exo libXtst xproto libxfce4util libxfce4ui xfce4-panel xfconf gtk ];
   preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-datetime-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-datetime-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, libxfcegui4, xfce4panel
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, libxfcegui4, xfce4-panel
 , gtk }:
 
 with stdenv.lib;
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfcegui4 xfce4panel gtk ];
+  buildInputs = [ intltool libxfce4util libxfcegui4 xfce4-panel gtk ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-dict-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-dict-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ python2 vala gtk2 pythonPackages.wrapPython ]
-    ++ (with xfce; [ libxfce4util xfce4panel xfconf xfce4_dev_tools ])
+    ++ (with xfce; [ libxfce4util xfce4-panel xfconf xfce4-dev-tools ])
     ++ pythonPath;
 
   postPatch = ''

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-eyes-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-eyes-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-fsguard-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-fsguard-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-genmon-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-genmon-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, autoreconfHook, gnome2,
-  libgtop, libxfce4ui, libxfce4util, xfce4panel, lm_sensors
+  libgtop, libxfce4ui, libxfce4util, xfce4-panel, lm_sensors
 }:
 
 stdenv.mkDerivation rec {
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     libgtop
     libxfce4ui
     libxfce4util
-    xfce4panel
+    xfce4-panel
     lm_sensors
    ];
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui,
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui,
 libxfcegui4, xfconf, gtk, exo, gnutls, libgcrypt }:
 
 with stdenv.lib;
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel
     libxfcegui4 xfconf gtk exo gnutls libgcrypt ];
 
   meta = {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui,
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui,
 libxfcegui4, xfconf, gtk, exo }:
 
 with stdenv.lib;
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel
     libxfcegui4 xfconf gtk exo ];
 
   meta = {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgconfig, fetchFromGitHub, python2, vala, gtk2, libwnck, libxfce4util, xfce4panel }:
+{ stdenv, pkgconfig, fetchFromGitHub, python2, vala, gtk2, libwnck, libxfce4util, xfce4-panel }:
 
 stdenv.mkDerivation rec {
   ver = "0.3.1";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ python2 vala gtk2 libwnck libxfce4util xfce4panel ];
+  buildInputs = [ python2 vala gtk2 libwnck libxfce4util xfce4-panel ];
 
   postPatch = ''
     substituteInPlace src/preferences.vala --replace 'Environment.get_system_data_dirs()' "{ \"$out/share\" }"

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
   preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, libxfcegui4, xfconf, gtk, libunique }:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk, libunique }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk libunique ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk libunique ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, gnome2, libxfce4ui,
-  libxfce4util, xfce4panel, libnotify, lm_sensors, hddtemp, netcat-gnu
+  libxfce4util, xfce4-panel, libnotify, lm_sensors, hddtemp, netcat-gnu
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     gnome2.gtk
     libxfce4ui
     libxfce4util
-    xfce4panel
+    xfce4-panel
     libnotify
     lm_sensors
     hddtemp

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel, libxfce4ui, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, gtk}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel gtk ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel
 , libxfce4ui, libxfcegui4, xfconf, gtk, hicolor-icon-theme }:
 
 with stdenv.lib;
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf
     gtk hicolor-icon-theme ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-verve-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-verve-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, exo, pcre
-, libxfce4util, xfce4panel, libxfce4ui, xfconf, gtk }:
+, libxfce4util, xfce4-panel, libxfce4ui, xfconf, gtk }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool glib exo pcre libxfce4util libxfce4ui xfce4panel xfconf gtk ];
+  buildInputs = [ intltool glib exo pcre libxfce4util libxfce4ui xfce4-panel xfconf gtk ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk, libxml2, libsoup, upower,
-libxfce4ui, libxfce4util, xfce4panel }:
+libxfce4ui, libxfce4util, xfce4-panel }:
 
 stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool ];
 
   buildInputs = [ gtk libxml2 libsoup upower libxfce4ui libxfce4util
-   xfce4panel ];
+   xfce4-panel ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, intltool, libxfce4util, libxfcegui4
-, xfce4panel, gtk, exo, garcon }:
+, xfce4-panel, gtk, exo, garcon }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -17,13 +17,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig intltool ];
 
-  buildInputs = [ libxfce4util libxfcegui4 xfce4panel gtk exo garcon ];
+  buildInputs = [ libxfce4util libxfcegui4 xfce4-panel gtk exo garcon ];
 
   enableParallelBuilding = true;
 
   preFixup = ''
     substituteInPlace $out/bin/xfce4-popup-whiskermenu \
-      --replace $out/bin/xfce4-panel ${xfce4panel.out}/bin/xfce4-panel
+      --replace $out/bin/xfce4-panel ${xfce4-panel.out}/bin/xfce4-panel
   '';
 
   meta = {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, intltool, python3, imagemagick, libwnck, gtk2
-, exo, libxfce4ui, libxfce4util, xfce4panel, xfconf, xfce4_dev_tools }:
+, exo, libxfce4ui, libxfce4util, xfce4-panel, xfconf, xfce4-dev-tools }:
 
 stdenv.mkDerivation rec {
   p_name  = "xfce4-windowck-plugin";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ intltool python3 imagemagick libwnck gtk2
-    exo libxfce4ui libxfce4util xfce4panel xfconf xfce4_dev_tools ];
+    exo libxfce4ui libxfce4util xfce4-panel xfconf xfce4-dev-tools ];
 
   preConfigure = ''
     ./autogen.sh

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-xkb-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-xkb-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, libxfce4ui, xfce4panel
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, libxfce4ui, xfce4-panel
 , garcon, gtk, libxklavier, librsvg, libwnck
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4panel garcon
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel garcon
     gtk libxklavier librsvg libwnck  ];
 
   meta = {

--- a/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, xfce4_dev_tools
+{ stdenv, fetchFromGitHub, pkgconfig, xfce4-dev-tools
 , gtk
 , thunarx-2-dev
 , exo, libxfce4util, libxfce4ui
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    xfce4_dev_tools
+    xfce4-dev-tools
     thunarx-2-dev
     exo gtk libxfce4util libxfce4ui
     xfconf udev libnotify

--- a/pkgs/misc/screensavers/light-locker/default.nix
+++ b/pkgs/misc/screensavers/light-locker/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   patches = [ ./systemd.patch ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ which xfce.xfce4_dev_tools glib systemd
+  buildInputs = [ which xfce.xfce4-dev-tools glib systemd
                   libX11 libXScrnSaver libXxf86misc gtk3 dbus-glib wrapGAppsHook ];
 
   preConfigure = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18456,21 +18456,21 @@ with pkgs;
 
   xmonad_log_applet_gnome2 = callPackage ../applications/window-managers/xmonad-log-applet {
     desktopSupport = "gnome2";
-    inherit (xfce) libxfce4util xfce4panel;
+    inherit (xfce) libxfce4util xfce4-panel;
     gnome2_panel = gnome2.gnome_panel;
     GConf2 = gnome2.GConf;
   };
 
   xmonad_log_applet_gnome3 = callPackage ../applications/window-managers/xmonad-log-applet {
     desktopSupport = "gnome3";
-    inherit (xfce) libxfce4util xfce4panel;
+    inherit (xfce) libxfce4util xfce4-panel;
     gnome2_panel = gnome2.gnome_panel;
     GConf2 = gnome2.GConf;
   };
 
   xmonad_log_applet_xfce = callPackage ../applications/window-managers/xmonad-log-applet {
     desktopSupport = "xfce4";
-    inherit (xfce) libxfce4util xfce4panel;
+    inherit (xfce) libxfce4util xfce4-panel;
     gnome2_panel = gnome2.gnome_panel;
     GConf2 = gnome2.GConf;
   };


### PR DESCRIPTION
###### Motivation for this change

cleanup, do not use names deprecated in https://github.com/NixOS/nixpkgs/pull/33600
cc @yegortimoshenko 
