### PR TITLE
enlightenment.enlightenment: 0.22.1 -> 0.22.2

### DIFF
--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "enlightenment-${version}";
-  version = "0.22.1";
+  version = "0.22.2";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/enlightenment/${name}.tar.xz";
-    sha256 = "1q57fz57d0b26z06m1wiq7c1sniwh885b0vs02mk4jgwva46nyr0";
+    sha256 = "0b33w75s4w7xmz9cv8dyp8vy2gcffnrvjys20fhcpw26abw1wn2d";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_imc -h` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_imc --help` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_imc help` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_start -h` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_start --help` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_filemanager -h` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_filemanager --help` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_filemanager -V` and found version 0.22.2
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_filemanager --version` and found version 0.22.2
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_open -h` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_open --help` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_open -V` and found version 0.22.2
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_open --version` and found version 0.22.2
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_remote -h` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_remote --help` got 0 exit code
- ran `/nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2/bin/enlightenment_remote help` got 0 exit code
- found 0.22.2 with grep in /nix/store/5y0pdir9db44nxkjmlgxxjizda4j2irc-enlightenment-0.22.2
- directory tree listing: https://gist.github.com/882eb35c7b2e21205a6202b105bb0f11

cc @matejc @ftrvxmtrx @romildo for review