### PR TITLE
pmd: 6.0.1 -> 6.1.0

### DIFF
--- a/pkgs/development/tools/analysis/pmd/default.nix
+++ b/pkgs/development/tools/analysis/pmd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pmd-${version}";
-  version = "6.0.1";
+  version = "6.1.0";
 
   buildInputs = [ unzip ];
 
   src = fetchurl {
     url = "mirror://sourceforge/pmd/pmd-bin-${version}.zip";
-    sha256 = "13wmmy345p8bzvxdb8ldpkv85m3m8x9qs5f0jjhn0gkn65a988iq";
+    sha256 = "1d2hbsnyvwvawhfh832yy3w93kr4whrk99zpg4q5ws2b2hhdvzv8";
   };
 
   installPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 6.1.0 with grep in /nix/store/qh8xnf46qfyijvskdznwl08r6js4wg7y-pmd-6.1.0
- found 6.1.0 in filename of file in /nix/store/qh8xnf46qfyijvskdznwl08r6js4wg7y-pmd-6.1.0