### PR TITLE
libmysql: 2.3.4 -> 3.0.3

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -167,11 +167,11 @@ everything = stdenv.mkDerivation (common // {
 
 connector-c = stdenv.mkDerivation rec {
   name = "mariadb-connector-c-${version}";
-  version = "2.3.4";
+  version = "3.0.3";
 
   src = fetchurl {
     url = "https://downloads.mariadb.org/interstitial/connector-c-${version}/mariadb-connector-c-${version}-src.tar.gz/from/http%3A//ftp.hosteurope.de/mirror/archive.mariadb.org/?serve";
-    sha256 = "1g1sq5knarxkfhpkcczr6qxmq12pid65cdkqnhnfs94av89hbswb";
+    sha256 = "1spfhj4kcdl0d15clrqyfz7iwf4q19d9x3p9p0yms8sb87ihw3r1";
     name   = "mariadb-connector-c-${version}-src.tar.gz";
   };
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/5q3n98r2lvf7q589mhqs7df23yj2b100-mariadb-connector-c-3.0.3/bin/mariadb_config -h` got 0 exit code
- ran `/nix/store/5q3n98r2lvf7q589mhqs7df23yj2b100-mariadb-connector-c-3.0.3/bin/mariadb_config --help` got 0 exit code
- ran `/nix/store/5q3n98r2lvf7q589mhqs7df23yj2b100-mariadb-connector-c-3.0.3/bin/mariadb_config help` got 0 exit code
- ran `/nix/store/5q3n98r2lvf7q589mhqs7df23yj2b100-mariadb-connector-c-3.0.3/bin/mariadb_config --help` and found version 3.0.3
- found 3.0.3 with grep in /nix/store/5q3n98r2lvf7q589mhqs7df23yj2b100-mariadb-connector-c-3.0.3
- directory tree listing: https://gist.github.com/aa0782fcdef6d85d003c2b7ec9fc81f0

cc @globin for review