### PR TITLE
gnustep-make: 2.6.8 -> 2.7.0

### DIFF
--- a/pkgs/desktops/gnustep/make/default.nix
+++ b/pkgs/desktops/gnustep/make/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, clang, which, libobjc }:
 
 let
-  version = "2.6.8";
+  version = "2.7.0";
 in
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-make-${version}.tar.gz";
-    sha256 = "0r00439f7vrggdwv60n8p626gnyymhq968i5x9ad2i4v6g8x4gk0";
+    sha256 = "1khiygfkz0zhh9b5nybn40g0xnnjxchk24n49hff1bwanszir84h";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/9bilynlmzsc8z4wv6qjpgz983r434yad-gnustep-make-2.7.0/bin/gnustep-tests -h` got 0 exit code
- ran `/nix/store/9bilynlmzsc8z4wv6qjpgz983r434yad-gnustep-make-2.7.0/bin/gnustep-tests --help` got 0 exit code
- ran `/nix/store/9bilynlmzsc8z4wv6qjpgz983r434yad-gnustep-make-2.7.0/bin/gnustep-tests -h` and found version 2.7.0
- ran `/nix/store/9bilynlmzsc8z4wv6qjpgz983r434yad-gnustep-make-2.7.0/bin/gnustep-tests --help` and found version 2.7.0
- ran `/nix/store/9bilynlmzsc8z4wv6qjpgz983r434yad-gnustep-make-2.7.0/bin/openapp --help` got 0 exit code
- ran `/nix/store/9bilynlmzsc8z4wv6qjpgz983r434yad-gnustep-make-2.7.0/bin/opentool --help` got 0 exit code
- ran `/nix/store/9bilynlmzsc8z4wv6qjpgz983r434yad-gnustep-make-2.7.0/bin/gnustep-config --help` got 0 exit code
- found 2.7.0 with grep in /nix/store/9bilynlmzsc8z4wv6qjpgz983r434yad-gnustep-make-2.7.0
- directory tree listing: https://gist.github.com/30c82119c95760404469e4a1fcfa0d8d

cc @ashalkhakov @matthewbauer for review