### PR TITLE
evince: 3.26.0 -> 3.28.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   name = "evince-${version}";
-  version = "3.26.0";
+  version = "3.28.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evince/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "79567bdb743cf0c3ed7b638da32afc9b850298f9b4edd532455df4a7e2a4c9d8";
+    sha256 = "1a3kcls18dcz1lj8hrx8skcli9xxfyi71c17xjwayh71cm5jc8zs";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/evince -h` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/evince --help` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/evince --version` and found version 3.28.0
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/evince-thumbnailer -h` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/evince-thumbnailer --help` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/evince-previewer -h` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/evince-previewer --help` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/.evince-wrapped -h` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/.evince-wrapped --help` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/.evince-wrapped --version` and found version 3.28.0
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/.evince-thumbnailer-wrapped -h` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/.evince-thumbnailer-wrapped --help` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/.evince-previewer-wrapped -h` got 0 exit code
- ran `/nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0/bin/.evince-previewer-wrapped --help` got 0 exit code
- found 3.28.0 with grep in /nix/store/xa8kjq7jlp5dy53nfd91lmiw7liwg5vw-evince-3.28.0

cc @lethalman @jtojnar @vcunat for review