### PR TITLE
pythonPackages.tablib: fix build

### DIFF
--- a/pkgs/development/python-modules/tablib/default.nix
+++ b/pkgs/development/python-modules/tablib/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, stdenv, fetchPypi, pytest, unicodecsv, pandas
+, xlwt, openpyxl, pyyaml, xlrd, odfpy, fetchpatch
+}:
+
+buildPythonPackage rec {
+  pname = "tablib";
+  version = "0.12.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11wxchj0qz77dn79yiq30k4b4gsm429f4bizk4lm4rb63nk51kxq";
+  };
+
+  checkInputs = [ pytest unicodecsv pandas ];
+  propagatedBuildInputs = [ xlwt openpyxl pyyaml xlrd odfpy ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/kennethreitz/tablib/commit/0e51a2d0944022af186d2dcd34c0ab3c47141ba5.patch";
+      sha256 = "0lbbl871zdn5vpgqyjkil0c2ap3b5hz19rmihhyvrx7m4mlh1aij";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Tablib: format-agnostic tabular dataset library";
+    homepage = http://python-tablib.org;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2650,22 +2650,7 @@ in {
 
   pyunifi = callPackage ../development/python-modules/pyunifi { };
 
-  tablib = buildPythonPackage rec {
-    name = "tablib-${version}";
-    version = "0.12.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/tablib/tablib-${version}.tar.gz";
-      sha256 = "11wxchj0qz77dn79yiq30k4b4gsm429f4bizk4lm4rb63nk51kxq";
-    };
-
-    buildInputs = with self; [ pytest unicodecsv pandas ];
-    propagatedBuildInputs = with self; [ xlwt openpyxl pyyaml xlrd odfpy ];
-    meta = with stdenv.lib; {
-      description = "Tablib: format-agnostic tabular dataset library";
-      homepage = "http://python-tablib.org";
-    };
-  };
+  tablib = callPackage ../development/python-modules/tablib { };
 
   wakeonlan = callPackage ../development/python-modules/wakeonlan { };
 


### PR DESCRIPTION
###### Motivation for this change

`openpyxl` v5 broke `tablib`: https://github.com/kennethreitz/tablib/issues/324

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

