### PR TITLE
libpqxx: 6.1.0 -> 6.1.1

### DIFF
--- a/pkgs/development/libraries/libpqxx/default.nix
+++ b/pkgs/development/libraries/libpqxx/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libpqxx-${version}";
-  version = "6.1.0";
+  version = "6.1.1";
 
   src = fetchFromGitHub {
     owner = "jtv";
     repo = "libpqxx";
     rev = version;
-    sha256 = "1dv96h10njg115216n2zm6fsvi4kb502hmhhn8cjhlfbxr9vc84q";
+    sha256 = "0yw0wvnpw0j560f5zv4gvmafi19d9hrknwjzl7qrss926aqx65jq";
   };
 
   nativeBuildInputs = [ gnused python2 ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config -h` got 0 exit code
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config --help` got 0 exit code
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config help` got 0 exit code
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config -V` and found version 6.1.1
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config -v` and found version 6.1.1
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config --version` and found version 6.1.1
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config version` and found version 6.1.1
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config -h` and found version 6.1.1
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config --help` and found version 6.1.1
- ran `/nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1/bin/pqxx-config help` and found version 6.1.1
- found 6.1.1 with grep in /nix/store/kk2j3iz4kllp58v3k0jy88pr78gqb53d-libpqxx-6.1.1
- directory tree listing: https://gist.github.com/5915a75a4c094a7918ab2b42fc150b80

cc @edolstra for review