### PR TITLE
xml2rfc: init at 2.9.6

### DIFF
--- a/pkgs/tools/typesetting/xml2rfc/default.nix
+++ b/pkgs/tools/typesetting/xml2rfc/default.nix
@@ -1,0 +1,24 @@
+{ python, stdenv }:
+
+with python.pkgs;
+
+buildPythonPackage rec {
+  pname = "xml2rfc";
+  version = "2.9.6";
+
+  buildInputs = [ intervaltree lxml requests pyflakes ];
+  propagatedBuildInputs = [ intervaltree lxml requests six ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wr161lx6f1b3fq14ddr3y4jl0myrcmqs1s3fzsighvlmqfdihj7";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://xml2rfc.tools.ietf.org/";
+    license = licenses.bsdOriginal;
+    description = "Xml2rfc generates RFCs and IETF drafts from document source in XML according to the dtd in RFC2629.";
+    maintainers = [ maintainers.yrashk ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20980,4 +20980,6 @@ with pkgs;
   simplehttp2server = callPackage ../servers/simplehttp2server { };
 
   diceware = callPackage ../tools/security/diceware { };
+
+  xml2rfc = callPackage ../tools/typesetting/xml2rfc { };
 }


### PR DESCRIPTION
###### Motivation for this change

xml2rfc not present in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

