### PR TITLE
poco: 1.8.1 -> 1.9.0

### DIFF
--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "poco-${version}";
 
-  version = "1.8.1";
+  version = "1.9.0";
 
   src = fetchurl {
     url = "https://pocoproject.org/releases/${name}/${name}-all.tar.gz";
-    sha256 = "1pg48kk0354vsc6j2wnrk893l5xcsr3bjmkgykd3harcnvfqs7l8";
+    sha256 = "11z1i0drbacs7c7d5virc3kz7wh79svd06iffh8j6giikl7vz1q3";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/n66s6hq39pqk83sn77pz2ff02m642hzs-poco-1.9.0/bin/cpspc -h` got 0 exit code
- ran `/nix/store/n66s6hq39pqk83sn77pz2ff02m642hzs-poco-1.9.0/bin/cpspc --help` got 0 exit code
- ran `/nix/store/n66s6hq39pqk83sn77pz2ff02m642hzs-poco-1.9.0/bin/cpspc help` got 0 exit code
- ran `/nix/store/n66s6hq39pqk83sn77pz2ff02m642hzs-poco-1.9.0/bin/f2cpsp -h` got 0 exit code
- ran `/nix/store/n66s6hq39pqk83sn77pz2ff02m642hzs-poco-1.9.0/bin/f2cpsp --help` got 0 exit code
- ran `/nix/store/n66s6hq39pqk83sn77pz2ff02m642hzs-poco-1.9.0/bin/f2cpsp help` got 0 exit code
- found 1.9.0 with grep in /nix/store/n66s6hq39pqk83sn77pz2ff02m642hzs-poco-1.9.0

cc @orivej for review