### PR TITLE
backintime-common: 1.1.12 -> 1.1.24

### DIFF
--- a/pkgs/applications/networking/sync/backintime/common.nix
+++ b/pkgs/applications/networking/sync/backintime/common.nix
@@ -3,7 +3,7 @@
 let
   inherit (python3Packages) python dbus-python keyring;
 in stdenv.mkDerivation rec {
-  version = "1.1.12";
+  version = "1.1.24";
 
   name = "backintime-common-${version}";
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
     owner = "bit-team";
     repo = "backintime";
     rev = "v${version}";
-    sha256 = "0n3x48wa8aa7i8fff85h3b5h3xpabk51ld0ymy3pkqh0krfgs59a";
+    sha256 = "0g6gabnr60ns8854hijdddbanks7319q4n3fj5l6rc4xsq0qck18";
   };
 
   buildInputs = [ makeWrapper gettext python dbus-python keyring openssh cron rsync sshfs-fuse encfs ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/8dj6mrs62z7z7d42v0jwcwz7k46i927i-backintime-common-1.1.24/bin/backintime -h` got 0 exit code
- ran `/nix/store/8dj6mrs62z7z7d42v0jwcwz7k46i927i-backintime-common-1.1.24/bin/backintime --help` got 0 exit code
- ran `/nix/store/8dj6mrs62z7z7d42v0jwcwz7k46i927i-backintime-common-1.1.24/bin/backintime -v` and found version 1.1.24
- ran `/nix/store/8dj6mrs62z7z7d42v0jwcwz7k46i927i-backintime-common-1.1.24/bin/backintime --version` and found version 1.1.24
- found 1.1.24 with grep in /nix/store/8dj6mrs62z7z7d42v0jwcwz7k46i927i-backintime-common-1.1.24