### PR TITLE
archivemount: 0.8.7 -> 0.8.9

### DIFF
--- a/pkgs/tools/filesystems/archivemount/default.nix
+++ b/pkgs/tools/filesystems/archivemount/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, pkgconfig, fuse, libarchive }:
 
 let
-  name = "archivemount-0.8.7";
+  name = "archivemount-0.8.9";
 in
 stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
     url = "http://www.cybernoia.de/software/archivemount/${name}.tar.gz";
-    sha256 = "1diiw6pnlnrnikn6l5ld92dx59lhrxjlqms8885vwbynsjl5q127";
+    sha256 = "0v4si1ri6lhnq9q87gkx7fsh6lv6xz4bynknwndqncpvfp5cy1jg";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/sn92kb7bgpg6arj6jfgg7yv78ap2fkll-archivemount-0.8.9/bin/archivemount -V` and found version 0.8.9
- ran `/nix/store/sn92kb7bgpg6arj6jfgg7yv78ap2fkll-archivemount-0.8.9/bin/archivemount --version` and found version 0.8.9
- found 0.8.9 with grep in /nix/store/sn92kb7bgpg6arj6jfgg7yv78ap2fkll-archivemount-0.8.9