### PR TITLE
dehydrated: 0.5.0 -> 0.6.1

### DIFF
--- a/pkgs/tools/admin/dehydrated/default.nix
+++ b/pkgs/tools/admin/dehydrated/default.nix
@@ -1,7 +1,7 @@
 { stdenv, bash, coreutils, curl, diffutils, gawk, gnugrep, gnused, openssl, makeWrapper, fetchFromGitHub }:
 let
   pkgName = "dehydrated";
-  version = "0.5.0";
+  version = "0.6.1";
 in
 stdenv.mkDerivation rec {
   name = pkgName + "-" + version;
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "lukas2511";
     repo = "dehydrated";
     rev = "v${version}";
-    sha256 = "0ysfsz1ny3gcc4r9szrr09dg63zd7ppv6aih13wmai806yapwxrr";
+    sha256 = "0390fnycl3l4yqacwvaf7dp08rx2vvs27s06q7b478qzrn59flz4";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

The newer version is needed to support letsencrypt wildcard certificates.

###### Things done

- [X] built on NixOS
- [X] verified version # is 0.6.1
- [X] issued a wildcard certificate from the letsencrypt staging server