### PR TITLE
tensorflow: add a binary wheel release for Darwin

### DIFF
--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, fetchurl
+, buildPythonPackage
+, isPy3k, isPy36, pythonOlder
+, numpy
+, six
+, protobuf
+, absl-py
+, mock
+, backports_weakref
+, enum34
+, tensorflow-tensorboard
+, cudaSupport ? false
+}:
+
+# tensorflow is built from a downloaded wheel because the source
+# build doesn't yet work on Darwin.
+
+buildPythonPackage rec {
+  pname = "tensorflow";
+  version = "1.5.0";
+  format = "wheel";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-${version}-py3-none-any.whl";
+    sha256 = "1mapv45n9wmgcq3i3im0pv0gmhwkxw5z69nsnxb1gfxbj1mz5h9m";
+  };
+
+  propagatedBuildInputs = [ numpy six protobuf absl-py ]
+                 ++ lib.optional (!isPy3k) mock
+                 ++ lib.optionals (pythonOlder "3.4") [ backports_weakref enum34 ]
+                 ++ lib.optional (pythonOlder "3.6") tensorflow-tensorboard;
+
+  # tensorflow depends on tensorflow_tensorboard, which cannot be
+  # built at the moment (some of its dependencies do not build
+  # [htlm5lib9999999 (seven nines) -> tensorboard], and it depends on an old version of
+  # bleach) Hence we disable dependency checking for now.
+  installFlags = lib.optional isPy36 "--no-dependencies";
+
+  meta = with stdenv.lib; {
+    description = "Computation using data flow graphs for scalable machine learning";
+    homepage = http://tensorflow.org;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jyp abbradar ];
+    platforms = platforms.darwin;
+    # Python 2.7 build uses different string encoding.
+    # See https://github.com/NixOS/nixpkgs/pull/37044#issuecomment-373452253
+    broken = cudaSupport || !isPy3k;
+  };
+}

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -149,7 +149,7 @@ in buildPythonPackage rec {
     homepage = http://tensorflow.org;
     license = licenses.asl20;
     maintainers = with maintainers; [ jyp abbradar ];
-    platforms = with platforms; if cudaSupport then linux else linux ++ darwin;
+    platforms = platforms.linux;
     broken = !(xlaSupport -> cudaSupport);
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20484,12 +20484,15 @@ EOF
 
   tensorflow-tensorboard = callPackage ../development/python-modules/tensorflow-tensorboard { };
 
-  tensorflow = callPackage ../development/python-modules/tensorflow rec {
-    cudaSupport = pkgs.config.cudaSupport or false;
-    inherit (pkgs.linuxPackages) nvidia_x11;
-    cudatoolkit = pkgs.cudatoolkit9;
-    cudnn = pkgs.cudnn_cudatoolkit9;
-  };
+  tensorflow =
+    if stdenv.isDarwin
+    then callPackage ../development/python-modules/tensorflow/bin.nix { }
+    else callPackage ../development/python-modules/tensorflow rec {
+      cudaSupport = pkgs.config.cudaSupport or false;
+      inherit (pkgs.linuxPackages) nvidia_x11;
+      cudatoolkit = pkgs.cudatoolkit9;
+      cudnn = pkgs.cudnn_cudatoolkit9;
+    };
 
   tensorflowWithoutCuda = self.tensorflow.override {
     cudaSupport = false;


### PR DESCRIPTION
###### Motivation for this change

Re-add Tensorflow on Darwin, albeit in binary form. Closes #34420.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Can someone on Darwin check if this works? Or maybe one knows how can you spin up a Darwin VM on an AMD processor?