### PR TITLE
jsonnet: 0.9.5 -> 0.10.0

### DIFF
--- a/pkgs/development/compilers/jsonnet/default.nix
+++ b/pkgs/development/compilers/jsonnet/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, emscripten }:
 
-let version = "0.9.5"; in
+let version = "0.10.0"; in
 
 stdenv.mkDerivation {
   name = "jsonnet-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     rev = "v${version}";
     owner = "google";
     repo = "jsonnet";
-    sha256 = "193sa4hdhvml0c32nmdkjii41hbyc5l0zisdn699ar0gaq7yiqan";
+    sha256 = "0xj540140r89qrdh3h4kzlz4x8c576ynq9i1x82zzl3d7fxbk5f0";
   };
 
   buildInputs = [ emscripten ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/348mi6qinpcnhrk0l8zy9m9lk43xqpml-jsonnet-0.10.0/bin/jsonnet -h` got 0 exit code
- ran `/nix/store/348mi6qinpcnhrk0l8zy9m9lk43xqpml-jsonnet-0.10.0/bin/jsonnet --help` got 0 exit code
- ran `/nix/store/348mi6qinpcnhrk0l8zy9m9lk43xqpml-jsonnet-0.10.0/bin/jsonnet -v` and found version 0.10.0
- ran `/nix/store/348mi6qinpcnhrk0l8zy9m9lk43xqpml-jsonnet-0.10.0/bin/jsonnet --version` and found version 0.10.0
- ran `/nix/store/348mi6qinpcnhrk0l8zy9m9lk43xqpml-jsonnet-0.10.0/bin/jsonnet -h` and found version 0.10.0
- ran `/nix/store/348mi6qinpcnhrk0l8zy9m9lk43xqpml-jsonnet-0.10.0/bin/jsonnet --help` and found version 0.10.0
- found 0.10.0 with grep in /nix/store/348mi6qinpcnhrk0l8zy9m9lk43xqpml-jsonnet-0.10.0
- directory tree listing: https://gist.github.com/9a4279146abdaa645fdcd5481889e783

cc @benley @copumpkin for review