### PR TITLE
digikam: 5.8.0 -> 5.9.0

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -50,13 +50,13 @@
 
 mkDerivation rec {
   name    = "digikam-${version}";
-  version = "5.8.0";
+  version = "5.9.0";
 
   src = fetchFromGitHub {
     owner  = "KDE";
     repo   = "digikam";
     rev    = "v${version}";
-    sha256 = "1bvidg0fn92xvw5brhb34lm7m4iy4jb5xpvnhbgh8vik2m4n41w1";
+    sha256 = "09diw273h9i7rss89ba82yrfy6jb2njv3k0dknrrg7bb998vrw2d";
   };
 
   nativeBuildInputs = [ cmake doxygen extra-cmake-modules kdoctools wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 5.9.0 with grep in /nix/store/a0lvk4dyi87si7gdyblvh3zs16s0kp76-digikam-5.9.0
- found 5.9.0 in filename of file in /nix/store/a0lvk4dyi87si7gdyblvh3zs16s0kp76-digikam-5.9.0
- directory tree listing: https://gist.github.com/5e9b0273318688eb36b670f51aa482ec

cc @the-kenny for review