### PR TITLE
glm: fix darwin build

### DIFF
--- a/pkgs/development/libraries/glm/default.nix
+++ b/pkgs/development/libraries/glm/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   # fetch newer version of platform.h which correctly supports gcc 7.3
   gcc7PlatformPatch = fetchurl {
-    url = "https://raw.githubusercontent.com/g-truc/glm/dd48b56e44d699a022c69155c8672caacafd9e8a/glm/simd/platform.h";
-    sha256 = "0y91hlbgn5va7ijg5mz823gqkq9hqxl00lwmdwnf8q2g086rplzw";
+    url = "https://raw.githubusercontent.com/g-truc/glm/384dab02e45a8ad3c1a3fa0906e0d5682c5b27b9/glm/simd/platform.h";
+    sha256 = "0ym0sgwznxhfyi014xs55x3ql7r65fjs34sqb5jiaffkdhkqgzia";
   };
 
   postPatch = ''
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
       --replace '"''${CMAKE_CURRENT_BINARY_DIR}/''${GLM_INSTALL_CONFIGDIR}' '"''${GLM_INSTALL_CONFIGDIR}'
     cp ${gcc7PlatformPatch} glm/simd/platform.h
   '';
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionals stdenv.isDarwin [
+    "-DGLM_COMPILER=0"
+  ];
 
   postInstall = ''
     mkdir -p $doc/share/doc/glm


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

