### PR TITLE
cifs-utils: 6.7 -> 6.8

### DIFF
--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cifs-utils-${version}";
-  version = "6.7";
+  version = "6.8";
 
   src = fetchurl {
     url = "mirror://samba/pub/linux-cifs/cifs-utils/${name}.tar.bz2";
-    sha256 = "1ayghnkryy1n1zm5dyvyyr7n3807nsm6glfcbbki5c2a8w91dwmj";
+    sha256 = "0ygz3pagjpaj5ky11hzh4byyymb7fpmqiqkprn11zwj31h2zdlg7";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/55ryin1a2l4h78wka5k55b223mhsv4ah-cifs-utils-6.8/bin/cifs.upcall -v` and found version 6.8
- ran `/nix/store/55ryin1a2l4h78wka5k55b223mhsv4ah-cifs-utils-6.8/bin/cifs.upcall --version` and found version 6.8
- found 6.8 with grep in /nix/store/55ryin1a2l4h78wka5k55b223mhsv4ah-cifs-utils-6.8
- directory tree listing: https://gist.github.com/97fa73e76891fadb3a329476169aa13c