### PR TITLE
libcouchbase: 2.8.4 -> 2.8.5

### DIFF
--- a/pkgs/development/libraries/libcouchbase/default.nix
+++ b/pkgs/development/libraries/libcouchbase/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libcouchbase-${version}";
-  version = "2.8.4";
+  version = "2.8.5";
 
   src = fetchFromGitHub {
     owner = "couchbase";
     repo = "libcouchbase";
     rev = version;
-    sha256 = "0i5kmv8grsnh2igvlkgjr8lz3h3yrxh82yxbbdsjfpslv61l0gpi";
+    sha256 = "1iwzf0y5f25g5hgdkmv6qf3k5mzlazrpx5sj3m2pvrl9jg9wn4s1";
   };
 
   cmakeFlags = "-DLCB_NO_MOCK=ON";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc help` got 0 exit code
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc version` and found version 2.8.5
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc-pillowfight --help` got 0 exit code
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc-n1qlback --help` got 0 exit code
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc-n1qlback --help` and found version 2.8.5
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc-subdoc --help` got 0 exit code
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc-subdoc --help` and found version 2.8.5
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc-proxy --help` got 0 exit code
- ran `/nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5/bin/cbc-proxy --help` and found version 2.8.5
- found 2.8.5 with grep in /nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5
- found 2.8.5 in filename of file in /nix/store/hl81vpsfg8v265spqy58yy25hccl66i2-libcouchbase-2.8.5