### PR TITLE
gdl: 3.26.0 -> 3.28.0

### DIFF
--- a/pkgs/desktops/gnome-3/devtools/gdl/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/gdl/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gdl-${version}";
-  version = "3.26.0";
+  version = "3.28.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gdl/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "f3ad03f9a34f751f52464e22d962c0dec8ff867b7b7b37fe24907f3dcd54c079";
+    sha256 = "1dipnzqpxl0yfwzl2lqdf6vb3174gb9f1d5jndkq8505q7n9ik2j";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.28.0 with grep in /nix/store/x4px8ii63cj13w6jnv1l6lk96mw09kyj-gdl-3.28.0
- directory tree listing: https://gist.github.com/b2e0057f3d2763487ab2240b786d922c

cc @lethalman @jtojnar for review