### PR TITLE
Make "localizations" sane again

### DIFF
--- a/pkgs/applications/audio/ncmpc/default.nix
+++ b/pkgs/applications/audio/ncmpc/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib ncurses mpd_clientlib ];
   nativeBuildInputs = [ meson ninja pkgconfig gettext ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
-
   meta = with stdenv.lib; {
     description = "Curses-based interface for MPD (music player daemon)";
     homepage    = https://www.musicpd.org/clients/ncmpc/;

--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk2, which, pkgconfig, intltool, file }:
+{ stdenv, fetchurl, gtk2, which, pkgconfig, intltool, file, libintl }:
 
 with stdenv.lib;
 
@@ -14,9 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "66baaff43f12caebcf0efec9a5533044dc52837f799c73a1fd7312caa86099c2";
   };
 
-  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
-
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ pkgconfig intltool libintl ];
   buildInputs = [ gtk2 which file ];
 
   doCheck = true;

--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -46,8 +46,7 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   # "screenshot" needs this.
-  NIX_LDFLAGS = "-rpath ${xorg.libX11.out}/lib"
-    + stdenv.lib.optionalString stdenv.isDarwin " -lintl";
+  NIX_LDFLAGS = "-rpath ${xorg.libX11.out}/lib";
 
   meta = {
     description = "The GNU Image Manipulation Program";

--- a/pkgs/applications/misc/djvulibre/default.nix
+++ b/pkgs/applications/misc/djvulibre/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libjpeg, libtiff, librsvg, libintlOrEmpty }:
+{ stdenv, fetchurl, libjpeg, libtiff, librsvg, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "djvulibre-3.5.27";
@@ -10,9 +10,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" ];
 
-  buildInputs = [ libjpeg libtiff librsvg ] ++ libintlOrEmpty;
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
+  buildInputs = [ libjpeg libtiff librsvg libiconv ];
 
   meta = with stdenv.lib; {
     description = "A library and viewer for the DJVU file format for scanned images";

--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, gettext, ncurses, libiconv, libintlOrEmpty
+{ stdenv, fetchurl, pkgconfig, gtk, gettext, ncurses, libiconv, libintl
 , withBuildColors ? true
 }:
 
@@ -19,10 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk gettext libintlOrEmpty ]
-    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
+  buildInputs = [ gtk gettext libintl libiconv ];
 
   makeFlags = [
     "PREFIX=$(out)"

--- a/pkgs/applications/misc/sdcv/default.nix
+++ b/pkgs/applications/misc/sdcv/default.nix
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
     mkdir locale
   '';
 
-  NIX_CFLAGS_COMPILE = "-D__GNU_LIBRARY__"
-    + stdenv.lib.optionalString stdenv.isDarwin " -lintl";
+  NIX_CFLAGS_COMPILE = "-D__GNU_LIBRARY__";
 
   meta = with stdenv.lib; {
     homepage = https://dushistov.github.io/sdcv/;

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig
 , gtk, girara, ncurses, gettext, docutils
-, file, sqlite, glib, texlive, libintlOrEmpty
+, file, sqlite, glib, texlive, libintl
 , gtk-mac-integration, synctexSupport ? true
 }:
 
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
   icon = ./icon.xpm;
 
   nativeBuildInputs = [
-    pkgconfig
-  ] ++ optional stdenv.isDarwin [ libintlOrEmpty ];
+    pkgconfig libintl
+  ];
 
   buildInputs = [
     file gtk girara
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
   ] ++ optional synctexSupport texlive.bin.core
     ++ optional stdenv.isDarwin [ gtk-mac-integration ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   makeFlags = [

--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, ncurses, glib, openssl, perl, libintlOrEmpty }:
+{ stdenv, fetchurl, pkgconfig, ncurses, glib, openssl, perl, libintl }:
 
 stdenv.mkDerivation rec {
   version = "1.1.1";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ncurses glib openssl perl libintlOrEmpty ];
+  buildInputs = [ ncurses glib openssl perl libintl ];
 
   configureFlags = [
     "--with-proxy"

--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libIDL, libintlOrEmpty }:
+{ stdenv, fetchurl, pkgconfig, glib, libIDL, libintl }:
 
 stdenv.mkDerivation rec {
   name = "ORBit2-${minVer}.19";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0l3mhpyym9m5iz09fz0rgiqxl2ym6kpkwpsp1xrr4aa80nlh1jam";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ glib libIDL ] ++ libintlOrEmpty;
+  nativeBuildInputs = [ pkgconfig libintl ];
+  propagatedBuildInputs = [ glib libIDL ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/desktops/gnome-2/platform/libglade/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libglade/default.nix
@@ -14,6 +14,4 @@ stdenv.mkDerivation {
   buildInputs = [ gtk python gettext ];
 
   propagatedBuildInputs = [ libxml2 ];
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 }

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, flex, bison, libxslt, autoconf, graphviz
-, glib, libiconv, libintlOrEmpty, libtool, expat
+, glib, libiconv, libintl, libtool, expat
 }:
 
 let
@@ -16,7 +16,7 @@ let
 
     nativeBuildInputs = [ pkgconfig flex bison libxslt ] ++ extraNativeBuildInputs;
 
-    buildInputs = [ glib libiconv ] ++ libintlOrEmpty ++ extraBuildInputs;
+    buildInputs = [ glib libiconv libintl ] ++ extraBuildInputs;
 
     meta = with stdenv.lib; {
       description = "Compiler for GObject type system";

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -23,10 +23,7 @@ stdenv.mkDerivation rec {
   # ToDo: on non-NixOS we create a symlink from there?
   configureFlags = "--with-dbus-daemondir=/run/current-system/sw/bin/";
 
-  NIX_LDFLAGS = with stdenv; lib.optionalString isDarwin "-lintl";
-
   meta = with stdenv.lib; {
     platforms = platforms.unix;
   };
 }
-

--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, gettext, pkgconfig, glib, libintlOrEmpty, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, meson, ninja, gettext, pkgconfig, glib, gobjectIntrospection, gnome3 }:
 
 let
   pname = "atk";
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
   ];
 
   outputs = [ "out" "dev" ];
-
-  buildInputs = libintlOrEmpty;
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection ];
 

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchFromGitHub, fetchpatch, pkgconfig, libiconv
-, libintlOrEmpty, expat, zlib, libpng, pixman, fontconfig, freetype, xorg
+, libintl, expat, zlib, libpng, pixman, fontconfig, freetype, xorg
 , gobjectSupport ? true, glib
 , xcbSupport ? true # no longer experimental since 1.12
 , glSupport ? true, libGL ? null # libGLU_combined is no longer a big dependency
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig
     libiconv
-  ] ++ libintlOrEmpty ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    libintl
+  ] ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     CoreGraphics
     CoreText
     ApplicationServices

