### PR TITLE
live555: 2018.02.12 -> 2018.02.28

### DIFF
--- a/pkgs/development/libraries/live555/default.nix
+++ b/pkgs/development/libraries/live555/default.nix
@@ -2,14 +2,14 @@
 
 # Based on https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD
 let
-  version = "2018.02.12";
+  version = "2018.02.28";
 in
 stdenv.mkDerivation {
   name = "live555-${version}";
 
   src = fetchurl { # the upstream doesn't provide a stable URL
     url = "mirror://sourceforge/slackbuildsdirectlinks/live.${version}.tar.gz";
-    sha256 = "08860q07hfiln44d6qaasmfalf4hb9na5jsfd4yps6jn4r54xxwx";
+    sha256 = "0zi47asv1qmb09g321m02q684i3c90vci0mgkdh1mlmx2rbg1d1d";
   };
 
   postPatch = "sed 's,/bin/rm,rm,g' -i genMakefiles"


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2018.02.28 with grep in /nix/store/gfv4ai63b95lkydlxj9579driy60h4v6-live555-2018.02.28
- found 2018.02.28 in filename of file in /nix/store/gfv4ai63b95lkydlxj9579driy60h4v6-live555-2018.02.28