### PR TITLE
hologram: 20170130 -> 20180319

### DIFF
--- a/nixos/modules/services/security/hologram-server.nix
+++ b/nixos/modules/services/security/hologram-server.nix
@@ -12,9 +12,12 @@ let
         dn       = cfg.ldapBindDN;
         password = cfg.ldapBindPassword;
       };
-      insecureldap = cfg.ldapInsecure;
-      userattr     = cfg.ldapUserAttr;
-      baseDN       = cfg.ldapBaseDN;
+      insecureldap    = cfg.ldapInsecure;
+      userattr        = cfg.ldapUserAttr;
+      baseDN          = cfg.ldapBaseDN;
+      enableldapRoles = cfg.enableLdapRoles;
+      roleAttr        = cfg.roleAttr;
+      groupClassAttr  = cfg.groupClassAttr;
     };
     aws = {
       account     = cfg.awsAccount;
@@ -68,6 +71,24 @@ in {
       ldapBindPassword = mkOption {
         type        = types.str;
         description = "Password of account to use to query the LDAP server";
+      };
+
+      enableLdapRoles = mkOption {
+        type        = types.bool;
+        default     = false;
+        description = "Whether to assign user roles based on the user's LDAP group memberships";
+      };
+
+      groupClassAttr = mkOption {
+        type = types.str;
+        default = "groupOfNames";
+        description = "The objectclass attribute to search for groups when enableLdapRoles is true";
+      };
+
+      roleAttr = mkOption {
+        type        = types.str;
+        default     = "businessCategory";
+        description = "Which LDAP group attribute to search for authorized role ARNs";
       };
 
       awsAccount = mkOption {

--- a/pkgs/tools/security/hologram/default.nix
+++ b/pkgs/tools/security/hologram/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, lib, buildGoPackage, fetchgit, fetchhg, fetchbzr, fetchsvn }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "hologram-${version}";
-  version = "20170130-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "d20d1c30379e7010e8f9c428a5b9e82f54d390e1";
+  version = "20180319-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "a7bab58642b530edb75b9cf6c1d834c85822ceac";
 
-  src = fetchgit {
+  src = fetchFromGitHub {
+    owner = "AdRoll";
+    repo = "hologram";
     inherit rev;
-    url = "https://github.com/AdRoll/hologram";
-    sha256 = "0dg5kfs16kf2gzhpmzsg83qzi2pxgnc9g81lw5zpa6fmzpa9kgsn";
+    sha256 = "00scryz8js6gbw8lp2y23qikbazz2dd992r97rqh0l1q4baa0ckn";
   };
 
   goPackagePath = "github.com/AdRoll/hologram";


### PR DESCRIPTION
In AdRoll/hologram#62 support was added to hologram to configure
LDAP-based authorization of which roles a user was allowed to get
credentials for. This adds the ability to configure that.

Additionally, AdRoll/hologram#94 added support to customize the LDAP
group query, so this also feeds that configuration through.

###### Motivation for this change

Support new Hologram features

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

