### PR TITLE
rocksdb: fixed rocksdb_lite build

### DIFF
--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "19d8i8map8qz639mhflmxc0w9gp78fvkq1l46y5s6b5imwh0w7xq";
   };
-  
+
   nativeBuildInputs = [ which perl ];
   buildInputs = [ snappy google-gflags zlib bzip2 lz4 malloc fixDarwinDylibNames ];
 
@@ -43,13 +43,13 @@ stdenv.mkDerivation rec {
   CMAKE_CXX_FLAGS = "-std=gnu++11";
   JEMALLOC_LIB = stdenv.lib.optionalString (malloc == jemalloc) "-ljemalloc";
 
-  ${if enableLite then "LIBNAME" else null} = "librocksdb_lite";
+  LIBNAME = if enableLite then "librocksdb_lite" else "librocksdb";
   ${if enableLite then "CXXFLAGS" else null} = "-DROCKSDB_LITE=1";
-  
+
   buildAndInstallFlags = [
     "USE_RTTI=1"
     "DEBUG_LEVEL=0"
-    "DISABLE_WARNING_AS_ERROR=1"     
+    "DISABLE_WARNING_AS_ERROR=1"
   ];
 
   buildFlags = buildAndInstallFlags ++ [
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     echo "BUILD CONFIGURATION FOR SANITY CHECKING"
     cat make_config.mk
     mkdir -pv $static/lib/
-    mv -vi $out/lib/librocksdb.a $static/lib/
+    mv -vi $out/lib/${LIBNAME}.a $static/lib/
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
I saw `rocksdb_lite` [is failing](https://hydra.nixos.org/build/70885758) in the latest builds, so I decided to fix it :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

