### PR TITLE
libsolv: 0.6.32 -> 0.6.33

### DIFF
--- a/pkgs/development/libraries/libsolv/default.nix
+++ b/pkgs/development/libraries/libsolv/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, zlib, expat, rpm, db }:
 
 stdenv.mkDerivation rec {
-  rev  = "0.6.32";
+  rev  = "0.6.33";
   name = "libsolv-${rev}";
 
   src = fetchFromGitHub {
     inherit rev;
     owner  = "openSUSE";
     repo   = "libsolv";
-    sha256 = "0gqvnnc1s5n0yj82ia6w2wjhhn8hpl6wm4lki2kzvjqjgla45fnq";
+    sha256 = "1vf8mwqzjjqkd5ir71h4lifybibs5nhqgfgq5zzlazby02zx2yiz";
   };
 
   cmakeFlags = "-DENABLE_RPMMD=true -DENABLE_RPMDB=true -DENABLE_PUBKEY=true -DENABLE_RPMDB_BYRPMHEADER=true";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/mergesolv -h` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/mergesolv --help` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/mergesolv -V` and found version 0.6.33
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/mergesolv -v` and found version 0.6.33
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/mergesolv --version` and found version 0.6.33
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/mergesolv --help` and found version 0.6.33
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/dumpsolv -h` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/testsolv -h` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/testsolv help` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/rpmdb2solv -h` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/repomdxml2solv -h` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/rpmmd2solv -h` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/updateinfoxml2solv -h` got 0 exit code
- ran `/nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33/bin/deltainfoxml2solv -h` got 0 exit code
- found 0.6.33 with grep in /nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33
- found 0.6.33 in filename of file in /nix/store/qrx54k5d7x10525872inmmqir4f9bxng-libsolv-0.6.33

cc @copumpkin for review