### PR TITLE
SDL_gfx: 2.0.25 -> 2.0.26

### DIFF
--- a/pkgs/development/libraries/SDL_gfx/default.nix
+++ b/pkgs/development/libraries/SDL_gfx/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "SDL_gfx-${version}";
-  version = "2.0.25";
+  version = "2.0.26";
 
   src = fetchurl {
     url = "http://www.ferzkopp.net/Software/SDL_gfx-2.0/${name}.tar.gz";
-    sha256 = "1h2rj34dxi5xlwpvm293v2d91gsirhnpzlmnjns9xwkcdg0fsvjm";
+    sha256 = "0ijljhs0v99dj6y27hc10z6qchyp8gdp4199y6jzngy6dzxlzsvw";
   };
 
   buildInputs = [ SDL ] ;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:
- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.0.26 with grep in /nix/store/cbvm4r21kf3acf43hff5sf6r1vbd6lpg-SDL_gfx-2.0.26