### PR TITLE
mysql_jdbc: 5.1.45 -> 5.1.46

### DIFF
--- a/pkgs/servers/sql/mysql/jdbc/default.nix
+++ b/pkgs/servers/sql/mysql/jdbc/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, ant, unzip}:
 
 stdenv.mkDerivation rec {
-  name = "mysql-connector-java-5.1.45";
+  name = "mysql-connector-java-5.1.46";
   builder = ./builder.sh;
 
   src = fetchurl {
     url = "http://dev.mysql.com/get/Downloads/Connector-J/${name}.zip";
-    sha256 = "1x3dygygj15p7zk825mqr0g80wlm3rfsqgbqnb11l133rk4s1ylw";
+    sha256 = "0dfjshrrx0ndfb6xbdpwhn1f1jkw0km57rgpar0ny8ixmgdnlwnm";
   };
 
   buildInputs = [ unzip ant ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/81178700485a613e552bedbac7095177