### PR TITLE
nixos/tests/atd : remove non-deterministic test of batch command

### DIFF
--- a/nixos/tests/atd.nix
+++ b/nixos/tests/atd.nix
@@ -17,20 +17,14 @@ import ./make-test.nix ({ pkgs, lib, ... }:
     startAll;
 
     $machine->fail("test -f ~root/at-1");
-    $machine->fail("test -f ~root/batch-1");
     $machine->fail("test -f ~alice/at-1");
-    $machine->fail("test -f ~alice/batch-1");
 
     $machine->succeed("echo 'touch ~root/at-1' | at now+1min");
-    $machine->succeed("echo 'touch ~root/batch-1' | batch");
     $machine->succeed("su - alice -c \"echo 'touch at-1' | at now+1min\"");
-    $machine->succeed("su - alice -c \"echo 'touch batch-1' | batch\"");
 
     $machine->succeed("sleep 1.5m");
 
     $machine->succeed("test -f ~root/at-1");
-    $machine->succeed("test -f ~root/batch-1");
     $machine->succeed("test -f ~alice/at-1");
-    $machine->succeed("test -f ~alice/batch-1");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

The `atd` test usually failed on Hydra and usually succeded on a local machine. What failed was the test of the  `batch` command, which executes jobs when system load is low - rarely happens on Hydra.

Removed this non-deterministic test case.

/cc ZHF #36453
/cc maintainer @bjornfor 

###### Things done

Manually tested.

