### PR TITLE
Revert "splix: move to DRVs over PPDs"

### DIFF
--- a/pkgs/misc/cups/drivers/splix/default.nix
+++ b/pkgs/misc/cups/drivers/splix/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, fetchsvn, cups, zlib, jbigkit }:
-
+{ stdenv, fetchsvn, fetchurl, cups, zlib }:
 let rev = "315"; in
 stdenv.mkDerivation rec {
   name = "splix-svn-${rev}";
-
   src = fetchsvn {
     # We build this from svn, because splix hasn't been in released in several years
     # although the community has been adding some new printer models.
@@ -13,17 +11,12 @@ stdenv.mkDerivation rec {
   };
 
   preBuild = ''
-    makeFlags="$makeFlags CUPSFILTER=$out/lib/cups/filter CUPSDRV=$out/share/cups/drv"
+    makeFlags="V=1 DISABLE_JBIG=1 CUPSFILTER=$out/lib/cups/filter CUPSPPD=$out/share/cups/model"
   '';
 
-  buildFlags = [ "drv" "all" ];
-
-  makeFlags = [ "DRV_ONLY=1" ];
-
-  buildInputs = [ cups zlib jbigkit ];
+  buildInputs = [cups zlib];
 
   meta = {
-    description = "CUPS drivers for SPL (Samsung Printer Language) printers";
     homepage = http://splix.sourceforge.net;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.peti ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#37048. Does not work properly, unfortunately. I am sorry for merging too early.

Cc: @abbradar 