### PR TITLE
fanficfare: 2.22.0 -> 2.23.0

### DIFF
--- a/pkgs/tools/text/fanficfare/default.nix
+++ b/pkgs/tools/text/fanficfare/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, python27Packages }:
 
 python27Packages.buildPythonApplication rec {
-  version = "2.22.0";
+  version = "2.23.0";
   name = "fanficfare-${version}";
   nameprefix = "";
 
   src = fetchurl {
     url = "https://github.com/JimmXinu/FanFicFare/archive/v${version}.tar.gz";
-    sha256 = "1gwr2qk0wff8f69w21ffj6cq8jklqd89vcdhhln6ii1h1kf8k031";
+    sha256 = "0589b5pg03rfv9x753cnbkz6pz508xs1n2lla3qfpagxc0pyg8i1";
   };
 
   propagatedBuildInputs = with python27Packages; [ beautifulsoup4 chardet html5lib html2text ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0/bin/.fanficfare-wrapped -h` got 0 exit code
- ran `/nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0/bin/.fanficfare-wrapped --help` got 0 exit code
- ran `/nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0/bin/.fanficfare-wrapped -v` and found version 2.23.0
- ran `/nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0/bin/.fanficfare-wrapped --version` and found version 2.23.0
- ran `/nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0/bin/fanficfare -h` got 0 exit code
- ran `/nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0/bin/fanficfare --help` got 0 exit code
- ran `/nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0/bin/fanficfare -v` and found version 2.23.0
- ran `/nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0/bin/fanficfare --version` and found version 2.23.0
- found 2.23.0 with grep in /nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0
- found 2.23.0 in filename of file in /nix/store/3f3695k3x1y2jnq4l62rifazm9hkrwri-fanficfare-2.23.0

cc @lucas8 for review