### PR TITLE
simp_le: 0.6.1 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/acme/default.nix
+++ b/pkgs/development/python-modules/acme/default.nix
@@ -1,6 +1,18 @@
 { stdenv, buildPythonPackage, fetchPypi
-, certbot, nose, cryptography, pyasn1, pyopenssl, pyRFC3339
-, pytz, requests, six, werkzeug, mock, ndg-httpsclient }:
+, certbot
+, nose
+, cryptography
+, pyasn1
+, pyopenssl
+, pyRFC3339
+, josepy
+, pytz
+, requests
+, six
+, werkzeug
+, mock
+, ndg-httpsclient
+}:
 
 buildPythonPackage rec {
   inherit (certbot) src version;
@@ -10,10 +22,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     cryptography pyasn1 pyopenssl pyRFC3339 pytz requests six werkzeug mock
-    ndg-httpsclient
+    ndg-httpsclient josepy
   ];
 
-  buildInputs = [ nose ];
+  checkInputs = [ nose ];
 
   postUnpack = "sourceRoot=\${sourceRoot}/acme";
 }

--- a/pkgs/development/python-modules/josepy/default.nix
+++ b/pkgs/development/python-modules/josepy/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchPypi, buildPythonPackage
+# buildInputs
+, six
+, setuptools
+, pyopenssl
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "josepy";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1k0ahzzaq2rrjiifwbhbp7vm8z4zk0ipgiqwicil80kzlf6bhj4z";
+  };
+
+  propagatedBuildInputs = [
+    pyopenssl
+    cryptography
+    six
+    setuptools
+  ];
+
+  # too many unpackaged check requirements
+  doCheck = false;
+
+  meta = with lib; {
+    description = "JOSE protocol implementation in Python";
+    homepage = https://github.com/jezdez/josepy;
+    license = licenses.asl20;
+    maintainers = with maintainers; [  ];
+  };
+}
+

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, python2Packages, fetchFromGitHub, dialog }:
+{ stdenv, pythonPackages, fetchFromGitHub, dialog }:
 
 # Latest version of certbot supports python3 and python3 version of pythondialog
 
-python2Packages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication rec {
   name = "certbot-${version}";
-  version = "0.19.0";
+  version = "0.22.2";
 
   src = fetchFromGitHub {
     owner = "certbot";
     repo = "certbot";
     rev = "v${version}";
-    sha256 = "14i3q59v7j0q2pa1dri420fhil4h0vgl4vb471hp81f4y14gq6h7";
+    sha256 = "08x80x9d71j84mwjm5wzd0x5gcw6gwyvkvadi2js39js6hfnc6jg";
   };
 
-  propagatedBuildInputs = with python2Packages; [
+  propagatedBuildInputs = with pythonPackages; [
     ConfigArgParse
     acme
     configobj
@@ -28,7 +28,7 @@ python2Packages.buildPythonApplication rec {
     zope_component
     zope_interface
   ];
-  buildInputs = [ dialog ] ++ (with python2Packages; [ nose mock gnureadline ]);
+  buildInputs = [ dialog ] ++ (with pythonPackages; [ nose mock gnureadline ]);
 
   patchPhase = ''
     substituteInPlace certbot/notify.py --replace "/usr/sbin/sendmail" "/run/wrappers/bin/sendmail"

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pythonPackages }:
+{ stdenv, fetchFromGitHub, fetchpatch, pythonPackages, bash }:
  
 pythonPackages.buildPythonApplication rec {
   pname = "simp_le-client";
@@ -8,6 +8,11 @@ pythonPackages.buildPythonApplication rec {
     inherit pname version;
     sha256 = "0nv9mm99rm8i9flgfgwvmajbsxb5rm162nfxlq3wk66bbbyr6y1i";
   };
+
+  postPatch = ''
+    substituteInPlace simp_le.py \
+      --replace "/bin/sh" "${bash}/bin/sh"
+  '';
 
   checkPhase = ''
     $out/bin/simp_le --test

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -1,26 +1,26 @@
 { stdenv, fetchFromGitHub, fetchpatch, pythonPackages }:
-
+ 
 pythonPackages.buildPythonApplication rec {
   pname = "simp_le-client";
-  version = "0.6.1";
-  name = "${pname}-${version}";
+  version = "0.8.0";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "0x4fky9jizs3xi55cdy217cvm3ikpghiabysan71b07ackkdfj6k";
+    sha256 = "0nv9mm99rm8i9flgfgwvmajbsxb5rm162nfxlq3wk66bbbyr6y1i";
   };
 
   checkPhase = ''
     $out/bin/simp_le --test
   '';
 
-  propagatedBuildInputs = with pythonPackages; [ acme setuptools_scm ];
+  propagatedBuildInputs = with pythonPackages; [ acme setuptools_scm josepy ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/zenhack/simp_le;
     description = "Simple Let's Encrypt client";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ gebner makefu ];
     platforms = platforms.all;
   };
 }
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5219,6 +5219,8 @@ in {
 
   JPype1 = callPackage ../development/python-modules/JPype1 {};
 
+  josepy = callPackage ../development/python-modules/josepy {};
+
   jsbeautifier = callPackage ../development/python-modules/jsbeautifier {};
 
   jug = callPackage ../development/python-modules/jug {};


### PR DESCRIPTION
###### Motivation for this change

according to the changelog, the release 0.6.2 of simp_le will be future-proof by not hard-coding the TOS checksum.
To update simp_le, the latest version is required which is bumped by this PR. Additionally josepy is added which is required for simp_le and certbot.
related: #31944 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

