### PR TITLE
lua52Packages.luafilesystem: 1.6.3 -> 1.7.0.2

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -268,14 +268,14 @@ let
   };
 
   luafilesystem = buildLuaPackage rec {
-    version = "1.6.3";
+    version = "1.7.0.2";
     name = "filesystem-${version}";
 
     src = fetchFromGitHub {
       owner = "keplerproject";
       repo = "luafilesystem";
       rev = "v${stdenv.lib.replaceChars ["."] ["_"] version}";
-      sha256 = "1hxcnqj53540ysyw8fzax7f09pl98b8f55s712gsglcdxp2g2pri";
+      sha256 = "0zmprgkm9zawdf9wnw0v3w6ibaj442wlc6alp39hmw610fl4vghi";
     };
 
     preConfigure = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/c94b6f142be9168c99e75cf335389c22

cc @flosse for review