### PR TITLE
electron-cash: 3.1.2 -> 3.1.6

### DIFF
--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -7,14 +7,14 @@ let
 in
 
 python3Packages.buildPythonApplication rec {
-  version = "3.1.2";
+  version = "3.1.6";
   name = "electron-cash-${version}";
 
   src = fetchurl {
     url = "https://electroncash.org/downloads/${version}/win-linux/ElectronCash-${version}.tar.gz";
     # Verified using official SHA-1 and signature from
     # https://github.com/fyookball/keys-n-hashes
-    sha256 = "18h44jfbc2ksj34hdzgszvvq82xi28schl3wp3lkq9fjp7ny0mf3";
+    sha256 = "062k5iw0jcp10zxrffvgiyfg51c5xzs7gmm638icx01yy67d58dm";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6/bin/.electron-cash-wrapped -h` got 0 exit code
- ran `/nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6/bin/.electron-cash-wrapped --help` got 0 exit code
- ran `/nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6/bin/.electron-cash-wrapped help` got 0 exit code
- ran `/nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6/bin/.electron-cash-wrapped version` and found version 3.1.6
- ran `/nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6/bin/electron-cash -h` got 0 exit code
- ran `/nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6/bin/electron-cash --help` got 0 exit code
- ran `/nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6/bin/electron-cash help` got 0 exit code
- ran `/nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6/bin/electron-cash version` and found version 3.1.6
- found 3.1.6 with grep in /nix/store/9f6kwyk2zhwhgxkvk2ms8v6g3qz3g154-electron-cash-3.1.6
- directory tree listing: https://gist.github.com/76db342c6da1ceac5b3b7dced43798f9

cc @Lassulus for review