### PR TITLE
gnustep.back: 0.25.0 -> 0.26.2

### DIFF
--- a/pkgs/desktops/gnustep/back/default.nix
+++ b/pkgs/desktops/gnustep/back/default.nix
@@ -8,13 +8,13 @@
 , libXmu
 }:
 let
-  version = "0.25.0";
+  version = "0.26.2";
 in
 gsmakeDerivation {
   name = "gnustep-back-${version}";
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-back-${version}.tar.gz";
-    sha256 = "14gs1b32ahnihd7mwpjrws2b8hl11rl1wl24a7651d3z2l7f6xj2";
+    sha256 = "012gsc7x66gmsw6r5w65a64krcigf7rzqzd5x86d4gv94344knlf";
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cairo base gui freetype x11 libXmu ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/7jhldrzqcz3ymbm30j635m9sf6q7b3ac-gnustep-back-0.26.2/bin/gpbs --help` got 0 exit code
- ran `/nix/store/7jhldrzqcz3ymbm30j635m9sf6q7b3ac-gnustep-back-0.26.2/bin/gpbs help` got 0 exit code
- ran `/nix/store/7jhldrzqcz3ymbm30j635m9sf6q7b3ac-gnustep-back-0.26.2/bin/.gpbs-wrapped --help` got 0 exit code
- ran `/nix/store/7jhldrzqcz3ymbm30j635m9sf6q7b3ac-gnustep-back-0.26.2/bin/.gpbs-wrapped help` got 0 exit code
- found 0.26.2 with grep in /nix/store/7jhldrzqcz3ymbm30j635m9sf6q7b3ac-gnustep-back-0.26.2
- directory tree listing: https://gist.github.com/54fd76edf6d8b2835f52c660d901708a

cc @ashalkhakov @matthewbauer for review