### PR TITLE
calaos_installer: init at 3.1

### DIFF
--- a/pkgs/misc/calaos/installer/default.nix
+++ b/pkgs/misc/calaos/installer/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, qmake, qttools, qtbase }:
+
+stdenv.mkDerivation rec {
+  name = "calaos_installer-3.1";
+  version = "3.1";
+
+  src = fetchFromGitHub {
+    owner = "calaos";
+    repo = "calaos_installer";
+    rev = "v${version}";
+    sha256 = "0g8igj5sax5vjqzrpbil7i6329708lqqwvg5mwiqd0zzzha9sawd";
+  };
+
+  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtbase ];
+
+  qmakeFlags = [ "REVISION=${version}" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a calaos_installer $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Calaos Installer, a tool to create calaos configuration";
+    homepage = https://www.calaos.fr/;
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ tiramiseb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20112,6 +20112,8 @@ with pkgs;
 
   brgenml1cupswrapper = callPackage ../misc/cups/drivers/brgenml1cupswrapper {};
 
+  calaos_installer = libsForQt5.callPackage ../misc/calaos/installer {};
+
   cups = callPackage ../misc/cups {
     libusb = libusb1;
   };


### PR DESCRIPTION
###### Motivation for this change

Having a package for Calaos installer. This piece of software is necessary when you have a home automation setup running the Calaos OS (https://calaos.fr/).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).