### PR TITLE
lastpass-cli: 1.2.2 -> 1.3.0

### DIFF
--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "lastpass-cli-${version}";
 
-  version = "1.2.2";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "lastpass";
     repo = "lastpass-cli";
     rev = "v${version}";
-    sha256 = "0041z2awpmwq2fk8lbgp4fcia0r6wss2csvq5bxps0cx7fq69wc1";
+    sha256 = "0k3vnlibv05wnn6qn3qjlcyj2s07di7zkmdnijd6cp1hfk76z2r5";
   };
 
   nativeBuildInputs = [ asciidoc cmake docbook_xsl pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/l6j73nin5ip68kl9nn6zgllp88hlbdli-lastpass-cli-1.3.0/bin/lpass -V` and found version 1.3.0
- ran `/nix/store/l6j73nin5ip68kl9nn6zgllp88hlbdli-lastpass-cli-1.3.0/bin/lpass -v` and found version 1.3.0
- ran `/nix/store/l6j73nin5ip68kl9nn6zgllp88hlbdli-lastpass-cli-1.3.0/bin/lpass --version` and found version 1.3.0
- found 1.3.0 with grep in /nix/store/l6j73nin5ip68kl9nn6zgllp88hlbdli-lastpass-cli-1.3.0
- directory tree listing: https://gist.github.com/67aab5e731ed5d963e433d03c1a27870

cc @cstrahan for review