### PR TITLE
ipset: 6.35 -> 6.36

### DIFF
--- a/pkgs/os-specific/linux/ipset/default.nix
+++ b/pkgs/os-specific/linux/ipset/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libmnl }:
 
 stdenv.mkDerivation rec {
-  name = "ipset-6.35";
+  name = "ipset-6.36";
 
   src = fetchurl {
     url = "http://ipset.netfilter.org/${name}.tar.bz2";
-    sha256 = "1p7l1fj3lbv6rr24zxjiwq7jk1yvazk8db6yyni0qbprw49i01rp";
+    sha256 = "03fk40v0rbiv2b9ciy3zk8yix163803xvpmdlyvrfzbcvj84l8i2";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset -h` got 0 exit code
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset --help` got 0 exit code
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset help` got 0 exit code
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset -V` and found version 6.36
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset -v` and found version 6.36
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset --version` and found version 6.36
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset version` and found version 6.36
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset -h` and found version 6.36
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset --help` and found version 6.36
- ran `/nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36/bin/ipset help` and found version 6.36
- found 6.36 with grep in /nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36
- found 6.36 in filename of file in /nix/store/05yb8ry7k0xyxcjq16cx0wkw1fkifb05-ipset-6.36

cc @wkennington for review