### PR TITLE
treewide: s/xlibs/xorg/g

### DIFF
--- a/pkgs/applications/editors/kodestudio/default.nix
+++ b/pkgs/applications/editors/kodestudio/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, callPackage, fetchurl, makeDesktopItem, makeWrapper
 , # Patchelf dependencies:
   alsaLib, atomEnv, boehmgc, flac, libogg, libvorbis, libXScrnSaver, libGLU_combined
-, openssl, xlibs, xorg, zlib
+, openssl, xorg, zlib
 }:
 
 let

--- a/pkgs/applications/graphics/pencil/default.nix
+++ b/pkgs/applications/graphics/pencil/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, lib, makeWrapper,
   # build dependencies
   alsaLib, atk, cairo, cups, dbus, expat, fontconfig,
-  freetype, gdk_pixbuf, glib, gnome2, nspr, nss, xlibs,
+  freetype, gdk_pixbuf, glib, gnome2, nspr, nss, xorg,
   glibc, udev
 }:
 
@@ -55,17 +55,17 @@ stdenv.mkDerivation rec {
       gnome2.pango
       nspr
       nss
-      xlibs.libX11
-      xlibs.libXScrnSaver
-      xlibs.libXcomposite
-      xlibs.libXcursor
-      xlibs.libXdamage
-      xlibs.libXext
-      xlibs.libXfixes
-      xlibs.libXi
-      xlibs.libXrandr
-      xlibs.libXrender
-      xlibs.libXtst
+      xorg.libX11
+      xorg.libXScrnSaver
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
       stdenv.cc.cc.lib
       stdenv.cc.cc
       glibc

--- a/pkgs/applications/graphics/solvespace/default.nix
+++ b/pkgs/applications/graphics/solvespace/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, cmake, pkgconfig, zlib, libpng, cairo, freetype
-, json_c, fontconfig, gtkmm3, pangomm, glew, libGLU, xlibs, pcre
+, json_c, fontconfig, gtkmm3, pangomm, glew, libGLU, xorg, pcre
 , wrapGAppsHook
 }:
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     zlib libpng cairo freetype
     json_c fontconfig gtkmm3 pangomm glew libGLU
-    xlibs.libpthreadstubs xlibs.libXdmcp pcre
+    xorg.libpthreadstubs xorg.libXdmcp pcre
   ];
   enableParallelBuilding = true;
 

