### PR TITLE
unbound: 1.6.8 -> 1.7.0

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unbound-${version}";
-  version = "1.6.8";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "https://unbound.net/downloads/${name}.tar.gz";
-    sha256 = "0jfxhh4gc5amhndikskz1s7da27ycn442j3l20bm992n7zijid73";
+    sha256 = "18i6p6zqmbs9gj57mz3iwz828csaab26gb534b8wrn0kzdqr1pcl";
   };
 
   outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/p36fksfjzi9715cgx8s3kmngy51qfjki-unbound-1.7.0/bin/unbound-host help` got 0 exit code
- found 1.7.0 with grep in /nix/store/p36fksfjzi9715cgx8s3kmngy51qfjki-unbound-1.7.0
- directory tree listing: https://gist.github.com/bb22fcb9572c54b0464c82405bf26b56

cc @fpletz for review