### PR TITLE
antlr4: 4.7 -> 4.7.1

### DIFF
--- a/pkgs/development/tools/parsing/antlr/4.7.nix
+++ b/pkgs/development/tools/parsing/antlr/4.7.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "antlr-${version}";
-  version = "4.7";
+  version = "4.7.1";
   src = fetchurl {
     url ="http://www.antlr.org/download/antlr-${version}-complete.jar";
-    sha256 = "0r08ay63s5aajix5j8j7lf7j7l7wiwdkr112b66nyhkj5f6c72yd";
+    sha256 = "1236gwnzchama92apb2swmklnypj01m7bdwwfvwvl8ym85scw7gl";
   };
 
   unpackPhase = "true";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:
- built on NixOS
- ran `/nix/store/i4ipx4vd247inysxw0ygp7smcfx5yf05-antlr-4.7.1/bin/grun -h` got 0 exit code
- ran `/nix/store/i4ipx4vd247inysxw0ygp7smcfx5yf05-antlr-4.7.1/bin/grun --help` got 0 exit code
- ran `/nix/store/i4ipx4vd247inysxw0ygp7smcfx5yf05-antlr-4.7.1/bin/grun help` got 0 exit code
- found 4.7.1 with grep in /nix/store/i4ipx4vd247inysxw0ygp7smcfx5yf05-antlr-4.7.1
