### PR TITLE
imapfilter: 2.6.10 -> 2.6.11

### DIFF
--- a/pkgs/applications/networking/mailreaders/imapfilter.nix
+++ b/pkgs/applications/networking/mailreaders/imapfilter.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "imapfilter-${version}";
-  version = "2.6.10";
+  version = "2.6.11";
 
   src = fetchFromGitHub {
     owner = "lefcha";
     repo = "imapfilter";
     rev = "v${version}";
-    sha256 = "1011pbgbaz43kmxcc5alv06jly9wqmqgr0b64cm5i1md727v3rzc";
+    sha256 = "0cjnp7vqmgqym2zswabkmwlbj21r063vw7wkwxglj08z5qyjl5ps";
   };
 
   makeFlagsArray = "PREFIX=$(out)";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/vfixsp2napk2fv4dkhzdfv0nx473vz1j-imapfilter-2.6.11/bin/imapfilter -h` got 0 exit code
- ran `/nix/store/vfixsp2napk2fv4dkhzdfv0nx473vz1j-imapfilter-2.6.11/bin/imapfilter --help` got 0 exit code
- ran `/nix/store/vfixsp2napk2fv4dkhzdfv0nx473vz1j-imapfilter-2.6.11/bin/imapfilter -V` and found version 2.6.11
- ran `/nix/store/vfixsp2napk2fv4dkhzdfv0nx473vz1j-imapfilter-2.6.11/bin/imapfilter --version` and found version 2.6.11
- ran `/nix/store/vfixsp2napk2fv4dkhzdfv0nx473vz1j-imapfilter-2.6.11/bin/imapfilter -h` and found version 2.6.11
- ran `/nix/store/vfixsp2napk2fv4dkhzdfv0nx473vz1j-imapfilter-2.6.11/bin/imapfilter --help` and found version 2.6.11
- found 2.6.11 with grep in /nix/store/vfixsp2napk2fv4dkhzdfv0nx473vz1j-imapfilter-2.6.11
- directory tree listing: https://gist.github.com/3899407e9730a32a5b25ade7c1238086

cc @fuuzetsu for review