### PR TITLE
vassal: 3.2.15 -> 3.2.17

### DIFF
--- a/pkgs/games/vassal/default.nix
+++ b/pkgs/games/vassal/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, jre, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "VASSAL-3.2.15";
+  name = "VASSAL-3.2.17";
 
   src = fetchurl {
     url = "mirror://sourceforge/vassalengine/${name}-linux.tar.bz2";
-    sha256 = "10ng571nxr5zc2nlviyrk5bci8my67kq3qvhfn9bifzkxmjlqmk9";
+    sha256 = "0nxskr46janxnb31c03zv61kr46vy98l7cwxha3vll81l4ij1sjb";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:
- built on NixOS
- ran `/nix/store/6kxxp00xj8r1qh4kvvjdg954w00vpk57-VASSAL-3.2.17/bin/vassal -h` got 0 exit code
- ran `/nix/store/6kxxp00xj8r1qh4kvvjdg954w00vpk57-VASSAL-3.2.17/bin/vassal --help` got 0 exit code
- ran `/nix/store/6kxxp00xj8r1qh4kvvjdg954w00vpk57-VASSAL-3.2.17/bin/vassal --version` and found version 3.2.17
- found 3.2.17 with grep in /nix/store/6kxxp00xj8r1qh4kvvjdg954w00vpk57-VASSAL-3.2.17
cc @tvestelind for review