### PR TITLE
isl_0_15: 0.15 -> 0.19

### DIFF
--- a/pkgs/development/libraries/isl/0.15.0.nix
+++ b/pkgs/development/libraries/isl/0.15.0.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, gmp }:
 
 stdenv.mkDerivation rec {
-  name = "isl-0.15";
+  name = "isl-0.19";
 
   src = fetchurl {
     url = "http://isl.gforge.inria.fr/${name}.tar.xz";
-    sha256 = "1m922l5bz69lvkcxrib7lvjqwfqsr8rpbzgmb2aq07bp76460jhh";
+    sha256 = "19dqyvngwj51fw2nfshr3r2hrbwkpsfrlvd4kx8gqv9a1sh1lv3d";
   };
 
   buildInputs = [ gmp ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.19 with grep in /nix/store/7v1yglcv5qhqrms50skskf6xc5x4f8yn-isl-0.19
- directory tree listing: https://gist.github.com/618e40e3bd7e25cd0e6289515100a58d