### PR TITLE
mpd_clientlib: 2.13 -> 2.14

### DIFF
--- a/pkgs/servers/mpd/clientlib.nix
+++ b/pkgs/servers/mpd/clientlib.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, meson, ninja, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
-  version = "2.13";
+  version = "2.14";
   name = "libmpdclient-${version}";
 
   src = fetchFromGitHub {
     owner  = "MusicPlayerDaemon";
     repo   = "libmpdclient";
     rev    = "v${version}";
-    sha256 = "1g1n6rk8kn87mbjqxxj0vi7haj8xx21xmqlzbrx2fvyp5357zvsq";
+    sha256 = "15vn9m4qcsccff5rg7jkzy5503skz6bmqqk6qc2smgvjgwn533sm";
   };
 
   nativeBuildInputs = [ meson ninja ]


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.14 with grep in /nix/store/8q00s6prlgljs1imp7r40rq3jyafzlhc-libmpdclient-2.14
- found 2.14 in filename of file in /nix/store/8q00s6prlgljs1imp7r40rq3jyafzlhc-libmpdclient-2.14
- directory tree listing: https://gist.github.com/acd3295fdde722768ff964a7284a00c4