### PR TITLE
mythtv: 0.27.4 -> 29.1

### DIFF
--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -1,26 +1,31 @@
-{ stdenv, fetchurl, which, qt4, xlibsWrapper, libpulseaudio, fftwSinglePrec
-, lame, zlib, libGLU_combined, alsaLib, freetype, perl, pkgconfig
-, libX11, libXv, libXrandr, libXvMC, libXinerama, libXxf86vm, libXmu
-, yasm, libuuid, taglib, libtool, autoconf, automake, file
+{ stdenv, fetchFromGitHub, which, qtbase, qtwebkit, qtscript, xlibsWrapper
+, libpulseaudio, fftwSinglePrec , lame, zlib, libGLU_combined, alsaLib, freetype
+, perl, pkgconfig , libX11, libXv, libXrandr, libXvMC, libXinerama, libXxf86vm
+, libXmu , yasm, libuuid, taglib, libtool, autoconf, automake, file, exiv2
+, linuxHeaders
 }:
 
 stdenv.mkDerivation rec {
   name = "mythtv-${version}";
-  version = "0.27.4";
+  version = "29.1";
 
-  src = fetchurl {
-    url = "https://github.com/MythTV/mythtv/archive/v${version}.tar.gz";
-    sha256 = "0nrn4fbkkzh43n7jgbv21i92sb4z4yacwj9yj6m3hjbffzy4ywqz";
+  src = fetchFromGitHub {
+    owner = "MythTV";
+    repo = "mythtv";
+    rev = "v${version}";
+    sha256 = "0pjxv4bmq8h285jsr02svgaa03614arsyk12fn9d4rndjsi2cc3x";
   };
 
-  sourceRoot = "${name}/mythtv";
+  setSourceRoot = ''sourceRoot=$(echo */mythtv)'';
 
   buildInputs = [
-    freetype qt4 lame zlib xlibsWrapper libGLU_combined perl alsaLib libpulseaudio fftwSinglePrec
-    libX11 libXv libXrandr libXvMC libXmu libXinerama libXxf86vm libXmu
-    libuuid taglib
+    freetype qtbase qtwebkit qtscript lame zlib xlibsWrapper libGLU_combined
+    perl alsaLib libpulseaudio fftwSinglePrec libX11 libXv libXrandr libXvMC
+    libXmu libXinerama libXxf86vm libXmu libuuid taglib exiv2
   ];
   nativeBuildInputs = [ pkgconfig which yasm libtool autoconf automake file ];
+
+  configureFlags = [ "--dvb-path=${linuxHeaders}/include" ];
 
   meta = with stdenv.lib; {
     homepage = https://www.mythtv.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16838,7 +16838,7 @@ with pkgs;
 
   mypaint = callPackage ../applications/graphics/mypaint { };
 
-  mythtv = callPackage ../applications/video/mythtv { };
+  mythtv = libsForQt5.callPackage ../applications/video/mythtv { };
 
   micro = callPackage ../applications/editors/micro { };
 


### PR DESCRIPTION
###### Motivation for this change

mythtv is currently broken in unstable. This updates to the latest version, which also uses qt5, instead of qt4. Please backport to 18.03 for "zero hydra failures". I've tested that it builds fine and the frontend starts, but that's about it.

CC ZHF #36453 
Also #32997 #33248.
@titanous

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

