### PR TITLE
seafile-client: 6.1.5 -> 6.1.6

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -5,14 +5,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "6.1.5";
+  version = "6.1.6";
   name = "seafile-client-${version}";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile-client";
     rev = "v${version}";
-    sha256 = "1ahz55cw2p3s78x5f77drz4h2jhknfzpkk83qd0ggma31q1pnpl9";
+    sha256 = "0r02frlspjq8k0zz1z4wh2sx3jm6b1qby5mxg394sb3rjdxb8jhk";
   };
 
   nativeBuildInputs = [ pkgconfig cmake makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 6.1.6 with grep in /nix/store/304wh7gzixm9as2wa2b619jcimn0837k-seafile-client-6.1.6
- found 6.1.6 in filename of file in /nix/store/304wh7gzixm9as2wa2b619jcimn0837k-seafile-client-6.1.6