### PR TITLE
cgal: 4.11 -> 4.11.1

### DIFF
--- a/pkgs/development/libraries/CGAL/default.nix
+++ b/pkgs/development/libraries/CGAL/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, boost, gmp, mpfr }:
 
 stdenv.mkDerivation rec {
-  version = "4.11";
+  version = "4.11.1";
   name = "cgal-" + version;
 
   src = fetchFromGitHub {
     owner = "CGAL";
     repo = "releases";
     rev = "CGAL-${version}";
-    sha256 = "126r06aba5h8l73xmm5mwmxkir7sy122jn2j18cd4gz3z9p23npr";
+    sha256 = "04nn1lzsjdglzjygc72cq09xrvpqwwnbf6l0xz8bfwfp4x9g10jf";
   };
 
   # note: optional component libCGAL_ImageIO would need zlib and opengl;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/prp059sdh2cfi1n6m1y43w7hf33ixs7x-cgal-4.11.1/bin/cgal_create_CMakeLists -h` got 0 exit code
- ran `/nix/store/prp059sdh2cfi1n6m1y43w7hf33ixs7x-cgal-4.11.1/bin/cgal_create_CMakeLists help` got 0 exit code
- ran `/nix/store/prp059sdh2cfi1n6m1y43w7hf33ixs7x-cgal-4.11.1/bin/cgal_create_cmake_script -h` got 0 exit code
- ran `/nix/store/prp059sdh2cfi1n6m1y43w7hf33ixs7x-cgal-4.11.1/bin/cgal_create_cmake_script --help` got 0 exit code
- found 4.11.1 with grep in /nix/store/prp059sdh2cfi1n6m1y43w7hf33ixs7x-cgal-4.11.1

cc @7c6f434c for review