### PR TITLE
lua52Packages.luacheck: 0.20.0 -> 0.21.2

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -109,14 +109,14 @@ let
 
   luacheck = buildLuaPackage rec {
     pname = "luacheck";
-    version = "0.20.0";
+    version = "0.21.2";
     name = "${pname}-${version}";
 
     src = fetchFromGitHub {
       owner = "mpeterv";
       repo = "luacheck";
       rev = "${version}";
-      sha256 = "0ahfkmqcjhlb7r99bswy1sly6d7p4pyw5f4x4fxnxzjhbq0c5qcs";
+      sha256 = "1nwnblb55hyn80w3kxiy9pdh3d5di84zw4zmz8jlffrs8srg493n";
     };
 
     propagatedBuildInputs = [ lua ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/yywjm0miiknh8plmsvjzwczj0a4i7kwa-lua5.2-luacheck-0.21.2/bin/luacheck -h` got 0 exit code
- ran `/nix/store/yywjm0miiknh8plmsvjzwczj0a4i7kwa-lua5.2-luacheck-0.21.2/bin/luacheck --help` got 0 exit code
- ran `/nix/store/yywjm0miiknh8plmsvjzwczj0a4i7kwa-lua5.2-luacheck-0.21.2/bin/luacheck -v` and found version 0.21.2
- ran `/nix/store/yywjm0miiknh8plmsvjzwczj0a4i7kwa-lua5.2-luacheck-0.21.2/bin/luacheck --version` and found version 0.21.2
- ran `/nix/store/yywjm0miiknh8plmsvjzwczj0a4i7kwa-lua5.2-luacheck-0.21.2/bin/luacheck -h` and found version 0.21.2
- ran `/nix/store/yywjm0miiknh8plmsvjzwczj0a4i7kwa-lua5.2-luacheck-0.21.2/bin/luacheck --help` and found version 0.21.2
- found 0.21.2 with grep in /nix/store/yywjm0miiknh8plmsvjzwczj0a4i7kwa-lua5.2-luacheck-0.21.2
- directory tree listing: https://gist.github.com/22fe036c4213f0265616fb2db258d490

cc @vyp for review