### PR TITLE
libfixposix: 0.4.1 -> 0.4.3

### DIFF
--- a/pkgs/development/libraries/libfixposix/default.nix
+++ b/pkgs/development/libraries/libfixposix/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name="libfixposix-${version}";
-  version="0.4.1";
+  version="0.4.3";
 
   src = fetchFromGitHub {
     owner = "sionescu";
     repo = "libfixposix";
     rev = "v${version}";
-    sha256 = "19wjb43mn16f4lin5a2dfi3ym2hy7kqibs0z631d205b16vxas15";
+    sha256 = "1x4q6yspi5g2s98vq4qszw4z3zjgk9l5zs8471w4d4cs6l97w08j";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.4.3 with grep in /nix/store/ksrz74w4gzxb2mf8yb3f3i67i80cr93v-libfixposix-0.4.3
- directory tree listing: https://gist.github.com/ddc89b6def68fbc70c046bfdaa1c02b8

cc @orivej @7c6f434c for review