### PR TITLE
electron: 1.8.2 -> 1.8.4

### DIFF
--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, libXScrnSaver, makeWrapper, fetchurl, unzip, atomEnv }:
 
 let
-  version = "1.8.2";
+  version = "1.8.4";
   name = "electron-${version}";
 
   throwSystem = throw "Unsupported system: ${stdenv.system}";
@@ -24,7 +24,7 @@ let
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
-        sha256 = "07ggq9wgfz3z5z0lwzzgs6im0qs83pz0pcfwr0r42zgmwg7j78b8";
+        sha256 = "0bjsspqsz9b83jkmd9m1facqai6yj7dydcrrsk6066jlqg1xvyki";
       };
       armv7l-linux = fetchurl {
         url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-armv7l.zip";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.8.4 with grep in /nix/store/pr2apc18sf68fvrz95bmnid0m9jw19ky-electron-1.8.4
- directory tree listing: https://gist.github.com/26d5256ecdc99c89739d6a9f5ccf7f21

cc @travisbhartwell @manveru for review