### PR TITLE
gsettings-desktop-schemas: 3.24.1 -> 3.28.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/gsettings-desktop-schemas/default.nix
+++ b/pkgs/desktops/gnome-3/core/gsettings-desktop-schemas/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gsettings-desktop-schemas-${version}";
-  version = "3.24.1";
+  version = "3.28.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gsettings-desktop-schemas/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "76a3fa309f9de6074d66848987214f0b128124ba7184c958c15ac78a8ac7eea7";
+    sha256 = "0rwidacwrxlc54x90h9g3wx2zlisc4vm49vmxi15azmpj1vwvd2c";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.28.0 with grep in /nix/store/ml3fmcwy1k46bvr4109w5kcgb5598avs-gsettings-desktop-schemas-3.28.0
- directory tree listing: https://gist.github.com/45d02fd1581d000190298d033663f250

cc @lethalman @jtojnar for review