### PR TITLE
srtp: 1.5.4 -> 2.1.0

### DIFF
--- a/pkgs/development/libraries/srtp/default.nix
+++ b/pkgs/development/libraries/srtp/default.nix
@@ -5,13 +5,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libsrtp-${version}";
-  version = "1.5.4";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "cisco";
     repo = "libsrtp";
     rev = "v${version}";
-    sha256 = "0s029m4iw0nsvnsm2hlz8yajrasdvf315iv2dw8mfm7nhbshwsqa";
+    sha256 = "1q2rf1d2bsypdnw9k8ag6hrh9vbinfa504d1f42fdgdqw31d6lib";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.1.0 with grep in /nix/store/rgqp3xyxn4m88whigf4msz3kj07hhgkf-libsrtp-2.1.0
- directory tree listing: https://gist.github.com/d1a145c8a1c6845fe2715b901b9f99b2