### PR TITLE
jack1: 0.124.1 -> 0.125.0

### DIFF
--- a/pkgs/misc/jackaudio/jack1.nix
+++ b/pkgs/misc/jackaudio/jack1.nix
@@ -15,11 +15,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "jack1-${version}";
-  version = "0.124.1";
+  version = "0.125.0";
 
   src = fetchurl {
     url = "http://jackaudio.org/downloads/jack-audio-connection-kit-${version}.tar.gz";
-    sha256 = "1mk1wnx33anp6haxfjjkfhwbaknfblsvj35nxvz0hvspcmhdyhpb";
+    sha256 = "0i6l25dmfk2ji2lrakqq9icnwjxklgcjzzk65dmsff91z2zva5rm";
   };
   
   configureFlags = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/h64aj4vry98w3pmdqbd1bqkhxnghbvgb-jack1-0.125.0/bin/jackd -V` and found version 0.125.0
- ran `/nix/store/h64aj4vry98w3pmdqbd1bqkhxnghbvgb-jack1-0.125.0/bin/jackd --version` and found version 0.125.0
- ran `/nix/store/h64aj4vry98w3pmdqbd1bqkhxnghbvgb-jack1-0.125.0/bin/jack_server_control -h` got 0 exit code
- ran `/nix/store/h64aj4vry98w3pmdqbd1bqkhxnghbvgb-jack1-0.125.0/bin/jack_server_control -V` and found version 0.125.0
- ran `/nix/store/h64aj4vry98w3pmdqbd1bqkhxnghbvgb-jack1-0.125.0/bin/jack_server_control -v` and found version 0.125.0
- ran `/nix/store/h64aj4vry98w3pmdqbd1bqkhxnghbvgb-jack1-0.125.0/bin/jack_server_control -h` and found version 0.125.0
- ran `/nix/store/h64aj4vry98w3pmdqbd1bqkhxnghbvgb-jack1-0.125.0/bin/jack_midi_dump -h` got 0 exit code
- found 0.125.0 with grep in /nix/store/h64aj4vry98w3pmdqbd1bqkhxnghbvgb-jack1-0.125.0
- directory tree listing: https://gist.github.com/359dc1584108a662b645c49abe027c95

cc @wkennington for review