### PR TITLE
dnscrypt-wrapper: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/tools/networking/dnscrypt-wrapper/default.nix
+++ b/pkgs/tools/networking/dnscrypt-wrapper/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "dnscrypt-wrapper-${version}";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "Cofyc";
     repo = "dnscrypt-wrapper";
     rev = "v${version}";
-    sha256 = "121y93sb06qc50fj7vv47r6dpzv77hh7ywl7sgrfp8i4jf4kaspa";
+    sha256 = "187sq99zxdfv3xhq939rybb0pps3l6wgyyvbj3zns5jr6mms64vd";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/a48lz2a4vrs617kqdhwdiyjwjanfg0pq-dnscrypt-wrapper-0.4.1/bin/dnscrypt-wrapper -h` got 0 exit code
- ran `/nix/store/a48lz2a4vrs617kqdhwdiyjwjanfg0pq-dnscrypt-wrapper-0.4.1/bin/dnscrypt-wrapper --help` got 0 exit code
- ran `/nix/store/a48lz2a4vrs617kqdhwdiyjwjanfg0pq-dnscrypt-wrapper-0.4.1/bin/dnscrypt-wrapper -v` and found version 0.4.1
- ran `/nix/store/a48lz2a4vrs617kqdhwdiyjwjanfg0pq-dnscrypt-wrapper-0.4.1/bin/dnscrypt-wrapper --version` and found version 0.4.1
- found 0.4.1 with grep in /nix/store/a48lz2a4vrs617kqdhwdiyjwjanfg0pq-dnscrypt-wrapper-0.4.1

cc @joachifm for review