### PR TITLE
logrotate: 3.13.0 -> 3.14.0

### DIFF
--- a/pkgs/tools/system/logrotate/default.nix
+++ b/pkgs/tools/system/logrotate/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "logrotate-${version}";
-  version = "3.13.0";
+  version = "3.14.0";
 
   src = fetchFromGitHub {
     owner = "logrotate";
     repo = "logrotate";
     rev = version;
-    sha256 = "0b7dnch74pddml3ysavizq26jgwdv0rjmwc8lf6zfvn9fjz19vvs";
+    sha256 = "1wdjqbly97y1i11nl6cmlfpld3yqak270ixf29wixjgrjn8p4xzh";
   };
 
   # Logrotate wants to access the 'mail' program; to be done.


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/4y9bpdd23v1jpibrqzpnc4y4qipmz06y-logrotate-3.14.0/bin/logrotate --help` got 0 exit code
- found 3.14.0 in filename of file in /nix/store/4y9bpdd23v1jpibrqzpnc4y4qipmz06y-logrotate-3.14.0

cc @viric for review