### PR TITLE
rocksdb: 5.10.3 -> 5.11.3

### DIFF
--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -18,7 +18,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "rocksdb-${version}";
-  version = "5.10.3";
+  version = "5.11.3";
 
   outputs = [ "dev" "out" "static" ];
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "facebook";
     repo = "rocksdb";
     rev = "v${version}";
-    sha256 = "19d8i8map8qz639mhflmxc0w9gp78fvkq1l46y5s6b5imwh0w7xq";
+    sha256 = "15x2r7aib1xinwcchl32wghs8g96k4q5xgv6z97mxgp35475x01p";
   };
   
   nativeBuildInputs = [ which perl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4/bin/rednotebook -h` got 0 exit code
- ran `/nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4/bin/rednotebook --help` got 0 exit code
- found 5.11.3 in filename of file in /nix/store/0z5hqf7lmzgynw5vgliy7848dr7p6fis-rednotebook-2.4

cc @adevress @wkennington for review