### PR TITLE
igv: 2.4.8 -> 2.4.9

### DIFF
--- a/pkgs/applications/science/biology/igv/default.nix
+++ b/pkgs/applications/science/biology/igv/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "igv-${version}";
-  version = "2.4.8";
+  version = "2.4.9";
 
   src = fetchurl {
     url = "http://data.broadinstitute.org/igv/projects/downloads/2.4/IGV_${version}.zip";
-    sha256 = "1ca4lsb5j00066sd1gy8jr8jhzpd9142fhj4khb8nc45010wib0q";
+    sha256 = "0acyq7602g2pz6mc9ip1297c68kgl9pq9yzk3k2lli9l5qvxi3g1";
   };
 
   buildInputs = [ unzip jre ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.4.9 with grep in /nix/store/q5c9jyg6gc4v3ns7rw5lxj7v4v916a7f-igv-2.4.9
- found 2.4.9 in filename of file in /nix/store/q5c9jyg6gc4v3ns7rw5lxj7v4v916a7f-igv-2.4.9

cc @mimadrid for review