### PR TITLE
open-orienteering-mapper: init at 0.8.1

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -1,0 +1,66 @@
+{ stdenv, fetchFromGitHub, gdal, cmake, ninja, proj, clipper, zlib, qtbase, qttools
+  , qtlocation, qtsensors, doxygen, cups, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  name = "OpenOrienteering-Mapper-${version}";
+  version = "0.8.1";
+
+  buildInputs = [ gdal qtbase qttools qtlocation qtsensors clipper zlib proj doxygen cups];
+
+  nativeBuildInputs = [ cmake makeWrapper ninja ];
+
+  src = fetchFromGitHub {
+    owner = "OpenOrienteering";
+    repo = "mapper";
+    rev = "v${version}";
+    sha256 = "10viw8bddl76mc2gh84jsl7h237yzvh4nim61pbd63vg1hlqisi6";
+  };
+
+  cmakeFlags =
+    [
+    # Required by the build to be specified
+    "-DPROJ4_ROOT=${proj}"
+
+    # Building the manual and bundling licenses fails
+    "-DLICENSING_PROVIDER:BOOL=OFF"
+    "-DMapper_MANUAL_QTHELP:BOOL=OFF"
+    ] ++
+    (stdenv.lib.optionals stdenv.isDarwin
+    [
+    # Usually enabled on Darwin
+    "-DCMAKE_FIND_FRAMEWORK=never"
+    # FindGDAL is broken and always finds /Library/Framework unless this is
+    # specified
+    "-DGDAL_INCLUDE_DIR=${gdal}/include"
+    "-DGDAL_CONFIG=${gdal}/bin/gdal-config"
+    "-DGDAL_LIBRARY=${gdal}/lib/libgdal.dylib"
+    # Don't bundle libraries
+    "-DMapper_PACKAGE_PROJ=0"
+    "-DMapper_PACKAGE_QT=0"
+    "-DMapper_PACKAGE_ASSISTANT=0"
+    "-DMapper_PACKAGE_GDAL=0"
+    ]);
+
+
+  postInstall =
+    stdenv.lib.optionalString stdenv.isDarwin ''
+    # Fixes "This application failed to start because it could not find or load the Qt
+    # platform plugin "cocoa"."
+    wrapProgram $out/Mapper.app/Contents/MacOS/Mapper \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH ${qtbase.bin}/lib/qt-*/plugins/platforms
+    mkdir -p $out/bin
+    ln -s $out/Mapper.app/Contents/MacOS/Mapper $out/bin/mapper
+    '';
+
+  meta = {
+    description = ''
+      OpenOrienteering Mapper is an orienteering mapmaking program
+      and provides a free alternative to the existing proprietary solution.
+    '';
+    homepage = https://www.openorienteering.org/apps/mapper/;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = with stdenv.lib.platforms; darwin;
+    maintainers = with stdenv.lib.maintainers; [mpickering];
+  };
+}

--- a/pkgs/development/libraries/clipper/default.nix
+++ b/pkgs/development/libraries/clipper/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, cmake, ninja, unzip }:
+
+stdenv.mkDerivation rec {
+  version = "6.4.2";
+  name = "Clipper-${version}";
+  src = fetchurl {
+    url = "mirror://sourceforge/polyclipping/clipper_ver${version}.zip";
+    sha256 = "09q6jc5k7p9y5d75qr2na5d1gm0wly5cjnffh127r04l47c20hx1";
+  };
+
+  sourceRoot = "cpp";
+
+  buildInputs = [ ];
+
+  nativeBuildInputs = [ cmake ninja unzip ];
+
+  meta = with stdenv.lib; {
+    longDescription = ''
+      The Clipper library performs line & polygon clipping - intersection, union, difference & exclusive-or,
+      and line & polygon offsetting. The library is based on Vatti's clipping algorithm.
+    '';
+    homepage = https://www.angusj.com/delphi/clipper.php;
+    license = licenses.boost;
+    maintainers = with maintainers; [ mpickering ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8468,6 +8468,8 @@ with pkgs;
 
   clearsilver = callPackage ../development/libraries/clearsilver { };
 
+  clipper = callPackage ../development/libraries/clipper { };
+
   cln = callPackage ../development/libraries/cln { };
 
   clucene_core_2 = callPackage ../development/libraries/clucene-core/2.x.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16917,6 +16917,8 @@ with pkgs;
 
   openjump = callPackage ../applications/misc/openjump { };
 
+  openorienteering-mapper = libsForQt5.callPackage ../applications/gis/openorienteering-mapper { };
+
   openscad = callPackage ../applications/graphics/openscad {};
 
   opentx = callPackage ../applications/misc/opentx { };


### PR DESCRIPTION
###### Motivation for this change

Two new packages. I have only tested these on darwin. 

This also depends on #35667 as otherwise some dependencies don't build. 

I put this in the gis folder as it is related to qgis at least somewhat and if this doesn't get added there then nothing else ever will. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