--- a/pkgs/development/libraries/cogl/default.nix
+++ b/pkgs/development/libraries/cogl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libGL, glib, gdk_pixbuf, xorg, libintlOrEmpty
+{ stdenv, fetchurl, pkgconfig, libGL, glib, gdk_pixbuf, xorg, libintl
 , pangoSupport ? true, pango, cairo, gobjectIntrospection, wayland, gnome3
 , gstreamerSupport ? true, gst_all_1 }:
 
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
     sha256 = "03f0ha3qk7ca0nnkkcr1garrm1n1vvfqhkz9lwjm592fnv6ii9rr";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig libintl ];
 
   configureFlags = [
     "--enable-introspection"
@@ -27,7 +27,6 @@ in stdenv.mkDerivation rec {
       glib gdk_pixbuf gobjectIntrospection wayland
       libGL libXrandr libXfixes libXcomposite libXdamage
     ]
-    ++ libintlOrEmpty
     ++ stdenv.lib.optionals gstreamerSupport [ gst_all_1.gstreamer
                                                gst_all_1.gst-plugins-base ];
 
@@ -36,8 +35,6 @@ in stdenv.mkDerivation rec {
   COGL_PANGO_DEP_CFLAGS
     = stdenv.lib.optionalString (stdenv.isDarwin && pangoSupport)
       "-I${pango.dev}/include/pango-1.0 -I${cairo.dev}/include/cairo";
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   #doCheck = true; # all tests fail (no idea why)
 

--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libintlOrEmpty, zlib, gettext }:
+{ stdenv, fetchurl, zlib, gettext }:
 
 stdenv.mkDerivation rec {
   name = "cracklib-2.9.6";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hrkb0prf7n92w6rxgq0ilzkk6rkhpys2cfqkrbzswp27na7dkqp";
   };
 
-  buildInputs = [ libintlOrEmpty zlib gettext ];
+  buildInputs = [ zlib gettext ];
 
   meta = with stdenv.lib; {
     homepage    = https://github.com/cracklib/cracklib;

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, python3, libxml2, libxslt, docbook_xsl
 , docbook_xml_dtd_43, gtk-doc, glib, libtiff, libjpeg, libpng, libX11, gnome3
-, jasper, shared-mime-info, libintlOrEmpty, gobjectIntrospection, doCheck ? false, makeWrapper }:
+, jasper, shared-mime-info, libintl, gobjectIntrospection, doCheck ? false, makeWrapper }:
 
 let
   pname = "gdk-pixbuf";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
-  buildInputs = [ libX11 ] ++ stdenv.lib.optional (!stdenv.isDarwin) shared-mime-info ++ libintlOrEmpty;
+  buildInputs = [ libX11 libintl ] ++ stdenv.lib.optional (!stdenv.isDarwin) shared-mime-info;
 
   nativeBuildInputs = [
     meson ninja pkgconfig gettext python3 libxml2 libxslt docbook_xsl docbook_xml_dtd_43
@@ -78,4 +78,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 }
-

--- a/pkgs/development/libraries/gegl/3.0.nix
+++ b/pkgs/development/libraries/gegl/3.0.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, glib, babl, libpng, cairo, libjpeg, which
 , librsvg, pango, gtk, bzip2, json-glib, intltool, autoreconfHook, libraw
-, libwebp, gnome3 }:
+, libwebp, gnome3, libintl }:
 
 stdenv.mkDerivation rec {
   name = "gegl-0.3.28";
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     url = "http://download.gimp.org/pub/gegl/0.3/${name}.tar.bz2";
     sha256 = "1zr3gmmzjhp2d3d3h51x80r5q7gs9rv67ywx69sif6as99h8fbqm";
   };
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   hardeningDisable = [ "format" ];
 
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib json-glib babl ]; # for gegl-3.0.pc
 
