### PR TITLE
pommed_light: 1.50lw -> 1.51lw

### DIFF
--- a/pkgs/os-specific/linux/pommed-light/default.nix
+++ b/pkgs/os-specific/linux/pommed-light/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       and the like.
     '';
     homepage = https://github.com/bytbox/pommed-light;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = [ "x86_64-linux" ];
     license = stdenv.lib.licenses.gpl2;
   };
 }

--- a/pkgs/os-specific/linux/pommed-light/default.nix
+++ b/pkgs/os-specific/linux/pommed-light/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pkgname = "pommed-light";
-  version = "1.50lw";
+  version = "1.51lw";
   name = "${pkgname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/bytbox/${pkgname}/archive/v${version}.tar.gz";
 
-    sha256 = "1r2f28zqmyvzgymd0ng53hscbrq8vcqhxdnkq5dppjf9yrzn018b";
+    sha256 = "11wi17bh2br1hp8gmq40b1hm5drm6h969505f7432zam3cm8mc8q";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/yny32js35aqyd4rff303cand5a4w2g90-pommed-light-1.51lw/bin/pommed -v` and found version 1.51lw
- found 1.51lw with grep in /nix/store/yny32js35aqyd4rff303cand5a4w2g90-pommed-light-1.51lw
- directory tree listing: https://gist.github.com/efc712cdbd038d8f65b17ef4670992de