### PR TITLE
itk: 4.11.0 -> 4.12.2, fix build

### DIFF
--- a/pkgs/development/libraries/itk/default.nix
+++ b/pkgs/development/libraries/itk/default.nix
@@ -1,19 +1,12 @@
 { stdenv, fetchurl, fetchpatch, cmake, libX11, libuuid, xz, vtk }:
 
 stdenv.mkDerivation rec {
-  name = "itk-4.11.0";
+  name = "itk-4.12.2";
 
   src = fetchurl {
-    url = mirror://sourceforge/itk/InsightToolkit-4.11.0.tar.xz;
-    sha256 = "0axvyds0gads5914g0m70z5q16gzghr0rk0hy3qjpf1k9bkxvcq6";
+    url = mirror://sourceforge/itk/InsightToolkit-4.12.2.tar.xz;
+    sha256 = "1qw9mxbh083siljygahl4gdfv91xvfd8hfl7ghwii19f60xrvn2w";
   };
-
-  # Clang 4 dislikes signed comparisons of pointers against integers. Should no longer be
-  # necessary once we get past ITK 4.11.
-  patches = [ (fetchpatch {
-    url    = "https://github.com/InsightSoftwareConsortium/ITK/commit/d1407a55910ad9c232f3d241833cfd2e59024946.patch";
-    sha256 = "0h851afkv23fwgkibjss30fkbz4nkfg6rmmm4pfvkwpml23gzz7s";
-  }) ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"


### PR DESCRIPTION
###### Motivation for this change

previous version didn't build w/gcc7.

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

