### PR TITLE
apacheHttpd: 2.4.29 -> 2.4.32

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -16,12 +16,12 @@ assert ldapSupport -> aprutil.ldapSupport && openldap != null;
 assert http2Support -> nghttp2 != null;
 
 stdenv.mkDerivation rec {
-  version = "2.4.29";
+  version = "2.4.32";
   name = "apache-httpd-${version}";
 
   src = fetchurl {
     url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
-    sha256 = "777753a5a25568a2a27428b2214980564bc1c38c1abf9ccc7630b639991f7f00";
+    sha256 = "0adrca77awvf6vbq8943b1z25abqz6g8rk6zc8wm7y6w2mfd2lv3";
   };
 
   # FIXME: -dev depends on -doc


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/jqy7a2lm1zlq16al63hl6v66hvlgvw6i-apache-httpd-2.4.32/bin/httpd -V` and found version 2.4.32
- ran `/nix/store/jqy7a2lm1zlq16al63hl6v66hvlgvw6i-apache-httpd-2.4.32/bin/httpd -v` and found version 2.4.32
- ran `/nix/store/jqy7a2lm1zlq16al63hl6v66hvlgvw6i-apache-httpd-2.4.32/bin/apachectl -V` and found version 2.4.32
- ran `/nix/store/jqy7a2lm1zlq16al63hl6v66hvlgvw6i-apache-httpd-2.4.32/bin/apachectl -v` and found version 2.4.32
- found 2.4.32 with grep in /nix/store/jqy7a2lm1zlq16al63hl6v66hvlgvw6i-apache-httpd-2.4.32
- directory tree listing: https://gist.github.com/70eb713ae0f87b3472cac40abc006a26

cc @lovek323 @peti for review