### PR TITLE
btrbk: 0.26.0 -> 0.26.1

### DIFF
--- a/pkgs/tools/backup/btrbk/default.nix
+++ b/pkgs/tools/backup/btrbk/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "btrbk-${version}";
-  version = "0.26.0";
+  version = "0.26.1";
 
   src = fetchurl {
     url = "http://digint.ch/download/btrbk/releases/${name}.tar.xz";
-    sha256 = "1brnh5x3fd91j3v8rz3van08m9i0ym4lv4hqz274s86v1kx4k330";
+    sha256 = "04ahfm52vcf1w0c2km0wdgj2jpffp45bpawczmygcg8fdcm021lp";
   };
 
   buildInputs = with perlPackages; [ asciidoc-full makeWrapper perl DateCalc ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/.btrbk-wrapped -h` got 0 exit code
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/.btrbk-wrapped --help` got 0 exit code
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/.btrbk-wrapped --version` and found version 0.26.1
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/.btrbk-wrapped -h` and found version 0.26.1
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/.btrbk-wrapped --help` and found version 0.26.1
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/btrbk -h` got 0 exit code
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/btrbk --help` got 0 exit code
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/btrbk --version` and found version 0.26.1
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/btrbk -h` and found version 0.26.1
- ran `/nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1/bin/btrbk --help` and found version 0.26.1
- found 0.26.1 with grep in /nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1
- found 0.26.1 in filename of file in /nix/store/7sylf9ajn9ryic3752af47dsd93c82sc-btrbk-0.26.1

cc @the-kenny for review