### PR TITLE
Build QGIS and dependencies on darwin

### DIFF
--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, flex, bison, pkgconfig, zlib, libtiff, libpng, fftw
 , cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
-, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages
+, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages, lib
 }:
 
 stdenv.mkDerivation {
@@ -14,6 +14,10 @@ stdenv.mkDerivation {
   buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo
   readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql mysql.connector-c blas ]
     ++ (with python2Packages; [ python dateutil wxPython30 numpy ]);
+
+  # On Darwin the installer tries to symlink the help files into a system
+  # directory
+  patches = [] ++ lib.optional stdenv.isDarwin [ ./no_symbolic_links.patch ];
 
   configureFlags = [
     "--with-proj-share=${proj}/share/proj"

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, flex, bison, pkgconfig, zlib, libtiff, libpng, fftw
 , cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
-, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages, lib
+, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages
 }:
 
 stdenv.mkDerivation {
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   # On Darwin the installer tries to symlink the help files into a system
   # directory
-  patches = [] ++ lib.optional stdenv.isDarwin [ ./no_symbolic_links.patch ];
+  patches = [ ./no_symbolic_links.patch ];
 
   configureFlags = [
     "--with-proj-share=${proj}/share/proj"

--- a/pkgs/applications/gis/grass/no_symbolic_links.patch
+++ b/pkgs/applications/gis/grass/no_symbolic_links.patch
@@ -1,0 +1,37 @@
+diff --git a/include/Make/Install.make b/include/Make/Install.make
+index 0aba138..8ba74bc 100644
+--- a/include/Make/Install.make
++++ b/include/Make/Install.make
+@@ -116,11 +116,6 @@ real-install: | $(INST_DIR) $(UNIX_BIN)
+ 	-$(INSTALL) config.status $(INST_DIR)/config.status
+ 	-$(CHMOD) -R a+rX $(INST_DIR) 2>/dev/null
+ 
+-ifneq ($(findstring darwin,$(ARCH)),)
+-	@# enable OSX Help Viewer
+-	@/bin/ln -sfh "$(INST_DIR)/docs/html" /Library/Documentation/Help/GRASS-$(GRASS_VERSION_MAJOR).$(GRASS_VERSION_MINOR)
+-endif
+-
+ $(INST_DIR) $(UNIX_BIN):
+ 	$(MAKE_DIR_CMD) $@
+ 
+diff --git a/macosx/app/build_html_user_index.sh b/macosx/app/build_html_user_index.sh
+index 04e63eb..c9d9c2c 100755
+--- a/macosx/app/build_html_user_index.sh
++++ b/macosx/app/build_html_user_index.sh
+@@ -140,7 +140,6 @@ else
+ #      echo "<tr><td valign=\"top\"><a href=\"$HTMLDIRG/$i\">$BASENAME</a></td> <td>$SHORTDESC</td></tr>" >> $FULLINDEX
+       # make them local to user to simplify page links
+       echo "<tr><td valign=\"top\"><a href=\"global_$i\">$BASENAME</a></td> <td>$SHORTDESC</td></tr>" >> $FULLINDEX
+-      ln -sf "$HTMLDIRG/$i" global_$i
+     done
+   done
+ fi
+@@ -183,8 +182,3 @@ echo "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\">
+ </html>" > $i.html
+ done
+ 
+-# add Help Viewer links in user docs folder
+-
+-mkdir -p $HOME/Library/Documentation/Help/
+-ln -sfh ../../GRASS/$GRASS_MMVER/Modules/docs/html $HOME/Library/Documentation/Help/GRASS-$GRASS_MMVER-addon
+-ln -sfh $GISBASE/docs/html $HOME/Library/Documentation/Help/GRASS-$GRASS_MMVER

--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -1,22 +1,30 @@
 { stdenv, fetchurl, fetchpatch, gdal, cmake, qt4, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
 , qwt, fcgi, python2Packages, libspatialindex, libspatialite, qscintilla, postgresql, makeWrapper
-, qjson, qca2, txt2tags, openssl
-, withGrass ? false, grass
+, qjson, qca2, txt2tags, openssl, darwin, pkgconfig
+, withGrass ? false, grass, IOKit, ApplicationServices
 }:
 
 stdenv.mkDerivation rec {
   name = "qgis-2.18.16";
 
   buildInputs = [ gdal qt4 flex openssl bison proj geos xlibsWrapper sqlite gsl qwt qscintilla
-    fcgi libspatialindex libspatialite postgresql qjson qca2 txt2tags ] ++
+    fcgi libspatialindex libspatialite postgresql qjson qca2 txt2tags pkgconfig ]
+  ++
+    (stdenv.lib.optionals stdenv.isDarwin [IOKit ApplicationServices])
+  ++
     (stdenv.lib.optional withGrass grass) ++
+    (stdenv.lib.optional (stdenv.isDarwin && withGrass) darwin.apple_sdk.libs.utmp) ++
     (with python2Packages; [ jinja2 numpy psycopg2 pygments requests python2Packages.qscintilla sip ]);
 
-  nativeBuildInputs = [ cmake makeWrapper ];
+  nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
 
   # `make -f src/providers/wms/CMakeFiles/wmsprovider_a.dir/build.make src/providers/wms/CMakeFiles/wmsprovider_a.dir/qgswmssourceselect.cpp.o`:
   # fatal error: ui_qgsdelimitedtextsourceselectbase.h: No such file or directory
   enableParallelBuilding = false;
+
+  preConfigure = ''
+    NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags libspatialindex)"
+  '';
 
   # To handle the lack of 'local' RPATH; required, as they call one of
   # their built binaries requiring their libs, in the build process.
@@ -29,19 +37,44 @@ stdenv.mkDerivation rec {
     sha256 = "0d880m013kzi4qiyr27yjx6hzpb652slp66gyqgw9ziw03wy12c9";
   };
 
-  cmakeFlags = stdenv.lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}";
+  # CMAKE_FIND_FRAMEWORK=never stops the installer choosing system
+  # installed frameworks
+  # QGIS_MACAPP_BUNDLE=0 stops the installer copying the Qt binaries into the
+  # installation which causes havoc
+  # Building RelWithDebInfo allows QGIS_DEBUG to print debugging information
+  cmakeFlags = stdenv.lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}"
+               ++ stdenv.lib.optional stdenv.isDarwin
+                    (["-DCMAKE_FIND_FRAMEWORK=never"]
+                      ++ ["-DQGIS_MACAPP_BUNDLE=0"]);
+#                     ++ ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"];
 
