### PR TITLE
varnish4: init at 4.1.9; varnish6: init at 6.0.0

### DIFF
--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -6,12 +6,21 @@ let
   cfg = config.services.varnish;
 
   commandLine = "-f ${pkgs.writeText "default.vcl" cfg.config}" +
-      optionalString (cfg.extraModules != []) " -p vmod_path='${makeSearchPathOutput "lib" "lib/varnish/vmods" ([pkgs.varnish] ++ cfg.extraModules)}' -r vmod_path";
+      optionalString (cfg.extraModules != []) " -p vmod_path='${makeSearchPathOutput "lib" "lib/varnish/vmods" ([cfg.package] ++ cfg.extraModules)}' -r vmod_path";
 in
 {
   options = {
     services.varnish = {
       enable = mkEnableOption "Varnish Server";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.varnish5;
+        defaultText = "pkgs.varnish5";
+        description = ''
+          The package to use
+        '';
+      };
 
       http_address = mkOption {
         type = types.str;
@@ -39,7 +48,7 @@ in
       extraModules = mkOption {
         type = types.listOf types.package;
         default = [];
-        example = literalExample "[ pkgs.varnish-geoip ]";
+        example = literalExample "[ pkgs.varnish5Packages.geoip ]";
         description = "
           Varnish modules (except 'std').
         ";
@@ -73,7 +82,7 @@ in
       serviceConfig = {
         Type = "simple";
         PermissionsStartOnly = true;
-        ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -n ${cfg.stateDir} -F ${cfg.extraCommandLine} ${commandLine}";
+        ExecStart = "${cfg.package}/sbin/varnishd -a ${cfg.http_address} -n ${cfg.stateDir} -F ${cfg.extraCommandLine} ${commandLine}";
         Restart = "always";
         RestartSec = "5s";
         User = "varnish";
@@ -84,13 +93,13 @@ in
       };
     };
 
-    environment.systemPackages = [ pkgs.varnish ];
+    environment.systemPackages = [ cfg.package ];
 
     # check .vcl syntax at compile time (e.g. before nixops deployment)
     system.extraDependencies = [
       (pkgs.stdenv.mkDerivation {
         name = "check-varnish-syntax";
-        buildCommand = "${pkgs.varnish}/sbin/varnishd -C ${commandLine} 2> $out";
+        buildCommand = "${cfg.package}/sbin/varnishd -C ${commandLine} 2> $out || (cat $out; exit 1)";
       })
     ];
 

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -1,37 +1,53 @@
 { stdenv, fetchurl, pcre, libxslt, groff, ncurses, pkgconfig, readline, libedit
 , python, pythonPackages, makeWrapper }:
 
-stdenv.mkDerivation rec {
-  version = "5.2.1";
-  name = "varnish-${version}";
+let
+  common = { version, sha256 }:
+    stdenv.mkDerivation rec {
+      name = "varnish-${version}";
 
-  src = fetchurl {
-    url = "http://varnish-cache.org/_downloads/${name}.tgz";
+      src = fetchurl {
+        url = "http://varnish-cache.org/_downloads/${name}.tgz";
+        inherit sha256;
+      };
+
+      nativeBuildInputs = [ pkgconfig ];
+      buildInputs = [
+        pcre libxslt groff ncurses readline python libedit
+        pythonPackages.docutils makeWrapper
+      ];
+
+      buildFlags = "localstatedir=/var/spool";
+
+      postInstall = ''
+        wrapProgram "$out/sbin/varnishd" --prefix PATH : "${stdenv.lib.makeBinPath [ stdenv.cc ]}"
+      '';
+
+      # https://github.com/varnishcache/varnish-cache/issues/1875
+      NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isi686 "-fexcess-precision=standard";
+
+      outputs = [ "out" "dev" "man" ];
+
+      meta = with stdenv.lib; {
+        description = "Web application accelerator also known as a caching HTTP reverse proxy";
+        homepage = https://www.varnish-cache.org;
+        license = licenses.bsd2;
+        maintainers = with maintainers; [ garbas fpletz ];
+        platforms = platforms.unix;
+      };
+    };
+in
+{
+  varnish4 = common {
+    version = "4.1.9";
+    sha256 = "11zwyasz2fn9qxc87r175wb5ba7388sd79mlygjmqn3yv2m89n12";
+  };
+  varnish5 = common {
+    version = "5.2.1";
     sha256 = "1cqlj12m426c1lak1hr1fx5zcfsjjvka3hfirz47hvy1g2fjqidq";
   };
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    pcre libxslt groff ncurses readline python libedit
-    pythonPackages.docutils makeWrapper
-  ];
-
-  buildFlags = "localstatedir=/var/spool";
-
-  postInstall = ''
-    wrapProgram "$out/sbin/varnishd" --prefix PATH : "${stdenv.lib.makeBinPath [ stdenv.cc ]}"
-  '';
-
-  # https://github.com/varnishcache/varnish-cache/issues/1875
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isi686 "-fexcess-precision=standard";
-
-  outputs = [ "out" "dev" "man" ];
-
-  meta = with stdenv.lib; {
-    description = "Web application accelerator also known as a caching HTTP reverse proxy";
-    homepage = https://www.varnish-cache.org;
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ garbas fpletz ];
-    platforms = platforms.unix;
+  varnish6 = common {
+    version = "6.0.0";
+    sha256 = "1vhbdch33m6ig4ijy57zvrramhs9n7cba85wd8rizgxjjnf87cn7";
   };
 }

--- a/pkgs/servers/varnish/digest.nix
+++ b/pkgs/servers/varnish/digest.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, libmhash, docutils }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.1";
-  name = "varnish-digest-${version}";
+  version = "1.0.2";
+  name = "${varnish.name}-digest-${version}";
 
   src = fetchFromGitHub {
     owner = "varnish";
     repo = "libvmod-digest";
     rev = "libvmod-digest-${version}";
-    sha256 = "0v18bqbsblhajpx5qvczic3psijhx5l2p2qlw1dkd6zl33hhppy7";
+    sha256 = "0jwkqqalydn0pwfdhirl5zjhbc3hldvhh09hxrahibr72fgmgpbx";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig docutils ];
   buildInputs = [ varnish libmhash ];
 
   postPatch = ''
-    substituteInPlace autogen.sh  --replace "-I \''${dataroot}/aclocal"                  ""
-    substituteInPlace Makefile.am --replace "-I \''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" ""
+    substituteInPlace autogen.sh  --replace "''${dataroot}/aclocal"                  "${varnish.dev}/share/aclocal"
+    substituteInPlace Makefile.am --replace "''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" "${varnish.dev}/share/aclocal"
   '';
 
   configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];

--- a/pkgs/servers/varnish/dynamic.nix
+++ b/pkgs/servers/varnish/dynamic.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, python, docutils }:
+
+stdenv.mkDerivation rec {
+  version = "0.3";
+  name = "${varnish.name}-dynamic-${version}";
+
+  src = fetchFromGitHub {
+    owner = "nigoroll";
+    repo = "libvmod-dynamic";
+    rev = "475be183fddbd727c3d2523f0518effa9aa881f8"; # 5.2 branch for Varnish-5.2 https://github.com/nigoroll/libvmod-dynamic/commits/5.2
+    sha256 = "12a42lbv0vf6fn3qnvngw893kmbd006f8pgab4ir7irc8855xjgf";
+  };
+
+  nativeBuildInputs = [ pkgconfig docutils autoreconfHook ];
+  buildInputs = [ varnish python ];
+  postPatch = ''
+    substituteInPlace Makefile.am --replace "''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" "${varnish.dev}/share/aclocal"
+  '';
+  configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];
+
+  meta = with stdenv.lib; {
+    description = "Dynamic director similar to the DNS director from Varnish 3";
+    homepage = https://github.com/nigoroll/libvmod-dynamic;
+    inherit (varnish.meta) license platforms maintainers;
+  };
+}

