### PR TITLE
apache-jena-fuseki: 3.5.0 -> 3.6.0

### DIFF
--- a/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
+++ b/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
@@ -3,10 +3,10 @@ let
   s = # Generated upstream information
   rec {
     baseName="apache-jena-fuseki";
-    version = "3.5.0";
+    version = "3.6.0";
     name="${baseName}-${version}";
     url="http://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${version}.tar.gz";
-    sha256 = "0pdq103vqpkbwi84yyigw4dy60ch7xzazaj3gfcbipg73v81wpvp";
+    sha256 = "0wmhfr1jlk34cimpz7gvfbi4bh8ki02acbmwdksnkal61f2dxj8q";
   };
   buildInputs = [
     makeWrapper


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/hw41ds5rdx4shi4712c5njz4wrp5kyp0-apache-jena-fuseki-3.6.0/bin/fuseki-server -h` got 0 exit code
- ran `/nix/store/hw41ds5rdx4shi4712c5njz4wrp5kyp0-apache-jena-fuseki-3.6.0/bin/fuseki-server --help` got 0 exit code
- ran `/nix/store/hw41ds5rdx4shi4712c5njz4wrp5kyp0-apache-jena-fuseki-3.6.0/bin/fuseki-server --version` and found version 3.6.0
- found 3.6.0 with grep in /nix/store/hw41ds5rdx4shi4712c5njz4wrp5kyp0-apache-jena-fuseki-3.6.0
- directory tree listing: https://gist.github.com/68036e0a33596f731e456c34f3606cdd

cc @7c6f434c for review