### PR TITLE
weston: 3.0.0 -> 3.0.91

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   name = "weston-${version}";
-  version = "3.0.0";
+  version = "3.0.91";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "19936zlkb75xcaidd8fag4ah8000wrh2ziqy7nxkq36pimgdbqfd";
+    sha256 = "0wd35y4d57n9nhhgjk2w2qxq2052ahhcyxz2raywv8jay0mq5k8x";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/yrw1xlwj1c89zhlcmwaq17cqfz7h05x2-weston-3.0.91/bin/weston -h` got 0 exit code
- ran `/nix/store/yrw1xlwj1c89zhlcmwaq17cqfz7h05x2-weston-3.0.91/bin/weston --help` got 0 exit code
- ran `/nix/store/yrw1xlwj1c89zhlcmwaq17cqfz7h05x2-weston-3.0.91/bin/weston --version` and found version 3.0.91
- ran `/nix/store/yrw1xlwj1c89zhlcmwaq17cqfz7h05x2-weston-3.0.91/bin/weston -h` and found version 3.0.91
- ran `/nix/store/yrw1xlwj1c89zhlcmwaq17cqfz7h05x2-weston-3.0.91/bin/weston --help` and found version 3.0.91
- ran `/nix/store/yrw1xlwj1c89zhlcmwaq17cqfz7h05x2-weston-3.0.91/bin/wcap-decode --help` got 0 exit code
- found 3.0.91 with grep in /nix/store/yrw1xlwj1c89zhlcmwaq17cqfz7h05x2-weston-3.0.91
- directory tree listing: https://gist.github.com/92cbc56a42c86c98a2b52933d942adc5

cc @wkennington for review