### PR TITLE
appstream-glib: 0.7.6 -> 0.7.7

### DIFF
--- a/pkgs/development/libraries/appstream-glib/default.nix
+++ b/pkgs/development/libraries/appstream-glib/default.nix
@@ -4,7 +4,7 @@
 , libuuid, json-glib, meson, gperf, ninja
 }:
 stdenv.mkDerivation rec {
-  name = "appstream-glib-0.7.6";
+  name = "appstream-glib-0.7.7";
 
   outputs = [ "out" "dev" "man" ];
   outputBin = "dev";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "hughsie";
     repo = "appstream-glib";
     rev = stdenv.lib.replaceStrings ["." "-"] ["_" "_"] name;
-    sha256 = "1nzm6w9n7fb2m06w88gwszaqf74bnip87ay0ca59wajq6y4mpfgv";
+    sha256 = "127m5ds355i1vfvmn9nd4zqqnqm16jpqcn4p2p2pvn7i4wqxra40";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/brwc3b2jcc6d0gv1396m1lvwy18j62fh-appstream-glib-0.7.7/bin/appstream-builder -h` got 0 exit code
- ran `/nix/store/brwc3b2jcc6d0gv1396m1lvwy18j62fh-appstream-glib-0.7.7/bin/appstream-builder --help` got 0 exit code
- ran `/nix/store/brwc3b2jcc6d0gv1396m1lvwy18j62fh-appstream-glib-0.7.7/bin/appstream-builder help` got 0 exit code
- ran `/nix/store/brwc3b2jcc6d0gv1396m1lvwy18j62fh-appstream-glib-0.7.7/bin/appstream-util -h` got 0 exit code
- ran `/nix/store/brwc3b2jcc6d0gv1396m1lvwy18j62fh-appstream-glib-0.7.7/bin/appstream-util --help` got 0 exit code
- ran `/nix/store/brwc3b2jcc6d0gv1396m1lvwy18j62fh-appstream-glib-0.7.7/bin/appstream-compose -h` got 0 exit code
- ran `/nix/store/brwc3b2jcc6d0gv1396m1lvwy18j62fh-appstream-glib-0.7.7/bin/appstream-compose --help` got 0 exit code
- found 0.7.7 with grep in /nix/store/brwc3b2jcc6d0gv1396m1lvwy18j62fh-appstream-glib-0.7.7
- directory tree listing: https://gist.github.com/fe0ad92e5aceb451004822363fb14bf7

cc @lethalman @matthewbauer for review