### PR TITLE
hdf4: 4.2.12 -> 4.2.13

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -8,10 +8,10 @@
 
 stdenv.mkDerivation rec {
   name = "hdf-${version}";
-  version = "4.2.12";
+  version = "4.2.13";
   src = fetchurl {
     url = "https://support.hdfgroup.org/ftp/HDF/releases/HDF${version}/src/hdf-${version}.tar.bz2";
-    sha256 = "020jh563sjyxsgml8l809d2i1d4ms9shivwj3gbm7n0ilxbll8id";
+    sha256 = "1wz0586zh91pqb95wvr0pbh71a8rz358fdj6n2ksp85x2cis9lsm";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdfls help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdfls help` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/vmake -h` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/vmake --help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/vmake help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/vshow -h` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/vshow --help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/vshow help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdp help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdp version` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdp help` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdfimport -h` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdfimport -V` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdfimport -h` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hdiff -V` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hrepack -h` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hrepack --help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hrepack help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hrepack -V` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hrepack_check -h` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hrepack_check --help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/hrepack_check help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/ncgen -V` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/ncdump -h` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/ncdump help` got 0 exit code
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/ncdump -V` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/ncdump version` and found version 4.2.13
- ran `/nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin/bin/ncdump help` and found version 4.2.13
- found 4.2.13 with grep in /nix/store/64fqrr4d4m0v3qcqxx0lvn2s4hw16g05-hdf-4.2.13-bin
- directory tree listing: https://gist.github.com/556f493010a550af3ca5bbf318e609eb

cc @knedlsepp for review