### PR TITLE
krita: 3.3.3 -> 4.0.0

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -9,11 +9,11 @@
 
 mkDerivation rec {
   name = "krita-${version}";
-  version = "3.3.3";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "https://download.kde.org/stable/krita/${version}/${name}.tar.gz";
-    sha256 = "0pc6hnakkqy81x5b5ncivaps6hqv43i50sjwgi3i3cz9j8rlxh5y";
+    sha256 = "14sm67vkpxzpnh4c2mzvr0rpk8a3i8kzxx6fi3lpczrcc1g7di09";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.0.0 with grep in /nix/store/k8xscjzkd9w5n6hly18qcwgg62m3fjh9-krita-4.0.0
- directory tree listing: https://gist.github.com/c2d48bc58cc453eac241620389f2b9ce

cc @abbradar for review