### PR TITLE
gp2c: 0.0.10 -> 0.0.10pl1

### DIFF
--- a/pkgs/applications/science/math/pari/gp2c.nix
+++ b/pkgs/applications/science/math/pari/gp2c.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
 
   name = "gp2c-${version}";
-  version = "0.0.10";
+  version = "0.0.10pl1";
 
   src = fetchurl {
     url = "http://pari.math.u-bordeaux.fr/pub/pari/GP2C/${name}.tar.gz";
-    sha256 = "1xhpz5p81iw261ay1kip283ggr0ir8ydz8qx3v24z8jfms1r3y70";
+    sha256 = "16hgmdvzxbmv63x1f72q1xgfyh0qhx7kaf9nbaamy0gdawxjxcav";
   };
 
   buildInputs = [ pari perl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/phmgqwmf0fa3q2d62zq220zpgi64hssj-gp2c-0.0.10pl1/bin/gp2c -h` got 0 exit code
- ran `/nix/store/phmgqwmf0fa3q2d62zq220zpgi64hssj-gp2c-0.0.10pl1/bin/gp2c -v` and found version 0.0.10pl1
- ran `/nix/store/phmgqwmf0fa3q2d62zq220zpgi64hssj-gp2c-0.0.10pl1/bin/gp2c -h` and found version 0.0.10pl1
- ran `/nix/store/phmgqwmf0fa3q2d62zq220zpgi64hssj-gp2c-0.0.10pl1/bin/gp2c-run -h` got 0 exit code
- ran `/nix/store/phmgqwmf0fa3q2d62zq220zpgi64hssj-gp2c-0.0.10pl1/bin/gp2c-run --help` got 0 exit code
- ran `/nix/store/phmgqwmf0fa3q2d62zq220zpgi64hssj-gp2c-0.0.10pl1/bin/gp2c-run -h` and found version 0.0.10pl1
- ran `/nix/store/phmgqwmf0fa3q2d62zq220zpgi64hssj-gp2c-0.0.10pl1/bin/gp2c-run --help` and found version 0.0.10pl1
- found 0.0.10pl1 with grep in /nix/store/phmgqwmf0fa3q2d62zq220zpgi64hssj-gp2c-0.0.10pl1
- directory tree listing: https://gist.github.com/27f1364bf90110b801070fcb28c64e0e

cc @AndersonTorres for review