### PR TITLE
trackballs: 1.2.4 -> 1.3.0

### DIFF
--- a/pkgs/games/trackballs/default.nix
+++ b/pkgs/games/trackballs/default.nix
@@ -4,13 +4,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "trackballs-${version}";
-  version = "1.2.4";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "trackballs";
     repo = "trackballs";
     rev = "v${version}";
-    sha256 = "0y5y8xzfsjd0rxl5wnxdq7m9n97s5xvcqyjsckz4qxrjcc3lk297";
+    sha256 = "1rahqsydpbh8nmh41fxggzj5f6s3ldf7p5krik5fnhpy0civfsxd";
   };
 
   buildInputs = [ cmake zlib SDL2 SDL2_ttf SDL2_mixer SDL2_image guile gettext libGLU_combined ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/csh6sqxivlzv49n5w7jrjjagfnnkaswa-trackballs-1.3.0/bin/trackballs -h` got 0 exit code
- ran `/nix/store/csh6sqxivlzv49n5w7jrjjagfnnkaswa-trackballs-1.3.0/bin/trackballs --help` got 0 exit code
- ran `/nix/store/csh6sqxivlzv49n5w7jrjjagfnnkaswa-trackballs-1.3.0/bin/trackballs -v` and found version 1.3.0
- ran `/nix/store/csh6sqxivlzv49n5w7jrjjagfnnkaswa-trackballs-1.3.0/bin/trackballs --version` and found version 1.3.0
- ran `/nix/store/csh6sqxivlzv49n5w7jrjjagfnnkaswa-trackballs-1.3.0/bin/trackballs -h` and found version 1.3.0
- ran `/nix/store/csh6sqxivlzv49n5w7jrjjagfnnkaswa-trackballs-1.3.0/bin/trackballs --help` and found version 1.3.0
- found 1.3.0 with grep in /nix/store/csh6sqxivlzv49n5w7jrjjagfnnkaswa-trackballs-1.3.0