### PR TITLE
mate-sensors-applet: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/mate-sensors-applet/default.nix
+++ b/pkgs/desktops/mate/mate-sensors-applet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-sensors-applet-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1yj8zr9w0a1h4bpd27w7ssg97vnrz7yr10jqhx67yyb900ccr3ik";
+    sha256 = "0lnr3jjq30zw1i2rv5n69dhsa3x39lc91xcgbj4vyj1rxj9ff05x";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.20.1](https://github.com/mate-desktop/mate-sensors-applet/blob/44ed6dbf2a7cda45f333bf4d894fb4558193cad9/NEWS#L1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).