### PR TITLE
gnomeExtensions.timepp: init at 2018.03.17

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/timepp/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/timepp/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extension-timepp-${version}";
+  version = "2018.03.17";
+
+  src = fetchFromGitHub {
+    owner = "zagortenay333";
+    repo = "timepp__gnome";
+    rev = "440cf85dc68d9e6ba876793f13910ee6239622cf";
+    sha256 = "0idsqsii5rvynvj78w2j7xiiz9rrl3384m5mj6bf6rg8vprpfi8v";
+  };
+
+  uuid = "timepp@zagortenay333";
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r . $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  meta = with stdenv.lib; {
+    description = " A todo.txt manager, time tracker, timer, stopwatch, pomodoro, and alarms gnome-shell extension.";
+    homepage = https://github.com/zagortenay333/timepp__gnome;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ svsdep ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19355,6 +19355,7 @@ with pkgs;
     no-title-bar = callPackage ../desktops/gnome-3/extensions/no-title-bar { };
     remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };
     taskwhisperer = callPackage ../desktops/gnome-3/extensions/taskwhisperer { };
+    timepp = callPackage ../desktops/gnome-3/extensions/timepp { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
   };
 


### PR DESCRIPTION
###### Motivation for this change
I need this extension for my desktop setup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

