### PR TITLE
ibus-engines.table-others: 1.3.7 -> 1.3.9

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-others/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-others/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ibus-table-others-${version}";
-  version = "1.3.7";
+  version = "1.3.9";
 
   src = fetchurl {
     url = "https://github.com/moebiuscurve/ibus-table-others/releases/download/${version}/${name}.tar.gz";
-    sha256 = "0vmz82il796062jbla5pawsr5dqyhs7ald7xjp84zfccc09dg9kx";
+    sha256 = "0270a9njyzb1f8nw5w9ghwxcl3m6f13d8p8a01fjm8rnjs04mcb3";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.3.9 with grep in /nix/store/xjlb70932y0prqlw4p7iizbffm89pi7a-ibus-table-others-1.3.9
- directory tree listing: https://gist.github.com/aafa62fbd6afde2d7ca2d96e39eaa850

cc @laMudri for review