### PR TITLE
archiveopteryx: fix build w/gcc7

### DIFF
--- a/pkgs/servers/mail/archiveopteryx/default.nix
+++ b/pkgs/servers/mail/archiveopteryx/default.nix
@@ -19,6 +19,13 @@ stdenv.mkDerivation rec {
     sed -i 's:MANDIR = $(PREFIX)/man:MANDIR = '$out'/share/man:' ./Jamsettings
     sed -i 's:READMEDIR = $(PREFIX):READMEDIR = '$out'/share/doc/archiveopteryx:' ./Jamsettings
   '';
+
+  # fix build on gcc7
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=builtin-declaration-mismatch"
+    "-Wno-error=implicit-fallthrough"
+  ];
+
   buildPhase = ''jam "-j$NIX_BUILD_CORES" '';
   installPhase = ''
     jam install


### PR DESCRIPTION
###### Motivation for this change

Didn't build with gcc7.

cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

