### PR TITLE
pgbouncer: 1.7.2 -> 1.8.1

### DIFF
--- a/pkgs/servers/sql/pgbouncer/default.nix
+++ b/pkgs/servers/sql/pgbouncer/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pgbouncer-${version}";
-  version = "1.7.2";
+  version = "1.8.1";
 
   src = fetchurl {
     url = "https://pgbouncer.github.io/downloads/files/${version}/${name}.tar.gz";
-    sha256 = "de36b318fe4a2f20a5f60d1c5ea62c1ca331f6813d2c484866ecb59265a160ba";
+    sha256 = "1j4d7rkivg3vg27pvirigq9cy4v7pi48x7w57baq131c5lmdx2zs";
   };
 
   buildInputs = [ libevent openssl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/29ywgqx9kl3bv67b4r19yydrvwj29ssb-pgbouncer-1.8.1/bin/pgbouncer -h` got 0 exit code
- ran `/nix/store/29ywgqx9kl3bv67b4r19yydrvwj29ssb-pgbouncer-1.8.1/bin/pgbouncer --help` got 0 exit code
- ran `/nix/store/29ywgqx9kl3bv67b4r19yydrvwj29ssb-pgbouncer-1.8.1/bin/pgbouncer -V` and found version 1.8.1
- ran `/nix/store/29ywgqx9kl3bv67b4r19yydrvwj29ssb-pgbouncer-1.8.1/bin/pgbouncer --version` and found version 1.8.1
- found 1.8.1 with grep in /nix/store/29ywgqx9kl3bv67b4r19yydrvwj29ssb-pgbouncer-1.8.1
- found 1.8.1 in filename of file in /nix/store/29ywgqx9kl3bv67b4r19yydrvwj29ssb-pgbouncer-1.8.1