### PR TITLE
samplv1: 0.8.6 -> 0.9.0

### DIFF
--- a/pkgs/applications/audio/samplv1/default.nix
+++ b/pkgs/applications/audio/samplv1/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "samplv1-${version}";
-  version = "0.8.6";
+  version = "0.9.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/samplv1/${name}.tar.gz";
-    sha256 = "035bq7yfg1yirsqk63zwkzjw9dxl52lrzq9y0w7nga0vb11xdfij";
+    sha256 = "0g67vm9ilmq5nlvk0f3abia9pbinr4ck5v4mll6igni1rxz2n7wk";
   };
 
   buildInputs = [ libjack2 alsaLib liblo libsndfile lv2 qt5.qtbase qt5.qttools];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.0 with grep in /nix/store/qykrhn0p2fv48gyckvdgw9r621cy2s3y-samplv1-0.9.0
- found 0.9.0 in filename of file in /nix/store/qykrhn0p2fv48gyckvdgw9r621cy2s3y-samplv1-0.9.0

cc @cillianderoiste for review