### PR TITLE
lazarus: 1.8.0 -> 1.8.2

### DIFF
--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -8,10 +8,10 @@ stdenv, fetchurl
 let
   s =
   rec {
-    version = "1.8.0";
+    version = "1.8.2";
     versionSuffix = "";
     url = "mirror://sourceforge/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${version}/lazarus-${version}${versionSuffix}.tar.gz";
-    sha256 = "0i58ngrr1vjyazirfmz0cgikglc02z1m0gcrsfw9awpi3ax8h21j";
+    sha256 = "06ajdnyba3v3d37mjq1yim96hsmbx1w5n695m5zlhjbydgw62a15";
     name = "lazarus-${version}";
   };
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.8.2 with grep in /nix/store/z3r30kr064x672zqnrs1pwzshlvgnv9n-lazarus-1.8.2
- found 1.8.2 in filename of file in /nix/store/z3r30kr064x672zqnrs1pwzshlvgnv9n-lazarus-1.8.2
- directory tree listing: https://gist.github.com/895d2d01174298ff36a30bc7387286a2

cc @7c6f434c for review