### PR TITLE
heapster: fix build

### DIFF
--- a/pkgs/servers/monitoring/heapster/default.nix
+++ b/pkgs/servers/monitoring/heapster/default.nix
@@ -10,7 +10,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "kubernetes";
     repo = "heapster";
-    sha256 = "057z9imgd2gvcbvahja3i26jzgm33dmfaxraakmcr4a2xfhj50hq";
+    sha256 = "1vg83207y7yigydnnhlvzs3s94vx02i56lqgs6a96c6i3mr3ydpb";
   };
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

didn't build because fetchFromGitHub returned a different sha256 for the same revision.

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

