### PR TITLE
libgksu: fix build

### DIFF
--- a/pkgs/development/libraries/libgksu/default.nix
+++ b/pkgs/development/libraries/libgksu/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, wrapGAppsHook, gtk2, gnome2, gnome3,
   libstartup_notification, libgtop, perl, perlXMLParser,
-  autoreconfHook, intltool, gtk-doc, docbook_xsl, xauth, sudo
+  autoreconfHook, intltool, docbook_xsl, xauth, sudo
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig autoreconfHook intltool gtk-doc docbook_xsl wrapGAppsHook
+    pkgconfig autoreconfHook intltool docbook_xsl wrapGAppsHook
   ];
 
   buildInputs = [
@@ -66,6 +66,10 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     intltoolize --force --copy --automake
   '';
+
+  configureFlags = [
+    "--disable-gtk-doc"
+  ];
 
   meta = {
     description = "A library for integration of su into applications";


### PR DESCRIPTION
###### Motivation for this change

no longer builds after gtk-doc bump in https://github.com/NixOS/nixpkgs/commit/eb0368554661385ae470e245e50bd0bc10693bf0

https://hydra.nixos.org/build/70843465/nixlog/1

/cc @romildo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

