### PR TITLE
noteshrink: init at 0.1.1

### DIFF
--- a/pkgs/tools/misc/noteshrink/default.nix
+++ b/pkgs/tools/misc/noteshrink/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, python3, imagemagick }:
+
+with python3.pkgs;
+
+buildPythonApplication rec {
+  name = "noteshrink-${version}";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner  = "mzucker";
+    repo   = "noteshrink";
+    rev    = version;
+    sha256 = "0xhrvg3d8ffnbbizsrfppcd2y98znvkgxjdmvbvin458m2rwccka";
+  };
+
+  propagatedBuildInputs = [ numpy scipy imagemagick pillow ];
+
+  meta = with stdenv.lib; {
+    description = "Convert scans of handwritten notes to beautiful, compact PDFs";
+    homepage    = https://mzucker.github.io/2016/09/20/noteshrink.html;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ rnhmjoj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1308,6 +1308,8 @@ with pkgs;
 
   nfdump = callPackage ../tools/networking/nfdump { };
 
+  noteshrink = callPackage ../tools/misc/noteshrink { };
+
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
   onboard = callPackage ../applications/misc/onboard { };


### PR DESCRIPTION
###### Motivation for this change
Just saw this interesting little tool

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (new package)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---