### PR TITLE
toml: init at 0.9.4

### DIFF
--- a/pkgs/development/python-modules/toml/default.nix
+++ b/pkgs/development/python-modules/toml/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "toml";
+  version = "0.9.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bdbpbip67wdm6c7xwc6mmbmskyradj4cdxn1iibj4fcx1nbv1lf";
+  };
+
+  # This package has a test script (built for Travis) that involves a)
+  # looking in the home directory for a binary test runner and b) using
+  # git to download a test suite.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "a Python library for parsing and creating TOML";
+    homepage = "https://github.com/uiri/toml";
+    license = licenses.mit;
+    maintainers = with maintainers; [ twey ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -420,6 +420,8 @@ in {
 
   tokenserver = callPackage ../development/python-modules/tokenserver {};
 
+  toml = callPackage ../development/python-modules/toml { };
+
   unifi = callPackage ../development/python-modules/unifi { };
 
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

