### PR TITLE
emscripten: use matching binaryen version

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -1,14 +1,31 @@
-{ stdenv, cmake, fetchFromGitHub }:
+{ stdenv, cmake, fetchFromGitHub, emscriptenRev ? null }:
+
+let
+  defaultVersion = "44";
+
+  # Map from git revs to SHA256 hashes
+  sha256s = {
+    "version_44" = "0zsqppc05fm62807w6vyccxkk2y2gar7kxbxxixq8zz3xsp6w84p";
+    "1.37.36" = "1wgzfzjjzkiaz0rf2lnwrcvlcsjvjhyvbyh58jxhqq43vi34zyjc";
+  };
+in
 
 stdenv.mkDerivation rec {
-  version = "44";
-  rev = "version_${version}";
+  version = if emscriptenRev == null
+            then defaultVersion
+            else "emscripten-${emscriptenRev}";
+  rev = if emscriptenRev == null
+        then "version_${version}"
+        else emscriptenRev;
   name = "binaryen-${version}";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "binaryen";
-    sha256 = "0zsqppc05fm62807w6vyccxkk2y2gar7kxbxxixq8zz3xsp6w84p";
+    sha256 =
+      if builtins.hasAttr rev sha256s
+      then builtins.getAttr rev sha256s
+      else null;
     inherit rev;
   };
 

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -5,6 +5,7 @@
 let
   rev = emscriptenVersion;
   appdir = "share/emscripten";
+  binaryenVersioned = binaryen.override { emscriptenRev = rev; };
 in
 
 stdenv.mkDerivation {
@@ -44,7 +45,7 @@ stdenv.mkDerivation {
     echo "SPIDERMONKEY_ENGINE = []" >> $out/${appdir}/config
   ''
   + stdenv.lib.optionalString enableWasm ''
-    echo "BINARYEN_ROOT = '${binaryen}'" >> $out/share/emscripten/config
+    echo "BINARYEN_ROOT = '${binaryenVersioned}'" >> $out/share/emscripten/config
   ''
   +
   ''


### PR DESCRIPTION
This changes the emscripten package so that it specifies the rev from
the binaryen repo to use, and sets it to always use the version that has
been tagged for use with that version of emscripten.  This should force
future updates of emscripten to also update binaryen.

Binaryen can also be installed as a stand-alone package, so there's some
logic added to the binaryen package to allow building in both ways, and
distinguishing between them.

###### Motivation for this change

The reason for this change is that the emscripten-binaryen relationship seems quite brittle -- using the wrong version of binaryen seems to make emscripten unreliable.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

