### PR TITLE
Fix qca-qt5 build on darwin

### DIFF
--- a/pkgs/development/libraries/qca-qt5/default.nix
+++ b/pkgs/development/libraries/qca-qt5/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl qtbase ];
   nativeBuildInputs = [ cmake pkgconfig ];
 
+  # Without this patch cmake fails with a "No known features for CXX compiler"
+  # error
+  patches = [./move-project.patch];
+
   # tells CMake to use this CA bundle file if it is accessible
   preConfigure = ''export QC_CERTSTORE_PATH=/etc/ssl/certs/ca-certificates.crt'';
 
@@ -22,6 +26,6 @@ stdenv.mkDerivation rec {
     homepage = http://delta.affinix.com/qca;
     maintainers = with maintainers; [ ttuegel ];
     license = licenses.lgpl21Plus;
-    platforms = with platforms; linux;
+    platforms = with platforms; unix;
   };
 }

--- a/pkgs/development/libraries/qca-qt5/default.nix
+++ b/pkgs/development/libraries/qca-qt5/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   # Without this patch cmake fails with a "No known features for CXX compiler"
-  # error
-  patches = [./move-project.patch];
+  # error on darwin
+  patches = stdenv.lib.optional stdenv.isDarwin ./move-project.patch ;
 
   # tells CMake to use this CA bundle file if it is accessible
   preConfigure = ''export QC_CERTSTORE_PATH=/etc/ssl/certs/ca-certificates.crt'';

--- a/pkgs/development/libraries/qca-qt5/move-project.patch
+++ b/pkgs/development/libraries/qca-qt5/move-project.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 453fd8a..5f6ee11 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,13 +6,13 @@ if(NOT CMAKE_INSTALL_PREFIX)
+   unset(CMAKE_INSTALL_PREFIX CACHE)
+ endif(NOT CMAKE_INSTALL_PREFIX)
+
+-project(qca)
+
+ if(NOT APPLE)
+   cmake_minimum_required(VERSION 2.8.12)
+ else()
+   cmake_minimum_required(VERSION 3.0)
+ endif()
++project(qca)
+
+ set(QCA_LIB_MAJOR_VERSION "2")
+ set(QCA_LIB_MINOR_VERSION "1")


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

