### PR TITLE
libraw: 0.18.7 -> 0.18.8

### DIFF
--- a/pkgs/development/libraries/libraw/default.nix
+++ b/pkgs/development/libraries/libraw/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libraw-${version}";
-  version = "0.18.7";
+  version = "0.18.8";
 
   src = fetchurl {
     url = "http://www.libraw.org/data/LibRaw-${version}.tar.gz";
-    sha256 = "0wap67mb03fl2himbs20yncnnrr71mszsfm2v4spks58c714gqw7";
+    sha256 = "1qi0fkw2zmd0yplrf79z7lgpz0hxl45dj5rdgpaj7283jzys9b2n";
   };
 
   outputs = [ "out" "lib" "dev" "doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/raw-identify -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/raw-identify --help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/raw-identify help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/unprocessed_raw -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/unprocessed_raw --help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/unprocessed_raw help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/unprocessed_raw -V` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/unprocessed_raw -v` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/unprocessed_raw --version` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/unprocessed_raw -h` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/unprocessed_raw --help` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/4channels -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/4channels --help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/4channels help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/4channels -V` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/4channels -v` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/4channels --version` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/4channels -h` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/4channels --help` and found version 0.18.8
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/simple_dcraw -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/simple_dcraw --help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/simple_dcraw help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/mem_image -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/mem_image --help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/mem_image help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/dcraw_half -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/dcraw_half --help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/dcraw_half help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/half_mt -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/half_mt --help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/half_mt help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/multirender_test -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/multirender_test --help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/multirender_test help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/postprocessing_benchmark -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/postprocessing_benchmark help` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/dcraw_emu -h` got 0 exit code
- ran `/nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8/bin/dcraw_emu help` got 0 exit code
- found 0.18.8 with grep in /nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8
- found 0.18.8 in filename of file in /nix/store/k3cxddpbxlpyp3dx8gqif6s7c63zzbrm-libraw-0.18.8