### PR TITLE
pythonPackages.Pyomo: init at 5.4.3

### DIFF
--- a/pkgs/development/python-modules/pyomo/default.nix
+++ b/pkgs/development/python-modules/pyomo/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyutilib
+, ply
+, appdirs
+}:
+
+buildPythonPackage rec {
+  pname = "Pyomo";
+  version = "5.4.3";
+
+  propagatedBuildInputs = [ pyutilib ply appdirs ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08hgpf8fs8n8zlpmv3zlcgdw6306ymq1m9ma92v3x5nqnkhqfa3j";
+  };
+
+  # Tests try to install packages
+  doCheck = false;
+
+  meta = with lib; {
+    homepage    = http://www.pyomo.org/;
+    description = "Collection of software packages for formulating optimization models";
+    longDescription = ''
+      Pyomo is a Python-based, open-source optimization modeling language
+      with a diverse set of optimization capabilities.
+    '';
+    license     = lib.licenses.bsd3;
+    maintainers = with maintainers; [ ericsagnes ];
+  };
+}

--- a/pkgs/development/python-modules/pyutilib/default.nix
+++ b/pkgs/development/python-modules/pyutilib/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "PyUtilib";
+  version = "5.6.2";
+
+  propagatedBuildInputs = [ six nose ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17rynkkq728b7iy65m2rz9gcycipk0r8xiplfb5lvg5l27zm52gv";
+  };
+
+  # Tests requires text files that are not included in the pypi package
+  doCheck = false;
+
+  meta = with lib; {
+    homepage    = https://github.com/PyUtilib/pyutilib;
+    description = "collection of Python utilities";
+    longDescription = ''
+      The PyUtilib project supports a collection of Python utilities, including
+      a well-developed component architecture and extensions to the PyUnit testing
+      framework.
+    '';
+    license     = licenses.bsdOriginal;
+    maintainers = with maintainers; [ ericsagnes ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12993,6 +12993,8 @@ in {
 
   pylint = callPackage ../development/python-modules/pylint { };
 
+  pyomo = callPackage ../development/python-modules/pyomo { };
+
   pyopencl = callPackage ../development/python-modules/pyopencl { };
 
   pyproj = callPackage ../development/python-modules/pyproj {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13009,6 +13009,8 @@ in {
 
   pyspread = callPackage ../development/python-modules/pyspread { };
 
+  pyutilib = callPackage ../development/python-modules/pyutilib { };
+
   pyx = buildPythonPackage rec {
     name = "pyx-${version}";
     version = "0.14.1";


### PR DESCRIPTION
###### Motivation for this change

Add pyomo to nixpkgs, also add PyUtilib as a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

