### PR TITLE
usb-modeswitch-data: 20170205 -> 20170806

### DIFF
--- a/pkgs/development/tools/misc/usb-modeswitch/data.nix
+++ b/pkgs/development/tools/misc/usb-modeswitch/data.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "usb-modeswitch-data-${version}";
-  version = "20170205";
+  version = "20170806";
 
   src = fetchurl {
     url    = "http://www.draisberghof.de/usb_modeswitch/${name}.tar.bz2";
-    sha256 = "1l9q4xk02zd0l50bqhyk906wbcs26ji7259q0f7qv3cj52fzvp72";
+    sha256 = "0b1wari3aza6qjggqd0hk2zsh93k1q8scgmwh6f8wr0flpr3whff";
   };
 
   inherit (usb-modeswitch) makeFlags;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/8dc0e83055ce231aba53f5bb82ed0f59

cc @marcweber @peterhoeg for review