### PR TITLE
hdparm: 9.54 -> 9.55

### DIFF
--- a/pkgs/os-specific/linux/hdparm/default.nix
+++ b/pkgs/os-specific/linux/hdparm/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "hdparm-9.54";
+  name = "hdparm-9.55";
 
   src = fetchurl {
     url = "mirror://sourceforge/hdparm/${name}.tar.gz";
-    sha256 = "0ghnhdj7wfw6acfyhdawpfa5n9kvkvzgi1fw6i7sghgbjx5nhyjd";
+    sha256 = "1ivdvrzimaayiq03by8mcq0mhmdljndj06h012zkdpw34irnpixm";
 
   };
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/9abla9hl91wvxvcbrif9xjhsb164lgxc-hdparm-9.55/bin/hdparm -h` got 0 exit code
- ran `/nix/store/9abla9hl91wvxvcbrif9xjhsb164lgxc-hdparm-9.55/bin/hdparm -V` and found version 9.55
- ran `/nix/store/9abla9hl91wvxvcbrif9xjhsb164lgxc-hdparm-9.55/bin/hdparm -h` and found version 9.55
- found 9.55 with grep in /nix/store/9abla9hl91wvxvcbrif9xjhsb164lgxc-hdparm-9.55
- directory tree listing: https://gist.github.com/ded98c9055722d9f66f8346ae792663c

cc @fuuzetsu for review