### PR TITLE
redis: 4.0.7 -> 4.0.8

### DIFF
--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, lua }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.7";
+  version = "4.0.8";
   name = "redis-${version}";
 
   src = fetchurl {
     url = "http://download.redis.io/releases/${name}.tar.gz";
-    sha256 = "1lgcc5k6bg7f34lxbfx0xv74nj66khd5x8g1igyy2h7v8inm9fhv";
+    sha256 = "1b9jqacckx4qqyz905mnclxfcpsvrwc507n6zr4r4canq6w3h37z";
   };
 
   buildInputs = [ lua ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/jbp7m1gshmk8an8sb14glwijgw1chvvq-redis-4.0.8/bin/redis-server -v` and found version 4.0.8
- ran `/nix/store/jbp7m1gshmk8an8sb14glwijgw1chvvq-redis-4.0.8/bin/redis-server --version` and found version 4.0.8
- ran `/nix/store/jbp7m1gshmk8an8sb14glwijgw1chvvq-redis-4.0.8/bin/redis-benchmark --help` got 0 exit code
- ran `/nix/store/jbp7m1gshmk8an8sb14glwijgw1chvvq-redis-4.0.8/bin/redis-cli -v` and found version 4.0.8
- ran `/nix/store/jbp7m1gshmk8an8sb14glwijgw1chvvq-redis-4.0.8/bin/redis-cli --version` and found version 4.0.8
- found 4.0.8 with grep in /nix/store/jbp7m1gshmk8an8sb14glwijgw1chvvq-redis-4.0.8
- directory tree listing: https://gist.github.com/2870bd85351bae2037f6c3ffd93f9d51

cc @berdario for review