### PR TITLE
libbitcoin-protocol: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/tools/misc/libbitcoin/libbitcoin-protocol.nix
+++ b/pkgs/tools/misc/libbitcoin/libbitcoin-protocol.nix
@@ -3,7 +3,7 @@
 
 let
   pname = "libbitcoin-protocol";
-  version = "3.4.0";
+  version = "3.5.0";
 
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "libbitcoin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1wrlzani3wdjkmxqwjh30i8lg3clrzwcx2di7c9sdpnsbda985gb";
+    sha256 = "1ln9r04hlnc7qmv17rakyhrnzw1a541pg5jc1sw3ccn90a5x6cfv";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.5.0 with grep in /nix/store/6726g0ccxn9iklg3vmpllmbp9dxkckgg-libbitcoin-protocol-3.5.0
- directory tree listing: https://gist.github.com/31ff5b959604c484f3e037bf19fbb0d9

cc @asymmetric for review