### PR TITLE
mercurial: 4.5 -> 4.5.2

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -4,7 +4,7 @@
 
 let
   # if you bump version, update pkgs.tortoisehg too or ping maintainer
-  version = "4.5";
+  version = "4.5.2";
   name = "mercurial-${version}";
   inherit (python2Packages) docutils hg-git dulwich python;
 in python2Packages.buildPythonApplication {
@@ -13,7 +13,7 @@ in python2Packages.buildPythonApplication {
 
   src = fetchurl {
     url = "https://mercurial-scm.org/release/${name}.tar.gz";
-    sha256 = "0rgjy42zdlbzgp4qq49amzplfcvycyijf4kdhc5wk3fqz7cki4sd";
+    sha256 = "14732hhw2ibvy5khqxjc8a983z3rib5vp9lqfbws80lm3kyryjm4";
   };
 
   inherit python; # pass it so that the same version can be used in hg2git


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/hg -h` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/hg --help` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/hg help` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/hg --version` and found version 4.5.2
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/hg version` and found version 4.5.2
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/..hg-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/..hg-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/..hg-wrapped-wrapped help` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/..hg-wrapped-wrapped --version` and found version 4.5.2
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/..hg-wrapped-wrapped version` and found version 4.5.2
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/.hg-wrapped -h` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/.hg-wrapped --help` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/.hg-wrapped help` got 0 exit code
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/.hg-wrapped --version` and found version 4.5.2
- ran `/nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2/bin/.hg-wrapped version` and found version 4.5.2
- found 4.5.2 with grep in /nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2
- found 4.5.2 in filename of file in /nix/store/vr3mxrjhmmpqydkd69z3fdc7qjdsafgz-mercurial-4.5.2
- directory tree listing: https://gist.github.com/7a681b5af1e240918913ffd718e9b3e9

cc @edolstra for review