### PR TITLE
python27Packages.gst-python: 1.12.3 -> 1.12.4

### DIFF
--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-python";
-  version = "1.12.3";
+  version = "1.12.4";
   name = "${pname}-${version}";
 
   src = fetchurl {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
       "${meta.homepage}/src/gst-python/${name}.tar.xz"
       "mirror://gentoo/distfiles/${name}.tar.xz"
       ];
-    sha256 = "19rb06x2m7103zwfm0plxx95gb8bp01ng04h4q9k6ii9q7g2kxf3";
+    sha256 = "1sm3dy10klf6i3w6a6mz0rnm29l2lxci5hr8346496jwc7v6mki0";
   };
 
   patches = [ ./different-path-with-pygobject.patch ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.12.4 with grep in /nix/store/di04f095hxqfwch2fkiixhxm8lqdmngc-gst-python-1.12.4
- directory tree listing: https://gist.github.com/62f747534f69184c0f106607758f5083