### PR TITLE
gnome2.zenity: Add docbook_xml_dtd_412 to prevent build failure

### DIFF
--- a/pkgs/desktops/gnome-2/desktop/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gnome-control-center/default.nix
@@ -3,7 +3,7 @@
 , glib, gtk, pango, atk, gnome-doc-utils, intltool, GConf, libglade, libgnome, libgnomeui, libgnomekbd
 , librsvg, gnome_menus, gnome-desktop, gnome_panel, metacity, gnome-settings-daemon
 , libbonobo, libbonoboui, libgnomecanvas, libart_lgpl, gnome_vfs, ORBit2
-, libSM }:
+, libSM, docbook_xml_dtd_412 }:
 
 stdenv.mkDerivation {
   name = "gnome-control-center-2.32.1";
@@ -15,9 +15,9 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ dbus-glib libxml2Python libxslt libxklavier popt which python shared-mime-info desktop-file-utils
-                  gtk gnome-doc-utils intltool GConf libglade libgnomekbd libunique libtool bzip2 
+                  gtk gnome-doc-utils intltool GConf libglade libgnomekbd libunique libtool bzip2
                   libgnomeui librsvg gnome_menus gnome-desktop gnome_panel metacity gnome-settings-daemon
-                  libSM
+                  libSM docbook_xml_dtd_412
   ];
   configureFlags = "--disable-scrollkeeper";
 }

--- a/pkgs/desktops/gnome-2/desktop/zenity/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/zenity/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, cairo, libxml2, libxslt, glib, gtk, pango, atk
-, gnome-doc-utils, intltool, libglade, libX11, which }:
+, gnome-doc-utils, intltool, libglade, libX11, which, docbook_xml_dtd_412 }:
 
 stdenv.mkDerivation {
   name = "zenity-2.32.1";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   };
 
   configureFlags = "--disable-scrollkeeper";
-  buildInputs = [ gtk libglade libxml2 libxslt libX11 ];
+  buildInputs = [ gtk libglade libxml2 libxslt libX11 docbook_xml_dtd_412 ];
 
   nativeBuildInputs = [ pkgconfig intltool gnome-doc-utils which ];
 }


### PR DESCRIPTION
Adds docbook_xml_dtd_412 to build dependencies.

###### Motivation for this change

1. ensure a rebuild of gnome2.zenity (EG: change version number to 2.32.2 as done below)
2. build with `nix build -f default.nix pkgs.gnome2.zenity`

expectation is gnome2.zenity succeeds. Actual is build of gnome2.zenity fails with:

~~~
builder for '/nix/store/c64dr3z107aklgf0rzw9gka4wc6zxvl2-zenity-2.32.2.drv' failed with exit code 2; last 10 log lines:
  xsltproc -o zenity-C.omf --stringparam db2omf.basename zenity --stringparam db2omf.format 'docbook' --stringparam db2omf.dtd "-//OASIS//DTD DocBook XML V4.1.2//EN" --stringparam db2omf.lang C --stringparam db2omf.omf_dir "/nix/s
tore/zsp439gygfhxwzzvhqj9x3ck60sq0agb-zenity-2.32.2/share/omf" --stringparam db2omf.help_dir "/nix/store/zsp439gygfhxwzzvhqj9x3ck60sq0agb-zenity-2.32.2/share/gnome/help" --stringparam db2omf.omf_in "/tmp/nix-build-zenity-2.32.2.dr
v-0/zenity-2.32.1/help/zenity.omf.in"  `/nix/store/340wmknqs4by554nwpg3hcr52lshqdj2-pkg-config-0.29.2/bin/pkg-config --variable db2omf gnome-doc-utils` C/zenity.xml || { rm -f "zenity-C.omf"; exit 1; }
  http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd:22: parser error : Comment not terminated

   ^
  unable to parse C/zenity.xml
  make[2]: *** [Makefile:596: zenity-C.omf] Error 1
  make[2]: Leaving directory '/tmp/nix-build-zenity-2.32.2.drv-0/zenity-2.32.1/help'
  make[1]: *** [Makefile:322: all-recursive] Error 1
  make[1]: Leaving directory '/tmp/nix-build-zenity-2.32.2.drv-0/zenity-2.32.1'
  make: *** [Makefile:260: all] Error 2
~~~

Which means the DTD cannot be accessed.

The following patch adds the DTD to the build depends.

Strange this succeeded before. Difference in nix builder sandbox WRT network DTD references?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

