### PR TITLE
lynis: 2.6.2 -> 2.6.3

### DIFF
--- a/pkgs/tools/security/lynis/default.nix
+++ b/pkgs/tools/security/lynis/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "lynis";
-  version = "2.6.2";
+  version = "2.6.3";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "CISOfy";
     repo = "${pname}";
     rev = "${version}";
-    sha256 = "0jymp44dmc22cdrsd5hfyv9wc8a5sq92yh9p9c0rg22g53733910";
+    sha256 = "17xfs0jr0rf8xvk860l2wpxg0h1m2c1dq41lqnq6wga9jifxmzqd";
   };
 
   nativeBuildInputs = [ makeWrapper perl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/krpqgnp9b7j1f5wwfdkmsym5h03xak60-lynis-2.6.3/bin/lynis -V` and found version 2.6.3
- ran `/nix/store/krpqgnp9b7j1f5wwfdkmsym5h03xak60-lynis-2.6.3/bin/lynis --version` and found version 2.6.3
- ran `/nix/store/krpqgnp9b7j1f5wwfdkmsym5h03xak60-lynis-2.6.3/bin/.lynis-wrapped -V` and found version 2.6.3
- ran `/nix/store/krpqgnp9b7j1f5wwfdkmsym5h03xak60-lynis-2.6.3/bin/.lynis-wrapped --version` and found version 2.6.3
- found 2.6.3 with grep in /nix/store/krpqgnp9b7j1f5wwfdkmsym5h03xak60-lynis-2.6.3
- found 2.6.3 in filename of file in /nix/store/krpqgnp9b7j1f5wwfdkmsym5h03xak60-lynis-2.6.3

cc @ryneeverett for review