-  nativeBuildInputs = [ pkgconfig intltool which autoreconfHook ];
+  nativeBuildInputs = [ pkgconfig intltool which autoreconfHook libintl ];
 
   meta = with stdenv.lib; {
     description = "Graph-based image processing framework";

--- a/pkgs/development/libraries/gegl/default.nix
+++ b/pkgs/development/libraries/gegl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, babl, libpng, cairo, libjpeg
-, librsvg, pango, gtk2, bzip2, intltool
+, librsvg, pango, gtk2, bzip2, intltool, libintl
 , OpenGL ? null }:
 
 stdenv.mkDerivation rec {
@@ -20,14 +20,12 @@ stdenv.mkDerivation rec {
   # needs fonts otherwise  don't know how to pass them
   configureFlags = "--disable-docs";
 
-  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
-
-  buildInputs = [ babl libpng cairo libjpeg librsvg pango gtk2 bzip2 intltool ]
+  buildInputs = [ babl libpng cairo libjpeg librsvg pango gtk2 bzip2 intltool libintl ]
     ++ stdenv.lib.optional stdenv.isDarwin OpenGL;
 
   nativeBuildInputs = [ pkgconfig ];
 
-  meta = { 
+  meta = {
     description = "Graph-based image processing framework";
     homepage = http://www.gegl.org;
     license = stdenv.lib.licenses.gpl3;

--- a/pkgs/development/libraries/geoclue/2.0.nix
+++ b/pkgs/development/libraries/geoclue/2.0.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, intltool, libintlOrEmpty, pkgconfig, glib, json-glib, libsoup, geoip
+{ fetchurl, stdenv, intltool, pkgconfig, glib, json-glib, libsoup, geoip
 , dbus, dbus-glib, modemmanager, avahi, glib-networking, wrapGAppsHook, gobjectIntrospection
 }:
 
@@ -18,8 +18,7 @@ stdenv.mkDerivation rec {
     pkgconfig intltool wrapGAppsHook gobjectIntrospection
   ];
 
-  buildInputs = libintlOrEmpty ++
-   [ glib json-glib libsoup geoip
+  buildInputs = [ glib json-glib libsoup geoip
      dbus dbus-glib avahi
    ] ++ optionals (!stdenv.isDarwin) [ modemmanager ];
 
@@ -36,8 +35,6 @@ stdenv.mkDerivation rec {
                        "--disable-cdma-source"
                        "--disable-modem-gps-source"
                        "--disable-nmea-source" ];
-
-  NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin " -lintl";
 
   postInstall = ''
     sed -i $dev/lib/pkgconfig/libgeoclue-2.0.pc -e "s|includedir=.*|includedir=$dev/include|"

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   buildInputs = stdenv.lib.optional (!stdenv.isLinux && !hostPlatform.isCygwin) libiconv;
 
   setupHook = ./gettext-setup-hook.sh;
-  gettextNeedsLdflags = !hostPlatform.libc != "glibc";
+  gettextNeedsLdflags = hostPlatform.libc != "glibc";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
   buildInputs = stdenv.lib.optional (!stdenv.isLinux && !hostPlatform.isCygwin) libiconv;
 
   setupHook = ./gettext-setup-hook.sh;
+  gettextNeedsLdflags = !hostPlatform.libc != "glibc";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -12,4 +12,6 @@ gettextLdflags() {
     export NIX_LDFLAGS="$NIX_LDFLAGS -lintl"
 }
 
-addEnvHooks "$hostOffset" gettextLdflags
+if [ ! -z "@gettextNeedsLdflags@" ]; then
+    addEnvHooks "$hostOffset" gettextLdflags
+fi

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -5,3 +5,11 @@ gettextDataDirsHook() {
 }
 
 addEnvHooks "$hostOffset" gettextDataDirsHook
+
+# libintl must be listed in load flags on non-Glibc
+# it doesn't hurt to have it in Glibc either though
+gettextLdflags() {
+    export NIX_LDFLAGS="$NIX_LDFLAGS -lintl"
+}
+
+addEnvHooks "$hostOffset" gettextLdflags

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -47,4 +47,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 }
-

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, hostPlatform, fetchurl, pkgconfig, gettext, perl, python
-, libiconv, libintlOrEmpty, zlib, libffi, pcre, libelf, gnome3
+, libiconv, libintl, zlib, libffi, pcre, libelf, gnome3
 # use utillinuxMinimal to avoid circular dependency (utillinux, systemd, glib)
 , utillinuxMinimal ? null
 
@@ -66,10 +66,9 @@ stdenv.mkDerivation rec {
     ++ optionals stdenv.isLinux [ utillinuxMinimal ] # for libmount
     ++ optionals doCheck [ tzdata libxml2 desktop-file-utils shared-mime-info ];
 
-  nativeBuildInputs = [ pkgconfig gettext perl python ];
+  nativeBuildInputs = [ pkgconfig gettext perl python libintl libiconv ];
 
-  propagatedBuildInputs = [ zlib libffi libiconv ]
-    ++ libintlOrEmpty;
+  propagatedBuildInputs = [ zlib libffi ];
 
   # internal pcre would only add <200kB, but it's relatively common
   configureFlags = [ "--with-pcre=system" ]
@@ -84,8 +83,7 @@ stdenv.mkDerivation rec {
     # GElf only supports elf64 hosts
     ++ optional (!stdenv.hostPlatform.is64bit) "--disable-libelf";
 
-  NIX_CFLAGS_COMPILE = optional stdenv.isDarwin "-lintl"
-    ++ optional stdenv.isSunOS "-DBSD_COMP";
+  NIX_CFLAGS_COMPILE = optional stdenv.isSunOS "-DBSD_COMP";
 
   preConfigure = optionalString stdenv.isSunOS ''
     sed -i -e 's|inotify.h|foobar-inotify.h|g' configure

--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -40,9 +40,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ lzo lzip libtasn1 libidn p11-kit zlib gmp autogen libunistring unbound ]
-    ++ lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) libiconv
-    ++ lib.optional stdenv.isDarwin gettext
+  buildInputs = [ lzo lzip libtasn1 libidn p11-kit zlib gmp autogen libunistring unbound gettext libiconv ]
     ++ lib.optional (tpmSupport && stdenv.isLinux) trousers
     ++ lib.optional guileBindings guile
     ++ buildInputs;

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, flex, bison, pkgconfig, libffi, python
-, libintlOrEmpty, cctools, cairo, gnome3
+, libintl, cctools, cairo, gnome3
 , substituteAll, nixStoreDir ? builtins.storeDir
 , x11Support ? true
 }:
@@ -24,9 +24,8 @@ stdenv.mkDerivation rec {
   outputBin = "dev";
   outputMan = "dev"; # tiny pages
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig libintl ];
   buildInputs = [ flex bison python setupHook/*move .gir*/ ]
-    ++ libintlOrEmpty
     ++ stdenv.lib.optional stdenv.isDarwin cctools;
   propagatedBuildInputs = [ libffi glib ];
 

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -6,7 +6,7 @@
 , openjpeg, libopus, librsvg
 , wildmidi, fluidsynth, libvdpau, wayland
 , libwebp, xvidcore, gnutls, mjpegtools
-, libGLU_combined, libintlOrEmpty, libgme
+, libGLU_combined, libintl, libgme
 , openssl, x265, libxml2
 }:
 
@@ -63,8 +63,8 @@ stdenv.mkDerivation rec {
     fluidsynth libvdpau
     libwebp xvidcore gnutls libGLU_combined
     libgme openssl x265 libxml2
+    libintl
   ]
-    ++ libintlOrEmpty
     ++ optional faacSupport faac
     # for gtksink
     ++ optional gtkSupport gtk3
@@ -74,8 +74,6 @@ stdenv.mkDerivation rec {
     ++ optional (!stdenv.isDarwin) wildmidi
     # TODO: mjpegtools uint64_t is not compatible with guint64 on Darwin
     ++ optional (!stdenv.isDarwin) mjpegtools;
-
-  LDFLAGS = optionalString stdenv.isDarwin "-lintl";
 
   enableParallelBuilding = true;
 }

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, python, gstreamer, gobjectIntrospection
 , orc, alsaLib, libXv, pango, libtheora
-, cdparanoia, libvisual, libintlOrEmpty
+, cdparanoia, libvisual, libintl
 }:
 
 stdenv.mkDerivation rec {
@@ -25,9 +25,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    orc libXv pango libtheora cdparanoia
+    orc libXv pango libtheora cdparanoia libintl
   ]
-  ++ libintlOrEmpty
   ++ stdenv.lib.optional stdenv.isLinux alsaLib
   ++ stdenv.lib.optional (!stdenv.isDarwin) libvisual;
 
@@ -39,8 +38,6 @@ stdenv.mkDerivation rec {
     # Undefined symbols _cdda_identify and _cdda_identify_scsi in cdparanoia
     "--disable-cdparanoia"
   ] else null;
-
-  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
 
   enableParallelBuilding = true;
 }

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -3,7 +3,7 @@
 , libv4l, libdv, libavc1394, libiec61883
 , libvpx, speex, flac, taglib, libshout
 , cairo, gdk_pixbuf, aalib, libcaca
-, libsoup, libpulseaudio, libintlOrEmpty
+, libsoup, libpulseaudio, libintl
 , darwin
 }:
 
@@ -38,9 +38,8 @@ stdenv.mkDerivation rec {
     gst-plugins-base orc bzip2
     libdv libvpx speex flac taglib
     cairo gdk_pixbuf aalib libcaca
-    libsoup libshout
+    libsoup libshout libintl
   ]
-  ++ libintlOrEmpty
   ++ optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ]
   ++ optionals stdenv.isLinux [ libv4l libpulseaudio libavc1394 libiec61883 ];
 
@@ -48,6 +47,4 @@ stdenv.mkDerivation rec {
     mkdir -p "$dev/lib/gstreamer-1.0"
     mv "$out/lib/gstreamer-1.0/"*.la "$dev/lib/gstreamer-1.0"
   '';
-
-  LDFLAGS = optionalString stdenv.isDarwin "-lintl";
 }

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, pkgconfig, python, gstreamer, xorg, alsaLib, cdparanoia
 , libogg, libtheora, libvorbis, freetype, pango, liboil, glib, cairo, orc
-, libintlOrEmpty
+, libintl
 , ApplicationServices
 , # Whether to build no plugins that have external dependencies
   # (except the ALSA plugin).
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   # TODO : v4l, libvisual
   buildInputs =
-    [ pkgconfig glib cairo orc ]
+    [ pkgconfig glib cairo orc libintl ]
     # can't build alsaLib on darwin
     ++ stdenv.lib.optional (!stdenv.isDarwin) alsaLib
     ++ stdenv.lib.optionals (!minimalDeps)
@@ -37,10 +37,7 @@ stdenv.mkDerivation rec {
         liboil ]
     # can't build cdparanoia on darwin
     ++ stdenv.lib.optional (!minimalDeps && !stdenv.isDarwin) cdparanoia
-    ++ libintlOrEmpty
     ++ stdenv.lib.optional stdenv.isDarwin ApplicationServices;
