### PR TITLE
editres: 1.0.6 -> 1.0.7

### DIFF
--- a/pkgs/tools/graphics/editres/default.nix
+++ b/pkgs/tools/graphics/editres/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libXt, libXaw, libXres, utilmacros }:
 
 stdenv.mkDerivation rec {
-  name = "editres-1.0.6";
+  name = "editres-1.0.7";
 
   src = fetchurl {
     url = "mirror://xorg/individual/app/${name}.tar.gz";
-    sha256 = "06kv7dmw6pzlqc46dbh8k9xpb6sn4ihh0bcpxq0zpvw2lm66dx45";
+    sha256 = "10mbgijb6ac6wqb2grpy9mrazzw68jxjkxr9cbdf1111pa64yj19";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.0.7 in filename of file in /nix/store/3mbmc1niw3y2m109f6v0xlch0pn1ml8q-editres-1.0.7