### PR TITLE
treewide: never assert stdenv.isLinux or stdenv.isDarwin

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -3,8 +3,6 @@
 , androidsdk, jdk, cmake, libxml2, zlib, python3, ncurses
 }:
 
-assert stdenv.isLinux;
-
 with stdenv.lib;
 
 let

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, patchelf, makeWrapper, xorg, gcc, gcc-unwrapped }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
    name = "IPMIView-${version}";
    version = "2.13.0";
@@ -31,5 +29,6 @@ stdenv.mkDerivation rec {
 
    meta = with stdenv.lib; {
     license = licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
    };
   }

--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -21,8 +21,6 @@
 , curl
 }:
 
-assert stdenv.isLinux;
-
 let
   version = "4.2.12";
 

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -48,8 +48,6 @@
 , gnupg
 }:
 
-assert stdenv.isLinux;
-
 let
 
   inherit (generated) version sources;

--- a/pkgs/applications/networking/ike/default.nix
+++ b/pkgs/applications/networking/ike/default.nix
@@ -1,8 +1,6 @@
 { stdenv, fetchurl, cmake, openssl, libedit, flex, bison, qt4, makeWrapper
 , gcc, nettools, iproute, linuxHeaders }:
 
-assert stdenv.isLinux;
-
 # NOTE: use $out/etc/iked.conf as sample configuration and also set: dhcp_file "/etc/iked.dhcp";
 # launch with "iked -f /etc/iked.conf"
 
@@ -40,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://www.shrew.net/software;
     description = "IPsec Client for FreeBSD, NetBSD and many Linux based operating systems";
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = [ maintainers.domenkozar ];
     license = licenses.sleepycat;
   };

--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -3,8 +3,6 @@
 , alsaLib, dbus_libs, gtk2, libpulseaudio, openssl, xorg
 }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "jitsi-${version}";
   version = "2.10.5550";

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -24,8 +24,6 @@ let
     buildCore = monolithic || daemon;
 in
 
-assert stdenv.isLinux;
-
 assert monolithic -> !client && !daemon;
 assert client || daemon -> !monolithic;
 assert !buildClient -> !withKDE; # KDE is used by the client only

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -43,8 +43,6 @@
 , gnupg
 }:
 
-assert stdenv.isLinux;
-
 # imports `version` and `sources`
 with (import ./release_sources.nix);
 

--- a/pkgs/applications/science/logic/verifast/default.nix
+++ b/pkgs/applications/science/logic/verifast/default.nix
@@ -1,8 +1,6 @@
 { stdenv, fetchurl, gtk2, gdk_pixbuf, atk, pango, glib, cairo, freetype
 , fontconfig, libxml2, gnome2 }:
 
-assert stdenv.isLinux;
-
 let
   libPath = stdenv.lib.makeLibraryPath
     [ stdenv.cc.libc stdenv.cc.cc gtk2 gdk_pixbuf atk pango glib cairo

--- a/pkgs/desktops/gnome-2/desktop/libgweather/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/libgweather/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libxml2, gtk, intltool, GConf, libsoup, libtasn1, nettle, gmp }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "libgweather-2.30.3";
   src = fetchurl {

--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -3,8 +3,6 @@
 , platformTools
 }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "android-ndk-r10e";
 

--- a/pkgs/development/mobile/androidenv/androidndk_r8e.nix
+++ b/pkgs/development/mobile/androidenv/androidndk_r8e.nix
@@ -3,8 +3,6 @@
 , platformTools
 }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "android-ndk-r8e";
 
@@ -77,4 +75,8 @@ stdenv.mkDerivation rec {
         ln -sf ${pkg_path}/$i ${bin_path}/$i
     done
   '';
+
+  meta = {
+    platforms = stdenv.lib.platforms.linux;
+  };
 }

--- a/pkgs/games/ue4demos/default.nix
+++ b/pkgs/games/ue4demos/default.nix
@@ -1,8 +1,5 @@
 { stdenv, fetchurl, unzip, patchelf, xorg, openal }:
 
-assert stdenv.isLinux;
-assert stdenv.isx86_64;
-
 let
   buildDemo = { name, src }:
     stdenv.mkDerivation rec {
@@ -47,7 +44,7 @@ let
       meta = {
         description = "Unreal Engine 4 Linux demos";
         homepage = https://wiki.unrealengine.com/Linux_Demos;
-        platforms = stdenv.lib.platforms.linux;
+        platforms = [ "x86_64-linux" ];
         license = stdenv.lib.licenses.unfree;
       };
     };
@@ -189,4 +186,3 @@ in {
     };
   };
 }
-

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -6,7 +6,6 @@
   buildScript ? null, configureFlags ? ""
 }:
 
