### PR TITLE
chunksync: 0.3 -> 0.4

### DIFF
--- a/pkgs/tools/backup/chunksync/default.nix
+++ b/pkgs/tools/backup/chunksync/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, openssl, perl }:
 
 stdenv.mkDerivation rec {
-  version = "0.3";
+  version = "0.4";
   name = "chunksync-${version}";
 
   src = fetchurl {
     url = "http://chunksync.florz.de/chunksync_${version}.tar.gz";
-    sha256 = "e0c27f925c5cf811798466312a56772864b633728c433fb2fcce23c8712b52fc";
+    sha256 = "1gwqp1kjwhcmwhynilakhzpzgc0c6kk8c9vkpi30gwwrwpz3cf00";
   };
 
   buildInputs = [openssl perl];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/bgpzi08y1w7zgv0iaisdd974mdy6pdpl-chunksync-0.4/bin/chunksync -h` got 0 exit code
- ran `/nix/store/bgpzi08y1w7zgv0iaisdd974mdy6pdpl-chunksync-0.4/bin/chunksync -V` and found version 0.4
- ran `/nix/store/bgpzi08y1w7zgv0iaisdd974mdy6pdpl-chunksync-0.4/bin/chunksync -h` and found version 0.4
- found 0.4 with grep in /nix/store/bgpzi08y1w7zgv0iaisdd974mdy6pdpl-chunksync-0.4
- found 0.4 in filename of file in /nix/store/bgpzi08y1w7zgv0iaisdd974mdy6pdpl-chunksync-0.4