### PR TITLE
radarr: 0.2.0.980 -> 0.2.0.995

### DIFF
--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "radarr-${version}";
-  version = "0.2.0.980";
+  version = "0.2.0.995";
 
   src = fetchurl {
     url = "https://github.com/Radarr/Radarr/releases/download/v${version}/Radarr.develop.${version}.linux.tar.gz";
-    sha256 = "1939mmlp9hsmw0hd4c8m8p5fk6igvml30gk9ffi9mfhankas6fnf";
+    sha256 = "04sgs292qz65fcg5vsps0fk2669xzvyfw1rbc5sbbk3hig5lhlns";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.2.0.995 with grep in /nix/store/nlny430ihz2ydmabj5a2zz457h76vg3z-radarr-0.2.0.995
- directory tree listing: https://gist.github.com/791e8a8789572292f81465181d3aa586

cc @edwtjo for review