### PR TITLE
pythonPackages.svg-path: 2.0b1 -> 2.2

### DIFF
--- a/pkgs/development/python-modules/svg-path/default.nix
+++ b/pkgs/development/python-modules/svg-path/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "svg.path";
+  version = "2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08kp03i4yiqdkz7a7l7d7kzszahmhigrml2502zi1ybndrh7ayxw";
+  };
+
+  meta = with stdenv.lib; {
+    description = "SVG path objects and parser";
+    homepage = https://github.com/regebro/svg.path;
+    license = licenses.mit;
+    maintainers = with maintainers; [ goibhniu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6348,22 +6348,7 @@ in {
 
   };
 
-  svg-path = buildPythonPackage rec {
-    name = "svg.path-${version}";
-    version = "2.0b1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/svg.path/${name}.zip";
-      sha256 = "038x4wqkbvcs71x6n6kzr4kn99csyv8v4gqzssr8pqylqpxi56bm";
-    };
-
-    meta = {
-      description = "SVG path objects and parser";
-      homepage = https://github.com/regebro/svg.path;
-      license = licenses.cc0;
-      maintainers = with maintainers; [ goibhniu ];
-    };
-  };
+  svg-path = callPackage ../development/python-modules/svg-path { };
 
   regex = callPackage ../development/python-modules/regex { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

