### PR TITLE
inkscape: 0.92.2 -> 0.92.3

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -10,11 +10,11 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "inkscape-0.92.2";
+  name = "inkscape-0.92.3";
 
   src = fetchurl {
     url = "https://media.inkscape.org/dl/resources/file/${name}.tar.bz2";
-    sha256 = "1lyghk6yarcv9nwkh6k366p6hb7rfilqcvbyji09hki59khd0a56";
+    sha256 = "1chng2yw8dsjxc9gf92aqv7plj11cav8ax321wmakmv5bb09cch6";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/5khy2kbfjwvkj42lr6z0cvnd17xkfrfg-inkscape-0.92.3/bin/inkscape -h` got 0 exit code
- ran `/nix/store/5khy2kbfjwvkj42lr6z0cvnd17xkfrfg-inkscape-0.92.3/bin/inkscape --help` got 0 exit code
- ran `/nix/store/5khy2kbfjwvkj42lr6z0cvnd17xkfrfg-inkscape-0.92.3/bin/inkscape -V` and found version 0.92.3
- ran `/nix/store/5khy2kbfjwvkj42lr6z0cvnd17xkfrfg-inkscape-0.92.3/bin/inkscape --version` and found version 0.92.3
- found 0.92.3 with grep in /nix/store/5khy2kbfjwvkj42lr6z0cvnd17xkfrfg-inkscape-0.92.3