### PR TITLE
libsForQt5.kdb: 3.0.2 -> 3.1.0

### DIFF
--- a/pkgs/development/libraries/kdb/default.nix
+++ b/pkgs/development/libraries/kdb/default.nix
@@ -6,12 +6,12 @@
 
 mkDerivation rec {
   pname = "kdb";
-  version = "3.0.2";
+  version = "3.1.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
-    sha256 = "1n11xhqk3sf4a5nzvnrnj7bj21yqqqkm2d1xzfx3q82fkyah8s49";
+    sha256 = "1wi9z7j0nr9wi6aqqkdcpnr38ixyxbv00sblya7pakdf96hlamhp";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/a5vvjndyd5qccy1fphllczql9hdfnfah-kdb-3.1.0/bin/kdb3_sqlite3_dump -h` got 0 exit code
- ran `/nix/store/a5vvjndyd5qccy1fphllczql9hdfnfah-kdb-3.1.0/bin/kdb3_sqlite3_dump --help` got 0 exit code
- ran `/nix/store/a5vvjndyd5qccy1fphllczql9hdfnfah-kdb-3.1.0/bin/kdb3_sqlite3_dump -h` and found version 3.1.0
- ran `/nix/store/a5vvjndyd5qccy1fphllczql9hdfnfah-kdb-3.1.0/bin/kdb3_sqlite3_dump --help` and found version 3.1.0
- found 3.1.0 with grep in /nix/store/a5vvjndyd5qccy1fphllczql9hdfnfah-kdb-3.1.0
- directory tree listing: https://gist.github.com/05674b3e604ee41cd435090c4b6c8101

cc @zraexy for review