### PR TITLE
libjpeg_original: 8d -> 9c

### DIFF
--- a/pkgs/development/libraries/libjpeg/default.nix
+++ b/pkgs/development/libraries/libjpeg/default.nix
@@ -3,11 +3,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation {
-  name = "libjpeg-8d";
+  name = "libjpeg-9c";
 
   src = fetchurl {
-    url = http://www.ijg.org/files/jpegsrc.v8d.tar.gz;
-    sha256 = "1cz0dy05mgxqdgjf52p54yxpyy95rgl30cnazdrfmw7hfca9n0h0";
+    url = http://www.ijg.org/files/jpegsrc.v9c.tar.gz;
+    sha256 = "1m3a137r7m14wd92a03qdvp4jfazc0657nzry7rqzs2p1xhkyfhz";
   };
 
   configureFlags = optional static "--enable-static --disable-shared";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 9c with grep in /nix/store/m070zrgfdkwdqz5p3klbw9r27iz38mjh-libjpeg-9c-bin
- directory tree listing: https://gist.github.com/94ec29f471c8e23b5f10a875c612fd29