### PR TITLE
pypi2nix: update to current git master

### DIFF
--- a/pkgs/development/tools/pypi2nix/default.nix
+++ b/pkgs/development/tools/pypi2nix/default.nix
@@ -4,13 +4,13 @@
 
 let
 
-  version = "1.8.1";
+  version = "654c36cdb69572837cc242840e71361c156fd08d";
 
   src = fetchFromGitHub {
     owner = "garbas";
     repo = "pypi2nix";
-    rev = "v${version}";
-    sha256 = "039a2ys7ijzi2sa2haa6a8lbhncvd1wfsi6gcy9vm02gi31ghzyb";
+    rev = "${version}";
+    sha256 = "1ryivm71k3vbic57f7nqxwiw7zd00hd16hnrdqvz5gw869vnkd1d";
   };
 
   click = fetchurl {
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     requests
   ];
   buildInputs = [
-    pythonPackages.python pythonPackages.flake8
+    pythonPackages.python pythonPackages.flake8 pythonPackages.jinja2
     zip makeWrapper nix.out nix-prefetch-git nix-prefetch-hg
   ];
 


### PR DESCRIPTION
1.8.1 is pretty old now and there are some nice commits in git

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

