### PR TITLE
skrooge: 2.11.0 -> 2.12.0

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -7,11 +7,11 @@
 
 mkDerivation rec {
   name = "skrooge-${version}";
-  version = "2.11.0";
+  version = "2.12.0";
 
   src = fetchurl {
     url = "http://download.kde.org/stable/skrooge/${name}.tar.xz";
-    sha256 = "11ns0j3ss09aqd8snfzd52xf0cgsjjcgzalb031p7v17rn14yqaq";
+    sha256 = "0f7jwl05y4gjwasjcbsx2rrva81abyf0hgdbkh7h3dl7nxz9h6g1";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/yjdafzss769kl6jg9asxyalgy7a5xxz7-skrooge-2.12.0/bin/skroogeconvert -h` got 0 exit code
- ran `/nix/store/yjdafzss769kl6jg9asxyalgy7a5xxz7-skrooge-2.12.0/bin/skroogeconvert --help` got 0 exit code
- ran `/nix/store/yjdafzss769kl6jg9asxyalgy7a5xxz7-skrooge-2.12.0/bin/skroogeconvert -v` and found version 2.12.0
- ran `/nix/store/yjdafzss769kl6jg9asxyalgy7a5xxz7-skrooge-2.12.0/bin/skroogeconvert --version` and found version 2.12.0
- ran `/nix/store/yjdafzss769kl6jg9asxyalgy7a5xxz7-skrooge-2.12.0/bin/skroogeconvert -h` and found version 2.12.0
- ran `/nix/store/yjdafzss769kl6jg9asxyalgy7a5xxz7-skrooge-2.12.0/bin/skroogeconvert --help` and found version 2.12.0
- found 2.12.0 with grep in /nix/store/yjdafzss769kl6jg9asxyalgy7a5xxz7-skrooge-2.12.0
- found 2.12.0 in filename of file in /nix/store/yjdafzss769kl6jg9asxyalgy7a5xxz7-skrooge-2.12.0

cc @jokogr for review