### PR TITLE
libsForQt5.quazip: 0.7.1 -> 0.7.3

### DIFF
--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, zip, zlib, qtbase, qmake }:
 
 stdenv.mkDerivation rec {
-  name = "quazip-0.7.1";
+  name = "quazip-0.7.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/quazip/${name}.tar.gz";
-    sha256 = "1pijy6zn8kdx9m6wrckid24vkgp250hklbpmgrpixiam6l889jbq";
+    sha256 = "1db9w8ax1ki0p67a47h4cnbwfgi2di4y3k9nc3a610kffiag7m1a";
   };
 
   preConfigure = "cd quazip";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/fd2172c4a80f17d789d4e62fcb99e8a0