### PR TITLE
vault: 0.9.4 -> 0.9.5

### DIFF
--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -9,13 +9,13 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "vault-${version}";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "1a12pfzln6qdff08j9l1807anrsgn3ggnaqda020p6y9zg1p8xzd";
+    sha256 = "1ddki3bnp6yrajc0cxxjkbdlfp0xqx407nxvvv611lsnlbr2sz5g";
   };
 
   nativeBuildInputs = [ go gox removeReferencesTo ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/8w89f27dfrsksnm1xs4pyplbvi6y3sfa-vault-0.9.5/bin/vault -h` got 0 exit code
- ran `/nix/store/8w89f27dfrsksnm1xs4pyplbvi6y3sfa-vault-0.9.5/bin/vault --help` got 0 exit code
- ran `/nix/store/8w89f27dfrsksnm1xs4pyplbvi6y3sfa-vault-0.9.5/bin/vault -v` and found version 0.9.5
- ran `/nix/store/8w89f27dfrsksnm1xs4pyplbvi6y3sfa-vault-0.9.5/bin/vault --version` and found version 0.9.5
- ran `/nix/store/8w89f27dfrsksnm1xs4pyplbvi6y3sfa-vault-0.9.5/bin/vault version` and found version 0.9.5
- found 0.9.5 with grep in /nix/store/8w89f27dfrsksnm1xs4pyplbvi6y3sfa-vault-0.9.5

cc @rushmorem @offlinehacker @pradeepchhetri for review