### PR TITLE
intel-gpu-tools: 1.21 -> 1.22

### DIFF
--- a/pkgs/development/tools/misc/intel-gpu-tools/default.nix
+++ b/pkgs/development/tools/misc/intel-gpu-tools/default.nix
@@ -3,11 +3,11 @@
 , procps, autoreconfHook, utilmacros, gnome2 }:
 
 stdenv.mkDerivation rec {
-  name = "intel-gpu-tools-1.21";
+  name = "intel-gpu-tools-1.22";
 
   src = fetchurl {
     url = "http://xorg.freedesktop.org/archive/individual/app/${name}.tar.xz";
-    sha256 = "0gvh317dg5c7kvjxxkh8g70hh3r3dc73mc4dzyvfa8nb4ix6xbyr";
+    sha256 = "0p4swf9577p6hzglw1lh2sz63wjkk37b7691saj2qw8ha7fc2rix";
   };
 
   nativeBuildInputs = [ pkgconfig utilmacros ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/igt_stats -h` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/igt_stats --help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/igt_stats help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_reg --help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_reg help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_forcewaked -h` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_firmware_decode help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_gpu_top -h` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_gpu_top -h` and found version 1.22
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_guc_logger -h` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_guc_logger --help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_opregion_decode -h` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_opregion_decode --help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_dump_decode help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_error_decode help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_dp_compliance -h` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_dp_compliance --help` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_dp_compliance -h` and found version 1.22
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_dp_compliance --help` and found version 1.22
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_aubdump -h` got 0 exit code
- ran `/nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22/bin/intel_aubdump --help` got 0 exit code
- found 1.22 with grep in /nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22
- found 1.22 in filename of file in /nix/store/xk5lsqw4vfa5ndqvsg23w6jblxx0js78-intel-gpu-tools-1.22

cc @pSub for review