### PR TITLE
simplescreenrecorder: 0.3.9 -> 0.3.10

### DIFF
--- a/pkgs/applications/video/simplescreenrecorder/default.nix
+++ b/pkgs/applications/video/simplescreenrecorder/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "simplescreenrecorder-${version}";
-  version = "0.3.9";
+  version = "0.3.10";
 
   src = fetchurl {
     url = "https://github.com/MaartenBaert/ssr/archive/${version}.tar.gz";
-    sha256 = "1gnf9wbiq2fcbqcn1a5nfmp8r0nxrrlgh2wly2mfkkwymynhx0pk";
+    sha256 = "02rl9yyx3hlz9fqvgzv7ipmvx2qahj7ws5wx2m7zs3lssq3qag3g";
   };
 
   patches = [ ./fix-paths.patch ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/wvyzwhxb1c1l0ia3kc1idh2r8ydhfql9-simplescreenrecorder-0.3.10/bin/ssr-glinject --help` got 0 exit code
- ran `/nix/store/wvyzwhxb1c1l0ia3kc1idh2r8ydhfql9-simplescreenrecorder-0.3.10/bin/ssr-glinject help` got 0 exit code
- ran `/nix/store/wvyzwhxb1c1l0ia3kc1idh2r8ydhfql9-simplescreenrecorder-0.3.10/bin/ssr-glinject help` and found version 0.3.10
- found 0.3.10 with grep in /nix/store/wvyzwhxb1c1l0ia3kc1idh2r8ydhfql9-simplescreenrecorder-0.3.10

cc @cillianderoiste for review