### PR TITLE
inboxer: 1.0.2 -> 1.0.3

### DIFF
--- a/pkgs/applications/networking/mailreaders/inboxer/default.nix
+++ b/pkgs/applications/networking/mailreaders/inboxer/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "inboxer-${version}";
-  version = "1.0.2";
+  version = "1.0.3";
 
   meta = with stdenv.lib; {
     description = "Unofficial, free and open-source Google Inbox Desktop App";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/denysdovhan/inboxer/releases/download/v${version}/inboxer_${version}_amd64.deb";
-    sha256 = "0nqgsqxsjnj46wsfb60p7fr631yx3fx7dfa4fpj6x2ml4i42kxid";
+    sha256 = "1k2wgvs17lfxqmk0v7g8cf34h5ahr41vaibgb4a6ixay41hfx06d";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.0.3 with grep in /nix/store/5n2jwjv8x9a1sic8ia32vncq5i5smd0f-inboxer-1.0.3
- found 1.0.3 in filename of file in /nix/store/5n2jwjv8x9a1sic8ia32vncq5i5smd0f-inboxer-1.0.3

cc @mgttlinger for review