### PR TITLE
osinfo-db: 20170813 -> 20180311

### DIFF
--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, osinfo-db-tools, intltool, libxml2 }:
 
 stdenv.mkDerivation rec {
-  name = "osinfo-db-20170813";
+  name = "osinfo-db-20180311";
 
   src = fetchurl {
     url = "https://releases.pagure.org/libosinfo/${name}.tar.xz";
-    sha256 = "0v9i325aaflzj2y5780mj9b0jv5ysb1bn90bm3s4f2ck5n124ffw";
+    sha256 = "0pzm9vsr2f5943nlp2ljm19czcys5pvq6hjxh0ja2vx74pwhylb6";
   };
 
   nativeBuildInputs = [ osinfo-db-tools intltool libxml2 ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 20180311 with grep in /nix/store/2a26a2ic31kvg85krsqn5j1jnndhm70l-osinfo-db-20180311
- found 20180311 in filename of file in /nix/store/2a26a2ic31kvg85krsqn5j1jnndhm70l-osinfo-db-20180311

cc @bjornfor for review