### PR TITLE
gnustep.gorm: 1.2.22 -> 1.2.23

### DIFF
--- a/pkgs/desktops/gnustep/gorm/default.nix
+++ b/pkgs/desktops/gnustep/gorm/default.nix
@@ -1,13 +1,13 @@
 { fetchurl, base, back, gsmakeDerivation, gui }:
 let
-  version = "1.2.22";
+  version = "1.2.23";
 in
 gsmakeDerivation {
   name = "gorm-${version}";
   
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/dev-apps/gorm-${version}.tar.gz";
-    sha256 = "1mq5n65xd9bc4kppx19iijsgpz4crvhg7bfwbi9k78j159vclnmi";
+    sha256 = "18pf9vvzvdk8bg4lhjb96y1kdkmb9ahmvrqv2581vn45pjxmmlnb";
   };
   buildInputs = [ base back gui ];
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.2.23 with grep in /nix/store/x5gjxvy65qxjln9hrv42f7ki1d60qjds-gorm-1.2.23
- found 1.2.23 in filename of file in /nix/store/x5gjxvy65qxjln9hrv42f7ki1d60qjds-gorm-1.2.23
- directory tree listing: https://gist.github.com/1ae30a61c919a26161284bdb24b06d7d

cc @ashalkhakov @matthewbauer for review