### PR TITLE
urh: 1.9.2 -> 2.0.0

### DIFF
--- a/pkgs/applications/misc/urh/default.nix
+++ b/pkgs/applications/misc/urh/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "urh-${version}";
-  version = "1.9.2";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "jopohl";
     repo = "urh";
     rev = "v${version}";
-    sha256 = "02jq2jas6gm08z4l09azi6dcsydaaaqbxfv4mb7pnrc1w8m593zr";
+    sha256 = "0s8nbrkqcb4q3m8w17sqijbds5irk4xpzhjpwkkakzs0rm5g10sk";
   };
 
   buildInputs = [ hackrf rtl-sdr ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/4wwg83liy1bdignjg1vdfkxbckpd43jb-urh-2.0.0/bin/.urh-wrapped --version` and found version 2.0.0
- ran `/nix/store/4wwg83liy1bdignjg1vdfkxbckpd43jb-urh-2.0.0/bin/urh --version` and found version 2.0.0
- found 2.0.0 with grep in /nix/store/4wwg83liy1bdignjg1vdfkxbckpd43jb-urh-2.0.0

cc @fpletz for review