### PR TITLE
trayer: 1.1.7 -> 1.1.8

### DIFF
--- a/pkgs/applications/window-managers/trayer/default.nix
+++ b/pkgs/applications/window-managers/trayer/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, gdk_pixbuf, gtk2 }:
 
 stdenv.mkDerivation rec {
-  name = "trayer-1.1.7";
+  name = "trayer-1.1.8";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gdk_pixbuf gtk2 ];
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "sargon";
     repo = "trayer-srg";
     rev = name;
-    sha256 = "06lpgralggh5546qgvpilzxh4anshli2za41x68x2zbaizyqb09a";
+    sha256 = "1mvhwaqa9bng9wh3jg3b7y8gl7nprbydmhg963xg0r076jyzv0cg";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
New trayer version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

