### PR TITLE
home-assistant: 0.63.3 -> 0.65.5

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -15,11 +15,11 @@
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "3.0.5";
+  version = "3.0.9";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bb873da531401416acb7045a8f0bdf6555e9c6866989cd977166fae3cbbb954b";
+    sha256 = "281a9fa56b5ce587a2147ec285d18a224942f7e020581afa6cc44d7caecf937b";
   };
 
   disabled = pythonOlder "3.5";

--- a/pkgs/development/python-modules/hbmqtt/default.nix
+++ b/pkgs/development/python-modules/hbmqtt/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "hbmqtt";
-  version = "0.9.1";
+  version = "0.9.2";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04lqqcy84f9gcwqhrlvzp689r3mkdd8ipsnfzw8gryfny4lh8wrx";
+    sha256 = "6f61e05007648a4f33e300fafcf42776ca95508ba1141799f94169427ce5018c";
   };
 
   propagatedBuildInputs = [ transitions websockets passlib docopt pyyaml ];

--- a/pkgs/development/python-modules/idna-ssl/default.nix
+++ b/pkgs/development/python-modules/idna-ssl/default.nix
@@ -1,12 +1,12 @@
 { lib, buildPythonPackage, fetchPypi, idna }:
 
 buildPythonPackage rec {
-  pname = "idna_ssl";
-  version = "1.0.0";
+  pname = "idna-ssl";
+  version = "1.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1227e44039bd31e02adaeafdbba61281596d623d222643fb021f87f2144ea147";
+    sha256 = "1293f030bc608e9aa9cdee72aa93c1521bbb9c7698068c61c9ada6772162b979";
   };
 
   propagatedBuildInputs = [ idna ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.63.3";
+  version = "0.65.5";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
@@ -21,6 +21,7 @@
     "arduino" = ps: with ps; [  ];
     "arlo" = ps: with ps; [  ];
     "asterisk_mbox" = ps: with ps; [  ];
+    "august" = ps: with ps; [  ];
     "axis" = ps: with ps; [  ];
     "bbb_gpio" = ps: with ps; [  ];
     "binary_sensor.concord232" = ps: with ps; [  ];
@@ -32,10 +33,12 @@
     "binary_sensor.trend" = ps: with ps; [ numpy ];
     "binary_sensor.workday" = ps: with ps; [  ];
     "blink" = ps: with ps; [  ];
+    "bmw_connected_drive" = ps: with ps; [  ];
     "calendar.caldav" = ps: with ps; [  ];
     "calendar.todoist" = ps: with ps; [ todoist ];
     "camera.foscam" = ps: with ps; [  ];
     "camera.onvif" = ps: with ps; [  ];
+    "camera.proxy" = ps: with ps; [ pillow ];
     "camera.synology" = ps: with ps; [  ];
     "camera.uvc" = ps: with ps; [  ];
     "camera.xeoma" = ps: with ps; [  ];
@@ -56,7 +59,7 @@
     "cloud" = ps: with ps; [  ];
     "coinbase" = ps: with ps; [  ];
     "comfoconnect" = ps: with ps; [  ];
-    "conversation" = ps: with ps; [  ];
+    "config.config_entries" = ps: with ps; [  ];
     "cover.myq" = ps: with ps; [  ];
     "daikin" = ps: with ps; [  ];
     "datadog" = ps: with ps; [ datadog ];
@@ -89,6 +92,7 @@
     "dweet" = ps: with ps; [  ];
     "dyson" = ps: with ps; [  ];
     "ecobee" = ps: with ps; [  ];
+    "egardia" = ps: with ps; [  ];
     "eight_sleep" = ps: with ps; [  ];
     "emulated_hue" = ps: with ps; [ aiohttp-cors ];
     "enocean" = ps: with ps; [  ];
@@ -96,12 +100,13 @@
     "fan.xiaomi_miio" = ps: with ps; [  ];
     "feedreader" = ps: with ps; [ feedparser ];
     "ffmpeg" = ps: with ps; [  ];
-    "frontend" = ps: with ps; [ user-agents ];
+    "frontend" = ps: with ps; [  ];
     "gc100" = ps: with ps; [  ];
     "goalfeed" = ps: with ps; [  ];
     "google" = ps: with ps; [ google_api_python_client oauth2client ];
     "hdmi_cec" = ps: with ps; [  ];
     "hive" = ps: with ps; [  ];
+    "homekit" = ps: with ps; [  ];
     "homematic" = ps: with ps; [ pyhomematic ];
     "http" = ps: with ps; [ aiohttp-cors ];
     "hue" = ps: with ps; [  ];
@@ -159,6 +164,7 @@
     "media_player.bluesound" = ps: with ps; [ xmltodict ];
     "media_player.braviatv" = ps: with ps; [  ];
     "media_player.cast" = ps: with ps; [ PyChromecast ];
+    "media_player.channels" = ps: with ps; [  ];
     "media_player.clementine" = ps: with ps; [  ];
     "media_player.cmus" = ps: with ps; [  ];
     "media_player.denonavr" = ps: with ps; [  ];
@@ -187,12 +193,14 @@
     "media_player.russound_rnet" = ps: with ps; [  ];
     "media_player.samsungtv" = ps: with ps; [ wakeonlan ];
     "media_player.snapcast" = ps: with ps; [  ];
+    "media_player.songpal" = ps: with ps; [  ];
     "media_player.sonos" = ps: with ps; [  ];
     "media_player.soundtouch" = ps: with ps; [ libsoundtouch ];
     "media_player.spotify" = ps: with ps; [  ];
     "media_player.vizio" = ps: with ps; [  ];
     "media_player.vlc" = ps: with ps; [  ];
     "media_player.webostv" = ps: with ps; [ websockets ];
+    "media_player.xiaomi_tv" = ps: with ps; [  ];
     "media_player.yamaha" = ps: with ps; [  ];
     "media_player.yamaha_musiccast" = ps: with ps; [  ];
     "media_player.ziggo_mediabox_xl" = ps: with ps; [  ];
@@ -334,6 +342,7 @@
     "sensor.sabnzbd" = ps: with ps; [  ];
     "sensor.scrape" = ps: with ps; [ beautifulsoup4 ];
     "sensor.season" = ps: with ps; [ ephem ];
+    "sensor.sense" = ps: with ps; [  ];
     "sensor.sensehat" = ps: with ps; [  ];
     "sensor.serial" = ps: with ps; [  ];
     "sensor.serial_pm" = ps: with ps; [  ];
@@ -342,7 +351,9 @@
     "sensor.snmp" = ps: with ps; [ pysnmp ];
     "sensor.sochain" = ps: with ps; [  ];
     "sensor.speedtest" = ps: with ps; [  ];
+    "sensor.spotcrime" = ps: with ps; [  ];
     "sensor.sql" = ps: with ps; [ sqlalchemy ];
+    "sensor.startca" = ps: with ps; [ xmltodict ];
     "sensor.steam_online" = ps: with ps; [  ];
     "sensor.swiss_hydrological_data" = ps: with ps; [ xmltodict ];
     "sensor.swiss_public_transport" = ps: with ps; [  ];
@@ -366,9 +377,11 @@
     "sensor.yahoo_finance" = ps: with ps; [  ];
     "sensor.yr" = ps: with ps; [ xmltodict ];
     "sensor.yweather" = ps: with ps; [  ];
+    "sensor.zestimate" = ps: with ps; [ xmltodict ];
     "shiftr" = ps: with ps; [ paho-mqtt ];
     "skybell" = ps: with ps; [  ];
     "sleepiq" = ps: with ps; [  ];
+    "smappee" = ps: with ps; [  ];
     "spc" = ps: with ps; [ websockets ];
     "statsd" = ps: with ps; [ statsd ];
     "switch.acer_projector" = ps: with ps; [ pyserial ];
@@ -408,6 +421,7 @@
     "tts.google" = ps: with ps; [  ];
     "tts.microsoft" = ps: with ps; [  ];
     "twilio" = ps: with ps; [ twilio ];
+    "upcloud" = ps: with ps; [  ];
     "updater" = ps: with ps; [ distro ];
     "upnp" = ps: with ps; [  ];
     "usps" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -7,18 +7,11 @@ let
 
   py = python3.override {
     packageOverrides = self: super: {
-      yarl = super.yarl.overridePythonAttrs (oldAttrs: rec {
-        version = "1.1.0";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "162630v7f98l27h11msk9416lqwm2mpgxh4s636594nlbfs9by3a";
-        };
-      });
       aiohttp = super.aiohttp.overridePythonAttrs (oldAttrs: rec {
-        version = "2.3.10";
+        version = "3.0.6";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "8adda6583ba438a4c70693374e10b60168663ffa6564c5c75d3c7a9055290964";
+          sha256 = "5b588d21b454aaeaf2debf3c4a37f0752fb91a5c15b621deca7e8c49316154fe";
         };
       });
       pytest = super.pytest.overridePythonAttrs (oldAttrs: rec {
@@ -29,10 +22,10 @@ let
         };
       });
       voluptuous = super.voluptuous.overridePythonAttrs (oldAttrs: rec {
-        version = "0.10.5";
+        version = "0.11.1";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "15i3gaap8ilhpbah1ffc6q415wkvliqxilc6s69a4rinvkw6cx3s";
+          sha256 = "af7315c9fa99e0bfd195a21106c82c81619b42f0bd9b6e287b797c6b6b6a9918";
         };
       });
       hass-frontend = super.callPackage ./frontend.nix { };
