### PR TITLE
communi: fix darwin build

### DIFF
--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     "
   '';
 
-  postInstall = ''
+  postInstall = stdenv.lib.optionalString stdenv.isLinux ''
     substituteInPlace "$out/share/applications/communi.desktop" \
       --replace "/usr/bin" "$out/bin"
   '';

--- a/pkgs/development/libraries/libcommuni/default.nix
+++ b/pkgs/development/libraries/libcommuni/default.nix
@@ -19,12 +19,16 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   dontUseQmakeConfigure = true;
-  configureFlags = "-config release";
+  configureFlags = [ "-config" "release" ];
+
   preConfigure = ''
     sed -i -e 's|/bin/pwd|pwd|g' configure
   '';
 
-  doCheck = true;
+  # The tests fail on darwin because of install_name if they run
+  # before the frameworks are installed.
+  doInstallCheck = true;
+  installCheckTarget = "check";
 
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = "rm -rf lib";


### PR DESCRIPTION
###### Motivation for this change

/cc ZHF #36454

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
