### PR TITLE
openimageio: 1.8.8 -> 1.8.9

### DIFF
--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "openimageio-${version}";
-  version = "1.8.8";
+  version = "1.8.9";
 
   src = fetchFromGitHub {
     owner = "OpenImageIO";
     repo = "oiio";
     rev = "Release-${version}";
-    sha256 = "1jn4ph7giwxr65xxbm59i03wywnmxkqnpvqp0kcajl4k48vq3wkr";
+    sha256 = "0xyfb41arvi3cc5jvgj2m8skzjrb0xma8sml74svygjgagxfj65h";
   };
 
   outputs = [ "bin" "out" "dev" "doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtnode -h` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtnode --help` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtchat -h` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtchat --help` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtscanner -h` got 0 exit code
- ran `/nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0/bin/dhtscanner --help` got 0 exit code
- found 1.8.9 in filename of file in /nix/store/pr77bpwm850hdynaky1yddn1czy2rwx7-opendht-1.6.0

cc @cillianderoiste for review