### PR TITLE
arrow-cpp: init at 0.8.0

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, symlinkJoin, fetchurl, boost, brotli, cmake, flatbuffers, gtest, gflags, lz4, rapidjson, snappy, zlib, zstd }:
+{ stdenv, symlinkJoin, fetchurl, boost, brotli, cmake, flatbuffers, gtest, gflags, lz4, pythonPackages, rapidjson, snappy, zlib, zstd }:
 
 stdenv.mkDerivation rec {
   name = "arrow-cpp-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "apache-arrow-${version}/cpp";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ boost ];
+  buildInputs = [ boost pythonPackages.python pythonPackages.numpy ];
 
   preConfigure = ''
     substituteInPlace cmake_modules/FindBrotli.cmake --replace CMAKE_STATIC_LIBRARY CMAKE_SHARED_LIBRARY
@@ -29,6 +29,10 @@ stdenv.mkDerivation rec {
   SNAPPY_HOME = symlinkJoin { name="snappy-wrap"; paths = [ snappy snappy.dev ]; };
   ZLIB_HOME = symlinkJoin { name="zlib-wrap"; paths = [ zlib.dev zlib.static ]; };
   ZSTD_HOME = zstd;
+
+  cmakeFlags = [
+    "-DARROW_PYTHON=ON"
+  ];
 
   meta = {
     description = "A  cross-language development platform for in-memory data";

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "arrow-cpp-${version}";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchurl {
     url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "1i79sh9ip32agbrn4n51pjn9266i45s8spk5jsi8ax0hqy1vhhmi";
+    sha256 = "16l91fixb5dgx3v6xc73ipn1w1hjgbmijyvs81j7ywzpna2cdcdy";
   };
 
   sourceRoot = "apache-arrow-${version}/cpp";

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, symlinkJoin, fetchurl, boost, brotli, cmake, flatbuffers, gtest, gflags, lz4, rapidjson, snappy, zlib, zstd }:
+
+stdenv.mkDerivation rec {
+  name = "arrow-cpp-${version}";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
+    sha256 = "1i79sh9ip32agbrn4n51pjn9266i45s8spk5jsi8ax0hqy1vhhmi";
+  };
+
+  sourceRoot = "apache-arrow-${version}/cpp";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost ];
+
+  preConfigure = ''
+    substituteInPlace cmake_modules/FindBrotli.cmake --replace CMAKE_STATIC_LIBRARY CMAKE_SHARED_LIBRARY
+    substituteInPlace cmake_modules/FindLz4.cmake --replace CMAKE_STATIC_LIBRARY CMAKE_SHARED_LIBRARY
+    substituteInPlace cmake_modules/FindSnappy.cmake --replace CMAKE_STATIC_LIBRARY CMAKE_SHARED_LIBRARY
+  '';
+
+  BROTLI_HOME = symlinkJoin { name="brotli-wrap"; paths = [ brotli.lib brotli.dev ]; };
+  FLATBUFFERS_HOME = flatbuffers;
+  GTEST_HOME = gtest;
+  GFLAGS_HOME = gflags;
+  LZ4_HOME = symlinkJoin { name="lz4-wrap"; paths = [ lz4 lz4.dev ]; };
+  RAPIDJSON_HOME = rapidjson;
+  SNAPPY_HOME = symlinkJoin { name="snappy-wrap"; paths = [ snappy snappy.dev ]; };
+  ZLIB_HOME = symlinkJoin { name="zlib-wrap"; paths = [ zlib.dev zlib.static ]; };
+  ZSTD_HOME = zstd;
+
+  meta = {
+    description = "A  cross-language development platform for in-memory data";
+    homepage = https://arrow.apache.org/;
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/libraries/parquet-cpp/default.nix
+++ b/pkgs/development/libraries/parquet-cpp/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, symlinkJoin, fetchurl, arrow-cpp, boost, cmake, gtest, snappy, thrift, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "parquet-cpp-${version}";
+  version = "1.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/apache/parquet-cpp/archive/apache-${name}.tar.gz";
+    sha256 = "1kn7pjzi5san5f05qbl8l8znqsa3f9cq9bflfr4s2jfwr7k9p2aj";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost ];
+
+  preConfigure = ''
+    substituteInPlace cmake_modules/FindThrift.cmake --replace CMAKE_STATIC_LIBRARY CMAKE_SHARED_LIBRARY
+    substituteInPlace cmake_modules/FindSnappy.cmake --replace CMAKE_STATIC_LIBRARY CMAKE_SHARED_LIBRARY
+  '';
+
+  ARROW_HOME = arrow-cpp;
+  THRIFT_HOME = thrift;
+  GTEST_HOME = gtest;
+  SNAPPY_HOME = symlinkJoin { name="snappy-wrap"; paths = [ snappy snappy.dev ]; };
+  ZLIB_HOME = symlinkJoin { name="zlib-wrap"; paths = [ zlib.dev zlib.static ]; };
+
+  cmakeFlags = [
+    "-DPARQUET_BUILD_BENCHMARKS=OFF"
+  ];
+
+  meta = {
+    description = "A C++ library to read and write the Apache Parquet columnar data format";
+    homepage = http://parquet.apache.org;
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/libraries/rapidjson/default.nix
+++ b/pkgs/development/libraries/rapidjson/default.nix
@@ -13,14 +13,16 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  # detected by gcc7
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=implicit-fallthrough" ];
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt --replace "-Werror" ""
+    substituteInPlace example/CMakeLists.txt --replace "-Werror" ""
+  '';
 
   meta = with lib; {
     description = "Fast JSON parser/generator for C++ with both SAX/DOM style API";
     homepage = "http://rapidjson.org/";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan ];
   };
 }

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchurl, arrow-cpp, cmake, cython, futures, numpy, pandas, pytest, pkgconfig, setuptools_scm, six }:
+{ lib, buildPythonPackage, fetchurl, arrow-cpp, cmake, cython, futures, numpy, pandas, pytest, parquet-cpp, pkgconfig, setuptools_scm, six }:
 
 buildPythonPackage rec {
   pname = "pyarrow";
@@ -16,10 +16,14 @@ buildPythonPackage rec {
   checkInputs = [ pandas pytest ];
 
   PYARROW_BUILD_TYPE = "release";
-  PYARROW_BUNDLE_ARROW_CPP = 1; # sets RPATH on darwin
+  PYARROW_CMAKE_OPTIONS = "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib;${PARQUET_HOME}/lib";
 
   preBuild = ''
-    substituteInPlace CMakeLists.txt --replace "''${ARROW_SO_VERSION}" '"0"'
+    substituteInPlace CMakeLists.txt --replace "\''${ARROW_ABI_VERSION}" '"0.0.0"'
+    substituteInPlace CMakeLists.txt --replace "\''${ARROW_SO_VERSION}" '"0"'
+
+    # fix the hardcoded value
+    substituteInPlace cmake_modules/FindParquet.cmake --replace 'set(PARQUET_ABI_VERSION "1.0.0")' 'set(PARQUET_ABI_VERSION "${parquet-cpp.version}")'
   '';
 
   preCheck = ''
@@ -36,6 +40,9 @@ buildPythonPackage rec {
   '';
 
   ARROW_HOME = arrow-cpp;
+  PARQUET_HOME = parquet-cpp;
+
+  setupPyBuildFlags = ["--with-parquet" ];
 
   meta = with lib; {
     description = "A cross-language development platform for in-memory data";

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,0 +1,47 @@
+{ lib, buildPythonPackage, fetchurl, arrow-cpp, cmake, cython, futures, numpy, pandas, pytest, pkgconfig, setuptools_scm, six }:
+
+buildPythonPackage rec {
+  pname = "pyarrow";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
+    sha256 = "1i79sh9ip32agbrn4n51pjn9266i45s8spk5jsi8ax0hqy1vhhmi";
+  };
+
+  sourceRoot = "apache-arrow-${version}/python";
+
+  nativeBuildInputs = [ cmake cython pkgconfig setuptools_scm ];
+  propagatedBuildInputs = [ futures numpy six ];
+  checkInputs = [ pandas pytest ];
+
+  PYARROW_BUILD_TYPE = "release";
+  PYARROW_BUNDLE_ARROW_CPP = 1; # sets RPATH on darwin
+
+  preBuild = ''
+    substituteInPlace CMakeLists.txt --replace "''${ARROW_SO_VERSION}" '"0"'
+  '';
+
+  preCheck = ''
+    rm pyarrow/tests/test_hdfs.py
+
+    # fails: "ArrowNotImplementedError: Unsupported numpy type 22"
+    substituteInPlace pyarrow/tests/test_feather.py --replace "test_timedelta_with_nulls" "_disabled"
+
+    # runs out of memory on @grahamcofborg linux box
+    substituteInPlace pyarrow/tests/test_feather.py --replace "test_large_dataframe" "_disabled"
+
+    # probably broken on python2
+    substituteInPlace pyarrow/tests/test_feather.py --replace "test_unicode_filename" "_disabled"
+  '';
+
+  ARROW_HOME = arrow-cpp;
+
+  meta = with lib; {
+    description = "A cross-language development platform for in-memory data";
+    homepage = https://arrow.apache.org/;
+    license = lib.licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -43,6 +43,8 @@ buildPythonPackage rec {
     # when it is not intended to be imported at all
     rm pyarrow/tests/deserialize_buffer.py
     substituteInPlace pyarrow/tests/test_feather.py --replace "test_deserialize_buffer_in_different_process" "_disabled"
+
+    env | grep PYTHON
   '';
 
   ARROW_HOME = arrow-cpp;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10872,6 +10872,8 @@ with pkgs;
 
   paperkey = callPackage ../tools/security/paperkey { };
 
+  parquet-cpp = callPackage ../development/libraries/parquet-cpp {};
+
   pangoxsl = callPackage ../development/libraries/pangoxsl { };
 
   pcaudiolib = callPackage ../development/libraries/pcaudiolib {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8379,6 +8379,8 @@ with pkgs;
 
   armadillo = callPackage ../development/libraries/armadillo {};
 
+  arrow-cpp = callPackage ../development/libraries/arrow-cpp {};
+
   assimp = callPackage ../development/libraries/assimp { };
 
   asio = callPackage ../development/libraries/asio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -305,6 +305,10 @@ in {
 
   pyamf = callPackage ../development/python-modules/pyamf { };
 
+  pyarrow = callPackage ../development/python-modules/pyarrow {
+    inherit (pkgs) arrow-cpp cmake pkgconfig;
+  };
+
   pyatspi = disabledIf (!isPy3k) (callPackage ../development/python-modules/pyatspi { });
 
   pyaxmlparser = callPackage ../development/python-modules/pyaxmlparser { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

