### PR TITLE
Chromium: fix aarch64 build

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -176,7 +176,10 @@ let
       (githubPatch "ba4141e451f4e0b1b19410b1b503bd32e150df06" "1cjxw1f9fin6z12b0mcxnxf2mdjb0n3chwz7mgvmp9yij8qhqnxj")
       (githubPatch "b34ed1e6524479d61ee944ebf6ca7389ea47e563" "1s13zw93nsyr259dzck6gbhg4x46qg5sg14djf4bvrrc6hlkiczw")
       (githubPatch "4f2b52281ce1649ea8347489443965ad33262ecc" "1g59izkicn9cpcphamdgrijs306h5b9i7i4pmy134asn1ifiax5z")
-    ] ++ optional enableWideVine ./patches/widevine.patch;
+    ] ++ optional enableWideVine ./patches/widevine.patch
+      ++ optionals (stdenv.isAarch64 && versionRange "65" "66") [
+        ./patches/skia_buildfix.patch
+    ];
 
     postPatch = ''
       # We want to be able to specify where the sandbox is via CHROME_DEVEL_SANDBOX

--- a/pkgs/applications/networking/browsers/chromium/patches/skia_buildfix.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/skia_buildfix.patch
@@ -1,0 +1,22 @@
+Index: chromium-browser-65.0.3325.73/third_party/skia/src/jumper/SkJumper_stages.cpp
+===================================================================
+--- chromium-browser-65.0.3325.73.orig/third_party/skia/src/jumper/SkJumper_stages.cpp
++++ chromium-browser-65.0.3325.73/third_party/skia/src/jumper/SkJumper_stages.cpp
+@@ -666,7 +666,7 @@ SI F approx_powf(F x, F y) {
+ }
+ 
+ SI F from_half(U16 h) {
+-#if defined(__aarch64__) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
++#if defined(JUMPER_IS_NEON) && defined(__aarch64__) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+     return vcvt_f32_f16(h);
+ 
+ #elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)
+@@ -686,7 +686,7 @@ SI F from_half(U16 h) {
+ }
+ 
+ SI U16 to_half(F f) {
+-#if defined(__aarch64__) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
++#if defined(JUMPER_IS_NEON) && defined(__aarch64__) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+     return vcvt_f16_f32(f);
+ 
+ #elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)


### PR DESCRIPTION
###### Motivation for this change

Having a working chromium 65 on my aarch64 device.

I'm intending to use this ticket to track progress on making Chromium build on aarch64 again. So far I've only found a missing header and type error in Skia that occurs when building with not-clang.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
