### PR TITLE
ltl2ba: 1.1 -> 1.2b1

### DIFF
--- a/pkgs/applications/science/logic/ltl2ba/default.nix
+++ b/pkgs/applications/science/logic/ltl2ba/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ltl2ba-${version}";
-  version = "1.1";
+  version = "1.2b1";
 
   src = fetchurl {
     url    = "http://www.lsv.ens-cachan.fr/~gastin/ltl2ba/${name}.tar.gz";
-    sha256 = "16z0gc7a9dkarwn0l6rvg5jdhw1q4qyn4501zlchy0zxqddz0sx6";
+    sha256 = "1f4jnkfkyj8lcc5qfqbiypfc11rhhpqqi6xs9xx5dysg6r6303wm";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.2b1 in filename of file in /nix/store/jx5s7w6bmd6lfqvxl2lly3ggd4k9ncax-ltl2ba-1.2b1

cc @thoughtpolice for review