### PR TITLE
sqldeveloper: 17.4.0.355.2349 -> 17.4.1.054.0712

### DIFF
--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -1,7 +1,7 @@
 { stdenv, makeWrapper, requireFile, unzip, openjdk }:
 
 stdenv.mkDerivation rec {
-  version = "17.4.0.355.2349";
+  version = "17.4.1.054.0712";
   name = "sqldeveloper-${version}";
 
   src = requireFile rec {
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
         nix-prefetch-url --type sha256 file:///path/to/${name}
     '';
     # obtained by `sha256sum sqldeveloper-${version}-no-jre.zip`
-    sha256 = "70add9b5c998583416e3d127aeb63dde8e3d0489036982026b930c85496c7850";
+    sha256 = "7e92ca94d02489002db291c96f1d67f9b2501a8967ff3457103fcf60c1eb154a";
   };
 
   buildInputs = [ makeWrapper unzip ];


### PR DESCRIPTION
###### Motivation for this change
This bumps sqldeveloper to 17.4.1.

## Release notes
 - 17.4.1 includes minor updates to support Autonomous Data Warehouse Cloud Service.
 - Java 9 (JDK) is now supported
 - Data Guard in DBA panel is only available for 12c and higher connections
 - Updated the NoSQL drivers to version 4.5
 - Added support for defining consumer group mappings for CLIENT_ID
 - Preferences Search feature now covers all options
 - Differentiate between a temporary connection used in the unshared worksheet and a truly private connection used internally for things like the UT Repos or the Instance Viewer....the naming logic for the Unshared Worksheet is now 'MyConn (Unshared)' instead of 'MyConn__1'
 - RAC support added to Real Time SQL Monitoring

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