--- a/pkgs/servers/varnish/geoip.nix
+++ b/pkgs/servers/varnish/geoip.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.0.2";
-  name = "varnish-geoip-${version}";
+  name = "${varnish.name}-geoip-${version}";
 
   src = fetchFromGitHub {
     owner = "varnish";

--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -1,16 +1,23 @@
-{ stdenv, fetchurl, pkgconfig, varnish, python, docutils, removeReferencesTo }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, python, docutils, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
-  version = "0.13.0";
-  name = "varnish-modules-${version}";
+  version = "0.14.0";
+  name = "${varnish.name}-modules-${version}";
 
-  src = fetchurl {
-    url = "https://download.varnish-software.com/varnish-modules/varnish-modules-${version}.tar.gz";
-    sha256 = "1nj52va7cp0swcv87zd3si80knpaa4a7na37cy9wkvgyvhf9k8mh";
+  src = fetchFromGitHub {
+    owner = "varnish";
+    repo = "varnish-modules";
+    rev = version;
+    sha256 = "17fkbr4i70qgdqsrx1x28ag20xkfyz1v3q3d3ywmv409aczqhm40";
   };
 
-  nativeBuildInputs = [ pkgconfig docutils removeReferencesTo ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook docutils removeReferencesTo ];
   buildInputs = [ varnish python ];
+
+  postPatch = ''
+    substituteInPlace bootstrap   --replace "''${dataroot}/aclocal"                  "${varnish.dev}/share/aclocal"
+    substituteInPlace Makefile.am --replace "''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" "${varnish.dev}/share/aclocal"
+  '';
 
   postInstall = "find $out -type f -exec remove-references-to -t ${varnish.dev} '{}' +"; # varnish.dev captured only as __FILE__ in assert messages
 

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -1,0 +1,22 @@
+{ callPackage, varnish4, varnish5, varnish6 }:
+
+{
+  varnish4Packages = {
+    varnish = varnish4;
+    digest   = callPackage ./digest.nix   { varnish = varnish4; };
+    rtstatus = callPackage ./rtstatus.nix { varnish = varnish4; }; # varnish4 only
+    modules  = callPackage ./modules.nix  { varnish = varnish4; }; # varnish4 and varnish5 only
+    geoip    = callPackage ./geoip.nix    { varnish = varnish4; }; # varnish4 and varnish5 only
+  };
+  varnish5Packages = {
+    varnish = varnish5;
+    digest   = callPackage ./digest.nix   { varnish = varnish5; };
+    dynamic  = callPackage ./dynamic.nix  { varnish = varnish5; }; # varnish5 only (upstream has a separate branch for varnish4)
+    modules  = callPackage ./modules.nix  { varnish = varnish5; }; # varnish4 and varnish5 only
+    geoip    = callPackage ./geoip.nix    { varnish = varnish5; }; # varnish4 and varnish5 only
+  };
+  varnish6Packages = {
+    varnish = varnish6;
+    digest   = callPackage ./digest.nix   { varnish = varnish6; };
+  };
+}

--- a/pkgs/servers/varnish/rtstatus.nix
+++ b/pkgs/servers/varnish/rtstatus.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.2.0";
-  name = "varnish-rtstatus-${version}";
+  name = "${varnish.name}-rtstatus-${version}";
 
   src = fetchurl {
     url = "https://download.varnish-software.com/libvmod-rtstatus/libvmod-rtstatus-${version}.tar.gz";
@@ -17,6 +17,5 @@ stdenv.mkDerivation rec {
     description = "Varnish realtime status page";
     homepage = https://github.com/varnish/libvmod-rtstatus;
     inherit (varnish.meta) license platforms maintainers;
-    broken = true; # it has not ported to varnish 5.2 yet (5.1 is ok)
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5483,11 +5483,15 @@ with pkgs;
     inherit (gnome3) libgee;
   };
 
-  varnish = callPackage ../servers/varnish { };
-  varnish-modules = callPackage ../servers/varnish/modules.nix { };
-  varnish-digest = callPackage ../servers/varnish/digest.nix { };
-  varnish-geoip = callPackage ../servers/varnish/geoip.nix { };
-  varnish-rtstatus = callPackage ../servers/varnish/rtstatus.nix { };
+  inherit (callPackages ../servers/varnish { })
+    varnish4 varnish5 varnish6;
+  inherit (callPackages ../servers/varnish/packages.nix { })
+    varnish4Packages
+    varnish5Packages
+    varnish6Packages;
+
+  varnishPackages = varnish5Packages;
+  varnish = varnishPackages.varnish;
 
   venus = callPackage ../tools/misc/venus {
     python = python27;


### PR DESCRIPTION
###### Motivation for this change

added ```Varnish 6``` (new version) and ```Varnish 4``` (legacy version still supported by upstream) in additional to ```Varnish 5```.
