### PR TITLE
gedit: 3.22.1 -> 3.28.0

### DIFF
--- a/pkgs/desktops/gnome-3/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gedit/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "gedit-${version}";
-  version = "3.22.1";
+  version = "3.28.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gedit/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "aa7bc3618fffa92fdb7daf2f57152e1eb7962e68561a9c92813d7bbb7fc9492b";
+    sha256 = "0pyam0zi44xq776x20ycqnvmf86l98jns8ldv4m81gnp9wnhmycv";
   };
 
   passthru = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/gedit -h` got 0 exit code
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/gedit --help` got 0 exit code
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/gedit -V` and found version 3.28.0
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/gedit --version` and found version 3.28.0
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/gnome-text-editor -h` got 0 exit code
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/gnome-text-editor --help` got 0 exit code
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/gnome-text-editor -V` and found version 3.28.0
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/gnome-text-editor --version` and found version 3.28.0
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/.gedit-wrapped -h` got 0 exit code
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/.gedit-wrapped --help` got 0 exit code
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/.gedit-wrapped -V` and found version 3.28.0
- ran `/nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0/bin/.gedit-wrapped --version` and found version 3.28.0
- found 3.28.0 with grep in /nix/store/c9yyiqrmz3bamgy8b8ccwkhf0h545izs-gedit-3.28.0
- directory tree listing: https://gist.github.com/3a6dc9244a49773cf2c2a438ef503a49

cc @lethalman @jtojnar for review