### PR TITLE
gpx: init at 2.5.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1967,6 +1967,11 @@
     github = "leenaars";
     name = "Michiel Leenaars";
   };
+  leo60228 = {
+    email = "iakornfeld@gmail.com";
+    github = "leo60228";
+    name = "leo60228";
+  };
   leonardoce = {
     email = "leonardo.cecchi@gmail.com";
     github = "leonardoce";

--- a/pkgs/applications/misc/gpx/default.nix
+++ b/pkgs/applications/misc/gpx/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "gpx-${version}";
+  version = "2.5.2";
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  src = fetchFromGitHub {
+    owner = "markwal";
+    repo = "GPX";
+    rev = version;
+    sha256 = "1yab269x8qyf7rd04vaxyqyjv4pzz9lp4sc4dwh927k23avr3rw5";
+  };
+
+  meta = {
+    description = "Gcode to x3g conversion postprocessor";
+    homepage = https://github.com/markwal/GPX/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.leo60228 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15493,6 +15493,8 @@ with pkgs;
     gtk2 = gtk2-x11;
   };
 
+  gpx = callPackage ../applications/misc/gpx { };
+
   gqrx = qt5.callPackage ../applications/misc/gqrx { };
 
   gpx-viewer = callPackage ../applications/misc/gpx-viewer { };


### PR DESCRIPTION
###### Motivation for this change
I added GPX, a tool to convert Gcode to x3g files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] (N/A) Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] (N/A) Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

