### PR TITLE
arangodb: 3.3.3 -> 3.3.4

### DIFF
--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -3,14 +3,14 @@
 
 let
 in stdenv.mkDerivation rec {
-  version = "3.3.3";
+  version = "3.3.4";
   name    = "arangodb-${version}";
 
   src = fetchFromGitHub {
     repo = "arangodb";
     owner = "arangodb";
     rev = "v${version}";
-    sha256 = "0hw6yzxmhmnb7qz30pqjdbgin41w892pbf1xbl2821nsz9b290sd";
+    sha256 = "0gfjmva043f9nhqjpa0qy2cdbz84z7b1c2wgcy77i3wnskicy0pc";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangobench --help` got 0 exit code
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangobench --version` and found version 3.3.4
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangodump --help` got 0 exit code
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangodump --version` and found version 3.3.4
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangoexport --help` got 0 exit code
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangoexport --version` and found version 3.3.4
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangoimp --help` got 0 exit code
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangoimp --version` and found version 3.3.4
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangorestore --help` got 0 exit code
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangorestore --version` and found version 3.3.4
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangosh --help` got 0 exit code
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangosh --version` and found version 3.3.4
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangovpack --help` got 0 exit code
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangovpack --version` and found version 3.3.4
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangod --help` got 0 exit code
- ran `/nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4/bin/arangod --version` and found version 3.3.4
- found 3.3.4 with grep in /nix/store/vrgq52j00vwlq56wzq21rzq281lvrzrw-arangodb-3.3.4

cc @flosse for review