### PR TITLE
deepin.deepin-gtk-theme: 17.10.5 -> 17.10.6

### DIFF
--- a/pkgs/desktops/deepin/deepin-gtk-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-gtk-theme/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "deepin-gtk-theme-${version}";
-  version = "17.10.5";
+  version = "17.10.6";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = "deepin-gtk-theme";
     rev = version;
-    sha256 = "0ff1yg4gz4p7nd0qg3dcbsiw8yqlvqccm55kxi998w8j1wrg6pq3";
+    sha256 = "01mfn3i234ynjvxl0yddsqqadwh6zmiibzrjm9xd1f78rj4xxkll";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 17.10.6 with grep in /nix/store/ga3bv13qx17rpki527kh2wzmb8ri5h5w-deepin-gtk-theme-17.10.6
- directory tree listing: https://gist.github.com/8406a3329d9f397b5fe75ab8f0eea6ad

cc @romildo for review