### PR TITLE
fluidsynth: 1.1.9 -> 1.1.10

### DIFF
--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation  rec {
   name = "fluidsynth-${version}";
-  version = "1.1.9";
+  version = "1.1.10";
 
   src = fetchFromGitHub {
     owner = "FluidSynth";
     repo = "fluidsynth";
     rev = "v${version}";
-    sha256 = "0krvmb1idnf95l2ydzfcb08ayyx3n4m71hf9fgwv3srzaikvpf3q";
+    sha256 = "04jlgq1d1hd8r9cnmkl3lgf1fgm7kgy4hh9nfddap41fm1wp121p";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth -h` got 0 exit code
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth --help` got 0 exit code
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth help` got 0 exit code
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth -V` and found version 1.1.10
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth -v` and found version 1.1.10
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth --version` and found version 1.1.10
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth version` and found version 1.1.10
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth -h` and found version 1.1.10
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth --help` and found version 1.1.10
- ran `/nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10/bin/fluidsynth help` and found version 1.1.10
- found 1.1.10 with grep in /nix/store/23kh3gax6a023mi2r3q31fd1mixa1k14-fluidsynth-1.1.10
- directory tree listing: https://gist.github.com/fbd821b325f18bdbc65812caeb1e0ecc

cc @cillianderoiste @lovek323 for review