### PR TITLE
tevent: 0.9.35 -> 0.9.36

### DIFF
--- a/pkgs/development/libraries/tevent/default.nix
+++ b/pkgs/development/libraries/tevent/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "tevent-0.9.35";
+  name = "tevent-0.9.36";
 
   src = fetchurl {
     url = "mirror://samba/tevent/${name}.tar.gz";
-    sha256 = "1s8nbkmqz8dzdlsd6qynhvyl05pw93r151f3i2kgjfpbck9ak8r5";
+    sha256 = "0k1v4vnlzpf7h3p4khaw8a7damrc68g136bf2xzys08nzpinnaxx";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.36 with grep in /nix/store/6bqs8b2x2q1f8lxnkh11n1272agnaj5y-tevent-0.9.36
- found 0.9.36 in filename of file in /nix/store/6bqs8b2x2q1f8lxnkh11n1272agnaj5y-tevent-0.9.36

cc @wkennington for review