### PR TITLE
lib: Messed up `or` operator precedence

### DIFF
--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -122,7 +122,7 @@ rec {
     let res = builtins.tryEval (
       if isDerivation value then
         value.meta.hydraPlatforms
-          or supportedMatches (value.meta.platforms or [ "x86_64-linux" ])
+          or (supportedMatches (value.meta.platforms or [ "x86_64-linux" ]))
       else if value.recurseForDerivations or false || value.recurseForRelease or false then
         packagePlatforms value
       else


### PR DESCRIPTION
###### Motivation for this change

Github broke oddly on my previous PR, so I tested and merged by hand. Otherwise ofborg would have caught this.

Sorry!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

