### PR TITLE
androidenv.buildTools: 26.0.1 -> 26.0.2

### DIFF
--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,16 +1,16 @@
 {stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses}:
 
 stdenv.mkDerivation rec {
-  version = "26.0.1";
+  version = "26.0.2";
   name = "android-build-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/build-tools_r${version}-linux.zip";
-      sha256 = "1sp0ir1d88ffw0gz78zlbvnxalz02fsaxwdcvjfynanylwjpyqf8";
+      sha256 = "1kii880bwhjkc343zwx1ysxyisxhczrwhphnxbwsgi45mjgq8lm7";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/build-tools_r${version}-macosx.zip";
-      sha256 = "1ns6c8361l18s3a5x0jc2m3qr06glsb6ak7csrrw6dkzlv8cj5dk";
+      sha256 = "1x0ycprl6hgsm23kck5ind7x00hzydc5k3h3ch4a13407xbpvzvx";
     }
     else throw "System ${stdenv.system} not supported!";
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     cd $out/build-tools
     unzip $src
     mv android-* ${version}
-    
+
     ${stdenv.lib.optionalString (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
       ''
         cd ${version}
@@ -48,9 +48,9 @@ stdenv.mkDerivation rec {
           fi
         done
       ''}
-      
+
       patchShebangs .
   '';
-  
+
   buildInputs = [ unzip file ];
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

