### PR TITLE
libsass: 3.4.9 -> 3.5.1

### DIFF
--- a/pkgs/development/libraries/libsass/default.nix
+++ b/pkgs/development/libraries/libsass/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libsass-${version}";
-  version = "3.4.9";
+  version = "3.5.1";
 
   src = fetchurl {
     url = "https://github.com/sass/libsass/archive/${version}.tar.gz";
-    sha256 = "0f4mj91zzdzah7fxkdg3dnrimk9ip7czl4g26f32zgifz1nrqgjs";
+    sha256 = "0qy5hsglrdwzlb1x83v40pnm52hrjbdrc5zardp89i3vwcdzkrq8";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.5.1 with grep in /nix/store/k68941z8m2pw5jgmc0f7f2k9x0iv2pcj-libsass-3.5.1
- found 3.5.1 in filename of file in /nix/store/k68941z8m2pw5jgmc0f7f2k9x0iv2pcj-libsass-3.5.1

cc @codyopel @offlinehacker for review