### PR TITLE
libxml2: 2.9.7 -> 2.9.8

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -10,11 +10,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "libxml2-${version}";
-  version = "2.9.7";
+  version = "2.9.8";
 
   src = fetchurl {
     url = "http://xmlsoft.org/sources/${name}.tar.gz";
-    sha256 = "034hylzspvkm0p4bczqbf8q05a7r2disr8dz725x4bin61ymwg7n";
+    sha256 = "0ci7is75bwqqw2p32vxvrk6ds51ik7qgx73m920rakv5jlayax0b";
   };
 
   outputs = [ "bin" "dev" "out" "man" "doc" ]


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.9.8 in filename of file in /nix/store/cjycf1wx5a5l22a9kwhpnnh2h9i7pahk-libxc-4.0.4

cc @edolstra for review