### PR TITLE
spice-gtk: fix symlink errors, add withPolkit option

### DIFF
--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,8 +1,29 @@
 { stdenv, fetchurl, pkgconfig, spice-protocol, gettext, celt_0_5_1
 , openssl, libpulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
 , cyrus_sasl, python2Packages, autoreconfHook, usbredir, libsoup
-, polkit, acl, usbutils, vala
-, gtk3, epoxy }:
+, withPolkit ? true, polkit, acl, usbutils
+, vala, gtk3, epoxy }:
+
+# If this package is built with polkit support (withPolkit=true),
+# usb redirection reqires spice-client-glib-usb-acl-helper to run setuid root.
+# The helper confirms via polkit that the user has an active session,
+# then adds a device acl entry for that user.
+# Example NixOS config to create a setuid wrapper for the helper:
+# security.wrappers.spice-client-glib-usb-acl-helper.source =
+#   "${pkgs.spice-gtk}/bin/spice-client-glib-usb-acl-helper";
+# On non-NixOS installations, make a setuid copy of the helper
+# outside the store and adjust PATH to find the setuid version.
+
+# If this package is built without polkit support (withPolkit=false),
+# usb redirection requires read-write access to usb devices.
+# This can be granted by adding users to a custom group like "usb"
+# and using a udev rule to put all usb devices in that group.
+# Example NixOS config:
+#  users.groups.usb = {};
+#  users.users.dummy.extraGroups = [ "usb" ];
+#  services.udev.extraRules = ''
+#    KERNEL=="*", SUBSYSTEMS=="usb", MODE="0664", GROUP="usb"
+#  '';
 
 with stdenv.lib;
 
@@ -18,11 +39,16 @@ in stdenv.mkDerivation rec {
     sha256 = "1vknp72pl6v6nf3dphhwp29hk6gv787db2pmyg4m312z2q0hwwp9";
   };
 
+  postPatch = ''
+    # get rid of absolute path to helper in store so we can use a setuid wrapper
+    substituteInPlace src/usb-acl-helper.c \
+      --replace 'ACL_HELPER_PATH"/' '"'
+  '';
+
   buildInputs = [
     spice-protocol celt_0_5_1 openssl libpulseaudio pixman
     libjpeg_turbo zlib cyrus_sasl python pygtk usbredir gtk3 epoxy
-    polkit acl usbutils
-  ];
+  ] ++ optionals withPolkit [ polkit acl usbutils ] ;
 
   nativeBuildInputs = [ pkgconfig gettext libsoup autoreconfHook vala gobjectIntrospection ];
 
@@ -33,16 +59,6 @@ in stdenv.mkDerivation rec {
     "--enable-introspection"
     "--enable-vala"
   ];
-
-  # usb redirection needs spice-client-glib-usb-acl-helper to run setuid root
-  # the helper then uses polkit to check access
-  # in nixos, enable this with
-  # security.wrappers.spice-client-glib-usb-acl-helper.source =
-  #   "${pkgs.spice_gtk}/bin/spice-client-glib-usb-acl-helper.real";
-  postFixup = ''
-    mv $out/bin/spice-client-glib-usb-acl-helper $out/bin/spice-client-glib-usb-acl-helper.real
-    ln -sf /run/wrappers/bin/spice-client-glib-usb-acl-helper $out/bin/spice-client-glib-usb-acl-helper
-  '';
 
   dontDisableStatic = true; # Needed by the coroutine test
 


### PR DESCRIPTION
###### Motivation for this change

Fix bugs due to broken symlinks that were introduced by #35214. 
Make polkit support, which was added in #35214 and requires a setuid helper, optional but enabled by default. Add documentation.
Fixes #36533, #37110.

Please backport to 18.03.  /cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

