### PR TITLE
make-system-tarball: allow alternate compression methods

### DIFF
--- a/nixos/lib/make-system-tarball.nix
+++ b/nixos/lib/make-system-tarball.nix
@@ -1,4 +1,4 @@
-{ stdenv, perl, xz, pathsFromGraph
+{ stdenv, perl, pixz, pathsFromGraph
 
 , # The file name of the resulting tarball
   fileName ? "nixos-system-${stdenv.system}"
@@ -21,14 +21,20 @@
 
   # Extra tar arguments
 , extraArgs ? ""
+  # Command used for compression
+, compressCommand ? "pixz"
+  # Extension for the compressed tarball
+, compressionExtension ? ".xz"
+  # extra inputs, like the compressor to use
+, extraInputs ? [ pixz ]
 }:
 
 stdenv.mkDerivation {
   name = "tarball";
   builder = ./make-system-tarball.sh;
-  buildInputs = [perl xz];
+  buildInputs = [ perl ] ++ extraInputs;
 
-  inherit fileName pathsFromGraph extraArgs extraCommands;
+  inherit fileName pathsFromGraph extraArgs extraCommands compressCommand;
 
   # !!! should use XML.
   sources = map (x: x.source) contents;
@@ -41,4 +47,6 @@ stdenv.mkDerivation {
   # For obtaining the closure of `storeContents'.
   exportReferencesGraph =
     map (x: [("closure-" + baseNameOf x.object) x.object]) storeContents;
+
+  extension = compressionExtension;
 }

--- a/nixos/lib/make-system-tarball.sh
+++ b/nixos/lib/make-system-tarball.sh
@@ -1,5 +1,4 @@
 source $stdenv/setup
-set -x
 
 sources_=($sources)
 targets_=($targets)
@@ -54,8 +53,8 @@ mkdir -p $out/tarball
 
 rm env-vars
 
-tar --sort=name --mtime='@1' --owner=0 --group=0 --numeric-owner -cvJf $out/tarball/$fileName.tar.xz * $extraArgs
+time tar --sort=name --mtime='@1' --owner=0 --group=0 --numeric-owner -c * $extraArgs | $compressCommand > $out/tarball/$fileName.tar${extension}
 
 mkdir -p $out/nix-support
 echo $system > $out/nix-support/system
-echo "file system-tarball $out/tarball/$fileName.tar.xz" > $out/nix-support/hydra-build-products
+echo "file system-tarball $out/tarball/$fileName.tar${extension}" > $out/nix-support/hydra-build-products

--- a/nixos/modules/profiles/docker-container.nix
+++ b/nixos/modules/profiles/docker-container.nix
@@ -14,9 +14,7 @@ in {
   ];
 
   # Create the tarball
-  system.build.tarball = import ../../lib/make-system-tarball.nix {
-    inherit (pkgs) stdenv perl xz pathsFromGraph;
-
+  system.build.tarball = pkgs.callPackage ../../lib/make-system-tarball.nix {
     contents = [];
     extraArgs = "--owner=0";
 


### PR DESCRIPTION
###### Motivation for this change
sometimes an `xz` based tarball cant be used, and sometimes you may want to compress in parallel with `pixz` or `pigz`

###### Things done

added support for gzip, lzma, bzip2, parallel xz/gz
tested with `nix-build nixos/release.nix -A containerTarball.x86_64-linux`
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

the stats i gathered during testing:
```

xz:
real: 5m, user: 4m53s, size: 118mb

pixz:
real: 1m20, user: 5m26s, size: 129m

gzip:
real: 52sec, user: 39sec, size: 209mb

pigz:
real: 26sec, user: 41sec, size: 209mb

bzip2:
real: 1m39s, user: 1m18s, size: 180mb

lzma:
real: 5m3s, user: 4m56s, size: 118mb
```