### PR TITLE
tmuxp: 1.3.5 -> 1.4.0

### DIFF
--- a/pkgs/tools/misc/tmuxp/default.nix
+++ b/pkgs/tools/misc/tmuxp/default.nix
@@ -4,11 +4,11 @@ with python.pkgs;
 
 buildPythonApplication rec {
   pname = "tmuxp";
-  version = "1.3.5";
+  version = "1.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bdbbbf5980d6ec21838396a46cd5b599787e8540782b8e2e3f20d2135560a5d3";
+    sha256 = "1ghi6w0cfgs94zlz304q37h3lga2jalfm0hqi3g2060zfdnb96n7";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/pi67w2329w1lc8wbzbbvkvjcy2jrk09z-tmuxp-1.4.0/bin/.tmuxp-wrapped --help` got 0 exit code
- ran `/nix/store/pi67w2329w1lc8wbzbbvkvjcy2jrk09z-tmuxp-1.4.0/bin/.tmuxp-wrapped -V` and found version 1.4.0
- ran `/nix/store/pi67w2329w1lc8wbzbbvkvjcy2jrk09z-tmuxp-1.4.0/bin/.tmuxp-wrapped --version` and found version 1.4.0
- ran `/nix/store/pi67w2329w1lc8wbzbbvkvjcy2jrk09z-tmuxp-1.4.0/bin/tmuxp --help` got 0 exit code
- ran `/nix/store/pi67w2329w1lc8wbzbbvkvjcy2jrk09z-tmuxp-1.4.0/bin/tmuxp -V` and found version 1.4.0
- ran `/nix/store/pi67w2329w1lc8wbzbbvkvjcy2jrk09z-tmuxp-1.4.0/bin/tmuxp --version` and found version 1.4.0
- found 1.4.0 with grep in /nix/store/pi67w2329w1lc8wbzbbvkvjcy2jrk09z-tmuxp-1.4.0

cc @jgeerds for review