### PR TITLE
libdwarf: 20170709 -> 20180129

### DIFF
--- a/pkgs/development/libraries/libdwarf/default.nix
+++ b/pkgs/development/libraries/libdwarf/default.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchurl, libelf }:
 
 let
-  version = "20170709";
+  version = "20180129";
   src = fetchurl {
     url = "http://www.prevanders.net/libdwarf-${version}.tar.gz";
-    sha512 = "afff6716ef1af5d8aae2b887f36b9a6547fb576770bc6f630b82725ed1e59cbd"
-           + "387779aa729bbd1a5ae026a25ac76aacf64b038cd898b2419a8676f9aa8c59f1";
+    # Upstream displays this hash broken into three parts:
+    sha512 = "02f8024bb9959c91a1fe322459f7587a589d096595"
+           + "6d643921a173e6f9e0a184db7aef66f0fd2548d669"
+           + "5be7f9ee368f1cc8940cea4ddda01ff99d28bbf1fe58";
   };
   meta = {
     homepage = https://www.prevanders.net/dwarf.html;


### PR DESCRIPTION
Upstream describes changes:

Fixes libdwarf/dwarfdump vulnerabilities related to detecting corrupt
DWARF and includes other small improvements


Replaces https://github.com/NixOS/nixpkgs/pull/36606


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---