### PR TITLE
gcr: 3.20.0 -> 3.28.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/gcr/default.nix
+++ b/pkgs/desktops/gnome-3/core/gcr/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gcr-${version}";
-  version = "3.20.0";
+  version = "3.28.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gcr/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "90572c626d8a708225560c42b4421f7941315247fa1679d4ef569bde7f4bb379";
+    sha256 = "02xgky22xgvhgd525khqh64l5i21ca839fj9jzaqdi3yvb8pbq8m";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/9613r7rwjf4h7gyb9li1z9s614c8z7cy-gcr-3.28.0/bin/gcr-viewer -h` got 0 exit code
- ran `/nix/store/9613r7rwjf4h7gyb9li1z9s614c8z7cy-gcr-3.28.0/bin/gcr-viewer --help` got 0 exit code
- ran `/nix/store/9613r7rwjf4h7gyb9li1z9s614c8z7cy-gcr-3.28.0/bin/gcr-viewer --version` and found version 3.28.0
- ran `/nix/store/9613r7rwjf4h7gyb9li1z9s614c8z7cy-gcr-3.28.0/bin/.gcr-viewer-wrapped -h` got 0 exit code
- ran `/nix/store/9613r7rwjf4h7gyb9li1z9s614c8z7cy-gcr-3.28.0/bin/.gcr-viewer-wrapped --help` got 0 exit code
- ran `/nix/store/9613r7rwjf4h7gyb9li1z9s614c8z7cy-gcr-3.28.0/bin/.gcr-viewer-wrapped --version` and found version 3.28.0
- found 3.28.0 with grep in /nix/store/9613r7rwjf4h7gyb9li1z9s614c8z7cy-gcr-3.28.0
- directory tree listing: https://gist.github.com/9400c373d81867b548d8cfb5342623cd

cc @lethalman @jtojnar for review