-assert stdenv.isLinux;
 assert stdenv.cc.cc.isGNU or false;
 
 with import ./util.nix { inherit lib; };
@@ -83,7 +82,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   # Add capability to ignore known failing tests
   # and enable doCheck
   doCheck = false;
-  
+
   postInstall = let
     links = prefix: pkg: "ln -s ${pkg} $out/${prefix}/${pkg.name}";
   in ''
@@ -100,7 +99,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
       fi
     done
   '';
-  
+
   enableParallelBuilding = true;
 
   passthru = { inherit pkgArches; };

--- a/pkgs/os-specific/darwin/native-x11-and-opengl/default.nix
+++ b/pkgs/os-specific/darwin/native-x11-and-opengl/default.nix
@@ -1,7 +1,5 @@
 { stdenv, writeScript }:
 
-assert stdenv.isDarwin;
-
 stdenv.mkDerivation rec {
   name = "darwin-native-x11-and-opengl";
 
@@ -13,4 +11,8 @@ stdenv.mkDerivation rec {
     /bin/ln -sv /usr/X11/lib/pkgconfig/{x*.pc,gl*.pc} $out/lib/pkgconfig
     /bin/ln -sv /usr/X11/{bin,include,share} $out/
   '';
+
+  meta = {
+    platforms = stdenv.lib.platforms.darwin;
+  };
 }

--- a/pkgs/os-specific/linux/blcr/default.nix
+++ b/pkgs/os-specific/linux/blcr/default.nix
@@ -2,7 +2,6 @@
 
 # BLCR version 0.8.6 should works with linux kernel up to version 3.17.x
 
-assert stdenv.isLinux;
 assert builtins.compareVersions "3.18" kernel.version == 1;
 
 stdenv.mkDerivation {

--- a/pkgs/os-specific/linux/bluez/bluez5_28.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5_28.nix
@@ -2,13 +2,11 @@
   pythonPackages, readline, libsndfile, udev, libical,
   systemd, enableWiimote ? false }:
 
-assert stdenv.isLinux;
-
 let
   inherit (pythonPackages) python;
 in stdenv.mkDerivation rec {
   name = "bluez-5.28";
-   
+
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/${name}.tar.xz";
     sha256 = "1a8qzh38wpq5c0rydpx9isf0jc6g14g2qs18j1rmi8a79f7v9fl5";
@@ -22,7 +20,7 @@ in stdenv.mkDerivation rec {
       readline libsndfile udev libical
       # Disables GStreamer; not clear what it gains us other than a
       # zillion extra dependencies.
-      # gstreamer gst-plugins-base 
+      # gstreamer gst-plugins-base
     ];
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -2,8 +2,6 @@
   pythonPackages, readline, udev, libical,
   systemd, enableWiimote ? false }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "bluez-5.48";
 

--- a/pkgs/os-specific/linux/drbd/default.nix
+++ b/pkgs/os-specific/linux/drbd/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, flex, systemd, perl }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "drbd-8.4.4";
 

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -42,8 +42,6 @@
 , ...
 } @ args:
 
-assert stdenv.isLinux;
-
 let
 
   lib = stdenv.lib;

--- a/pkgs/os-specific/linux/lsscsi/default.nix
+++ b/pkgs/os-specific/linux/lsscsi/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation {
   name = "lsscsi-0.28";
 

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -3,8 +3,6 @@
 , buildPlatform, hostPlatform
 }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "mdadm-4.0";
 

--- a/pkgs/os-specific/linux/phc-intel/default.nix
+++ b/pkgs/os-specific/linux/phc-intel/default.nix
@@ -1,6 +1,5 @@
 { stdenv, fetchurl, kernel, which }:
 
-assert stdenv.isLinux;
 # Don't bother with older versions, though some might even work:
 assert stdenv.lib.versionAtLeast kernel.version "4.10";
 

--- a/pkgs/os-specific/linux/psmisc/default.nix
+++ b/pkgs/os-specific/linux/psmisc/default.nix
@@ -1,7 +1,5 @@
 {stdenv, fetchurl, ncurses}:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "psmisc-23.1";
 

--- a/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
+++ b/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
@@ -1,7 +1,5 @@
 { stdenv, systemd, cryptsetup }:
 
