### PR TITLE
Add `gcompris` educational package

### DIFF
--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -1,0 +1,31 @@
+{stdenv, qtdeclarative, fetchFromGitHub, qmake }:
+stdenv.mkDerivation rec {
+  name = "qml-box2d-2018-03-16";
+  src = fetchFromGitHub {
+    owner = "qml-box2d";
+    repo = "qml-box2d";
+    sha256 = "1fbsvv28b4r0szcv8bk5gxpf8v534jp2axyfp438384sy757wsq2";
+    rev = "21e57f1";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ qmake ];
+
+  buildInputs = [ qtdeclarative ];
+
+  patchPhase = ''
+    substituteInPlace box2d.pro \
+      --replace '$$[QT_INSTALL_QML]' "/$qtQmlPrefix/"
+    qmakeFlags="$qmakeFlags PREFIXSHORTCUT=$out"
+    '';
+
+  installFlags = [ "INSTALL_ROOT=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A QML plugin for Box2D engine";
+    homepage = "https://github.com/qml-box2d/qml-box2d";
+    maintainers = [ maintainers.guibou ];
+    platforms = platforms.linux;
+    license = licenses.zlib;
+  };
+}

--- a/pkgs/games/gcompris/default.nix
+++ b/pkgs/games/gcompris/default.nix
@@ -1,0 +1,37 @@
+{stdenv, cmake, qtbase, fetchurl, qtdeclarative, qtmultimedia, qttools, qtsensors, qmlbox2d, gettext, qtquickcontrols, qtgraphicaleffects, makeWrapper,
+  gst_all_1, ninja
+}:
+stdenv.mkDerivation rec {
+  version = "0.90";
+  name = "gcompris-${version}";
+
+  src = fetchurl {
+    url = "http://gcompris.net/download/qt/src/gcompris-qt-${version}.tar.xz";
+    sha256 = "1i5adxnhig849qxwi3c4v7r84q6agx1zxkd69fh4y7lcmq2qiaza";
+  };
+
+  cmakeFlags = "-DQML_BOX2D_LIBRARY=${qmlbox2d}/${qtbase.qtQmlPrefix}/Box2D.2.0";
+
+  nativeBuildInputs = [ cmake ninja makeWrapper ];
+  buildInputs = [ qtbase qtdeclarative qttools qtsensors qmlbox2d gettext qtquickcontrols qtmultimedia qtgraphicaleffects] ++ soundPlugins;
+  soundPlugins = with gst_all_1; [gst-plugins-good gstreamer gst-plugins-base gst-plugins-bad];
+
+  postInstall = ''
+    # install .desktop and icon file
+    mkdir -p $out/share/applications/
+    mkdir -p $out/share/icons/hicolor/256x256/apps/
+    cp ../org.kde.gcompris.desktop $out/share/applications/gcompris.desktop
+    cp -r ../images/256-apps-gcompris-qt.png $out/share/icons/hicolor/256x256/apps/gcompris-qt.png
+
+    wrapProgram "$out/bin/gcompris-qt" \
+       --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A high quality educational software suite, including a large number of activities for children aged 2 to 10";
+    homepage = "https://gcompris.net/";
+    maintainers = [ maintainers.guibou ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18986,6 +18986,8 @@ with pkgs;
 
   gcs = callPackage ../games/gcs { };
 
+  gcompris = libsForQt59.callPackage ../games/gcompris { };
+
   gemrb = callPackage ../games/gemrb { };
 
   gl117 = callPackage ../games/gl-117 {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11227,6 +11227,7 @@ with pkgs;
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
     qmltermwidget = callPackage ../development/libraries/qmltermwidget { };
+    qmlbox2d = libsForQt59.callPackage ../development/libraries/qmlbox2d { };
 
     qscintilla = callPackage ../development/libraries/qscintilla {
       withQt5 = true;


### PR DESCRIPTION
###### Motivation for this change

Add `gcompris`, which is a mandatory educational package for kids.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

