### PR TITLE
itstool: 2.0.2 -> 2.0.4

### DIFF
--- a/pkgs/development/tools/misc/itstool/default.nix
+++ b/pkgs/development/tools/misc/itstool/default.nix
@@ -2,11 +2,11 @@
 # We need the same Python as is used to build libxml2Python
 
 stdenv.mkDerivation rec {
-  name = "itstool-2.0.2";
+  name = "itstool-2.0.4";
 
   src = fetchurl {
     url = "http://files.itstool.org/itstool/${name}.tar.bz2";
-    sha256 = "bf909fb59b11a646681a8534d5700fec99be83bb2c57badf8c1844512227033a";
+    sha256 = "0q7b4qrc758zfx3adsgvz0r93swdbxjr42w37rahngm33nshihlp";
   };
 
   buildInputs = [ python2 libxml2Python ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/pg0jpmczm1gb3rzp3qfnnjl0xfd48nqz-itstool-2.0.4/bin/itstool -h` got 0 exit code
- ran `/nix/store/pg0jpmczm1gb3rzp3qfnnjl0xfd48nqz-itstool-2.0.4/bin/itstool --help` got 0 exit code
- ran `/nix/store/pg0jpmczm1gb3rzp3qfnnjl0xfd48nqz-itstool-2.0.4/bin/itstool -v` and found version 2.0.4
- ran `/nix/store/pg0jpmczm1gb3rzp3qfnnjl0xfd48nqz-itstool-2.0.4/bin/itstool --version` and found version 2.0.4
- found 2.0.4 with grep in /nix/store/pg0jpmczm1gb3rzp3qfnnjl0xfd48nqz-itstool-2.0.4
- found 2.0.4 in filename of file in /nix/store/pg0jpmczm1gb3rzp3qfnnjl0xfd48nqz-itstool-2.0.4