### PR TITLE
adapta-gtk-theme: 3.93.0.1 -> 3.93.0.174

### DIFF
--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "adapta-gtk-theme-${version}";
-  version = "3.93.0.1";
+  version = "3.93.0.174";
 
   src = fetchFromGitHub {
     owner = "adapta-project";
     repo = "adapta-gtk-theme";
     rev = version;
-    sha256 = "0l662l66ja8dsakcgwg6ab69lkl0va0r5h74dr6yjdsy0q4h2m7h";
+    sha256 = "0fkvcpx2vhyr3z74r5mcpjh293w3cfm07axj8dj84nl2hi6im8b6";
   };
 
   preferLocalBuild = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/06cdb7bbde8b5a7b86126b7c6f169357

cc @romildo for review