### PR TITLE
libupnp: 1.6.21 -> 1.8.3

### DIFF
--- a/pkgs/development/libraries/pupnp/default.nix
+++ b/pkgs/development/libraries/pupnp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libupnp-${version}";
-  version = "1.6.21";
+  version = "1.8.3";
 
   src = fetchFromGitHub {
     owner = "mrjimenez";
     repo = "pupnp";
     rev = "release-${version}";
-    sha256 = "07ksfhadinaa20542gblrxi9pqz0v6y70a836hp3qr4037id4nm9";
+    sha256 = "1w0kfq1pg3y2wl6gwkm1w872g0qz29w1z9wj08xxmwnk5mkpvsrl";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.8.3 with grep in /nix/store/54dv1yd3bi54ci4kvlj9j7jc1khxm1ax-libupnp-1.8.3
- directory tree listing: https://gist.github.com/b72d1e3b6abc82c6c158d097f98780b9