### PR TITLE
tortoisehg: 4.5 -> 4.5.2

### DIFF
--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -2,11 +2,11 @@
 
 python2Packages.buildPythonApplication rec {
     name = "tortoisehg-${version}";
-    version = "4.5";
+    version = "4.5.2";
 
     src = fetchurl {
       url = "https://bitbucket.org/tortoisehg/targz/downloads/${name}.tar.gz";
-      sha256 = "11m2hir2y1hblg9sqmansv16rcp560j2d3nhqzfhkim46a59fxvk";
+      sha256 = "0q12zjpgafdch4ns31k4afy25g837xm7v2qwj62806l2dz4rm4h9";
     };
 
     pythonPath = with python2Packages; [ pyqt4 mercurial qscintilla iniparse ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2/bin/.thg-wrapped -h` got 0 exit code
- ran `/nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2/bin/.thg-wrapped --help` got 0 exit code
- ran `/nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2/bin/.thg-wrapped help` got 0 exit code
- ran `/nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2/bin/.thg-wrapped version` and found version 4.5.2
- ran `/nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2/bin/thg -h` got 0 exit code
- ran `/nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2/bin/thg --help` got 0 exit code
- ran `/nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2/bin/thg help` got 0 exit code
- ran `/nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2/bin/thg version` and found version 4.5.2
- found 4.5.2 with grep in /nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2
- found 4.5.2 in filename of file in /nix/store/zffgxhajwm899w5ybwhr35j16xbx6lh7-tortoisehg-4.5.2

cc @danbst for review