### PR TITLE
gosmore: fix build with gcc7

### DIFF
--- a/pkgs/applications/misc/gosmore/default.nix
+++ b/pkgs/applications/misc/gosmore/default.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation {
   prePatch = ''
     sed -e '/curl.types.h/d' -i *.{c,h,hpp,cpp}
   '';
+
+  patches = [ ./pointer_int_comparison.patch ];
+  patchFlags = [ "-p1" "--binary" ]; # patch has dos style eol
       
   meta = with stdenv.lib; {
     description = "Open Street Map viewer";

--- a/pkgs/applications/misc/gosmore/pointer_int_comparison.patch
+++ b/pkgs/applications/misc/gosmore/pointer_int_comparison.patch
@@ -1,0 +1,11 @@
+--- blah_/jni/gosmore.cpp	1970-01-01 01:00:01.000000000 +0100
++++ /dev/stdin	2018-03-18 00:21:08.474217132 +0100
+@@ -1273,7 +1273,7 @@
+       if (deg[i] < -180 || deg[i] > 180) break;
+       if (i == 0 && (strncasecmp (t, "lat", 3) == 0 ||
+                      strncasecmp (t, "lon", 3) == 0)) { // lat=-25.7 lon=28.2
+-        for (t += 3; t != '\0' && !isalnum (*t); t++) {}
++        for (t += 3; *t != '\0' && !isalnum (*t); t++) {}
+       }
+       if (i == 1) { // Success !
+         //printf ("%lf %lf %u\n", deg[lonFirst ? 1 : 0], deg[lonFirst ? 0 : 1],


### PR DESCRIPTION
###### Motivation for this change
fix build with gcc7: https://hydra.nixos.org/build/70739382
cc ZHF https://github.com/NixOS/nixpkgs/issues/36453
cc @7c6f434c maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

