### PR TITLE
googler: 3.3 -> 3.5

### DIFF
--- a/pkgs/applications/misc/googler/default.nix
+++ b/pkgs/applications/misc/googler/default.nix
@@ -1,14 +1,14 @@
 {stdenv, fetchFromGitHub, python}:
 
 stdenv.mkDerivation rec {
-  version = "3.3";
+  version = "3.5";
   name = "googler-${version}";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "googler";
     rev = "v${version}";
-    sha256 = "0gkzgcf0qss7fskgswryk835vivlv1f99ym1pbxy3vv9wcwx6a43";
+    sha256 = "0z5cngg1kr3b484zddqlg9yn7crbmnd78pdb8vzd32mkp3fahcxa";
   };
 
   propagatedBuildInputs = [ python ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/g2q5sbf3gfjrm20zdgzpdk1fd01w5yj7-googler-3.5/bin/googler -h` got 0 exit code
- ran `/nix/store/g2q5sbf3gfjrm20zdgzpdk1fd01w5yj7-googler-3.5/bin/googler --help` got 0 exit code
- ran `/nix/store/g2q5sbf3gfjrm20zdgzpdk1fd01w5yj7-googler-3.5/bin/googler -v` and found version 3.5
- ran `/nix/store/g2q5sbf3gfjrm20zdgzpdk1fd01w5yj7-googler-3.5/bin/googler --version` and found version 3.5
- ran `/nix/store/g2q5sbf3gfjrm20zdgzpdk1fd01w5yj7-googler-3.5/bin/googler -h` and found version 3.5
- ran `/nix/store/g2q5sbf3gfjrm20zdgzpdk1fd01w5yj7-googler-3.5/bin/googler --help` and found version 3.5
- found 3.5 with grep in /nix/store/g2q5sbf3gfjrm20zdgzpdk1fd01w5yj7-googler-3.5
- found 3.5 in filename of file in /nix/store/g2q5sbf3gfjrm20zdgzpdk1fd01w5yj7-googler-3.5

cc @k0ral for review