### PR TITLE
picard-tools: 2.17.10 -> 2.17.11

### DIFF
--- a/pkgs/applications/science/biology/picard-tools/default.nix
+++ b/pkgs/applications/science/biology/picard-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "picard-tools-${version}";
-  version = "2.17.10";
+  version = "2.17.11";
 
   src = fetchurl {
     url = "https://github.com/broadinstitute/picard/releases/download/${version}/picard.jar";
-    sha256 = "0lf9appcs66mxmirzbys09xhq38kpa4ldxwwzrr9y2cklnxjn4hg";
+    sha256 = "1p50bzkwq5hrwal6i679yrkdqkh5hk4bb9l9gdff2x2i761v9y9b";
   };
 
   buildInputs = [ jre makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.17.11 with grep in /nix/store/xmlvcz212yl8bij12jpqibhv8c8mqabs-picard-tools-2.17.11
- found 2.17.11 in filename of file in /nix/store/xmlvcz212yl8bij12jpqibhv8c8mqabs-picard-tools-2.17.11

cc @jbedo for review