### PR TITLE
simple-scan: 3.26.3 -> 3.28.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/simple-scan/default.nix
+++ b/pkgs/desktops/gnome-3/core/simple-scan/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "simple-scan-${version}";
-  version = "3.26.3";
+  version = "3.28.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/simple-scan/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "0galkcc76j0p016fvwn16llh0kh4ykvjy4v7kc6qqnlp38g174n3";
+    sha256 = "0ki95d0v9l0pb5jvk1v8k49vb7snp9j7bnxw3m8q63m00yl33qhz";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/ivmw8s2bdhzk8kcgb03pzyw5iqiaa6q9-simple-scan-3.28.0/bin/simple-scan -h` got 0 exit code
- ran `/nix/store/ivmw8s2bdhzk8kcgb03pzyw5iqiaa6q9-simple-scan-3.28.0/bin/simple-scan --help` got 0 exit code
- ran `/nix/store/ivmw8s2bdhzk8kcgb03pzyw5iqiaa6q9-simple-scan-3.28.0/bin/.simple-scan-wrapped -h` got 0 exit code
- ran `/nix/store/ivmw8s2bdhzk8kcgb03pzyw5iqiaa6q9-simple-scan-3.28.0/bin/.simple-scan-wrapped --help` got 0 exit code
- found 3.28.0 with grep in /nix/store/ivmw8s2bdhzk8kcgb03pzyw5iqiaa6q9-simple-scan-3.28.0
- found 3.28.0 in filename of file in /nix/store/ivmw8s2bdhzk8kcgb03pzyw5iqiaa6q9-simple-scan-3.28.0

cc @lethalman @jtojnar for review