### PR TITLE
ssh: drop DSA support, fixes #33381

### DIFF
--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -189,10 +189,6 @@ in
 
         ForwardX11 ${if cfg.forwardX11 then "yes" else "no"}
 
-        # Allow DSA keys for now. (These were deprecated in OpenSSH 7.0.)
-        PubkeyAcceptedKeyTypes +ssh-dss
-        HostKeyAlgorithms +ssh-dss
-
         ${cfg.extraConfig}
       '';
 


### PR DESCRIPTION
DSA is predictable when nonce is not random, and support usually is only restricted to 1024 bits. 

See 401782cb678d2e28c0f7f2d40c6421624f410148 and a7b7ac8bfb948f05c8956f8de23d806fb7686438. Resolves #33381.

/cc @edolstra @yorickvP @aneeshusa