### PR TITLE
graalvm8: dontFixup = true

### DIFF
--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -116,6 +116,7 @@ in rec {
       mv jdk1.8.0_*/linux-amd64/product $out
       find $out -type f -exec sed -i "s#${oraclejdk8}#$out#g" {} \;
     '';
+    dontFixup = true; # do not nuke path of ffmpeg etc
     dontStrip = true; # why? see in oraclejdk derivation
     inherit (oraclejdk8) meta;
   };
@@ -174,6 +175,7 @@ in rec {
         --replace file:/dev/random    file:/dev/./urandom \
         --replace NativePRNGBlocking  SHA1PRNG
     '';
+    dontFixup = true; # do not nuke path of ffmpeg etc
     dontStrip = true; # why? see in oraclejdk derivation
     doInstallCheck = true;
     installCheckPhase = ''


### PR DESCRIPTION
###### Motivation for this change

It does not fix anything, just reduce binary diff between ```oraclejdk8``` and derivatives ```jvmci8``` and ```graalvm8```

It breaks the mystical magic which allowed processing3 to work on graalvm8 only
https://github.com/NixOS/nixpkgs/pull/35643#issuecomment-372184272

@dtzWill 