### PR TITLE
pythonPackages.pycurl: Fix darwin build

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13013,8 +13013,10 @@ in {
 
     buildInputs = with self; [ pkgs.curl pkgs.openssl.out ];
 
-    # error: invalid command 'test'
-    doCheck = false;
+    checkInputs = with self; [ bottle pytest nose ];
+    checkPhase = ''
+      py.test -k "not test_ssl_in_static_libs" tests
+    '';
 
     preConfigure = ''
       substituteInPlace setup.py --replace '--static-libs' '--libs'
@@ -13024,7 +13026,6 @@ in {
     meta = {
       homepage = http://pycurl.sourceforge.net/;
       description = "Python wrapper for libcurl";
-      platforms = platforms.linux;
     };
   });
 


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

