### PR TITLE
abcmidi: 2018.02.22 -> 2018.03.08

### DIFF
--- a/pkgs/tools/audio/abcmidi/default.nix
+++ b/pkgs/tools/audio/abcmidi/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "abcMIDI-${version}";
-  version = "2018.02.22";
+  version = "2018.03.08";
 
   src = fetchzip {
     url = "http://ifdo.ca/~seymour/runabc/${name}.zip";
-    sha256 = "03ln05012yhlq8aalm00af6pidb44phmmidlc953453isfllg82a";
+    sha256 = "0pdia3n23l4nhc4lmyphgh6swq35nnzqk2z4ykif1xajbkbddxm3";
   };
 
   # There is also a file called "makefile" which seems to be preferred by the standard build phase


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:
- built on NixOS
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/abc2abc -h` got 0 exit code
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/abcmatch -h` got 0 exit code
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/mftext -h` got 0 exit code
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/mftext --help` got 0 exit code
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/mftext help` got 0 exit code
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/mftext -V` and found version 2018.03.08
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/mftext -v` and found version 2018.03.08
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/mftext --version` and found version 2018.03.08
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/mftext -h` and found version 2018.03.08
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/mftext --help` and found version 2018.03.08
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/yaps -h` got 0 exit code
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/abc2midi -h` got 0 exit code
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/midi2abc -h` got 0 exit code
- ran `/nix/store/3r7nwg28yy402gl01m9b14h5j865365g-abcMIDI-2018.03.08/bin/midi2abc --help` got 0 exit code