### PR TITLE
shotwell: 0.27.4 -> 0.28.0

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -7,13 +7,13 @@
 
 let
   pname = "shotwell";
-  version = "0.27.4";
+  version = "0.28.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "0g2vphhpxrljpy9sryfsgaayix807i1i9plj9bay72dk0zphqab2";
+    sha256 = "1d797nmlz9gs6ri0h65b76s40ss6ma6h6405xqx03lhg5xni3kmg";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/shotwell -h` got 0 exit code
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/shotwell --help` got 0 exit code
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/shotwell help` got 0 exit code
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/shotwell -V` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/shotwell -v` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/shotwell --version` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/shotwell version` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/shotwell help` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/.shotwell-wrapped -h` got 0 exit code
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/.shotwell-wrapped --help` got 0 exit code
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/.shotwell-wrapped help` got 0 exit code
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/.shotwell-wrapped -V` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/.shotwell-wrapped -v` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/.shotwell-wrapped --version` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/.shotwell-wrapped version` and found version 0.28.0
- ran `/nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0/bin/.shotwell-wrapped help` and found version 0.28.0
- found 0.28.0 with grep in /nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0
- found 0.28.0 in filename of file in /nix/store/j5gy9i80mz8gjdcvkya2hm9jkvr86b2z-shotwell-0.28.0

cc @domenkozar for review