### PR TITLE
nixos/libvirtd: add option to run qemu as non-root

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -325,6 +325,7 @@
       hydron = 298;
       cfssl = 299;
       cassandra = 300;
+      qemu-libvirtd = 301;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -610,6 +611,7 @@
       hydron = 298;
       cfssl = 299;
       cassandra = 300;
+      qemu-libvirtd = 301;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal


### PR DESCRIPTION
###### Motivation for this change

In current NixOS, `libvirtd` runs `qemu` processes as root by default. This increases security risk and is not necessary for most applications.

Users can of course manually modify the user for qemu processes using the `virtualisation.libvirtd.qemuVerbatimConfig` option, but that is rather inconvenient.

This change adds a new NixOS option `virtualisation.libvirtd.qemuRunAsRoot`.
If false ~~(the default)~~, `qemu` is run as a non-privileged user `qemu-libvirtd`.

Other distros with a similar default behaviour include Debian, Arch and Fedora.


Edit: As per discussion below, this now implements a first step by adding the `qemuRunAsRoot` option but setting it to `false` by default to avoid permission issues with existing guests.
The plan is to change the default to `true` later in a separate PR to ease the transition.

###### Things done

Manually tested.

---

/cc @fpletz @volth 
