### PR TITLE
wine: correct install order for WoW wine build.

### DIFF
--- a/pkgs/misc/emulators/wine/builder-wow.sh
+++ b/pkgs/misc/emulators/wine/builder-wow.sh
@@ -26,7 +26,7 @@ buildPhase
 # checkPhase
 
 eval "$preInstall"
-cd $TMP/wine64 && make install
 cd $TMP/wine-wow && make install
+cd $TMP/wine64 && make install
 eval "$postInstall"
 fixupPhase


### PR DESCRIPTION
Per the wiki at https://wiki.winehq.org/Building_Wine#Shared_WoW64

"if you do choose to install your WoW64 build, you should run make                                                                                                                    
install in the 32-bit build tree first, then in the 64-bit one."                                                                                                                      
                                                                                                                                                                                      
This is required, for instance, for the resulting "wineserver"                                                                                                                        
executable to be the 64 bit variant not 32 bit. Which is expected by the                                                                                                              
binary loader for WoW64.                                                                                                                                                              
                                                                                                                                                                                      
This odd dependency is vaguely mentioned on the packaging wiki page:                                                                                                                  
                                                                                                                                                                                      
* https://wiki.winehq.org/Packaging#Binaries                                                                                                                                          

Build with nixpkgs config option `wine.build = "wineWow";`.

###### Motivation for this change

* "wineserver" executable in wine WoW is 32 bit, not 64 bit frontend.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

