### PR TITLE
cross stdenv: Make depsBuildBuild overrideable by config too.

### DIFF
--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -10,9 +10,15 @@ let
     config = builtins.removeAttrs config [ "replaceStdenv" ];
   };
 
-in bootStages ++ [
+in lib.init bootStages ++ [
 
-  # Build Packages
+  # Regular native packages
+  (somePrevStage: lib.last bootStages somePrevStage // {
+    # It's OK to change the built-time dependencies
+    allowCustomOverrides = true;
+  })
+
+  # Build tool Packages
   (vanillaPackages: {
     inherit config overlays;
     selfBuild = false;


### PR DESCRIPTION
###### Motivation for this change

It's useful to override all `buildPackages.buildPackages.buildPackages.buildPackages....`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

