### PR TITLE
libsemanage: fix build w/gcc7

### DIFF
--- a/pkgs/os-specific/linux/libsemanage/default.nix
+++ b/pkgs/os-specific/linux/libsemanage/default.nix
@@ -13,7 +13,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ bison flex ];
   buildInputs = [ libsepol libselinux ustr bzip2 libaudit ];
 
-  NIX_CFLAGS_COMPILE = "-fstack-protector-all -std=gnu89";
+  NIX_CFLAGS_COMPILE = [
+    "-fstack-protector-all"
+    "-std=gnu89"
+    # these were added to fix build with gcc7. review on update
+    "-Wno-error=format-truncation"
+    "-Wno-error=implicit-fallthrough"
+  ];
 
   preBuild = ''
     makeFlagsArray+=("PREFIX=$out")


### PR DESCRIPTION
###### Motivation for this change

didn't build with gcc7.

/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

