### PR TITLE
libbitcoin-client: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/tools/misc/libbitcoin/libbitcoin-client.nix
+++ b/pkgs/tools/misc/libbitcoin/libbitcoin-client.nix
@@ -3,7 +3,7 @@
 
 let
   pname = "libbitcoin-client";
-  version = "3.4.0";
+  version = "3.5.0";
 
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "libbitcoin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1vdp6qgpxshh6nhdvr81z3nvh42wgmsm4prli4ajigwp970y8p56";
+    sha256 = "0a9c00f1pfi8wczbfd1djkvr7di3iw1ynak6if910w01dkhbm6v4";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.5.0 with grep in /nix/store/gmwvkr4gj2n0ak2ppxwmhakqsr8ihxhc-libbitcoin-client-3.5.0
- directory tree listing: https://gist.github.com/afab2c737b7764c7fb6ea2f0bc8b9ee8

cc @chris-martin for review