### PR TITLE
atk: 2.26.1 -> 2.28.1

### DIFF
--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -2,14 +2,14 @@
 
 let
   pname = "atk";
-  version = "2.26.1";
+  version = "2.28.1";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "1jwpx8az0iifw176dc2hl4mmg6gvxzxdkd1qvg4ds7c5hdmzy07g";
+    sha256 = "1z7laf6qwv5zsqcnj222dm5f43c6f3liil0cgx4s4s62xjk1wfnd";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.28.1 with grep in /nix/store/gqr774xsr2qkb7g7s5zz56lyvdf0qm0c-atk-2.28.1
- found 2.28.1 in filename of file in /nix/store/gqr774xsr2qkb7g7s5zz56lyvdf0qm0c-atk-2.28.1

cc @7c6f434c for review