### PR TITLE
languagetool: 3.9 -> 4.0

### DIFF
--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "LanguageTool-${version}";
-  version = "3.9";
+  version = "4.0";
 
   src = fetchzip {
     url = "https://www.languagetool.org/download/${name}.zip";
-    sha256 = "0hqb4hbl7iryw1xk8q1i606azzgzdr17sy6xfr1zpas4r2pnvhfq";
+    sha256 = "0nfqn04fb5kvxvpsc6xbgj03rmqcsn8vy2xj0zazijhvbxaf0zfb";
   };
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jre ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:
- built on NixOS
- ran `/nix/store/q7ycrljxhd7pbkgvbhsh8fz4496x798n-LanguageTool-4.0/bin/languagetool-commandline --version` and found version 4.0
- found 4.0 with grep in /nix/store/q7ycrljxhd7pbkgvbhsh8fz4496x798n-LanguageTool-4.0
cc @edwtjo @jgeerds for review