### PR TITLE
fox: 1.6.49 -> 1.6.56

### DIFF
--- a/pkgs/development/libraries/fox/fox-1.6.nix
+++ b/pkgs/development/libraries/fox/fox-1.6.nix
@@ -3,7 +3,7 @@
 , CoreServices }:
 
 let
-  version = "1.6.49";
+  version = "1.6.56";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "ftp://ftp.fox-toolkit.org/pub/${name}.tar.gz";
-    sha256 = "03m9wm8hpzh1i0fxx5mpvjr67384pfm9hn7gzdcq55b4639fqy9n";
+    sha256 = "1ckcb12gblz1ad1371ah1qirxn3r9zdngh9w0357hsqfmkyfa5y5";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/84izmk7vawbjy8jq443ym0wx7k2a89my-fox-1.6.56/bin/reswrap -h` got 0 exit code
- ran `/nix/store/84izmk7vawbjy8jq443ym0wx7k2a89my-fox-1.6.56/bin/reswrap --help` got 0 exit code
- ran `/nix/store/84izmk7vawbjy8jq443ym0wx7k2a89my-fox-1.6.56/bin/adie -h` got 0 exit code
- ran `/nix/store/84izmk7vawbjy8jq443ym0wx7k2a89my-fox-1.6.56/bin/adie --help` got 0 exit code
- ran `/nix/store/84izmk7vawbjy8jq443ym0wx7k2a89my-fox-1.6.56/bin/fox-config --version` and found version 1.6.56
- found 1.6.56 with grep in /nix/store/84izmk7vawbjy8jq443ym0wx7k2a89my-fox-1.6.56
- directory tree listing: https://gist.github.com/04085b0f58d3548a56ff6ed257520c45