### PR TITLE
keepassxc: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -25,13 +25,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "keepassxc-${version}";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = "${version}";
-    sha256 = "1zch1qbqgphhp2p2kvjlah8s337162m69yf4y00kcnfb3539ii5f";
+    sha256 = "1xlg8zb22c2f1pi2has4f4qwggd0m2z254f0d6jrgz368x4g3p87";
   };
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang "-Wno-old-style-cast";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/q87wl52sicp88w63rlcb5wzy7c8gajb1-keepassxc-2.3.1/bin/keepassxc-cli -h` got 0 exit code
- ran `/nix/store/q87wl52sicp88w63rlcb5wzy7c8gajb1-keepassxc-2.3.1/bin/keepassxc-cli --help` got 0 exit code
- ran `/nix/store/q87wl52sicp88w63rlcb5wzy7c8gajb1-keepassxc-2.3.1/bin/keepassxc-cli -V` and found version 2.3.1
- ran `/nix/store/q87wl52sicp88w63rlcb5wzy7c8gajb1-keepassxc-2.3.1/bin/keepassxc-cli -v` and found version 2.3.1
- ran `/nix/store/q87wl52sicp88w63rlcb5wzy7c8gajb1-keepassxc-2.3.1/bin/keepassxc-cli --version` and found version 2.3.1
- ran `/nix/store/q87wl52sicp88w63rlcb5wzy7c8gajb1-keepassxc-2.3.1/bin/keepassxc-cli -h` and found version 2.3.1
- ran `/nix/store/q87wl52sicp88w63rlcb5wzy7c8gajb1-keepassxc-2.3.1/bin/keepassxc-cli --help` and found version 2.3.1
- found 2.3.1 with grep in /nix/store/q87wl52sicp88w63rlcb5wzy7c8gajb1-keepassxc-2.3.1
- directory tree listing: https://gist.github.com/552879736d7405822ddc3857eac17345

cc @s1lvester @jonafato for review