### PR TITLE
hubstaff: 1.3.0 → 1.3.1

### DIFF
--- a/pkgs/applications/misc/hubstaff/default.nix
+++ b/pkgs/applications/misc/hubstaff/default.nix
@@ -5,7 +5,7 @@
 
 let
 
-  version = "1.3.0-9b2ba62";
+  version = "1.3.1-ff75f26";
 
   rpath = stdenv.lib.makeLibraryPath
     [ libX11 zlib libSM libICE libXext freetype libXrender fontconfig libXft
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/${version}/Hubstaff-${version}.sh";
-    sha256 = "1dxzyl3yxbfmbw1pv8k3vhqzbmyyf16zkgrhzsbm866nmbgnqk1s";
+    sha256 = "0jm5l34r6lkfkg8vsdfqbr0axngxznhagwcl9y184lnyji91fmdl";
   };
 
   nativeBuildInputs = [ unzip makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

