### PR TITLE
ibus-engines.libpinyin: 1.9.2 -> 1.9.3

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "ibus-libpinyin-${version}";
-  version = "1.9.2";
+  version = "1.9.3";
 
   src = fetchFromGitHub {
     owner  = "libpinyin";
     repo   = "ibus-libpinyin";
     rev    = version;
-    sha256 = "067w926gcf0kwwn71yshhjmyzkad0qsdm1dsi2xwz1j633qd4xlb";
+    sha256 = "02rwddv1lxzk70946v3rjsx1p7hx1d9bnwb7cx406cbws73yb2r9";
   };
 
   buildInputs = [ ibus glib sqlite libpinyin python3 gtk3 db ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.9.3 with grep in /nix/store/z3sdj8l860r4vdb41pi3siakp98pnx8j-ibus-libpinyin-1.9.3
- directory tree listing: https://gist.github.com/bf125939ed0636cedf0daea5f6d08219

cc @ericsagnes for review