### PR TITLE
fwts: 18.01.00 -> 18.02.00

### DIFF
--- a/pkgs/os-specific/linux/fwts/default.nix
+++ b/pkgs/os-specific/linux/fwts/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "fwts-${version}";
-  version = "18.01.00";
+  version = "18.02.00";
 
   src = fetchzip {
     url = "http://fwts.ubuntu.com/release/fwts-V${version}.tar.gz";
-    sha256 = "043wkq4hz5pz79masppya67b8i5jw61p1j8dw17jwc8w6gp8csfb";
+    sha256 = "0z8yvicp4qk1xi8xmbrngnc294fjdnb9qn5d9lnyls4i6mmvpr2d";
     stripRoot = false;
   };
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00/bin/fwts -h` got 0 exit code
- ran `/nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00/bin/fwts --help` got 0 exit code
- ran `/nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00/bin/fwts -V` and found version 18.02.00
- ran `/nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00/bin/fwts -v` and found version 18.02.00
- ran `/nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00/bin/fwts --version` and found version 18.02.00
- ran `/nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00/bin/fwts -h` and found version 18.02.00
- ran `/nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00/bin/fwts --help` and found version 18.02.00
- found 18.02.00 with grep in /nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00
- found 18.02.00 in filename of file in /nix/store/crwgi7517lb2f7b0dag5nnyvqcdr8iw3-fwts-18.02.00

cc @tadfisher for review