### PR TITLE
packagekit: 1.1.8 -> 1.1.9

### DIFF
--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   name = "packagekit-${version}";
-  version = "1.1.8";
+  version = "1.1.9";
 
   src = fetchFromGitHub {
     owner = "hughsie";
     repo = "PackageKit";
     rev = "PACKAGEKIT_${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "0bn9flsjbzlwmlbv2gphqwgzy9sx8ahch28z6dzgak4csbz5wcws";
+    sha256 = "1zs7xkk3b2izdnis7ir5h93p8f2i9513663h2xhxb0sh6i2h18y4";
   };
 
   buildInputs = [ glib polkit systemd python gobjectIntrospection vala_0_38 ]


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/68d30mrbaqki61sqqqlwysbb0csa40i4-packagekit-1.1.9/bin/pkcon -h` got 0 exit code
- ran `/nix/store/68d30mrbaqki61sqqqlwysbb0csa40i4-packagekit-1.1.9/bin/pkcon --help` got 0 exit code
- ran `/nix/store/68d30mrbaqki61sqqqlwysbb0csa40i4-packagekit-1.1.9/bin/pkmon -h` got 0 exit code
- ran `/nix/store/68d30mrbaqki61sqqqlwysbb0csa40i4-packagekit-1.1.9/bin/pkmon --help` got 0 exit code
- ran `/nix/store/68d30mrbaqki61sqqqlwysbb0csa40i4-packagekit-1.1.9/bin/pkmon --version` and found version 1.1.9
- found 1.1.9 with grep in /nix/store/68d30mrbaqki61sqqqlwysbb0csa40i4-packagekit-1.1.9
- found 1.1.9 in filename of file in /nix/store/68d30mrbaqki61sqqqlwysbb0csa40i4-packagekit-1.1.9

cc @matthewbauer for review