### PR TITLE
allegro: 5.2.3.0 -> 5.2.4.0

### DIFF
--- a/pkgs/development/libraries/allegro/5.nix
+++ b/pkgs/development/libraries/allegro/5.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   name = "allegro-${version}";
-  version = "5.2.3.0";
+  version = "5.2.4.0";
 
   src = fetchFromGitHub {
     owner = "liballeg";
     repo = "allegro5";
     rev = version;
-    sha256 = "0bx240x0filalfarylqjgqf3g80c7dhzhy4m162swjlg0vjpgblr";
+    sha256 = "01y3hirn5b08f188nnhb2cbqj4vzysr7l2qpz2208srv8arzmj2d";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 5.2.4.0 with grep in /nix/store/ffhc3yjpm6avrds564k83vgn1ppw00yr-allegro-5.2.4.0
- directory tree listing: https://gist.github.com/1045c5013f37df121b7965ce4f5c9f5a

cc @7c6f434c for review