### PR TITLE
tiled: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/applications/editors/tiled/default.nix
+++ b/pkgs/applications/editors/tiled/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "tiled-${version}";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "bjorn";
     repo = "tiled";
     rev = "v${version}";
-    sha256 = "1bzp89914rlrwf2whky3fx10rwxqiwbw9acyqllvam3l4hmv4nlz";
+    sha256 = "0rf50w7nkdm70999q1mj7sy5hyjj41qjf4izi849q9a7xnhddv44";
   };
 
   nativeBuildInputs = [ pkgconfig qmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.1.3 with grep in /nix/store/vx3qsix626qzpfrb2sxrgapymrlmwq4b-tiled-1.1.3

cc @dywedir for review