### PR TITLE
gnustep.base: 1.24.9 -> 1.25.1

### DIFF
--- a/pkgs/desktops/gnustep/base/default.nix
+++ b/pkgs/desktops/gnustep/base/default.nix
@@ -11,13 +11,13 @@
 , pkgconfig, portaudio
 }:
 let
-  version = "1.24.9";
+  version = "1.25.1";
 in
 gsmakeDerivation {
   name = "gnustep-base-${version}";
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-base-${version}.tar.gz";
-    sha256 = "1vvjlbqmlwr82b4pf8c62rxjgz475bmg0x2yd0bbkia6yvwhk585";
+    sha256 = "17mnilg28by74wc08nkwp6gi06x3j2nrcf05wg64nrw5ljffp2zj";
   };
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/HTMLLinker -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/HTMLLinker --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/HTMLLinker help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/HTMLLinker -V` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/HTMLLinker --version` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/cvtenc -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/cvtenc --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/cvtenc help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/defaults --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/defaults help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdnc --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap -V` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap -v` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap --version` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap version` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap -h` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap --help` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/gdomap help` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/make_strings --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/make_strings --help` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/pl -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/pl --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/pl help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/pldes -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/pldes --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/pldes help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plmerge -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plmerge --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plmerge help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plparse -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plparse --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plparse help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plser -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plser --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/plser help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/sfparse -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/sfparse --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/sfparse help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/xmlparse -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/xmlparse --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/xmlparse help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.HTMLLinker-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.HTMLLinker-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.HTMLLinker-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.HTMLLinker-wrapped -V` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.HTMLLinker-wrapped --version` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.cvtenc-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.cvtenc-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.cvtenc-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.defaults-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.defaults-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdnc-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped -V` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped -v` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped --version` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped version` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped -h` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped --help` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.gdomap-wrapped help` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.make_strings-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.make_strings-wrapped --help` and found version 1.25.1
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.pl-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.pl-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.pl-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.pldes-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.pldes-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.pldes-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plmerge-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plmerge-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plmerge-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plparse-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plparse-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plparse-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plser-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plser-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.plser-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.sfparse-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.sfparse-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.sfparse-wrapped help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.xmlparse-wrapped -h` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.xmlparse-wrapped --help` got 0 exit code
- ran `/nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1/bin/.xmlparse-wrapped help` got 0 exit code
- found 1.25.1 with grep in /nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1
- found 1.25.1 in filename of file in /nix/store/2r2d8ah4kwyz7xzsidhj35qqzz04cay9-gnustep-base-1.25.1
- directory tree listing: https://gist.github.com/c986015538b421054f0bb49a5b5bf2ca

cc @ashalkhakov @matthewbauer for review