### PR TITLE
datamash: 1.2 -> 1.3

### DIFF
--- a/pkgs/tools/misc/datamash/default.nix
+++ b/pkgs/tools/misc/datamash/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "datamash-${version}";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchurl {
     url = "mirror://gnu/datamash/${name}.tar.gz";
-    sha256 = "15jrv3ly0vgvwwi2qjmhi39n7wrklwifdk961wwfaxyc5jr6zm78";
+    sha256 = "19jpcv4ryvbz0476d6dgpxpbjkpmih4q84wj06nslls338bm5fzf";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/chqcg1al11i9hbk156k4dsn8rnigwiap-datamash-1.3/bin/datamash --help` got 0 exit code
- ran `/nix/store/chqcg1al11i9hbk156k4dsn8rnigwiap-datamash-1.3/bin/datamash --version` and found version 1.3
- ran `/nix/store/chqcg1al11i9hbk156k4dsn8rnigwiap-datamash-1.3/bin/datamash --help` and found version 1.3
- found 1.3 with grep in /nix/store/chqcg1al11i9hbk156k4dsn8rnigwiap-datamash-1.3
- directory tree listing: https://gist.github.com/0a3f8ea7a3daa6dd6ff2888a8298d6f7

cc @pSub @vrthra for review