### PR TITLE
sawfish: 1.12.0 -> 1.12.90

### DIFF
--- a/pkgs/applications/window-managers/sawfish/default.nix
+++ b/pkgs/applications/window-managers/sawfish/default.nix
@@ -11,12 +11,12 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "sawfish-${version}";
-  version = "1.12.0";
+  version = "1.12.90";
   sourceName = "sawfish_${version}";
 
   src = fetchurl {
     url = "http://download.tuxfamily.org/sawfish/${sourceName}.tar.xz";
-    sha256 = "1z7awzgw8d15aw17kpbj460pcxq8l2rhkaxk47w7yg9qrmg0xja4";
+    sha256 = "18p8srqqj9vjffg13qhspfz2gr1h4vfs10qzlv89g76r289iam31";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/pq9arr25llfihg0gmhbsl411d6ycvbrv-sawfish-1.12.90/bin/sawfish --help` got 0 exit code
- ran `/nix/store/pq9arr25llfihg0gmhbsl411d6ycvbrv-sawfish-1.12.90/bin/sawfish --version` and found version 1.12.90
- ran `/nix/store/pq9arr25llfihg0gmhbsl411d6ycvbrv-sawfish-1.12.90/bin/sawfish --help` and found version 1.12.90
- ran `/nix/store/pq9arr25llfihg0gmhbsl411d6ycvbrv-sawfish-1.12.90/bin/.sawfish-wrapped --help` got 0 exit code
- ran `/nix/store/pq9arr25llfihg0gmhbsl411d6ycvbrv-sawfish-1.12.90/bin/.sawfish-wrapped --version` and found version 1.12.90
- ran `/nix/store/pq9arr25llfihg0gmhbsl411d6ycvbrv-sawfish-1.12.90/bin/.sawfish-wrapped --help` and found version 1.12.90
- found 1.12.90 with grep in /nix/store/pq9arr25llfihg0gmhbsl411d6ycvbrv-sawfish-1.12.90

cc @AndersonTorres for review