### PR TITLE
eccodes: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -6,11 +6,11 @@
 with stdenv.lib; 
 stdenv.mkDerivation rec {
   name = "eccodes-${version}";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src = fetchurl {
     url = "https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-${version}-Source.tar.gz";
-    sha256 = "0pzibd3vdqmqsqsnfir6q66p6f3cmr9hrrixzpfhf7k62vv9y1ha";
+    sha256 = "0slfim64wdyd97nwv7ry0xwhiarphl93ij2v19c8a1c0dz7ld3qi";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/codes_info -v` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_histogram -h` got 0 exit code
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_histogram --help` got 0 exit code
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_filter -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_ls -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_dump -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_merge -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib2ppm -h` got 0 exit code
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib2ppm --help` got 0 exit code
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_set -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_get -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_get_data -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_copy -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_compare -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_index_build help` got 0 exit code
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_index_build -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_ls -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_dump -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_set -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_get -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_copy -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_compare -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_index_build help` got 0 exit code
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_index_build -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/gts_get -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/gts_compare -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/gts_copy -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/gts_dump -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/gts_filter -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/gts_ls -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/metar_dump -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/metar_ls -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/metar_compare -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/metar_get -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/metar_filter -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/metar_copy -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/grib_to_netcdf -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/codes_bufr_filter -V` and found version 2.7.0
- ran `/nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0/bin/bufr_filter -V` and found version 2.7.0
- found 2.7.0 with grep in /nix/store/bfvhxcjlapkmg74v72z65csmqbpdy3fx-eccodes-2.7.0

cc @knedlsepp for review