### PR TITLE
libbitcoin: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/tools/misc/libbitcoin/libbitcoin.nix
+++ b/pkgs/tools/misc/libbitcoin/libbitcoin.nix
@@ -3,7 +3,7 @@
 
 let
   pname = "libbitcoin";
-  version = "3.4.0";
+  version = "3.5.0";
 
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1h6h7cxbwkdk8bzbkfvnrrdzajw1d4lr8wqs66is735bksh6gk1y";
+    sha256 = "1qy637hpv6kkhf602yxxi5b9j0qhsp644fazljcqbnxzp7vv2qyd";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.5.0 with grep in /nix/store/ciln99fn6lhwnb1z1h6cyrk6vc4a0ngn-libbitcoin-3.5.0
- directory tree listing: https://gist.github.com/57d42e66f139b59578e1c681316c0ec6

cc @chris-martin for review