### PR TITLE
CVE-2018-5146 updates (libvorbis & tremor)

### DIFF
--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -1,26 +1,16 @@
 { stdenv, fetchurl, libogg, pkgconfig, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  name = "libvorbis-1.3.5";
+  name = "libvorbis-1.3.6";
 
   src = fetchurl {
     url = "http://downloads.xiph.org/releases/vorbis/${name}.tar.xz";
-    sha256 = "1lg1n3a6r41492r7in0fpvzc7909mc5ir9z0gd3qh2pz4yalmyal";
+    sha256 = "05dlzjkdpv46zb837wysxqyn8l636x3dw8v8ymlrwz2fg1dbn05g";
   };
 
   outputs = [ "out" "dev" "doc" ];
 
   patches = [
-    (fetchpatch {
-      url = "https://github.com/xiph/vorbis/commit/a79ec216cd119069c68b8f3542c6a425a74ab993.patch";
-      sha256 = "0xhsa96n3dlh2l85bxpz4b9m78mfxfgi2ibhjp77110a0nvkjr6h";
-      name = "CVE-2017-14633";
-    })
-    (fetchpatch {
-      url = "https://github.com/xiph/vorbis/commit/c1c2831fc7306d5fbd7bc800324efd12b28d327f.patch";
-      sha256 = "17lb86105im6fc0h0cx5sn94p004jsdbbs2vj1m9ll6z9yb4rxwc";
-      name = "CVE-2017-14632";
-    })
     (fetchpatch {
       url = "https://gitlab.xiph.org/xiph/vorbis/uploads/a68cf70fa10c8081a633f77b5c6576b7/0001-CVE-2017-14160-make-sure-we-don-t-overflow.patch";
       sha256 = "0v21p59cb3z77ch1v6q5dcrd733h91f3m8ifnd7kkkr8gzn17d5x";

--- a/pkgs/development/libraries/tremor/default.nix
+++ b/pkgs/development/libraries/tremor/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchsvn, autoreconfHook, pkgconfig, libogg }:
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, libogg }:
 
 stdenv.mkDerivation rec {
-  name = "tremor-svn-${src.rev}";
+  name = "tremor-git-${src.rev}";
 
-  src = fetchsvn {
-    url = http://svn.xiph.org/trunk/Tremor;
-    rev = "17866";
-    sha256 = "161411cbefa1527da7a8fc087e78d8e21d19143d3a6eb42fb281e5026aad7568";
+  src = fetchgit {
+    url = https://git.xiph.org/tremor.git;
+    rev = "562307a4a7082e24553f3d2c55dab397a17c4b4f";
+    sha256 = "0m07gq4zfgigsiz8b518xyb19v7qqp76qmp7lb262825vkqzl3zq";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Fixing CVE-2018-5146 [1].


[1] http://seclists.org/oss-sec/2018/q1/243

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

