### PR TITLE
gobjectIntrospection: fix incorrect GIR shared library paths

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
@@ -1,8 +1,6 @@
-diff --git a/giscanner/scannermain.py b/giscanner/scannermain.py
-index 89ec193..54f1d2e 100755
 --- a/giscanner/scannermain.py
 +++ b/giscanner/scannermain.py
-@@ -94,6 +94,39 @@ def get_windows_option_group(parser):
+@@ -100,6 +100,39 @@
      return group
  
  
@@ -42,7 +40,7 @@ index 89ec193..54f1d2e 100755
  def _get_option_parser():
      parser = optparse.OptionParser('%prog [options] sources')
      parser.add_option('', "--quiet",
-@@ -200,6 +233,10 @@ match the namespace prefix.""")
+@@ -209,6 +242,10 @@
      parser.add_option("", "--filelist",
                        action="store", dest="filelist", default=[],
                        help="file containing headers and sources to be scanned")
@@ -53,57 +51,50 @@ index 89ec193..54f1d2e 100755
  
      group = get_preprocessor_option_group(parser)
      parser.add_option_group(group)
-diff --git a/giscanner/shlibs.py b/giscanner/shlibs.py
-index 838d343..ca7fc0d 100644
 --- a/giscanner/shlibs.py
 +++ b/giscanner/shlibs.py
-@@ -53,10 +53,27 @@ def _resolve_libtool(options, binary, libraries):
- # Match absolute paths on OS X to conform to how libraries are usually
- # referenced on OS X systems.
- def _ldd_library_pattern(library_name):
-+    nix_store_dir = re.escape('@nixStoreDir@'.rstrip('/'))
-     pattern = "(?<![A-Za-z0-9_-])(lib*%s[^A-Za-z0-9_-][^\s\(\)]*)"
-     if platform.system() == 'Darwin':
+@@ -63,6 +63,11 @@
          pattern = "([^\s]*lib*%s[^A-Za-z0-9_-][^\s\(\)]*)"
--    return re.compile(pattern % re.escape(library_name))
-+        return re.compile(pattern % re.escape(library_name))
-+    pattern = r'''
-+        (
-+          (?:
-+            # First match Nix store paths because they need to be absolute.
-+            (?:%s(?:/[^/]*)+)
-+            # Everything else not a store path remains relative, because we
-+            # would end up with temporary paths that are only valid during
-+            # build time in the resulting GIR file.
-+            | (?<=/)
-+          )
-+          # And finally the library itself:
-+          (?:lib%s[^A-Za-z0-9_-][^\s\(\)]*)
-+        )
-+    '''
-+    return re.compile(pattern % (nix_store_dir, re.escape(library_name)),
-+                      re.VERBOSE)
+     return re.compile(pattern % re.escape(library_name))
  
++def _ldd_library_nix_pattern(library_name):
++    nix_store_dir = re.escape('@nixStoreDir@'.rstrip('/'))
++    pattern = r'(%s(?:/[^/]*)+lib%s[^A-Za-z0-9_-][^\s\(\)]*)'
++    return re.compile(pattern % (nix_store_dir, re.escape(library_name)))
++
  
  # This is a what we do for non-la files. We assume that we are on an
-@@ -115,7 +132,11 @@ def _resolve_non_libtool(options, binary, libraries):
-                 m = pattern.search(line)
+ # ELF-like system where ldd exists and the soname extracted with ldd is
+@@ -112,7 +117,7 @@
+         proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+         patterns = {}
+         for library in libraries:
+-            patterns[library] = _ldd_library_pattern(library)
++            patterns[library] = (_ldd_library_pattern(library), _ldd_library_nix_pattern(library))
+ 
+         shlibs = []
+         for line in proc.stdout:
+@@ -122,11 +127,14 @@
+             # possible for the name of the binary to match _ldd_library_pattern.
+             if line == binary.args[0] + ':\n':
+                 continue
+-            for library, pattern in patterns.items():
+-                m = pattern.search(line)
++            for library, (pattern, nix_pattern) in patterns.items():
++                if line.find('@nixStoreDir@') != -1:
++                    m = nix_pattern.search(line)
++                else:
++                    m = pattern.search(line)
                  if m:
                      del patterns[library]
 -                    shlibs.append(m.group(1))
-+                    match = m.group(1)
-+                    if not match.startswith('/') \
-+                       and len(options.fallback_libpath) > 0:
-+                        match = os.path.join(options.fallback_libpath, match)
-+                    shlibs.append(match)
++                    shlibs.append(os.path.join(options.fallback_libpath, m.group(1)))
                      break
  
          if len(patterns) > 0:
-diff --git a/giscanner/utils.py b/giscanner/utils.py
-index 660081e..c9c767a 100644
 --- a/giscanner/utils.py
 +++ b/giscanner/utils.py
-@@ -109,17 +109,11 @@ def extract_libtool_shlib(la_file):
+@@ -113,17 +113,11 @@
      if dlname is None:
          return None
  


### PR DESCRIPTION
###### Motivation for this change
When a library path contained the library name it was eagerly matched

    libfwupd.so.2 => /build/fwupd-1.0.5/build/libfwupd/libfwupd.so.2 (0x00007ffff7bbd000)
                                              ^^^^^^^^^^^^^^^^^^^^^^
    libgweather-3.so.15 => /build/libgweather-3.28.0/build/libgweather/libgweather-3.so.15 (0x00007ffff7bae000)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

which lead to a broken shared library path in the generated GIR file.

This patch allows the soname on the left-hand side of the arrow to
be matched to avoid the trap of the right-hand side. A negative
lookahead had to be added to select the store path, since only
the first match is taken into account.

    libglib-2.0.so.0 => /nix/store/dqlc8y4phlg1hmdbwkhqfwhnxcac88d1-glib-2.56.0/lib/libglib-2.0.so.0 (0x00007ffff6400000)

This will not fix non-GNU platforms, where the soname is not printed
first, but we cannot do much without structured ldd output.

Closes: https://github.com/NixOS/nixpkgs/issues/34988

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @hedning 