### PR TITLE
libbitcoin-explorer: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/tools/misc/libbitcoin/libbitcoin-explorer.nix
+++ b/pkgs/tools/misc/libbitcoin/libbitcoin-explorer.nix
@@ -3,7 +3,7 @@
 
 let
   pname = "libbitcoin-explorer";
-  version = "3.4.0";
+  version = "3.5.0";
 
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "libbitcoin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0rxiimklzqyp9vswznz9aia71dn6jxm2pxx5ljlhzs5rs583cj00";
+    sha256 = "033nrdzrha4kypxk4biixjsbjd16r4m2mjvpid4gdj5hzbbj1p93";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/j07vd1p6h4c5fxyiskqqvfvi902vvsn2-libbitcoin-explorer-3.5.0/bin/bx help` got 0 exit code
- found 3.5.0 with grep in /nix/store/j07vd1p6h4c5fxyiskqqvfvi902vvsn2-libbitcoin-explorer-3.5.0
- directory tree listing: https://gist.github.com/672afbcda72ddef99aebfc49a81edc45

cc @chris-martin @asymmetric for review