### PR TITLE
nix-serve: patch for nix 2.0

### DIFF
--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchFromGitHub,
+{ stdenv, fetchFromGitHub, fetchpatch,
   bzip2, nix, perl, perlPackages,
 }:
 
 with stdenv.lib;
 
 let
-  rev = "7e09caa2a7a435aeb2cd5446aa590d6f9ae1699d";
-  sha256 = "0mjzsiknln3isdri9004wwjjjpak5fj8ncizyncf5jv7g4m4q1pj";
+  rev = "e4675e38ab54942e351c7686e40fabec822120b9";
+  sha256 = "1wm24p6pkxl1d7hrvf4ph6mwzawvqi22c60z9xzndn5xfyr4v0yr";
 in
 
 stdenv.mkDerivation rec {


### PR DESCRIPTION
Fixes incompatible secret file handling. See https://github.com/edolstra/nix-serve/pull/8

###### Motivation for this change

nix-serve broke after updating to nixos-18.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

