### PR TITLE
vnstat: 1.17 -> 1.18

### DIFF
--- a/pkgs/applications/networking/vnstat/default.nix
+++ b/pkgs/applications/networking/vnstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "vnstat-${version}";
-  version = "1.17";
+  version = "1.18";
 
   src = fetchurl {
-    sha256 = "0wbrmb4zapblb3b61180ryqy6i0c7gcacqz0y3r1x7nafqswbr0q";
+    sha256 = "1mc7qqvrnl0zyhgh8n7wx1g1cbwq74xpvbz8rfjmyi77p693a6fp";
     url = "http://humdi.net/vnstat/${name}.tar.gz";
   };
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstat --help` got 0 exit code
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstat -v` and found version 1.18
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstat --version` and found version 1.18
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstat --help` and found version 1.18
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstati --help` got 0 exit code
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstati -v` and found version 1.18
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstati --version` and found version 1.18
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstati --help` and found version 1.18
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstatd --help` got 0 exit code
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstatd -v` and found version 1.18
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstatd --version` and found version 1.18
- ran `/nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18/bin/vnstatd --help` and found version 1.18
- found 1.18 with grep in /nix/store/zaidqa5gzm2wdfg0mrybj180k73jbkpq-vnstat-1.18