### PR TITLE
pythonPackages.pushover: init at 0.3

### DIFF
--- a/pkgs/development/python-modules/pushover/default.nix
+++ b/pkgs/development/python-modules/pushover/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, requests }:
+
+buildPythonPackage rec {
+  pname = "python-pushover";
+  version = "0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xlghiqd9rsgn7jdhc8v1xh3xspssihrw1vyy85gvjzxa1ah19sk";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # checks crash
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Bindings and command line utility for the Pushover notification service";
+    homepage = https://github.com/Thibauth/python-pushover;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/pushover/default.nix
+++ b/pkgs/development/python-modules/pushover/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ requests ];
 
-  # checks crash
+  # there are no tests
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -234,7 +234,7 @@
     "notify.message_bird" = ps: with ps; [  ];
     "notify.pushbullet" = ps: with ps; [ pushbullet ];
     "notify.pushetta" = ps: with ps; [  ];
-    "notify.pushover" = ps: with ps; [  ];
+    "notify.pushover" = ps: with ps; [ python-pushover ];
     "notify.rocketchat" = ps: with ps; [  ];
     "notify.sendgrid" = ps: with ps; [  ];
     "notify.simplepush" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12409,7 +12409,6 @@ in {
 
   py = callPackage ../development/python-modules/py { };
 
-
   pyacoustid = buildPythonPackage rec {
     name = "pyacoustid-1.1.0";
 
@@ -12518,6 +12517,8 @@ in {
       homepage = "https://github.com/rohe/pysaml2";
     };
   };
+
+  python-pushover = callPackage ../development/python-modules/pushover {};
 
   mongodict = buildPythonPackage rec {
     name = "mongodict-${version}";


### PR DESCRIPTION
###### Motivation for this change

Needed for home-assistant.

Cc: @FRidh @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

