### PR TITLE
policycoreutils: build with gcc6

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13694,7 +13694,10 @@ with pkgs;
 
   pmtools = callPackage ../os-specific/linux/pmtools { };
 
-  policycoreutils = callPackage ../os-specific/linux/policycoreutils { };
+  policycoreutils = callPackage ../os-specific/linux/policycoreutils {
+    # v2.4 doesn't build with gcc7. remove this for v2.7
+    stdenv = overrideCC stdenv gcc6;
+  };
 
   powerdns = callPackage ../servers/dns/powerdns { };
 


### PR DESCRIPTION
###### Motivation for this change

Current version 2.4 doesn't build w/gcc7.
This fix is 18.03-only. On master, an update of all SELinux tools to v2.7 is being prepared (#36978)
/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

