### PR TITLE
xorg.utilmacros: 1.19.1 -> 1.19.2

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1364,11 +1364,11 @@ let
   }) // {inherit libICE libSM libX11 libXext libXmu xproto libXt ;};
 
   utilmacros = (mkDerivation "utilmacros" {
-    name = "util-macros-1.19.1";
+    name = "util-macros-1.19.2";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/util/util-macros-1.19.1.tar.bz2;
-      sha256 = "19h6wflpmh7xxqr6lk5z8pds6r9r0dn7ijbvaacymx2q0m05km0q";
+      url = mirror://xorg/individual/util/util-macros-1.19.2.tar.bz2;
+      sha256 = "04p7ydqxgq37jklnfj18b70zsifiz4h50wvrk94i2112mmv37r6p";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.19.2 with grep in /nix/store/0dsmsg3p8dzp24h3ldc8xl0kzjwxpg6b-util-macros-1.19.2
- directory tree listing: https://gist.github.com/c2988d9a6c1d7cd8bfd5b9513e60d79c