### PR TITLE
audit: 2.8.2 -> 2.8.3

### DIFF
--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -6,11 +6,11 @@
 assert enablePython -> python != null;
 
 stdenv.mkDerivation rec {
-  name = "audit-2.8.2";
+  name = "audit-2.8.3";
 
   src = fetchurl {
     url = "http://people.redhat.com/sgrubb/audit/${name}.tar.gz";
-    sha256 = "1fmw8whraz1q3y3z5mgdpgsa3wz6r3zq0kgsgbc9xvmgfwmrpdb7";
+    sha256 = "06lacv9zjn0sf076dydwmvjhdmik3xzhdjvyrkq75917xv54ajbl";
   };
 
   outputs = [ "bin" "dev" "out" "man" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.8.3 in filename of file in /nix/store/gqr774xsr2qkb7g7s5zz56lyvdf0qm0c-atk-2.28.1

cc @fuuzetsu for review