### PR TITLE
redir: 3.1 -> 3.2

### DIFF
--- a/pkgs/tools/networking/redir/default.nix
+++ b/pkgs/tools/networking/redir/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "redir-${version}";
-  version = "3.1";
+  version = "3.2";
 
   src = fetchFromGitHub {
     owner = "troglobit";
     repo = "redir";
     rev = "v${version}";
-    sha256 = "1m05dchi15bzz9zfdb7jg59624sx4khp5zq0wf4pzr31s64f69cx";
+    sha256 = "015vxpy6n7xflkq0lgls4f4vw7ynvv2635bwykzglin3v5ssrm2k";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/1d9lg45iqc404f728bdcdr3s3sq9c8wf-redir-3.2/bin/redir -h` got 0 exit code
- ran `/nix/store/1d9lg45iqc404f728bdcdr3s3sq9c8wf-redir-3.2/bin/redir --help` got 0 exit code
- ran `/nix/store/1d9lg45iqc404f728bdcdr3s3sq9c8wf-redir-3.2/bin/redir -v` and found version 3.2
- ran `/nix/store/1d9lg45iqc404f728bdcdr3s3sq9c8wf-redir-3.2/bin/redir --version` and found version 3.2
- found 3.2 with grep in /nix/store/1d9lg45iqc404f728bdcdr3s3sq9c8wf-redir-3.2
- found 3.2 in filename of file in /nix/store/1d9lg45iqc404f728bdcdr3s3sq9c8wf-redir-3.2

cc @globin for review