### PR TITLE
dehydrated: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/tools/admin/dehydrated/default.nix
+++ b/pkgs/tools/admin/dehydrated/default.nix
@@ -1,7 +1,7 @@
 { stdenv, bash, coreutils, curl, diffutils, gawk, gnugrep, gnused, openssl, makeWrapper, fetchFromGitHub }:
 let
   pkgName = "dehydrated";
-  version = "0.5.0";
+  version = "0.6.0";
 in
 stdenv.mkDerivation rec {
   name = pkgName + "-" + version;
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "lukas2511";
     repo = "dehydrated";
     rev = "v${version}";
-    sha256 = "0ysfsz1ny3gcc4r9szrr09dg63zd7ppv6aih13wmai806yapwxrr";
+    sha256 = "1ybxfmvr24lxl0n5f88bkzww9g0z5s7qkskj2d66fd8knjfrk73r";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0/bin/dehydrated -h` got 0 exit code
- ran `/nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0/bin/dehydrated --help` got 0 exit code
- ran `/nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0/bin/dehydrated -h` and found version 0.6.0
- ran `/nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0/bin/dehydrated --help` and found version 0.6.0
- ran `/nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0/bin/.dehydrated-wrapped -h` got 0 exit code
- ran `/nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0/bin/.dehydrated-wrapped --help` got 0 exit code
- ran `/nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0/bin/.dehydrated-wrapped -h` and found version 0.6.0
- ran `/nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0/bin/.dehydrated-wrapped --help` and found version 0.6.0
- found 0.6.0 with grep in /nix/store/i596g294cbwbmz27x89j79kr2lspplbc-dehydrated-0.6.0