### PR TITLE
manticore: 2014.08.18 -> 2017.08.22, fix build

### DIFF
--- a/pkgs/development/compilers/manticore/default.nix
+++ b/pkgs/development/compilers/manticore/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchFromGitHub, coreutils, autoreconfHook, smlnj }:
 
 let
-    rev = "592a5714595b4448b646a7d49df04c285668c2f8";
+  rev= "f8e08c89dd98b7b8dba318d245dcd4abd3328ae2";
 in stdenv.mkDerivation rec {
   name = "manticore-${version}";
-  version = "2014.08.18";
+  version = "2017.08.22";
  
   src = fetchFromGitHub {
-    owner = "rrnewton";
-    repo = "manticore_temp_mirror";
-    sha256 = "1snwlm9a31wfgvzb80y7r7yvc6n0k0bi675lqwzll95as7cdswwi";
+    owner = "ManticoreProject";
+    repo = "manticore";
+    sha256 = "06icq0qdzwyzbsyms53blxpb9i26n2vn7ci8p9xvvnq687hxhr73";
     inherit rev;
   };
 
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out
     cd $out
     unpackFile $src
-    mv manticore_temp_mirror-${rev}-src repo_checkout
+    mv source repo_checkout
     cd repo_checkout
     chmod u+w . -R
   ''; 


### PR DESCRIPTION
###### Motivation for this change

build was broken since Nov 2017. 

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

