### PR TITLE
ibus-engines.table: 1.9.16 -> 1.9.18

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "ibus-table-${version}";
-  version = "1.9.16";
+  version = "1.9.18";
 
   src = fetchFromGitHub {
     owner  = "kaio";
     repo   = "ibus-table";
     rev    = version;
-    sha256 = "1gkb6nsibk59kp404b394sg638jgah2a2b6ffq3gkacqg5j30wjb";
+    sha256 = "0isxgz7f6xhrcv5qrdd6gm3ysmqp3mi5ngnbqz08f7pclllaridp";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/mrix6kd1pgli5i7hji39f1pigx0d7s5z-ibus-table-1.9.18/bin/ibus-table-createdb -h` got 0 exit code
- ran `/nix/store/mrix6kd1pgli5i7hji39f1pigx0d7s5z-ibus-table-1.9.18/bin/ibus-table-createdb --help` got 0 exit code
- found 1.9.18 with grep in /nix/store/mrix6kd1pgli5i7hji39f1pigx0d7s5z-ibus-table-1.9.18
- directory tree listing: https://gist.github.com/8f2d6146d5348401ca9117762e2befbc

cc @laMudri for review