### PR TITLE
lib: Split Darwin into macOS and iOS

### DIFF
--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -21,9 +21,11 @@ rec {
     LittleEndian = { cpu = { significantByte = significantBytes.littleEndian; }; };
 
     BSD          = { kernel = { families = { inherit (kernelFamilies) bsd; }; }; };
+    Darwin       = { kernel = { families = { inherit (kernelFamilies) darwin; }; }; };
     Unix         = [ BSD Darwin Linux SunOS Hurd Cygwin ];
 
-    Darwin       = { kernel = kernels.darwin; };
+    MacOS        = { kernel = kernels.macos; };
+    iOS          = { kernel = kernels.ios; };
     Linux        = { kernel = kernels.linux; };
     SunOS        = { kernel = kernels.solaris; };
     FreeBSD      = { kernel = kernels.freebsd; };


### PR DESCRIPTION
###### Motivation for this change

I noticed LLVM accepts `ios` as its own OS in platform triples; a recent change as far as I know. I see it also accepts `macos*` for macOS (formerly OS X). If it's now customary to distinguish iOS like so (rather than guessing from the aarch, lets add both so our OSes are still disjoint, and make Darwin a family instead.

But changing the config everywhere would probably be a mass rebuild, and I'm not sure how well other software supports OSes besides "darwin", so I'm keeping that the default name for macOS for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @kmicklas @angerman @nixos/darwin-maintainers