### PR TITLE
opendht: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/development/libraries/opendht/default.nix
+++ b/pkgs/development/libraries/opendht/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   name = "opendht-${version}";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "savoirfairelinux";
     repo = "opendht";
     rev = "${version}";
-    sha256 = "0zkxvs3vdlc4yzhfi2jh02bsnhh50fbfigqhnkmbx69lssnkyr05";
+    sha256 = "0ybv41nbh86ricxfv478z4izbxvnvk86csr29c6qf4dinmrysf96";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtnode -h` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtnode --help` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtchat -h` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtchat --help` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtscanner -h` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtscanner --help` got 0 exit code
- found 1.6.0 with grep in /nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0
- found 1.6.0 in filename of file in /nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0

cc @Radvendii @olynch for review