### PR TITLE
lua51Packages.luaevent: 0.4.3 -> 0.4.4

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -167,7 +167,7 @@ let
   };
 
   luaevent = buildLuaPackage rec {
-    version = "0.4.3";
+    version = "0.4.4";
     name = "luaevent-${version}";
     disabled = isLua52;
 
@@ -175,7 +175,7 @@ let
       owner = "harningt";
       repo = "luaevent";
       rev = "v${version}";
-      sha256 = "1c1n2zqx5rwfwkqaq1jj8gvx1vswvbihj2sy445w28icz1xfhpik";
+      sha256 = "1krzxr0jkv3gmhpckp02byhdd9s5dd0hpyqc8irc8i79dd8x0p53";
     };
 
     preBuild = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.4.4 with grep in /nix/store/p0130dpjhicsqkx4dxhi707893lgq8bi-lua5.1-luaevent-0.4.4
- directory tree listing: https://gist.github.com/41f797478b7c735e48a957dd7c2166ec

cc @k0ral for review