### PR TITLE
Merge swi-prolog 7.4.2 -> 7.6.4 plus enable JPL feature

### DIFF
--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -4,14 +4,14 @@
 }:
 
 let
-  version = "7.4.2";
+  version = "7.6.4";
 in
 stdenv.mkDerivation {
   name = "swi-prolog-${version}";
 
   src = fetchurl {
     url = "http://www.swi-prolog.org/download/stable/src/swipl-${version}.tar.gz";
-    sha256 = "12yzy3w2l1p9fv77lv20xbqq47d0zjw5rkz96mx1xg1lldyja5vz";
+    sha256 = "14bq4sqs61maqpnmgy6687jjj0shwc27cpfsqbf056nrssmplg9d";
   };
 
   buildInputs = [ jdk gmp readline openssl libjpeg unixODBC libXinerama

--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gmp, readline, openssl, libjpeg, unixODBC, zlib
+{ stdenv, fetchurl, jdk, gmp, readline, openssl, libjpeg, unixODBC, zlib
 , libXinerama, libXft, libXpm, libSM, libXt, freetype, pkgconfig
 , fontconfig, makeWrapper ? stdenv.isDarwin
 }:
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "12yzy3w2l1p9fv77lv20xbqq47d0zjw5rkz96mx1xg1lldyja5vz";
   };
 
-  buildInputs = [ gmp readline openssl libjpeg unixODBC libXinerama
+  buildInputs = [ jdk gmp readline openssl libjpeg unixODBC libXinerama
     libXft libXpm libSM libXt zlib freetype pkgconfig fontconfig ]
   ++ stdenv.lib.optional stdenv.isDarwin makeWrapper;
 


### PR DESCRIPTION
###### Motivation for this change

1. update SWI prolog to 7.6.4
2. Add JDK dependency required by JPL prolog library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [a few ] Tested execution of all binary files (usually in `./result/bin/`)
- [hopefully] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

