### PR TITLE
libyamlcpp: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/development/libraries/libyaml-cpp/default.nix
+++ b/pkgs/development/libraries/libyaml-cpp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libyaml-cpp-${version}";
-  version = "0.6.1";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "jbeder";
     repo = "yaml-cpp";
     rev = "yaml-cpp-${version}";
-    sha256 = "16x53p9gfch7gpyg865j7m1zhqsixx2hbbd206ffjv0ip8cjipjf";
+    sha256 = "16lclpa487yghf9019wymj419wkyx4795wv9q7539hhimajw9kpb";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.6.2 with grep in /nix/store/cfm3y6c18a0ys0ndbv4g4zixay7zh331-libyaml-cpp-0.6.2
- found 0.6.2 in filename of file in /nix/store/cfm3y6c18a0ys0ndbv4g4zixay7zh331-libyaml-cpp-0.6.2
- directory tree listing: https://gist.github.com/54fa524e8988d3fbe9920824135802a0

cc @andir for review