### PR TITLE
sassc: 3.4.8 -> 3.5.0

### DIFF
--- a/pkgs/development/tools/sassc/default.nix
+++ b/pkgs/development/tools/sassc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "sassc-${version}";
-  version = "3.4.8";
+  version = "3.5.0";
 
   src = fetchurl {
     url = "https://github.com/sass/sassc/archive/${version}.tar.gz";
-    sha256 = "02lnibrl6zgczkhvz01bdp0d2b0rbl69dfv5mdnbr4l8km7sa7b1";
+    sha256 = "0hl0j4ky13fzcv2y7w352gaq8fjmypwgazf7ddqdv0sbj8qlxx96";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/jw8q07zqpmpzny6qz3zx2slxjng7lf9i-sassc-3.5.0/bin/sassc -h` got 0 exit code
- ran `/nix/store/jw8q07zqpmpzny6qz3zx2slxjng7lf9i-sassc-3.5.0/bin/sassc --help` got 0 exit code
- ran `/nix/store/jw8q07zqpmpzny6qz3zx2slxjng7lf9i-sassc-3.5.0/bin/sassc -v` and found version 3.5.0
- ran `/nix/store/jw8q07zqpmpzny6qz3zx2slxjng7lf9i-sassc-3.5.0/bin/sassc --version` and found version 3.5.0
- ran `/nix/store/jw8q07zqpmpzny6qz3zx2slxjng7lf9i-sassc-3.5.0/bin/sassc -h` and found version 3.5.0
- ran `/nix/store/jw8q07zqpmpzny6qz3zx2slxjng7lf9i-sassc-3.5.0/bin/sassc --help` and found version 3.5.0
- found 3.5.0 with grep in /nix/store/jw8q07zqpmpzny6qz3zx2slxjng7lf9i-sassc-3.5.0
- found 3.5.0 in filename of file in /nix/store/jw8q07zqpmpzny6qz3zx2slxjng7lf9i-sassc-3.5.0

cc @codyopel @pjones for review