### PR TITLE
resilio-sync: 2.5.2 -> 2.5.12

### DIFF
--- a/pkgs/applications/networking/resilio-sync/default.nix
+++ b/pkgs/applications/networking/resilio-sync/default.nix
@@ -9,13 +9,13 @@ let
 
 in stdenv.mkDerivation rec {
   name = "resilio-sync-${version}";
-  version = "2.5.2";
+  version = "2.5.12";
 
   src = fetchurl {
     url = "https://download-cdn.resilio.com/${version}/linux-${arch}/resilio-sync_${arch}.tar.gz";
     sha256 = {
-      "x86_64-linux" = "15gji5zqs1py92bpwvvq0r1spl0yynbrsnh4ajphwq17bqys3192";
-      "i686-linux"   = "1y67bd63b95va7g2676rgp2clvcy09pnmivy00r2w46y7kwwwbj8";
+      "x86_64-linux" = "176gf5704wh22kqig8n0gg83048w71grw7h37k2qvxjaf4vypnc7";
+      "i686-linux"   = "15m2s2cqrkpb7ladbwimbs9agqb4ww9jr4gf0ifjwzm2grv5ffnh";
     }.${stdenv.system};
   };
 


### PR DESCRIPTION
###### Motivation for this change

resilio-sync: 2.5.2 -> 2.5.12

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

