### PR TITLE
xca: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/applications/misc/xca/default.nix
+++ b/pkgs/applications/misc/xca/default.nix
@@ -3,11 +3,11 @@
 
 mkDerivation rec {
   name = "xca-${version}";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/xca/${name}.tar.gz";
-    sha256 = "1gygj6kljj3r1y0pg67mks36vfcz4vizjsqnqdvrk6zlgqjbzm7z";
+    sha256 = "11niik2m4yswkp71hrdh54z5kgkvdg8y0b6wdqbrn6vy1n8gz63q";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.4.1 with grep in /nix/store/zbqzc6j7104bdpdmpxzj8i11dsxmp3h4-xca-1.4.1

cc @offlinehacker @peterhoeg for review