--- a/pkgs/applications/misc/deco/default.nix
+++ b/pkgs/applications/misc/deco/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, scsh, feh, xlibs }:
+{ stdenv, fetchFromGitHub, scsh, feh, xorg }:
 
 stdenv.mkDerivation rec {
   pname = "deco";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     substituteInPlace $out/bin/deco --replace "/usr/bin/env scsh" "${scsh}/bin/scsh"
     substituteInPlace $out/bin/deco --replace "feh" "${feh}/bin/feh"
-    substituteInPlace $out/bin/deco --replace "xdpyinfo" "${xlibs.xdpyinfo}/bin/xdpyinfo"
+    substituteInPlace $out/bin/deco --replace "xdpyinfo" "${xorg.xdpyinfo}/bin/xdpyinfo"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -50,7 +50,7 @@ let
     else if stdenv.system == "i686-linux" then "${stdenv.cc}/nix-support/dynamic-linker"
     else throw "Unsupported platform for PlayOnLinux: ${stdenv.system}";
   ld64 = "${stdenv.cc}/nix-support/dynamic-linker";
-  libs = pkgs: stdenv.lib.makeLibraryPath [ pkgs.xlibs.libX11 ];
+  libs = pkgs: stdenv.lib.makeLibraryPath [ pkgs.xorg.libX11 ];
 
 in stdenv.mkDerivation {
   name = "playonlinux-${version}";

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -5,7 +5,7 @@
 , gtk2, hunspell, icu, libevent, libjpeg, libnotify
 , libstartup_notification, libvpx, makeWrapper, libGLU_combined
 , nspr, nss, pango, perl, python, libpulseaudio, sqlite
-, unzip, xlibs, which, yasm, zip, zlib
+, unzip, xorg, which, yasm, zip, zlib
 }:
 
 stdenv.mkDerivation rec {
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     hunspell icu libevent libjpeg libnotify libstartup_notification
     libvpx makeWrapper libGLU_combined nspr nss pango perl pkgconfig python
     libpulseaudio sqlite unzip which yasm zip zlib
-  ] ++ (with xlibs; [
+  ] ++ (with xorg; [
     libX11 libXext libXft libXi libXrender libXScrnSaver
     libXt pixman scrnsaverproto xextproto
   ]);

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -32,7 +32,7 @@ in
 buildFHSUserEnv {
   name = "dropbox";
 
-  targetPkgs = pkgs: with pkgs; with xlibs; [
+  targetPkgs = pkgs: with pkgs; with xorg; [
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender
     libXxf86vm libxcb xkeyboardconfig
     curl dbus firefox-bin fontconfig freetype gcc glib gnutar libxml2 libxslt

--- a/pkgs/applications/networking/instant-messengers/ring-daemon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ring-daemon/default.nix
@@ -24,7 +24,7 @@
 , gnutls
 , zlib
 , jsoncpp
-, xlibs
+, xorg
 , libargon2
 , cryptopp
 , openssl
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
     zlib
     jsoncpp
     restbed
-    xlibs.libX11
+    xorg.libX11
     libargon2
     cryptopp
     openssl

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/beta.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/beta.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, dpkg, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
-fontconfig, dbus, libX11, xlibs, libXi, libXcursor, libXdamage, libXrandr,
+fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
 }:
@@ -33,7 +33,7 @@ let
     nss
     stdenv.cc.cc
     udev
-    xlibs.libxcb
+    xorg.libxcb
   ];
 
 in

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, dpkg, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
-fontconfig, dbus, libX11, xlibs, libXi, libXcursor, libXdamage, libXrandr,
+fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
 }:
@@ -33,7 +33,7 @@ let
     nss
     stdenv.cc.cc
     udev
-    xlibs.libxcb
+    xorg.libxcb
   ];
 
 in

--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -15,7 +15,7 @@
 , cairo
 , pango
 , gnome3
-, xlibs
+, xorg
 , libpng12
 , freetype
 , fontconfig
@@ -143,11 +143,11 @@ let
         cairo
         pango
         gnome3.dconf
-        xlibs.libX11
-        xlibs.libXext
-        xlibs.libXrender
-        xlibs.libXinerama
-        xlibs.libXfixes
+        xorg.libX11
+        xorg.libXext
+        xorg.libXrender
+        xorg.libXinerama
+        xorg.libXfixes
         libpng12
         libidn
         zlib

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -9,7 +9,7 @@ let
 
   mkLdPath = ps: lib.makeLibraryPath (with ps; [ qt4 dbus alsaLib ]);
 
-  deps = ps: (with ps; [ dbus zlib alsaLib fontconfig freetype libpng12 libjpeg ]) ++ (with ps.xlibs; [ libX11 libXext libXdamage libXrandr libXrender libXfixes libSM libXtst libXinerama]);
+  deps = ps: (with ps; [ dbus zlib alsaLib fontconfig freetype libpng12 libjpeg ]) ++ (with ps.xorg; [ libX11 libXext libXdamage libXrandr libXrender libXfixes libSM libXtst libXinerama]);
   tvldpath32 = lib.makeLibraryPath (with pkgsi686Linux; [ qt4 "$out/share/teamviewer/tv_bin/wine" ] ++ deps pkgsi686Linux);
   tvldpath64 = lib.makeLibraryPath (deps pkgs);
 in

--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -24,7 +24,6 @@
 , qtwebengine
 , sqlite
 , xorg
-, xlibs
 , zlib
 # The provided wrapper does this, but since we don't use it
 # we emulate the behavior.  The downside is that this
@@ -78,7 +77,7 @@ let
     orc
     sqlite
     xorg.libX11
-    xlibs.xcbutilkeysyms
+    xorg.xcbutilkeysyms
     xorg.libxcb
     xorg.libXcomposite
     xorg.libXext

--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -31,7 +31,7 @@ zoteroSrc = stdenv.mkDerivation rec {
 
 fhsEnv = buildFHSUserEnv {
   name = "zotero-fhs-env";
-  targetPkgs = pkgs: with pkgs; with xlibs; [
+  targetPkgs = pkgs: with pkgs; with xorg; [
     gtk3 dbus-glib
     libXt nss
   ];

--- a/pkgs/applications/science/logic/mcrl2/default.nix
+++ b/pkgs/applications/science/logic/mcrl2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, xlibs, cmake, subversion, libGLU_combined, qt5, boost,
+{stdenv, fetchurl, cmake, subversion, libGLU_combined, qt5, boost,
  python27, python27Packages}:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/science/math/scilab-bin/default.nix
+++ b/pkgs/applications/science/math/scilab-bin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, xlibs }:
+{ stdenv, fetchurl, lib, xorg }:
 
 let
   name = "scilab-bin-${ver}";
@@ -33,12 +33,12 @@ stdenv.mkDerivation rec {
 
   libPath = lib.makeLibraryPath [
     stdenv.cc.cc
-    xlibs.libX11
-    xlibs.libXext
-    xlibs.libXi
-    xlibs.libXrender
-    xlibs.libXtst
-    xlibs.libXxf86vm
+    xorg.libX11
+    xorg.libXext
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libXxf86vm
   ];
 
   phases = [ "unpackPhase" "fixupPhase" "installPhase" ];

--- a/pkgs/applications/window-managers/wtftw/default.nix
+++ b/pkgs/applications/window-managers/wtftw/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, cargo, libXinerama, libX11, xlibs, pkgconfig }:
+{ stdenv, fetchFromGitHub, rustPlatform, cargo, libXinerama, libX11, pkgconfig }:
 
 rustPlatform.buildRustPackage rec {
   name = "wtftw-0.0pre20170921";

--- a/pkgs/development/libraries/AntTweakBar/default.nix
+++ b/pkgs/development/libraries/AntTweakBar/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, unzip, xlibs, libGLU_combined }:
+{ stdenv, fetchurl, unzip, xorg, libGLU_combined }:
 
 stdenv.mkDerivation rec {
   name = "AntTweakBar-1.16";
 
-  buildInputs = [ unzip xlibs.libX11 libGLU_combined ];
+  buildInputs = [ unzip xorg.libX11 libGLU_combined ];
 
   src = fetchurl {
     url = "mirror://sourceforge/project/anttweakbar/AntTweakBar_116.zip";

--- a/pkgs/development/libraries/kde-frameworks/kdelibs4support/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdelibs4support/default.nix
@@ -5,7 +5,7 @@
   kdbusaddons, kded, kdesignerplugin, kemoticons, kglobalaccel, kguiaddons,
   ki18n, kiconthemes, kio, kitemmodels, kinit, knotifications, kparts, kservice,
   ktextwidgets, kunitconversion, kwidgetsaddons, kwindowsystem, kxmlgui,
-  networkmanager, qtbase, qtsvg, qttools, qtx11extras, xlibs
+  networkmanager, qtbase, qtsvg, qttools, qtx11extras, xorg
 }:
 
 mkDerivation {
@@ -17,7 +17,7 @@ mkDerivation {
   propagatedNativeBuildInputs = [ kdoctools ];
   buildInputs = [
     kcompletion kconfig kded kglobalaccel ki18n kio kservice kwidgetsaddons
-    kxmlgui networkmanager qtsvg qtx11extras xlibs.libSM
+    kxmlgui networkmanager qtsvg qtx11extras xorg.libSM
   ];
   propagatedBuildInputs = [
     kauth karchive kconfigwidgets kcoreaddons kcrash kdbusaddons kdesignerplugin

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig, doxygen, graphviz, valgrind
-, glib, dbus, gst_all_1, v4l_utils, alsaLib, ffmpeg, libjack2, libudev, libva, xlibs
+, glib, dbus, gst_all_1, v4l_utils, alsaLib, ffmpeg, libjack2, libudev, libva, xorg
 , sbc, SDL2, makeFontsConf, freefont_ttf
 }:
 
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib dbus gst_all_1.gst-plugins-base gst_all_1.gstreamer v4l_utils
-    alsaLib ffmpeg libjack2 libudev libva xlibs.libX11 sbc SDL2
+    alsaLib ffmpeg libjack2 libudev libva xorg.libX11 sbc SDL2
   ];
 
   patches = [

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -10,7 +10,7 @@
   dbus, fontconfig, freetype, glib, harfbuzz, icu, libX11, libXcomposite,
   libXcursor, libXext, libXi, libXrender, libinput, libjpeg, libpng, libtiff,
   libxcb, libxkbcommon, libxml2, libxslt, openssl, pcre16, pcre2, sqlite, udev,
-  xcbutil, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, xcbutilwm, xlibs,
+  xcbutil, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, xcbutilwm, xorg,
   zlib,
 
   # optional dependencies

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -3,7 +3,7 @@
 
 , bison, coreutils, flex, git, gperf, ninja, pkgconfig, python2, which
 
-, xlibs, libXcursor, libXScrnSaver, libXrandr, libXtst
+, xorg, libXcursor, libXScrnSaver, libXrandr, libXtst
 , fontconfig, freetype, harfbuzz, icu, dbus
 , zlib, minizip, libjpeg, libpng, libtiff, libwebp, libopus
 , jsoncpp, protobuf, libvpx, srtp, snappy, nss, libevent
@@ -103,8 +103,8 @@ qtModule {
     pciutils
 
     # X11 libs
-    xlibs.xrandr libXScrnSaver libXcursor libXrandr xlibs.libpciaccess libXtst
-    xlibs.libXcomposite
+    xorg.xrandr libXScrnSaver libXcursor libXrandr xorg.libpciaccess libXtst
+    xorg.libXcomposite
   ];
 
   dontUseNinjaBuild = true;

--- a/pkgs/development/libraries/webkitgtk/2.18.nix
+++ b/pkgs/development/libraries/webkitgtk/2.18.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, perl, python2, ruby, bison, gperf, cmake
 , pkgconfig, gettext, gobjectIntrospection, libnotify, gnutls
-, gtk3, wayland, libwebp, enchant, xlibs, libxkbcommon, epoxy, at-spi2-core
+, gtk3, wayland, libwebp, enchant, xorg, libxkbcommon, epoxy, at-spi2-core
 , libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs, pcre, nettle, libtasn1, p11-kit
 , libidn, libedit, readline, libGLU_combined, libintlOrEmpty
 , enableGeoLocation ? true, geoclue2, sqlite
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     sqlite gst-plugins-base gst-plugins-bad libxkbcommon epoxy at-spi2-core
   ] ++ optional enableGeoLocation geoclue2
     ++ optional enableGtk2Plugins gtk2
-    ++ (with xlibs; [ libXdmcp libXt libXtst ])
+    ++ (with xorg; [ libXdmcp libXt libXtst ])
     ++ optionals stdenv.isDarwin [ libedit readline libGLU_combined ]
     ++ optional stdenv.isLinux wayland;
 

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -21,7 +21,7 @@
 , libiconv, postgresql, v8_3_16_14, clang, sqlite, zlib, imagemagick
 , pkgconfig , ncurses, xapian_1_2_22, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
 , cmake, libssh2, openssl, mysql, darwin, git, perl, pcre, gecode_3, curl
-, libmsgpack, qt48, libsodium, snappy, libossp_uuid, lxc, libpcap, xlibs, gtk2, buildRubyGem
+, libmsgpack, qt48, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
 , cairo, re2, rake, gobjectIntrospection, gdk_pixbuf
 }@args:
 
@@ -60,12 +60,12 @@ in
 
   cairo = attrs: {
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ gtk2 pcre xlibs.libpthreadstubs xlibs.libXdmcp];
+    buildInputs = [ gtk2 pcre xorg.libpthreadstubs xorg.libXdmcp];
   };
 
   cairo-gobject = attrs: {
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ cairo pcre xlibs.libpthreadstubs xlibs.libXdmcp ];
+    buildInputs = [ cairo pcre xorg.libpthreadstubs xorg.libXdmcp ];
   };
 
   capybara-webkit = attrs: {
@@ -87,14 +87,14 @@ in
       sed -i $installPath/lib/dep-selector-libgecode.rb -e 's@VENDORED_GECODE_DIR =.*@VENDORED_GECODE_DIR = "${gecode_3}"@'
     '';
   };
-  
+
   ethon = attrs: {
     dontBuild = false;
     postPatch = ''
       substituteInPlace lib/ethon/curls/settings.rb \
         --replace "libcurl" "${curl.out}/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary}"
     '';
-  }; 
+  };
 
   eventmachine = attrs: {
     buildInputs = [ openssl ];
@@ -128,7 +128,7 @@ in
 
   gtk2 = attrs: {
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ gtk2 pcre xlibs.libpthreadstubs xlibs.libXdmcp];
+    buildInputs = [ gtk2 pcre xorg.libpthreadstubs xorg.libXdmcp];
     # CFLAGS must be set for this gem to detect gdkkeysyms.h correctly
     CFLAGS = "-I${gtk2.dev}/include/gtk-2.0 -I/non-existent-path";
   };
@@ -205,7 +205,7 @@ in
 
   pango = attrs: {
   nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ gtk2 xlibs.libXdmcp pcre xlibs.libpthreadstubs ];
+    buildInputs = [ gtk2 xorg.libXdmcp pcre xorg.libpthreadstubs ];
   };
 
   patron = attrs: {

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, gnome2, fetchurl, pkgs, xlibs, udev, makeWrapper, makeDesktopItem }:
+{ stdenv, lib, gnome2, fetchurl, pkgs, xorg, udev, makeWrapper, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   name = "postman-${version}";
@@ -54,19 +54,19 @@ stdenv.mkDerivation rec {
       pkgs.nss
       pkgs.nspr
       pkgs.udev.lib
-      xlibs.libX11
-      xlibs.libxcb
-      xlibs.libXi
-      xlibs.libXcursor
-      xlibs.libXdamage
-      xlibs.libXrandr
-      xlibs.libXcomposite
-      xlibs.libXext
-      xlibs.libXfixes
-      xlibs.libXrender
-      xlibs.libX11
-      xlibs.libXtst
-      xlibs.libXScrnSaver
+      xorg.libX11
+      xorg.libxcb
+      xorg.libXi
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXrandr
+      xorg.libXcomposite
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrender
+      xorg.libX11
+      xorg.libXtst
+      xorg.libXScrnSaver
     ];
   in ''
     patchelf \

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -15,7 +15,7 @@ let
       pciutils
       python2
       # Games' dependencies
-      xlibs.xrandr
+      xorg.xrandr
       which
       # Needed by gdialog, including in the steam-runtime
       perl
@@ -51,12 +51,12 @@ in buildFHSUserEnv rec {
 
   multiPkgs = pkgs: with pkgs; [
     # These are required by steam with proper errors
-    xlibs.libXcomposite
-    xlibs.libXtst
-    xlibs.libXrandr
-    xlibs.libXext
-    xlibs.libX11
-    xlibs.libXfixes
+    xorg.libXcomposite
+    xorg.libXtst
+    xorg.libXrandr
+    xorg.libXext
+    xorg.libX11
+    xorg.libXfixes
 
     # Needed to properly check for libGL.so.1 in steam-wrapper.sh
     pkgsi686Linux.glxinfo
@@ -67,7 +67,7 @@ in buildFHSUserEnv rec {
     libdrm
     mono
     xorg.xkeyboardconfig
-    xlibs.libpciaccess
+    xorg.libpciaccess
 
     (steamPackages.steam-runtime-wrapped.override {
       inherit nativeOnly runtimeOnly;

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -15,15 +15,15 @@ let
     gdk_pixbuf
 
     # Without these it silently fails
-    xlibs.libXinerama
-    xlibs.libXdamage
-    xlibs.libXcursor
-    xlibs.libXrender
-    xlibs.libXScrnSaver
-    xlibs.libXxf86vm
-    xlibs.libXi
-    xlibs.libSM
-    xlibs.libICE
+    xorg.libXinerama
+    xorg.libXdamage
+    xorg.libXcursor
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libXxf86vm
+    xorg.libXi
+    xorg.libSM
+    xorg.libICE
     gnome2.GConf
     freetype
     (curl.override { gnutlsSupport = true; sslSupport = false; })
@@ -46,8 +46,8 @@ let
     networkmanager098
 
     # Verified games requirements
-    xlibs.libXmu
-    xlibs.libxcb
+    xorg.libXmu
+    xorg.libxcb
     libGLU
     libuuid
     libogg
@@ -60,7 +60,7 @@ let
     tbb
 
     # Other things from runtime
-    xlibs.libXinerama
+    xorg.libXinerama
     flac
     freeglut
     libjpeg

--- a/pkgs/tools/misc/x11idle/default.nix
+++ b/pkgs/tools/misc/x11idle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, xlibs, fetchgit, libXScrnSaver, libX11 }:
+{ stdenv, fetchgit, libXScrnSaver, libX11 }:
 
 stdenv.mkDerivation {
   name = "x11idle-unstable-2017-07-01";

--- a/pkgs/tools/typesetting/pdf2htmlEX/default.nix
+++ b/pkgs/tools/typesetting/pdf2htmlEX/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig
-, poppler, xlibs, pcre, python, glib, fontforge, cairo, pango, openjdk8
+, poppler, xorg, pcre, python, glib, fontforge, cairo, pango, openjdk8
 
 }:
 
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    xlibs.libpthreadstubs
-    xlibs.libXdmcp
+    xorg.libpthreadstubs
+    xorg.libXdmcp
     pcre
     python
     glib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9533,7 +9533,7 @@ with pkgs;
   libburn = callPackage ../development/libraries/libburn { };
 
   libcaca = callPackage ../development/libraries/libcaca {
-    inherit (xlibs) libX11 libXext;
+    inherit (xorg) libX11 libXext;
   };
 
   libcanberra = callPackage ../development/libraries/libcanberra { };


### PR DESCRIPTION
###### Motivation for this change

part of cleaning up from using aliases' old names

```xlibs``` was renamed to ```xorg``` in 2015 and still popping up 
