### PR TITLE
asio: 1.10.8 -> 1.12.0

### DIFF
--- a/pkgs/development/libraries/asio/default.nix
+++ b/pkgs/development/libraries/asio/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, boost, openssl}:
 
 stdenv.mkDerivation rec {
-  name = "asio-1.10.8";
+  name = "asio-1.12.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/asio/${name}.tar.bz2";
-    sha256 = "0jgdl4fxw0hwy768rl3lhdc0czz7ak7czf3dg10j21pdpfpfvpi6";
+    sha256 = "1bfk746kcs3cmvfvxjp3w9y6zpybjj8s002jjd3snrp2syd0nd9c";
   };
 
   propagatedBuildInputs = [ boost ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.12.0 with grep in /nix/store/1js10q8jgqmpk6ashz63am7f9xl37kvs-asio-1.12.0
- directory tree listing: https://gist.github.com/834ad2743ce2f56612f8ba9ff9a4e5b5