### PR TITLE
mpich2: 3.2.1 -> 3.3b1

### DIFF
--- a/pkgs/development/libraries/mpich2/default.nix
+++ b/pkgs/development/libraries/mpich2/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation  rec {
   name = "mpich-${version}";
-  version = "3.2.1";
+  version = "3.3b1";
 
   src = fetchurl {
     url = "http://www.mpich.org/static/downloads/${version}/mpich-${version}.tar.gz";
-    sha256 = "1w9h4g7d46d9l5jbcyfxpaqzpjrc5hyvr9d0ns7278psxpr3pdax";
+    sha256 = "161wk0dfb0s9c9ig4a1gdvm0qwxh8nlq5j1yqrz060gf92n25j7h";
   };
 
   configureFlags = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/parkill -h` got 0 exit code
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/parkill help` got 0 exit code
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpicc --help` got 0 exit code
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpicc -v` and found version 3.3b1
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpicxx --help` got 0 exit code
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpicxx -v` and found version 3.3b1
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpiexec.hydra -h` got 0 exit code
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpiexec.hydra --help` got 0 exit code
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpiexec.hydra --version` and found version 3.3b1
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpichversion -v` and found version 3.3b1
- ran `/nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1/bin/mpichversion --version` and found version 3.3b1
- found 3.3b1 with grep in /nix/store/xmp1026d9gjmisf4z5fcwiw0iis1c49w-mpich-3.3b1
- directory tree listing: https://gist.github.com/bfaeb16995b481e7aced98b13372fa41

cc @markuskowa for review