### PR TITLE
krunner-pass: init at version v1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3986,6 +3986,11 @@
     github = "yrashk";
     name = "Yurii Rashkovskii";
   };
+  ysndr = {
+    email = "me@ysndr.de";
+    github = "ysndr";
+    name = "Yannik Sander";
+  };
   yuriaisaka = {
     email = "yuri.aisaka+nix@gmail.com";
     github = "yuriaisaka";

--- a/pkgs/tools/security/krunner-pass/default.nix
+++ b/pkgs/tools/security/krunner-pass/default.nix
@@ -1,0 +1,44 @@
+{ mkDerivation, stdenv,
+  fetchFromGitHub,
+  cmake, extra-cmake-modules, gnumake,
+
+  pass, pass-otp ? null, krunner,
+}:
+let
+  pname = "krunner-pass";
+  version = "1.3.0";
+in
+mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "akermu";
+    repo = "krunner-pass";
+    rev = "v${version}";
+    sha256 = "032fs2174ls545kjixbhzyd65wgxkw4s5vg8b20irc5c9ak3pxm0";
+  };
+
+  buildInputs  = [
+    pass
+    pass-otp
+    krunner
+  ];
+
+  nativeBuildInputs = [cmake extra-cmake-modules gnumake];
+
+  patches = [
+    ./pass-path.patch
+  ];
+
+  CXXFLAGS = [
+    ''-DNIXPKGS_PASS=\"${stdenv.lib.getBin pass}/bin/pass\"''
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Integrates krunner with pass the unix standard password manager (https://www.passwordstore.org/)";
+    homepage = https://github.com/akermu/krunner-pass;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ysndr ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/krunner-pass/pass-path.patch
+++ b/pkgs/tools/security/krunner-pass/pass-path.patch
@@ -1,0 +1,13 @@
+diff --git a/pass.cpp b/pass.cpp
+index c02f9d0..85c5b99 100644
+--- a/pass.cpp
++++ b/pass.cpp
+@@ -193,7 +193,7 @@ void Pass::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch &m
+     } else {
+         args << "show" << match.text();
+     }
+-    pass->start("pass", args);
++    pass->start(NIXPKGS_PASS, args);
+
+     connect(pass, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+             [=](int exitCode, QProcess::ExitStatus exitStatus) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3176,6 +3176,8 @@ with pkgs;
 
   krename = libsForQt5.callPackage ../applications/misc/krename { };
 
+  krunner-pass = libsForQt5.callPackage ../tools/security/krunner-pass { };
+
   kronometer = libsForQt5.callPackage ../tools/misc/kronometer { };
 
   elisa = libsForQt5.callPackage ../applications/audio/elisa { };


### PR DESCRIPTION
###### Motivation for this change
accessing passwords through krunner

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

P.S. I'm not entirely sure if I located this at the right place.. I'm very open for comments as this is also my first commit to nixpkgs :)

