### PR TITLE
mcelog: 154 -> 156

### DIFF
--- a/pkgs/os-specific/linux/mcelog/default.nix
+++ b/pkgs/os-specific/linux/mcelog/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mcelog-${version}";
-  version = "154";
+  version = "156";
 
   src = fetchFromGitHub {
     owner  = "andikleen";
     repo   = "mcelog";
     rev    = "v${version}";
-    sha256 = "0vq7r3zknr62rmi9g0zd7mmxframm79vmrdw029pc7z6wrlv40cy";
+    sha256 = "0mv4sxcysl3m9wqybg6b363mawr9amzhc9v53775p4p2a47z774r";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/3zc741ihwv728148wk2m7a61hj9rrp5c-mcelog-156/bin/mcelog --help` got 0 exit code
- ran `/nix/store/3zc741ihwv728148wk2m7a61hj9rrp5c-mcelog-156/bin/mcelog --version` and found version 156
- ran `/nix/store/3zc741ihwv728148wk2m7a61hj9rrp5c-mcelog-156/bin/mcelog --help` and found version 156
- found 156 with grep in /nix/store/3zc741ihwv728148wk2m7a61hj9rrp5c-mcelog-156
- found 156 in filename of file in /nix/store/3zc741ihwv728148wk2m7a61hj9rrp5c-mcelog-156