### PR TITLE
lighttpd: 1.4.48 -> 1.4.49

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -9,11 +9,11 @@ assert enableMysql -> mysql != null;
 assert enableLdap -> openldap != null;
 
 stdenv.mkDerivation rec {
-  name = "lighttpd-1.4.48";
+  name = "lighttpd-1.4.49";
 
   src = fetchurl {
     url = "http://download.lighttpd.net/lighttpd/releases-1.4.x/${name}.tar.xz";
-    sha256 = "0djgsx06x3p22rjvzml5klq7gqd9nk88qzlxifa7p7ajqymdb2hg";
+    sha256 = "02ff77cpvy1006cwfym38vf78xm18plyj636ll74r7kx2bblkpxf";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd -h` got 0 exit code
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd -V` and found version 1.4.49
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd -v` and found version 1.4.49
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd -h` and found version 1.4.49
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd-angel -h` got 0 exit code
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd-angel --help` got 0 exit code
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd-angel help` got 0 exit code
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd-angel -V` and found version 1.4.49
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd-angel -v` and found version 1.4.49
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd-angel --version` and found version 1.4.49
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd-angel -h` and found version 1.4.49
- ran `/nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49/bin/lighttpd-angel --help` and found version 1.4.49
- found 1.4.49 with grep in /nix/store/zqq4z003jl443djfygasflfqk091wphx-lighttpd-1.4.49
- directory tree listing: https://gist.github.com/3f87cc8cd06f4c87b583c225172f1c2e

cc @bjornfor for review