### PR TITLE
rednotebook: 2.3 -> 2.4

### DIFF
--- a/pkgs/applications/editors/rednotebook/default.nix
+++ b/pkgs/applications/editors/rednotebook/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonApplication rec {
   name = "rednotebook-${version}";
-  version = "2.3";
+  version = "2.4";
 
   src = fetchFromGitHub {
     owner = "jendrikseipp";
     repo = "rednotebook";
     rev = "v${version}";
-    sha256 = "0zkfid104hcsf20r6829v11wxdghqkd3j1zbgyvd1s7q4nxjn5lj";
+    sha256 = "1vfddlqrrgbjql8yrsfisqzmjbcbpdpv161cfrdigxf9myksybdk";
   };
 
   # We have not packaged tests.


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4/bin/rednotebook -h` got 0 exit code
- ran `/nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4/bin/rednotebook --help` got 0 exit code
- ran `/nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4/bin/rednotebook --version` and found version 2.4
- ran `/nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4/bin/rednotebook -h` and found version 2.4
- ran `/nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4/bin/rednotebook --help` and found version 2.4
- found 2.4 with grep in /nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4
- found 2.4 in filename of file in /nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4

cc @orivej for review