### PR TITLE
pidgin-sipe: 1.23.0 -> 1.23.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/sipe/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/sipe/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pidgin, intltool, libxml2, nss, nspr }:
 
-let version = "1.23.0"; in
+let version = "1.23.2"; in
 
 stdenv.mkDerivation {
   name = "pidgin-sipe-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/sipe/pidgin-sipe-${version}.tar.gz";
-    sha256 = "795811ced33fcc5affae259828f6452bfc0e0b02737ea68483e1bd9ec0459013";
+    sha256 = "1xj4nn5h103q4agar167xwcp98qf8knrgs918nl07qaxp9g4558w";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.23.2 with grep in /nix/store/r7pl30mgdnrdig95aq6qy3d4dbvy8vji-pidgin-sipe-1.23.2
- directory tree listing: https://gist.github.com/c400423782c0ab85deea92ca910a179b