### PR TITLE
google-drive-ocamlfuse and gapi-ocaml update

### DIFF
--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,24 +1,23 @@
 { stdenv, fetchFromGitHub, zlib
-, ocaml, ocamlbuild, ocamlfuse, findlib, gapi_ocaml, ocaml_sqlite3, camlidl }:
+, ocaml, jbuilder, opam, ocamlfuse, findlib, gapi_ocaml, ocaml_sqlite3, camlidl }:
 
 stdenv.mkDerivation rec {
   name = "google-drive-ocamlfuse-${version}";
-  version = "0.6.21";
+  version = "0.6.25";
 
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "google-drive-ocamlfuse";
     rev = "v${version}";
-    sha256 = "14qvhz18pzxdgxk5vcs024ajbkxccfwc9p3z5r6vfkc9mm851v59";
+    sha256 = "1rjm2jcc93sz7l25zbgqal81534vvvbmwy7847s0k8fkr5nq97gp";
   };
 
-  nativeBuildInputs = [ ocamlbuild ];
+  nativeBuildInputs = [ jbuilder opam ];
 
   buildInputs = [ zlib ocaml ocamlfuse findlib gapi_ocaml ocaml_sqlite3 camlidl ];
 
-  configurePhase = "ocaml setup.ml -configure --prefix \"$out\"";
-  buildPhase = "ocaml setup.ml -build";
-  installPhase = "ocaml setup.ml -install";
+  buildPhase = "jbuilder build @install";
+  installPhase = "mkdir $out && jbuilder install --prefix $out";
 
   meta = {
     homepage = http://gdfuse.forge.ocamlcore.org/;

--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -1,20 +1,19 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder, opam, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm }:
 
 stdenv.mkDerivation rec {
   name = "gapi-ocaml-${version}";
-  version = "0.3.4";
+  version = "0.3.6";
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "gapi-ocaml";
     rev = "v${version}";
-    sha256 = "07p6p108fyf9xz54jbcld40k3r9zyybxmr5i3rrkhgwm8gb6sbhv";
+    sha256 = "0qgsy51bhkpfgl5rdnjw4bqs5fbh2w4vwrfbl8y3lh1wrqmnwci4";
   };
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ ocaml jbuilder findlib ];
   propagatedBuildInputs = [ ocurl cryptokit ocaml_extlib yojson ocamlnet xmlm ];
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out";
-  buildPhase = "ocaml setup.ml -build";
-  installPhase = "ocaml setup.ml -install";
+  installPhase = "${opam}/bin/opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR";
+
   createFindlibDestdir = true;
 
   meta = {


### PR DESCRIPTION
This required changing the build process for both packages. I noticed two things I'd like feedback on:

1. While both libraries claimed to have migrated to "jbuilder" I still needed different commands for each.
2. There are other ocaml packages using "opam" to build as well. I grabbed the "opam-install" command from one of these. Is there a standard script that should be referenced instead?

###### Motivation for this change

1. update google-drive-ocamlfuse to 0.3.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

