### PR TITLE
commonsIo: 2.4 -> 2.6

### DIFF
--- a/pkgs/development/libraries/java/commons/io/default.nix
+++ b/pkgs/development/libraries/java/commons/io/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.4";
+  version = "2.6";
   name    = "commons-io-${version}";
 
   src = fetchurl {
     url    = "mirror://apache/commons/io/binaries/${name}-bin.tar.gz";
-    sha256 = "0m5xmjfr9k2zmbrz425q530jd0lm6368c4wm3jsjlsrqmqjpsvz1";
+    sha256 = "1nzkv8gi56l1m4h7s8bcvqm0naq3bhh7fazcmgdhcr2zkjs5zfmn";
   };
 
   installPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.6 with grep in /nix/store/5yl4dj084qj2x6xawqpbgs9bmlgxjjkb-commons-io-2.6
- found 2.6 in filename of file in /nix/store/5yl4dj084qj2x6xawqpbgs9bmlgxjjkb-commons-io-2.6
- directory tree listing: https://gist.github.com/a62494f31c4e13128a99cb347f615952

cc @copumpkin for review