### PR TITLE
treewide: isArm -> isAarch32

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -26,7 +26,7 @@ in rec {
 
   none = [];
 
-  arm     = filterDoubles predicates.isArm;
+  arm     = filterDoubles predicates.isAarch32;
   aarch64 = filterDoubles predicates.isAarch64;
   x86     = filterDoubles predicates.isx86;
   i686    = filterDoubles predicates.isi686;

--- a/lib/systems/for-meta.nix
+++ b/lib/systems/for-meta.nix
@@ -7,7 +7,7 @@ in rec {
   all     = [ {} ]; # `{}` matches anything
   none    = [];
 
-  arm     = [ patterns.isArm ];
+  arm     = [ patterns.isAarch32 ];
   aarch64 = [ patterns.isAarch64 ];
   x86     = [ patterns.isx86 ];
   i686    = [ patterns.isi686 ];

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -9,8 +9,8 @@ rec {
     isx86_64       = { cpu = cpuTypes.x86_64; };
     isPowerPC      = { cpu = cpuTypes.powerpc; };
     isx86          = { cpu = { family = "x86"; }; };
-    isArm          = { cpu = { family = "arm"; }; };
-    isAarch64      = { cpu = { family = "aarch64"; }; };
+    isAarch32      = { cpu = { family = "arm"; bits = 32; }; };
+    isAarch64      = { cpu = { family = "arm"; bits = 64; }; };
     isMips         = { cpu = { family = "mips"; }; };
     isRiscV        = { cpu = { family = "riscv"; }; };
     isWasm         = { cpu = { family = "wasm"; }; };
@@ -41,6 +41,9 @@ rec {
 
     isEfi          = map (family: { cpu.family = family; })
                        [ "x86" "arm" "aarch64" ];
+
+    # Deprecated
+    isArm = isAarch32;
   };
 
   matchAnyAttrs = patterns:

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -72,7 +72,7 @@ rec {
     armv6l   = { bits = 32; significantByte = littleEndian; family = "arm"; };
     armv7a   = { bits = 32; significantByte = littleEndian; family = "arm"; };
     armv7l   = { bits = 32; significantByte = littleEndian; family = "arm"; };
-    aarch64  = { bits = 64; significantByte = littleEndian; family = "aarch64"; };
+    aarch64  = { bits = 64; significantByte = littleEndian; family = "arm"; };
     i686     = { bits = 32; significantByte = littleEndian; family = "x86"; };
     x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; };
     mips     = { bits = 32; significantByte = bigEndian;    family = "mips"; };

--- a/nixos/lib/qemu-flags.nix
+++ b/nixos/lib/qemu-flags.nix
@@ -9,7 +9,7 @@
     ];
 
   qemuSerialDevice = if pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64 then "ttyS0"
-        else if pkgs.stdenv.isArm || pkgs.stdenv.isAarch64 then "ttyAMA0"
+        else if pkgs.stdenv.isAarch32 || pkgs.stdenv.isAarch64 then "ttyAMA0"
         else throw "Unknown QEMU serial device for system '${pkgs.stdenv.system}'";
 
   qemuBinary = qemuPkg: {

--- a/nixos/modules/config/gnu.nix
+++ b/nixos/modules/config/gnu.nix
@@ -26,11 +26,11 @@ with lib;
         nano zile
         texinfo # for the stand-alone Info reader
       ]
-      ++ stdenv.lib.optional (!stdenv.isArm) grub2;
+      ++ stdenv.lib.optional (!stdenv.isAarch32) grub2;
 
 
     # GNU GRUB, where available.
-    boot.loader.grub.enable = !pkgs.stdenv.isArm;
+    boot.loader.grub.enable = !pkgs.stdenv.isAarch32;
     boot.loader.grub.version = 2;
 
     # GNU lsh.

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -437,7 +437,7 @@ in
     # FIXME: Consolidate this one day.
     virtualisation.qemu.options = mkMerge [
       (mkIf (pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) [ "-vga std" "-usb" "-device usb-tablet,bus=usb-bus.0" ])
-      (mkIf (pkgs.stdenv.isArm || pkgs.stdenv.isAarch64) [ "-device virtio-gpu-pci" "-device usb-ehci,id=usb0" "-device usb-kbd" "-device usb-tablet" ])
+      (mkIf (pkgs.stdenv.isAarch32 || pkgs.stdenv.isAarch64) [ "-device virtio-gpu-pci" "-device usb-ehci,id=usb0" "-device usb-kbd" "-device usb-tablet" ])
     ];
 
     # Mount the host filesystem via 9P, and bind-mount the Nix store

--- a/pkgs/applications/audio/sunvox/default.nix
+++ b/pkgs/applications/audio/sunvox/default.nix
@@ -5,7 +5,7 @@ let
   arch =
     if stdenv.isAarch64
     then "arm64"
-    else if stdenv.isArm
+    else if stdenv.isAarch32
     then "arm_armhf_raspberry_pi"
     else if stdenv.is64bit
     then "x86_64"

--- a/pkgs/applications/networking/instant-messengers/toxic/default.nix
+++ b/pkgs/applications/networking/instant-messengers/toxic/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libtoxcore libsodium ncurses curl gdk_pixbuf libnotify
-  ] ++ stdenv.lib.optionals (!stdenv.isArm) [
+  ] ++ stdenv.lib.optionals (!stdenv.isAarch32) [
     openal libopus libvpx freealut libqrencode
   ];
   nativeBuildInputs = [ pkgconfig libconfig ];

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -4,7 +4,7 @@
 , makeWrapper
 , attr, libcap, libcap_ng
 , CoreServices, Cocoa, rez, setfile
-, numaSupport ? stdenv.isLinux && !stdenv.isArm, numactl
+, numaSupport ? stdenv.isLinux && !stdenv.isAarch32, numactl
 , seccompSupport ? stdenv.isLinux, libseccomp
 , pulseSupport ? !stdenv.isDarwin, libpulseaudio
 , sdlSupport ? !stdenv.isDarwin, SDL2
@@ -29,7 +29,7 @@ let
 
   hostCpuTargets = if stdenv.isx86_64 then "i386-softmmu,x86_64-softmmu"
                    else if stdenv.isi686 then "i386-softmmu"
-                   else if stdenv.isArm then "arm-softmmu"
+                   else if stdenv.isAarch32 then "arm-softmmu"
                    else if stdenv.isAarch64 then "aarch64-softmmu"
                    else throw "Don't know how to build a 'hostCpuOnly = true' QEMU";
 in
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
   postInstall =
     if stdenv.isx86_64       then ''makeWrapper $out/bin/qemu-system-x86_64  $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
     else if stdenv.isi686    then ''makeWrapper $out/bin/qemu-system-i386    $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
-    else if stdenv.isArm     then ''makeWrapper $out/bin/qemu-system-arm     $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
+    else if stdenv.isAarch32     then ''makeWrapper $out/bin/qemu-system-arm     $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
     else if stdenv.isAarch64 then ''makeWrapper $out/bin/qemu-system-aarch64 $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
     else "";
 

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -57,7 +57,7 @@ let
     else if targetPlatform.system == "i686-linux"     then "${libc_lib}/lib/ld-linux.so.2"
     else if targetPlatform.system == "x86_64-linux"   then "${libc_lib}/lib/ld-linux-x86-64.so.2"
     # ARM with a wildcard, which can be "" or "-armhf".
-    else if (with targetPlatform; isArm && isLinux)   then "${libc_lib}/lib/ld-linux*.so.3"
+    else if (with targetPlatform; isAarch32 && isLinux)   then "${libc_lib}/lib/ld-linux*.so.3"
     else if targetPlatform.system == "aarch64-linux"  then "${libc_lib}/lib/ld-linux-aarch64.so.1"
     else if targetPlatform.system == "powerpc-linux"  then "${libc_lib}/lib/ld.so.1"
     else if targetPlatform.isMips                     then "${libc_lib}/lib/ld.so.1"
@@ -176,7 +176,7 @@ stdenv.mkDerivation {
     sep = optionalString (!targetPlatform.isMips) "-";
     arch =
       /**/ if targetPlatform.isAarch64 then endianPrefix + "aarch64"
-      else if targetPlatform.isArm     then endianPrefix + "arm"
+      else if targetPlatform.isAarch32     then endianPrefix + "arm"
       else if targetPlatform.isx86_64  then "x86-64"
       else if targetPlatform.isi686    then "i386"
       else if targetPlatform.isMips    then {

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -289,7 +289,7 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms =
     # TODO(@Ericson2314): Figure out what's going wrong with Arm
-    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isArm
+    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isAarch32
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -298,7 +298,7 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms =
     # TODO(@Ericson2314): Figure out what's going wrong with Arm
-    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isArm
+    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isAarch32
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -318,7 +318,7 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms =
     # TODO(@Ericson2314): Figure out what's going wrong with Arm
-    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isArm
+    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isAarch32
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -322,7 +322,7 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms =
     # TODO(@Ericson2314): Figure out what's going wrong with Arm
-    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isArm
+    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isAarch32
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -327,7 +327,7 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms =
     # TODO(@Ericson2314): Figure out what's going wrong with Arm
-    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isArm
+    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isAarch32
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -290,7 +290,7 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms =
     # TODO(@Ericson2314): Figure out what's going wrong with Arm
-    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isArm
+    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isAarch32
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 

--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     or (throw "cannot bootstrap GHC on this platform"));
 
   nativeBuildInputs = [ perl ];
-  buildInputs = stdenv.lib.optionals stdenv.targetPlatform.isArm [ llvm_35 ];
+  buildInputs = stdenv.lib.optionals stdenv.targetPlatform.isAarch32 [ llvm_35 ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     or (throw "cannot bootstrap GHC on this platform"));
 
   nativeBuildInputs = [ perl ];
-  buildInputs = stdenv.lib.optionals (stdenv.targetPlatform.isArm || stdenv.targetPlatform.isAarch64) [ llvm_39 ];
+  buildInputs = stdenv.lib.optionals (stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64) [ llvm_39 ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -26,7 +26,7 @@
   enableShared ?
     !(targetPlatform.isDarwin
       # On iOS, dynamic linking is not supported
-      && (targetPlatform.isAarch64 || targetPlatform.isArm))
+      && (targetPlatform.isAarch64 || targetPlatform.isAarch32))
 , # Whether to backport https://phabricator.haskell.org/D4388 for
   # deterministic profiling symbol names, at the cost of a slightly
   # non-standard GHC API
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isArm ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
@@ -138,7 +138,7 @@ stdenv.mkDerivation rec {
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
-  ] ++ stdenv.lib.optionals (targetPlatform.isArm) [
+  ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
     "CFLAGS=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isArm ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
@@ -138,7 +138,7 @@ stdenv.mkDerivation rec {
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
-  ] ++ stdenv.lib.optionals (targetPlatform.isArm) [
+  ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
     "CFLAGS=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"

--- a/pkgs/development/compilers/ghc/8.4.2.nix
+++ b/pkgs/development/compilers/ghc/8.4.2.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isArm ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
@@ -120,7 +120,7 @@ stdenv.mkDerivation rec {
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
-  ] ++ stdenv.lib.optionals (targetPlatform.isArm) [
+  ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
     "CFLAGS=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isArm ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
@@ -125,7 +125,7 @@ stdenv.mkDerivation rec {
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
-  ] ++ stdenv.lib.optionals (targetPlatform.isArm) [
+  ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
     "CFLAGS=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"

--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
 
   '' + optionalString stdenv.isLinux ''
     sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
-  '' + optionalString stdenv.isArm ''
+  '' + optionalString stdenv.isAarch32 ''
     sed -i '/TestCurrent/areturn' src/os/user/user_test.go
     echo '#!${stdenv.shell}' > misc/cgo/testplugin/test.bash
   '' + optionalString stdenv.isDarwin ''
@@ -130,7 +130,7 @@ stdenv.mkDerivation rec {
   GOARCH = if stdenv.isDarwin then "amd64"
            else if stdenv.system == "i686-linux" then "386"
            else if stdenv.system == "x86_64-linux" then "amd64"
-           else if stdenv.isArm then "arm"
+           else if stdenv.isAarch32 then "arm"
            else if stdenv.isAarch64 then "arm64"
            else throw "Unsupported system";
   GOARM = optionalString (stdenv.system == "armv5tel-linux") "5";

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -130,7 +130,7 @@ stdenv.mkDerivation rec {
   GOARCH = if stdenv.isDarwin then "amd64"
            else if stdenv.system == "i686-linux" then "386"
            else if stdenv.system == "x86_64-linux" then "amd64"
-           else if stdenv.isArm then "arm"
+           else if stdenv.isAarch32 then "arm"
            else throw "Unsupported system";
   GOARM = stdenv.lib.optionalString (stdenv.system == "armv5tel-linux") "5";
   GO386 = 387; # from Arch: don't assume sse2 on i686

--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
 
   '' + optionalString stdenv.isLinux ''
     sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
-  '' + optionalString stdenv.isArm ''
+  '' + optionalString stdenv.isAarch32 ''
     sed -i '/TestCurrent/areturn' src/os/user/user_test.go
     echo '#!${stdenv.shell}' > misc/cgo/testplugin/test.bash
   '' + optionalString stdenv.isDarwin ''
@@ -132,7 +132,7 @@ stdenv.mkDerivation rec {
   GOARCH = if stdenv.isDarwin then "amd64"
            else if stdenv.system == "i686-linux" then "386"
            else if stdenv.system == "x86_64-linux" then "amd64"
-           else if stdenv.isArm then "arm"
+           else if stdenv.isAarch32 then "arm"
            else if stdenv.isAarch64 then "arm64"
            else throw "Unsupported system";
   GOARM = optionalString (stdenv.system == "armv5tel-linux") "5";

--- a/pkgs/development/compilers/ocaml/3.12.1.nix
+++ b/pkgs/development/compilers/ocaml/3.12.1.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, ncurses, xlibsWrapper }:
 
 let
-   useX11 = !stdenv.isArm && !stdenv.isMips;
+   useX11 = !stdenv.isAarch32 && !stdenv.isMips;
    useNativeCompilers = !stdenv.isMips;
    inherit (stdenv.lib) optionals optionalString;
 in

--- a/pkgs/development/compilers/ocaml/4.00.1.nix
+++ b/pkgs/development/compilers/ocaml/4.00.1.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, ncurses, xlibsWrapper }:
 
 let
-   useX11 = !stdenv.isArm && !stdenv.isMips;
+   useX11 = !stdenv.isAarch32 && !stdenv.isMips;
    useNativeCompilers = !stdenv.isMips;
    inherit (stdenv.lib) optionals optionalString;
 in

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -7,7 +7,7 @@ let
   real_url = if url == null then
     "http://caml.inria.fr/pub/distrib/ocaml-${versionNoPatch}/ocaml-${version}.tar.xz"
   else url;
-  safeX11 = stdenv: !(stdenv.isArm || stdenv.isMips);
+  safeX11 = stdenv: !(stdenv.isAarch32 || stdenv.isMips);
 in
 
 { stdenv, fetchurl, ncurses, buildEnv
@@ -15,7 +15,7 @@ in
 , flambdaSupport ? false
 }:
 
-assert useX11 -> !stdenv.isArm && !stdenv.isMips;
+assert useX11 -> !stdenv.isAarch32 && !stdenv.isMips;
 assert flambdaSupport -> stdenv.lib.versionAtLeast version "4.03";
 
 let

--- a/pkgs/development/compilers/sbcl/bootstrap.nix
+++ b/pkgs/development/compilers/sbcl/bootstrap.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
       --add-flags "--core $out/share/sbcl/sbcl.core"
   '';
 
-  postFixup = stdenv.lib.optionalString (!stdenv.isArm && stdenv.isLinux) ''
+  postFixup = stdenv.lib.optionalString (!stdenv.isAarch32 && stdenv.isLinux) ''
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/share/sbcl/sbcl
   '';
 

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
                (setf features (remove x features))))
     ''
     + (if threadSupport then "(enable :sb-thread)" else "(disable :sb-thread)")
-    + stdenv.lib.optionalString stdenv.isArm "(enable :arm)"
+    + stdenv.lib.optionalString stdenv.isAarch32 "(enable :arm)"
     + ''
       )) " > customize-target-features.lisp
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -932,11 +932,11 @@ self: super: {
   JuicyPixels = dontHaddock super.JuicyPixels;
 
   # aarch64 and armv7l fixes.
-  happy = if (pkgs.stdenv.hostPlatform.isArm || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.happy else super.happy; # Similar to https://ghc.haskell.org/trac/ghc/ticket/13062
-  hashable = if (pkgs.stdenv.hostPlatform.isArm || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.hashable else super.hashable; # https://github.com/tibbe/hashable/issues/95
-  servant-docs = if (pkgs.stdenv.hostPlatform.isArm || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.servant-docs else super.servant-docs;
-  servant-swagger = if (pkgs.stdenv.hostPlatform.isArm || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.servant-swagger else super.servant-swagger;
-  swagger2 = if (pkgs.stdenv.hostPlatform.isArm || pkgs.stdenv.hostPlatform.isAarch64) then dontHaddock (dontCheck super.swagger2) else super.swagger2;
+  happy = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.happy else super.happy; # Similar to https://ghc.haskell.org/trac/ghc/ticket/13062
+  hashable = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.hashable else super.hashable; # https://github.com/tibbe/hashable/issues/95
+  servant-docs = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.servant-docs else super.servant-docs;
+  servant-swagger = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.servant-swagger else super.servant-swagger;
+  swagger2 = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontHaddock (dontCheck super.swagger2) else super.swagger2;
 
   # Tries to read a file it is not allowed to in the test suite
   load-env = dontCheck super.load-env;

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -136,7 +136,7 @@ let
     (optionalString (enableSharedExecutables && stdenv.isDarwin) "--ghc-option=-optl=-Wl,-headerpad_max_install_names")
     (optionalString enableParallelBuilding "--ghc-option=-j$NIX_BUILD_CORES")
     (optionalString useCpphs "--with-cpphs=${cpphs}/bin/cpphs --ghc-options=-cpp --ghc-options=-pgmP${cpphs}/bin/cpphs --ghc-options=-optP--cpp")
-    (enableFeature (enableDeadCodeElimination && !hostPlatform.isArm && !hostPlatform.isAarch64 && (versionAtLeast "8.0.1" ghc.version)) "split-objs")
+    (enableFeature (enableDeadCodeElimination && !hostPlatform.isAarch32 && !hostPlatform.isAarch64 && (versionAtLeast "8.0.1" ghc.version)) "split-objs")
     (enableFeature enableLibraryProfiling "library-profiling")
     (optionalString ((enableExecutableProfiling || enableLibraryProfiling) && versionOlder "8" ghc.version) "--profiling-detail=${profilingDetail}")
     (enableFeature enableExecutableProfiling (if versionOlder ghc.version "8" then "executable-profiling" else "profiling"))

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -86,7 +86,7 @@ let
 
     preConfigure = optionalString (!crossCompiling) ''
         configureFlags="$configureFlags -Dprefix=$out -Dman1dir=$out/share/man/man1 -Dman3dir=$out/share/man/man3"
-      '' + optionalString (stdenv.isArm || stdenv.isMips) ''
+      '' + optionalString (stdenv.isAarch32 || stdenv.isMips) ''
         configureFlagsArray=(-Dldflags="-lm -lrt")
       '' + optionalString stdenv.isDarwin ''
         substituteInPlace hints/darwin.sh --replace "env MACOSX_DEPLOYMENT_TARGET=10.3" ""

--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1k3x6mvk9b34iiyml142bzh3gf241f25ywjlaagbxzb9vklpws75";
   };
   buildInputs = optional stdenv.is64bit jdk;
-  patchPhase = optionalString stdenv.isArm ''
+  patchPhase = optionalString stdenv.isAarch32 ''
     sed -i s/-m32//g Makefile
     cat >>Makefile <<EOF
     ext.o: ext.c

--- a/pkgs/development/interpreters/spidermonkey/1.8.5.nix
+++ b/pkgs/development/interpreters/spidermonkey/1.8.5.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ nspr ];
 
-  nativeBuildInputs = [ pkgconfig ] ++ lib.optional stdenv.isArm autoconf213;
+  nativeBuildInputs = [ pkgconfig ] ++ lib.optional stdenv.isAarch32 autoconf213;
   buildInputs = [ perl python2 zip ];
 
   postUnpack = "sourceRoot=\${sourceRoot}/js/src";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${nspr.dev}/include/nspr"
     export LIBXUL_DIST=$out
-    ${lib.optionalString stdenv.isArm "autoreconf --verbose --force"}
+    ${lib.optionalString stdenv.isAarch32 "autoreconf --verbose --force"}
   '';
 
   patches = [
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
       url = "https://anonscm.debian.org/cgit/collab-maint/mozjs.git/plain/debian/patches/fix-811665.patch?id=00b15c7841968ab4f7fec409a6b93fa5e1e1d32e";
       sha256 = "1q8477xqxiy5d8376k5902l45gd0qkd4nxmhl8vr6rr1pxfcny99";
     })
-  ] ++ stdenv.lib.optionals stdenv.isArm [
+  ] ++ stdenv.lib.optionals stdenv.isAarch32 [
     # Explained below in configureFlags for ARM
     ./1.8.5-findvanilla.patch
     # Fix for hard float flags.
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   # hack around a make problem, see https://github.com/NixOS/nixpkgs/issues/1279#issuecomment-29547393
   preBuild = ''
     touch -- {.,shell,jsapi-tests}/{-lpthread,-ldl}
-    ${if stdenv.isArm then "rm -r jit-test/tests/jaeger/bug563000" else ""}
+    ${if stdenv.isAarch32 then "rm -r jit-test/tests/jaeger/bug563000" else ""}
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -7,8 +7,8 @@
 # Build options
 , runtimeCpuDetectBuild ? true # Detect CPU capabilities at runtime
 , multithreadBuild ? true # Multithreading via pthreads/win32 threads
-, sdlSupport ? !stdenv.isArm, SDL ? null, SDL2 ? null
-, vdpauSupport ? !stdenv.isArm, libvdpau ? null
+, sdlSupport ? !stdenv.isAarch32, SDL ? null, SDL2 ? null
+, vdpauSupport ? !stdenv.isAarch32, libvdpau ? null
 # Developer options
 , debugDeveloper ? false
 , optimizationsDeveloper ? true
@@ -42,7 +42,7 @@
  */
 
 let
-  inherit (stdenv) icCygwin isDarwin isFreeBSD isLinux isArm;
+  inherit (stdenv) icCygwin isDarwin isFreeBSD isLinux isAarch32;
   inherit (stdenv.lib) optional optionals enableFeature;
 
   cmpVer = builtins.compareVersions;
@@ -55,9 +55,9 @@ let
   verFix = withoutFix: fixVer: withFix: if reqMatch fixVer then withFix else withoutFix;
 
   # Disable dependency that needs fixes before it will work on Darwin or Arm
-  disDarwinOrArmFix = origArg: minVer: fixArg: if ((isDarwin || isArm) && reqMin minVer) then fixArg else origArg;
+  disDarwinOrArmFix = origArg: minVer: fixArg: if ((isDarwin || isAarch32) && reqMin minVer) then fixArg else origArg;
 
-  vaapiSupport = reqMin "0.6" && ((isLinux || isFreeBSD) && !isArm);
+  vaapiSupport = reqMin "0.6" && ((isLinux || isFreeBSD) && !isAarch32);
 in
 
 assert openglSupport -> libGLU_combined != null;
@@ -153,8 +153,8 @@ stdenv.mkDerivation rec {
     bzip2 fontconfig freetype gnutls libiconv lame libass libogg libtheora
     libvdpau libvorbis lzma soxr x264 x265 xvidcore zlib libopus
   ] ++ optional openglSupport libGLU_combined
-    ++ optionals (!isDarwin && !isArm) [ libvpx libpulseaudio ] # Need to be fixed on Darwin and ARM
-    ++ optional ((isLinux || isFreeBSD) && !isArm) libva
+    ++ optionals (!isDarwin && !isAarch32) [ libvpx libpulseaudio ] # Need to be fixed on Darwin and ARM
+    ++ optional ((isLinux || isFreeBSD) && !isAarch32) libva
     ++ optional isLinux alsaLib
     ++ optionals isDarwin darwinFrameworks
     ++ optional vdpauSupport libvdpau

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
   configureFlags = [ "--disable-static" "--bindir=$(dev)/bin" ];
 
   # The asm for armel is written with the 'asm' keyword.
-  CFLAGS = optionalString stdenv.isArm "-std=gnu99";
+  CFLAGS = optionalString stdenv.isAarch32 "-std=gnu99";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -127,7 +127,7 @@ stdenv.mkDerivation ({
       (if cross ? float && cross.float == "soft" then "--without-fp" else "--with-fp")
     ] ++ lib.optionals (cross != null) [
       "--with-__thread"
-    ] ++ lib.optionals (cross == null && stdenv.isArm) [
+    ] ++ lib.optionals (cross == null && stdenv.isAarch32) [
       "--host=arm-linux-gnueabi"
       "--build=arm-linux-gnueabi"
 

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -37,7 +37,7 @@ let self = stdenv.mkDerivation rec {
   # The config.guess in GMP tries to runtime-detect various
   # ARM optimization flags via /proc/cpuinfo (and is also
   # broken on multicore CPUs). Avoid this impurity.
-  preConfigure = optionalString stdenv.isArm ''
+  preConfigure = optionalString stdenv.isAarch32 ''
       configureFlagsArray+=("--build=$(./configfsf.guess)")
     '';
 

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -38,7 +38,7 @@ let self = stdenv.mkDerivation rec {
   # The config.guess in GMP tries to runtime-detect various
   # ARM optimization flags via /proc/cpuinfo (and is also
   # broken on multicore CPUs). Avoid this impurity.
-  preConfigure = optionalString stdenv.isArm ''
+  preConfigure = optionalString stdenv.isAarch32 ''
       configureFlagsArray+=("--build=$(./configfsf.guess)")
     '';
 

--- a/pkgs/development/libraries/gnu-efi/default.nix
+++ b/pkgs/development/libraries/gnu-efi/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     "AR=${stdenv.cc.targetPrefix}ar"
     "RANLIB=${stdenv.cc.targetPrefix}ranlib"
     "OBJCOPY=${stdenv.cc.targetPrefix}objcopy"
-  ] ++ stdenv.lib.optional stdenv.isArm "ARCH=arm"
+  ] ++ stdenv.lib.optional stdenv.isAarch32 "ARCH=arm"
     ++ stdenv.lib.optional stdenv.isAarch64 "ARCH=aarch64";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/icu/base.nix
+++ b/pkgs/development/libraries/icu/base.nix
@@ -31,7 +31,7 @@ let
 
       # $(includedir) is different from $(prefix)/include due to multiple outputs
       sed -i -e 's|^\(CPPFLAGS = .*\) -I\$(prefix)/include|\1 -I$(includedir)|' config/Makefile.inc.in
-    '' + stdenv.lib.optionalString stdenv.isArm ''
+    '' + stdenv.lib.optionalString stdenv.isAarch32 ''
       # From https://archlinuxarm.org/packages/armv7h/icu/files/icudata-stdlibs.patch
       sed -e 's/LDFLAGSICUDT=-nodefaultlibs -nostdlib/LDFLAGSICUDT=/' -i config/mh-linux
     '';

--- a/pkgs/development/libraries/jemalloc/common.nix
+++ b/pkgs/development/libraries/jemalloc/common.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (rec {
                    # jemalloc is unable to correctly detect transparent hugepage support on
                    # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
                    # kernel ARMv6/7 kernel does not enable it, so we explicitly disable support
-                   ++ stdenv.lib.optional stdenv.isArm "--disable-thp";
+                   ++ stdenv.lib.optional stdenv.isAarch32 "--disable-thp";
   doCheck = true;
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     "echo : \\\${ac_cv_func_clock_gettime=\'yes\'} > config.cache";
 
   configureFlags = [ "--enable-install-test-programs" ]
-    ++ stdenv.lib.optionals (stdenv.isArm || stdenv.isAarch64)
+    ++ stdenv.lib.optionals (stdenv.isAarch32 || stdenv.isAarch64)
       [ "--enable-tegra-experimental-api" "--enable-etnaviv-experimental-api" ]
     ++ stdenv.lib.optional stdenv.isDarwin "-C";
 

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libsodium libmsgpack ncurses libconfig
-  ] ++ stdenv.lib.optionals (!stdenv.isArm) [
+  ] ++ stdenv.lib.optionals (!stdenv.isAarch32) [
     libopus
     libvpx
   ];

--- a/pkgs/development/libraries/libtoxcore/new-api.nix
+++ b/pkgs/development/libraries/libtoxcore/new-api.nix
@@ -33,11 +33,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [
     autoreconfHook libsodium ncurses check libconfig
-  ] ++ stdenv.lib.optionals (!stdenv.isArm) [
+  ] ++ stdenv.lib.optionals (!stdenv.isAarch32) [
     libopus
   ];
 
-  propagatedBuildInputs = stdenv.lib.optionals (!stdenv.isArm) [ libvpx ];
+  propagatedBuildInputs = stdenv.lib.optionals (!stdenv.isAarch32) [ libvpx ];
 
   # Some tests fail randomly due to timeout. This kind of problem is well known
   # by upstream: https://github.com/irungentoo/toxcore/issues/{950,1054}

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -41,7 +41,7 @@
 }:
 
 let
-  inherit (stdenv) isi686 isx86_64 isArm is64bit isMips isDarwin isCygwin;
+  inherit (stdenv) isi686 isx86_64 isAarch32 is64bit isMips isDarwin isCygwin;
   inherit (stdenv.lib) enableFeature optional optionals;
 in
 

--- a/pkgs/development/libraries/libvpx/git.nix
+++ b/pkgs/development/libraries/libvpx/git.nix
@@ -43,11 +43,11 @@
 }:
 
 let
-  inherit (stdenv) isi686 isx86_64 isArm is64bit isMips isDarwin isCygwin;
+  inherit (stdenv) isi686 isx86_64 isAarch32 is64bit isMips isDarwin isCygwin;
   inherit (stdenv.lib) enableFeature optional optionals;
 in
 
-assert isi686 || isx86_64 || isArm || isMips; # Requires ARM with floating point support
+assert isi686 || isx86_64 || isAarch32 || isMips; # Requires ARM with floating point support
 
 assert vp8DecoderSupport || vp8EncoderSupport || vp9DecoderSupport || vp9EncoderSupport;
 assert internalStatsSupport && (vp9DecoderSupport || vp9EncoderSupport) -> postprocSupport;

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -33,17 +33,17 @@ else
 
 let
   defaultGalliumDrivers =
-    if stdenv.isArm
+    if stdenv.isAarch32
     then ["nouveau" "freedreno" "vc4" "etnaviv" "imx"]
     else if stdenv.isAarch64
     then ["nouveau" "vc4" ]
     else ["svga" "i915" "r300" "r600" "radeonsi" "nouveau"];
   defaultDriDrivers =
-    if (stdenv.isArm || stdenv.isAarch64)
+    if (stdenv.isAarch32 || stdenv.isAarch64)
     then ["nouveau"]
     else ["i915" "i965" "nouveau" "radeon" "r200"];
   defaultVulkanDrivers =
-    if (stdenv.isArm || stdenv.isAarch64)
+    if (stdenv.isAarch32 || stdenv.isAarch64)
     then []
     else ["intel"] ++ lib.optional enableRadv "radeon";
 in

--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = stdenv.lib.optional doCheck libpng;
 
-  configureFlags = stdenv.lib.optional stdenv.isArm "--disable-arm-iwmmxt";
+  configureFlags = stdenv.lib.optional stdenv.isAarch32 "--disable-arm-iwmmxt";
 
   doCheck = true;
 

--- a/pkgs/development/libraries/pth/default.nix
+++ b/pkgs/development/libraries/pth/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ckjqw5kz5m30srqi87idj7xhpw6bpki43mj07bazjm2qmh3cdbj";
   };
 
-  preConfigure = stdenv.lib.optionalString stdenv.isArm ''
+  preConfigure = stdenv.lib.optionalString stdenv.isAarch32 ''
     configureFlagsArray=("CFLAGS=-DJB_SP=8 -DJB_PC=9")
   '';
 

--- a/pkgs/development/libraries/v8/3.16.14.nix
+++ b/pkgs/development/libraries/v8/3.16.14.nix
@@ -3,10 +3,10 @@
 assert readline != null;
 
 let
-  arch = if stdenv.isArm
+  arch = if stdenv.isAarch32
     then (if stdenv.is64bit then "arm64" else "arm")
     else (if stdenv.is64bit then "x64" else "ia32");
-  armHardFloat = stdenv.isArm && (stdenv.platform.gcc.float or null) == "hard";
+  armHardFloat = stdenv.isAarch32 && (stdenv.platform.gcc.float or null) == "hard";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/v8/6_x.nix
+++ b/pkgs/development/libraries/v8/6_x.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  arch = if stdenv.isArm
+  arch = if stdenv.isAarch32
          then if stdenv.is64bit
               then"arm64"
               else "arm"

--- a/pkgs/development/libraries/v8/default.nix
+++ b/pkgs/development/libraries/v8/default.nix
@@ -10,7 +10,7 @@ let
   arch = if stdenv.isx86_64 then "x64"
             else if stdenv.isi686 then "ia32"
             else if stdenv.isAarch64 then "arm64"
-            else if stdenv.isArm then "arm"
+            else if stdenv.isAarch32 then "arm"
             else throw "Unknown architecture for v8";
   git_url = "https://chromium.googlesource.com";
   clangFlag = if stdenv.isDarwin then "1" else "0";

--- a/pkgs/development/libraries/webrtc-audio-processing/default.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   # Avoid this error:
   # signal_processing/filter_ar_fast_q12_armv7.S:88: Error: selected processor does not support `sbfx r11,r6,#12,#16' in ARM mode
-  patchPhase = stdenv.lib.optionalString stdenv.isArm ''
+  patchPhase = stdenv.lib.optionalString stdenv.isAarch32 ''
     substituteInPlace configure --replace 'armv7*|armv8*' 'disabled'
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
     substituteInPlace webrtc/base/checks.cc --replace 'defined(__UCLIBC__)' 1

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
   # TODO(@Ericson2314): Always pass "--target" and always targetPrefix.
   configurePlatforms =
     # TODO(@Ericson2314): Figure out what's going wrong with Arm
-    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isArm
+    if buildPlatform == hostPlatform && hostPlatform == targetPlatform && targetPlatform.isAarch32
     then []
     else [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 

--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -38,14 +38,14 @@ in stdenv.mkDerivation {
   # /nix/store/wd6r25miqbk9ia53pp669gn4wrg9n9cj-gcc-7.3.0/include/c++/7.3.0/bits/vector.tcc:394:7: note: parameter passing for argument of type 'std::vector<uhd::range_t>::iterator {aka __gnu_cxx::__normal_iterator<uhd::range_t*, std::vector<uhd::range_t> >}' changed in GCC 7.1
 
   cmakeFlags = [ "-DLIBUSB_INCLUDE_DIRS=${libusb1.dev}/include/libusb-1.0"] ++
-               [ (stdenv.lib.optionalString stdenv.isArm "-DCMAKE_CXX_FLAGS=-Wno-psabi") ];
+               [ (stdenv.lib.optionalString stdenv.isAarch32 "-DCMAKE_CXX_FLAGS=-Wno-psabi") ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ python pythonPackages.pyramid_mako orc libusb1 boost ];
 
   # Build only the host software
   preConfigure = "cd host";
-  patches = if stdenv.isArm then ./neon.patch else null;
+  patches = if stdenv.isAarch32 then ./neon.patch else null;
 
   postPhases = [ "installFirmware" ];
 

--- a/pkgs/os-specific/darwin/apple-source-releases/system_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/system_cmds/default.nix
@@ -11,7 +11,7 @@ appleDerivation rec {
                   apple_sdk.frameworks.IOKit openbsm ];
   # NIX_CFLAGS_COMPILE = lib.optionalString hostPlatform.isi686 "-D__i386__"
   #                    + lib.optionalString hostPlatform.isx86_64 "-D__x86_64__"
-  #                    + lib.optionalString hostPlatform.isArm "-D__arm__";
+  #                    + lib.optionalString hostPlatform.isAarch32 "-D__arm__";
   NIX_CFLAGS_COMPILE = [ "-DDAEMON_UID=1"
                          "-DDAEMON_GID=1"
                          "-DDEFAULT_AT_QUEUE=\'a\'"

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
       # We get a warning in armv5tel-linux and the fuloong2f, so we
       # disable -Werror in it.
-      ${stdenv.lib.optionalString (stdenv.isArm || stdenv.hostPlatform.isMips) ''
+      ${stdenv.lib.optionalString (stdenv.isAarch32 || stdenv.hostPlatform.isMips) ''
         sed -i s/-Werror// src/Makefile.am
       ''}
     '';

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -355,7 +355,7 @@ with stdenv.lib;
   SECURITY_SELINUX_BOOTPARAM_VALUE 0 # Disable SELinux by default
   SECURITY_YAMA? y # Prevent processes from ptracing non-children processes
   DEVKMEM n # Disable /dev/kmem
-  ${optionalString (! stdenv.hostPlatform.isArm)
+  ${optionalString (! stdenv.hostPlatform.isAarch32)
     (if versionOlder version "3.14" then ''
         CC_STACKPROTECTOR? y # Detect buffer overflows on the stack
       '' else ''

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -79,7 +79,7 @@ in stdenv.mkDerivation rec {
     "-Dsystem-gid-max=499"
     # "-Dtime-epoch=1"
 
-    (if stdenv.isArm || stdenv.isAarch64 || !hostPlatform.isEfi then "-Dgnu-efi=false" else "-Dgnu-efi=true")
+    (if stdenv.isAarch32 || stdenv.isAarch64 || !hostPlatform.isEfi then "-Dgnu-efi=false" else "-Dgnu-efi=true")
     "-Defi-libdir=${toString gnu-efi}/lib"
     "-Defi-includedir=${toString gnu-efi}/include/efi"
     "-Defi-ldsdir=${toString gnu-efi}/lib"

--- a/pkgs/os-specific/linux/uclibc/default.nix
+++ b/pkgs/os-specific/linux/uclibc/default.nix
@@ -43,7 +43,7 @@ let
     UCLIBC_SUSV4_LEGACY y
     UCLIBC_HAS_THREADS_NATIVE y
     KERNEL_HEADERS "${linuxHeaders}/include"
-  '' + stdenv.lib.optionalString (stdenv.isArm && cross == null) ''
+  '' + stdenv.lib.optionalString (stdenv.isAarch32 && cross == null) ''
     CONFIG_ARM_EABI y
     ARCH_WANTS_BIG_ENDIAN n
     ARCH_BIG_ENDIAN n

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -123,7 +123,7 @@ everything = stdenv.mkDerivation (common // {
   buildInputs = common.buildInputs ++ [
     xz lzo lz4 bzip2 snappy
     libxml2 boost judy libevent cracklib
-  ] ++ optional (stdenv.isLinux && !stdenv.isArm) numactl;
+  ] ++ optional (stdenv.isLinux && !stdenv.isAarch32) numactl;
 
   cmakeFlags = common.cmakeFlags ++ [
     "-DMYSQL_DATADIR=/var/lib/mysql"

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -117,7 +117,7 @@ let
       # Utility flags to test the type of platform.
       inherit (hostPlatform)
         isDarwin isLinux isSunOS isHurd isCygwin isFreeBSD isOpenBSD
-        isi686 isx86_64 is64bit isArm isAarch64 isMips isBigEndian;
+        isi686 isx86_64 is64bit isAarch32 isAarch64 isMips isBigEndian;
 
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;

--- a/pkgs/tools/networking/cjdns/default.nix
+++ b/pkgs/tools/networking/cjdns/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     stdenv.lib.optional stdenv.isLinux utillinux;
 
   buildPhase =
-    stdenv.lib.optionalString stdenv.isArm "Seccomp_NO=1 "
+    stdenv.lib.optionalString stdenv.isAarch32 "Seccomp_NO=1 "
     + "bash do";
   installPhase = ''
     install -Dt "$out/bin/" cjdroute makekeys privatetopublic publictoip6

--- a/pkgs/tools/networking/filegive/default.nix
+++ b/pkgs/tools/networking/filegive/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchgit, go }:
 
-assert stdenv.isLinux && (stdenv.isi686 || stdenv.isx86_64 || stdenv.isArm);
+assert stdenv.isLinux && (stdenv.isi686 || stdenv.isx86_64 || stdenv.isAarch32);
 
 let
 

--- a/pkgs/tools/system/storebrowse/default.nix
+++ b/pkgs/tools/system/storebrowse/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchhg, go, sqlite}:
 
-assert stdenv.isLinux && (stdenv.isi686 || stdenv.isx86_64 || stdenv.isArm);
+assert stdenv.isLinux && (stdenv.isi686 || stdenv.isx86_64 || stdenv.isAarch32);
 
 stdenv.mkDerivation rec {
   name = "storebrowse-20130318212204";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6471,12 +6471,12 @@ with pkgs;
 
   openjdk = openjdk8;
 
-  jdk8 = if stdenv.isArm || stdenv.isAarch64 then oraclejdk8 else openjdk8 // { outputs = [ "out" ]; };
-  jre8 = if stdenv.isArm || stdenv.isAarch64 then oraclejre8 else lib.setName "openjre-${lib.getVersion pkgs.openjdk8.jre}"
+  jdk8 = if stdenv.isAarch32 || stdenv.isAarch64 then oraclejdk8 else openjdk8 // { outputs = [ "out" ]; };
+  jre8 = if stdenv.isAarch32 || stdenv.isAarch64 then oraclejre8 else lib.setName "openjre-${lib.getVersion pkgs.openjdk8.jre}"
     (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
       (openjdk8.jre // { outputs = [ "jre" ]; }));
   jre8_headless =
-    if stdenv.isArm || stdenv.isAarch64 then
+    if stdenv.isAarch32 || stdenv.isAarch64 then
       oraclejre8
     else if stdenv.isDarwin then
       jre8
@@ -6485,12 +6485,12 @@ with pkgs;
         (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
           ((openjdk8.override { minimal = true; }).jre // { outputs = [ "jre" ]; }));
 
-  jdk10 = if stdenv.isArm || stdenv.isAarch64 then oraclejdk10 else openjdk10 // { outputs = [ "out" ]; };
-  jre10 = if stdenv.isArm || stdenv.isAarch64 then oraclejre10 else lib.setName "openjre-${lib.getVersion pkgs.openjdk10.jre}"
+  jdk10 = if stdenv.isAarch32 || stdenv.isAarch64 then oraclejdk10 else openjdk10 // { outputs = [ "out" ]; };
+  jre10 = if stdenv.isAarch32 || stdenv.isAarch64 then oraclejre10 else lib.setName "openjre-${lib.getVersion pkgs.openjdk10.jre}"
     (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
       (openjdk10.jre // { outputs = [ "jre" ]; }));
   jre10_headless =
-    if stdenv.isArm || stdenv.isAarch64 then
+    if stdenv.isAarch32 || stdenv.isAarch64 then
       oraclejre10
     else if stdenv.isDarwin then
       jre10
@@ -9247,7 +9247,7 @@ with pkgs;
 
   cairo = callPackage ../development/libraries/cairo {
     glSupport = config.cairo.gl or (stdenv.isLinux &&
-      !stdenv.isArm && !stdenv.isMips);
+      !stdenv.isAarch32 && !stdenv.isMips);
   };
 
 


### PR DESCRIPTION
Following legacy packing conventions, `isArm` was defined just for
32-bit ARM instruction set. This is confusing to non packagers though,
because Aarch64 is an ARM instruction set.

The official ARM overview for ARMv8[1] is surprisingly not confusing,
given the overall state of affairs for ARM naming conventions, and
offers us a solution. It divides the nomenclature into three levels:

```
ISA:             ARMv8   {-A, -R, -M}
                 /    \
Mode:     Aarch64     Aarch32
             |         /   \
Encoding:   A64      A32   T32
```

At the top is the overall v8 instruction set archicture. Second are the
two modes, defined by bitwidth but differing in other semantics too, and
buttom are the encodings, (hopefully?) isomorphic if they encode the
same mode.

The 32 bit encodings are mostly backwards compatible with previous
non-Thumb and Thumb encodings, and if so we can pun the mode names to
instead mean "sets of compatable or isomorphic encodings", and then
voilà we have nice names for 32-bit and 64-bit arm instruction sets
which do not use the word ARM so as to not confused either laymen or
experienced ARM packages.

[1]: https://developer.arm.com/products/architecture/a-profile

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

