### PR TITLE
gst_all_1.gstreamer: 1.12.3 -> 1.13.1

### DIFF
--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gstreamer-1.12.3";
+  name = "gstreamer-1.13.1";
 
   meta = {
     description = "Open source multimedia framework";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer/${name}.tar.xz";
-    sha256 = "0vi1g8rmmsnd630ds3jwv2iph46ll8y07fzf04mz15q88j9g926k";
+    sha256 = "012q94af2rwkd3pw65mfcfsgj7jbj7ikl7p4ikq8kkrksnbchbbx";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.13.1 with grep in /nix/store/4cp45np1llbg6nn14gvyarzc8w2v5lz1-gstreamer-1.13.1
- directory tree listing: https://gist.github.com/b972bfa30a36896df43b1bf02531d916

cc @ttuegel for review