### PR TITLE
waf: 2.0.4 -> 2.0.6

### DIFF
--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "waf-${version}";
-  version = "2.0.4";
+  version = "2.0.6";
 
   src = fetchurl {
     url = "https://waf.io/waf-${version}.tar.bz2";
-    sha256 = "0zmnwgccq5j7ipfi2j0k5s40q27krp1m6v2bd650axgzdbpa7ain";
+    sha256 = "1wyl0jl10i0p2rj49sig5riyppgkqlkqmbvv35d5bqxri3y4r38q";
   };
 
   buildInputs = [ python2 ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.0.6 with grep in /nix/store/5rgayqfl64bn9pyrfsc9kcm2c4vdqybi-waf-2.0.6
- found 2.0.6 in filename of file in /nix/store/5rgayqfl64bn9pyrfsc9kcm2c4vdqybi-waf-2.0.6

cc @vrthra for review