### PR TITLE
latte-dock: 0.7.3 -> 0.7.4

### DIFF
--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, cmake, xorg, plasma-framework, fetchFromGitHub
 , extra-cmake-modules, karchive, kwindowsystem, qtx11extras, kcrash }:
 
-let version = "0.7.3"; in
+let version = "0.7.4"; in
 
 mkDerivation {
   name = "latte-dock-${version}";
@@ -10,7 +10,7 @@ mkDerivation {
     owner = "psifidotos";
     repo = "Latte-Dock";
     rev = "v${version}";
-    sha256 = "110bal0dairsvgj624n5k0zabh2qfy9dk560a4wy7icxv0cjh7hg";
+    sha256 = "0w4fphgpdvql31wrypxyfahmr4cv5ap96wjc4270yyawnrqrx0y6";
   };
 
   buildInputs = [ plasma-framework xorg.libpthreadstubs xorg.libXdmcp xorg.libSM ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.7.4 with grep in /nix/store/n1ad51hdp3jagm7fx91gp3i580ghid4q-latte-dock-0.7.4
- found 0.7.4 in filename of file in /nix/store/n1ad51hdp3jagm7fx91gp3i580ghid4q-latte-dock-0.7.4

cc @benley for review