### PR TITLE
emscripten: 1.37.16 -> 1.37.36

### DIFF
--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  rev = "1.37.16";
+  rev = "1.37.36";
   appdir = "share/emscripten";
 in
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten";
-    sha256 = "1qyhjx5zza01vnwmj6qzxbkagxknn4kzb6gw12fqw5q8pa8fy4zy";
+    sha256 = "02p0cp86vd1mydlpq544xbydggpnrq9dhbxx7h08j235frjm5cdc";
     inherit rev;
   };
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.37.36 with grep in /nix/store/yfy594rfgcbk7qyf94wyx2ychjkzi2xj-emscripten-1.37.36
- directory tree listing: https://gist.github.com/740ee9af9dc3c5b912dd0da75e114b41

cc @qknight @matthewbauer for review