### PR TITLE
modemmanager: 1.6.8 -> 1.7.990

### DIFF
--- a/pkgs/tools/networking/modemmanager/default.nix
+++ b/pkgs/tools/networking/modemmanager/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "ModemManager-${version}";
-  version = "1.6.8";
+  version = "1.7.990";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/ModemManager/${name}.tar.xz";
-    sha256 = "0xj3ng7qcqxkib5qkprwghcivaz0mn449fw08l67h1zbpz23bh7z";
+    sha256 = "1v4hixmghlrw7w4ajq2x4k62js0594h223d0yma365zwqr7hjrfl";
   };
 
   nativeBuildInputs = [ intltool pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/mmcli -h` got 0 exit code
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/mmcli --help` got 0 exit code
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/mmcli -V` and found version 1.7.990
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/mmcli --version` and found version 1.7.990
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/ModemManager -h` got 0 exit code
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/ModemManager --help` got 0 exit code
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/ModemManager help` got 0 exit code
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/ModemManager -V` and found version 1.7.990
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/ModemManager --version` and found version 1.7.990
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/ModemManager version` and found version 1.7.990
- ran `/nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990/bin/ModemManager help` and found version 1.7.990
- found 1.7.990 with grep in /nix/store/fhdp2fqwskd6lapfh48jx2i0cl2kigia-ModemManager-1.7.990
- directory tree listing: https://gist.github.com/592c27801440ea1a5b2d0968b89177dd