### PR TITLE
wine: WIP make "unsafe" GStreamer plugins non-default

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -48,7 +48,8 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   ++ lib.optional pulseaudioSupport      pkgs.libpulseaudio
   ++ lib.optional xineramaSupport        pkgs.xorg.libXinerama
   ++ lib.optional udevSupport            pkgs.udev
-  ++ lib.optionals gstreamerSupport      (with pkgs.gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ])
+  ++ lib.optionals gstreamerSupport      (with pkgs.gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav ])
+  ++ lib.optionals gstreamerUglySupport  (with pkgs.gst_all_1; [ gst-plugins-ugly ])
   ++ lib.optionals gtkSupport    [ pkgs.gtk3 pkgs.glib ]
   ++ lib.optionals openclSupport [ pkgs.opencl-headers pkgs.ocl-icd ]
   ++ lib.optionals xmlSupport    [ pkgs.libxml2 pkgs.libxslt ]
@@ -83,7 +84,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   # Add capability to ignore known failing tests
   # and enable doCheck
   doCheck = false;
-  
+
   postInstall = let
     links = prefix: pkg: "ln -s ${pkg} $out/${prefix}/${pkg.name}";
   in ''
@@ -100,7 +101,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
       fi
     done
   '';
-  
+
   enableParallelBuilding = true;
 
   # https://bugs.winehq.org/show_bug.cgi?id=43530

--- a/pkgs/misc/emulators/wine/default.nix
+++ b/pkgs/misc/emulators/wine/default.nix
@@ -20,6 +20,7 @@
   openglSupport ? false,
   tlsSupport ? false,
   gstreamerSupport ? false,
+  gstreamerUglySupport ? false,
   cupsSupport ? false,
   colorManagementSupport ? false,
   dbusSupport ? false,
@@ -42,6 +43,8 @@
   xineramaSupport ? false,
   xmlSupport ? false }:
 
+assert gstreamerUglySupport -> gstreamerSupport;
+
 let wine-build = build: release:
       lib.getAttr build (callPackage ./packages.nix {
         wineRelease = release;
@@ -51,7 +54,7 @@ let wine-build = build: release:
                   netapiSupport cursesSupport vaSupport pcapSupport v4lSupport saneSupport
                   gsmSupport gphoto2Support ldapSupport fontconfigSupport alsaSupport
                   pulseaudioSupport xineramaSupport gtkSupport openclSupport xmlSupport tlsSupport
-                  openglSupport gstreamerSupport udevSupport;
+                  openglSupport gstreamerSupport gstreamerUglySupport udevSupport;
         };
       });
 


### PR DESCRIPTION

###### Motivation for this change

* the "gst-plugins-bad gst-plugins-ugly" packages both should not be default. These have license or quality concerns that should be avoided unless requested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

