### PR TITLE
altermime: fix build

### DIFF
--- a/pkgs/tools/networking/altermime/default.nix
+++ b/pkgs/tools/networking/altermime/default.nix
@@ -10,7 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "15zxg6spcmd35r6xbidq2fgcg2nzyv1sbbqds08lzll70mqx4pj7";
   };
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=format";
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=format"
+    "-Wno-error=format-truncation"
+    "-Wno-error=pointer-compare"
+    "-Wno-error=memset-elt-size"
+  ];
 
   postPatch = ''
     sed -i Makefile -e "s@/usr/local@$out@"


### PR DESCRIPTION
###### Motivation for this change

didn't build with gcc7.
/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

