### PR TITLE
alembic: 1.7.5 -> 1.7.6

### DIFF
--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec
 {
   name = "alembic-${version}";
-  version = "1.7.5";
+  version = "1.7.6";
 
   src = fetchFromGitHub {
     owner = "alembic";
     repo = "alembic";
     rev = "${version}";
-    sha256 = "1p5zd9kdwnrwg604bq79ianc5bw6mx6i5d7yc4r11xrbphlc9m1g";
+    sha256 = "0vz7pda7n50d490vv9i044xpi8rhrvs6qxcapwd49wzwrvkg67dk";
   };
 
   outputs = [ "bin" "dev" "out" "lib" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/lq17m55g4javshd8v5qlw3mmcpcy6zc4-alembic-1.7.6-bin/bin/abcls -h` got 0 exit code
- ran `/nix/store/lq17m55g4javshd8v5qlw3mmcpcy6zc4-alembic-1.7.6-bin/bin/abcls --help` got 0 exit code
- ran `/nix/store/lq17m55g4javshd8v5qlw3mmcpcy6zc4-alembic-1.7.6-bin/bin/abcls help` got 0 exit code
- ran `/nix/store/lq17m55g4javshd8v5qlw3mmcpcy6zc4-alembic-1.7.6-bin/bin/abctree -h` got 0 exit code
- ran `/nix/store/lq17m55g4javshd8v5qlw3mmcpcy6zc4-alembic-1.7.6-bin/bin/abctree --help` got 0 exit code
- ran `/nix/store/lq17m55g4javshd8v5qlw3mmcpcy6zc4-alembic-1.7.6-bin/bin/abcconvert --help` got 0 exit code
- found 1.7.6 with grep in /nix/store/lq17m55g4javshd8v5qlw3mmcpcy6zc4-alembic-1.7.6-bin

cc @guibou for review