### PR TITLE
h5utils: init at 1.13.1

### DIFF
--- a/pkgs/tools/misc/h5utils/default.nix
+++ b/pkgs/tools/misc/h5utils/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, lib
+, hdf5, libpng, libjpeg
+, hdf4 ? null
+, libmatheval ? null
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.13.1";
+  name = "h5utils-${version}";
+
+  # fetchurl is used instead of fetchFromGitHub because the git repo version requires
+  # additional tools to build compared to the tarball release; see the README for details.
+  src = fetchurl {
+    url = "https://github.com/stevengj/h5utils/releases/download/${version}/h5utils-${version}.tar.gz";
+    sha256 = "0rbx3m8p5am8z5m0f3sryryfc41541hjpkixb1jkxakd9l36z9y5";
+  };
+
+  # libdf is an alternative name for libhdf (hdf4)
+  preConfigure = lib.optionalString (hdf4 != null)
+  ''
+    substituteInPlace configure \
+    --replace "-ldf" "-lhdf" \
+  '';
+
+  preBuild = lib.optionalString hdf5.mpiSupport "export CC=${hdf5.mpi}/bin/mpicc";
+
+  buildInputs = with lib; [ hdf5 libjpeg libpng ] ++ optional hdf5.mpiSupport hdf5.mpi
+    ++ optional (hdf4 != null) hdf4
+    ++ optional (libmatheval != null) libmatheval;
+
+  meta = with lib; {
+    description = "A set of utilities for visualization and conversion of scientific data in the free, portable HDF5 format";
+    homepage = https://github.com/stevengj/h5utils;
+    license = with licenses; [ mit gpl2 ];
+    maintainers = with maintainers; [ sfrijters ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2769,6 +2769,11 @@ with pkgs;
 
   h2 = callPackage ../servers/h2 { };
 
+  h5utils = callPackage ../tools/misc/h5utils {
+    libmatheval = null;
+    hdf4 = null;
+  };
+
   haproxy = callPackage ../tools/networking/haproxy { };
 
   haveged = callPackage ../tools/security/haveged { };


### PR DESCRIPTION
###### Motivation for this change

New package: "A set of utilities for visualization and conversion of scientific data in the free, portable HDF5 format"

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

