### PR TITLE
profile-cleaner: 2.36 -> 2.37

### DIFF
--- a/pkgs/tools/misc/profile-cleaner/default.nix
+++ b/pkgs/tools/misc/profile-cleaner/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, makeWrapper, parallel, sqlite, bc, file }:
 
 stdenv.mkDerivation rec {
-  version = "2.36";
+  version = "2.37";
   name = "profile-cleaner-${version}";
 
   src = fetchFromGitHub {
     owner = "graysky2";
     repo = "profile-cleaner";
     rev = "v${version}";
-    sha256 = "0vm4ca99dyr6i0sfjsr0w06i0rbmqf40kp37h04bk4c8yassq1zq";
+    sha256 = "1fbsn2xvcjkqhhkhidn04iwc0zha68cpkyc9vs5yly38qr1q238a";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner -h` got 0 exit code
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner --help` got 0 exit code
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner help` got 0 exit code
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner -V` and found version 2.37
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner -v` and found version 2.37
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner --version` and found version 2.37
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner version` and found version 2.37
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner -h` and found version 2.37
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner --help` and found version 2.37
- ran `/nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37/bin/profile-cleaner help` and found version 2.37
- found 2.37 with grep in /nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37
- found 2.37 in filename of file in /nix/store/b8vjlszy2ksb98qnmyyc49p2yhinvcr1-profile-cleaner-2.37

cc @devhell for review