### PR TITLE
criu: 3.7 -> 3.8

### DIFF
--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name    = "criu-${version}";
-  version = "3.7";
+  version = "3.8";
 
   src = fetchurl {
     url    = "http://download.openvz.org/criu/${name}.tar.bz2";
-    sha256 = "0qrpz7pvnks34v7d8lb73flz3mb7qwnib94pdwaxh0mskn8470fq";
+    sha256 = "0gmvbnb5wa3f4nzam7gssclfai8g5363dhp8qc7q32dcx4wxbgam";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/rhcppqwmdlwak4ifncamjiqqybwlhvcj-criu-3.8/bin/compel -h` got 0 exit code
- ran `/nix/store/rhcppqwmdlwak4ifncamjiqqybwlhvcj-criu-3.8/bin/compel --help` got 0 exit code
- ran `/nix/store/rhcppqwmdlwak4ifncamjiqqybwlhvcj-criu-3.8/bin/criu -h` got 0 exit code
- ran `/nix/store/rhcppqwmdlwak4ifncamjiqqybwlhvcj-criu-3.8/bin/criu --help` got 0 exit code
- ran `/nix/store/rhcppqwmdlwak4ifncamjiqqybwlhvcj-criu-3.8/bin/criu -V` and found version 3.8
- ran `/nix/store/rhcppqwmdlwak4ifncamjiqqybwlhvcj-criu-3.8/bin/criu --version` and found version 3.8
- found 3.8 with grep in /nix/store/rhcppqwmdlwak4ifncamjiqqybwlhvcj-criu-3.8
- directory tree listing: https://gist.github.com/6bc3ef9b1f4c69a6862043a1158fba16

cc @thoughtpolice for review