### PR TITLE
pgroonga: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/servers/sql/postgresql/pgroonga/default.nix
+++ b/pkgs/servers/sql/postgresql/pgroonga/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pgroonga-${version}";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchurl {
     url = "http://packages.groonga.org/source/pgroonga/${name}.tar.gz";
-    sha256 = "0023747i2x3j50z54l78maq7dya5ldd2sdydn6l5l7k6b6g4yr2d";
+    sha256 = "0jlaxkj33dgr2hgh0f861ja1z53kqw0g1syinl2sacsna2i9pdxy";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.0.3 with grep in /nix/store/dqrb6v4lfppacrl4x3q7jhdfw344k733-pgroonga-2.0.3
- found 2.0.3 in filename of file in /nix/store/dqrb6v4lfppacrl4x3q7jhdfw344k733-pgroonga-2.0.3

cc @DerTim1 for review