### PR TITLE
xgboost: Enable building on Darwin

### DIFF
--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -2,6 +2,7 @@
 , avxSupport ? false
 , cudaSupport ? false, cudatoolkit
 , ncclSupport ? false, nccl
+, llvmPackages
 }:
 
 assert ncclSupport -> cudaSupport;
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ] ++ lib.optional stdenv.isDarwin llvmPackages.openmp;
 
   buildInputs = lib.optional cudaSupport cudatoolkit
                 ++ lib.optional ncclSupport nccl;
@@ -27,10 +28,12 @@ stdenv.mkDerivation rec {
   cmakeFlags = lib.optionals cudaSupport [ "-DUSE_CUDA=ON" "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc" ]
                ++ lib.optional ncclSupport "-DUSE_NCCL=ON";
 
-  installPhase = ''
+  installPhase = let
+    libname = if stdenv.isDarwin then "libxgboost.dylib" else "libxgboost.so";
+  in ''
     mkdir -p $out
     cp -r ../include $out
-    install -Dm755 ../lib/libxgboost.so $out/lib/libxgboost.so
+    install -Dm755 ../lib/${libname} $out/lib/${libname}
     install -Dm755 ../xgboost $out/bin/xgboost
   '';
 
@@ -38,7 +41,7 @@ stdenv.mkDerivation rec {
     description = "Scalable, Portable and Distributed Gradient Boosting (GBDT, GBRT or GBM) Library";
     homepage = https://github.com/dmlc/xgboost;
     license = licenses.asl20;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/development/python-modules/xgboost/default.nix
+++ b/pkgs/development/python-modules/xgboost/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, lib
+, pkgs
+, buildPythonPackage
+, nose
+, scipy
+, nativeXgboost ? pkgs.xgboost
+}:
+
+buildPythonPackage rec {
+  name = "xgboost-${version}";
+
+  inherit (nativeXgboost) version src meta;
+
+  propagatedBuildInputs = [ scipy ];
+  checkInputs = [ nose ];
+
+  postPatch = let
+    libname = if stdenv.isDarwin then "libxgboost.dylib" else "libxgboost.so";
+
+  in ''
+    cd python-package
+
+    sed "s/CURRENT_DIR = os.path.dirname(__file__)/CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))/g" -i setup.py
+    sed "/^LIB_PATH.*/a LIB_PATH = [os.path.relpath(LIB_PATH[0], CURRENT_DIR)]" -i setup.py
+    cat <<EOF >xgboost/libpath.py
+    def find_lib_path():
+      return ["${nativeXgboost}/lib/${libname}"]
+    EOF
+  '';
+
+  postInstall = ''
+    rm -rf $out/xgboost
+  '';
+}

--- a/pkgs/development/python-modules/xgboost/default.nix
+++ b/pkgs/development/python-modules/xgboost/default.nix
@@ -4,13 +4,13 @@
 , buildPythonPackage
 , nose
 , scipy
-, nativeXgboost ? pkgs.xgboost
+, xgboost
 }:
 
 buildPythonPackage rec {
   name = "xgboost-${version}";
 
-  inherit (nativeXgboost) version src meta;
+  inherit (xgboost) version src meta;
 
   propagatedBuildInputs = [ scipy ];
   checkInputs = [ nose ];
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     sed "/^LIB_PATH.*/a LIB_PATH = [os.path.relpath(LIB_PATH[0], CURRENT_DIR)]" -i setup.py
     cat <<EOF >xgboost/libpath.py
     def find_lib_path():
-      return ["${nativeXgboost}/lib/${libname}"]
+      return ["${xgboost}/lib/${libname}"]
     EOF
   '';
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20076,7 +20076,9 @@ EOF
     };
   };
 
-  xgboost = callPackage ../development/python-modules/xgboost { };
+  xgboost = callPackage ../development/python-modules/xgboost {
+    xgboost = pkgs.xgboost;
+  };
 
   xkcdpass = buildPythonPackage rec {
     name = "xkcdpass-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20076,29 +20076,7 @@ EOF
     };
   };
 
-  xgboost = buildPythonPackage rec {
-    name = "xgboost-${version}";
-
-    inherit (pkgs.xgboost) version src meta;
-
-    propagatedBuildInputs = with self; [ scipy ];
-    checkInputs = with self; [ nose ];
-
-    postPatch = ''
-      cd python-package
-
-      sed "s/CURRENT_DIR = os.path.dirname(__file__)/CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))/g" -i setup.py
-      sed "/^LIB_PATH.*/a LIB_PATH = [os.path.relpath(LIB_PATH[0], CURRENT_DIR)]" -i setup.py
-      cat <<EOF >xgboost/libpath.py
-      def find_lib_path():
-        return ["${pkgs.xgboost}/lib/libxgboost.so"]
-      EOF
-    '';
-
-    postInstall = ''
-      rm -rf $out/xgboost
-    '';
-  };
+  xgboost = callPackage ../development/python-modules/xgboost { };
 
   xkcdpass = buildPythonPackage rec {
     name = "xkcdpass-${version}";


### PR DESCRIPTION
###### Motivation for this change
I was able to get this working on Darwin by adding a dependency on OpenMP and properly handling the `so` / `dylib` difference.  I don't know a ton about Nix on macOS, so I would appreciate feedback from people more experienced than I!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @abbradar (maintainer)