### PR TITLE
feh: 2.25 -> 2.25.1

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -6,11 +6,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "feh-${version}";
-  version = "2.25";
+  version = "2.25.1";
 
   src = fetchurl {
     url = "https://feh.finalrewind.org/${name}.tar.bz2";
-    sha256 = "102rwi30n09l8rih6kv6bb7lhv3djklgzill4p2zag0h700yqfq6";
+    sha256 = "197sm78bm33dvahr5nxqkbmpmdn4b13ahc9mrgn1l7n104bg4phc";
   };
 
   outputs = [ "out" "man" "doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1/bin/feh -h` got 0 exit code
- ran `/nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1/bin/feh --help` got 0 exit code
- ran `/nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1/bin/feh -v` and found version 2.25.1
- ran `/nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1/bin/feh --version` and found version 2.25.1
- ran `/nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1/bin/.feh-wrapped -h` got 0 exit code
- ran `/nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1/bin/.feh-wrapped --help` got 0 exit code
- ran `/nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1/bin/.feh-wrapped -v` and found version 2.25.1
- ran `/nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1/bin/.feh-wrapped --version` and found version 2.25.1
- found 2.25.1 with grep in /nix/store/cyjk3r8pig6cypvfv4fwx888ml4zd4vs-feh-2.25.1
- directory tree listing: https://gist.github.com/6fb1817519334ef951e6661a3c41dda6

cc @viric @willibutz for review