### PR TITLE
libwebsockets: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libwebsockets-${version}";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "warmcat";
     repo = "libwebsockets";
     rev = "v${version}";
-    sha256 = "0d3xqdq3hpk5l9cg4dqkba6jm6620y6knqqywya703662spmj2xw";
+    sha256 = "0gbprzsi054f9gr31ihcf0cq7zfkybrmdp6894pmzb5hcv4wnh9i";
   };
 
   buildInputs = [ cmake openssl zlib libuv ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.4.2 with grep in /nix/store/y3zmgw1wy80xwfmjx8d97nvrr5qfzrmp-libwebsockets-2.4.2
- found 2.4.2 in filename of file in /nix/store/y3zmgw1wy80xwfmjx8d97nvrr5qfzrmp-libwebsockets-2.4.2