### PR TITLE
eigen: 3.3.3 -> 3.3.4

### DIFF
--- a/pkgs/development/libraries/eigen/3.3.nix
+++ b/pkgs/development/libraries/eigen/3.3.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, cmake}:
 
 let
-  version = "3.3.3";
+  version = "3.3.4";
 in
 stdenv.mkDerivation {
   name = "eigen-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   src = fetchurl {
     url = "http://bitbucket.org/eigen/eigen/get/${version}.tar.gz";
     name = "eigen-${version}.tar.gz";
-    sha256 = "0pz7k8kd9nydmsj2prjs67apixipl6pll3f0cjy0y3bvlazqr1wl";
+    sha256 = "1q85bgd6hnsgn0kq73wa4jwh4qdwklfg73pgqrz4zmxvzbqyi1j2";
   };
   
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.3.4 with grep in /nix/store/q5xnlq781hvj0skjlhnb1qw1k69pf048-eigen-3.3.4
- directory tree listing: https://gist.github.com/d83ce54c91cb6ecf3fd3eb94b666357f

cc @svanderburg @7c6f434c for review