### PR TITLE
acpica-tools: 20180209 -> 20180313

### DIFF
--- a/pkgs/tools/system/acpica-tools/default.nix
+++ b/pkgs/tools/system/acpica-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "acpica-tools-${version}";
-  version = "20180209";
+  version = "20180313";
 
   src = fetchurl {
     url = "https://acpica.org/sites/acpica/files/acpica-unix-${version}.tar.gz";
-    sha256 = "1rpdfwa4vwnvyxdp9ygqjckmabc3s8kyg3jyq4n4f0rhr1zl4zy5";
+    sha256 = "05ab2xfv9wqwbzjaa9xqgrvvan87rxv29hw48h1gcckpc5smp2wm";
   };
 
   NIX_CFLAGS_COMPILE = "-O3";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpibin help` got 0 exit code
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpibin version` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpibin help` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpidump -h` got 0 exit code
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpidump --help` got 0 exit code
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpidump -v` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpihelp help` got 0 exit code
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpihelp version` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpihelp help` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpinames -h` got 0 exit code
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpinames --help` got 0 exit code
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpinames -V` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpinames -v` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpinames --version` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpinames -h` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpinames --help` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpixtract -h` got 0 exit code
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpixtract --help` got 0 exit code
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpixtract -V` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpixtract -v` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpixtract --version` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpixtract -h` and found version 20180313
- ran `/nix/store/kvhbn4g3yvlyn86fssfaydzpkhk46f7a-acpica-tools-20180313/bin/acpixtract --help` and found version 20180313
- directory tree listing: https://gist.github.com/e9140e5d5a76e25c06c6e9299bdc1666

cc @tadfisher for review