### PR TITLE
spaceFM: 1.0.5 -> 1.0.6

### DIFF
--- a/pkgs/applications/misc/spacefm/default.nix
+++ b/pkgs/applications/misc/spacefm/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "spacefm-${version}";
-  version = "1.0.5";
+  version = "1.0.6";
 
   src = fetchFromGitHub {
     owner = "IgnorantGuru";
     repo = "spacefm";
     rev = "${version}";
-    sha256 = "06askkrwls09d1x382zjrmnvcm0ghfgz4cms2qbhdkazfyy0ff65";
+    sha256 = "089r6i40lxcwzp60553b18f130asspnzqldlpii53smz52kvpirx";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/.spacefm-wrapped -h` got 0 exit code
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/.spacefm-wrapped --help` got 0 exit code
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/.spacefm-wrapped --version` and found version 1.0.6
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/spacefm -h` got 0 exit code
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/spacefm --help` got 0 exit code
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/spacefm --version` and found version 1.0.6
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/.spacefm-installer-wrapped --help` got 0 exit code
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/.spacefm-installer-wrapped help` got 0 exit code
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/spacefm-installer --help` got 0 exit code
- ran `/nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6/bin/spacefm-installer help` got 0 exit code
- found 1.0.6 with grep in /nix/store/4hdgd1vlac5isgsb728f3qjpqcs2zxqp-spacefm-1.0.6
- directory tree listing: https://gist.github.com/1af4e8f53a36978c67e557c6c4c22b8d

cc @jagajaga @obadz for review