### PR TITLE
rspamd: 1.6.6 -> 1.7.0

### DIFF
--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -6,13 +6,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "rspamd-${version}";
-  version = "1.6.6";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "vstakhov";
     repo = "rspamd";
     rev = version;
-    sha256 = "04jqrki7rlxywdig264kavy1h5882rspi2drkbdzrk35jjq8rh3h";
+    sha256 = "1y54kh8ccpmbcg5n8fcdwl0p8s92yn3zjhghci2nwqgn6ylx1myz";
   };
 
   nativeBuildInputs = [ cmake pkgconfig perl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamd -h` got 0 exit code
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamd --help` got 0 exit code
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamd -v` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamd --version` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamd -h` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamd --help` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamc --help` got 0 exit code
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamc help` got 0 exit code
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamc version` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamc --help` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamc help` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamadm -h` got 0 exit code
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamadm --help` got 0 exit code
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamadm help` got 0 exit code
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamadm -v` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamadm --version` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamadm -h` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamadm --help` and found version 1.7.0
- ran `/nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0/bin/rspamadm help` and found version 1.7.0
- found 1.7.0 with grep in /nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0
- found 1.7.0 in filename of file in /nix/store/xl2awz14zbw0id5fhg7anbwm1j547krp-rspamd-1.7.0

cc @avnik @fpletz for review