### PR TITLE
s3ql: 2.21 -> 2.26

### DIFF
--- a/pkgs/tools/backup/s3ql/default.nix
+++ b/pkgs/tools/backup/s3ql/default.nix
@@ -3,11 +3,11 @@
 python3Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "s3ql";
-  version = "2.21";
+  version = "2.26";
 
   src = fetchurl {
     url = "https://bitbucket.org/nikratio/${pname}/downloads/${name}.tar.bz2";
-    sha256 = "1mifmxbsxc2rcrydk2vs5cjfd5r0510q5y7rmavlzi8grpcqdf3d";
+    sha256 = "0xs1jbak51zwjrd6jmd96xl3a3jpw0p1s05f7sw5wipvvg0xnmfn";
   };
 
   buildInputs = [ which ]; # tests will fail without which


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.fsck.s3ql-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.fsck.s3ql-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.fsck.s3ql-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/fsck.s3ql -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/fsck.s3ql --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/fsck.s3ql --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.mkfs.s3ql-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.mkfs.s3ql-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.mkfs.s3ql-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/mkfs.s3ql -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/mkfs.s3ql --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/mkfs.s3ql --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.mount.s3ql-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.mount.s3ql-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.mount.s3ql-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/mount.s3ql -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/mount.s3ql --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/mount.s3ql --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3ql_oauth_client-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3ql_oauth_client-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3ql_oauth_client-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3ql_oauth_client -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3ql_oauth_client --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3ql_oauth_client --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3ql_verify-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3ql_verify-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3ql_verify-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3ql_verify -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3ql_verify --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3ql_verify --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qladm-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qladm-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qladm-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qladm -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qladm --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qladm --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlcp-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlcp-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlcp-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlcp -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlcp --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlcp --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlctrl-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlctrl-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlctrl-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlctrl -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlctrl --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlctrl --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qllock-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qllock-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qllock-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qllock -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qllock --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qllock --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlrm-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlrm-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlrm-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlrm -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlrm --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlrm --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlstat-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlstat-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.s3qlstat-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlstat -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlstat --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/s3qlstat --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.umount.s3ql-wrapped -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.umount.s3ql-wrapped --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/.umount.s3ql-wrapped --version` and found version 2.26
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/umount.s3ql -h` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/umount.s3ql --help` got 0 exit code
- ran `/nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26/bin/umount.s3ql --version` and found version 2.26
- found 2.26 with grep in /nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26
- found 2.26 in filename of file in /nix/store/rkms0h08sfvsbpz7yp7fikhd272g28p2-s3ql-2.26

cc @rushmorem for review