### PR TITLE
edbrowse: 3.6.1 -> 3.7.2

### DIFF
--- a/pkgs/applications/editors/edbrowse/default.nix
+++ b/pkgs/applications/editors/edbrowse/default.nix
@@ -1,26 +1,24 @@
-{ stdenv, fetchurl, spidermonkey, unzip, curl, pcre, readline, openssl, perl, html-tidy }:
+{ stdenv, fetchurl, duktape, curl, pcre, readline, openssl, perl, html-tidy }:
 
 stdenv.mkDerivation rec {
   name = "edbrowse-${version}";
-  version = "3.6.1";
+  version = "3.7.2";
 
-  nativeBuildInputs = [ unzip ];
-  buildInputs = [ curl pcre readline openssl spidermonkey perl html-tidy ];
+  buildInputs = [ curl pcre readline openssl duktape perl html-tidy ];
 
   patchPhase = ''
-    substituteInPlace src/ebjs.c --replace \"edbrowse-js\" \"$out/bin/edbrowse-js\"
     for i in ./tools/*.pl
     do
       substituteInPlace $i --replace "/usr/bin/perl" "${perl}/bin/perl"
     done
   '';
 
-  NIX_CFLAGS_COMPILE = "-I${spidermonkey}/include/mozjs-31";
   makeFlags = "-C src prefix=$(out)";
 
   src = fetchurl {
-    url = "http://edbrowse.org/${name}.zip";
-    sha256 = "1grkn09r31nmvcnm76jkd8aclmd9n5141mpqvb86wndp9pa7gz7q";
+    name = "${name}.tar.gz";
+    url = "https://github.com/CMB/edbrowse/archive/v${version}.tar.gz";
+    sha256 = "1g9cwk4wszahk2m8k34i3rx44yhqfnv67zls0lk5g7jhrhpbf433";
   };
   meta = with stdenv.lib; {
     description = "Command Line Editor Browser";
@@ -35,6 +33,5 @@ stdenv.mkDerivation rec {
     homepage = http://edbrowse.org/;
     maintainers = [ maintainers.schmitthenner maintainers.vrthra ];
     platforms = platforms.linux;
-    broken = true;  # no compatible spidermonkey
   };
 }

--- a/pkgs/development/interpreters/duktape/default.nix
+++ b/pkgs/development/interpreters/duktape/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation rec {
     install -d $out/bin
     install -m755 duk $out/bin/
     install -d $out/lib
-    install -m755 libduktape* $out/lib/
+    install -d $out/include
+    make -f Makefile.sharedlibrary install INSTALL_PREFIX=$out
   '';
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Update edbrowse to a version that is not broken WRT its dependencies (particularly, spidermonkey).

###### Things done

edbrowse version updated, newer version using duktape instead of spidermonkey.
duktape package fixed so it additionally produces symlinks to the real shared object files (nothing in nixpkgs previously depended on it, so this probably went unnoticed).

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

