### PR TITLE
pythonPackages.diff_cover: fix build

### DIFF
--- a/pkgs/development/python-modules/diff_cover/default.nix
+++ b/pkgs/development/python-modules/diff_cover/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi, jinja2, jinja2_pluralize, pygments,
   six, inflect, mock, nose, coverage, pycodestyle, flake8, pyflakes, git,
-  pylint, pydocstyle, fetchpatch }:
+  pylint, pydocstyle, fetchpatch, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "diff_cover";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ jinja2 jinja2_pluralize pygments six inflect ];
 
-  checkInputs = [ mock nose coverage pycodestyle flake8 pyflakes pylint pydocstyle git ];
+  checkInputs = [ mock nose coverage pycodestyle flake8 pyflakes pylint pydocstyle git glibcLocales ];
 
   meta = with stdenv.lib; {
     description = "Automatically find diff lines that need test coverage";


### PR DESCRIPTION
###### Motivation for this change

In order to adjust the language with `LC_ALL` properly the
`glibcLocales` is needed as `checkInput`. This was the only thing
preventing the testsuite from passing.

Furthermore I moved the default package from `diff_cover` to
`diff-cover` and added an alias for `diff_cover` for compatibility
reasons.

See ticket #36453
See https://hydra.nixos.org/build/70682982/nixlog/3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

