### PR TITLE
commonsCompress: 1.8.1 -> 1.16.1

### DIFF
--- a/pkgs/development/libraries/java/commons/compress/default.nix
+++ b/pkgs/development/libraries/java/commons/compress/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "1.8.1";
+  version = "1.16.1";
   name    = "commons-compress-${version}";
 
   src = fetchurl {
     url    = "mirror://apache/commons/compress/binaries/${name}-bin.tar.gz";
-    sha256 = "11viabgf34r3zx1avj51n00hzmx89kym3i90l6a5v5dbfh61h0lp";
+    sha256 = "0yz2m3qac1idg9346i64mjfrkq4kniajzx2manyybhj43v9dpx37";
   };
 
   installPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.16.1 in filename of file in /nix/store/bkj0f3csgr7z46ancws66bzgcxpamq8x-commons-compress-1.16.1
- directory tree listing: https://gist.github.com/2f7f8d5e9ede388260bcf5a3e305bd80

cc @copumpkin for review