### PR TITLE
unixODBCDrivers.psql: 09.05.0210 -> 10.01.0000

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -5,11 +5,11 @@
 {
   psql = stdenv.mkDerivation rec {
     name = "psqlodbc-${version}";
-    version = "09.05.0210";
+    version = "10.01.0000";
 
     src = fetchurl {
       url = "http://ftp.postgresql.org/pub/odbc/versions/src/${name}.tar.gz";
-      sha256 = "0317zrxaiy209xzcc6b5sz6hsyiv4zm74iikp91rgz7z3ll4n4dc";
+      sha256 = "1cyams7157f3gry86x64xrplqi2vyqrq3rqka59gv4lb4rpl7jl7";
     };
 
     buildInputs = [ unixODBC postgresql ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 10.01.0000 with grep in /nix/store/bvl6a27bgljx6ps5sxmv8cy980hmpdqc-psqlodbc-10.01.0000
- directory tree listing: https://gist.github.com/6dac0c7dcf593adfd4d8cc805483dba1