### PR TITLE
libs3: 2015-04-23 -> 2017-06-01, fix build

### DIFF
--- a/pkgs/development/libraries/libs3/default.nix
+++ b/pkgs/development/libraries/libs3/default.nix
@@ -1,16 +1,19 @@
 { stdenv, fetchFromGitHub, curl, libxml2 }:
 
 stdenv.mkDerivation {
-  name = "libs3-2015-04-23";
+  name = "libs3-2017-06-01";
 
   src = fetchFromGitHub {
     owner = "bji";
     repo = "libs3";
-    rev = "11a4e976c28ba525e7d61fbc3867c345a2af1519";
-    sha256 = "0xjjwyw14sk9am6s2m25hxi55vmsrc2yiawd6ln2lvg59xjcr48i";
+    rev = "fd8b149044e429ad30dc4c918f0713cdd40aadd2";
+    sha256 = "0a4c9rsd3wildssvnvph6cd11adn0p3rd4l02z03lvxkjhm20gw3";
   };
 
   buildInputs = [ curl libxml2 ];
+
+  # added to fix build with gcc7, review on update
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" ];
 
   DESTDIR = "\${out}";
 


### PR DESCRIPTION
###### Motivation for this change

didn't build with gcc7, newer version available

/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

