### PR TITLE
hwdata: 0.309 -> 0.310

### DIFF
--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "hwdata-${version}";
-  version = "0.309";
+  version = "0.310";
 
   src = fetchurl {
-    url = "https://github.com/vcrhonek/hwdata/archive/v0.309.tar.gz";
-    sha256 = "1njx4lhg7a0cawz82x535vk4mslmnfj7nmf8dbq8kgqxiqh6h2c7";
+    url = "https://github.com/vcrhonek/hwdata/archive/v0.310.tar.gz";
+    sha256 = "08mhwwc9g9cpfyxrwwviflkdk2jnqs6hc95iv4r5d59hqrj5kida";
   };
 
   preConfigure = "patchShebangs ./configure";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.310 with grep in /nix/store/m4pqcazp9c7nn1kkzi12l9m6hr8drl7v-hwdata-0.310
- found 0.310 in filename of file in /nix/store/m4pqcazp9c7nn1kkzi12l9m6hr8drl7v-hwdata-0.310