### PR TITLE
buildbot: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -14,11 +14,11 @@ let
   package = pythonPackages.buildPythonApplication rec {
     name = "${pname}-${version}";
     pname = "buildbot";
-    version = "1.0.0";
+    version = "1.1.0";
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "0y7gpymxl09gd9dyqj7zqhaihpl9da1v8ppxi4r161ywd8jv9b1g";
+      sha256 = "1rhmlcvw0dsr4f37sb3xmb9xcn76lsrsw2g1z611g339nmxzi0sc";
     };
 
     buildInputs = with pythonPackages; [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/7ai407y4sr374513fcvnp9b8p4g9h829-buildbot-1.1.0/bin/.buildbot-wrapped --help` got 0 exit code
- ran `/nix/store/7ai407y4sr374513fcvnp9b8p4g9h829-buildbot-1.1.0/bin/.buildbot-wrapped --version` and found version 1.1.0
- ran `/nix/store/7ai407y4sr374513fcvnp9b8p4g9h829-buildbot-1.1.0/bin/buildbot --help` got 0 exit code
- ran `/nix/store/7ai407y4sr374513fcvnp9b8p4g9h829-buildbot-1.1.0/bin/buildbot --version` and found version 1.1.0
- found 1.1.0 with grep in /nix/store/7ai407y4sr374513fcvnp9b8p4g9h829-buildbot-1.1.0

cc @nand0p @ryansydnor for review