### PR TITLE
qt5ct: 0.34 -> 0.35

### DIFF
--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -4,11 +4,11 @@ let inherit (stdenv.lib) getDev; in
 
 stdenv.mkDerivation rec {
   name = "qt5ct-${version}";
-  version = "0.34";
+  version = "0.35";
 
   src = fetchurl {
     url = "mirror://sourceforge/qt5ct/${name}.tar.bz2";
-    sha256 = "0aqbilz7acx077zg5rwf2909xabw16047yjdn9nx2gmhp31y00pl";
+    sha256 = "0xzgd12cvm4vyzl8qax6izdmaf46bf18h055z6k178s8pybm1sqw";
   };
 
   nativeBuildInputs = [ qmake qttools ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.35 with grep in /nix/store/09w800gzw7r649858m96yq9vi4c7ap46-qt5ct-0.35
- found 0.35 in filename of file in /nix/store/09w800gzw7r649858m96yq9vi4c7ap46-qt5ct-0.35

cc @ralith for review