### PR TITLE
ape: init at 6.7-131003

### DIFF
--- a/pkgs/applications/misc/ape/apeclex.nix
+++ b/pkgs/applications/misc/ape/apeclex.nix
@@ -1,0 +1,8 @@
+{ stdenv, attemptoClex, callPackage }:
+
+callPackage ./. {
+  pname = "ape-clex";
+  lexicon = "${attemptoClex}/clex_lexicon.pl";
+  description = "Parser for Attempto Controlled English (ACE) with a large lexicon (~100,000 entries)";
+  license = with stdenv.lib; [ licenses.lgpl3 licenses.gpl3 ];
+}

--- a/pkgs/applications/misc/ape/clex.nix
+++ b/pkgs/applications/misc/ape/clex.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "attempto-clex-${version}";
+  version = "5133afe";
+
+  src = fetchFromGitHub {
+     owner = "Attempto";
+     repo = "Clex";
+     rev = version;
+     sha256 = "0p9s64g1jic213bwm6347jqckszgnni9szrrz31qjgaf32kf7nkp";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    cp clex_lexicon.pl $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Large lexicon for APE (~100,000 entries)";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ yrashk ];
+  };
+}

--- a/pkgs/applications/misc/ape/default.nix
+++ b/pkgs/applications/misc/ape/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, swiProlog, makeWrapper,
+  fetchFromGitHub,
+  lexicon ? "lexicon/clex_lexicon.pl",
+  pname ? "ape",
+  description ? "Parser for Attempto Controlled English (ACE)",
+  license ? with stdenv.lib; licenses.lgpl3
+  }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  version = "6.7-131003";
+
+  buildInputs = [ swiProlog makeWrapper ];
+
+  src = fetchFromGitHub {
+     owner = "Attempto";
+     repo = "APE";
+     rev = version;
+     sha256 = "0cw47qjg4896kw3vps6rfs02asvscsqvcfdiwgfmqb3hvykb1sdx";
+  };
+
+  patchPhase = ''
+    # We move the file first to avoid "same file" error in the default case
+    cp ${lexicon} new_lexicon.pl
+    rm lexicon/clex_lexicon.pl
+    cp new_lexicon.pl lexicon/clex_lexicon.pl
+  '';
+
+  buildPhase = ''
+    make build
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ape.exe $out
+    makeWrapper $out/ape.exe $out/bin/ape --add-flags ace
+  '';
+
+  meta = with stdenv.lib; {
+    description = description;
+    license = license;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ yrashk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21457,6 +21457,10 @@ with pkgs;
 
   teseq = callPackage ../applications/misc/teseq {  };
 
+  ape = callPackage ../applications/misc/ape { };
+  attemptoClex = callPackage ../applications/misc/ape/clex.nix { };
+  apeClex = callPackage ../applications/misc/ape/apeclex.nix { };
+
   # Unix tools
   unixtools = recurseIntoAttrs (callPackages ./unix-tools.nix { });
   inherit (unixtools) hexdump ps logger eject umount


### PR DESCRIPTION
###### Motivation for this change

Attempto APE is not in Nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

