### PR TITLE
fwup: 0.18.1 -> 1.0.0

### DIFF
--- a/pkgs/tools/misc/fwup/default.nix
+++ b/pkgs/tools/misc/fwup/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "fwup-${version}";
-  version = "0.18.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "fhunleth";
     repo = "fwup";
     rev = "v${version}";
-    sha256 = "0qdld8jy1rkpfzbfhnssr58q1gciln3pw9m6fj0jarfgja4gj31l";
+    sha256 = "1v79q5s4lm8scrz9nmqcszyh40is6k7hkr15r4aljyfbp1gamsfs";
   };
 
   doCheck = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/1w5mk97wzbp6xdwj0phwmdr0z7rfc1nf-fwup-1.0.0/bin/fwup -h` got 0 exit code
- ran `/nix/store/1w5mk97wzbp6xdwj0phwmdr0z7rfc1nf-fwup-1.0.0/bin/fwup --help` got 0 exit code
- ran `/nix/store/1w5mk97wzbp6xdwj0phwmdr0z7rfc1nf-fwup-1.0.0/bin/fwup --version` and found version 1.0.0
- found 1.0.0 with grep in /nix/store/1w5mk97wzbp6xdwj0phwmdr0z7rfc1nf-fwup-1.0.0
- directory tree listing: https://gist.github.com/9b3eafd6e201b20c76f1f8f4d8ed13f8

cc @georgewhewell for review