### PR TITLE
teyjus: actually update to 2.1

### DIFF
--- a/pkgs/development/compilers/teyjus/default.nix
+++ b/pkgs/development/compilers/teyjus/default.nix
@@ -1,11 +1,15 @@
 { stdenv, fetchurl, omake, ocaml, flex, bison }:
 
+let
+  version = "2.1";
+in
+
 stdenv.mkDerivation {
-  name = "teyjus-2.1";
+  name = "teyjus-${version}";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/teyjus/teyjus-source-2.0-b2.tar.gz";
-    sha256 = "0llhm5nrfyj7ihz2qq1q9ijrh6y4f8vl39mpfkkad5bh1m3gp2gm";
+    url = "https://github.com/teyjus/teyjus/archive/v${version}.tar.gz";
+    sha256 = "0393wpg8v1vvarqy2xh4fdmrwlrl6jaj960kql7cq79mb9p3m269";
   };
 
   patches = [ ./fix-lex-to-flex.patch ];

--- a/pkgs/development/compilers/teyjus/fix-lex-to-flex.patch
+++ b/pkgs/development/compilers/teyjus/fix-lex-to-flex.patch
@@ -1,9 +1,9 @@
 diff --git a/source/OMakefile b/source/OMakefile
-index 6b19d84..095b8b6 100644
+index e6bd37e..1bbc0a8 100644
 --- a/source/OMakefile
 +++ b/source/OMakefile
-@@ -164,12 +164,17 @@ LNK_MAIN = $(FNT)/linkerfront
- DEP_MAIN = $(FNT)/dependfront
+@@ -184,6 +184,12 @@ DEP_MAIN = $(FNT)/dependfront
+ PAR_MAIN = $(FNT)/parsefront
  
  ############################################################
 +# Nixpkgs specific changes
@@ -15,9 +15,11 @@ index 6b19d84..095b8b6 100644
  # Platform specific changes
  #
  
+@@ -194,7 +200,6 @@ if $(mem $(SYSNAME), Linux)
+ 
  if $(mem $(OSTYPE), Cygwin Win32)
      YACC = bison -by
 -    LEX = flex
-     CFLAGS += -mno-cygwin
+     CC = i686-pc-mingw32-gcc
      INC_C[] += $(INC)/byteswap $(INC)/search
      export


### PR DESCRIPTION
My automatic update of teyjus did not properly update it, as reported in https://github.com/NixOS/nixpkgs/pull/36702#issuecomment-373307935

Note, the binaries in this release still report 2.0-b2

https://github.com/teyjus/teyjus/issues/117 tracks asking upstream to
release versions with new version numbers.

cc @joachifm @vbgl @bcdarwin for review