### PR TITLE
copyq: 3.1.2 -> 3.3.0

### DIFF
--- a/pkgs/applications/misc/copyq/default.nix
+++ b/pkgs/applications/misc/copyq/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "CopyQ-${version}";
-  version = "3.1.2";
+  version = "3.3.0";
 
   src  = fetchFromGitHub {
     owner = "hluk";
     repo = "CopyQ";
     rev = "v${version}";
-    sha256 = "0gdx1bqqqr4fk6wcrxqm9li6z48j1w84wjwyjpzp2cjzg96bp6bl";
+    sha256 = "0j46h87ifinkydi0m725p422m9svk3dpcz8dnrci4mxx0inn6qs3";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq -h` got 0 exit code
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq --help` got 0 exit code
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq help` got 0 exit code
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq -v` and found version 3.3.0
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq --version` and found version 3.3.0
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq version` and found version 3.3.0
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq -h` and found version 3.3.0
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq --help` and found version 3.3.0
- ran `/nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0/bin/copyq help` and found version 3.3.0
- found 3.3.0 with grep in /nix/store/9iss35v7mnmaa30c8lgwahh3vdi7zfgi-CopyQ-3.3.0
- directory tree listing: https://gist.github.com/d350765fb7038f7a4d3810c0ab3825d0