### PR TITLE
aws-sdk-cpp: 1.4.10 -> 1.4.15

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -15,13 +15,13 @@ let
         else throw "Unsupported system!";
 in stdenv.mkDerivation rec {
   name = "aws-sdk-cpp-${version}";
-  version = "1.4.10";
+  version = "1.4.15";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-sdk-cpp";
     rev = version;
-    sha256 = "0gw0ph6v2w4zqmixqfw5ab08c0r3d7iy2z1hll5pydlp5vwfmn7g";
+    sha256 = "10nk8zbrh2sgw7cp03g8yqylyi29bb99w8v6dbw97pnxf689m635";
   };
 
   # FIXME: might be nice to put different APIs in different outputs


### PR DESCRIPTION
Bump.

Motivated by using address sanitizer,
which aws-sdk-cpp fails due to mismatched
use of new/delete vs malloc/free.

New version does not cause these error reports,
which seems a good reason to upgrade ;).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---