### PR TITLE
nodejs: add headers output

### DIFF
--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -7,5 +7,6 @@ in
     inherit enableNpm;
     version = "6.13.0";
     sha256 = "012dpfqxsrmd3xc4dmq0mik1kab4czf56s8wm2jvm7xjqvi6y5mp";
+    headersSha256 = "0lmmy1gz3xkisp5i3yqxc1z1sj57qp08g6jwcp9if65gr8xjcnqw";
     patches = lib.optionals stdenv.isDarwin [ ./no-xcode.patch ./no-xcodebuild.patch ];
   }

--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -7,5 +7,6 @@ in
     inherit enableNpm;
     version = "8.9.4";
     sha256 = "0vy8rlg58kg75j4sw3xadmbrwxfa56iaykmjl18g9a8wkjfdxp3c";
+    headersSha256 = "1993kcghzr56zmw5sdj8wr8c42mna25806bcjknfxnh62zl4hwpg";
     patches = lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ./no-xcodebuild.patch ];
   }

--- a/pkgs/development/web/nodejs/v9.nix
+++ b/pkgs/development/web/nodejs/v9.nix
@@ -7,5 +7,6 @@ in
     inherit enableNpm;
     version = "9.7.1";
     sha256 = "0hlhj817s5bji2qdghxkwxjj40kwkyzgax4zyv32r5pbl6af3yh6";
+    headersSha256 = "1c8rjrbvb3g2n2cp2lcnxhy96q5bxm6prq6kh4jscn4p373gyxgi";
     patches = lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];
   }


### PR DESCRIPTION
###### Motivation for this change
These headers are needed when building npm modules that include natively compiled code.
They can now be accessed with `nodejs.headers`.

See i.e. https://github.com/NixOS/nixpkgs/pull/35334

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @manveru @zimbatm @domenkozar @rvl @cleverca22 

cc @fpletz @vcunat for potential backporting candidate