### PR TITLE
bash-completion: 2.7 -> 2.8

### DIFF
--- a/pkgs/shells/bash-completion/default.nix
+++ b/pkgs/shells/bash-completion/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "bash-completion-${version}";
-  version = "2.7";
+  version = "2.8";
 
   src = fetchurl {
     url = "https://github.com/scop/bash-completion/releases/download/${version}/${name}.tar.xz";
-    sha256 = "07j484vb3k90f4989xh1g1x99g01akrp69p3dml4lza27wnqkfj1";
+    sha256 = "0kgmflrr1ga9wfk770vmakna3nj46ylb5ky9ipd0v2k9ymq5a7y0";
   };
 
   doCheck = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.8 with grep in /nix/store/svgfjl0v59ff90l6h2gzbsplhbk3aqhp-bash-completion-2.8
- directory tree listing: https://gist.github.com/23a9bb8eddc5667ef5a94d69ea7ab340

cc @peti for review