### PR TITLE
otter-browser: 0.9.94 -> 0.9.96

### DIFF
--- a/pkgs/applications/networking/browsers/otter/default.nix
+++ b/pkgs/applications/networking/browsers/otter/default.nix
@@ -1,7 +1,7 @@
 { stdenv, cmake, openssl, gst_all_1, fetchFromGitHub
 , qtbase, qtmultimedia, qtwebengine
-, version ? "0.9.94"
-, sourceSha ? "19mfm0f6qqkd78aa6q4nq1y9gnlasqiyk68zgqjp1i03g70h08k5"
+, version ? "0.9.96"
+, sourceSha ? "1xzfy3jjx9sskwwbk7l8hnwnjf8af62p4kjkydp0ld0j50apc39p"
 }:
 stdenv.mkDerivation {
   name = "otter-browser-${version}";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.96 with grep in /nix/store/hy3dyckwbq8x0ylgydqf3hsd0yyj38mf-otter-browser-0.9.96
- directory tree listing: https://gist.github.com/3ba5ac755cab96acd876703e94dff4b4

cc @lheckemann for review