### PR TITLE
rtv: 1.21.0 -> 1.22.1

### DIFF
--- a/pkgs/applications/misc/rtv/default.nix
+++ b/pkgs/applications/misc/rtv/default.nix
@@ -2,14 +2,14 @@
 
 with pythonPackages;
 buildPythonApplication rec {
-  version = "1.21.0";
+  version = "1.22.1";
   name = "rtv-${version}";
 
   src = fetchFromGitHub {
     owner = "michael-lazar";
     repo = "rtv";
     rev = "v${version}";
-    sha256 = "0srm01nrb23hdmj3ripsa9p8nv2cgss3m6and9rdr875qw5ii130";
+    sha256 = "1jil8cwhnpf2mclgah7s79j4c38hzm0j6di2mffrqhlsnn2vxbf4";
   };
 
   # Tests try to access network


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1/bin/.rtv-wrapped -h` got 0 exit code
- ran `/nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1/bin/.rtv-wrapped --help` got 0 exit code
- ran `/nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1/bin/.rtv-wrapped -V` and found version 1.22.1
- ran `/nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1/bin/.rtv-wrapped --version` and found version 1.22.1
- ran `/nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1/bin/rtv -h` got 0 exit code
- ran `/nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1/bin/rtv --help` got 0 exit code
- ran `/nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1/bin/rtv -V` and found version 1.22.1
- ran `/nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1/bin/rtv --version` and found version 1.22.1
- found 1.22.1 with grep in /nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1
- found 1.22.1 in filename of file in /nix/store/mpyc1z74lsma9vfc4b04glvvyfs0l40j-rtv-1.22.1

cc @matthiasbeyer @jgeerds for review