### PR TITLE
v8_6_x: 6.2.414.27 -> 6.6.335

### DIFF
--- a/pkgs/development/libraries/v8/6_x.nix
+++ b/pkgs/development/libraries/v8/6_x.nix
@@ -96,7 +96,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "v8-${version}";
-  version = "6.2.414.27";
+  version = "6.6.335";
 
   inherit doCheck;
 
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
     owner = "v8";
     repo = "v8";
     rev = version;
-    sha256 = "15zrb9bcpnhljhrilqnjaak3a4xnhj8li6ra12g3gkrw3fzir9a2";
+    sha256 = "0rsdim4iccw2qzdjxl8239dv623bh6jdmgspzc79h6f9m10whgn2";
   };
 
   postUnpack = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/la04m55w302h4jzmhh44yzd2kgjcxm1m-v8-6.6.335/bin/d8 --help` got 0 exit code
- ran `/nix/store/la04m55w302h4jzmhh44yzd2kgjcxm1m-v8-6.6.335/bin/mksnapshot --help` got 0 exit code
- found 6.6.335 with grep in /nix/store/la04m55w302h4jzmhh44yzd2kgjcxm1m-v8-6.6.335
- directory tree listing: https://gist.github.com/234944092ecf3c19f9889846f3e37ce7

cc @cstrahan @proglodyte for review