### PR TITLE
glib: 2.54.3 -> 2.56.0

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -42,7 +42,7 @@ let
     ln -sr -t "''${!outputInclude}/include/" "''${!outputInclude}"/lib/*/include/* 2>/dev/null || true
   '';
 
-  version = "2.54.3";
+  version = "2.56.0";
 in
 
 stdenv.mkDerivation rec {
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "963fdc6685dc3da8e5381dfb9f15ca4b5709b28be84d9d05a9bb8e446abac0a8";
+    sha256 = "1iqgi90fmpl3l23jm2iv44qp7hqsxvnv7978s18933bvx4bnxvzc";
   };
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.56.0 with grep in /nix/store/dqlc8y4phlg1hmdbwkhqfwhnxcac88d1-glib-2.56.0
- directory tree listing: https://gist.github.com/4db1d66f41a35f3981a18a10f12ea935

cc @lovek323 @7c6f434c for review