### PR TITLE
libtins: init at 3.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1256,6 +1256,11 @@
     github = "fare";
     name = "Francois-Rene Rideau";
   };
+  fdns = {
+    email = "fdns02@gmail.com";
+    github = "fdns";
+    name = "Felipe Espinoza";
+  };
   fgaz = {
     email = "francygazz@gmail.com";
     github = "fgaz";

--- a/pkgs/development/libraries/libtins/default.nix
+++ b/pkgs/development/libraries/libtins/default.nix
@@ -1,0 +1,43 @@
+{ boost, cmake, fetchFromGitHub, gtest, libpcap, openssl, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "libtins-${version}";
+  version = "3.5";
+  
+  src = fetchFromGitHub {
+    owner = "mfontanini";
+    repo = "libtins";
+    rev = "v${version}";
+    sha256 = "00d1fxyg8q6djljm79ms69gcrsqxxksny3b16v99bzf3aivfss5x";
+  };
+
+  postPatch = ''
+    rm -rf googletest
+    cp -r ${gtest.src}/googletest googletest
+    chmod -R a+w googletest
+  '';
+
+  nativeBuildInputs = [ cmake gtest ];
+  buildInputs = [
+    openssl
+    libpcap
+    boost
+  ];
+
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--with-boost=${boost.dev}"
+  ];
+
+  enableParallelBuilding = true;
+  doCheck = true;
+  checkPhase = "make tests && LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib make test";
+
+  meta = with stdenv.lib; {
+    description = "High-level, multiplatform C++ network packet sniffing and crafting library";
+    homepage = https://libtins.github.io/;
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = with maintainers; [ fdns ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3392,6 +3392,8 @@ with pkgs;
 
   libtirpc = callPackage ../development/libraries/ti-rpc { };
 
+  libtins = callPackage ../development/libraries/libtins { };
+
   libshout = callPackage ../development/libraries/libshout { };
 
   libqb = callPackage ../development/libraries/libqb { };


### PR DESCRIPTION
###### Motivation for this change
Adding library required for pushing https://github.com/dns-stats/compactor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---