### PR TITLE
anki: 2.0.47 -> 2.0.50

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -28,7 +28,7 @@ let
     qt4 = pyqt4.qt;
 
 in buildPythonApplication rec {
-    version = "2.0.47";
+    version = "2.0.50";
     name = "anki-${version}";
 
     src = fetchurl {
@@ -37,7 +37,7 @@ in buildPythonApplication rec {
         # "http://ankisrs.net/download/mirror/${name}.tgz"
         # "http://ankisrs.net/download/mirror/archive/${name}.tgz"
       ];
-      sha256 = "067bsidqzy1zc301i2pk4biwp2kwvgk4kydp5z5s551acinkbdgv";
+      sha256 = "05hq1f9m4vv3zpv7d05m4y6d82ibp1kk0gpwp73vza1ffq0wdcip";
     };
 
     propagatedBuildInputs = [ pyqt4 sqlalchemy pyaudio beautifulsoup httplib2 ]


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:
- built on NixOS
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/..anki-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/..anki-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/..anki-wrapped-wrapped --version` and found version 2.0.50
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/anki -h` got 0 exit code
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/anki --help` got 0 exit code
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/anki --version` and found version 2.0.50
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/.anki-wrapped -h` got 0 exit code
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/.anki-wrapped --help` got 0 exit code
- ran `/nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50/bin/.anki-wrapped --version` and found version 2.0.50
- found 2.0.50 with grep in /nix/store/yxxxxgsdxr65bgnv1xn0h9pdivpm2bvx-anki-2.0.50