-
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   propagatedBuildInputs = [ gstreamer ];
 

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, lib, pkgconfig, gst-plugins-base, aalib, cairo
 , flac, libjpeg, zlib, speex, libpng, libdv, libcaca, libvpx
 , libiec61883, libavc1394, taglib, libpulseaudio, gdk_pixbuf, orc
-, glib, gstreamer, bzip2, libsoup, libshout, ncurses, libintlOrEmpty
+, glib, gstreamer, bzip2, libsoup, libshout, ncurses, libintl
 , # Whether to build no plugins that have external dependencies
   # (except the PulseAudio plugin).
   minimalDeps ? false
@@ -23,14 +23,11 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-experimental" "--disable-oss" ];
 
   buildInputs =
-    [ pkgconfig glib gstreamer gst-plugins-base ]
+    [ pkgconfig glib gstreamer gst-plugins-base libintl ]
     ++ lib.optional stdenv.isLinux libpulseaudio
-    ++ libintlOrEmpty
     ++ lib.optionals (!minimalDeps)
       [ aalib libcaca cairo libdv flac libjpeg libpng speex
         taglib bzip2 libvpx gdk_pixbuf orc libsoup libshout ];
-
-  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-ugly/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, glib, gstreamer, gst-plugins-base
-, libmad, libdvdread, libmpeg2, libcdio, a52dec, x264, orc, lame, libintlOrEmpty }:
+, libmad, libdvdread, libmpeg2, libcdio, a52dec, x264, orc, lame, libintl }:
 
 stdenv.mkDerivation rec {
   name = "gst-plugins-ugly-0.10.19";
@@ -13,9 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig glib gstreamer gst-plugins-base libmad libdvdread a52dec x264 orc lame ] ++ libintlOrEmpty;
-
-  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
+    [ pkgconfig glib gstreamer gst-plugins-base libmad libdvdread a52dec x264 orc lame libintl ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, perl, bison, flex, pkgconfig, glib, libxml2, libintlOrEmpty }:
+{ fetchurl, stdenv, perl, bison, flex, pkgconfig, glib, libxml2, libintl }:
 
 stdenv.mkDerivation rec {
   name = "gstreamer-0.10.36";
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig libintl ];
   buildInputs = [ perl bison flex ];
-  propagatedBuildInputs = [ glib libxml2 ] ++ libintlOrEmpty;
+  propagatedBuildInputs = [ glib libxml2 ];
 
   patchPhase = ''
     sed -i -e 's/^   /\t/' docs/gst/Makefile.in docs/libs/Makefile.in docs/plugins/Makefile.in

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, python
 , gst-plugins-base, orc
 , a52dec, libcdio, libdvdread
-, lame, libmad, libmpeg2, x264, libintlOrEmpty, mpg123
+, lame, libmad, libmpeg2, x264, libintl, mpg123
 }:
 
 stdenv.mkDerivation rec {
@@ -33,7 +33,6 @@ stdenv.mkDerivation rec {
     gst-plugins-base orc
     a52dec libcdio libdvdread
     lame libmad libmpeg2 x264 mpg123
-  ] ++ libintlOrEmpty;
-
-  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
+    libintl
+  ];
 }

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gettext, glib, atk, pango, cairo, perl, xorg
-, gdk_pixbuf, libintlOrEmpty, xlibsWrapper, gobjectIntrospection
+, gdk_pixbuf, xlibsWrapper, gobjectIntrospection
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? true, cups ? null
 , gdktarget ? "x11"
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  NIX_CFLAGS_COMPILE = optionalString (libintlOrEmpty != []) "-lintl";
-
   setupHook = ./setup-hook.sh;
 
   nativeBuildInputs = [ setupHook perl pkgconfig gettext gobjectIntrospection ];
@@ -38,7 +36,6 @@ stdenv.mkDerivation rec {
          libXrandr libXrender libXcomposite libXi libXcursor
        ]
     ++ optionals stdenv.isDarwin [ xlibsWrapper libXdamage ]
-    ++ libintlOrEmpty
     ++ optional xineramaSupport libXinerama
     ++ optionals cupsSupport [ cups ]
     ++ optionals stdenv.isDarwin [ AppKit Cocoa ];

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -46,8 +46,6 @@ stdenv.mkDerivation rec {
     ++ optional cupsSupport cups;
   #TODO: colord?
 
-  NIX_LDFLAGS = optionalString stdenv.isDarwin "-lintl";
-
   # demos fail to install, no idea where's the problem
   preConfigure = "sed '/^SRC_SUBDIRS /s/demos//' -i Makefile.in";
 

--- a/pkgs/development/libraries/gts/default.nix
+++ b/pkgs/development/libraries/gts/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib ] ++ stdenv.lib.optional (stdenv.system == "x86_64-darwin") gettext;
+  buildInputs = [ glib gettext ];
 
   meta = {
     homepage = http://gts.sourceforge.net/;

--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, freetype, cairo, libintlOrEmpty
+{ stdenv, fetchurl, pkgconfig, glib, freetype, cairo, libintl
 , icu, graphite2, harfbuzz # The icu variant uses and propagates the non-icu one.
 , withIcu ? false # recommended by upstream as default, but most don't needed and it's big
 , withGraphite2 ? true # it is small and major distros do include it
@@ -25,9 +25,8 @@ stdenv.mkDerivation {
     ( "--with-icu=" +       (if withIcu       then "yes" else "no") )
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib freetype cairo ] # recommended by upstream
-    ++ libintlOrEmpty;
+  nativeBuildInputs = [ pkgconfig libintl ];
+  buildInputs = [ glib freetype cairo ]; # recommended by upstream
   propagatedBuildInputs = []
     ++ optional withGraphite2 graphite2
     ++ optionals withIcu [ icu harfbuzz ]

--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, glib, meson, ninja, pkgconfig, gettext
-, gobjectIntrospection, dbus, libintlOrEmpty
+, gobjectIntrospection, dbus
 , fixDarwinDylibNames
 }:
 
@@ -14,10 +14,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib ];
   nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection ];
-  buildInputs = libintlOrEmpty
-    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
+  buildInputs = stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   patches = [
     # https://gitlab.gnome.org/GNOME/json-glib/issues/27

--- a/pkgs/development/libraries/libassuan/default.nix
+++ b/pkgs/development/libraries/libassuan/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "info" ];
   outputBin = "dev"; # libassuan-config
 
-  buildInputs = [ libgpgerror pth ]
-    ++ stdenv.lib.optional stdenv.isDarwin gettext;
+  buildInputs = [ libgpgerror pth gettext];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/libgsf/default.nix
+++ b/pkgs/development/libraries/libgsf/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, intltool, gettext, glib, libxml2, zlib, bzip2
-, python, perl, gdk_pixbuf, libiconv, libintlOrEmpty }:
+, python, perl, gdk_pixbuf, libiconv, libintl }:
 
 let inherit (stdenv.lib) optionals; in
 
@@ -11,20 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "1hhdz0ymda26q6bl5ygickkgrh998lxqq4z9i8dzpcvqna3zpzr9";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ pkgconfig intltool libintl ];
 
   buildInputs = [ gettext bzip2 zlib python ]
     ++ stdenv.lib.optional doCheck perl;
 
