### PR TITLE
atlas: 3.10.2 -> 3.10.3

### DIFF
--- a/pkgs/development/libraries/science/math/atlas/default.nix
+++ b/pkgs/development/libraries/science/math/atlas/default.nix
@@ -45,7 +45,7 @@
 
 let
   inherit (stdenv.lib) optional optionalString;
-  version = "3.10.2";
+  version = "3.10.3";
 in
 
 stdenv.mkDerivation {
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/math-atlas/atlas${version}.tar.bz2";
-    sha256 = "0bqh4bdnjdyww4mcpg6kn0x7338mfqbdgysn97dzrwwb26di7ars";
+    sha256 = "1dyjlq3fiparvm8ypwk6rsmjzmnwk81l88gkishphpvc79ryp216";
   };
 
   buildInputs = [ gfortran ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.10.3 with grep in /nix/store/79z1zd6ydm6b7x6xbf8b908iirah8hqn-atlas-3.10.3

cc @ttuegel for review