### PR TITLE
m17n_db: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/tools/inputmethods/m17n-db/default.nix
+++ b/pkgs/tools/inputmethods/m17n-db/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "m17n-db-1.7.0";
+  name = "m17n-db-1.8.0";
 
   src = fetchurl {
     url = "http://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
-    sha256 = "1w08hnsbknrcjlzp42c99bgwc9hzsnf5m4apdv0dacql2s09zfm2";
+    sha256 = "0vfw7z9i2s9np6nmx1d4dlsywm044rkaqarn7akffmb6bf1j6zv5";
   };
 
   buildInputs = [ gettext ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/l9vsx891cc7hrp4gic87djcmbfi3dg1a-m17n-db-1.8.0/bin/m17n-db -h` got 0 exit code
- ran `/nix/store/l9vsx891cc7hrp4gic87djcmbfi3dg1a-m17n-db-1.8.0/bin/m17n-db --help` got 0 exit code
- ran `/nix/store/l9vsx891cc7hrp4gic87djcmbfi3dg1a-m17n-db-1.8.0/bin/m17n-db -v` and found version 1.8.0
- ran `/nix/store/l9vsx891cc7hrp4gic87djcmbfi3dg1a-m17n-db-1.8.0/bin/m17n-db --version` and found version 1.8.0
- ran `/nix/store/l9vsx891cc7hrp4gic87djcmbfi3dg1a-m17n-db-1.8.0/bin/m17n-db -h` and found version 1.8.0
- ran `/nix/store/l9vsx891cc7hrp4gic87djcmbfi3dg1a-m17n-db-1.8.0/bin/m17n-db --help` and found version 1.8.0
- found 1.8.0 with grep in /nix/store/l9vsx891cc7hrp4gic87djcmbfi3dg1a-m17n-db-1.8.0
- directory tree listing: https://gist.github.com/dfe2a7729da99276c71f68cf0c227fcd

cc @astsmtl for review