### PR TITLE
jags: 4.1.0 -> 4.3.0

### DIFF
--- a/pkgs/applications/science/math/jags/default.nix
+++ b/pkgs/applications/science/math/jags/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, gfortran, openblas}:
 
 stdenv.mkDerivation rec {
-  name = "JAGS-4.1.0";
+  name = "JAGS-4.3.0";
   src = fetchurl {
     url = "mirror://sourceforge/mcmc-jags/${name}.tar.gz";
-    sha256 = "08pmrnbwibc0brgn5cx860jcl0s2xaw4amw7g45649r1bcdz7v25";
+    sha256 = "1z3icccg2ic56vmhyrpinlsvpq7kcaflk1731rgpvz9bk1bxvica";
   };
   buildInputs = [gfortran openblas];
   configureFlags = [ "--with-blas=-lopenblas" "--with-lapack=-lopenblas" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:
- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.3.0 with grep in /nix/store/aw897502z5bcn6dw6rp7jca90flfrjab-JAGS-4.3.0
cc @kosmikus for review