### PR TITLE
ace: 6.4.6 -> 6.4.7

### DIFF
--- a/pkgs/development/libraries/ace/default.nix
+++ b/pkgs/development/libraries/ace/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ace-${version}";
-  version = "6.4.6";
+  version = "6.4.7";
 
   src = fetchurl {
     url = "http://download.dre.vanderbilt.edu/previous_versions/ACE-${version}.tar.bz2";
-    sha256 = "0xvdwk2505s615fgsy6g33ncxx70vszqspx0bg6lm8hfd3hb4qyj";
+    sha256 = "1zbncdxkkwnx4aphy0apnp7xn4aspxvq2h9bbjh33dpsy0j81afd";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/l2wdk2hk7xr28qc76xdmsnsjlialsrw3-ace-6.4.7/bin/ace_gperf -v` and found version 6.4.7
- found 6.4.7 with grep in /nix/store/l2wdk2hk7xr28qc76xdmsnsjlialsrw3-ace-6.4.7
- found 6.4.7 in filename of file in /nix/store/l2wdk2hk7xr28qc76xdmsnsjlialsrw3-ace-6.4.7
- directory tree listing: https://gist.github.com/df8ae93ced1ab4c4b624c7739501f2a7

cc @nico202 for review