-  propagatedBuildInputs = [ libxml2 glib gdk_pixbuf libiconv ]
-    ++ libintlOrEmpty;
+  propagatedBuildInputs = [ libxml2 glib gdk_pixbuf libiconv ];
 
   outputs = [ "out" "dev" ];
 
   doCheck = true;
   preCheck = "patchShebangs ./tests/";
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   meta = with stdenv.lib; {
     description = "GNOME's Structured File Library";

--- a/pkgs/development/libraries/libgtop/default.nix
+++ b/pkgs/development/libraries/libgtop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, pkgconfig, perl, gettext, gobjectIntrospection, libintlOrEmpty, gnome3 }:
+{ stdenv, fetchurl, glib, pkgconfig, perl, gettext, gobjectIntrospection, libintl, gnome3 }:
 let
   pname = "libgtop";
   version = "2.38.0";
@@ -12,10 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   propagatedBuildInputs = [ glib ];
-  buildInputs = libintlOrEmpty;
   nativeBuildInputs = [ pkgconfig perl gettext gobjectIntrospection ];
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "0y1ij745r4p48mxq84rax40p10ln7fc7m243p8k8sia519i3dxfc";
   };
 
+  setupHook = ./setup-hook.sh;
+
   postPatch =
     lib.optionalString ((hostPlatform != buildPlatform && hostPlatform.libc == "msvcrt") || stdenv.cc.nativeLibc)
       ''

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -1,0 +1,7 @@
+# libintl must be listed in load flags on non-Glibc
+# it doesn't hurt to have it in Glibc either though
+iconvLdflags() {
+    export NIX_LDFLAGS="$NIX_LDFLAGS -iconv"
+}
+
+addEnvHooks "$hostOffset" iconvLdflags

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -1,7 +1,7 @@
-# libintl must be listed in load flags on non-Glibc
+# libiconv must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
 iconvLdflags() {
-    export NIX_LDFLAGS="$NIX_LDFLAGS -iconv"
+    export NIX_LDFLAGS="$NIX_LDFLAGS -liconv"
 }
 
 addEnvHooks "$hostOffset" iconvLdflags

--- a/pkgs/development/libraries/libinfinity/default.nix
+++ b/pkgs/development/libraries/libinfinity/default.nix
@@ -4,7 +4,7 @@
 , avahiSupport ? false # build support for Avahi in libinfinity
 , stdenv, fetchurl, pkgconfig, glib, libxml2, gnutls, gsasl
 , gtk2 ? null, gtkdoc ? null, avahi ? null, libdaemon ? null, libidn, gss
-, libintlOrEmpty }:
+, libintl }:
 
 let
   edf = flag: feature: (if flag then "--with-" else "--without-") + feature;
@@ -19,14 +19,14 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libxml2 gsasl libidn gss libintlOrEmpty ]
+  buildInputs = [ glib libxml2 gsasl libidn gss libintl ]
     ++ optional gtkWidgets gtk2
     ++ optional documentation gtkdoc
     ++ optional avahiSupport avahi
     ++ optional daemon libdaemon;
 
   propagatedBuildInputs = [ gnutls ];
-  
+
   configureFlags = ''
     ${if documentation then "--enable-gtk-doc" else "--disable-gtk-doc"}
     ${edf gtkWidgets "inftextgtk"}
@@ -35,8 +35,6 @@ in stdenv.mkDerivation rec {
     ${edf daemon "libdaemon"}
     ${edf avahiSupport "avahi"}
   '';
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   meta = {
     homepage = http://gobby.0x539.de/;

--- a/pkgs/development/libraries/libksba/default.nix
+++ b/pkgs/development/libraries/libksba/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "info" ];
 
-  buildInputs = stdenv.lib.optional stdenv.isDarwin gettext;
+  buildInputs = [ gettext ];
   propagatedBuildInputs = [ libgpgerror ];
 
   postInstall = ''

--- a/pkgs/development/libraries/libmicrohttpd/default.nix
+++ b/pkgs/development/libraries/libmicrohttpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libgcrypt, curl, gnutls, pkgconfig, libiconv, libintlOrEmpty }:
+{ stdenv, fetchurl, libgcrypt, curl, gnutls, pkgconfig, libiconv, libintl }:
 
 stdenv.mkDerivation rec {
   name = "libmicrohttpd-${version}";
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "devdoc" "info" ];
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libgcrypt curl gnutls ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv libintlOrEmpty ];
+  buildInputs = [ libgcrypt curl gnutls libiconv libintl ];
 
   preCheck = ''
     # Since `localhost' can't be resolved in a chroot, work around it.
@@ -38,4 +37,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 }
-

--- a/pkgs/development/libraries/libnatspec/default.nix
+++ b/pkgs/development/libraries/libnatspec/default.nix
@@ -19,6 +19,5 @@ stdenv.mkDerivation (rec {
     maintainers = [ ];
   };
 } // stdenv.lib.optionalAttrs (!stdenv.isLinux) {
-  NIX_LDFLAGS = "-liconv";
   propagatedBuildInputs = [ libiconv ];
 })

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkgconfig, glib, gdk_pixbuf, pango, cairo, libxml2, libgsf
-, bzip2, libcroco, libintlOrEmpty, darwin, rust, gnome3
+, bzip2, libcroco, libintl, darwin, rust, gnome3
 , withGTK ? false, gtk3 ? null
 , vala, gobjectIntrospection }:
 
@@ -15,11 +15,9 @@ stdenv.mkDerivation rec {
     sha256 = "0c550a0bffef768a436286116c03d9f6cd3f97f5021c13e7f093b550fac12562";
   };
 
-  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
-
   outputs = [ "out" "dev" ];
 
-  buildInputs = [ libxml2 libgsf bzip2 libcroco pango libintlOrEmpty ];
+  buildInputs = [ libxml2 libgsf bzip2 libcroco pango libintl ];
 
   propagatedBuildInputs = [ glib gdk_pixbuf cairo ] ++ lib.optional withGTK gtk3;
 

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, pkgconfig, intltool, libxslt, docbook_xsl, gtk-doc
-, libgcrypt, gobjectIntrospection, vala_0_38, gnome3 }:
+, libgcrypt, gobjectIntrospection, vala_0_38, gnome3, libintl }:
 let
   pname = "libsecret";
   version = "0.18.5";

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -14,10 +14,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
-
   propagatedBuildInputs = [ glib ];
-  nativeBuildInputs = [ pkgconfig intltool libxslt docbook_xsl ];
+  nativeBuildInputs = [ pkgconfig intltool libxslt docbook_xsl libintl ];
   buildInputs = [ libgcrypt gobjectIntrospection vala_0_38 ];
   # optional: build docs with gtk-doc? (probably needs a flag as well)
 

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, glib, libxml2, pkgconfig, gnome3
 , gnomeSupport ? true, sqlite, glib-networking, gobjectIntrospection
 , valaSupport ? true, vala_0_40
-, libintlOrEmpty
 , intltool, python3 }:
+
 let
   pname = "libsoup";
   version = "2.62.0";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = libintlOrEmpty ++ [ python3 sqlite ];
+  buildInputs = [ python3 sqlite ];
   nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ]
     ++ stdenv.lib.optionals valaSupport [ vala_0_40 ];
   propagatedBuildInputs = [ glib libxml2 ];
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
     "--enable-vala=${if valaSupport then "yes" else "no"}"
     "--with-gnome=${if gnomeSupport then "yes" else "no"}"
   ];
