### PR TITLE
eventstore: 4.0.3 -> 4.1.0

### DIFF
--- a/pkgs/servers/nosql/eventstore/default.nix
+++ b/pkgs/servers/nosql/eventstore/default.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation rec {
   name = "EventStore-${version}";
-  version = "4.0.3";
+  version = "4.1.0";
   src = fetchFromGitHub {
     owner  = "EventStore";
     repo   = "EventStore";
     rev    = "oss-v${version}";
-    sha256 = "1905bnqyyiqprva67cp49rgib324iipw2l71jzj0ynzi7kxr4mgg";
+    sha256 = "0mvjz327kfg157fwvy8xkkf5h0g3v373pfwr70cslsy96n45jp10";
   };
 
   buildPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/8z6xvzan192jya1l1cqfrzfzqrqnfw33-EventStore-4.1.0/bin/clusternode -h` got 0 exit code
- ran `/nix/store/8z6xvzan192jya1l1cqfrzfzqrqnfw33-EventStore-4.1.0/bin/clusternode --help` got 0 exit code
- ran `/nix/store/8z6xvzan192jya1l1cqfrzfzqrqnfw33-EventStore-4.1.0/bin/clusternode help` got 0 exit code
- ran `/nix/store/8z6xvzan192jya1l1cqfrzfzqrqnfw33-EventStore-4.1.0/bin/clusternode --version` and found version 4.1.0
- ran `/nix/store/8z6xvzan192jya1l1cqfrzfzqrqnfw33-EventStore-4.1.0/bin/clusternode version` and found version 4.1.0
- ran `/nix/store/8z6xvzan192jya1l1cqfrzfzqrqnfw33-EventStore-4.1.0/bin/clusternode help` and found version 4.1.0
- found 4.1.0 with grep in /nix/store/8z6xvzan192jya1l1cqfrzfzqrqnfw33-EventStore-4.1.0
- directory tree listing: https://gist.github.com/aeb82087f0c9c92394ee5d61f1f4bf3b

cc @puffnfresh for review