### PR TITLE
libsForQt5.libopenshot: 0.1.7 -> 0.1.9

### DIFF
--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -8,13 +8,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libopenshot-${version}";
-  version = "0.1.7";
+  version = "0.1.9";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot";
     rev = "v${version}";
-    sha256 = "1dk40qild8d3s99p2kkm0mjvxfxrz2wns7ij1brzqmcdnaxqdhlp";
+    sha256 = "0c7q5cfnp481ysyvgzznvix7j4licq9knwrb83g3xqs4cx573xr3";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.1.9 with grep in /nix/store/nrg54a2kxlz3r8c4wf2if5vzq0y452fs-libopenshot-0.1.9
- found 0.1.9 in filename of file in /nix/store/nrg54a2kxlz3r8c4wf2if5vzq0y452fs-libopenshot-0.1.9
- directory tree listing: https://gist.github.com/a521e923923cd5ac4f188b8dede33a2e

cc @AndersonTorres for review