### PR TITLE
bitmath: init at 1.3.1.2

### DIFF
--- a/pkgs/development/python-modules/bitmath/default.nix
+++ b/pkgs/development/python-modules/bitmath/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, progressbar231, progressbar33, mock }:
+
+buildPythonPackage rec {
+  pname = "bitmath";
+  version = "1.3.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1k8d1wmxqjc8cqzaixpxf45k6dl1kqhblr0g4wyjl0qa18q8wasd";
+  };
+
+  checkInputs = [ (if isPy3k then progressbar33 else progressbar231) mock ];
+
+  meta = with stdenv.lib; {
+    description = "Module for representing and manipulating file sizes with different prefix";
+    homepage = https://github.com/tbielawa/bitmath;
+    license = licenses.mit;
+    maintainers = with maintainers; [ twey ];
+  };
+}

--- a/pkgs/development/python-modules/progressbar231/default.nix
+++ b/pkgs/development/python-modules/progressbar231/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "progressbar231";
+  version = "2.3.1";
+
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0j0ifxk87xz3wkyacxaiqygghn27wwz6y5pj9k8j2yq7n33fbdam";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://pypi.python.org/pypi/progressbar231;
+    description = "Text progressbar library for python";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ twey ];
+  };
+}

--- a/pkgs/development/python-modules/progressbar33/default.nix
+++ b/pkgs/development/python-modules/progressbar33/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "progressbar33";
+  version = "2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zvf6zs5hzrc03p9nfs4p16vhilqikycvv1yk0pxn8s07fdhvzji";
+  };
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://pypi.python.org/pypi/progressbar33;
+    description = "Text progressbar library for python";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ twey ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11482,6 +11482,8 @@ in {
 
   progressbar231 = callPackage ../development/python-modules/progressbar231 { };
 
+  progressbar33 = callPackage ../development/python-modules/progressbar33 { };
+
   ldap = callPackage ../development/python-modules/ldap {
     inherit (pkgs) openldap cyrus_sasl;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1003,6 +1003,8 @@ in {
   binwalk = self.binwalk_fun { };
   binwalk-full = self.binwalk_fun { visualizationSupport = true; pyqtgraph = self.pyqtgraph; };
 
+  bitmath = callPackage ../development/python-modules/bitmath { };
+
   caldavclientlibrary-asynk = buildPythonPackage rec {
     version = "asynkdev";
     name = "caldavclientlibrary-asynk-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11480,6 +11480,8 @@ in {
 
   progressbar2 = callPackage ../development/python-modules/progressbar2 { };
 
+  progressbar231 = callPackage ../development/python-modules/progressbar231 { };
+
   ldap = callPackage ../development/python-modules/ldap {
     inherit (pkgs) openldap cyrus_sasl;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

