### PR TITLE
goxel: 0.7.2 -> 0.7.3

### DIFF
--- a/pkgs/applications/graphics/goxel/default.nix
+++ b/pkgs/applications/graphics/goxel/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "goxel-${version}";
-  version = "0.7.2";
+  version = "0.7.3";
 
   src = fetchFromGitHub {
     owner = "guillaumechereau";
     repo = "goxel";
     rev = "v${version}";
-    sha256 = "1d6waj8zz9iq3ddbi9wbpcnh200ajjy9x53xrj5bij01pb8jwskv";
+    sha256 = "114s1pbv3ixc2gzkg7n927hffd6ly5gg59izw4z6drgjcdhd7xj9";
   };
 
   nativeBuildInputs = [ scons pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/zinzc9bkhn7n97jlp7mian6bzw1dzz8d-goxel-0.7.3/bin/goxel --help` got 0 exit code
- ran `/nix/store/zinzc9bkhn7n97jlp7mian6bzw1dzz8d-goxel-0.7.3/bin/goxel -V` and found version 0.7.3
- ran `/nix/store/zinzc9bkhn7n97jlp7mian6bzw1dzz8d-goxel-0.7.3/bin/goxel --version` and found version 0.7.3
- ran `/nix/store/zinzc9bkhn7n97jlp7mian6bzw1dzz8d-goxel-0.7.3/bin/.goxel-wrapped --help` got 0 exit code
- ran `/nix/store/zinzc9bkhn7n97jlp7mian6bzw1dzz8d-goxel-0.7.3/bin/.goxel-wrapped -V` and found version 0.7.3
- ran `/nix/store/zinzc9bkhn7n97jlp7mian6bzw1dzz8d-goxel-0.7.3/bin/.goxel-wrapped --version` and found version 0.7.3
- found 0.7.3 with grep in /nix/store/zinzc9bkhn7n97jlp7mian6bzw1dzz8d-goxel-0.7.3
- directory tree listing: https://gist.github.com/86658b436ae3d2085eba59f7c23e0825

cc @tilpner for review