### PR TITLE
fricas: 1.3.2 -> 1.3.3

### DIFF
--- a/pkgs/applications/science/math/fricas/default.nix
+++ b/pkgs/applications/science/math/fricas/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, sbcl, libX11, libXpm, libICE, libSM, libXt, libXau, libXdmcp }:
 
 let
-  version = "1.3.2";
+  version = "1.3.3";
   name = "fricas-" + version;
 in
 stdenv.mkDerivation {
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url    = "http://sourceforge.net/projects/fricas/files/fricas/${version}/${name}-full.tar.bz2";
-    sha256 = "17a3vfvsn2idydqslf5r6z3sk6a5bdgj6z1n3dmnwmpkc4z152vr";
+    sha256 = "1avp9mbl5yn192c7kz5c2d18k33hay9lwii363b0v5hj3qgq2hhl";
   };
 
   buildInputs = [ sbcl libX11 libXpm libICE libSM libXt libXau libXdmcp ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/gbxxlzids227g9xaiqyqp2hp8ccmkfvq-fricas-1.3.3/bin/fricas -h` got 0 exit code
- ran `/nix/store/gbxxlzids227g9xaiqyqp2hp8ccmkfvq-fricas-1.3.3/bin/fricas -h` and found version 1.3.3
- ran `/nix/store/gbxxlzids227g9xaiqyqp2hp8ccmkfvq-fricas-1.3.3/bin/efricas --help` got 0 exit code
- found 1.3.3 with grep in /nix/store/gbxxlzids227g9xaiqyqp2hp8ccmkfvq-fricas-1.3.3

cc @sprock for review