### PR TITLE
Rewrite meta-check.nix type checking logic.

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -31,6 +31,9 @@ let
     options = callLibs ./options.nix;
     types = callLibs ./types.nix;
 
+    # type checking plain nix values
+    types-simple = callLibs ./types-simple.nix;
+
     # constants
     licenses = callLibs ./licenses.nix;
     systems = callLibs ./systems;

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -126,7 +126,8 @@ rec {
       if attrNames v == [ "__pretty" "val" ] && allowPrettyValues
          then v.__pretty v.val
       # TODO: there is probably a better representation?
-      else if v ? type && v.type == "derivation" then "<δ>"
+      else if v ? type && v.type == "derivation" then
+        "<δ:${v.name}>"
       else "{ "
           + libStr.concatStringsSep " " (libAttr.mapAttrsToList
               (name: value:

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -7,7 +7,7 @@ let
 
 in
 
-lib.mapAttrs (n: v: v // { shortName = n; }) rec {
+lib.mapAttrs (n: v: v // { shortName = n; free = v.free or true; }) rec {
   /* License identifiers from spdx.org where possible.
    * If you cannot find your license here, then look for a similar license or
    * add it to this list. The URL mentioned above is a good source for inspiration.

--- a/lib/tests/README.md
+++ b/lib/tests/README.md
@@ -1,0 +1,11 @@
+# lib tests
+
+Here you can find tests for the library.
+
+* Tests for the module system are defined in `./modules.sh`.
+* Tests for most other library functions are defined in `./misc.sh`.
+
+You can build everything by running `nix build -f ./release.nix`, though calling
+test suites directly is considerably faster. Consult the files listed above to
+find out how to do that.
+

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3,7 +3,11 @@
 # if the resulting list is empty, all tests passed
 with import ../default.nix;
 
-runTests {
+# types-simple tests
+import ./types-simple.nix
+
+# misc tests
+++ (runTests {
 
 
 # TRIVIAL
@@ -360,4 +364,4 @@ runTests {
     expected = true;
   };
 
-}
+})

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -312,7 +312,7 @@ import ./types-simple.nix
       functionArgs = "<λ:{(arg),foo}>";
       list = "[ 3 4 ${function} [ false ] ]";
       attrs = "{ \"foo\" = null; \"foo bar\" = \"baz\"; }";
-      drv = "<δ>";
+      drv = "<δ:test>";
     };
   };
 

--- a/lib/tests/types-simple.nix
+++ b/lib/tests/types-simple.nix
@@ -1,0 +1,130 @@
+# tests for /lib/types-simple
+let lib = import ../default.nix;
+in with lib.types-simple;
+
+let
+
+  # Generate a type checker error.
+  # expectedType is the type expected at that position
+  # val is the value that was badly typed
+  err = expectedType: val: {
+    inherit val;
+    should = expectedType.description;
+  };
+  # a successful type check
+  ok = {};
+
+  # Test the checkType function results.
+  # type is the type to check for
+  # val is the value that should be of type type
+  # result is the expected checkType result
+  test = type: val: result: {
+    expr = checkType type val;
+    expected = result;
+  };
+
+  # TODO test the return type of checkType to be
+  # nested attrs (product { should = string; val = any; })
+
+in lib.runTests {
+
+  testVoid = test void 23 (err void 23);
+
+  testAnyInt = test any 42 ok;
+  testAnyString = test any "foo" ok;
+  testAnyList = test any [ 3 "45" { dont = "do this"; } "ever" ] ok;
+
+  testUnitOk = test unit {} ok;
+  testUnitFoo = test unit "foo" (err unit "foo");
+
+  testBoolOk = test bool true ok;
+  testBoolFoo = test bool 23 (err bool 23);
+
+  testStringOk = test string "foo" ok;
+  testStringFoo = test string false (err string false);
+
+  testIntOk = test int 42 ok;
+  testIntFoo = test int {} (err int {});
+
+  testFloatOk = test float 3.14 ok;
+  testFloatOkStrange = test float 23. ok;
+  testFloatNotInt = test float 23 (err float 23);
+  testFloatFoo = test float [ "nope" ] (err float [ "nope" ]);
+
+  testListEmpty = test (list void) [] ok;
+  testListIntOk = test (list int) [ 1 2 3 ] ok;
+  testListPosFoo = test (list int) [ 1 "ahh" 3 true ] {
+    "1" = (err int "ahh");
+    "3" = (err int true);
+  };
+  testListOfListUnitOk = test (list (list unit)) [ [] [{}] [{} {} {}] ] ok;
+  testListOfListUnitFoo = test (list (list unit)) [ {} [ {} "ups" ] [[]] ] {
+    "0" = err (list unit) {};
+    "1"."1" = err unit "ups";
+    "2"."0" = err unit [];
+   };
+
+  testAttrsEmpty = test (attrs void) {} ok;
+  testAttrsIntOk = test (attrs int) { foo = 1; bar = 2; } ok;
+  testAttrsIntListFoo = test (attrs int) [] (err (attrs int) []);
+  testAttrsIntFoo = test (attrs int) { foo.bar = 1; baz = 2; quux = true; } {
+    foo = err int { bar = 1; };
+    quux = err int true;
+  };
+  testAttrsOfAttrsOk = test (attrs (attrs unit)) { foo.bar = {}; baz.quux = {}; } ok;
+  testAttrsOfAttrsEmptyOk = test (attrs (attrs unit)) {} ok;
+  testAttrsOfAttrsFoo = test (attrs (attrs unit)) { a = []; b.c.d.e = false; } {
+    a = err (attrs unit) [];
+    b.c = err unit { d.e = false; };
+  };
+
+  testListOfAttrsOk1 = test (list (attrs unit)) [] ok;
+  testListOfAttrsOk2 = test (list (attrs unit)) [ { a = {}; } { b = {}; } ] ok;
+  testListOfAttrsFoo = test (list (attrs unit))
+    [ 42 { a = {}; b.c.d = "x"; } { x = []; } {} ]
+    {
+      "0" = err (attrs unit) 42;
+      "1".b = err unit { c.d = "x"; };
+      "2".x = err unit [];
+    };
+
+  testProductOk = test (product { name = string; age = int; })
+    { name = "hans"; age = 42; } ok;
+  testProductWrongTypes = test (product { name = string; age = int; })
+    { name = true; age = 23.5; }
+    {
+      name = err string true;
+      age = err int 23.5;
+    };
+  testProductWrongField = test (product { foo = bool; })
+    { bar = "foo"; }
+    (err (product { foo = bool; }) { bar = "foo"; });
+  testProductTooManyFields = test (product { a = int; b = int; })
+    { a = 1; b = 2; c = "hello"; }
+    (err (product { a = int; b = int; }) { a = 1; b = 2; c = "hello"; });
+  testProductEmptyOk = test (product {}) {} ok;
+  testProductEmptyFoo = test (product {}) { name = "hans"; }
+    (err (product {}) { name = "hans"; });
+
+  testSumLeftOk = test (sum { left = string; right = unit; })
+    { left = "errör!"; } ok;
+  testSumRightOk = test (sum { left = string; right = unit; })
+    { right = {}; } ok;
+  testSumWrongField = test (sum { a = int; b = bool; })
+    { c = "ups"; }
+    (err (sum { a = int; b = bool; }) { c = "ups"; });
+  testSumIsNotUnion = test (sum { a = string; b = int; })
+    42
+    (err (sum { a = string; b = int; }) 42);
+  testSumTooManyFields = test (sum { a = int; b = unit; })
+    { a = 21; b = {}; }
+    (err (sum { a = int; b = unit; }) { a = 21; b = {}; });
+
+  testUnionOk1 = test (union [ int string (list unit) ]) 23 ok;
+  testUnionOk2 = test (union [ int string (list unit) ]) "foo" ok;
+  testUnionOk3 = test (union [ int string (list unit) ]) [{}{}] ok;
+  testUnionWrongType = test (union [ int string ]) true
+    (err (union [ int string ]) true);
+  testUnionOne = test (union [ int ]) 23 ok;
+
+}

--- a/lib/tests/types-simple.nix
+++ b/lib/tests/types-simple.nix
@@ -152,23 +152,4 @@ in lib.runTests {
   testUnionSimilar = test (union [ (list string) (attrs string) ])
     { foo = "string"; } ok;
 
-
-  testDefaultsUnit = testDef unit {};
-  testDefaultsBool = testDef bool false;
-  testDefaultsString = testDef string "";
-  testDefaultsInt = testDef int 0;
-  testDefaultsFloat = testDef float 0.0;
-  testDefaultsList1 = testDef (list void) [];
-  testDefaultsList2 = testDef (list (list void)) [];
-  testDefaultsAttrs1 = testDef (attrs void) {};
-  testDefaultsAttrs2 = testDef (attrs (attrs void)) {};
-  testDefaultsProductEmpty = testDef (product {}) {};
-  testDefaultsProduct = testDef
-    (product { a = int; b = bool; })
-    { a = 0; b = false; };
-  testDefaultsSum = testDef
-    (sum { a = int; b = bool; })
-    { a = 0; }; # depends on sorting of attrNames
-  testDefaultsUnion = testDef (union [ int bool ]) 0;
-
 }

--- a/lib/tests/types-simple.nix
+++ b/lib/tests/types-simple.nix
@@ -138,6 +138,14 @@ in lib.runTests ({
     { p = { x = 23; }; } # missing the required p.y
     { p = (err (product { x = int; y = bool; }) { x = 23; }); };
 
+  testProductOptOpenOk = test
+    (productOpt { req = { a = unit; }; opt = {}; open = true; })
+    { a = {}; rest1 = 12; rest2 = "foo"; } ok;
+  testProductOptOpenIgnoreRest = test
+    (productOpt { req = { a = unit; }; opt = { b = int; }; open = true; })
+    { a = 23; b = false; rest = "foo"; x = {}; y = 23; }
+    { a = err unit 23; b = err int false; };
+
 
   # -- Sums --
 

--- a/lib/tests/types-simple.nix
+++ b/lib/tests/types-simple.nix
@@ -149,6 +149,8 @@ in lib.runTests {
   testUnionWrongType = test (union [ int string ]) true
     (err (union [ int string ]) true);
   testUnionOne = test (union [ int ]) 23 ok;
+  testUnionSimilar = test (union [ (list string) (attrs string) ])
+    { foo = "string"; } ok;
 
 
   testDefaultsUnit = testDef unit {};

--- a/lib/tests/types-simple.nix
+++ b/lib/tests/types-simple.nix
@@ -51,6 +51,9 @@ in lib.runTests ({
   testStringOk = test string "foo" ok;
   testStringFoo = test string false (err string false);
 
+  testPathOk = test path /. ok;
+  testPathFoo = test path "/nope" (err path "/nope");
+
   testIntOk = test int 42 ok;
   testIntFoo = test int {} (err int {});
 

--- a/lib/tests/types-simple.nix
+++ b/lib/tests/types-simple.nix
@@ -210,6 +210,16 @@ in lib.runTests ({
     + " ]";
   };
 
+  transitive = restrict {
+    description = "neither a nor b";
+    check = v: v != "b";
+    type = restrict {
+      description = "not a";
+      check = v: v != "a";
+      type = string;
+    };
+  };
+
 in {
   testRestrictEvenOk = test (list even)
     [ 2 4 128 42 ] ok;
@@ -237,6 +247,12 @@ in {
   testDeepRestrictionFoo = test thirdElementIsListOf23
     [ [] [] [24] [] [] ]
     (err thirdElementIsListOf23 [ [] [] [24] [] [] ]);
+
+  testRestrictTransitiveOk = test transitive "c" ok;
+  testRestrictTransitiveA = test transitive "a"
+    (err transitive "a");
+  testRestrictTransitiveB = test transitive "b"
+    (err transitive "b");
 
   testRestrictIntBetweenOk = test (list (intBetween (-2) 3))
     [ (-2) (-1) 0 1 2 3 ] ok;

--- a/lib/types-simple.nix
+++ b/lib/types-simple.nix
@@ -1,0 +1,331 @@
+# A simple type system to check plain nix values
+# and get detailed error messages on type mismatch.
+#
+# Contains support for
+# scalars (simple values)
+# recursive types (lists of t and attrs of t)
+# products (attribute sets with named fields)
+# sums (tagged unions where you can match on the different cases)
+# unions (untagged unions of the specified types)
+# We can’t type functions (lambda expressions). Maybe in the future.
+#
+# What is the difference to `./types.nix`? / Why another type system?
+#
+# `./types.nix` is deeply entangled with the module system,
+# in order to use it on plain nix values, you have to invoke the
+# module system, which is pretty heavyweight and hard/verbose to do.
+# Contrary to popular opinion, the `check` functions on module types
+# does *not* do a recursive check for complex types/values.
+# Plus, it is not possible to catch a type error, since the module
+# system always instantly aborts nix evaluation on type error.
+# The `checkType` function in this module returns a detailed,
+# structured # error for each part of the substructure that
+# does not match the given expected type.
+# Concerning expressibility, an attrset with fixed fields can
+# be given as easy as `product { field1 = type; … }`, whereas
+# in `./types.nix` you need to use the complictated `submodule`
+# mechanism. We also support tagged unions (`./types.nix` does not)
+# and untagged unions of an arbitrary set of types (can be emulated
+# with nested `either`s in `./types.nix`).
+#
+# In short: if you want to check a module option, use `./types.nix`.
+# If you want to check a plain (possibly complex) nix value,
+# use this module.
+#
+# The main function is `checkType`.
+# Tests can be found in './tests/types-simple.nix`.
+
+{ lib }:
+let
+
+  # The type functor.
+  # t is the recursion “not yet inserted”.
+  #
+  # data Type t
+  #   = Scalar
+  #   | Recursive (Rec t)
+  #   | Sum (Map String t)
+  #   | Product (Map String t)
+  #   | Union (List t)
+  #  deriving (Functor)
+  #
+  # Fix Type is every t replaced with Type, recursively.
+
+  # The alternatives above are tagged manually, by this variant enum:
+  variants = {
+    scalar = 0;
+    recursive = 1;
+    sum = 2;
+    product = 3;
+    # TODO: it feels like union (or sum or product) is not axiomatic
+    union = 4;
+  };
+
+  ## -- HELPERS --
+
+  unimplemented = abort "unimplemented";
+  unreachable = abort "should not be reached";
+
+  # Functor instance of Type
+  # fmap :: (a -> b) -> (Type a) -> (Type b)
+  fmap = f: t:
+         if t.variant == variants.scalar    then t
+    else if t.variant == variants.recursive then
+      t // { nested = f t.nested; }
+    else if t.variant == variants.sum       then
+      t // { alts   = lib.mapAttrs (lib.const f) t.alts; }
+    else if t.variant == variants.product   then
+      t // { fields = lib.mapAttrs (lib.const f) t.fields; }
+    else if t.variant == variants.union     then
+      t // { altList = map f t.altList; }
+    else unreachable;
+
+  # cata :: (Type a -> a) -> Fix Type -> a
+  # collapses the structure Fix Type (nested types) into an a,
+  # by collapsing one layer at a time with the function (/algebra)
+  # alg :: (Type a -> a)
+  cata = alg: t: alg (fmap (cata alg) t);
+
+
+  ## -- MAIN --
+
+  # Main type checking function.
+  # Example:
+  # > checkType (list string) [ "foo" "bar" ]
+  # { }
+  # > checkType (list string) [ "foo" 42 ]
+  # { "1" = { should = "string"; val = 42; }; }
+  #
+  # checkType :: Fix Type -> Value -> (Nested Attrs) Errors
+  #
+  # where { } means no error
+  # or { should : String, val : Value } for a type mismatch.
+  checkType =
+    let
+      # filters out non-error messages
+      mapAndFilter = f: vals:
+        lib.filterAttrs (_: v: v != {}) (lib.mapAttrs f vals);
+      # alg :: Type (Value -> Errors) -> (Value -> Errors)
+      alg = t: v:
+            # TODO: some errors should throw some more context.
+            # e.g. putting more than one field in a sum value.
+            if !(t.check v) then { should = t.description; val = v; }
+        else if t.variant == variants.scalar    then {}
+        else if t.variant == variants.recursive then
+          mapAndFilter (_: el: t.nested el) (t.each v)
+        else if t.variant == variants.sum       then
+              # we already tested length == 1 in .check
+          let alt = builtins.head (builtins.attrNames v);
+          in t.alts.${alt} v.${alt}
+        else if t.variant == variants.product   then
+          mapAndFilter (n: f: f v.${n}) t.fields
+        else if t.variant == variants.union     then
+          # unions are awkward, the type checker can’t do much here
+          if lib.all (res: res != {}) (map (f: f v) t.altList)
+          then { should = t.description; val = v; }
+          else {}
+        else unreachable;
+    in t: v: cata alg t v;
+
+
+  ## -- TYPE SETUP STUFF --
+
+  mkBaseType = {
+    # the type description
+    description,
+    # a function to check the outermost type, given a value (Val -> Bool)
+    # TODO: this is value-specific, maybe this should be inside the type checker
+    # logic instead of the type definiton? There’s some repetition.
+    check,
+    # the variant of this type
+    variant,
+    # extra fields belonging to the variant
+    extraFields
+  }: { inherit description check variant; } // extraFields;
+
+  mkScalar = { description, check }: mkBaseType {
+    inherit description check;
+    variant = variants.scalar;
+    extraFields = {};
+  };
+
+  mkRecursive = { description, check,
+    # return all children for a value of this type T t,
+    # give each child (of type t) a displayable name.
+    # (T -> Map Name t)
+    each,
+    # The nested value t of the type functor
+    nested
+  }: mkBaseType {
+    inherit description check;
+    variant = variants.recursive;
+    extraFields = { inherit each nested; };
+  };
+
+
+  ## -- TYPES --
+
+  # the type with no inhabitants (kind of useless …)
+  void = mkScalar {
+    description = "void";
+    # there are no values of type void
+    check = lib.const false;
+  };
+
+  # the any type, every value is an inhabitant
+  # tt basically turns of the type system, use with care
+  any = mkScalar {
+    description = "any type";
+    check = lib.const true;
+  };
+
+  # the type with exactly one inhabitant
+  unit = mkScalar {
+    description = "unit";
+    # there is exactly one unit value, we represent it with {};
+    check = v: v == {};
+  };
+
+  # the type with two inhabitants
+  bool = mkScalar {
+    description = "boolean";
+    check = builtins.isBool;
+  };
+
+  # a nix string
+  string = mkScalar {
+    description = "string";
+    check = builtins.isString;
+  };
+
+  # a signed nix integer
+  int = mkScalar {
+    description = "integer";
+    check = builtins.isInt;
+  };
+
+  # a nix floating point number
+  float = mkScalar {
+    description = "float";
+    check = builtins.isFloat;
+  };
+
+  # helper for descriptions of recursive types
+  # TODO: descriptions need to assume t is a type,
+  # which is only true for Fix Type. How to make nice?
+  describe = t: t.description or "<non-type>";
+
+  # list with children of type t
+  # list bool: [ true false false ]
+  # list (attrs unit):
+  #   [ { a = {}; } { b = {}; } ]
+  #   []
+  list = t: mkRecursive {
+    description = "list of ${describe t}";
+    check = builtins.isList;
+    # each child gets named by its index
+    each = l: builtins.listToAttrs
+      (lib.imap0 (i: v: lib.nameValuePair (toString i) v) l);
+    nested = t;
+  };
+
+  # attrset with children of type t
+  # attrs int: { foo = 23; bar = 42; }
+  # attrs (attrs string):
+  #  { foo.bar = "hello"; baz.quux = "x"; }
+  #  { x = { y = "wow"; }; }
+  attrs = t: mkRecursive {
+    description = "attrset of ${describe t}";
+    check = builtins.isAttrs;
+    each = lib.id;
+    nested = t;
+  };
+
+  # product type with fields of the specified types
+  # product { x = int; y = unit; }:
+  #   { x = 23; y = {}; }
+  #   { x = 42; y = {}; }
+  # product {}: <- yeah, that’s isomorphic to unit
+  #   { }
+  # product { foo = void; }:
+  #   just kidding. :)
+  product = fields: mkBaseType {
+    description = "{ " +
+      lib.concatStringsSep ", "
+        (lib.mapAttrsToList (n: t: "${n}: ${describe t}") fields)
+      + " }";
+    check = v: builtins.isAttrs v
+      # all fields have to be given by the value
+      && builtins.attrNames fields == builtins.attrNames v;
+    variant = variants.product;
+    extraFields = {
+      inherit fields;
+    };
+  };
+
+  # sum type with alternatives of the specified types
+  # sum { left = string; right = bool; }:
+  #   { left = "work it"; }
+  #   { right = false; }
+  # sum { true = unit; false = unit; } <- that’s isomorphic to bool
+  #   { true = {}; }
+  #   { false = {}; }
+  # sum { X = product { name = string; age = int; }; Y = list unit; }
+  #   { X = { name = "peter shaw"; age = 22; }; }
+  #   { Y = [ {} {} {} {} {} {} {} {} ]; }
+  sum = alts: assert alts != {}; mkBaseType {
+    description = "< " +
+      lib.concatStringsSep " | "
+        (lib.mapAttrsToList (n: t: "${n}: ${describe t}") alts)
+      + " >";
+    check = v:
+      let alt = builtins.attrNames v;
+      in builtins.isAttrs v
+      # exactly one of the alts has to be used by the value
+      && builtins.length alt == 1
+      && alts ? ${lib.head alt};
+    variant = variants.sum;
+    extraFields = {
+      inherit alts;
+    };
+  };
+
+  # untagged union type
+  # ATTENTION: this leads to *bad* type checker errors in practice,
+  # you also can’t do pattern matching; use sum if possible.
+  # union [ bool int ]
+  #   3
+  #   true
+  # list (union [ int string ])
+  #   [ "foo" 34 "bar" ]
+  # please don’t use this.
+  union = altList: assert altList != []; mkBaseType {
+    description = "one of [ "
+      + lib.concatMapStringsSep ", " describe altList
+      + " ]";
+    check = v: lib.any (t: t.check v) altList;
+    variant = variants.union;
+    extraFields = {
+      inherit altList;
+    };
+  };
+
+  # TODO: should scalars be allowed as nest types?
+  # TODO: how to implement?
+  # nested = nest: t: mkBaseType {
+  #   description = "nested ${describe nest} of ${describe t}";
+  #   check = nest.check ;
+  #   variant = nest.variant;
+  #   extraFields = {
+
+
+in {
+  # The type of nix types, as non-recursive functor.
+  # fmap and cata are specialized to Type.
+  Type = { inherit variants fmap cata; };
+  # Constructor functions for types.
+  # Their internal structure/fields are an *implementation detail*.
+  inherit void any unit bool string int float list attrs product sum union;
+  # Type checking.
+  inherit checkType;
+}

--- a/lib/types-simple.nix
+++ b/lib/types-simple.nix
@@ -314,34 +314,34 @@ let
     # opt and rec fields must not contain the same fields
     assert (lib.intersectLists reqfs optfs == []);
     mkBaseType {
-    name = "product";
-    description = "{ " +
-      lib.concatStringsSep ", "
-        (  lib.mapAttrsToList (n: t: "${n}: ${describe t}") req
-        ++ lib.mapAttrsToList (n: t: "[${n}: ${describe t}]") opt
-        # TODO: maybe but this at the beginning: [ …,
-        # so that it’s easier to see that an attrset is open
-        ++ lib.optional open "…")
-      + " }";
-    check = v:
+      name = "product";
+      description = "{ " +
+        lib.concatStringsSep ", "
+          (  lib.mapAttrsToList (n: t: "${n}: ${describe t}") req
+          ++ lib.mapAttrsToList (n: t: "[${n}: ${describe t}]") opt
+          # TODO: maybe but this at the beginning: [ …,
+          # so that it’s easier to see that an attrset is open
+          ++ lib.optional open "…")
+        + " }";
+      check = v:
         let vfs = builtins.attrNames v; in
         lib.foldl lib.and (builtins.isAttrs v) [
-      # if there’s only required fields, this is an optimization
-        (opt == {} && !open -> reqfs == vfs)
-        # all required fields have to exist in the value
-        # reqfs - vfs
-        (lib.subtractLists vfs reqfs == [])
-        # whithout req, and if the product is not open
-        # only opt fields must be in the value
-        # (vfs - reqfs) - otfs
-        (!open -> [] == lib.subtractLists optfs
-                          (lib.subtractLists reqfs vfs))
-      ];
-    variant = variants.product;
-    extraFields = {
+          # if there’s only required fields, this is an optimization
+          (opt == {} && !open -> reqfs == vfs)
+          # all required fields have to exist in the value
+          # reqfs - vfs
+          (lib.subtractLists vfs reqfs == [])
+          # whithout req, and if the product is not open
+          # only opt fields must be in the value
+          # (vfs - reqfs) - otfs
+          (!open -> [] == lib.subtractLists optfs
+                            (lib.subtractLists reqfs vfs))
+        ];
+      variant = variants.product;
+      extraFields = {
         inherit opt req open;
+      };
     };
-  };
 
   # sum type with alternatives of the specified types
   # sum { left = string; right = bool; }:

--- a/lib/types-simple.nix
+++ b/lib/types-simple.nix
@@ -225,6 +225,15 @@ let
     check = builtins.isString;
   };
 
+  # a nix path
+  path = mkScalar {
+    name = "path";
+    description = "path";
+    # there is no `isPath` predicate,
+    # but `typeOf` exists since 1.6.1
+    check = v: builtins.typeOf v == "path";
+  };
+
   # a signed nix integer
   int = mkScalar {
     name = "int";
@@ -330,7 +339,7 @@ let
       ];
     variant = variants.product;
     extraFields = {
-      inherit opt req;
+        inherit opt req open;
     };
   };
 
@@ -448,7 +457,7 @@ in {
   Type = { inherit variants fmap cata; };
   # Constructor functions for types.
   # Their internal structure/fields are an *implementation detail*.
-  inherit void any unit bool string int float
+  inherit void any unit bool string path int float
           list attrs product productOpt sum union
           restrict;
   # Type checking.

--- a/pkgs/applications/misc/yate/default.nix
+++ b/pkgs/applications/misc/yate/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     homepage = http://yate.null.ro/;
     # Yate's license is GPL with an exception for linking with
     # OpenH323 and PWlib (licensed under MPL).
-    license = ["GPL" "MPL"];
+    license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.marcweber ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -184,8 +184,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "Mozilla Firefox, free web browser (binary package)";
     homepage = http://www.mozilla.org/firefox/;
-    license = {
-      free = false;
+    license = licenses.unfree // {
       url = http://www.mozilla.org/en-US/foundation/trademarks/policy/;
     };
     platforms = builtins.attrNames mozillaPlatforms;

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -102,6 +102,7 @@ stdenv.mkDerivation rec {
     description = "The TeamSpeak voice communication tool";
     homepage = http://teamspeak.com/;
     license = {
+      shortName = "teamspeak-client-license";
       fullName = "Teamspeak client license";
       url = http://sales.teamspeakusa.com/licensing.php;
       free = false;

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -171,6 +171,8 @@ stdenv.mkDerivation {
     description = "Mozilla Thunderbird, a full-featured email client (binary package)";
     homepage = http://www.mozilla.org/thunderbird/;
     license = {
+      shortName = "thunderbird-binary-license";
+      fullName = "Thunderbird Binary License Unfree";
       free = false;
       url = http://www.mozilla.org/en-US/foundation/trademarks/policy/;
     };

--- a/pkgs/applications/science/biology/diamond/default.nix
+++ b/pkgs/applications/science/biology/diamond/default.nix
@@ -34,7 +34,9 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/bbuchfink/diamond;
     license = {
       fullName = "University of Tuebingen, Benjamin Buchfink";
+      shortName = "uni-tuebingen-buchfink";
       url = https://raw.githubusercontent.com/bbuchfink/diamond/master/src/COPYING;
+      free = false;
     };
     maintainers = [ maintainers.metabar ];
   };

--- a/pkgs/applications/science/chemistry/molden/default.nix
+++ b/pkgs/applications/science/chemistry/molden/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
      description = "Display and manipulate molecular structures";
      homepage = http://www.cmbi.ru.nl/molden/;
      license = {
+       shortName = "molden-unfree";
        fullName = "Free for academic/non-profit use";
        url = http://www.cmbi.ru.nl/molden/CopyRight.html;
        free = false;

--- a/pkgs/applications/science/electronics/ngspice/default.nix
+++ b/pkgs/applications/science/electronics/ngspice/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "The Next Generation Spice (Electronic Circuit Simulator)";
     homepage = http://ngspice.sourceforge.net;
-    license = with licenses; [ "BSD" gpl2 ];
+    license = with licenses; [ bsd3 gpl2 ];
     maintainers = with maintainers; [ viric rongcuid ];
     platforms = platforms.linux;
   };

--- a/pkgs/data/fonts/tewi/default.nix
+++ b/pkgs/data/fonts/tewi/default.nix
@@ -42,8 +42,10 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/lucy/tewi-font;
     license = {
+      shortName = "gpl3-with-font-exception";
       fullName = "GNU General Public License with a font exception";
       url = "https://www.gnu.org/licenses/gpl-faq.html#FontException";
+      free = true;
     };
     maintainers = [ maintainers.fro_ozen ];
     platforms = platforms.unix;

--- a/pkgs/desktops/maxx/default.nix
+++ b/pkgs/desktops/maxx/default.nix
@@ -83,6 +83,7 @@ in stdenv.mkDerivation {
     description = "A replica of IRIX Interactive Desktop";
     homepage = http://www.maxxinteractive.com;
     license = {
+      shortName = "maxx-interactive-desktop-linux-agreement";
       fullName = "The MaXX Interactive Desktop for Linux License Agreement";
       url = http://www.maxxinteractive.com/site/?page_id=97;
       free = false; # redistribution is only allowed to *some* hardware, etc.

--- a/pkgs/development/libraries/goocanvas/default.nix
+++ b/pkgs/development/libraries/goocanvas/default.nix
@@ -13,10 +13,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gtk2 cairo glib ];
 
-  meta = { 
+  meta = {
     description = "Canvas widget for GTK+ based on the the Cairo 2D library";
     homepage = http://goocanvas.sourceforge.net/;
-    license = ["GPL" "LGPL"];
+    license = with stdenv.lib.licenses; [ gpl2 lgpl2 ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/mpich2/default.nix
+++ b/pkgs/development/libraries/mpich2/default.nix
@@ -39,8 +39,10 @@ stdenv.mkDerivation  rec {
     '';
     homepage = http://www.mcs.anl.gov/mpi/mpich2/;
     license = {
+      shortName = "mpich-license-permissive";
       url = http://git.mpich.org/mpich.git/blob/a385d6d0d55e83c3709ae851967ce613e892cd21:/COPYRIGHT;
       fullName = "MPICH license (permissive)";
+      free = false;
     };
     maintainers = [ maintainers.markuskowa ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/build-managers/buildbot/plugins.nix
+++ b/pkgs/development/tools/build-managers/buildbot/plugins.nix
@@ -97,7 +97,7 @@
     meta = with stdenv.lib; {
       homepage = http://buildbot.net/;
       description = "Buildbot WSGI dashboards Plugin";
-      maintainers = with maintainers; [ akazakov ];
+      maintainers = with maintainers; [ ];
       license = licenses.gpl2;
     };
   };

--- a/pkgs/os-specific/linux/beegfs/default.nix
+++ b/pkgs/os-specific/linux/beegfs/default.nix
@@ -145,6 +145,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://www.beegfs.io";
     platforms = [ "i686-linux" "x86_64-linux" ];
     license = {
+      shortName = "beegfs-eula";
       fullName = "BeeGFS_EULA";
       url = "https://www.beegfs.io/docs/BeeGFS_EULA.txt";
       free = false;

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -83,7 +83,20 @@ stdenv.mkDerivation rec {
   meta = {
     description = "SQL relational database management system";
     homepage = http://www.firebirdnews.org;
-    license = ["IDPL" "Interbase-1.0"];
+    license = [
+      {
+        shortName = "IDPL";
+        fullName = "Initial Developer Public License";
+        url = "https://firebirdsql.org/en/initial-developer-s-public-license-version-1-0/";
+        free = false;
+      }
+      {
+        shortName = "Interbase-1.0";
+        fullName = "InterBase Public License";
+        url = "https://firebirdsql.org/en/interbase-public-license/";
+        free = false;
+      }
+    ];
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -149,7 +149,20 @@ let
         longDescription = string;
         branch = string;
         downloadPage = string;
-        license = union [ (list string) (attrs string) (list (attrs string)) string ];
+        license =
+          let
+            licenseT = productOpt {
+              req = {
+                shortName = string;
+                fullName = string;
+                free = bool;
+              };
+              opt = {
+                spdxId = string;
+                url = string;
+              };
+            };
+          in union [ licenseT (list licenseT) string ];
         maintainers = list (productOpt {
           req = {
             name = string;

--- a/pkgs/tools/misc/sl/default.nix
+++ b/pkgs/tools/misc/sl/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
       shortName = "Toyoda Masashi's free software license";
       fullName = shortName;
       url = https://github.com/mtoyoda/sl/blob/master/LICENSE;
+      free = false;
     };
     description = "Steam Locomotive runs across your terminal when you type 'sl'";
     platforms = with stdenv.lib.platforms; unix;

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -60,7 +60,13 @@ pythonPackages.buildPythonApplication rec {
       are unavailable, malfunctioning, or malicious.
     '';
     homepage = http://tahoe-lafs.org/;
-    license = [ lib.licenses.gpl2Plus /* or */ "TGPPLv1+" ];
+    license = [
+      lib.licenses.gpl2Plus /* or */
+      { shortName = "TGPPLv1+";
+        fullName = "Transitive Grace Period Public Licence v. 1.0 or later";
+        url = "https://github.com/zooko/tgppl/blob/master/COPYING.TGPPL-v1.rst";
+        free = false; }
+    ];
     maintainers = with lib.maintainers; [ MostAwesomeDude ];
     platforms = lib.platforms.gnu;  # arbitrary choice
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10381,10 +10381,10 @@ in {
       license = with licenses; [
         asl20
         # third-party program licenses (embedded in the sources)
-        "LGPL" # Crystal_Clear
+        lgpl2Plus # Crystal_Clear
         free # dns
         asl20 # graphy
-        "BSD" # jinja2
+        bsd3 # jinja2
       ];
       longDescription = ''
         It hunts down the fastest DNS servers available for your computer to


### PR DESCRIPTION
Description of the main commit:

```
stdenv/generic/check-meta: rewrite type checking code  …
The previous code used some ad-hoc attribute enumeration to check for missing
fields and did not really type check the attributes, because it used `t.check`
from the module system types, which only does shallow checks for nested types,
e.g. just `builtins.isList` for (listOf strings).

This new version uses `types-simple` to recursively check every attribute,
outputting accurate information for type errors in nested fields, e.g.:

Package ‘hello-2.10’ in … has an invalid meta attrset:
maintainers.1.email should be: string
but is: null

When we set
meta.maintainers [ eelco foobar ];
in `hello/default.nix` and foobar is defined as
{ name = "foobar"; email = null; };
in `maintainers-list.nix`.

The path accurately pins down where the type check failed:
In the `maintainers` field, the second element of the list (counting from 0)
and the field email in that element.

Further work: If an unsupported meta field is used, the type error will print
the complete type of the meta product, which is quite big. The type error should
show a diff of the problematic fields in that case.
This is possible but not yet integrated into the type checking logic.
```

<s>Please go trough the commits one-by-one, since they all add some pretty different changes and are built on each other as single units.</s>
Adding the type library might be a bit controversial, but I hope I have provided enough incentive in the docstrings and the commit messages to persuade you that it is a good addition.

Meta can be checked with [this invocation](https://github.com/NixOS/ofborg/#running-meta-checks-locally) from the ofborg readme.