### PR TITLE
rocksndiamonds: 4.0.1.1 -> 4.0.1.3

### DIFF
--- a/pkgs/games/rocksndiamonds/default.nix
+++ b/pkgs/games/rocksndiamonds/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "${project}-${version}";
   project = "rocksndiamonds";
-  version = "4.0.1.1";
+  version = "4.0.1.3";
 
   src = fetchurl {
     url = "https://www.artsoft.org/RELEASES/unix/${project}/${name}.tar.gz";
-    sha256 = "0f2m29m53sngg2kv4km91nxbr53rzhchbpqx5dzrv3p5hq1hp936";
+    sha256 = "0y8w96hav7k5qwpm6rvzn3g4czfpsc58dix3x98anqii9l6vwrdd";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/9xclaqwjhfkghjb7yhkzl0w3gc5l83zg-rocksndiamonds-4.0.1.3/bin/rocksndiamonds -h` got 0 exit code
- ran `/nix/store/9xclaqwjhfkghjb7yhkzl0w3gc5l83zg-rocksndiamonds-4.0.1.3/bin/rocksndiamonds --help` got 0 exit code
- ran `/nix/store/9xclaqwjhfkghjb7yhkzl0w3gc5l83zg-rocksndiamonds-4.0.1.3/bin/rocksndiamonds -V` and found version 4.0.1.3
- ran `/nix/store/9xclaqwjhfkghjb7yhkzl0w3gc5l83zg-rocksndiamonds-4.0.1.3/bin/rocksndiamonds --version` and found version 4.0.1.3
- found 4.0.1.3 with grep in /nix/store/9xclaqwjhfkghjb7yhkzl0w3gc5l83zg-rocksndiamonds-4.0.1.3

cc @orivej for review