### PR TITLE
homebank: 5.1.7 -> 5.1.8

### DIFF
--- a/pkgs/applications/office/homebank/default.nix
+++ b/pkgs/applications/office/homebank/default.nix
@@ -2,10 +2,10 @@
 , hicolor-icon-theme, libsoup, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "homebank-5.1.7";
+  name = "homebank-5.1.8";
   src = fetchurl {
     url = "http://homebank.free.fr/public/${name}.tar.gz";
-    sha256 = "19szz86jxya8v4r3pa5czng9q2kn5hhbk273x1wqvdv40z0577jp";
+    sha256 = "0fzjmwz2pgi0nw49xljp1za3vp67kjh88gf688d9ig4wc2ygr0qh";
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/bw0i5a1j6ns2glaznqhgna1wz25aglq8-homebank-5.1.8/bin/.homebank-wrapped -h` got 0 exit code
- ran `/nix/store/bw0i5a1j6ns2glaznqhgna1wz25aglq8-homebank-5.1.8/bin/.homebank-wrapped --help` got 0 exit code
- ran `/nix/store/bw0i5a1j6ns2glaznqhgna1wz25aglq8-homebank-5.1.8/bin/.homebank-wrapped --version` and found version 5.1.8
- ran `/nix/store/bw0i5a1j6ns2glaznqhgna1wz25aglq8-homebank-5.1.8/bin/homebank -h` got 0 exit code
- ran `/nix/store/bw0i5a1j6ns2glaznqhgna1wz25aglq8-homebank-5.1.8/bin/homebank --help` got 0 exit code
- ran `/nix/store/bw0i5a1j6ns2glaznqhgna1wz25aglq8-homebank-5.1.8/bin/homebank --version` and found version 5.1.8
- found 5.1.8 with grep in /nix/store/bw0i5a1j6ns2glaznqhgna1wz25aglq8-homebank-5.1.8
- directory tree listing: https://gist.github.com/c202495e9cca14cd25802f63062ac26b

cc @viric @pSub for review