### PR TITLE
m17n_lib: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, m17n_db}:
 stdenv.mkDerivation rec {
-  name = "m17n-lib-1.7.0";
+  name = "m17n-lib-1.8.0";
 
   src = fetchurl {
     url = "http://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
-    sha256 = "10yv730i25g1rpzv6q49m6xn4p8fjm7jdwvik2h70sn8w3hm7f4f";
+    sha256 = "0jp61y09xqj10mclpip48qlfhniw8gwy8b28cbzxy8hq8pkwmfkq";
   };
 
   buildInputs = [ m17n_db ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0/bin/m17n-conv -h` got 0 exit code
- ran `/nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0/bin/m17n-conv --help` got 0 exit code
- ran `/nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0/bin/m17n-conv help` got 0 exit code
- ran `/nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0/bin/m17n-conv --version` and found version 1.8.0
- ran `/nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0/bin/m17n-date -h` got 0 exit code
- ran `/nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0/bin/m17n-date --help` got 0 exit code
- ran `/nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0/bin/m17n-date --version` and found version 1.8.0
- ran `/nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0/bin/m17n-config --version` and found version 1.8.0
- found 1.8.0 with grep in /nix/store/28baccpjkyg7rb0alf8j2hpnczz22jzq-m17n-lib-1.8.0
- directory tree listing: https://gist.github.com/3d3a5a6fc658c968ce3a1298c9f32c56

cc @astsmtl for review