### PR TITLE
libdynd: fix build w/gcc7

### DIFF
--- a/pkgs/development/libraries/libdynd/default.nix
+++ b/pkgs/development/libraries/libdynd/default.nix
@@ -15,6 +15,12 @@ stdenv.mkDerivation {
     "-DDYND_BUILD_BENCHMARKS=OFF"
   ];
 
+  # added to fix build with gcc7
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=implicit-fallthrough"
+    "-Wno-error=nonnull"
+  ];
+
   buildInputs = [ cmake ];
 
   outputs = [ "out" "dev" ];
@@ -24,5 +30,6 @@ stdenv.mkDerivation {
     description = "C++ dynamic ndarray library, with Python exposure.";
     homepage = http://libdynd.org;
     license = licenses.bsd2;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

didn't build with gcc7.

/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

