### PR TITLE
lua52Packages.luazlib: 1.1 -> 1.2

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -138,7 +138,7 @@ let
   };
 
   luacyrussasl = buildLuaPackage rec {
-    version = "1.1.0";
+    version = "1.2.0";
     name = "lua-cyrussasl-${version}";
     src = fetchFromGitHub {
       owner = "JorjBauer";
@@ -512,13 +512,13 @@ let
 
   luazlib = buildLuaPackage rec {
     name = "zlib-${version}";
-    version = "1.1";
+    version = "1.2";
 
     src = fetchFromGitHub {
       owner = "brimworks";
       repo = "lua-zlib";
       rev = "v${version}";
-      sha256 = "1520lk4xpf094xn2zallqgqhs0zb4w61l49knv9y8pmhkdkxzzgy";
+      sha256 = "0bbcj0zsz5z8zclz6gk6fg047cassz8dhxjm4jf4j6cwh8xxh06y";
     };
 
     buildInputs = [ zlib ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.2 with grep in /nix/store/nf5cxj4xvhsm518xh6vlyb5vi0v678ss-lua5.2-zlib-1.2
- directory tree listing: https://gist.github.com/edf9d62b1c415e9a2d1e569336c044dc

cc @k0ral for review