### PR TITLE
gnome-themes-standard: 3.22.3 -> 3.27.90

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-themes-standard/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-themes-standard/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-themes-standard-${version}";
-  version = "3.22.3";
+  version = "3.27.90";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-themes-standard/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "61dc87c52261cfd5b94d65e8ffd923ddeb5d3944562f84942eeeb197ab8ab56a";
+    sha256 = "1p1ibm0f2py0lrxrw8wv1jvs630mmz9q97f404jyzr4a8nswrizz";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.27.90 with grep in /nix/store/bawbjvlldazy2xmvhkq478709ygg04by-gnome-themes-standard-3.27.90

cc @lethalman @jtojnar for review