### PR TITLE
polyml56: 5.6 -> 5.7.1

### DIFF
--- a/pkgs/development/compilers/polyml/5.6.nix
+++ b/pkgs/development/compilers/polyml/5.6.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, autoreconfHook}:
 
 let
-  version = "5.6";
+  version = "5.7.1";
 in
 
 stdenv.mkDerivation {
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/polyml/polyml.${version}.tar.gz";
-    sha256 = "05d6l2a5m9jf32a8kahwg2p2ph4x9rjf1nsl83331q3gwn5bkmr0";
+    sha256 = "1s45jzj2y2kx4fz7qdzmq8v7vk0fk5rz9rk279fqsb1yckq0g9xw";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/ai5rg50b9vy1rxrzbblixl2x96wl89hy-polyml-5.7.1/bin/poly --help` got 0 exit code
- ran `/nix/store/ai5rg50b9vy1rxrzbblixl2x96wl89hy-polyml-5.7.1/bin/poly -v` and found version 5.7.1
- ran `/nix/store/ai5rg50b9vy1rxrzbblixl2x96wl89hy-polyml-5.7.1/bin/poly --help` and found version 5.7.1
- ran `/nix/store/ai5rg50b9vy1rxrzbblixl2x96wl89hy-polyml-5.7.1/bin/polyc --help` got 0 exit code
- ran `/nix/store/ai5rg50b9vy1rxrzbblixl2x96wl89hy-polyml-5.7.1/bin/polyc --help` and found version 5.7.1
- found 5.7.1 with grep in /nix/store/ai5rg50b9vy1rxrzbblixl2x96wl89hy-polyml-5.7.1
- directory tree listing: https://gist.github.com/03942ac8941a8c3124c65aa94587e73a

cc @maggesi for review