### PR TITLE
lua51Packages.luarocks: 2.4.3 -> 2.4.4

### DIFF
--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -3,11 +3,11 @@ let
   s = # Generated upstream information
   rec {
     baseName="luarocks";
-    version="2.4.3";
+    version="2.4.4";
     name="${baseName}-${version}";
-    hash="0binkd8mpzdzvx0jw0dwm4kr1p7jny015zykf8f15fymzqr4shad";
-    url="http://luarocks.org/releases/luarocks-2.4.3.tar.gz";
-    sha256="0binkd8mpzdzvx0jw0dwm4kr1p7jny015zykf8f15fymzqr4shad";
+    hash="0d7rl60dwh52qh5pfsphgx5ypp7k190h9ri6qpr2yx9kvqrxyf1r";
+    url="http://luarocks.org/releases/luarocks-2.4.4.tar.gz";
+    sha256="0d7rl60dwh52qh5pfsphgx5ypp7k190h9ri6qpr2yx9kvqrxyf1r";
   };
   buildInputs = [
     lua curl makeWrapper which unzip


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks --help` got 0 exit code
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks help` got 0 exit code
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks --version` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks --help` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks help` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-5.1 --help` got 0 exit code
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-5.1 help` got 0 exit code
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-5.1 --version` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-5.1 --help` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-5.1 help` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin --help` got 0 exit code
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin help` got 0 exit code
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin --version` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin --help` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin help` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin-5.1 --help` got 0 exit code
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin-5.1 help` got 0 exit code
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin-5.1 --version` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin-5.1 --help` and found version 2.4.4
- ran `/nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4/bin/luarocks-admin-5.1 help` and found version 2.4.4
- found 2.4.4 with grep in /nix/store/az3lanws83s5q26z1s03rx6z6yxphjbq-luarocks-2.4.4
- directory tree listing: https://gist.github.com/cb3889fda28e8066faebd32a433c69d2

cc @7c6f434c for review