-assert stdenv.isLinux;
-
 stdenv.lib.overrideDerivation systemd (p: {
   version = p.version;
   name = "systemd-cryptsetup-generator";
@@ -21,4 +19,8 @@ stdenv.lib.overrideDerivation systemd (p: {
     mkdir -p $out/lib/systemd/system-generators/
     cp systemd-cryptsetup-generator $out/lib/systemd/system-generators/systemd-cryptsetup-generator
   '';
+
+  meta = {
+    platforms = stdenv.lib.platforms.linux;
+  };
 })

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -11,8 +11,6 @@
 , hostPlatform
 }:
 
-assert stdenv.isLinux;
-
 let
   pythonLxmlEnv = python3Packages.python.withPackages ( ps: with ps; [ python3Packages.lxml ]);
 

--- a/pkgs/os-specific/linux/uclibc/default.nix
+++ b/pkgs/os-specific/linux/uclibc/default.nix
@@ -1,7 +1,6 @@
 {stdenv, fetchzip, linuxHeaders, libiconvReal, cross ? null, gccCross ? null,
 extraConfig ? ""}:
 
-assert stdenv.isLinux;
 assert cross != null -> gccCross != null;
 
 let

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -3,8 +3,6 @@
 , useSystemd ? true, systemd, gobjectIntrospection
 }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "upower-0.99.7";
 

--- a/pkgs/os-specific/linux/xf86-input-multitouch/default.nix
+++ b/pkgs/os-specific/linux/xf86-input-multitouch/default.nix
@@ -11,8 +11,6 @@
 , libpciaccess
 }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation {
   name = "xf86-input-multitouch-20110312";
 
@@ -53,5 +51,6 @@ stdenv.mkDerivation {
     description = "Brings multitouch gestures to the Linux desktop";
 
     license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/audio/aucdtect/default.nix
+++ b/pkgs/tools/audio/aucdtect/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, lib, rpmextract }:
 
-assert stdenv.isLinux;
-
 with lib;
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -190,7 +190,7 @@ in pythonPackages.buildPythonApplication rec {
     runHook preCheck
 
     LANG=en_US.UTF-8 \
-    LOCALE_ARCHIVE=${assert stdenv.isLinux; glibcLocales}/lib/locale/locale-archive \
+    LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive \
     BEETS_TEST_SHELL="${testShell}" \
     BASH_COMPLETION_SCRIPT="${completion}" \
     HOME="$(mktemp -d)" \

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, writeText, zlib, rpmextract, patchelf, which }:
 
-assert stdenv.isLinux;
-
 let
   p = if stdenv.is64bit then {
       arch = "x86_64";
@@ -13,7 +11,7 @@ let
       gcclib = "${stdenv.cc.cc.lib}/lib";
       sha256 = "09h71i3k9d24ki81jdwhnav63fqbc44glbx228s9g3cr4ap41jcx";
     };
-in 
+in
 stdenv.mkDerivation rec {
 
   name = "yandex-disk-${version}";
@@ -64,4 +62,3 @@ stdenv.mkDerivation rec {
     '';
   };
 }
-

--- a/pkgs/tools/misc/pk2cmd/default.nix
+++ b/pkgs/tools/misc/pk2cmd/default.nix
@@ -1,7 +1,5 @@
 {stdenv, fetchurl, libusb, makeWrapper}:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation {
   name = "pk2cmd-1.20";
   src = fetchurl {
@@ -24,5 +22,6 @@ stdenv.mkDerivation {
     homepage = http://www.microchip.com/pickit2;
     license = stdenv.lib.licenses.unfree; #MicroChip-PK2
     description = "Microchip PIC programming software for the PICKit2 programmer";
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/misc/trash-cli/default.nix
+++ b/pkgs/tools/misc/trash-cli/default.nix
@@ -1,8 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, coreutils
 , python3, python3Packages, substituteAll }:
 
-assert stdenv.isLinux;
-
 python3Packages.buildPythonApplication rec {
   name = "trash-cli-${version}";
   version = "0.17.1.14";
@@ -37,7 +35,7 @@ python3Packages.buildPythonApplication rec {
     homepage = https://github.com/andreafrancia/trash-cli;
     description = "Command line tool for the desktop trash can";
     maintainers = [ maintainers.rycee ];
-    platforms = platforms.all;
+    platforms = platforms.unix;
     license = licenses.gpl2;
   };
 }

--- a/pkgs/tools/networking/logmein-hamachi/default.nix
+++ b/pkgs/tools/networking/logmein-hamachi/default.nix
@@ -2,8 +2,6 @@
 
 with stdenv.lib;
 
-assert stdenv.isLinux;
-
 let
   arch =
     if stdenv.system == "x86_64-linux" then "x64"

--- a/pkgs/tools/networking/miniupnpd/default.nix
+++ b/pkgs/tools/networking/miniupnpd/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, iptables, libuuid, pkgconfig }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "miniupnpd-2.0.20180203";
 


### PR DESCRIPTION
Assertions shouldn't be used in Nixpkgs for checking the platform. "meta.platforms" provides a much more robust way of handling this.

This treewide commit removes all references to 'assert stdenv.isLinux' and 'assert stdenv.isDarwin'.
