### PR TITLE
drumkv1: 0.8.6 -> 0.9.0

### DIFF
--- a/pkgs/applications/audio/drumkv1/default.nix
+++ b/pkgs/applications/audio/drumkv1/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "drumkv1-${version}";
-  version = "0.8.6";
+  version = "0.9.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/drumkv1/${name}.tar.gz";
-    sha256 = "0fwxrfyp15a4m77mzz4mwj36mhdrj646whlrkvcys33p2w75f8cq";
+    sha256 = "1vm8lrk3lykdic6fyfpl12jx1xg6rcaid242s8sij30p1ix4zdab";
   };
 
   buildInputs = [ libjack2 alsaLib libsndfile liblo lv2 qt5.qtbase qt5.qttools ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.0 with grep in /nix/store/an15ybvqbh12vslgbsv3422mjkvcvsws-drumkv1-0.9.0
- found 0.9.0 in filename of file in /nix/store/an15ybvqbh12vslgbsv3422mjkvcvsws-drumkv1-0.9.0

cc @cillianderoiste for review