-  postInstall = ''
-    wrapProgram $out/bin/qgis \
-      --prefix PYTHONPATH : $PYTHONPATH \
-      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl ]}
-  '';
+
+
+  postInstall =
+    (stdenv.lib.optionalString stdenv.isLinux ''
+          wrapProgram $out/bin/qgis \
+            --set PYTHONPATH $PYTHONPATH \
+            --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl ]}
+          '') +
+    (stdenv.lib.optionalString stdenv.isDarwin ''
+      # Necessary for QGIS to find the correct default GRASS path
+      ${stdenv.lib.optionalString withGrass "ln -sf ${grass} $out/QGIS.app/Contents/MacOS/grass"}
+      for file in $(find $out -type f -name "QGIS"); do
+        wrapProgram "$file" \
+          --prefix DYLD_LIBRARY_PATH : "${qwt}/lib" \
+          --prefix DYLD_LIBRARY_PATH : "${qscintilla}/lib" \
+          ${stdenv.lib.optionalString withGrass "--prefix PATH : ${grass}/bin"} \
+          --set PYTHONPATH $PYTHONPATH
+      done
+      mkdir -p $out/bin
+      ln -s $out/QGIS.app/Contents/MacOS/QGIS $out/bin/qgis
+      '');
 
   meta = {
     description = "User friendly Open Source Geographic Information System";
     homepage = http://www.qgis.org;
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; unix;
     maintainers = with stdenv.lib.maintainers; [viric];
   };
 }

--- a/pkgs/development/libraries/libspatialindex/default.nix
+++ b/pkgs/development/libraries/libspatialindex/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     description = "Extensible spatial index library in C++";
     homepage = http://libspatialindex.github.io/;
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/qca2/default.nix
+++ b/pkgs/development/libraries/qca2/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     license = "LGPL";
     homepage = http://delta.affinix.com/qca;
     maintainers = [ maintainers.sander ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/qca2/default.nix
+++ b/pkgs/development/libraries/qca2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, qt }:
+{ stdenv, fetchurl, cmake, pkgconfig, qt, darwin }:
 
 stdenv.mkDerivation rec {
   name = "qca-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ qt ];
+  buildInputs = [ (stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security) qt ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -3,6 +3,11 @@
 , withQt5 ? false, qtbase ? null, qtmacextras ? null, qmake ? null
 }:
 
+# Fix Xcode 8 compilation problem
+let xcodePatch =
+  fetchurl { url = "https://raw.githubusercontent.com/Homebrew/formula-patches/a651d71/qscintilla2/xcode-8.patch";
+             sha256 = "1a88309fdfd421f4458550b710a562c622d72d6e6fdd697107e4a43161d69bc9"; };
+in
 stdenv.mkDerivation rec {
   pname = "qscintilla";
   version = "2.9.4";
@@ -18,6 +23,9 @@ stdenv.mkDerivation rec {
     ++ lib.optional (withQt5 && stdenv.isDarwin) qtmacextras;
   nativeBuildInputs = [ unzip ]
     ++ (if withQt5 then [ qmake ] else [ qmake4Hook ]);
+
+
+  patches = [] ++ lib.optional withQt5 [ xcodePatch ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/qwt/6.nix
+++ b/pkgs/development/libraries/qwt/6.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = http://qwt.sourceforge.net/;
     # LGPL 2.1 plus a few exceptions (more liberal)
     license = stdenv.lib.licenses.qwt;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
     branch = "6";
   };

--- a/pkgs/development/libraries/qwt/default.nix
+++ b/pkgs/development/libraries/qwt/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     homepage = http://qwt.sourceforge.net/;
     # LGPL 2.1 plus a few exceptions (more liberal)
     license = stdenv.lib.licenses.qwt;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17225,7 +17225,9 @@ with pkgs;
 
   qemu-riscv = callPackage ../applications/virtualization/qemu/riscv.nix {};
 
-  qgis = callPackage ../applications/gis/qgis {};
+  qgis = callPackage ../applications/gis/qgis {
+    inherit (darwin.apple_sdk.frameworks) IOKit ApplicationServices;
+  };
 
   qgroundcontrol = libsForQt5.callPackage ../applications/science/robotics/qgroundcontrol { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14189,7 +14189,7 @@ in {
         description = "A Python binding to QScintilla, Qt based text editing control";
         license = licenses.lgpl21Plus;
         maintainers = with maintainers; [ danbst ];
-        platforms = platforms.linux;
+        platforms = platforms.unix;
       };
     });
 


### PR DESCRIPTION
###### Motivation for this change

QGIS didn't build on darwin but now it does. I have only tested these patches on OSX. I'm not sure the original QGIS derivation worked properly on nixos anyway, is anyone using it? 

It would be good to test the following attributes using @GrahamcOfBorg 

grass qgis

The rest should be dependencies of qgis. 

cc @viric 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

