### PR TITLE
libbson: 1.9.2 -> 1.9.3

### DIFF
--- a/pkgs/development/libraries/libbson/default.nix
+++ b/pkgs/development/libraries/libbson/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libbson-${version}";
-  version = "1.9.2";
+  version = "1.9.3";
 
   src = fetchFromGitHub {
     owner = "mongodb";
     repo = "libbson";
     rev = version;
-    sha256 = "1dlmcqsb43269z4pa3xmqb1gf1jsji82sk5yyibq0ndhk326iyck";
+    sha256 = "0dbpmvd2p9bdqdyiijmsc1hd9d6l36migk79smw7fpfvh0y6ldsk";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.9.3 with grep in /nix/store/2wb2wdhn8wqxcmh8vp75gnnb5sncmf3n-libbson-1.9.3
- found 1.9.3 in filename of file in /nix/store/2wb2wdhn8wqxcmh8vp75gnnb5sncmf3n-libbson-1.9.3