### PR TITLE
enlightenment.efl: 1.20.6 -> 1.20.7

### DIFF
--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   name = "efl-${version}";
-  version = "1.20.6";
+  version = "1.20.7";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/efl/${name}.tar.xz";
-    sha256 = "1h9jkb1pkp2g6ld7ra9mxgblx3x5id4162ja697klx9mfjkpxijn";
+    sha256 = "1zkn5ix81xck3n84dxvkjh4alwc6zj8x989d0zqi5c6ppijvgadh";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eina_btlog -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eet -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eet --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eolian_gen -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eolian_gen -v` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eolian_gen -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/evas_cserve2_shm_debug -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/evas_cserve2_shm_debug --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/evas_cserve2_shm_debug help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/evas_cserve2_shm_debug -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eldbus-codegen -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eldbus-codegen --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eldbus-codegen help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_mount -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_mount --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_mount -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_mount --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_mount -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_mount --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_umount -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_umount --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_umount -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_umount --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_umount -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_umount --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls -v` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eeze_disk_ls help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eetpack -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eetpack --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eetpack help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_cc -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_cc -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_cc --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_decc -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player -v` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_player help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_inspector -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_inspector --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_inspector -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_inspector --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_inspector -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_inspector --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_external_inspector -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_external_inspector --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_external_inspector -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_external_inspector --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_external_inspector -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_external_inspector --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_codegen -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_codegen --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_codegen -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_codegen --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_codegen -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/edje_codegen --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumb -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumb --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumb -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumb --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumb -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumb --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumbd -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumbd --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumbd -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumbd --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumbd -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/ethumbd --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elementary_codegen -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elementary_codegen --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elementary_codegen -V` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elementary_codegen --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elementary_codegen -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elementary_codegen --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elm_prefs_cc -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eolian_cxx -v` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eolian_cxx --version` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elua -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elua --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elua -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/elua --help` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eina-bench-cmp -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eina-bench-cmp --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eo_debug -h` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eo_debug --help` got 0 exit code
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eo_debug -h` and found version 1.20.7
- ran `/nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7/bin/eo_debug --help` and found version 1.20.7
- found 1.20.7 with grep in /nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7
- found 1.20.7 in filename of file in /nix/store/vc2lyks2j92bi7anl097f19ymdl5sjs6-efl-1.20.7
- directory tree listing: https://gist.github.com/087102bea4216e207ad77278be475a89

cc @matejc @ftrvxmtrx for review