### PR TITLE
most: 5.0.0 -> 5.0.0a

### DIFF
--- a/pkgs/tools/misc/most/default.nix
+++ b/pkgs/tools/misc/most/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, slang, ncurses }:
 
 stdenv.mkDerivation {
-  name = "most-5.0.0";
+  name = "most-5.0.0a";
 
   src = fetchurl {
-    url = ftp://space.mit.edu/pub/davis/most/most-5.0.0.tar.bz2;
-    sha256 = "1f5x7rvjg89b5klfqs1gb91jmbnd3fy08d8rwgdvgg0plqkxr7ja";
+    url = ftp://space.mit.edu/pub/davis/most/most-5.0.0a.tar.bz2;
+    sha256 = "1aas904g8x48vsfh3wcr2k6mjzkm5808lfgl2qqhdfdnf4p5mjwl";
   };
 
   preConfigure = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/hl99dyzq83jifdjg00d4zcdxj3j6hqxy-most-5.0.0a/bin/most -h` got 0 exit code
- ran `/nix/store/hl99dyzq83jifdjg00d4zcdxj3j6hqxy-most-5.0.0a/bin/most help` got 0 exit code
- ran `/nix/store/hl99dyzq83jifdjg00d4zcdxj3j6hqxy-most-5.0.0a/bin/most -h` and found version 5.0.0a
- found 5.0.0a with grep in /nix/store/hl99dyzq83jifdjg00d4zcdxj3j6hqxy-most-5.0.0a
- directory tree listing: https://gist.github.com/c97521034492f9bccb53c5402a867290