### PR TITLE
cfitsio: Change hash for 3.43 to reflect upstream

### DIFF
--- a/pkgs/development/libraries/cfitsio/default.nix
+++ b/pkgs/development/libraries/cfitsio/default.nix
@@ -5,7 +5,7 @@
 
   src = fetchurl {
     url = "ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3430.tar.gz";
-    sha256 = "1rw481bv5srfmldf1h8bqmyljjh0siqh87xh6rip67ms59ssxpn8";
+    sha256 = "07fghxh5fl8nqk3q0dh8rvc83npnm0hisxzcj16a6r7gj5pmp40l";
   };
 
   # Shared-only build


### PR DESCRIPTION
###### Motivation for this change

The file for cfitsio 3.43 was updated 2 days after #36316 (see below). I can't find a reason for this change, however it renders the current version unbuildable as the source is unavailable.

As FTP links seem to not work, here is the URL showing the modified time of the file:
ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