@@ -51,11 +44,13 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.63.3";
+  hassVersion = "0.65.5";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
   version = assert (componentPackages.version == hassVersion); hassVersion;
+
+  disabled = pythonOlder "3.5";
 
   inherit availableComponents;
 
@@ -64,14 +59,14 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "1lrdrn0x8i81vbqxziv5fgcc8ldz7x5r62kfz3nyg4g43rk3dqq8";
+    sha256 = "1jd44y3f31926g08h2zykp9hnigh6yms38mqn3i5gcl01n1n368k";
   };
 
   propagatedBuildInputs = [
     # From setup.py
-    requests pyyaml pytz pip jinja2 voluptuous typing aiohttp yarl async-timeout chardet astral certifi attrs
+    requests pyyaml pytz pip jinja2 voluptuous typing aiohttp async-timeout astral certifi attrs
     # From http, frontend and recorder components
-    sqlalchemy aiohttp-cors hass-frontend user-agents
+    sqlalchemy aiohttp-cors hass-frontend
   ] ++ componentBuildInputs ++ extraBuildInputs;
 
   checkInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchPypi, buildPythonPackage }:
+{ stdenv, fetchPypi, buildPythonPackage, user-agents }:
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20180209.0";
+  version = "20180310.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b85f0e833871408a95619ae38d5344701a6466e8f7b5530e718ccc260b68d3ed";
+    sha256 = "5a7cca7ed461d650859df7d036ff4c579366bbcde5eb6407b1aff6a0dbbae2c2";
   };
+
+  propagatedBuildInputs = [ user-agents ];
 }


### PR DESCRIPTION
###### Motivation for this change
https://home-assistant.io/blog/2018/02/26/release-64/
https://home-assistant.io/blog/2018/03/09/release-65/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @peterhoeg 