### PR TITLE
memcached: 1.5.5 -> 1.5.6

### DIFF
--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, cyrus_sasl, libevent}:
 
 stdenv.mkDerivation rec {
-  version = "1.5.5";
+  version = "1.5.6";
   name = "memcached-${version}";
 
   src = fetchurl {
     url = "http://memcached.org/files/${name}.tar.gz";
-    sha256 = "1v87gvhxih5jav20cp9zdddna31s968xdm2iskc9mqzb5li6di72";
+    sha256 = "00szy9d4szaixi260dcd4846zci04y0sd47ia2lzg0bxkn2ywxcn";
   };
 
   buildInputs = [cyrus_sasl libevent];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/d6hf5flqvv4cw0pfbbnx8m99gs1apsk0-memcached-1.5.6/bin/memcached -h` got 0 exit code
- ran `/nix/store/d6hf5flqvv4cw0pfbbnx8m99gs1apsk0-memcached-1.5.6/bin/memcached --help` got 0 exit code
- ran `/nix/store/d6hf5flqvv4cw0pfbbnx8m99gs1apsk0-memcached-1.5.6/bin/memcached -V` and found version 1.5.6
- ran `/nix/store/d6hf5flqvv4cw0pfbbnx8m99gs1apsk0-memcached-1.5.6/bin/memcached --version` and found version 1.5.6
- ran `/nix/store/d6hf5flqvv4cw0pfbbnx8m99gs1apsk0-memcached-1.5.6/bin/memcached -h` and found version 1.5.6
- ran `/nix/store/d6hf5flqvv4cw0pfbbnx8m99gs1apsk0-memcached-1.5.6/bin/memcached --help` and found version 1.5.6
- found 1.5.6 with grep in /nix/store/d6hf5flqvv4cw0pfbbnx8m99gs1apsk0-memcached-1.5.6
- directory tree listing: https://gist.github.com/4f05e6b4a66fc90f9ebcb02b05aead27

cc @coreyoconnor for review