### PR TITLE
ant: 1.9.6 -> 1.10.2

### DIFF
--- a/pkgs/development/tools/build-managers/apache-ant/default.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, coreutils, makeWrapper }:
 
-let version = "1.9.6"; in
+let version = "1.10.2"; in
 
 stdenv.mkDerivation {
   name = "ant-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://apache/ant/binaries/apache-ant-${version}-bin.tar.bz2";
-    sha256 = "1cwd5vq175gyicw0hkm8idwa33zxwhf7xlxywaqxcqqdjql0jfx4";
+    sha256 = "0662qammjvibh9kgkxzadkayfn2r7iwnagbwaw28crqqclrb2rp1";
   };
 
   contrib = fetchurl {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.10.2 with grep in /nix/store/l6n421jvbmphjri6w4q9yjnx4jnhrdsr-ant-1.10.2
- directory tree listing: https://gist.github.com/7e0f3ca51161af0caff245d3a57b87c7

cc @edolstra for review