### PR TITLE
icmake: 9.02.06 -> 9.02.07

### DIFF
--- a/pkgs/development/tools/build-managers/icmake/default.nix
+++ b/pkgs/development/tools/build-managers/icmake/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "icmake-${version}";
-  version = "9.02.06";
+  version = "9.02.07";
 
   src = fetchFromGitHub {
-    sha256 = "1hs7fhqpkhlrjvjhfarf5bmxl8dw3r0immzdib27gwh3sfzgpx0b";
+    sha256 = "1q3rwri5s1sqm4h75bahkjnlym4bk2ygg4fb75yrniwnj8rhdp12";
     rev = version;
     repo = "icmake";
     owner = "fbb-git";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped -h` got 0 exit code
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped --help` got 0 exit code
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped help` got 0 exit code
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped -V` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped -v` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped --version` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped version` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped -h` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped --help` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/.icmbuild-wrapped help` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmake -h` got 0 exit code
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmake --help` got 0 exit code
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmake -v` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmake --version` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmake -h` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmake --help` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild -h` got 0 exit code
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild --help` got 0 exit code
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild help` got 0 exit code
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild -V` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild -v` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild --version` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild version` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild -h` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild --help` and found version 9.02.07
- ran `/nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07/bin/icmbuild help` and found version 9.02.07
- found 9.02.07 with grep in /nix/store/q6mncjxq8npypddw9p7lnam4i7ka8vvn-icmake-9.02.07
- directory tree listing: https://gist.github.com/cb0c3794c3041c9ab8beb16f8f616671

cc @pSub for review