### PR TITLE
libcap_ng: 0.7.8 -> 0.7.9

### DIFF
--- a/pkgs/os-specific/linux/libcap-ng/default.nix
+++ b/pkgs/os-specific/linux/libcap-ng/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
   name = "libcap-ng-${version}";
   # When updating make sure to test that the version with
   # all of the python bindings still works
-  version = "0.7.8";
+  version = "0.7.9";
 
   src = fetchurl {
     url = "${meta.homepage}/${name}.tar.gz";
-    sha256 = "0pyhjxgsph3p28ayk4ynxab6wvzaqmazk1nkamx11m2w8jbzj6n2";
+    sha256 = "0a0k484kwv0zilry2mbl9k56cnpdhsjxdxin17jas6kkyfy345aa";
   };
 
   nativeBuildInputs = [ swig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/s6hxbgihfzp3phh3904idpw3jpn1k371-libcap-ng-0.7.9/bin/captest -h` got 0 exit code
- ran `/nix/store/s6hxbgihfzp3phh3904idpw3jpn1k371-libcap-ng-0.7.9/bin/captest --help` got 0 exit code
- ran `/nix/store/s6hxbgihfzp3phh3904idpw3jpn1k371-libcap-ng-0.7.9/bin/captest help` got 0 exit code
- found 0.7.9 with grep in /nix/store/s6hxbgihfzp3phh3904idpw3jpn1k371-libcap-ng-0.7.9
- directory tree listing: https://gist.github.com/eec1818588ca8e5fe720bfe3febec73b

cc @wkennington for review