### PR TITLE
cfitsio: 3.43 -> 3.430

### DIFF
--- a/pkgs/development/libraries/cfitsio/default.nix
+++ b/pkgs/development/libraries/cfitsio/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv }:
 
  stdenv.mkDerivation {
-  name = "cfitsio-3.43";
+  name = "cfitsio-3.430";
 
   src = fetchurl {
     url = "ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3430.tar.gz";
-    sha256 = "1rw481bv5srfmldf1h8bqmyljjh0siqh87xh6rip67ms59ssxpn8";
+    sha256 = "07fghxh5fl8nqk3q0dh8rvc83npnm0hisxzcj16a6r7gj5pmp40l";
   };
 
   # Shared-only build


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.430 with grep in /nix/store/nlysxv2yb8v91i8lj8zqflibgvzpccyp-cfitsio-3.430
- found 3.430 in filename of file in /nix/store/nlysxv2yb8v91i8lj8zqflibgvzpccyp-cfitsio-3.430