### PR TITLE
liferea: 1.12.1 -> 1.12.2

### DIFF
--- a/pkgs/applications/networking/newsreaders/liferea/default.nix
+++ b/pkgs/applications/networking/newsreaders/liferea/default.nix
@@ -6,13 +6,13 @@
 
 let
   pname = "liferea";
-  version = "1.12.1";
+  version = "1.12.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/lwindolf/${pname}/releases/download/v${version}/${name}.tar.bz2";
-    sha256 = "14qx3x2xjcnydc4ma8vdac63phas7jzwbjl4b9r5hf6vxv3mpvdq";
+    sha256 = "18mz1drp6axvjbr9jdw3i0ijl3l2m191198p4c93qnm7g96ldh15";
   };
 
   nativeBuildInputs = [ wrapGAppsHook python3Packages.wrapPython intltool pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2/bin/liferea -h` got 0 exit code
- ran `/nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2/bin/liferea --help` got 0 exit code
- ran `/nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2/bin/liferea -v` and found version 1.12.2
- ran `/nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2/bin/liferea --version` and found version 1.12.2
- ran `/nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2/bin/.liferea-wrapped -h` got 0 exit code
- ran `/nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2/bin/.liferea-wrapped --help` got 0 exit code
- ran `/nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2/bin/.liferea-wrapped -v` and found version 1.12.2
- ran `/nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2/bin/.liferea-wrapped --version` and found version 1.12.2
- found 1.12.2 with grep in /nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2
- found 1.12.2 in filename of file in /nix/store/wjf8q5k0hh2vcjw65v2skcn54pq3vb0q-liferea-1.12.2

cc @vcunat @romildo for review