### PR TITLE
phonon-qt4: 4.9.1 -> 4.10.0

### DIFF
--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -6,7 +6,7 @@
 with lib;
 
 let
-  v = "4.9.1";
+  v = "4.10.0";
 
   soname = if withQt5 then "phonon4qt5" else "phonon";
   buildsystemdir = "share/cmake/${soname}";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://kde/stable/phonon/${v}/phonon-${v}.tar.xz";
-    sha256 = "177647r2jqfm32hqcz2nqfqv6v48hn5ab2vc31svba2wz23fkgk7";
+    sha256 = "0gyhlnwamzfw31kw4qh0v6rj0m47k9wfygd6h07klg9ggp60xhg2";
   };
 
   buildInputs =


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.10.0 with grep in /nix/store/p57cd67h4wb6npgvfs779hg7xb316nxx-phonon-qt4-4.10.0
- found 4.10.0 in filename of file in /nix/store/p57cd67h4wb6npgvfs779hg7xb316nxx-phonon-qt4-4.10.0
- directory tree listing: https://gist.github.com/c80d4af5d5499b4f084fbfd3ba6220dc

cc @ttuegel for review