### PR TITLE
vim: 8.0.1451 -> 8.0.1605

### DIFF
--- a/pkgs/applications/editors/vim/common.nix
+++ b/pkgs/applications/editors/vim/common.nix
@@ -1,12 +1,12 @@
 { lib, fetchFromGitHub }:
 rec {
-  version = "8.0.1451";
+  version = "8.0.1605";
 
   src = fetchFromGitHub {
     owner = "vim";
     repo = "vim";
     rev = "v${version}";
-    sha256 = "1vxd5mr8c62qyf7ax7gi2wka48282yplckq91154yd55xcqw36zx";
+    sha256 = "0a8zf43q806py14vq1frm350wycn47cmanj1hn1i7bqx1gdgcal9";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/5afa788kqasx65plvzwjnffq9ihzdbmn-vim-8.0.1605/bin/vim -h` got 0 exit code
- ran `/nix/store/5afa788kqasx65plvzwjnffq9ihzdbmn-vim-8.0.1605/bin/vim --help` got 0 exit code
- ran `/nix/store/5afa788kqasx65plvzwjnffq9ihzdbmn-vim-8.0.1605/bin/vim --version` and found version 8.0.1605
- found 8.0.1605 with grep in /nix/store/5afa788kqasx65plvzwjnffq9ihzdbmn-vim-8.0.1605
- directory tree listing: https://gist.github.com/f9af564ba8cc53b90d1d262c2e786eee

cc @lovek323 for review