### PR TITLE
calibre: 3.17.0 -> 3.19.0

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,28 +5,20 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.17.0";
+  version = "3.19.0";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "1w6hw1s0d4daa4q2ykzhxdndiq61l8z7ls7rxh7k7p62ia0i5sxp";
+    sha256 = "0sann0aw6ngvmqp7049zg6hyqjrb5myq5ivr4r9x732c1cnjhhw9";
   };
 
   patches = [
     # Patches from Debian that:
     # - disable plugin installation (very insecure)
+    ./disable_plugins.patch
     # - switches the version update from enabled to disabled by default
-    (fetchpatch {
-      name = "disable_plugins.patch";
-      url = "http://bazaar.launchpad.net/~calibre-packagers/calibre/debian/download/head:/disable_plugins.py-20111220183043-dcl08ccfagjxt1dv-1/disable_plugins.py";
-      sha256 = "19spdx52dhbrfn9lm084yl3cfwm6f90imd51k97sf7flmpl569pk";
-    })
-    (fetchpatch {
-      name = "no_updates_dialog.patch";
-      url = "http://bazaar.launchpad.net/~calibre-packagers/calibre/debian/download/head:/no_updates_dialog.pa-20081231120426-rzzufl0zo66t3mtc-16/no_updates_dialog.patch";
-      sha256 = "16xwa2fa47jvs954fjrwr8rhh89aljgi1d1wrfxa40sknlmfwxif";
-    })
+    ./no_updates_dialog.patch
     # the unrar patch is not from debian
   ] ++ stdenv.lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
 

--- a/pkgs/applications/misc/calibre/disable_plugins.patch
+++ b/pkgs/applications/misc/calibre/disable_plugins.patch
@@ -1,0 +1,17 @@
+Description: Disable plugin dialog. It uses a totally non-authenticated and non-trusted way of installing arbitrary code.
+Author: Martin Pitt <mpitt@debian.org>
+Bug-Debian: http://bugs.debian.org/640026
+
+Index: calibre-0.8.29+dfsg/src/calibre/gui2/actions/preferences.py
+===================================================================
+--- calibre-0.8.29+dfsg.orig/src/calibre/gui2/actions/preferences.py	2011-12-16 05:49:14.000000000 +0100
++++ calibre-0.8.29+dfsg/src/calibre/gui2/actions/preferences.py	2011-12-20 19:29:04.798468930 +0100
+@@ -28,8 +28,6 @@
+             pm.addAction(QIcon(I('config.png')), _('Preferences'), self.do_config)
+         cm('welcome wizard', _('Run welcome wizard'),
+                 icon='wizard.png', triggered=self.gui.run_wizard)
+-        cm('plugin updater', _('Get plugins to enhance calibre'),
+-                icon='plugins/plugin_updater.png', triggered=self.get_plugins)
+         if not DEBUG:
+             pm.addSeparator()
+             cm('restart', _('Restart in debug mode'), icon='debug.png',

--- a/pkgs/applications/misc/calibre/no_updates_dialog.patch
+++ b/pkgs/applications/misc/calibre/no_updates_dialog.patch
@@ -1,0 +1,27 @@
+diff -burN calibre-2.9.0.orig/src/calibre/gui2/main.py calibre-2.9.0/src/calibre/gui2/main.py
+--- calibre-2.9.0.orig/src/calibre/gui2/main.py	2014-11-09 20:09:54.081231882 +0800
++++ calibre-2.9.0/src/calibre/gui2/main.py	2014-11-09 20:15:48.193033844 +0800
+@@ -37,8 +37,9 @@
+                       help=_('Start minimized to system tray.'))
+     parser.add_option('-v', '--verbose', default=0, action='count',
+                       help=_('Ignored, do not use. Present only for legacy reasons'))
+-    parser.add_option('--no-update-check', default=False, action='store_true',
+-            help=_('Do not check for updates'))
++    parser.add_option('--update-check', dest='no_update_check', default=True,
++            action='store_false',
++            help=_('Check for updates'))
+     parser.add_option('--ignore-plugins', default=False, action='store_true',
+             help=_('Ignore custom plugins, useful if you installed a plugin'
+                 ' that is preventing calibre from starting'))
+diff -burN calibre-2.9.0.orig/src/calibre/gui2/update.py calibre-2.9.0/src/calibre/gui2/update.py
+--- calibre-2.9.0.orig/src/calibre/gui2/update.py	2014-11-09 20:09:54.082231864 +0800
++++ calibre-2.9.0/src/calibre/gui2/update.py	2014-11-09 20:17:49.954767115 +0800
+@@ -154,6 +154,8 @@
+             self.update_checker.signal.update_found.connect(self.update_found,
+                     type=Qt.QueuedConnection)
+             self.update_checker.start()
++        else:
++            self.update_checker = None
+ 
+     def recalc_update_label(self, number_of_plugin_updates):
+         self.update_found(self.last_newest_calibre_version, number_of_plugin_updates)


### PR DESCRIPTION
Also adding locally the lost patches

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

