### PR TITLE
liblouis: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/development/libraries/liblouis/default.nix
+++ b/pkgs/development/libraries/liblouis/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "3.4.0";
+  version = "3.5.0";
 in stdenv.mkDerivation rec {
   name = "liblouis-${version}";
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
     owner = "liblouis";
     repo = "liblouis";
     rev = "v${version}";
-    sha256 = "1b3vf6sq2iffdvj0r2q5g5k198camy3sq2nwfz391brpwivsnayh";
+    sha256 = "0klmyh6cg9khv59j4xdsrwwjzdgylw689gvrjiy5jsvqll58fcsd";
   };
 
   outputs = [ "out" "dev" "man" "info" "doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_maketable.d/submit_rows.sh -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_maketable.d/submit_rows.sh --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_maketable.d/submit_rules.sh -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_maketable.d/submit_rules.sh --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_maketable.d/submit_rules.sh help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_allround -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_allround --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_allround -v` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_allround --version` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_allround -h` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_allround --help` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkhyphens -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkhyphens --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkhyphens -v` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkhyphens --version` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkhyphens -h` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkhyphens --help` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checktable -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checktable --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checktable -v` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checktable --version` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checktable -h` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checktable --help` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_debug -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_debug --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_debug -v` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_debug --version` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_debug -h` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_debug --help` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_translate -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_translate --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_translate -v` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_translate --version` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_translate -h` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_translate --help` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_trace -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_trace --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_trace -v` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_trace --version` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_trace -h` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_trace --help` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_tableinfo -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_tableinfo --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_tableinfo -v` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_tableinfo --version` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_tableinfo -h` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_tableinfo --help` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkyaml -h` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkyaml --help` got 0 exit code
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkyaml -v` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkyaml --version` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkyaml -h` and found version 3.5.0
- ran `/nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0/bin/lou_checkyaml --help` and found version 3.5.0
- found 3.5.0 with grep in /nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0
- found 3.5.0 in filename of file in /nix/store/4g34bsgi8mz9xha1n8yrdwn9bm5pxqmw-liblouis-3.5.0

cc @jtojnar for review