### PR TITLE
jetbrains.idea-community: 2017.3.4 -> 2017.3.5

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -273,12 +273,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2017.3.4"; /* updated by script */
+    version = "2017.3.5"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "15qsfirzmmjhwzkhx36zr4n0z5lhs021n2n3wim01g309ymr4gl9"; /* updated by script */
+      sha256 = "124rzc46f4bqyhllwyb26lkavh7zwbj62axrwhif34rayl2rcmpm"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IDEA_Release";
@@ -286,7 +286,7 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2017.3.4"; /* updated by script */
+    version = "2017.3.5"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
@@ -299,7 +299,7 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2017.3.4"; /* updated by script */
+    version = "2017.3.5"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
@@ -364,7 +364,7 @@ in
 
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
-    version = "2017.3.4"; /* updated by script */
+    version = "2017.3.5"; /* updated by script */
     description = "Professional IDE for Web and JavaScript development";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2017.3.5 with grep in /nix/store/ab0p44xfk9ych3x6jf4narxkf75vxmkd-idea-community-2017.3.5
- directory tree listing: https://gist.github.com/ee37c996baee7e9c7141b5598c09cba3

cc @edwtjo for review