### PR TITLE
pythonPackages.cython: 0.27.3 -> 0.28.1

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -13,26 +13,17 @@
 
 buildPythonPackage rec {
   pname = "Cython";
-  name = "${pname}-${version}";
-  version = "0.27.3";
+  version = "0.28.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64";
+    sha256 = "152ee5f345012ca3bb7cc71da2d3736ee20f52cd8476e4d49e5e25c5a4102b12";
   };
-
-  # With Python 2.x on i686-linux or 32-bit ARM this test fails because the
-  # result is "3L" instead of "3", so let's fix it in-place.
-  #
-  # Upstream issue: https://github.com/cython/cython/issues/1548
-  postPatch = lib.optionalString ((stdenv.isi686 || stdenv.isArm) && !isPy3k) ''
-    sed -i -e 's/\(>>> *\)\(verify_resolution_GH1533()\)/\1int(\2)/' \
-      tests/run/cpdef_enums.pyx
-  '';
 
   nativeBuildInputs = [
     pkgconfig
-    # For testing
+  ];
+  checkInputs = [
     numpy ncurses
   ];
   buildInputs = [ glibcLocales gdb ];
@@ -45,10 +36,6 @@ buildPythonPackage rec {
     ${python.interpreter} runtests.py \
       ${if stdenv.cc.isClang or false then ''--exclude="(cpdef_extern_func|libcpp_algo)"'' else ""}
   '';
-
-  # Disable tests temporarily
-  # https://github.com/cython/cython/issues/1676
-  doCheck = false;
 
   meta = {
     description = "An optimising static compiler for both the Python programming language and the extended Cython programming language";


### PR DESCRIPTION
###### Motivation for this change
Both issues previously mentioned in the expression were closed.
Cython 0.28.1 builds fine on Python 2 and 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

