### PR TITLE
znc: 1.6.5 -> 1.6.6

### DIFF
--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -9,11 +9,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "znc-${version}";
-  version = "1.6.5";
+  version = "1.6.6";
 
   src = fetchurl {
     url = "http://znc.in/releases/archive/${name}.tar.gz";
-    sha256 = "1jia6kq6bp8yxfj02d5vj9vqb4pylqcldspyjj6iz82kkka2a0ig";
+    sha256 = "09cmsnxvi7jg9a0dicf60fxnxdff4aprw7h8vjqlj5ywf6y43f3z";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/z51kkm0wj1wv4bxkib8lv7nqizdly9jw-znc-1.6.6/bin/znc -h` got 0 exit code
- ran `/nix/store/z51kkm0wj1wv4bxkib8lv7nqizdly9jw-znc-1.6.6/bin/znc --help` got 0 exit code
- ran `/nix/store/z51kkm0wj1wv4bxkib8lv7nqizdly9jw-znc-1.6.6/bin/znc -v` and found version 1.6.6
- ran `/nix/store/z51kkm0wj1wv4bxkib8lv7nqizdly9jw-znc-1.6.6/bin/znc --version` and found version 1.6.6
- ran `/nix/store/z51kkm0wj1wv4bxkib8lv7nqizdly9jw-znc-1.6.6/bin/znc -h` and found version 1.6.6
- ran `/nix/store/z51kkm0wj1wv4bxkib8lv7nqizdly9jw-znc-1.6.6/bin/znc --help` and found version 1.6.6
- found 1.6.6 with grep in /nix/store/z51kkm0wj1wv4bxkib8lv7nqizdly9jw-znc-1.6.6

cc @viric @schneefux @lnl7 for review