### PR TITLE
aws-sdk-cpp: 1.3.22 -> 1.4.10

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -15,13 +15,13 @@ let
         else throw "Unsupported system!";
 in stdenv.mkDerivation rec {
   name = "aws-sdk-cpp-${version}";
-  version = "1.3.22";
+  version = "1.4.10";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-sdk-cpp";
     rev = version;
-    sha256 = "0sdgy8kqhxnw7n0sw4m3p3ay7yic3rhad5ab8m5lbx61ad9bq3c2";
+    sha256 = "0gw0ph6v2w4zqmixqfw5ab08c0r3d7iy2z1hll5pydlp5vwfmn7g";
   };
 
   # FIXME: might be nice to put different APIs in different outputs


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.4.10 with grep in /nix/store/qb91mvvbzd45xcnd640m0wq8z915d257-aws-sdk-cpp-1.4.10

cc @edolstra for review