### PR TITLE
vips: 8.6.2 -> 8.6.3

### DIFF
--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "vips-${version}";
-  version = "8.6.2";
+  version = "8.6.3";
 
   src = fetchurl {
     url = "https://github.com/jcupitt/libvips/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "18hjwk000w49yjjb41qrk4s39mr1xccisrvwy2x063vyjbdbr1ll";
+    sha256 = "14h9w61gaimldmqaym0zhf9fkxjj1pkd5lhglhs6pxphynwxnnpq";
   };
 
   buildInputs =


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vips -h` got 0 exit code
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vips --help` got 0 exit code
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vips help` got 0 exit code
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vips -v` and found version 8.6.3
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vips --version` and found version 8.6.3
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vipsedit --help` got 0 exit code
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vipsthumbnail -h` got 0 exit code
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vipsthumbnail --help` got 0 exit code
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vipsheader -h` got 0 exit code
- ran `/nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3/bin/vipsheader --help` got 0 exit code
- found 8.6.3 with grep in /nix/store/bp442wm5qgvy88dgyl1qa60jsp068yg4-vips-8.6.3

cc @kovirobi for review