### PR TITLE
metrics: fixup sed expr to work with Nix 2

### DIFF
--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -35,7 +35,7 @@ runCommand "nixpkgs-metrics"
       [[ -n $x ]] || exit 1
       echo "$name.allocations $x B" >> $out/nix-support/hydra-metrics
 
-      x=$(sed -e 's/.*values allocated: \([0-9]\+\) .*/\1/ ; t ; d' stats)
+      x=$(sed -e 's/.*values allocated bytes: \([0-9]\+\).*/\1/ ; t ; d' stats)
       [[ -n $x ]] || exit 1
       echo "$name.values $x" >> $out/nix-support/hydra-metrics
     }


### PR DESCRIPTION
Currently metrics job fails, which is blocking the unstable channel.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

EDIT: fixed zed in https://github.com/NixOS/nixpkgs/commit/708e3fb160ad7f7e5fc1e126c26293ce618ded4f


---


Currently still fails on one of the items due to some problem in node-env.nix missing 'libtool',
which is mentioned in recent commits so hopefully will be fixed soon, and maybe has already :).

Here's the error, FWIW:

```
  error: anonymous function at /nix/store/q6gd10jvcr0gp8w2c5nrr00jz596drdy-nixpkgs/pkgs/development/node-packages/node-env.nix:3:1 called without required argument 'libtool', at /nix/store/q6gd10jvcr0gp8w2c5nrr00jz596drdy-nixpkgs/pkgs/applications/editors/zed/node.nix:8:13
```