### PR TITLE
lib: Make platform predicates greppable

### DIFF
--- a/lib/systems/for-meta.nix
+++ b/lib/systems/for-meta.nix
@@ -7,21 +7,21 @@ in rec {
   inherit (lib.systems.doubles) all mesaPlatforms;
   none = [];
 
-  arm     = [ patterns.Arm ];
-  aarch64 = [ patterns.Aarch64 ];
-  x86     = [ patterns.x86 ];
-  i686    = [ patterns.i686 ];
-  x86_64  = [ patterns.x86_64 ];
-  mips    = [ patterns.Mips ];
+  arm     = [ patterns.isArm ];
+  aarch64 = [ patterns.isAarch64 ];
+  x86     = [ patterns.isx86 ];
+  i686    = [ patterns.isi686 ];
+  x86_64  = [ patterns.isx86_64 ];
+  mips    = [ patterns.isMips ];
 
-  cygwin  = [ patterns.Cygwin ];
-  darwin  = [ patterns.Darwin ];
-  freebsd = [ patterns.FreeBSD ];
+  cygwin  = [ patterns.isCygwin ];
+  darwin  = [ patterns.isDarwin ];
+  freebsd = [ patterns.isFreeBSD ];
   # Should be better, but MinGW is unclear, and HURD is bit-rotted.
   gnu     = [ { kernel = parse.kernels.linux; abi = parse.abis.gnu; } ];
-  illumos = [ patterns.SunOS ];
-  linux   = [ patterns.Linux ];
-  netbsd  = [ patterns.NetBSD ];
-  openbsd = [ patterns.OpenBSD ];
-  unix    = patterns.Unix; # Actually a list
+  illumos = [ patterns.isSunOS ];
+  linux   = [ patterns.isLinux ];
+  netbsd  = [ patterns.isNetBSD ];
+  openbsd = [ patterns.isOpenBSD ];
+  unix    = patterns.isUnix; # Actually a list
 }

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -5,53 +5,51 @@ with lib.lists;
 
 rec {
   patterns = rec {
-    i686         = { cpu = cpuTypes.i686; };
-    x86_64       = { cpu = cpuTypes.x86_64; };
-    PowerPC      = { cpu = cpuTypes.powerpc; };
-    x86          = { cpu = { family = "x86"; }; };
-    Arm          = { cpu = { family = "arm"; }; };
-    Aarch64      = { cpu = { family = "aarch64"; }; };
-    Mips         = { cpu = { family = "mips"; }; };
-    RiscV        = { cpu = { family = "riscv"; }; };
-    Wasm         = { cpu = { family = "wasm"; }; };
+    isi686         = { cpu = cpuTypes.i686; };
+    isx86_64       = { cpu = cpuTypes.x86_64; };
+    isPowerPC      = { cpu = cpuTypes.powerpc; };
+    isx86          = { cpu = { family = "x86"; }; };
+    isArm          = { cpu = { family = "arm"; }; };
+    isAarch64      = { cpu = { family = "aarch64"; }; };
+    isMips         = { cpu = { family = "mips"; }; };
+    isRiscV        = { cpu = { family = "riscv"; }; };
+    isWasm         = { cpu = { family = "wasm"; }; };
 
-    "32bit"      = { cpu = { bits = 32; }; };
-    "64bit"      = { cpu = { bits = 64; }; };
-    BigEndian    = { cpu = { significantByte = significantBytes.bigEndian; }; };
-    LittleEndian = { cpu = { significantByte = significantBytes.littleEndian; }; };
+    is32bit        = { cpu = { bits = 32; }; };
+    is64bit        = { cpu = { bits = 64; }; };
+    isBigEndian    = { cpu = { significantByte = significantBytes.bigEndian; }; };
+    isLittleEndian = { cpu = { significantByte = significantBytes.littleEndian; }; };
 
-    BSD          = { kernel = { families = { inherit (kernelFamilies) bsd; }; }; };
-    Darwin       = { kernel = { families = { inherit (kernelFamilies) darwin; }; }; };
-    Unix         = [ BSD Darwin Linux SunOS Hurd Cygwin ];
+    isBSD          = { kernel = { families = { inherit (kernelFamilies) bsd; }; }; };
+    isDarwin       = { kernel = { families = { inherit (kernelFamilies) darwin; }; }; };
+    isUnix         = [ isBSD isDarwin isLinux isSunOS isHurd isCygwin ];
 
-    MacOS        = { kernel = kernels.macos; };
-    iOS          = { kernel = kernels.ios; };
-    Linux        = { kernel = kernels.linux; };
-    SunOS        = { kernel = kernels.solaris; };
-    FreeBSD      = { kernel = kernels.freebsd; };
-    Hurd         = { kernel = kernels.hurd; };
-    NetBSD       = { kernel = kernels.netbsd; };
-    OpenBSD      = { kernel = kernels.openbsd; };
-    Windows      = { kernel = kernels.windows; };
-    Cygwin       = { kernel = kernels.windows; abi = abis.cygnus; };
-    MinGW        = { kernel = kernels.windows; abi = abis.gnu; };
+    isMacOS        = { kernel = kernels.macos; };
+    isiOS          = { kernel = kernels.ios; };
+    isLinux        = { kernel = kernels.linux; };
+    isSunOS        = { kernel = kernels.solaris; };
+    isFreeBSD      = { kernel = kernels.freebsd; };
+    isHurd         = { kernel = kernels.hurd; };
+    isNetBSD       = { kernel = kernels.netbsd; };
+    isOpenBSD      = { kernel = kernels.openbsd; };
+    isWindows      = { kernel = kernels.windows; };
+    isCygwin       = { kernel = kernels.windows; abi = abis.cygnus; };
+    isMinGW        = { kernel = kernels.windows; abi = abis.gnu; };
 
-    Android      = [ { abi = abis.android; } { abi = abis.androideabi; } ];
-    Musl         = with abis; map (a: { abi = a; }) [ musl musleabi musleabihf ];
+    isAndroid      = [ { abi = abis.android; } { abi = abis.androideabi; } ];
+    isMusl         = with abis; map (a: { abi = a; }) [ musl musleabi musleabihf ];
 
-    Kexecable    = map (family: { kernel = kernels.linux; cpu.family = family; })
-                     [ "x86" "arm" "aarch64" "mips" ];
-    Efi          = map (family: { cpu.family = family; })
-                     [ "x86" "arm" "aarch64" ];
-    Seccomputable = map (family: { kernel = kernels.linux; cpu.family = family; })
-                      [ "x86" "arm" "aarch64" "mips" ];
+    isKexecable    = map (family: { kernel = kernels.linux; cpu.family = family; })
+                       [ "x86" "arm" "aarch64" "mips" ];
+    isEfi          = map (family: { cpu.family = family; })
+                       [ "x86" "arm" "aarch64" ];
+    isSeccomputable = map (family: { kernel = kernels.linux; cpu.family = family; })
+                        [ "x86" "arm" "aarch64" "mips" ];
   };
 
   matchAnyAttrs = patterns:
     if builtins.isList patterns then attrs: any (pattern: matchAttrs pattern attrs) patterns
     else matchAttrs patterns;
 
-  predicates = mapAttrs'
-    (name: value: nameValuePair ("is" + name) (matchAnyAttrs value))
-    patterns;
+  predicates = mapAttrs (_: matchAnyAttrs) patterns;
 }


### PR DESCRIPTION
###### Motivation for this change

So everyone can find these definitions. Sorry I didn't get around to doing this sooner!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

