### PR TITLE
terminus: init at 1.0.0-alpha.42

### DIFF
--- a/pkgs/applications/misc/terminus/default.nix
+++ b/pkgs/applications/misc/terminus/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, fetchurl, dpkg, gtk2, atk, glib, pango, gdk_pixbuf, cairo
+, freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr
+, libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver
+, libxcb, makeWrapper, nodejs
+, GConf, nss, nspr, alsaLib, cups, expat, libudev, libpulseaudio }:
+
+let
+  libPath = stdenv.lib.makeLibraryPath [
+    stdenv.cc.cc gtk2 atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
+    libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes libxcb
+    libXrender libX11 libXtst libXScrnSaver GConf nss nspr alsaLib cups expat libudev libpulseaudio
+  ];
+in
+stdenv.mkDerivation rec {
+  version = "1.0.0-alpha.42";
+  name = "terminus-${version}";
+  src = fetchurl {
+    url = "https://github.com/Eugeny/terminus/releases/download/v${version}/terminus_${version}_amd64.deb";
+    sha256 = "1r5n75n71zwahg4rxlnf9qzrb0651gxv0987m6bykqmfpnw91nmb";
+  };
+  buildInputs = [ dpkg makeWrapper ];
+  unpackPhase = ''
+    mkdir pkg
+    dpkg-deb -x $src pkg
+    sourceRoot=pkg
+  '';
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mv opt "$out/"
+    ln -s "$out/opt/Terminus/terminus" "$out/bin/terminus"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/Terminus/terminus"
+    mv usr/* "$out/"
+    wrapProgram $out/bin/terminus --prefix PATH : ${lib.makeBinPath [ nodejs ]}
+  '';
+  dontPatchELF = true;
+  meta = with lib; {
+    description = "A terminal for a more modern age";
+    homepage    = https://eugeny.github.io/terminus/;
+    maintainers = with maintainers; [ jlesquembre ];
+    license     = licenses.mit;
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17778,6 +17778,8 @@ with pkgs;
     vte = gnome2.vte.override { pythonSupport = true; };
   };
 
+  terminus = callPackage ../applications/misc/terminus { inherit (gnome2) GConf; };
+
   lxterminal = callPackage ../applications/misc/lxterminal {
     vte = gnome3.vte;
   };


### PR DESCRIPTION
###### Motivation for this change
terminus: init at 1.0.0-alpha.42

Since it is an electron app I'm not building it from source (not sure how to do it). I only adapted the hyper package: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/hyper/default.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

