### PR TITLE
pythonPackages.thumbor: fix build

### DIFF
--- a/pkgs/development/python-modules/thumbor/default.nix
+++ b/pkgs/development/python-modules/thumbor/default.nix
@@ -1,0 +1,54 @@
+{ buildPythonPackage, stdenv, tornado, pycrypto, pycurl, pytz
+, pillow, derpconf, python_magic, pexif, libthumbor, opencv, webcolors
+, piexif, futures, statsd, thumborPexif, fetchPypi, fetchpatch, isPy3k, lib
+}:
+
+buildPythonPackage rec {
+  pname = "thumbor";
+  version = "6.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0y9mf78j80vjh4y0xvgnybc1wqfcwm5s19xhsfgkn12hh8pmh14d";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/thumbor/thumbor/commit/4f2bc99451409e404f7fa0f3e4a3bdaea7b49869.patch";
+      sha256 = "0qqw1n1pfd8f8cn168718gzwf4b35j2j9ajyw643xpf92s0iq2cc";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace "setup.py" \
+      --replace '"argparse",' "" ${lib.optionalString isPy3k ''--replace '"futures",' ""''}
+  '';
+
+  propagatedBuildInputs = [
+    tornado
+    pycrypto
+    pycurl
+    pytz
+    pillow
+    derpconf
+    python_magic
+    pexif
+    libthumbor
+    opencv
+    webcolors
+    piexif
+    statsd
+  ] ++ lib.optionals (!isPy3k) [ futures thumborPexif ];
+
+  # disabled due to too many impure tests and issues with native modules in
+  # the pure testing environment. See https://github.com/NixOS/nixpkgs/pull/37147
+  # for further reference.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A smart imaging service";
+    homepage = https://github.com/thumbor/thumbor/wiki;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19011,51 +19011,7 @@ EOF
   };
 
 
-  thumbor = buildPythonPackage rec {
-    name = "thumbor-${version}";
-    version = "6.3.2";
-
-    disabled = ! isPy27;
-
-    buildInputs = with self; [ statsd nose ];
-
-    propagatedBuildInputs = with self; [
-      tornado
-      pycrypto
-      pycurl
-      pytz
-      pillow
-      derpconf
-      python_magic
-      # thumborPexif
-      pexif
-      libthumbor
-      opencv
-    ] ++ optionals (!isPy3k) [ futures ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/thumbor/${name}.tar.gz";
-      sha256 = "0787245x4yci34cdfc9xaxhds0lv60476qgp132pwa78hrpc9m31";
-    };
-
-    patches = [
-      (pkgs.fetchurl {
-          url = "https://github.com/thumbor/thumbor/commit/376f688a8a0b82e50388c885d9d733572f2eb3e6.patch";
-          sha256 = "1j2434yqb6pz61d65dsy8w6lvyzvh5ksizadi5hgjzfw6s46v6yn";
-      })
-    ];
-
-    prePatch = ''
-      substituteInPlace setup.py \
-        --replace '"argparse",' ""
-    '';
-
-    meta = {
-      description = "A smart imaging service";
-      homepage = https://github.com/globocom/thumbor/wiki;
-      license = licenses.mit;
-    };
-  };
+  thumbor = callPackage ../development/python-modules/thumbor { };
 
   thumborPexif = self.buildPythonPackage rec {
     name = "thumbor-pexif-0.14";


### PR DESCRIPTION
###### Motivation for this change

Origianlly the package was broken as bumping `pythonPackages.pillow` to
5.x broke `thumbor`. The latest upstream version `6.4.2` solved this
issue, so a simple package bump was sufficient.

Furthermore the following changes were made:

- moved the expression into its own file
- added myself as maintainer in case of any further breackage
- re-enabled python3 build: 6.4.2 is fine with python3, however the
  `futures` dependency can't be satisfied anymore as it's part of
  Python3. Therefore a patch for `setup.py` will be applied for Python3
  buildsto drop the dependency

Note: the testsuite is disabled for now as several impure tests are done
and our testing environment seems to be unable to work the with the
natively compiled python modules properly.

Therefore I tested the module using the following expression:

``` nix
with import ./. {};

stdenv.mkDerivation {
  name = "thumbor-test";
  src = null;
  buildInputs = [ python pythonPackages.thumbor ];
}
```

Inside this nix shell `thumbor` works fine and the native modules can be
imported.

See https://hydra.nixos.org/build/71062729/log
See ticket #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

