### PR TITLE
bluez: 5.28 -> 5.49

### DIFF
--- a/pkgs/os-specific/linux/bluez/bluez5_28.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5_28.nix
@@ -7,11 +7,11 @@ assert stdenv.isLinux;
 let
   inherit (pythonPackages) python;
 in stdenv.mkDerivation rec {
-  name = "bluez-5.28";
+  name = "bluez-5.49";
    
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/${name}.tar.xz";
-    sha256 = "1a8qzh38wpq5c0rydpx9isf0jc6g14g2qs18j1rmi8a79f7v9fl5";
+    sha256 = "15ffsaz7l3fgdg03l7g1xx9jw7xgs6pc548zxqsxawsca5x1sc1k";
   };
 
   pythonPath = with pythonPackages;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluetoothctl -h` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluetoothctl --help` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluetoothctl -V` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluetoothctl -v` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluetoothctl --version` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluetoothctl -h` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluetoothctl --help` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/btmon -h` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/btmon --help` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/btmon -v` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/btmon --version` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bccmd -h` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bccmd --help` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bccmd -V` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bccmd -v` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bccmd --version` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluemoon -h` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluemoon --help` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluemoon -v` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/bluemoon --version` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/hex2hcd -h` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/hex2hcd --help` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/hex2hcd help` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/hex2hcd -v` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/hex2hcd --version` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/mpris-proxy -h` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/mpris-proxy --help` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/mpris-proxy -v` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/mpris-proxy --version` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/btattach -h` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/btattach --help` got 0 exit code
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/btattach -v` and found version 5.49
- ran `/nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49/bin/btattach --version` and found version 5.49
- found 5.49 with grep in /nix/store/ffs2r0398pl6nn4v0vdan0djslaaxii4-bluez-5.49
- directory tree listing: https://gist.github.com/fa0d5bf97223c22133fcaafdf63f56c7