### PR TITLE
gllvm: init at 2018-02-09

### DIFF
--- a/pkgs/development/tools/gllvm/default.nix
+++ b/pkgs/development/tools/gllvm/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "gllvm-${version}";
+  version = "2018-02-09";
+
+  goPackagePath = "github.com/SRI-CSL/gllvm";
+
+  src = fetchFromGitHub {
+    owner = "SRI-CSL";
+    repo = "gllvm";
+    rev = "ef83222afd22452dd1277329df227a326db9f84f";
+    sha256 = "068mc8q7jmpjzh6pr0ygvv39mh4k7vz0dmiacxf3pdsigy3d1y1a";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/SRI-CSL/gllvm;
+    description = "Whole Program LLVM: wllvm ported to go";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1222,6 +1222,8 @@ with pkgs;
 
   gixy = callPackage ../tools/admin/gixy { };
 
+  gllvm = callPackage ../development/tools/gllvm { };
+
   glide = callPackage ../development/tools/glide { };
 
   glock = callPackage ../development/tools/glock { };


### PR DESCRIPTION
Concurrent version of WLLVM written in go,
more self-contained and faster.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
This is just the bare tool itself, like the WLLVM package we have,
and needs a wrapper or similar to work in Nix builds.