### PR TITLE
nextcloud-news-updater: 10.0.0 -> 10.0.1

### DIFF
--- a/pkgs/servers/nextcloud/news-updater.nix
+++ b/pkgs/servers/nextcloud/news-updater.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   name = "nextcloud-news-updater-${version}";
-  version = "10.0.0";
+  version = "10.0.1";
 
   src = fetchurl {
     url = "mirror://pypi/n/nextcloud_news_updater/nextcloud_news_updater-${version}.tar.gz";
-    sha256 = "00pscz0p4s10y1ymb6sm0gx4a5wdbhimn30582x8i28n58nnl8j0";
+    sha256 = "14jj3w417wfsm1ki34d980b0s6vfn8i29g4c66qb2fizdq1d0z6q";
   };
 
   doCheck = false;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1/bin/.nextcloud-news-updater-wrapped -h` got 0 exit code
- ran `/nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1/bin/.nextcloud-news-updater-wrapped --help` got 0 exit code
- ran `/nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1/bin/.nextcloud-news-updater-wrapped -v` and found version 10.0.1
- ran `/nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1/bin/.nextcloud-news-updater-wrapped --version` and found version 10.0.1
- ran `/nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1/bin/nextcloud-news-updater -h` got 0 exit code
- ran `/nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1/bin/nextcloud-news-updater --help` got 0 exit code
- ran `/nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1/bin/nextcloud-news-updater -v` and found version 10.0.1
- ran `/nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1/bin/nextcloud-news-updater --version` and found version 10.0.1
- found 10.0.1 with grep in /nix/store/58kz8y29n2habv056d7iz20484rq87mr-nextcloud-news-updater-10.0.1
- directory tree listing: https://gist.github.com/ef3eb260a3fd46598a3b70c142c2ef2c

cc @schneefux for review