### PR TITLE
lua52Packages.lpeg: 0.12 -> 1.0.1

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -635,11 +635,11 @@ let
 
   lpeg = buildLuaPackage rec {
     name = "lpeg-${version}";
-    version = "0.12";
+    version = "1.0.1";
 
     src = fetchurl {
       url = "http://www.inf.puc-rio.br/~roberto/lpeg/${name}.tar.gz";
-      sha256 = "0xlbfw1w7l65a5qhnx5sfw327hkq1zcj8xmg4glfw6fj9ha4b9gg";
+      sha256 = "0sq25z3r324a324ky73izgq9mbf66j2xvjp0fxf227rwxalzgnb2";
     };
 
     preBuild = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.0.1 with grep in /nix/store/fsk2jl678p62lafynavdwx0mwp6bsv2a-lua5.2-lpeg-1.0.1
- directory tree listing: https://gist.github.com/1fff696fb315e4419018e006583e5859

cc @vyp for review