### PR TITLE
linuxHeaders: 4.15 -> 4.15.10

### DIFF
--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -48,7 +48,7 @@ let
 in {
 
   linuxHeaders = common {
-    version = "4.15";
-    sha256 = "0sd7l9n9h7vf9c6gd6ciji28hawda60yj0llh17my06m0s4lf9js";
+    version = "4.15.10";
+    sha256 = "14i6028l1y8y88sw5cbfihzs3wp66vwy33g1598i0dkyf1sbw5cg";
   };
 }


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.15.10 with grep in /nix/store/sklb3i3iiy58pwd9yrrr2h6jh8p60q53-linux-headers-4.15.10
- directory tree listing: https://gist.github.com/4e8e75a25145e12b06b36c836751e5d7