### PR TITLE
libgit2_0_25: 0.25.1 -> 0.26.3

### DIFF
--- a/pkgs/development/libraries/git2/0.25.nix
+++ b/pkgs/development/libraries/git2/0.25.nix
@@ -4,14 +4,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.25.1";
+  version = "0.26.3";
   name = "libgit2-${version}";
 
   src = fetchFromGitHub {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    sha256 = "1jhikg0gqpdzfzhgv44ybdpm24lvgkc7ki4306lc5lvmj1s2nylj";
+    sha256 = "0q6jwx2bqvyhbhj2z206mvmc144flbxhlk1lnvffcx0hrryf1fc3";
   };
 
   cmakeFlags = [ "-DTHREADSAFE=ON" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.26.3 with grep in /nix/store/6ky8njgnkgk8jc7ihr9gm6q89jfdmbh9-libgit2-0.26.3
- found 0.26.3 in filename of file in /nix/store/6ky8njgnkgk8jc7ihr9gm6q89jfdmbh9-libgit2-0.26.3
- directory tree listing: https://gist.github.com/9f6ae0719125266e9fe072a1e281851a