### PR TITLE
uget: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/tools/networking/uget/default.nix
+++ b/pkgs/tools/networking/uget/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "uget-${version}";
-  version = "2.2.0";
+  version = "2.2.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/urlget/${name}.tar.gz";
-    sha256 = "0rg2mr2cndxvnjib8zm5dp7y2hgbvnqkz2j2jmg0xlzfh9d34b2m";
+    sha256 = "0dlrjhnm1pg2vwmp7nl2xv1aia5hyirb3021rl46x859k63zap24";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/uget-gtk -h` got 0 exit code
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/uget-gtk --help` got 0 exit code
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/uget-gtk -V` and found version 2.2.1
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/uget-gtk --version` and found version 2.2.1
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/uget-gtk -h` and found version 2.2.1
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/uget-gtk --help` and found version 2.2.1
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/.uget-gtk-wrapped -h` got 0 exit code
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/.uget-gtk-wrapped --help` got 0 exit code
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/.uget-gtk-wrapped -V` and found version 2.2.1
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/.uget-gtk-wrapped --version` and found version 2.2.1
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/.uget-gtk-wrapped -h` and found version 2.2.1
- ran `/nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1/bin/.uget-gtk-wrapped --help` and found version 2.2.1
- found 2.2.1 with grep in /nix/store/ycadchyn77y6aqxnvp5jkhjv0nw6jqi0-uget-2.2.1

cc @romildo for review