-
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   passthru = {
     propagatedUserEnvPackages = [ glib-networking.out ];

--- a/pkgs/development/libraries/libui/default.nix
+++ b/pkgs/development/libraries/libui/default.nix
@@ -16,8 +16,8 @@ in
   nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ cmake ] ++
       (if backend == "darwin" then [darwin.apple_sdk.frameworks.Cocoa]
-       else if backend == "unix" then [gtk3])
-       else null;
+       else if backend == "unix" then [gtk3]
+       else null);
 
     preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
       sed -i 's/set(CMAKE_OSX_DEPLOYMENT_TARGET "10.8")//' ./CMakeLists.txt

--- a/pkgs/development/libraries/libui/default.nix
+++ b/pkgs/development/libraries/libui/default.nix
@@ -15,7 +15,9 @@ in
 
   nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ cmake ] ++
-      (if stdenv.isDarwin then [darwin.apple_sdk.frameworks.Cocoa] else [gtk3]);
+      (if backend == "darwin" then [darwin.apple_sdk.frameworks.Cocoa]
+       else if backend == "unix" then [gtk3])
+       else null;
 
     preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
       sed -i 's/set(CMAKE_OSX_DEPLOYMENT_TARGET "10.8")//' ./CMakeLists.txt

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, libXft, cairo, harfbuzz
-, libintlOrEmpty, gobjectIntrospection, darwin
+, libintl, gobjectIntrospection, darwin
 }:
 
 with stdenv.lib;
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
        CoreGraphics
        CoreText
     ]);
-  propagatedBuildInputs = [ cairo harfbuzz libXft ] ++ libintlOrEmpty;
+  propagatedBuildInputs = [ cairo harfbuzz libXft libintl ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, cmake, ninja, pkgconfig, libiconv, libintlOrEmpty
+{ stdenv, lib, fetchurl, cmake, ninja, pkgconfig, libiconv, libintl
 , zlib, curl, cairo, freetype, fontconfig, lcms, libjpeg, openjpeg
 , withData ? true, poppler_data
 , qt5Support ? false, qtbase ? null
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = [ libiconv ] ++ libintlOrEmpty ++ lib.optional withData poppler_data;
+  buildInputs = [ libiconv libintl ] ++ lib.optional withData poppler_data;
 
   # TODO: reduce propagation to necessary libs
   propagatedBuildInputs = with lib;

--- a/pkgs/development/libraries/stfl/default.nix
+++ b/pkgs/development/libraries/stfl/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     sed -i s/gcc/cc/g Makefile
     sed -i s%ncursesw/ncurses.h%ncurses.h% stfl_internals.h
-  '' + stdenv.lib.optionalString (stdenv.hostPlatform.libc != "glibc") ''
-    sed -i 's/LDLIBS += -lncursesw/LDLIBS += -lncursesw -liconv/' Makefile
   '' + ( stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i s/-soname/-install_name/ Makefile
   '' ) + ''
@@ -36,4 +34,3 @@ stdenv.mkDerivation rec {
     platforms   = stdenv.lib.platforms.unix;
   };
 }
-

--- a/pkgs/development/libraries/webkitgtk/2.20.nix
+++ b/pkgs/development/libraries/webkitgtk/2.20.nix
@@ -2,7 +2,7 @@
 , pkgconfig, gettext, gobjectIntrospection, libnotify, gnutls, libgcrypt
 , gtk3, wayland, libwebp, enchant2, xorg, libxkbcommon, epoxy, at-spi2-core
 , libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs, pcre, nettle, libtasn1, p11-kit
-, libidn, libedit, readline, libGLU_combined, libintlOrEmpty
+, libidn, libedit, readline, libGLU_combined, libintl
 , enableGeoLocation ? true, geoclue2, sqlite
 , enableGtk2Plugins ? false, gtk2 ? null
 , gst-plugins-base, gst-plugins-bad, woff2
@@ -60,15 +60,13 @@ stdenv.mkDerivation rec {
   "-DENABLE_GTKDOC=OFF"
   ];
 
-  NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin " -lintl";
-
   nativeBuildInputs = [
     cmake ninja perl python2 ruby bison gperf
     pkgconfig gettext gobjectIntrospection
   ];
 
-  buildInputs = libintlOrEmpty ++ [
-    libwebp enchant2 libnotify gnutls pcre nettle libidn libgcrypt woff2
+  buildInputs = [
+    libintl libwebp enchant2 libnotify gnutls pcre nettle libidn libgcrypt woff2
     libxml2 libsecret libxslt harfbuzz libpthreadstubs libtasn1 p11-kit
     sqlite gst-plugins-base gst-plugins-bad libxkbcommon epoxy at-spi2-core
   ] ++ optional enableGeoLocation geoclue2

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -3,9 +3,9 @@
 { name, buildInputs ? [], ... } @ attrs:
 
 stdenv.mkDerivation ({
-  buildInputs = buildInputs ++ [R] ++
+  buildInputs = buildInputs ++ [R gettext] ++
                 stdenv.lib.optionals attrs.requireX [utillinux xvfb_run] ++
-                stdenv.lib.optionals stdenv.isDarwin [Cocoa Foundation gettext gfortran];
+                stdenv.lib.optionals stdenv.isDarwin [Cocoa Foundation gfortran];
 
   NIX_CFLAGS_COMPILE =
     stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";

--- a/pkgs/games/lbreakout2/default.nix
+++ b/pkgs/games/lbreakout2/default.nix
@@ -1,16 +1,14 @@
-{ stdenv, fetchurl, SDL, SDL_mixer, zlib, libpng, libintlOrEmpty }:
+{ stdenv, fetchurl, SDL, SDL_mixer, zlib, libpng, libintl }:
 
 stdenv.mkDerivation rec {
   name = "lbreakout2-${version}";
   version = "2.6.5";
-  buildInputs = [ SDL SDL_mixer zlib libpng ] ++ libintlOrEmpty;
+  buildInputs = [ SDL SDL_mixer zlib libpng libintl ];
 
   src = fetchurl {
     url = "mirror://sourceforge/lgames/${name}.tar.gz";
     sha256 = "0vwdlyvh7c4y80q5vp7fyfpzbqk9lq3w8pvavi139njkalbxc14i";
   };
-
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   meta = with stdenv.lib; {
     description = "Breakout clone from the LGames series";

--- a/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
@@ -14,6 +14,8 @@ appleDerivation {
       -Wl,-reexport_library -Wl,$out/lib/libcharset.dylib
   '';
 
+  setup-hook = ../../../../development/libraries/libiconv/setup-hook.sh;
+
   meta = {
     platforms = stdenv.lib.platforms.darwin;
   };

--- a/pkgs/os-specific/linux/policycoreutils/default.nix
+++ b/pkgs/os-specific/linux/policycoreutils/default.nix
@@ -65,4 +65,3 @@ stdenv.mkDerivation rec {
     inherit (libsepol.meta) homepage platforms maintainers;
   };
 }
-

--- a/pkgs/servers/dns/knot-dns/default.nix
+++ b/pkgs/servers/dns/knot-dns/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gnutls, liburcu, lmdb, libcap_ng, libidn
-, systemd, nettle, libedit, zlib, libiconv, libintlOrEmpty
+, systemd, nettle, libedit, zlib, libiconv, libintl
 }:
 
 let inherit (stdenv.lib) optional optionals; in
@@ -20,11 +20,10 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gnutls liburcu libidn
     nettle libedit
-    libiconv lmdb
+    libiconv lmdb libintl
     # without sphinx &al. for developer documentation
   ]
     ++ optionals stdenv.isLinux [ libcap_ng systemd ]
-    ++ libintlOrEmpty
     ++ optional stdenv.isDarwin zlib; # perhaps due to gnutls
 
   enableParallelBuilding = true;
@@ -43,4 +42,3 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.vcunat ];
   };
 }
-

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkgconfig texinfo ];
-  buildInputs = [ libuuid ] ++ stdenv.lib.optional (!stdenv.isLinux) gettext;
+  buildInputs = [ libuuid gettext ];
 
   configureFlags =
     if stdenv.isLinux then [

--- a/pkgs/tools/graphics/exif/default.nix
+++ b/pkgs/tools/graphics/exif/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libexif, popt, libintlOrEmpty }:
+{ stdenv, fetchurl, pkgconfig, libexif, popt, libintl }:
 
 stdenv.mkDerivation rec {
   name = "exif-0.6.21";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libexif popt ] ++ libintlOrEmpty;
