### PR TITLE
insomnia: 5.14.7 -> 5.14.9

### DIFF
--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -18,11 +18,11 @@ let
   runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl ];
 in stdenv.mkDerivation rec {
   name = "insomnia-${version}";
-  version = "5.14.7";
+  version = "5.14.9";
 
   src = fetchurl {
     url = "https://github.com/getinsomnia/insomnia/releases/download/v${version}/insomnia_${version}_amd64.deb";
-    sha256 = "1y6bn9kaxxplzyv7jjrcsfkrjnivjqdk5mbdp8vz32hv2bmdvzzy";
+    sha256 = "0hq9pcfw1ic2acaknwp2d5yphg901dmk7d4n7ikx42nya8p39c6j";
   };
 
   nativeBuildInputs = [ makeWrapper dpkg ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 5.14.9 with grep in /nix/store/5pw045b91pq83nph1x95pqqfd3fbjpi1-insomnia-5.14.9
- found 5.14.9 in filename of file in /nix/store/5pw045b91pq83nph1x95pqqfd3fbjpi1-insomnia-5.14.9

cc @markus1189 for review