### PR TITLE
mdv: init at 1.6.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3426,6 +3426,11 @@
     github = "symphorien";
     name = "Guillaume Girol";
   };
+  synthetica = {
+    email = "nix@hilhorst.be";
+    github = "Synthetica9";
+    name = "Patrick Hilhorst";
+  };
   szczyp = {
     email = "qb@szczyp.com";
     github = "szczyp";

--- a/pkgs/development/python-modules/mdv/default.nix
+++ b/pkgs/development/python-modules/mdv/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage,
+  fetchPypi, markdown, pygments, pyyaml, docopt
+}:
+
+buildPythonPackage rec {
+  pname = "mdv";
+  version = "1.6.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1x4d1gyvmdqh2zpdc415ak10d4yfli04pw4mxwfv2jnjk94d1y0k";
+  };
+
+  propagatedBuildInputs = [ markdown pygments pyyaml docopt ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/axiros/terminal_markdown_viewer;
+    description = "Terminal Markdown Viewer";
+    license = licenses.bsd;
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/development/python-modules/mdv/default.nix
+++ b/pkgs/development/python-modules/mdv/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/axiros/terminal_markdown_viewer;
     description = "Terminal Markdown Viewer";
-    license = licenses.bsd;
+    license = licenses.bsd3;
     maintainers = with maintainers; [ synthetica ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8810,7 +8810,7 @@ in {
   keyutils = callPackage ../development/python-modules/keyutils { };
 
   klein = callPackage ../development/python-modules/klein { };
- 
+
   koji = callPackage ../development/python-modules/koji { };
 
   kombu = buildPythonPackage rec {
@@ -20203,6 +20203,8 @@ EOF
   pytoml = callPackage ../development/python-modules/pytoml { };
 
   pypandoc = callPackage ../development/python-modules/pypandoc { };
+
+  mdv = callPackage ../development/python-modules/mdv { };
 
   yamllint = callPackage ../development/python-modules/yamllint { };
 


### PR DESCRIPTION
###### Motivation for this change

`mvd` wasn't in packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

