### PR TITLE
gqrx: 2.10 -> 2.11.1

### DIFF
--- a/pkgs/applications/misc/gqrx/default.nix
+++ b/pkgs/applications/misc/gqrx/default.nix
@@ -8,13 +8,13 @@ assert pulseaudioSupport -> libpulseaudio != null;
 
 stdenv.mkDerivation rec {
   name = "gqrx-${version}";
-  version = "2.10";
+  version = "2.11.1";
 
   src = fetchFromGitHub {
     owner = "csete";
     repo = "gqrx";
     rev = "v${version}";
-    sha256 = "1qc944sn1kjdnhdhcsdc39764vqcryk86808xxl49vy8sznqr0mf";
+    sha256 = "06l90m3lx05290lvgghrgqrcg6732p69dvv3bsyw7cyxy3fvdhm6";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.11.1 with grep in /nix/store/f5yrc3hjc7rzc3zg57vss2av1djk6496-gqrx-2.11.1
- directory tree listing: https://gist.github.com/3716484adfc25ea5af04b853ac010788

cc @bjornfor @the-kenny @fpletz for review