### PR TITLE
clutter-gst: 3.0.24 -> 3.0.26

### DIFF
--- a/pkgs/development/libraries/clutter-gst/default.nix
+++ b/pkgs/development/libraries/clutter-gst/default.nix
@@ -2,13 +2,13 @@
 
 let
   pname = "clutter-gst";
-  version = "3.0.24";
+  version = "3.0.26";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "0v6cg0syh4vx7y7ni47jsvr2r57q0j3h1f1gjlp0ciscixywiwg9";
+    sha256 = "0fnblqm4igdx4rn3681bp1gm1y2i00if3iblhlm0zv6ck9nqlqfq";
   };
 
   propagatedBuildInputs = [ clutter gtk3 glib cogl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.0.26 with grep in /nix/store/3x1gsqxcrbyiq3jncz9k8dfa8bi0bamf-clutter-gst-3.0.26
- found 3.0.26 in filename of file in /nix/store/3x1gsqxcrbyiq3jncz9k8dfa8bi0bamf-clutter-gst-3.0.26

cc @lethalman for review