### PR TITLE
llvm6: Build with support for the experimental WASM backend

### DIFF
--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -16,6 +16,7 @@
 , debugVersion ? false
 , enableManpages ? false
 , enableSharedLibraries ? true
+, enableWasm ? true
 , darwin
 }:
 
@@ -115,7 +116,9 @@ in stdenv.mkDerivation (rec {
 
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
     "-DCOMPILER_RT_BUILD_XRAY=OFF"
-  ];
+  ] ++ stdenv.lib.optional enableWasm
+   "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
+  ;
 
   postBuild = ''
     rm -fR $out


### PR DESCRIPTION
So folks can try building things with it :).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---