### PR TITLE
miniupnpc_2: 2.0.20171212 -> 2.0.20180222

### DIFF
--- a/pkgs/tools/networking/miniupnpc/default.nix
+++ b/pkgs/tools/networking/miniupnpc/default.nix
@@ -27,8 +27,8 @@ let
     };
 in {
   miniupnpc_2 = generic {
-    version = "2.0.20171212";
-    sha256 = "0za7pr6hrr3ajkifirhhxfn3hlhl06f622g8hnj5h8y18sp3bwff";
+    version = "2.0.20180222";
+    sha256 = "0xavcrifk8v8gwig3mj0kjkm7rvw1kbsxcs4jxrrzl39cil48yaq";
   };
   miniupnpc_1 = generic {
     version = "1.9.20160209";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip -h` got 0 exit code
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip --help` got 0 exit code
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip help` got 0 exit code
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip -V` and found version 2.0.20180222
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip -v` and found version 2.0.20180222
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip --version` and found version 2.0.20180222
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip version` and found version 2.0.20180222
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip -h` and found version 2.0.20180222
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip --help` and found version 2.0.20180222
- ran `/nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222/bin/external-ip help` and found version 2.0.20180222
- found 2.0.20180222 with grep in /nix/store/akl3iiz899jl683calinfyf1wfgfl6a2-miniupnpc-2.0.20180222
- directory tree listing: https://gist.github.com/d79d8cc6872502e398d403b10aad9934