### PR TITLE
slurm: 17.11.3 -> 17.11.4

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-${version}";
-  version = "17.11.3";
+  version = "17.11.4";
 
   src = fetchurl {
     url = "https://download.schedmd.com/slurm/${name}.tar.bz2";
-    sha256 = "1x3i6z03d9m46fvj1cslrapm1drvgyqch9pn4xf23kvbz4gkhaps";
+    sha256 = "1wkdfvjcj59lf67am7lsiqajw6b3yss80r4h1lsbn2v6wlw6l88q";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/h9czl5bz6d2qwdc30fwgs6yyv47fclmj-slurm-17.11.4/bin/sattach -h` got 0 exit code
- ran `/nix/store/h9czl5bz6d2qwdc30fwgs6yyv47fclmj-slurm-17.11.4/bin/sattach --help` got 0 exit code
- ran `/nix/store/h9czl5bz6d2qwdc30fwgs6yyv47fclmj-slurm-17.11.4/bin/sattach -V` and found version 17.11.4
- ran `/nix/store/h9czl5bz6d2qwdc30fwgs6yyv47fclmj-slurm-17.11.4/bin/sattach --version` and found version 17.11.4
- ran `/nix/store/h9czl5bz6d2qwdc30fwgs6yyv47fclmj-slurm-17.11.4/bin/slurmd -h` got 0 exit code
- ran `/nix/store/h9czl5bz6d2qwdc30fwgs6yyv47fclmj-slurm-17.11.4/bin/slurmd -V` and found version 17.11.4
- found 17.11.4 with grep in /nix/store/h9czl5bz6d2qwdc30fwgs6yyv47fclmj-slurm-17.11.4

cc @jagajaga for review