### PR TITLE
browserpass: 2.0.11 -> 2.0.13

### DIFF
--- a/pkgs/tools/security/browserpass/default.nix
+++ b/pkgs/tools/security/browserpass/default.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "browserpass-${version}";
-  version = "2.0.11";
+  version = "2.0.13";
 
   goPackagePath = "github.com/dannyvankooten/browserpass";
 
@@ -13,7 +13,7 @@ buildGoPackage rec {
     repo = "browserpass";
     owner = "dannyvankooten";
     rev = version;
-    sha256 = "0d6rpkka27a57nv69yiw71jj3m6axdj5hygsz36dznnn8w76vvyv";
+    sha256 = "0pch0jddphgaaw208ddqjhnkiy5916n0kjxfza1cpc78fa8zw82l";
   };
 
   postInstall = ''

--- a/pkgs/tools/security/browserpass/deps.nix
+++ b/pkgs/tools/security/browserpass/deps.nix
@@ -19,6 +19,15 @@
     };
   }
   {
+    goPackagePath = "github.com/sahilm/fuzzy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sahilm/fuzzy";
+      rev = "a154b19bb758dcdd6ede58dc11ea53c2950527b2";
+      sha256 = "0jkw6474d5ik2fq2zznqxj4y3p42z47r7mbg856ln5wyara2sg0l";
+    };
+  }
+  {
     goPackagePath = "rsc.io/qr";
     fetch = {
       type = "git";


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

