### PR TITLE
slic3r-prusa3d: 1.38.7 -> 1.39.1

### DIFF
--- a/pkgs/applications/misc/slic3r-prusa3d/default.nix
+++ b/pkgs/applications/misc/slic3r-prusa3d/default.nix
@@ -33,7 +33,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "slic3r-prusa-edition-${version}";
-  version = "1.38.7";
+  version = "1.39.1";
 
   enableParallelBuilding = true;
 
@@ -70,6 +70,10 @@ stdenv.mkDerivation rec {
     XMLSAX
   ]);
 
+  prePatch = ''
+    sed -i 's|"/usr/include/asm-generic/ioctls.h"|<asm-generic/ioctls.h>|g' xs/src/libslic3r/GCodeSender.cpp
+  '';
+
   postInstall = ''
     echo 'postInstall'
     wrapProgram "$out/bin/slic3r-prusa3d" \
@@ -84,7 +88,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "Slic3r";
-    sha256 = "1nrryd2bxmk4y59bq5fp7n2alyvc5a9xvnbx5j4fg4mqr91ccs5c";
+    sha256 = "0frkjgzmiy788ijkcqz3baxcrncqmk9s2vcd99hb8p2q13cg51ff";
     rev = "version_${version}";
   };
 


### PR DESCRIPTION
###### Motivation for this change
keep slic3r-prusa3d up to date

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

