### PR TITLE
jetbrains.pycharm-community: 2017.3.3 -> 2017.3.4

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -234,7 +234,7 @@ in
 
   clion = buildClion rec {
     name = "clion-${version}";
-    version = "2017.3.3"; /* updated by script */
+    version = "2017.3.4"; /* updated by script */
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
@@ -312,12 +312,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2017.3.3"; /* updated by script */
+    version = "2017.3.4"; /* updated by script */
     description = "PyCharm Community Edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "1j9pp8lfy62d9l3953d5mpij60s6sqyv3bcjimgy85hsrw570x3r"; /* updated by script */
+      sha256 = "027w73qrrj7aml2kdj3sx890q7jyj2jfnsg0pivi7i4kh8i11204"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm_Release";
@@ -325,7 +325,7 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2017.3.3"; /* updated by script */
+    version = "2017.3.4"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2017.3.4 with grep in /nix/store/a4jgz8vkvrlxai3cbk94jsisszzl90q7-pycharm-community-2017.3.4
- directory tree listing: https://gist.github.com/702aff8faf1eb19af49b052e12a00b8d

cc @jgeerds for review