### PR TITLE
pythonPackages.pyschedule: init at 0.2.17

### DIFF
--- a/pkgs/development/python-modules/pyschedule/default.nix
+++ b/pkgs/development/python-modules/pyschedule/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pulp
+}:
+
+buildPythonPackage rec {
+  pname = "pyschedule";
+  version = "0.2.17";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mlcmz1cm9yixlvh1d1c6c91j48hhcmbxf8cacqqh7dmgi7pmrs9";
+  };
+
+  propagatedBuildInputs = [ pulp ];
+
+  meta = with lib; {
+    homepage    = https://github.com/timnon/pyschedule;
+    description = "resource-constrained scheduling in python";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ ericsagnes ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -368,6 +368,8 @@ in {
 
   pyscard = callPackage ../development/python-modules/pyscard { inherit (pkgs.darwin.apple_sdk.frameworks) PCSC; };
 
+  pyschedule = callPackage ../development/python-modules/pyschedule { };
+
   pyside = callPackage ../development/python-modules/pyside { };
 
   pysideShiboken = callPackage ../development/python-modules/pyside/shiboken.nix {


### PR DESCRIPTION
###### Motivation for this change

add pyschedule to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

