### PR TITLE
nq: 0.2.2 -> 0.3.1

### DIFF
--- a/pkgs/tools/system/nq/default.nix
+++ b/pkgs/tools/system/nq/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "nq-${version}";
-  version = "0.2.2";
+  version = "0.3.1";
   src = fetchFromGitHub {
     owner = "chneukirchen";
     repo = "nq";
     rev = "v${version}";
-    sha256 = "0348r3j5y445psm8lj35z100cfvbfp05s7ji6bxd0gg4n66l2c4l";
+    sha256 = "1db96ykz35r273jyhf7cdknqk4p2jj9l8gbz7pjy1hq4pb6ffk99";
   };
   makeFlags = "PREFIX=$(out)";
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/gyphh3yyw7k1m0igds051f5rnkap5j8q-nq-0.3.1/bin/nq help` got 0 exit code
- ran `/nix/store/gyphh3yyw7k1m0igds051f5rnkap5j8q-nq-0.3.1/bin/fq help` got 0 exit code
- ran `/nix/store/gyphh3yyw7k1m0igds051f5rnkap5j8q-nq-0.3.1/bin/tq help` got 0 exit code
- found 0.3.1 with grep in /nix/store/gyphh3yyw7k1m0igds051f5rnkap5j8q-nq-0.3.1
- directory tree listing: https://gist.github.com/572554e36b5b4ef6af9d80ebc5153935

cc @cstrahan for review