### PR TITLE
kitty: 0.8.0 -> 0.8.2

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -1,8 +1,11 @@
-{ stdenv, fetchFromGitHub, pkgs, python3Packages, glfw, libunistring, harfbuzz, fontconfig, zlib, pkgconfig, ncurses, imagemagick, makeWrapper, xsel, libstartup_notification, libX11, libXrandr, libXinerama, libXcursor, libxkbcommon, libXi, libXext }:
+{ stdenv, fetchFromGitHub, pkgs, python3Packages, glfw, libunistring, harfbuzz,
+  fontconfig, zlib, pkgconfig, ncurses, imagemagick, makeWrapper, xsel,
+  libstartup_notification, libX11, libXrandr, libXinerama, libXcursor,
+  libxkbcommon, libXi, libXext }:
 
 with python3Packages;
 buildPythonApplication rec {
-  version = "0.8.0";
+  version = "0.8.2";
   name = "kitty-${version}";
   format = "other";
 
@@ -10,10 +13,13 @@ buildPythonApplication rec {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "12pj4js704r4f6idam3ljg7yllij9v158ayq6ym24zq18bv1nmbz";
+    sha256 = "08s8l59bib363ykg4djcxrc1968n5j1cjlp6fwwv7xmf18wd1a6c";
   };
 
-  buildInputs = [ fontconfig glfw ncurses libunistring harfbuzz libX11 libXrandr libXinerama libXcursor libxkbcommon libXi libXext ];
+  buildInputs = [
+    fontconfig glfw ncurses libunistring harfbuzz libX11
+    libXrandr libXinerama libXcursor libxkbcommon libXi libXext
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
###### Motivation for this change
Update kitty to 0.8.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

