### PR TITLE
treewide: get rid of platforms.allBut

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -24,10 +24,11 @@ let
 in rec {
   inherit all;
 
-  allBut = platforms: lists.filter (x: !(builtins.elem x platforms)) all;
   none = [];
 
   arm     = filterDoubles predicates.isArm;
+  aarch64 = filterDoubles predicates.isAarch64;
+  x86     = filterDoubles predicates.isx86;
   i686    = filterDoubles predicates.isi686;
   mips    = filterDoubles predicates.isMips;
   x86_64  = filterDoubles predicates.isx86_64;

--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -37,7 +37,9 @@ stdenv.mkDerivation rec {
     description = "A GTK2 image viewer, manga reader, and booru browser";
     maintainers = with maintainers; [ skrzyp xzfc ];
     license = licenses.mit;
-    platforms = platforms.allBut [ "darwin" "cygwin" ];
+    # Unintentionally not working on Darwin:
+    # https://github.com/ahodesuka/ahoviewer/issues/62
+    platforms = platforms.linux;
   };
 }
 

--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
 
     # Needs the SSE2 instruction set. See upstream issue
     # https://github.com/chrjguill/i3lock-color/issues/44
-    platforms = platforms.i686 ++ platforms.x86_64;
+    platforms = platforms.x86;
   };
 }

--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "Numix icon theme (square version)";
     homepage = https://numixproject.org;
     license = licenses.gpl3;
-    platforms = with platforms; allBut darwin;
+    platforms = platforms.linux; # Maybe other non-darwin Unix
     maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/development/compilers/chicken/default.nix
+++ b/pkgs/development/compilers/chicken/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
     homepage = http://www.call-cc.org/;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ the-kenny ];
-    platforms = with stdenv.lib.platforms; allBut darwin;
+    platforms = stdenv.lib.platforms.linux; # Maybe other non-darwin Unix
     description = "A portable compiler for the Scheme programming language";
     longDescription = ''
       CHICKEN is a compiler for the Scheme programming language.

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://mono-project.com/;
     description = "Cross platform, open source .NET development framework";
-    platforms = with stdenv.lib.platforms; allBut [ "aarch64-linux" ];
+    platforms = stdenv.lib.platforms.x86;
     maintainers = with stdenv.lib.maintainers; [ viric thoughtpolice obadz vrthra ];
     license = stdenv.lib.licenses.free; # Combination of LGPL/X11/GPL ?
   };

--- a/pkgs/development/libraries/buddy/default.nix
+++ b/pkgs/development/libraries/buddy/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "Binary decision diagram package";
     license = "as-is";
 
-    platforms = with stdenv.lib.platforms; allBut cygwin;
+    platforms = stdenv.lib.platforms.unix; # Once had cygwin problems
     maintainers = [ stdenv.lib.maintainers.peti ];
   };
 }

--- a/pkgs/development/libraries/cln/default.nix
+++ b/pkgs/development/libraries/cln/default.nix
@@ -15,6 +15,6 @@ stdenv.mkDerivation rec {
     description = "C/C++ library for numbers, a part of GiNaC";
     homepage = http://www.ginac.de/CLN/;
     maintainers = [ ];
-    platforms = with stdenv.lib.platforms; allBut cygwin;
+    platforms = stdenv.lib.platforms.unix; # Once had cygwin problems
   };
 }

--- a/pkgs/development/libraries/cloog-ppl/default.nix
+++ b/pkgs/development/libraries/cloog-ppl/default.nix
@@ -69,6 +69,6 @@ stdenv.mkDerivation rec {
        make[3]: *** [Box.lo] Error 1
 
     */
-    platforms = with stdenv.lib.platforms; allBut cygwin;
+    platforms = stdenv.lib.platforms.unix; # Once had cygwin problems
   };
 }

--- a/pkgs/development/libraries/cloog/0.18.0.nix
+++ b/pkgs/development/libraries/cloog/0.18.0.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
        make[3]: *** [Box.lo] Error 1
 
     */
-    platforms = with stdenv.lib.platforms; allBut cygwin;
+    platforms = stdenv.lib.platforms.unix; # Once had cygwin problems
   };
 }

--- a/pkgs/development/libraries/cloog/default.nix
+++ b/pkgs/development/libraries/cloog/default.nix
@@ -59,6 +59,6 @@ stdenv.mkDerivation rec {
        make[3]: *** [Box.lo] Error 1
 
     */
-    platforms = with stdenv.lib.platforms; allBut cygwin;
+    platforms = stdenv.lib.platforms.unix; # Once had cygwin problems
   };
 }

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     homepage = http://rocksdb.org;
     description = "A library that provides an embeddable, persistent key-value store for fast storage";
     license = licenses.bsd3;
-    platforms = platforms.allBut [ "i686-linux" ];
+    platforms = platforms.x86_64 ++ platforms.aarch64;
     maintainers = with maintainers; [ adev wkennington ];
   };
 }

--- a/pkgs/development/tools/rtags/default.nix
+++ b/pkgs/development/tools/rtags/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     description = "C/C++ client-server indexer based on clang";
     homepage = https://github.com/andersbakken/rtags;
     license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.allBut [ "i686-linux" ];
+    platforms = with stdenv.lib.platforms; x86_64 ++ aarch64;
   };
 }

--- a/pkgs/games/endless-sky/default.nix
+++ b/pkgs/games/endless-sky/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
       gpl3Plus cc-by-sa-30 cc-by-sa-40 publicDomain
     ];
     maintainers = with maintainers; [ lheckemann ];
