### PR TITLE
mpc-qt: 17.11 -> 18.03

### DIFF
--- a/pkgs/applications/video/mpc-qt/default.nix
+++ b/pkgs/applications/video/mpc-qt/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mpc-qt-${version}";
-  version = "17.11";
+  version = "18.03";
 
   src = fetchFromGitHub {
     owner = "cmdrkotori";
     repo = "mpc-qt";
     rev = "v${version}";
-    sha256 = "1vi4zsmbzxj6ms8wls9zv15vrskdrhgnj6l41m1fk4scs4jzvbkm";
+    sha256 = "0mhzdgjgv08cvnscbfndpr0s8ndbcf91b61zfqspa1qv4wlqd716";
   };
 
   nativeBuildInputs = [ pkgconfig qmake qttools ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 18.03 with grep in /nix/store/b23s2dr5x7zrhp4vgbh8nf2gajp8a44b-mpc-qt-18.03
- directory tree listing: https://gist.github.com/4792f038cb0905bcd3405765bb63b792

cc @romildo for review