### PR TITLE
varnish: 5.2.1 -> 6.0.0

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -2,12 +2,12 @@
 , python, pythonPackages, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "5.2.1";
+  version = "6.0.0";
   name = "varnish-${version}";
 
   src = fetchurl {
     url = "http://varnish-cache.org/_downloads/${name}.tgz";
-    sha256 = "1cqlj12m426c1lak1hr1fx5zcfsjjvka3hfirz47hvy1g2fjqidq";
+    sha256 = "1vhbdch33m6ig4ijy57zvrramhs9n7cba85wd8rizgxjjnf87cn7";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishadm -h` got 0 exit code
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishhist -h` got 0 exit code
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishhist -V` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishhist -h` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishlog -h` got 0 exit code
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishlog -V` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishlog -h` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishncsa -h` got 0 exit code
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishncsa -V` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishncsa -h` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishstat -h` got 0 exit code
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishstat --help` got 0 exit code
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishstat -V` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishstat -h` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishstat --help` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishtop -h` got 0 exit code
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishtop -V` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishtop -h` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/.varnishd-wrapped -V` and found version 6.0.0
- ran `/nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0/bin/varnishd -V` and found version 6.0.0
- found 6.0.0 with grep in /nix/store/355pmbhqp7y7ji8icm9yrq1hcry9as6r-varnish-6.0.0
- directory tree listing: https://gist.github.com/8a5eb2638dedfc43bdf3f4c91cd22310

cc @garbas @fpletz for review