### PR TITLE
grib-api: 1.24.0 -> 1.26.0

### DIFF
--- a/pkgs/development/libraries/grib-api/default.nix
+++ b/pkgs/development/libraries/grib-api/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec{
   name = "grib-api-${version}";
-  version = "1.24.0";
+  version = "1.26.0";
 
   src = fetchurl {
     url = "https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-${version}-Source.tar.gz";
-    sha256 = "1kbvyzaghbn1bqn97sslskmb6k3ki1dnr0g5abk5sb40n0y483bb";
+    sha256 = "00cmmj44bhdlzhqbvwb3bb4xks3bpva669m6g3g6ffjaqm25b90c";
   };
 
   preConfigure = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_histogram -h` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_histogram --help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_histogram help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_debug -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_info -v` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_filter -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_ls help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_ls -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_dump -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib2ppm -h` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib2ppm --help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib2ppm help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_set -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_get -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_get_data -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_copy -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_packing help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_packing version` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_packing help` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_convert -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_corruption_check help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_corruption_check version` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_corruption_check help` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_compare -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_parser help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_count help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_index_build help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_index_build -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_to_json help` got 0 exit code
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_to_netcdf -V` and found version 1.26.0
- ran `/nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0/bin/grib_list_keys help` got 0 exit code
- found 1.26.0 with grep in /nix/store/7371b0i6vd3ryh90kikrfcpa6am6ls8y-grib-api-1.26.0

cc @knedlsepp for review