### PR TITLE
mod_wsgi: 4.5.24 -> 4.6.2

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mod_wsgi-${version}";
-  version = "4.5.24";
+  version = "4.6.2";
 
   src = fetchurl {
     url = "https://github.com/GrahamDumpleton/mod_wsgi/archive/${version}.tar.gz";
-    sha256 = "1anxml8i3q90x8n30xfydpmv41cxlwqrg3vr98ayzaak02maxr99";
+    sha256 = "0gviv9x4w4i8d26d8vyrr8zk4p5hdx63rxpzqw769cmhvvy8r3g2";
   };
 
   buildInputs = [ apacheHttpd python2 ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.6.2 with grep in /nix/store/c5q74ipv6p7mwri4p0ab0x32b76kfa2n-mod_wsgi-4.6.2
- directory tree listing: https://gist.github.com/2ddf866000f57f596c938b529d3f6fa9