### PR TITLE
Use non-official branding by default for Pale Moon

### DIFF
--- a/pkgs/applications/networking/browsers/newmoon/default.nix
+++ b/pkgs/applications/networking/browsers/newmoon/default.nix
@@ -5,11 +5,13 @@
 , gtk2, hunspell, icu, libevent, libjpeg, libnotify
 , libstartup_notification, libvpx, makeWrapper, libGLU_combined
 , nspr, nss, pango, perl, python, libpulseaudio, sqlite
-, unzip, xorg, which, yasm, zip, zlib
+, unzip, xorg, which, yasm, zip, zlib, enableOfficialBranding ? false
 }:
 
+with stdenv.lib;
+
 stdenv.mkDerivation rec {
-  name = "palemoon-${version}";
+  name = "newmoon-${version}";
   version = "27.8.0";
 
   src = fetchFromGitHub {
@@ -62,7 +64,7 @@ stdenv.mkDerivation rec {
     ac_add_options --prefix=$out
     ac_add_options --with-pthreads
     ac_add_options --enable-application=browser
-    ac_add_options --enable-official-branding
+    ${optionalString enableOfficialBranding "ac_add_options --enable-official-branding"}
     ac_add_options --enable-optimize="-O2"
     ac_add_options --enable-release
     ac_add_options --enable-devtools
@@ -99,7 +101,7 @@ stdenv.mkDerivation rec {
     $src/mach install
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "A web browser";
     longDescription = ''
       Pale Moon is an Open Source, Goanna-based web browser focusing on

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -156,6 +156,7 @@ mapAliases (rec {
   openssh_with_kerberos = openssh; # added 2018-01-28
   owncloudclient = owncloud-client;  # added 2016-08
   p11_kit = p11-kit; # added 2018-02-25
+  palemoon = newmoon; # added 2018-03-13
   pgp-tools = signing-party; # added 2017-03-26
   pidgin-with-plugins = pidgin; # added 2016-06
   pidginlatexSF = pidgin-latex; # added 2014-11-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16970,7 +16970,7 @@ with pkgs;
 
   osquery = callPackage ../tools/system/osquery { };
 
-  palemoon = callPackage ../applications/networking/browsers/palemoon {
+  newmoon = callPackage ../applications/networking/browsers/newmoon {
     # https://forum.palemoon.org/viewtopic.php?f=57&t=15296#p111146
     stdenv = overrideCC stdenv gcc49;
   };


### PR DESCRIPTION
I would suggest dropping Pale Moon, because it's currently built with non-standard options and native libraries and upstream is aggressive towards this. For context, see: https://github.com/jasperla/openbsd-wip/issues/86 and https://github.com/nylira/prism-break/issues/1385#issuecomment-371951915.

Pale Moon redistribution policy: https://www.palemoon.org/redist.shtml

I should note that there are no legal repercussions for redistribution, so no need to pull it from cache, but would be nice to resolve this prior to 18.03 release.

Alternative resolution would be to switch to New Moon branding (i.e. only dropping `ac_add_options --enable-official-branding`) and change attribute name and such.

/cc @rnhmjoj @AndersonTorres