### PR TITLE
bind: 9.12.0 -> 9.12.1

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -4,14 +4,14 @@
 
 assert enableSeccomp -> libseccomp != null;
 
-let version = "9.12.0"; in
+let version = "9.12.1"; in
 
 stdenv.mkDerivation rec {
   name = "bind-${version}";
 
   src = fetchurl {
     url = "http://ftp.isc.org/isc/bind9/${version}/${name}.tar.gz";
-    sha256 = "10iwkghl5g50b7wc17bsb9wa0dh2gd57bjlk6ynixhywz6dhx1r9";
+    sha256 = "043mjcw405qa0ghm5dkhfsq35gsy279724fz3mjqpr1mbi14dr0n";
   };
 
   outputs = [ "out" "lib" "dev" "man" "dnsutils" "host" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/delv help` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/delv -v` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named-rrchecker -h` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named-rrchecker --help` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named-rrchecker -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named-rrchecker -v` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named-rrchecker --version` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named-rrchecker --help` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/mdig -h` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/mdig -v` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/ddns-confgen -h` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-cds -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-dsfromkey -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-importkey -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-keyfromlabel -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-keygen -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-revoke -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-settime -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-signzone -h` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-signzone --help` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-signzone -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-signzone -v` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-signzone --version` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-signzone -h` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-signzone --help` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-verify -h` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-verify --help` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-verify -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-verify -v` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-verify --version` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-verify -h` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/dnssec-verify --help` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named -V` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named -v` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named-checkconf -v` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/named-checkzone -v` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/rndc -h` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/rndc -h` and found version 9.12.1
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/rndc-confgen -h` got 0 exit code
- ran `/nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1/bin/rndc-confgen -h` and found version 9.12.1
- found 9.12.1 with grep in /nix/store/9i6c9yx3p0gvhphd4ahj8pfcm0n78han-bind-9.12.1
- directory tree listing: https://gist.github.com/e9daefd05b7c96cd83a144018a3b6aaf

cc @viric @peti for review