### PR TITLE
[17.09] firefox: fix build

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -208,7 +208,7 @@ stdenv.mkDerivation (rec {
 
   postInstall = ''
     # For grsecurity kernels
-    paxmark m $out/lib/firefox-[0-9]*/{firefox,firefox-bin,plugin-container}
+    paxmark m $out/lib/firefox*/{firefox,firefox-bin,plugin-container}
 
     # Remove SDK cruft. FIXME: move to a separate output?
     rm -rf $out/share/idl $out/include $out/lib/firefox-devel-*
@@ -220,8 +220,8 @@ stdenv.mkDerivation (rec {
   postFixup = ''
     # Fix notifications. LibXUL uses dlopen for this, unfortunately; see #18712.
     patchelf --set-rpath "${lib.getLib libnotify
-      }/lib:$(patchelf --print-rpath "$out"/lib/firefox-*/libxul.so)" \
-        "$out"/lib/firefox-*/libxul.so
+      }/lib:$(patchelf --print-rpath "$out"/lib/firefox*/libxul.so)" \
+        "$out"/lib/firefox*/libxul.so
   '';
 
   doInstallCheck = true;

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -9,8 +9,8 @@ let
 
   certdata2pem = fetchurl {
     name = "certdata2pem.py";
-    url = "https://anonscm.debian.org/cgit/collab-maint/ca-certificates.git/plain/mozilla/certdata2pem.py?h=debian/20160104";
-    sha256 = "0bw11mgfrf19qziyvdnq22kirp0nn54lfsanrg5h6djs6ig1c2im";
+    url = "https://anonscm.debian.org/cgit/collab-maint/ca-certificates.git/plain/mozilla/certdata2pem.py?h=debian/20170717";
+    sha256 = "1d4q27j1gss0186a5m8bs5dk786w07ccyq0qi6xmd2zr1a8q16wy";
   };
 
 in

--- a/pkgs/development/libraries/nss/85_security_load.patch
+++ b/pkgs/development/libraries/nss/85_security_load.patch
@@ -13,10 +13,10 @@ diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/cmd/shlibsign/shlibsign.c nss/cmd/sh
 diff -ru -x '*~' -x '*.orig' -x '*.rej' nss/coreconf/config.mk nss/coreconf/config.mk
 --- nss/coreconf/config.mk	2017-01-04 15:24:24.000000000 +0100
 +++ nss/coreconf/config.mk	2017-01-24 14:43:47.989432372 +0100
-@@ -208,3 +208,6 @@
- # exported symbols, which causes problem when NSS is built as part of Mozilla.
- # So we add a NSS_SSL_ENABLE_ZLIB variable to allow Mozilla to turn this off.
- NSS_SSL_ENABLE_ZLIB = 1
+@@ -202,3 +202,6 @@
+ 
+ # Hide old, deprecated, TLS cipher suite names when building NSS
+ DEFINES += -DSSL_DISABLE_DEPRECATED_CIPHER_SUITE_NAMES
 +
 +# Nix specific stuff.
 +DEFINES += -DNIX_NSS_LIBDIR=\"$(out)/lib/\"

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -9,11 +9,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "nss-${version}";
-  version = "3.34.1";
+  version = "3.35";
 
   src = fetchurl {
-    url = "mirror://mozilla/security/nss/releases/NSS_3_34_1_RTM/src/${name}.tar.gz";
-    sha256 = "186x33wsk4mzjz7dzbn8p0py9a0nzkgzpfkdv4rlyy5gghv5vhd3";
+    url = "mirror://mozilla/security/nss/releases/NSS_3_35_RTM/src/${name}.tar.gz";
+    sha256 = "1ypn68z9ncbbshi3184ywrhx5i846lyd72gps1grzqzdkgh7s4pl";
   };
 
   buildInputs = [ perl zlib sqlite ];


### PR DESCRIPTION
###### Motivation for this change

Firefox fails to build on 17.09 - https://hydra.nixos.org/build/71543368/ Only tested firefox for now (which looks to build and work fine - only basic usage tested though). Currently waiting on firefox-esr to finish building.

nss update triggers a substantial rebuild, I don't have capacity to test the build of all the reverse dependencies and am unsure on how risky the update is.

/cc @vcunat @andir 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

