### PR TITLE
workrave: 1.10.7 -> 1.10.20

### DIFF
--- a/pkgs/applications/misc/workrave/default.nix
+++ b/pkgs/applications/misc/workrave/default.nix
@@ -1,39 +1,29 @@
-{ stdenv, fetchFromGitHub, fetchpatch
-, autoconf, automake, gettext, intltool, libtool, pkgconfig
+{ stdenv, fetchFromGitHub, wrapGAppsHook
+, autoconf, autoconf-archive, automake, gettext, intltool, libtool, pkgconfig
 , libICE, libSM, libXScrnSaver, libXtst, cheetah
-, glib, glibmm, gtkmm2, atk, pango, pangomm, cairo, cairomm
-, dbus, dbus-glib, GConf, gconfmm, gdome2, gstreamer, libsigcxx }:
+, gobjectIntrospection, glib, glibmm, gtkmm3, atk, pango, pangomm, cairo
+, cairomm , dbus, dbus-glib, gdome2, gstreamer, libsigcxx }:
 
 stdenv.mkDerivation rec {
   name = "workrave-${version}";
-  version = "1.10.7";
+  version = "1.10.20";
 
   src = let
   in fetchFromGitHub {
-    sha256 = "1mxg882rfih7xzadrpj51m9r33f6s3rzwv61nfwi94vzd68qjnxb";
+    sha256 = "099a87zkrkmsgfz9isrfm89dh545x52891jh6qxmn19h6wwsi941";
     rev = with stdenv.lib;
       "v" + concatStringsSep "_" (splitString "." version);
     repo = "workrave";
     owner = "rcaelers";
   };
 
-  patches = [
-    # Building with gtk{,mm}3 works just fine, but let's be conservative for once:
-    (fetchpatch {
-      name = "workrave-fix-compilation-with-gtk2.patch";
-      url = "https://github.com/rcaelers/workrave/commit/"
-        + "271efdcd795b3592bfede8b1af2162af4b1f0f26.patch";
-      sha256 = "1a3d4jj8516m3m24bl6y8alanl1qnyzv5dv1hz5v3hjgk89fj6rk";
-    })
-  ];
-
   nativeBuildInputs = [
-    autoconf automake gettext intltool libtool pkgconfig
+    autoconf autoconf-archive automake gettext intltool libtool pkgconfig wrapGAppsHook
   ];
   buildInputs = [
     libICE libSM libXScrnSaver libXtst cheetah
-    glib glibmm gtkmm2 atk pango pangomm cairo cairomm
-    dbus dbus-glib GConf gconfmm gdome2 gstreamer libsigcxx
+    gobjectIntrospection glib glibmm gtkmm3 atk pango pangomm cairo cairomm
+    dbus dbus-glib gdome2 gstreamer libsigcxx
   ];
 
   preConfigure = "./autogen.sh";

--- a/pkgs/applications/misc/workrave/default.nix
+++ b/pkgs/applications/misc/workrave/default.nix
@@ -2,7 +2,8 @@
 , autoconf, autoconf-archive, automake, gettext, intltool, libtool, pkgconfig
 , libICE, libSM, libXScrnSaver, libXtst, cheetah
 , gobjectIntrospection, glib, glibmm, gtkmm3, atk, pango, pangomm, cairo
-, cairomm , dbus, dbus-glib, gdome2, gstreamer, libsigcxx }:
+, cairomm , dbus, dbus-glib, gdome2, gstreamer, gst-plugins-base
+, gst-plugins-good, libsigcxx }:
 
 stdenv.mkDerivation rec {
   name = "workrave-${version}";
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libICE libSM libXScrnSaver libXtst cheetah
     gobjectIntrospection glib glibmm gtkmm3 atk pango pangomm cairo cairomm
-    dbus dbus-glib gdome2 gstreamer libsigcxx
+    dbus dbus-glib gdome2 gstreamer gst-plugins-base gst-plugins-good libsigcxx
   ];
 
   preConfigure = "./autogen.sh";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18189,7 +18189,6 @@ with pkgs;
   worker = callPackage ../applications/misc/worker { };
 
   workrave = callPackage ../applications/misc/workrave {
-    inherit (gnome2) GConf gconfmm;
     inherit (python27Packages) cheetah;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18190,6 +18190,7 @@ with pkgs;
 
   workrave = callPackage ../applications/misc/workrave {
     inherit (python27Packages) cheetah;
+    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good;
   };
 
   worldengine-cli = python3Packages.worldengine;


### PR DESCRIPTION
Also: switch to GTK-3, fix GSettings by using wrapGAppsHook.

###### Motivation for this change

Couldn't set the timers at all, making it pretty much useless. Switching it to gtk-3 is just to simplify by making it closer to upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

