### PR TITLE
libgpgerror: 1.27 -> 1.28

### DIFF
--- a/pkgs/development/libraries/libgpg-error/default.nix
+++ b/pkgs/development/libraries/libgpg-error/default.nix
@@ -17,11 +17,11 @@
   };
 in stdenv.mkDerivation (rec {
   name = "libgpg-error-${version}";
-  version = "1.27";
+  version = "1.28";
 
   src = fetchurl {
     url = "mirror://gnupg/libgpg-error/${name}.tar.bz2";
-    sha256 = "1li95ni122fzinzlmxbln63nmgij63irxfvi52ws4zfbzv3am4sg";
+    sha256 = "0jfsfnh9bxlxiwxws60yah4ybjw2hshmvqp31pri4m4h8ivrbnry";
   };
 
   patches = if hostPlatform.isRiscV then ./riscv.patch else null;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.28 with grep in /nix/store/2lp3zzqckbcc0mvsdmf38p9kw24izwb0-libgpg-error-1.28
- directory tree listing: https://gist.github.com/5af1cff4b9e1e948506caefbaf7384e8

cc @fuuzetsu @vrthra for review