### PR TITLE
autoconf-archive: 2017.09.28 -> 2018.03.13

### DIFF
--- a/pkgs/development/tools/misc/autoconf-archive/default.nix
+++ b/pkgs/development/tools/misc/autoconf-archive/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "autoconf-archive-${version}";
-  version = "2017.09.28";
+  version = "2018.03.13";
 
   src = fetchurl {
     url = "mirror://gnu/autoconf-archive/autoconf-archive-${version}.tar.xz";
-    sha256 = "00gsh9hkrgg291my98plkrwlcpxkfrpq64pglf18kciqbf2bb7sw";
+    sha256 = "0ng1lvpijf3kv7w7nb1shqs23vp0398yicyvkf9lsk56kw6zjxb1";
   };
 
   buildInputs = [ xz ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2018.03.13 with grep in /nix/store/gpwn8923mppc2h6vx2rgg8q52ss2mg2l-autoconf-archive-2018.03.13
- directory tree listing: https://gist.github.com/eaaa4f78b6bd461710c33aea9e21fdea