### PR TITLE
qtkeychain: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -7,13 +7,13 @@ assert withQt5 -> qttools != null;
 
 stdenv.mkDerivation rec {
   name = "qtkeychain-${if withQt5 then "qt5" else "qt4"}-${version}";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "frankosterfeld";
     repo = "qtkeychain";
     rev = "v${version}";
-    sha256 = "04v6ymkw7qd1pf9lwijgqrl89w2hhsnqgz7dm4cdrh8i8dffpn52";
+    sha256 = "1r6qp9l2lp5jpc6ciklbg1swvvzcpc37rg9py46hk0wxy6klnm0b";
   };
 
   cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.8.0 with grep in /nix/store/6dsbk1bbm0kcm7nsywd7cpgwsm5lx1ls-qtkeychain-qt4-0.8.0
- found 0.8.0 in filename of file in /nix/store/6dsbk1bbm0kcm7nsywd7cpgwsm5lx1ls-qtkeychain-qt4-0.8.0
- directory tree listing: https://gist.github.com/5e2789436d13ff2a44aa497ee8365ba2