### PR TITLE
splix: move to DRVs over PPDs

### DIFF
--- a/pkgs/misc/cups/drivers/splix/default.nix
+++ b/pkgs/misc/cups/drivers/splix/default.nix
@@ -1,7 +1,9 @@
-{ stdenv, fetchsvn, fetchurl, cups, zlib }:
+{ stdenv, fetchsvn, cups, zlib, jbigkit }:
+
 let rev = "315"; in
 stdenv.mkDerivation rec {
   name = "splix-svn-${rev}";
+
   src = fetchsvn {
     # We build this from svn, because splix hasn't been in released in several years
     # although the community has been adding some new printer models.
@@ -11,12 +13,17 @@ stdenv.mkDerivation rec {
   };
 
   preBuild = ''
-    makeFlags="V=1 DISABLE_JBIG=1 CUPSFILTER=$out/lib/cups/filter CUPSPPD=$out/share/cups/model"
+    makeFlags="$makeFlags CUPSFILTER=$out/lib/cups/filter CUPSDRV=$out/share/cups/drv"
   '';
 
-  buildInputs = [cups zlib];
+  buildFlags = [ "drv" "all" ];
+
+  makeFlags = [ "DRV_ONLY=1" ];
+
+  buildInputs = [ cups zlib jbigkit ];
 
   meta = {
+    description = "CUPS drivers for SPL (Samsung Printer Language) printers";
     homepage = http://splix.sourceforge.net;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.peti ];


### PR DESCRIPTION
###### Motivation for this change

Install .drvs instead of .ppds for CUPS to generate PPDs by itself. Hopefully fixes #36876.

Also enable JBIG support for newer printers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@husnoo Can you test if this fixes the issue for you? Probably you'll need to:

1. Remove your printer;
2. Verify that adding it again doesn't work (prints garbage) to ensure your fixed PPD is gone;
3. Remove printer;
4. Apply this patch to nixpkgs and `nixos-rebuild switch`;
5. Add the printer and see if it works.

@peti I was able to add a bogus Samsung ML-2160 printer into CUPS (using a fake IPP URL). Generated PPD looks okay. Can you try to reproduce this? Maybe you have something unusual in your CUPS configuration?