### PR TITLE
python27Packages.nevow: fix build, 0.14.2->0.14.3

### DIFF
--- a/pkgs/development/python-modules/nevow/default.nix
+++ b/pkgs/development/python-modules/nevow/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, twisted }:
+
+buildPythonPackage rec {
+  pname = "Nevow";
+  version = "0.14.3";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0pid8dj3p8ai715n9a59cryfxrrbxidpda3f8hvgmfpcrjdmnmmb";
+  };
+
+  propagatedBuildInputs = [ twisted ];
+
+  checkPhase = ''
+    trial formless nevow
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Nevow, a web application construction kit for Python";
+    longDescription = ''
+      Nevow - Pronounced as the French "nouveau", or "noo-voh", Nevow
+      is a web application construction kit written in Python.  It is
+      designed to allow the programmer to express as much of the view
+      logic as desired in Python, and includes a pure Python XML
+      expression syntax named stan to facilitate this.  However it
+      also provides rich support for designer-edited templates, using
+      a very small XML attribute language to provide bi-directional
+      template manipulation capability.
+
+      Nevow also includes formless, a declarative syntax for
+      specifying the types of method parameters and exposing these
+      methods to the web.  Forms can be rendered automatically, and
+      form posts will be validated and input coerced, rendering error
+      pages if appropriate.  Once a form post has validated
+      successfully, the method will be called with the coerced values.
+    '';
+    homepage = https://github.com/twisted/nevow;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10689,48 +10689,7 @@ in {
     };
   };
 
-  nevow = buildPythonPackage (rec {
-    name = "nevow-${version}";
-    version = "0.14.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/N/Nevow/Nevow-${version}.tar.gz";
-      sha256 = "0wsh40ysj5gvfc777nrdvf5vbkr606r1gh7ibvw7x8b5g8afdy3y";
-      name = "${name}.tar.gz";
-    };
-
-    disabled = isPy3k;
-
-    propagatedBuildInputs = with self; [ twisted ];
-
-    postInstall = "twistd --help > /dev/null";
-
-    meta = {
-      description = "Nevow, a web application construction kit for Python";
-
-      longDescription = ''
-        Nevow - Pronounced as the French "nouveau", or "noo-voh", Nevow
-        is a web application construction kit written in Python.  It is
-        designed to allow the programmer to express as much of the view
-        logic as desired in Python, and includes a pure Python XML
-        expression syntax named stan to facilitate this.  However it
-        also provides rich support for designer-edited templates, using
-        a very small XML attribute language to provide bi-directional
-        template manipulation capability.
-
-        Nevow also includes formless, a declarative syntax for
-        specifying the types of method parameters and exposing these
-        methods to the web.  Forms can be rendered automatically, and
-        form posts will be validated and input coerced, rendering error
-        pages if appropriate.  Once a form post has validated
-        successfully, the method will be called with the coerced values.
-      '';
-
-      homepage = http://divmod.org/trac/wiki/DivmodNevow;
-
-      license = "BSD-style";
-    };
-  });
+  nevow = callPackage ../development/python-modules/nevow { };
 
   nibabel = callPackage ../development/python-modules/nibabel {};
 


### PR DESCRIPTION
###### Motivation for this change

didn't build (error in test setup). 

/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

