### PR TITLE
buildbot-worker: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/build-managers/buildbot/worker.nix
+++ b/pkgs/development/tools/build-managers/buildbot/worker.nix
@@ -3,11 +3,11 @@
 pythonPackages.buildPythonApplication (rec {
   name = "${pname}-${version}";
   pname = "buildbot-worker";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "0ws31ypmksah1c83h4npwg560p8v7n9j6l94p79y5pispjsgzqzl";
+    sha256 = "0hpiawf0dq8phsvihlcx9bpl70n7s3rhcgbgma36bark6sgr4y8y";
   };
 
   buildInputs = with pythonPackages; [ setuptoolsTrial mock ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/y8nbk5hk9d291bgwi1aag83z01w1l04i-buildbot-worker-1.1.0/bin/.buildbot-worker-wrapped --help` got 0 exit code
- ran `/nix/store/y8nbk5hk9d291bgwi1aag83z01w1l04i-buildbot-worker-1.1.0/bin/.buildbot-worker-wrapped --version` and found version 1.1.0
- ran `/nix/store/y8nbk5hk9d291bgwi1aag83z01w1l04i-buildbot-worker-1.1.0/bin/buildbot-worker --help` got 0 exit code
- ran `/nix/store/y8nbk5hk9d291bgwi1aag83z01w1l04i-buildbot-worker-1.1.0/bin/buildbot-worker --version` and found version 1.1.0
- found 1.1.0 with grep in /nix/store/y8nbk5hk9d291bgwi1aag83z01w1l04i-buildbot-worker-1.1.0

cc @nand0p @ryansydnor for review