### PR TITLE
aspino: fix build

### DIFF
--- a/pkgs/applications/science/logic/aspino/default.nix
+++ b/pkgs/applications/science/logic/aspino/default.nix
@@ -1,34 +1,46 @@
-{ stdenv, fetchFromGitHub, zlib, boost, glucose }:
+{ stdenv, fetchurl, fetchFromGitHub, zlib, boost, glucose }:
+
+let
+  glucose' = fetchurl {
+    url = "http://www.labri.fr/perso/lsimon/downloads/softwares/glucose-syrup.tgz";
+    sha256 = "0bq5l2jabhdfhng002qfk0mcj4pfi1v5853x3c7igwfrgx0jmfld";
+  };
+in
+
 stdenv.mkDerivation rec {
-  name = "aspino-2016-01-31";
+  name = "aspino-unstable-2017-03-09";
 
   src = fetchFromGitHub {
     owner = "alviano";
     repo = "aspino";
-    rev = "d28579b5967988b88bce6d9964a8f0a926286e9c";
-    sha256 = "0r9dnkq3rldv5hhnmycmzqyg23hv5w3g3i5a00a8zalnzfiyirnq";
+    rev = "e31c3b4e5791a454e6602439cb26bd98d23c4e78";
+    sha256 = "0annsjs2prqmv1lbs0lxr7yclfzh47xg9zyiq6mdxcc02rxsi14f";
   };
 
   buildInputs = [ zlib boost ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace "GCC = g++" "GCC = c++"
+
+    patchShebangs .
   '';
 
   preBuild = ''
-    cp ${glucose.src} patches/glucose-syrup.tgz
+    cp ${glucose'} patches/glucose-syrup.tgz
     ./bootstrap.sh
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -m0755 build/release/{aspino,fairino-{bs,ls,ps},maxino-2015-{k16,kdyn}} $out/bin
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {
     description = "SAT/PseudoBoolean/MaxSat/ASP solver using glucose";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ gebner ma27 ];
     platforms = platforms.unix;
     license = licenses.asl20;
     homepage = http://alviano.net/software/maxino/;


### PR DESCRIPTION
###### Motivation for this change

Aspino patched `libglucose` for their own uses, however they currently
depend on glucose v4.0.
(see https://github.com/alviano/aspino/tree/e31c3b4e5791a454e6602439cb26bd98d23c4e78/patches)

The patches don't apply properly on `glucose-4.1` anymore, furthermore
the new source directory caused the `bootstrap.sh` from `aspino` which
was supposed to apply the patches and recompile the setup to break.

Furthermore some minor changes to the derivation were introduced:

- upgraded from `2016-01-31` to `2017-03-09`
- the name contains an `-unstable-` infix as upstream has no releases
- instead of a `patchPhase` the `postPatch` hook will be used for
  `substituteInPlace` to keep advanced patching features from `nixpkgs`
  available.
- `patchShebangs` will be called to avoid impurities because of the
  implicit reliance on `/bin/sh`
- added myself as second maintainer to have more people available in
  case of any further breackage

See https://hydra.nixos.org/build/70688471/log
See ticket #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

