### PR TITLE
libsForQt5.kpmcore: 3.0.3 -> 3.3.0

### DIFF
--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -7,11 +7,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "3.0.3";
+  version = "3.3.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "17lqrp39w31fm7haigwq23cp92zwk3czjzqa2fhn3wafx3vafwd2";
+    sha256 = "0s6v0jfrhjg31ri5p6h9n4w29jvasf5dj954j3vfpzl91lygmmmq";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.3.0 with grep in /nix/store/axq1y6dwgl8xn4da4jwnf1zxjz7n74gz-kpmcore-3.3.0
- found 3.3.0 in filename of file in /nix/store/axq1y6dwgl8xn4da4jwnf1zxjz7n74gz-kpmcore-3.3.0
- directory tree listing: https://gist.github.com/c296e20046c16727398c12f703502545

cc @peterhoeg for review