### PR TITLE
activemq: 5.13.4 -> 5.14.5

### DIFF
--- a/pkgs/development/libraries/apache-activemq/default.nix
+++ b/pkgs/development/libraries/apache-activemq/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "apache-activemq-${version}";
-  version = "5.13.4";
+  version = "5.14.5";
 
   src = fetchurl {
-    sha256 = "0sp806bmv9vs19zbzlv71ag09p1jbl2wn2wpxfwa20mndri8lsmz";
+    sha256 = "0vm8z7rxb9n10xg5xjahy357704fw3q477hmpb83kd1zrc633g54";
     url = "mirror://apache/activemq/${version}/${name}-bin.tar.gz";
   };
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:
- built on NixOS
- ran `/nix/store/bryzxhk66p8wvdskcgah9a3n2h12f81r-apache-activemq-5.14.5/bin/activemq --version` and found version 5.14.5
- ran `/nix/store/bryzxhk66p8wvdskcgah9a3n2h12f81r-apache-activemq-5.14.5/bin/activemq version` and found version 5.14.5
- ran `/nix/store/bryzxhk66p8wvdskcgah9a3n2h12f81r-apache-activemq-5.14.5/bin/activemq help` and found version 5.14.5
- ran `/nix/store/bryzxhk66p8wvdskcgah9a3n2h12f81r-apache-activemq-5.14.5/bin/macosx/wrapper --help` got 0 exit code
- ran `/nix/store/bryzxhk66p8wvdskcgah9a3n2h12f81r-apache-activemq-5.14.5/bin/macosx/wrapper --help` and found version 5.14.5
- ran `/nix/store/bryzxhk66p8wvdskcgah9a3n2h12f81r-apache-activemq-5.14.5/bin/activemq-diag -h` got 0 exit code
- found 5.14.5 with grep in /nix/store/bryzxhk66p8wvdskcgah9a3n2h12f81r-apache-activemq-5.14.5
