### PR TITLE
time: 1.8 -> 1.9

### DIFF
--- a/pkgs/tools/misc/time/default.nix
+++ b/pkgs/tools/misc/time/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "time-${version}";
-  version = "1.8";
+  version = "1.9";
 
   src = fetchurl {
     url = "mirror://gnu/time/${name}.tar.gz";
-    sha256 = "06rfg8dn0q2r8pdq8i6brrs6rqrsgvkwbbl4kfx3a6lnal0m8bwa";
+    sha256 = "07jj7cz6lc13iqrpgn81ivqh8rkm73p4rnivwgrrshk23v4g1b7v";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/n7qc7s0q7mfaibp8rrwh62dadn4gar7f-time-1.9/bin/time --help` got 0 exit code
- ran `/nix/store/n7qc7s0q7mfaibp8rrwh62dadn4gar7f-time-1.9/bin/time -V` and found version 1.9
- ran `/nix/store/n7qc7s0q7mfaibp8rrwh62dadn4gar7f-time-1.9/bin/time --version` and found version 1.9
- ran `/nix/store/n7qc7s0q7mfaibp8rrwh62dadn4gar7f-time-1.9/bin/time --help` and found version 1.9
- found 1.9 with grep in /nix/store/n7qc7s0q7mfaibp8rrwh62dadn4gar7f-time-1.9