### PR TITLE
zoom-us: add desktop item

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -59,7 +59,7 @@ in stdenv.mkDerivation {
   ];
 
   installPhase = ''
-    $preInstallHooks
+    runHook preInstall
 
     packagePath=$out/share/zoom-us
     mkdir -p $packagePath

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, system, makeWrapper,
+{ stdenv, fetchurl, system, makeWrapper, makeDesktopItem,
   alsaLib, dbus, glib, gstreamer, fontconfig, freetype, libpulseaudio, libxml2,
   libxslt, libGLU_combined, nspr, nss, sqlite, utillinux, zlib, xorg, udev, expat, libv4l }:
 
@@ -88,8 +88,18 @@ in stdenv.mkDerivation {
     Prefix = $packagePath
     EOF
 
-    $postInstallHooks
+    runHook postInstall
   '';
+
+  postInstall = (makeDesktopItem {
+    name = "zoom-us";
+    exec = "$out/bin/zoom-us %U";
+    icon = "$out/share/zoom-us/application-x-zoom.png";
+    desktopName = "Zoom";
+    genericName = "Video Conference";
+    categories = "Network;Application;";
+    mimeType = "x-scheme-handler/zoommtg;";
+  }).buildCommand;
 
   meta = {
     homepage = https://zoom.us/;


### PR DESCRIPTION
###### Motivation for this change
This allows launching with desktop application launchers and also xdg-open for `zoommtg://...` links.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

