### PR TITLE
treewide: `meta.platforms` fixes now that it tracks the host platform

### DIFF
--- a/lib/systems/for-meta.nix
+++ b/lib/systems/for-meta.nix
@@ -24,6 +24,7 @@ in rec {
   netbsd  = [ patterns.isNetBSD ];
   openbsd = [ patterns.isOpenBSD ];
   unix    = patterns.isUnix; # Actually a list
+  windows = [ patterns.isWindows ];
 
   inherit (lib.systems.doubles) mesaPlatforms;
 }

--- a/lib/systems/for-meta.nix
+++ b/lib/systems/for-meta.nix
@@ -4,8 +4,8 @@ let
   inherit (lib.systems.inspect) patterns;
 
 in rec {
-  inherit (lib.systems.doubles) all mesaPlatforms;
-  none = [];
+  all     = [ {} ]; # `{}` matches anything
+  none    = [];
 
   arm     = [ patterns.isArm ];
   aarch64 = [ patterns.isAarch64 ];
@@ -24,4 +24,6 @@ in rec {
   netbsd  = [ patterns.isNetBSD ];
   openbsd = [ patterns.isOpenBSD ];
   unix    = patterns.isUnix; # Actually a list
+
+  inherit (lib.systems.doubles) mesaPlatforms;
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -34,8 +34,8 @@ in
 , enableStaticLibraries ? true
 , extraLibraries ? [], librarySystemDepends ? [], executableSystemDepends ? []
 , homepage ? "http://hackage.haskell.org/package/${pname}"
-, platforms ? ghc.meta.platforms
-, hydraPlatforms ? platforms
+, platforms ? with stdenv.lib.platforms; unix ++ windows # GHC can cross-compile
+, hydraPlatforms ? null
 , hyperlinkSource ? true
 , isExecutable ? false, isLibrary ? !isExecutable
 , jailbreak ? false
@@ -404,7 +404,7 @@ stdenv.mkDerivation ({
          // optionalAttrs broken               { inherit broken; }
          // optionalAttrs (description != "")  { inherit description; }
          // optionalAttrs (maintainers != [])  { inherit maintainers; }
-         // optionalAttrs (hydraPlatforms != platforms) { inherit hydraPlatforms; }
+         // optionalAttrs (hydraPlatforms != null) { inherit hydraPlatforms; }
          ;
 
 }

--- a/pkgs/development/libraries/libatomic_ops/default.nix
+++ b/pkgs/development/libraries/libatomic_ops/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     description = ''A library for semi-portable access to hardware-provided atomic memory update operations'';
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.unix;
+    platforms = with stdenv.lib.platforms; unix ++ windows;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

In https://github.com/NixOS/nixpkgs/pull/34444 I made `meta.platforms` track the host platform instead of the build platform. Now a few packages need to be updated so that the cross jobs don't all disappear.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

