### PR TITLE
openblas, numpy: fix w/musl

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -60,7 +60,7 @@ let
       TARGET = "ATHLON";
       DYNAMIC_ARCH = "1";
       CC = "gcc";
-      USE_OPENMP = "1";
+      USE_OPENMP = if stdenv.hostPlatform.isMusl then "0" else "1";
     };
   };
 in

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "numpy";
-  version = "1.14.1";
+  version = "1.14.2";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "fa0944650d5d3fb95869eaacd8eedbd2d83610c85e271bd9d3495ffa9bc4dc9c";
+    sha256 = "facc6f925c3099ac01a1f03758100772560a0b020fb9d70f210404be08006bcb";
   };
 
   disabled = isPyPy;

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -1,4 +1,4 @@
-{lib, fetchPypi, python, buildPythonPackage, isPy27, isPyPy, gfortran, nose, blas}:
+{lib, fetchPypi, python, buildPythonPackage, isPy27, isPyPy, gfortran, nose, blas, hostPlatform }:
 
 buildPythonPackage rec {
   pname = "numpy";
@@ -19,6 +19,18 @@ buildPythonPackage rec {
     # numpy.distutils is used by cython during it's check phase
     ./numpy-distutils-C++.patch
   ];
+
+  postPatch = lib.optionalString hostPlatform.isMusl ''
+    # Use fenv.h
+    sed -i \
+      numpy/core/src/npymath/ieee754.c.src \
+      numpy/core/include/numpy/ufuncobject.h \
+      -e 's/__GLIBC__/__linux__/'
+    # Don't use various complex trig functions
+    substituteInPlace numpy/core/src/private/npy_config.h \
+      --replace '#if defined(__GLIBC__)' "#if 1" \
+      --replace '#if !__GLIBC_PREREQ(2, 18)' "#if 1"
+  '';
 
   preConfigure = ''
     sed -i 's/-faltivec//' numpy/distutils/system_info.py


### PR DESCRIPTION
openblas needs to avoid openmp due to problems across fork,
(this fixes crashes and potentially hanging behavior)

numpy touched up to use fenv.h on non-glibc
as well as avoiding some complex trig functions
so that tests pass.

bump numpy version (minor) while visiting this.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---