### PR TITLE
exempi: 2.4.4 -> 2.4.5

### DIFF
--- a/pkgs/development/libraries/exempi/default.nix
+++ b/pkgs/development/libraries/exempi/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, expat, zlib, boost, libiconv, darwin }:
 
 stdenv.mkDerivation rec {
-  name = "exempi-2.4.4";
+  name = "exempi-2.4.5";
 
   src = fetchurl {
     url = "http://libopenraw.freedesktop.org/download/${name}.tar.bz2";
-    sha256 = "1c1xxiw9lazdaz4zvrnvcy9pif9l1wib7zy91m48i7a4bnf9mmd2";
+    sha256 = "07i29xmg8bqriviaf4vi1mwha4lrw85kfla29cfym14fp3z8aqa0";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.4.5 with grep in /nix/store/l4nmjlanshgdwrh95g1h0714zcm1kk3z-exempi-2.4.5
- directory tree listing: https://gist.github.com/2d437e9ea408cfda7abaa772865a0b82