### PR TITLE
gst_all_1.gst-validate: 1.12.3 -> 1.12.4

### DIFF
--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-validate-1.12.3";
+  name = "gst-validate-1.12.4";
 
   meta = {
     description = "Integration testing infrastructure for the GStreamer framework";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-validate/${name}.tar.xz";
-    sha256 = "17j812pkzgbyn9ys3b305yl5mrf9nbm8whwj4iqdskr742fr8fai";
+    sha256 = "18gvgavkqkcjq82v8hj9j0apg4iz5ns54mwcnfimnvsxdvz9vnpr";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/kf6yf2pwc0l4z8in9dfw7v2pbklm34jk-gst-validate-1.12.4/bin/gst-validate-1.0 -h` got 0 exit code
- ran `/nix/store/kf6yf2pwc0l4z8in9dfw7v2pbklm34jk-gst-validate-1.12.4/bin/gst-validate-1.0 --help` got 0 exit code
- ran `/nix/store/kf6yf2pwc0l4z8in9dfw7v2pbklm34jk-gst-validate-1.12.4/bin/gst-validate-transcoding-1.0 -h` got 0 exit code
- ran `/nix/store/kf6yf2pwc0l4z8in9dfw7v2pbklm34jk-gst-validate-1.12.4/bin/gst-validate-transcoding-1.0 --help` got 0 exit code
- ran `/nix/store/kf6yf2pwc0l4z8in9dfw7v2pbklm34jk-gst-validate-1.12.4/bin/gst-validate-media-check-1.0 -h` got 0 exit code
- ran `/nix/store/kf6yf2pwc0l4z8in9dfw7v2pbklm34jk-gst-validate-1.12.4/bin/gst-validate-media-check-1.0 --help` got 0 exit code
- ran `/nix/store/kf6yf2pwc0l4z8in9dfw7v2pbklm34jk-gst-validate-1.12.4/bin/gst-validate-media-check-1.0 help` got 0 exit code
- found 1.12.4 with grep in /nix/store/kf6yf2pwc0l4z8in9dfw7v2pbklm34jk-gst-validate-1.12.4
- directory tree listing: https://gist.github.com/b546fe6d5b5cad6d3cc2b5a822b9218d