-    platforms = with platforms; allBut darwin;
+    platforms = platforms.linux; # Maybe other non-darwin Unix
   };
 }

--- a/pkgs/misc/screensavers/alock/default.nix
+++ b/pkgs/misc/screensavers/alock/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       xscreensaver and never will. It's just for locking the current
       X session.
     '';
-    platforms = with platforms; allBut cygwin;
+    platforms = platforms.unix; # Cygwin had problems at one point
     maintainers = with maintainers; [ ftrvxmtrx chris-martin ];
   };
 }

--- a/pkgs/misc/screensavers/xscreensaver/default.nix
+++ b/pkgs/misc/screensavers/xscreensaver/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     homepage = https://www.jwz.org/xscreensaver/;
     description = "A set of screensavers";
     maintainers = with stdenv.lib.maintainers; [ raskin ];
-    platforms = with stdenv.lib.platforms; allBut cygwin;
+    platforms = stdenv.lib.platforms.unix; # Once had cygwin problems
     inherit version;
     downloadPage = "https://www.jwz.org/xscreensaver/download.html";
     updateWalker = true;

--- a/pkgs/tools/graphics/barcode/default.nix
+++ b/pkgs/tools/graphics/barcode/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "GNU barcode generator";
     maintainers = with maintainers; [ raskin ];
-    platforms = with platforms; allBut darwin;
+    platforms = platforms.linux; # Maybe other non-darwin Unix
     downloadPage = "http://ftp.gnu.org/gnu/barcode/";
     updateWalker = true;
     homepage = http://ftp.gnu.org/gnu/barcode/;

--- a/pkgs/tools/graphics/dcraw/default.nix
+++ b/pkgs/tools/graphics/dcraw/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.cybercom.net/~dcoffin/dcraw/;
     description = "Decoder for many camera raw picture formats";
     license = stdenv.lib.licenses.free;
-    platforms = with stdenv.lib.platforms; allBut cygwin;
+    platforms = stdenv.lib.platforms.unix; # Once had cygwin problems
     maintainers = [ ];
   };
 }

--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description  = "A tool for buffering data streams with a large set of unique features";
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ tokudan ];
-    platforms = with stdenv.lib.platforms; allBut darwin;
+    platforms = stdenv.lib.platforms.linux; # Maybe other non-darwin Unix
   };
 }

--- a/pkgs/tools/networking/dnscrypt-proxy/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     maintainers = with maintainers; [ joachifm jgeerds ];
     # upstream claims OSX support, but Hydra fails
-    platforms = with platforms; allBut darwin;
+    platforms = platforms.linux; # Maybe other non-darwin Unix
   };
 }

--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.zerotier.com;
     license = licenses.gpl3;
     maintainers = with maintainers; [ sjmackenzie zimbatm ehmry ];
-    platforms = platforms.allBut [ "i686-linux" ];
+    platforms = platforms.x86_64 ++ platforms.aarch64;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13517,7 +13517,7 @@ in {
       homepage = https://pypi.python.org/pypi/PyICU/;
       description = "Python extension wrapping the ICU C++ API";
       license = licenses.mit;
-      platforms = with platforms; allBut darwin;
+      platforms = platforms.linux; # Maybe other non-darwin Unix
       maintainers = [ maintainers.rycee ];
     };
   };

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -108,7 +108,7 @@ rec {
 
 
   /* Common platform groups on which to test packages. */
-  inherit (platforms) unix linux darwin cygwin allBut all mesaPlatforms;
+  inherit (platforms) unix linux darwin cygwin all mesaPlatforms;
 
   /* Platform groups for specific kinds of applications. */
   x11Supported = linux;

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -21,7 +21,7 @@ with import ./release-lib.nix { inherit supportedSystems; };
   atlas = linux;
   autoconf = all;
   automake = all;
-  avahi = allBut cygwin;  # Cygwin builds fail
+  avahi = unix; # Cygwin builds fail
   bash = all;
   bashInteractive = all;
   bc = all;
@@ -54,7 +54,7 @@ with import ./release-lib.nix { inherit supportedSystems; };
   gnumake = all;
   gnupatch = all;
   gnupg = linux;
-  gnuplot = allBut cygwin;
+  gnuplot = unix; # Cygwin builds fail
   gnused = all;
   gnutar = all;
   gnutls = linux;
@@ -128,7 +128,7 @@ with import ./release-lib.nix { inherit supportedSystems; };
   pkgconfig = all;
   pmccabe = linux;
   procps = linux;
-  python = allBut cygwin;
+  python = unix; # Cygwin builds fail
   readline = all;
   rlwrap = all;
   rpm = linux;
@@ -138,9 +138,9 @@ with import ./release-lib.nix { inherit supportedSystems; };
   scrot = linux;
   sdparm = linux;
   sharutils = all;
-  sloccount = allBut cygwin;
+  sloccount = unix; # Cygwin builds fail
   smartmontools = all;
-  sqlite = allBut cygwin;
+  sqlite = unix; # Cygwin builds fail
   squid = linux;
   ssmtp = linux;
   stdenv = all;


### PR DESCRIPTION
###### Motivation for this change

Negative reasoning like `allBut` is a bad idea with an open world of platforms. Concretely, if we add a new, quite different sort of platform, existing packages with `allBut` will claim they work on it even though they probably won't.

Also, there's no good/cheap way to implement this with a https://github.com/NixOS/nixpkgs/pull/34444-like strategy.

`all` is also bad, but at least as a good constructive interpretation of "I work everywhere because I require nothing; so give me nothing". Relatedly, everything we have left can be expressed with horn clauses, `allBut` couldn't be.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

