### PR TITLE
dhcpcd: 6.11.5 -> 7.0.1

### DIFF
--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   # when updating this to >=7, check, see previous reverts:
   # nix-build -A nixos.tests.networking.scripted.macvlan.x86_64-linux nixos/release-combined.nix
-  name = "dhcpcd-6.11.5";
+  name = "dhcpcd-7.0.1";
 
   src = fetchurl {
     url = "mirror://roy/dhcpcd/${name}.tar.xz";
-    sha256 = "17nnhxmbdcc7k2mh6sgvxisqcqbic5540xbig363ds97gvf795kg";
+    sha256 = "1j7kyg9gm5d1k6qjdscjz2rjgpqia0dxgk69lswp21y0pizm6dlb";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/r7s5qas1qb192iqsgg98ksjdrlila4qh-dhcpcd-7.0.1/bin/dhcpcd --help` got 0 exit code
- ran `/nix/store/r7s5qas1qb192iqsgg98ksjdrlila4qh-dhcpcd-7.0.1/bin/dhcpcd --version` and found version 7.0.1
- found 7.0.1 with grep in /nix/store/r7s5qas1qb192iqsgg98ksjdrlila4qh-dhcpcd-7.0.1

cc @edolstra @fpletz for review