### PR TITLE
haskellPackages.ghcWithPackages: Wrap haddock with GHC lib dir

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -95,6 +95,15 @@ symlinkJoin {
         makeWrapper ${ghc}/bin/$prg $out/bin/$prg --add-flags "${packageDBFlag}=${packageCfgDir}"
       fi
     done
+
+    # haddock was referring to the base ghc, https://github.com/NixOS/nixpkgs/issues/36976
+    if [[ -x "${ghc}/bin/haddock" ]]; then
+      rm -f $out/bin/haddock
+      makeWrapper ${ghc}/bin/haddock $out/bin/haddock    \
+        --add-flags '"-B$NIX_${ghcCommandCaps}_LIBDIR"'  \
+        --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
+    fi
+
   '' + (lib.optionalString targetPlatform.isDarwin ''
     # Work around a linker limit in macOS Sierra (see generic-builder.nix):
     local packageConfDir="$out/lib/${ghc.name}/package.conf.d";


### PR DESCRIPTION
###### Motivation for this change
#36976

haddock isn't wrapped up in ghcWithPackages and friends. I think it's safe to do so, but I'm unsure whether this is the right approach, so I'm looking for feedback.

###### Things done
Wrapped up haddock with *only* `-B$NIX_${ghcCommandCaps}_LIBDIR`. I think this is sufficient, but maybe it doesn't hurt to simply use [the wrapper used for eg. the ghc executable](https://github.com/srhb/nixpkgs/blob/ddfe28de224ea279ac4c5117bbe3b459fc742f90/pkgs/development/haskell-modules/with-packages-wrapper.nix#L64), which adds more env vars?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

