### PR TITLE
mkdocs: 0.17.2 -> 0.17.3

### DIFF
--- a/pkgs/development/tools/documentation/mkdocs/default.nix
+++ b/pkgs/development/tools/documentation/mkdocs/default.nix
@@ -4,14 +4,14 @@ with python.pkgs;
 
 buildPythonApplication rec {
   pname = "mkdocs";
-  version = "0.17.2";
+  version = "0.17.3";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "mkdocs";
     repo = "mkdocs";
     rev = version;
-    sha256 = "0hpjs9qj0nr57a249yv8xvl61d3d2rrdfqxp1fm28z77l2xjj772";
+    sha256 = "15lv60gdc837zja5kn2rfp78kwyb1ckc43jg01zfzqra4qz7b6rw";
   };
 
   checkInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3/bin/.mkdocs-wrapped -h` got 0 exit code
- ran `/nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3/bin/.mkdocs-wrapped --help` got 0 exit code
- ran `/nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3/bin/.mkdocs-wrapped -V` and found version 0.17.3
- ran `/nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3/bin/.mkdocs-wrapped --version` and found version 0.17.3
- ran `/nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3/bin/mkdocs -h` got 0 exit code
- ran `/nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3/bin/mkdocs --help` got 0 exit code
- ran `/nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3/bin/mkdocs -V` and found version 0.17.3
- ran `/nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3/bin/mkdocs --version` and found version 0.17.3
- found 0.17.3 with grep in /nix/store/wy5434b824p55fr8x67vz8q8ph9g65kn-mkdocs-0.17.3
- directory tree listing: https://gist.github.com/b9a97908c199575f84016b19365ae126