### PR TITLE
freenect: 0.5.5 -> 0.5.7, Enable Darwin

### DIFF
--- a/pkgs/development/libraries/freenect/default.nix
+++ b/pkgs/development/libraries/freenect/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, libusb, pkgconfig, freeglut, libGLU_combined, libXi, libXmu }:
+{ stdenv, lib, fetchFromGitHub, cmake, libusb, pkgconfig, freeglut, libGLU_combined, libXi, libXmu
+, GLUT, Cocoa
+ }:
 
 stdenv.mkDerivation rec {
   name = "freenect-${version}";
@@ -11,15 +13,17 @@ stdenv.mkDerivation rec {
     sha256 = "0vnc7z2avckh4mccqq6alsd2z7xvsh3kaslc5b0gnfxw0j269gl6";
   };
 
-  buildInputs = [ libusb freeglut libGLU_combined libXi libXmu ];
+  buildInputs = [ libusb freeglut libGLU_combined libXi libXmu ]
+    ++ lib.optionals stdenv.isDarwin [ GLUT Cocoa ];
+
   nativeBuildInputs = [ cmake pkgconfig ];
 
   meta = {
     description = "Drivers and libraries for the Xbox Kinect device on Windows, Linux, and macOS";
     inherit version;
     homepage = http://openkinect.org;
-    license = with stdenv.lib.licenses; [ gpl2 asl20 ];
-    maintainers = with stdenv.lib.maintainers; [ bennofs ];
-    platforms = stdenv.lib.platforms.linux;
+    license = with lib.licenses; [ gpl2 asl20 ];
+    maintainers = with lib.maintainers; [ bennofs ];
+    platforms = with lib.platforms; linux ++ darwin ;
   };
 }

--- a/pkgs/development/libraries/freenect/default.nix
+++ b/pkgs/development/libraries/freenect/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "freenect-${version}";
-  version = "0.5.5";
+  version = "0.5.7";
 
   src = fetchFromGitHub {
     owner = "OpenKinect";
     repo = "libfreenect";
     rev = "v${version}";
-    sha256 = "0qmbagfkxjgbwd2ajn7i5lkic9gx5y02bsnmqm7cjay99zfw9ifx";
+    sha256 = "0vnc7z2avckh4mccqq6alsd2z7xvsh3kaslc5b0gnfxw0j269gl6";
   };
 
   buildInputs = [ libusb freeglut libGLU_combined libXi libXmu ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8807,7 +8807,9 @@ with pkgs;
 
   freeglut = callPackage ../development/libraries/freeglut { };
 
-  freenect = callPackage ../development/libraries/freenect { };
+  freenect = callPackage ../development/libraries/freenect {
+    inherit (darwin.apple_sdk.frameworks) Cocoa GLUT;
+  };
 
   freetype = callPackage ../development/libraries/freetype { };
 


### PR DESCRIPTION
###### Motivation for this change
Version bump which fixes issues with device scanning.

Also enabled support for Darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

