### PR TITLE
luakit: init at 2018.08.10

### DIFF
--- a/pkgs/applications/networking/browsers/luakit/default.nix
+++ b/pkgs/applications/networking/browsers/luakit/default.nix
@@ -1,0 +1,61 @@
+{stdenv, fetchFromGitHub, pkgconfig, wrapGAppsHook, makeWrapper
+,help2man, lua5, luafilesystem, luajit, sqlite
+,webkitgtk, gtk3, gst_all_1}:
+
+let
+  lualibs = [luafilesystem];
+  getPath       = lib : type : "${lib}/lib/lua/${lua5.luaversion}/?.${type};${lib}/share/lua/${lua5.luaversion}/?.${type}";
+  getLuaPath    = lib : getPath lib "lua";
+  getLuaCPath   = lib : getPath lib "so";
+  luaPath       = stdenv.lib.concatStringsSep ";" (map getLuaPath lualibs);
+  luaCPath      = stdenv.lib.concatStringsSep ";" (map getLuaCPath lualibs);
+
+in stdenv.mkDerivation rec {
+
+  name = "luakit-${version}";
+  version = "2017.08.10";
+  src = fetchFromGitHub {
+    owner = "luakit";
+    repo = "luakit";
+    rev = "${version}";
+    sha256 = "09z88b50vf2y64vj79cymknyzk3py6azv4r50jng4cw9jx2ray7r";
+  };
+
+  nativeBuildInputs = [pkgconfig help2man wrapGAppsHook makeWrapper];
+
+  buildInputs = [webkitgtk lua5 luafilesystem luajit sqlite gtk3
+    gst_all_1.gstreamer gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
+                ];
+
+  postPatch =
+    #Kind of ugly seds here. There must be a better solution.
+  ''
+    patchShebangs ./build-utils
+    sed -i "2 s|require \"lib.lousy.util\"|dofile(\"./lib/lousy/util.lua\")|" ./build-utils/docgen/gen.lua;
+    sed -i "3 s|require \"lib.markdown\"|dofile(\"./lib/markdown.lua\")|" ./build-utils/docgen/gen.lua;
+    sed -i "1,2 s|require(\"lib.lousy.util\")|dofile(\"./lib/lousy/util.lua\")|" ./build-utils/find_files.lua;
+  '';
+
+  buildPhase = ''
+    make DEVELOPMENT_PATHS=0 USE_LUAJIT=1 INSTALLDIR=$out PREFIX=$out USE_GTK3=1
+  '';
+
+  installPhase = let
+    luaKitPath = "$out/share/luakit/lib/?/init.lua;$out/share/luakit/lib/?.lua";
+  in ''
+    make DEVELOPMENT_PATHS=0 INSTALLDIR=$out PREFIX=$out XDGPREFIX=$out/etc/xdg USE_GTK3=1 install
+    wrapProgram $out/bin/luakit                                         \
+      --prefix XDG_CONFIG_DIRS : "$out/etc/xdg"                         \
+      --set LUA_PATH '${luaKitPath};${luaPath};'                      \
+      --set LUA_CPATH '${luaCPath};'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fast, small, webkit based browser framework extensible in Lua";
+    homepage    = "http://luakit.org";
+    license     = licenses.gpl3;
+    platforms   = platforms.linux; # Only tested linux
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16428,6 +16428,11 @@ with pkgs;
     flavour = "git";
   };
 
+  luakit = callPackage ../applications/networking/browsers/luakit {
+    inherit (lua51Packages) luafilesystem;
+    lua5 = lua5_1;
+  };
+
   looking-glass-client = callPackage ../applications/virtualization/looking-glass-client { };
 
   lumail = callPackage ../applications/networking/mailreaders/lumail {


### PR DESCRIPTION
###### Motivation for this change
Since the package removal #23205 there has been two releases. Switching to a newer version of webkitgtk.
Most alternatives in nixpkgs seem to still use webkitgtk2.4.

###### Things done
It's based on the previous definition of luakit. It builds and I used it without troubles during the past 24h.
Still, some parts of nixpkgs are still a mystery to me so a review would be very welcome. (wrappers and gstreamer for example).

@matthiasbeyer , as previous maintainer, maybe you are still interested. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

