### PR TITLE
gucharmap: 10.0.3 -> 10.0.4

### DIFF
--- a/pkgs/desktops/gnome-3/core/gucharmap/default.nix
+++ b/pkgs/desktops/gnome-3/core/gucharmap/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   name = "gucharmap-${version}";
-  version = "10.0.3";
+  version = "10.0.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gucharmap/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "ac07d75924e2d8f436d9492e8f7d54cf109404d34de06886a3967563cd1726a4";
+    sha256 = "00gh3lll6wykd2qg1lrj05a4wvscsypmrx7rpb6jsbvb4scnh9mv";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/gucharmap -h` got 0 exit code
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/gucharmap --help` got 0 exit code
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/gucharmap --version` and found version 10.0.4
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/charmap -h` got 0 exit code
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/charmap --help` got 0 exit code
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/charmap --version` and found version 10.0.4
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/gnome-character-map -h` got 0 exit code
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/gnome-character-map --help` got 0 exit code
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/gnome-character-map --version` and found version 10.0.4
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/.gucharmap-wrapped -h` got 0 exit code
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/.gucharmap-wrapped --help` got 0 exit code
- ran `/nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4/bin/.gucharmap-wrapped --version` and found version 10.0.4
- found 10.0.4 with grep in /nix/store/bkbw31sb8p3klh6m9p1syvffwdm6zg7a-gucharmap-10.0.4
- directory tree listing: https://gist.github.com/f2d09169f8e3771af929b9c633adfb27

cc @lethalman @jtojnar for review