### PR TITLE
cmake: Setup default macOS flags

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -55,6 +55,9 @@ cmakeConfigurePhase() {
     # we don't want our binaries to have a "minimum" OSX version
     cmakeFlags="-DCMAKE_OSX_DEPLOYMENT_TARGET= $cmakeFlags"
 
+    # correctly detect our clang compiler
+    cmakeFlags="-DCMAKE_POLICY_DEFAULT_CMP0025=NEW $cmakeFlags"
+
     # This installs shared libraries with a fully-specified install
     # name. By default, cmake installs shared libraries with just the
     # basename as the install name, which means that, on Darwin, they

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -44,6 +44,10 @@ cmakeConfigurePhase() {
         cmakeFlags="-DCMAKE_STRIP=$(command -v $crossConfig-strip) $cmakeFlags"
     fi
 
+    # on macOS we want to prefer Unix-style headers to Frameworks
+    # because we usually do not package the framework
+    cmakeFlags="-DCMAKE_FIND_FRAMEWORK=last $cmakeFlags"
+
     # This installs shared libraries with a fully-specified install
     # name. By default, cmake installs shared libraries with just the
     # basename as the install name, which means that, on Darwin, they

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -51,6 +51,10 @@ cmakeConfigurePhase() {
     # we never want to use the global macOS SDK
     cmakeFlags="-DCMAKE_OSX_SYSROOT= $cmakeFlags"
 
+    # disable OSX deployment target
+    # we don't want our binaries to have a "minimum" OSX version
+    cmakeFlags="-DCMAKE_OSX_DEPLOYMENT_TARGET= $cmakeFlags"
+
     # This installs shared libraries with a fully-specified install
     # name. By default, cmake installs shared libraries with just the
     # basename as the install name, which means that, on Darwin, they

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -48,6 +48,9 @@ cmakeConfigurePhase() {
     # because we usually do not package the framework
     cmakeFlags="-DCMAKE_FIND_FRAMEWORK=last $cmakeFlags"
 
+    # we never want to use the global macOS SDK
+    cmakeFlags="-DCMAKE_OSX_SYSROOT= $cmakeFlags"
+
     # This installs shared libraries with a fully-specified install
     # name. By default, cmake installs shared libraries with just the
     # basename as the install name, which means that, on Darwin, they


### PR DESCRIPTION
###### Motivation for this change

This is a collection of new defaults to setup for CMake related to macOS. Many packages are already setting these, but this will just make them the default. If I have time, I can make a treewide commit that removes references to these flags.

This could potentially break many packages, so it should be extensively tested. If someone could setup a Hydra jobset for this, that would be great!

Also related to #36834