### PR TITLE
AgdaStdlib: 0.14 -> 0.15

### DIFF
--- a/pkgs/development/libraries/agda/agda-stdlib/default.nix
+++ b/pkgs/development/libraries/agda/agda-stdlib/default.nix
@@ -1,14 +1,14 @@
 { stdenv, agda, fetchFromGitHub, ghcWithPackages }:
 
 agda.mkDerivation (self: rec {
-  version = "0.14";
+  version = "0.15";
   name = "agda-stdlib-${version}";
 
   src = fetchFromGitHub {
     repo = "agda-stdlib";
     owner = "agda";
     rev = "v${version}";
-    sha256 = "0qx72w6lwskp18q608f95j5dcxb9xr4q4mzdkxp01sgib8v2v56l";
+    sha256 = "0c2vfib4fmljy98c3s3s7jmpjlqxvsbv7wf6qxr38kamwzbryrjj";
   };
 
   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.15 with grep in /nix/store/6787gs55hpa46z4507ji4jz5za51lyqy-agda-stdlib-0.15
- directory tree listing: https://gist.github.com/386f03ce4900379ef75d5d01bcc2cebb

cc @jwiegley @fuuzetsu @laMudri for review