### PR TITLE
fdk_aac: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/development/libraries/fdk-aac/default.nix
+++ b/pkgs/development/libraries/fdk-aac/default.nix
@@ -5,11 +5,11 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "fdk-aac-${version}";
-  version = "0.1.5";
+  version = "0.1.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/opencore-amr/fdk-aac/${name}.tar.gz";
-    sha256 = "1msdkcf559agmpycd4bk0scm2s2h9jyzbnnw1yrfarxlcwm5jr11";
+    sha256 = "1bfkpqba0v2jgxqwaf9xsrr63a089wckrir497lm6nbbmi11pdma";
   };
 
   configureFlags = [ ]


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.1.6 with grep in /nix/store/cp8yg64bk9zga197f0npsp23l1w23r1r-fdk-aac-0.1.6
- directory tree listing: https://gist.github.com/4a817b07a8c77aa7e3d16adb65f01186

cc @codyopel for review