### PR TITLE
profanity: fix build on darwin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, glib, openssl, expat, libmesode
-, ncurses, libotr, curl, readline, libuuid
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib, openssl
+, glibcLocales, expect, ncurses, libotr, curl, readline, libuuid
+, cmocka, libmicrohttpd, stabber, expat, libmesode
 
 , autoAwaySupport ? false,       libXScrnSaver ? null, libX11 ? null
 , notifySupport ? false,         libnotify ? null, gdk_pixbuf ? null
@@ -20,18 +21,22 @@ stdenv.mkDerivation rec {
   name = "profanity-${version}";
   version = "0.5.1";
 
-  src = fetchurl {
-    url = "http://www.profanity.im/profanity-${version}.tar.gz";
-    sha256 = "1f7ylw3mhhnii52mmk40hyc4kqhpvjdr3hmsplzkdhsfww9kflg3";
+  src = fetchFromGitHub {
+    owner = "boothj5";
+    repo = "profanity";
+    rev = "${version}";
+    sha256 = "1ppr02wivhlrqr62r901clnycna8zpn6kr7n5rw8y3zfw21ny17z";
   };
+
+  patches = [ ./patches/packages-osx.patch ./patches/undefined-macros.patch ];
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook glibcLocales pkgconfig ];
 
   buildInputs = [
-    readline libuuid libmesode
-    glib openssl expat ncurses libotr curl
+    expect readline libuuid glib openssl expat ncurses libotr
+    curl libmesode cmocka libmicrohttpd stabber
   ] ++ optionals autoAwaySupport     [ libXScrnSaver libX11 ]
     ++ optionals notifySupport       [ libnotify gdk_pixbuf ]
     ++ optionals traySupport         [ gnome2.gtk ]
@@ -44,6 +49,20 @@ stdenv.mkDerivation rec {
     ++ optionals traySupport         [ "--enable-icons" ]
     ++ optionals pgpSupport          [ "--enable-pgp" ]
     ++ optionals pythonPluginSupport [ "--enable-python-plugins" ];
+
+  preAutoreconf = ''
+    mkdir m4
+  '';
+
+  doCheck = true;
+
+  LC_ALL = "en_US.utf8";
+
+  NIX_CFLAGS_COMPILE = [ ]
+    ++ optionals pythonPluginSupport [ "-I${python}/include/${python.libPrefix}" ];
+
+  LDFLAGS = [ ]
+    ++ optionals pythonPluginSupport [ "-L${python}/lib" "-lpython${python.majorVersion}m" ];
 
   meta = {
     description = "A console based XMPP client";

--- a/pkgs/applications/networking/instant-messengers/profanity/patches/packages-osx.patch
+++ b/pkgs/applications/networking/instant-messengers/profanity/patches/packages-osx.patch
@@ -1,0 +1,11 @@
+diff --git a/configure.ac b/configure.ac
+index 1e55b1cc..0832a387 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -22,7 +22,6 @@ AC_CANONICAL_HOST
+ PLATFORM="unknown"
+ AS_CASE([$host_os],
+     [freebsd*], [PLATFORM="freebsd"],
+-    [darwin*], [PLATFORM="osx"],
+     [cygwin], [PLATFORM="cygwin"],
+     [PLATFORM="nix"])

--- a/pkgs/applications/networking/instant-messengers/profanity/patches/undefined-macros.patch
+++ b/pkgs/applications/networking/instant-messengers/profanity/patches/undefined-macros.patch
@@ -1,0 +1,40 @@
+diff --git a/configure.ac b/configure.ac
+index 1e55b1cc..0832a387 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -83,12 +81,12 @@ elif test "x$enable_python_plugins" != xno; then
+         AM_CONDITIONAL([BUILD_PYTHON_API], [true])
+         AC_DEFINE([HAVE_PYTHON], [1], [Python support])
+     else
+-        if test "x$enable_python_plugins" = xyes; then
+-            AC_MSG_ERROR([Python not found, cannot enable Python plugins.])
+-        else
+-            AM_CONDITIONAL([BUILD_PYTHON_API], [false])
+-            AC_MSG_NOTICE([Python development package not found, Python plugin support disabled.])
+-        fi
++        AS_IF(
++            [test "x$enable_python_plugins" = xyes],
++            [],
++            [AM_CONDITIONAL([BUILD_PYTHON_API], [false])
++            AC_MSG_NOTICE([Python development package not found, Python plugin support disabled.])]
++        )
+     fi
+     AS_IF([test "x$PLATFORM" = xosx], [rm -f Python.framework])
+ else
+@@ -107,7 +105,7 @@ else
+             [AM_CONDITIONAL([BUILD_C_API], [true]) LIBS="$LIBS -ldl" AC_DEFINE([HAVE_C], [1], [C support])],
+             [AS_IF(
+                 [test "x$enable_c_plugins" = xyes],
+-                    [AC_MSG_ERROR([dl library needed to run C plugins])],
++                [],
+                 [AM_CONDITIONAL([BUILD_C_API], [false])])
+             ])
+     else
+@@ -116,7 +114,6 @@ else
+ fi
+ 
+ # threading
+-ACX_PTHREAD([], [AC_MSG_ERROR([pthread is required])])
+ LIBS="$PTHREAD_LIBS $LIBS"
+ CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+ AS_IF([test "x$PTHREAD_CC" != x], [ CC="$PTHREAD_CC" ])


### PR DESCRIPTION
###### Motivation for this change

18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

