### PR TITLE
asciidoc: add enableJava option

### DIFF
--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -37,6 +37,9 @@
 # backends
 , enableDeckjsBackend ? false
 , enableOdfBackend ? false
+
+# java is problematic on some platforms, where it is unfree
+, enableJava ? true
 }:
 
 assert enableStandardFeatures ->
@@ -55,7 +58,7 @@ assert enableStandardFeatures ->
   docbook_xml_dtd_45 != null &&
   docbook5_xsl != null &&
   docbook_xsl != null &&
-  fop != null &&
+  (fop != null || !enableJava) &&
 # TODO: Package this:
 #  epubcheck != null &&
   gnused != null &&
@@ -63,7 +66,7 @@ assert enableStandardFeatures ->
 
 # filters
 assert enableExtraPlugins || enableDitaaFilter || enableMscgenFilter || enableDiagFilter || enableQrcodeFilter || enableAafigureFilter -> unzip != null;
-assert enableExtraPlugins || enableDitaaFilter -> jre != null;
+assert (enableExtraPlugins && enableJava) || enableDitaaFilter -> jre != null;
 assert enableExtraPlugins || enableMscgenFilter -> mscgen != null;
 assert enableExtraPlugins || enableDiagFilter -> blockdiag != null && seqdiag != null && actdiag != null && nwdiag != null;
 assert enableExtraPlugins || enableMatplotlibFilter -> matplotlib != null && numpy != null;
@@ -73,7 +76,7 @@ assert enableExtraPlugins || enableDeckjsBackend || enableOdfBackend -> unzip !=
 
 let
 
-  _enableDitaaFilter = enableExtraPlugins || enableDitaaFilter;
+  _enableDitaaFilter = (enableExtraPlugins && enableJava) || enableDitaaFilter;
   _enableMscgenFilter = enableExtraPlugins || enableMscgenFilter;
   _enableDiagFilter = enableExtraPlugins || enableDiagFilter;
   _enableQrcodeFilter = enableExtraPlugins || enableQrcodeFilter;
@@ -239,7 +242,7 @@ stdenv.mkDerivation rec {
         -e "s|^ASCIIDOC =.*|ASCIIDOC = '$out/bin/asciidoc'|" \
         -e "s|^XSLTPROC =.*|XSLTPROC = '${libxslt.bin}/bin/xsltproc'|" \
         -e "s|^DBLATEX =.*|DBLATEX = '${dblatexFull}/bin/dblatex'|" \
-        -e "s|^FOP =.*|FOP = '${fop}/bin/fop'|" \
+        ${optionalString enableJava ''-e "s|^FOP =.*|FOP = '${fop}/bin/fop'|"''} \
         -e "s|^W3M =.*|W3M = '${w3m}/bin/w3m'|" \
         -e "s|^LYNX =.*|LYNX = '${lynx}/bin/lynx'|" \
         -e "s|^XMLLINT =.*|XMLLINT = '${libxml2.bin}/bin/xmllint'|" \


### PR DESCRIPTION
###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/37045

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @bjornfor 