### PR TITLE
widelands: fix launchpad url

### DIFF
--- a/pkgs/games/widelands/default.nix
+++ b/pkgs/games/widelands/default.nix
@@ -26,9 +26,8 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "https://launchpad.net/widelands/build${version}/build${version}/+download/"
-        + "widelands-build${version}-src.tar.bz2";
-    sha256 = "19h1gina7k1ai2mn2fd75lxm8iz8wrs6dz6dchdvg8i8d39gj4g5";
+    url = "http://launchpad.net/widelands/build${version}/build${version}/+download/widelands-build${version}-src-gcc7.tar.bz2";
+    sha256 = "0n2lb1c2dix32j90nir96zfqivn63izr1pmabjnhns3wbb7vhwzg";
   };
 
   preConfigure = ''
@@ -47,12 +46,12 @@ stdenv.mkDerivation rec {
   ];
 
   prePatch = ''
-    substituteInPlace ./debian/widelands.desktop --replace "/usr/share/games/widelands/data/" "$out/share/widelands/"
+    substituteInPlace ./debian/org.widelands.widelands.desktop --replace "/usr/share/games/widelands/data/" "$out/share/widelands/"
   '';
 
   postInstall = ''
     mkdir -p "$out/share/applications/"
-    cp -v "../debian/widelands.desktop" "$out/share/applications/"
+    cp -v "../debian/org.widelands.widelands.desktop" "$out/share/applications/"
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
and .desktop name

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

