### PR TITLE
gparted: 0.30.0 -> 0.31.0

### DIFF
--- a/pkgs/tools/misc/gparted/default.nix
+++ b/pkgs/tools/misc/gparted/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gparted-0.30.0";
+  name = "gparted-0.31.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/gparted/${name}.tar.gz";
-    sha256 = "0jngbsbvg8k8vbpsphqbk8br2cbmxhabbm2c5bmxm2q5zvpr64fk";
+    sha256 = "1fh7rpgb4xxdhgyjsirb83zvjfc5mfngb8a1pjbv7r6r6jj4jyrv";
   };
 
   configureFlags = [ "--disable-doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.31.0 with grep in /nix/store/fvg6pam343ci69qdjrcw1yqjznmhnwq5-gparted-0.31.0
- directory tree listing: https://gist.github.com/4cc11c6b07976ff42e854ec92cc48f35