### PR TITLE
libsForQt5.libopenshot-audio: 0.1.4 -> 0.1.5

### DIFF
--- a/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
@@ -4,13 +4,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libopenshot-audio-${version}";
-  version = "0.1.4";
+  version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot-audio";
     rev = "v${version}";
-    sha256 = "07615vacbvi08pzm4lxfckfwib2xcfdjaggpda58hy8nr0677fzq";
+    sha256 = "0rn87jxyfq1yip1lb2255l5ilkakkqg9rn0lr0h6dn2xrmlbmg8l";
   };
 
   nativeBuildInputs =


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.1.5 with grep in /nix/store/0a0pk23wn2jqnkc9h7jb0i0wp8b5zkzm-libopenshot-audio-0.1.5
- found 0.1.5 in filename of file in /nix/store/0a0pk23wn2jqnkc9h7jb0i0wp8b5zkzm-libopenshot-audio-0.1.5
- directory tree listing: https://gist.github.com/6096ee421bf911b453a5b862e61452ec

cc @AndersonTorres for review