### PR TITLE
autofs: 5.1.3 -> 5.1.4

### DIFF
--- a/pkgs/os-specific/linux/autofs/default.nix
+++ b/pkgs/os-specific/linux/autofs/default.nix
@@ -2,14 +2,14 @@
 , libxml2, kerberos, kmod, openldap, sssd, cyrus_sasl, openssl }:
 
 let
-  version = "5.1.3";
+  version = "5.1.4";
   name = "autofs-${version}";
 in stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
     url = "mirror://kernel/linux/daemons/autofs/v5/${name}.tar.xz";
-    sha256 = "1gxifa93104pxlmxrikhwciy5zdgk20m63siyhq1myym7vzfnvp9";
+    sha256 = "08hpphawzcdibwbhw0r3y7hnfczlazpp90sf3bz2imgza7p31klg";
   };
 
   preConfigure = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/wbax6msw4jcf95a3b56rgb5qyy08v3gb-autofs-5.1.4/bin/automount -h` got 0 exit code
- ran `/nix/store/wbax6msw4jcf95a3b56rgb5qyy08v3gb-autofs-5.1.4/bin/automount --help` got 0 exit code
- ran `/nix/store/wbax6msw4jcf95a3b56rgb5qyy08v3gb-autofs-5.1.4/bin/automount -V` and found version 5.1.4
- ran `/nix/store/wbax6msw4jcf95a3b56rgb5qyy08v3gb-autofs-5.1.4/bin/automount --version` and found version 5.1.4
- ran `/nix/store/wbax6msw4jcf95a3b56rgb5qyy08v3gb-autofs-5.1.4/bin/automount -h` and found version 5.1.4
- ran `/nix/store/wbax6msw4jcf95a3b56rgb5qyy08v3gb-autofs-5.1.4/bin/automount --help` and found version 5.1.4
- found 5.1.4 with grep in /nix/store/wbax6msw4jcf95a3b56rgb5qyy08v3gb-autofs-5.1.4
- directory tree listing: https://gist.github.com/419a24d78045772aea1e7ca68b950f1f