### PR TITLE
pshs: 0.3.2 -> 0.3.3

### DIFF
--- a/pkgs/servers/http/pshs/default.nix
+++ b/pkgs/servers/http/pshs/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pshs-${version}";
-  version = "0.3.2";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "mgorny";
     repo = "pshs";
     rev = "v${version}";
-    sha256 = "1ffdyv5qiqdg3jq8y91fsml046g88d7fyy2k81yii11jw3yx2js0";
+    sha256 = "04l03myh99npl78y8nss053gnc7k8q60vdbdpml19sshmwaw3fgi";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3/bin/pshs -h` got 0 exit code
- ran `/nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3/bin/pshs --help` got 0 exit code
- ran `/nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3/bin/pshs -V` and found version 0.3.3
- ran `/nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3/bin/pshs -v` and found version 0.3.3
- ran `/nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3/bin/pshs --version` and found version 0.3.3
- ran `/nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3/bin/pshs -h` and found version 0.3.3
- ran `/nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3/bin/pshs --help` and found version 0.3.3
- found 0.3.3 with grep in /nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3
- found 0.3.3 in filename of file in /nix/store/gvhbbqnlgy8y79fcvprkwdmn0dlihjm5-pshs-0.3.3

cc @eduarrrd for review