### PR TITLE
miniupnpd: 2.0.20180203 -> 2.0.20180222

### DIFF
--- a/pkgs/tools/networking/miniupnpd/default.nix
+++ b/pkgs/tools/networking/miniupnpd/default.nix
@@ -3,11 +3,11 @@
 assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "miniupnpd-2.0.20180203";
+  name = "miniupnpd-2.0.20180222";
 
   src = fetchurl {
     url = "http://miniupnp.free.fr/files/download.php?file=${name}.tar.gz";
-    sha256 = "1djb0w76yd5jyqm5mzmxlxikxzzwqzjgy75h8saxc3rlz3r1a346";
+    sha256 = "1hdpyvz1z6crpa7as3srmbl64fx0k4wjra57jw7qaysdsb1b2kqr";
     name = "${name}.tar.gz";
   };
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/207d415090e19d752f7ec321bb409364