### PR TITLE
wllvm: 1.1.3 -> 1.1.5

### DIFF
--- a/pkgs/development/tools/wllvm/default.nix
+++ b/pkgs/development/tools/wllvm/default.nix
@@ -1,13 +1,13 @@
 { stdenv, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
-  version = "1.1.3";
+  version = "1.1.5";
   pname = "wllvm";
   name = "${pname}-${version}";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1scv9bwr888x2km8njg0000xkj8pz73c0gjbphhqaj8vy87y25cb";
+    sha256 = "02lnilhqz7mq0w6mp574rmjxiszp1wyla16jqr89r0z9vjg2j9rv";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Bump :).

Haven't tested extensively,
but looks fine after quick testing.

Behaves differently when reading input
from stdin:

https://github.com/travitch/whole-program-llvm/commit/bb16facc2a23dc433342932981acc6df92520216

Which may or may not be desirable.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---