+  buildInputs = [ libexif popt libintl ];
 
   meta = {
     homepage = http://libexif.sourceforge.net/;

--- a/pkgs/tools/graphics/graphviz/base.nix
+++ b/pkgs/tools/graphics/graphviz/base.nix
@@ -23,8 +23,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libpng libjpeg expat yacc libtool fontconfig gd gts libdevil flex pango
+    gettext
   ] ++ optionals (xorg != null) (with xorg; [ libXrender libXaw libXpm ])
-    ++ optionals (stdenv.isDarwin) [ ApplicationServices gettext ];
+    ++ optionals (stdenv.isDarwin) [ ApplicationServices ];
 
   hardeningDisable = [ "fortify" ];
 

--- a/pkgs/tools/misc/aescrypt/default.nix
+++ b/pkgs/tools/misc/aescrypt/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libiconv ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-liconv";
-
   meta = with stdenv.lib; {
     description = "Encrypt files with Advanced Encryption Standard (AES)";
     homepage    = https://www.aescrypt.com/;

--- a/pkgs/tools/misc/desktop-file-utils/default.nix
+++ b/pkgs/tools/misc/desktop-file-utils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libintlOrEmpty }:
+{ stdenv, fetchurl, pkgconfig, glib, libintl }:
 
 with stdenv.lib;
 
@@ -11,9 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libintlOrEmpty ];
-
-  NIX_LDFLAGS = optionalString stdenv.isDarwin "-lintl";
+  buildInputs = [ glib libintl ];
 
   meta = {
     homepage = http://www.freedesktop.org/wiki/Software/desktop-file-utils;

--- a/pkgs/tools/misc/fwup/default.nix
+++ b/pkgs/tools/misc/fwup/default.nix
@@ -23,9 +23,6 @@ stdenv.mkDerivation rec {
     ];
   propagatedBuildInputs = [ zip unzip mtools dosfstools coreutils ];
 
-  # segfaults on darwin without
-  NIX_LDFLAGS = lib.optional stdenv.isDarwin "-F/System/Library/Frameworks";
-
   meta = with stdenv.lib; {
     description = "Configurable embedded Linux firmware update creator and runner";
     homepage = https://github.com/fhunleth/fwup;

--- a/pkgs/tools/networking/lftp/default.nix
+++ b/pkgs/tools/networking/lftp/default.nix
@@ -15,8 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ gnutls readline zlib libidn2 gmp libiconv libunistring ]
-    ++ stdenv.lib.optional stdenv.isDarwin gettext;
+  buildInputs = [ gnutls readline zlib libidn2 gmp libiconv libunistring gettext ];
 
   hardeningDisable = stdenv.lib.optional stdenv.isDarwin "format";
 

--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gettext, pkgconfig, perl
-, libidn2, zlib, pcre, libuuid, libiconv
+, libidn2, zlib, pcre, libuuid, libiconv, libintl
 , IOSocketSSL, LWP, python3, lzip
 , libpsl ? null
 , openssl ? null }:
