### PR TITLE
libu2f-host: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/development/libraries/libu2f-host/default.nix
+++ b/pkgs/development/libraries/libu2f-host/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, json_c, hidapi }:
 
 stdenv.mkDerivation rec {
-  name = "libu2f-host-1.1.4";
+  name = "libu2f-host-1.1.5";
 
   src = fetchurl {
     url = "https://developers.yubico.com/libu2f-host/Releases/${name}.tar.xz";
-    sha256 = "0vvs2p3b25cbybccv3f4ridnp7sg5i4hkzx3hx48ldcn1l1fqhv0";
+    sha256 = "159slvjfq4bqslx5amjkk90xnkiv3x0yzvbi54pl2vnzbr1p2azk";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/npfpn2xy98yy13j3icli75mx4a3xlhmm-libu2f-host-1.1.5/bin/u2f-host -h` got 0 exit code
- ran `/nix/store/npfpn2xy98yy13j3icli75mx4a3xlhmm-libu2f-host-1.1.5/bin/u2f-host --help` got 0 exit code
- ran `/nix/store/npfpn2xy98yy13j3icli75mx4a3xlhmm-libu2f-host-1.1.5/bin/u2f-host -V` and found version 1.1.5
- ran `/nix/store/npfpn2xy98yy13j3icli75mx4a3xlhmm-libu2f-host-1.1.5/bin/u2f-host --version` and found version 1.1.5
- ran `/nix/store/npfpn2xy98yy13j3icli75mx4a3xlhmm-libu2f-host-1.1.5/bin/u2f-host -h` and found version 1.1.5
- ran `/nix/store/npfpn2xy98yy13j3icli75mx4a3xlhmm-libu2f-host-1.1.5/bin/u2f-host --help` and found version 1.1.5
- found 1.1.5 with grep in /nix/store/npfpn2xy98yy13j3icli75mx4a3xlhmm-libu2f-host-1.1.5
- found 1.1.5 in filename of file in /nix/store/npfpn2xy98yy13j3icli75mx4a3xlhmm-libu2f-host-1.1.5

cc @wkennington for review