### PR TITLE
mir-qualia: 1.0.0 -> 2.0.0

### DIFF
--- a/pkgs/tools/text/mir-qualia/default.nix
+++ b/pkgs/tools/text/mir-qualia/default.nix
@@ -2,14 +2,14 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "mir.qualia-${version}";
-  version = "1.0.0";
-  doCheck = false; # 1.0.0-released pytests are broken
+  version = "2.0.0";
+  doCheck = false; # 2.0.0-released pytests are broken
 
   buildInputs = with pythonPackages; [ pytest ];
 
   src = fetchurl {
     url = "mirror://pypi/m/mir.qualia/mir.qualia-${version}.tar.gz";
-    sha256 = "1g0nwncwk4nq7b7zszqi1q4d2bdga1q50g9nkxigdaq647wqdf7x";
+    sha256 = "1ybq6jb5clh9hw0sp3idp4hjv2gkm9yiaph48gcc208affflc8m9";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/k04xnvxmkwbyjis7x2fwfdhc8s1cdfyw-mir.qualia-2.0.0/bin/.qualia-wrapped -h` got 0 exit code
- ran `/nix/store/k04xnvxmkwbyjis7x2fwfdhc8s1cdfyw-mir.qualia-2.0.0/bin/.qualia-wrapped --help` got 0 exit code
- ran `/nix/store/k04xnvxmkwbyjis7x2fwfdhc8s1cdfyw-mir.qualia-2.0.0/bin/qualia -h` got 0 exit code
- ran `/nix/store/k04xnvxmkwbyjis7x2fwfdhc8s1cdfyw-mir.qualia-2.0.0/bin/qualia --help` got 0 exit code
- found 2.0.0 with grep in /nix/store/k04xnvxmkwbyjis7x2fwfdhc8s1cdfyw-mir.qualia-2.0.0
- directory tree listing: https://gist.github.com/18601b1231672c52d2a59f11fff236f8

cc @srhb for review