@@ -25,12 +25,10 @@ stdenv.mkDerivation rec {
     do
       sed -i "$i" -e's/localhost/127.0.0.1/g'
     done
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
-    export LIBS="-liconv -lintl"
   '';
 
-  nativeBuildInputs = [ gettext pkgconfig perl lzip ];
-  buildInputs = [ libidn2 libiconv zlib pcre libuuid ]
+  nativeBuildInputs = [ gettext pkgconfig perl lzip libiconv libintl ];
+  buildInputs = [ libidn2 zlib pcre libuuid ]
     ++ stdenv.lib.optionals doCheck [ IOSocketSSL LWP python3 ]
     ++ stdenv.lib.optional (openssl != null) openssl
     ++ stdenv.lib.optional (libpsl != null) libpsl

--- a/pkgs/tools/networking/whois/default.nix
+++ b/pkgs/tools/networking/whois/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
     for i in Makefile po/Makefile; do
       substituteInPlace $i --replace "prefix = /usr" "prefix = $out"
     done
-  '' + stdenv.lib.optionalString (stdenv.isDarwin || stdenv.hostPlatform.isMusl) ''
-    echo "whois_LDADD += -liconv" >> Makefile
   '';
 
   makeFlags = [ "HAVE_ICONV=1" ];

--- a/pkgs/tools/package-management/disnix/default.nix
+++ b/pkgs/tools/package-management/disnix/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, glib, libxml2, libxslt, getopt, nixUnstable, dysnomia, libintlOrEmpty, libiconv }:
+{ stdenv, fetchurl, pkgconfig, glib, libxml2, libxslt, getopt, nixUnstable, dysnomia, libintl, libiconv }:
 
 stdenv.mkDerivation {
   name = "disnix-0.8";
-  
+
   src = fetchurl {
     url = https://github.com/svanderburg/disnix/files/1756701/disnix-0.8.tar.gz;
     sha256 = "02cmj1jqk5i90szjsn5csr7qb7n42v04rvl9syx0zi9sx9ldnb0w";
   };
-  
+
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libxml2 libxslt getopt nixUnstable libintlOrEmpty libiconv dysnomia ];
+  buildInputs = [ glib libxml2 libxslt getopt nixUnstable libintl libiconv dysnomia ];
 
   meta = {
     description = "A Nix-based distributed service deployment tool";

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -28,8 +28,6 @@ stdenv.mkDerivation rec {
     readline libusb gnutls adns openldap zlib bzip2 sqlite
   ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
-
   patches = [
     ./fix-libusb-include-path.patch
   ];

--- a/pkgs/tools/text/odt2txt/default.nix
+++ b/pkgs/tools/text/odt2txt/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib libiconv ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-liconv";
-
   meta = {
     description = "Simple .odt to .txt converter";
     homepage = http://stosberg.net/odt2txt;

--- a/pkgs/tools/text/recode/default.nix
+++ b/pkgs/tools/text/recode/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, python, perl, intltool, flex, autoreconfHook,
-texinfo, libiconv }:
+{ stdenv, fetchFromGitHub, python, perl, intltool, flex, autoreconfHook
+, texinfo, libiconv, libintl }:
 
 stdenv.mkDerivation rec {
   name = "recode-3.7-2fd838565";
@@ -11,16 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "06vyjqaraamcc5vka66mlvxj27ihccqc74aymv2wn8nphr2rhh03";
   };
 
-  nativeBuildInputs = [ python perl intltool flex texinfo autoreconfHook libiconv ];
+  nativeBuildInputs = [ python perl intltool flex texinfo autoreconfHook libiconv libintl ];
 
   preAutoreconf = ''
     # fix build with new automake, https://bugs.gentoo.org/show_bug.cgi?id=419455
     substituteInPlace Makefile.am --replace "ACLOCAL = ./aclocal.sh @ACLOCAL@" ""
     sed -i '/^AM_C_PROTOTYPES/d' configure.ac
     substituteInPlace src/Makefile.am --replace "ansi2knr" ""
-  ''
-  + stdenv.lib.optionalString stdenv.isDarwin ''
-    export LDFLAGS=-lintl
   '';
 
   #doCheck = true; # doesn't work yet

--- a/pkgs/tools/text/unrtf/default.nix
+++ b/pkgs/tools/text/unrtf/default.nix
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoconf automake ];
 
-  buildInputs = [ ] ++ stdenv.lib.optional stdenv.isDarwin libiconv;
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-liconv";
+  buildInputs = [ libiconv ];
 
   preConfigure = "./bootstrap";
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -120,6 +120,7 @@ mapAliases (rec {
   libgnome_keyring = libgnome-keyring; # added 2018-02-25
   libgnome_keyring3 = libgnome-keyring3; # added 2018-02-25
   libgumbo = gumbo; # added 2018-01-21
+  libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || hostPlatform.libc != "glibc") gettext; # added 2018-03-14
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
   libtidy = html-tidy;  # added 2014-12-21

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9990,7 +9990,10 @@ with pkgs;
   };
 
   # On non-GNU systems we need GNU Gettext for libintl.
-  libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || hostPlatform.libc != "glibc") gettext;
+  libintl = if hostPlatform.libc != "glibc" then gettext else null;
+
+  # deprecated: provided for compatability
+  libintlOrEmpty = [ libintl ];
 
   libid3tag = callPackage ../development/libraries/libid3tag {
     gperf = gperf_3_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9986,9 +9986,6 @@ with pkgs;
   # On non-GNU systems we need GNU Gettext for libintl.
   libintl = if hostPlatform.libc != "glibc" then gettext else null;
 
-  # deprecated: provided for compatability
-  libintlOrEmpty = [ libintl ];
-
   libid3tag = callPackage ../development/libraries/libid3tag {
     gperf = gperf_3_0;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8898,12 +8898,10 @@ with pkgs;
   icon-lang = callPackage ../development/interpreters/icon-lang { };
 
   libgit2 = callPackage ../development/libraries/git2 {
-    inherit (darwin) libiconv;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
   libgit2_0_25 = callPackage ../development/libraries/git2/0.25.nix {
-    inherit (darwin) libiconv;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
@@ -9908,9 +9906,6 @@ with pkgs;
   };
 
   libnatspec = callPackage ../development/libraries/libnatspec (
-    stdenv.lib.optionalAttrs stdenv.isDarwin {
-      inherit (darwin) libiconv;
-    }
   );
 
   libndp = callPackage ../development/libraries/libndp { };
@@ -11702,9 +11697,7 @@ with pkgs;
     stdenv = overrideCC stdenv gcc6; # upstream code incompatible with gcc7
   };
 
-  wavpack = callPackage ../development/libraries/wavpack {
-    inherit (darwin) libiconv;
-  };
+  wavpack = callPackage ../development/libraries/wavpack { };
 
   wayland = callPackage ../development/libraries/wayland {
     graphviz = graphviz-nox;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9905,8 +9905,7 @@ with pkgs;
     mysql = mysql57;
   };
 
-  libnatspec = callPackage ../development/libraries/libnatspec (
-  );
+  libnatspec = callPackage ../development/libraries/libnatspec { };
 
   libndp = callPackage ../development/libraries/libndp { };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8072,7 +8072,6 @@ let self = _self // overrides; _self = with self; {
   LocaleGettext = buildPerlPackage {
     name = "LocaleGettext-1.05";
     buildInputs = stdenv.lib.optional (stdenv.isFreeBSD || stdenv.isDarwin || stdenv.isCygwin) pkgs.gettext;
-    NIX_CFLAGS_LINK = stdenv.lib.optional (stdenv.isFreeBSD || stdenv.isDarwin || stdenv.isCygwin) "-lintl";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PV/PVANDRY/gettext-1.05.tar.gz;
       sha256 = "15262a00vx714szpx8p2z52wxkz46xp7acl72znwjydyq4ypydi7";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3877,7 +3877,7 @@ let self = _self // overrides; _self = with self; {
       \$(BASEEXT)\$(OBJ_EXT): \$(BASEEXT).xsi
 
       \$(BASEEXT).xsi: \$(DBI_DRIVER_XST) $autodir/Driver_xst.h
-      	\$(PERL) -p -e "s/~DRIVER~/\$(BASEEXT)/g" \$(DBI_DRIVER_XST) > \$(BASEEXT).xsi
+       \$(PERL) -p -e "s/~DRIVER~/\$(BASEEXT)/g" \$(DBI_DRIVER_XST) > \$(BASEEXT).xsif
 
       # ---
       ';
@@ -8071,7 +8071,7 @@ let self = _self // overrides; _self = with self; {
 
   LocaleGettext = buildPerlPackage {
     name = "LocaleGettext-1.05";
-    buildInputs = stdenv.lib.optional (stdenv.isFreeBSD || stdenv.isDarwin || stdenv.isCygwin) pkgs.gettext;
+    buildInputs = [ pkgs.gettext ];
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PV/PVANDRY/gettext-1.05.tar.gz;
       sha256 = "15262a00vx714szpx8p2z52wxkz46xp7acl72znwjydyq4ypydi7";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3877,7 +3877,7 @@ let self = _self // overrides; _self = with self; {
       \$(BASEEXT)\$(OBJ_EXT): \$(BASEEXT).xsi
 
       \$(BASEEXT).xsi: \$(DBI_DRIVER_XST) $autodir/Driver_xst.h
-       \$(PERL) -p -e "s/~DRIVER~/\$(BASEEXT)/g" \$(DBI_DRIVER_XST) > \$(BASEEXT).xsif
+      	\$(PERL) -p -e "s/~DRIVER~/\$(BASEEXT)/g" \$(DBI_DRIVER_XST) > \$(BASEEXT).xsi
 
       # ---
       ';


### PR DESCRIPTION
###### Motivation for this change
This is a fairly big PR, so I'll list out what it does:

- deprecate "libintlOrEmpty". This was an ugly name for an attribute. Instead you can just use "libintl" which is an alias to gettext when libc != glibc. It now acts similarly to "libiconv" and you can add it to any derivation needing libintl (no need to use stdenv.isDarwin anymore!)
- adds setup-hook to gettext to add "-lintl" to LDFLAGS
- adds setup-hook to iconv to add "-liconv" to LDFLAGS
- removes all of the hacks adding "-liconv" and "-lintl", treewide

I'm interested in comments on whether this is a good idea!

/cc @Ericson2314 @LnL7 @copumpkin @NixOS/darwin-maintainers 