### PR TITLE
minissdpd: 1.5.20180203 -> 1.5.20180223

### DIFF
--- a/pkgs/tools/networking/minissdpd/default.nix
+++ b/pkgs/tools/networking/minissdpd/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "minissdpd-${version}";
-  version = "1.5.20180203";
+  version = "1.5.20180223";
 
   src = fetchurl {
-    sha256 = "1yiri887s8wxh4zrjc5dw19gyypqg63962aimcgd19blvpbwnfcv";
+    sha256 = "1c47h1zil04jnbxiaaci2rm8jij47zp5156v48hb6m87nh4l5adv";
     url = "http://miniupnp.free.fr/files/download.php?file=${name}.tar.gz";
     name = "${name}.tar.gz";
   };


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/a596018c138a1d359fa81cc983730be2