### PR TITLE
google-authenticator: 1.03 -> 1.05

### DIFF
--- a/pkgs/os-specific/linux/google-authenticator/default.nix
+++ b/pkgs/os-specific/linux/google-authenticator/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "google-authenticator-libpam-${version}";
-  version = "1.03";
+  version = "1.05";
 
   src = fetchurl {
     url = "https://github.com/google/google-authenticator-libpam/archive/${version}.tar.gz";
-    sha256 = "0wb95z5v1w4sk0p7y9pbn4v95w9hrbf80vw9k2z2sgs0156ljkb7";
+    sha256 = "026vljmddi0zqcb3c0vdpabmi4r17kahc00mh6fs3qbyjbb14946";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/f3718pm1ndwa2bj7q3pdbx01qiday4sj-google-authenticator-libpam-1.05/bin/google-authenticator -h` got 0 exit code
- ran `/nix/store/f3718pm1ndwa2bj7q3pdbx01qiday4sj-google-authenticator-libpam-1.05/bin/google-authenticator --help` got 0 exit code
- ran `/nix/store/f3718pm1ndwa2bj7q3pdbx01qiday4sj-google-authenticator-libpam-1.05/bin/google-authenticator help` got 0 exit code
- directory tree listing: https://gist.github.com/a10c019e5dc879bc33b83175a42ed947

cc @aneeshusa for review