### PR TITLE
ncurses: 6.0-20171125 -> 6.1-20180303

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -13,7 +13,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "6.0-20171125";
+  version = "6.1-20180303";
   name = "ncurses-${version}" + lib.optionalString (abiVersion == "5") "-abi5-compat";
 
   src = fetchurl {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       "ftp://ftp.invisible-island.net/ncurses/current/ncurses-${version}.tgz"
       "https://invisible-mirror.net/archives/ncurses/current/ncurses-${version}.tgz"
     ];
-    sha256 = "11adzj0k82nlgpfrflabvqn2m7fmhp2y6pd7ivmapynxqb9vvb92";
+    sha256 = "0qhzps9apq7gg2sx9j82h2rn3gr31bpbpjwffdvkqw6mkrw5q2yf";
   };
 
   patches = lib.optional (!stdenv.cc.isClang) ./clang.patch;


### PR DESCRIPTION
###### Motivation for this change
New ncurses version is out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

