### PR TITLE
qtbase: force to use bash in glibc system() and popen() calls

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -4,12 +4,14 @@
 { stdenv, lib
 , buildPlatform, hostPlatform
 , buildPackages
+, substituteAll
 , fetchurl, fetchpatch ? null
 , linuxHeaders ? null
 , gd ? null, libpng ? null
 }:
 
 { name
+, shPackage ? null
 , withLinuxHeaders ? false
 , profilingLibraries ? false
 , installLocales ? false
@@ -94,6 +96,11 @@ stdenv.mkDerivation ({
         name = "fix-with-musl.patch";
         url = "https://sourceware.org/bugzilla/attachment.cgi?id=10151&action=diff&collapsed=&headers=1&format=raw";
         sha256 = "18kk534k6da5bkbsy1ivbi77iin76lsna168mfcbwv4ik5vpziq2";
+      })
+    ++ lib.optional (shPackage != null)
+      (substituteAll {
+        src = ./custom-shell.patch;
+        shell = "${shPackage}/bin/sh";
       });
 
   postPatch =

--- a/pkgs/development/libraries/glibc/custom-shell.patch
+++ b/pkgs/development/libraries/glibc/custom-shell.patch
@@ -1,0 +1,55 @@
+--- a/sysdeps/generic/paths.h
++++ b/sysdeps/generic/paths.h
+@@ -38,7 +38,7 @@
+ #define	_PATH_STDPATH \
+ 	"/usr/bin:/bin:/usr/sbin:/sbin"
+ 
+-#define	_PATH_BSHELL	"/bin/sh"
++#define	_PATH_BSHELL	"@shell@"
+ #define	_PATH_CONSOLE	"/dev/console"
+ #define	_PATH_CSHELL	"/bin/csh"
+ #define	_PATH_DEVDB	"/var/run/dev.db"
+--- a/sysdeps/posix/system.c
++++ b/sysdeps/posix/system.c
+@@ -26,7 +26,7 @@
+ #include <sysdep-cancel.h>
+ 
+ 
+-#define	SHELL_PATH	"/bin/sh"	/* Path of the shell.  */
++#define	SHELL_PATH	"@shell@"	/* Path of the shell.  */
+ #define	SHELL_NAME	"sh"		/* Name to give it.  */
+ 
+ 
+--- a/sysdeps/unix/sysv/linux/paths.h
++++ b/sysdeps/unix/sysv/linux/paths.h
+@@ -38,7 +38,7 @@
+ #define	_PATH_STDPATH \
+ 	"/usr/bin:/bin:/usr/sbin:/sbin"
+ 
+-#define	_PATH_BSHELL	"/bin/sh"
++#define	_PATH_BSHELL	"@shell@"
+ #define	_PATH_CONSOLE	"/dev/console"
+ #define	_PATH_CSHELL	"/bin/csh"
+ #define	_PATH_DEVDB	"/var/run/dev.db"
+--- a/libio/oldiopopen.c
++++ b/libio/oldiopopen.c
+@@ -162,7 +162,7 @@
+       for (p = old_proc_file_chain; p; p = p->next)
+ 	_IO_close (_IO_fileno ((_IO_FILE *) p));
+ 
+-      _IO_execl ("/bin/sh", "sh", "-c", command, (char *) 0);
++      _IO_execl ("@shell@", "sh", "-c", command, (char *) 0);
+       _IO__exit (127);
+     }
+   _IO_close (child_end);
+--- a/libio/iopopen.c
++++ b/libio/iopopen.c
+@@ -191,7 +191,7 @@
+ 	    _IO_close (fd);
+ 	}
+ 
+-      _IO_execl ("/bin/sh", "sh", "-c", command, (char *) 0);
++      _IO_execl ("@shell@", "sh", "-c", command, (char *) 0);
+       _IO__exit (127);
+     }
+   _IO_close (child_end);

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -1,4 +1,5 @@
 { stdenv, callPackage
+, shPackage ? null
 , withLinuxHeaders ? true
 , installLocales ? true
 , profilingLibraries ? false
@@ -10,7 +11,7 @@ assert stdenv.cc.isGNU;
 callPackage ./common.nix { inherit stdenv; } {
     name = "glibc" + stdenv.lib.optionalString withGd "-gd";
 
-    inherit withLinuxHeaders profilingLibraries installLocales withGd;
+    inherit withLinuxHeaders profilingLibraries installLocales withGd shPackage;
 
     NIX_NO_SELF_RPATH = true;
 

--- a/pkgs/development/libraries/qt-5/5.10/default.nix
+++ b/pkgs/development/libraries/qt-5/5.10/default.nix
@@ -18,6 +18,7 @@ top-level attribute to `top-level/all-packages.nix`.
 {
   newScope,
   stdenv, fetchurl, makeSetupHook, makeWrapper,
+  qtbaseStdenv,
   bison, cups ? null, harfbuzz, libGL, perl,
   gstreamer, gst-plugins-base, gtk3, dconf,
 
@@ -65,6 +66,7 @@ let
 
       qtbase = callPackage ../modules/qtbase.nix {
         inherit (srcs.qtbase) src version;
+        stdenv = qtbaseStdenv;
         patches = patches.qtbase;
         inherit bison cups harfbuzz libGL;
         withGtk3 = true; inherit dconf gtk3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38,6 +38,18 @@ with pkgs;
 
   stdenvNoCC = stdenv.override { cc = null; };
 
+  stdenvBashGlibc = stdenv.override {
+    allowedRequisites = null;
+    cc = wrapCCWith {
+      cc = stdenv.cc.cc;
+      libc = glibc_bash;
+      bintools = wrapBintoolsWith {
+        bintools = binutils-unwrapped;
+        libc = glibc_bash;
+      };
+    };
+  };
+
   # For convenience, allow callers to get the path to Nixpkgs.
   path = ../..;
 
@@ -11032,6 +11044,7 @@ with pkgs;
     (import ../development/libraries/qt-5/5.10) {
       inherit newScope;
       inherit stdenv fetchurl makeSetupHook makeWrapper;
+      qtbaseStdenv = if stdenv.cc.libc == glibc then stdenvBashGlibc else stdenv;
       bison = bison2; # error: too few arguments to function 'int yylex(...
       inherit cups;
       harfbuzz = harfbuzz-icu;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8922,10 +8922,15 @@ with pkgs;
   glibc_2_26 = callPackage ../development/libraries/glibc {
     installLocales = config.glibc.locales or false;
   };
+  glibc_2_26_bash = callPackage ../development/libraries/glibc {
+    installLocales = config.glibc.locales or false;
+    shPackage = bash;
+  };
   glibc_2_27 = callPackage ../development/libraries/glibc/2.27.nix {
     installLocales = config.glibc.locales or false;
   };
   glibc = if hostPlatform.isRiscV then glibc_2_27 else glibc_2_26;
+  glibc_bash = glibc_2_26_bash;
 
   glibc_memusage = callPackage ../development/libraries/glibc {
     installLocales = false;


### PR DESCRIPTION
###### Motivation for this change

Due to inherent impurity in qmake (actually, glibc), it depends on `/bin/sh` to provide certain non-POSIX commands (qmake uses `command -v <tool>` to find tools like `moc`, you can find details at #36903). I've decided that it should be better to remove this impurity by forcing qmake to use version of glibc that has all references to `/bin/sh` replaced with essentially `${pkgs.bash}/bin/sh`.

I've build most of Qt stuff with this change with no problems.

This change should also help with some Qt package failures at #36453 (18.03 ZHF).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

