### PR TITLE
netcdf: 4.6.0 -> 4.6.1

### DIFF
--- a/pkgs/development/libraries/netcdf/default.nix
+++ b/pkgs/development/libraries/netcdf/default.nix
@@ -9,11 +9,11 @@ let
   mpiSupport = hdf5.mpiSupport;
   mpi = hdf5.mpi;
 in stdenv.mkDerivation rec {
-  name = "netcdf-4.6.0";
+  name = "netcdf-4.6.1";
 
   src = fetchurl {
     url = "https://www.unidata.ucar.edu/downloads/netcdf/ftp/${name}.tar.gz";
-    sha256 = "099qmdjj059wkj5za13zqnz0lcziqkcvyfdf894j4n6qq4c5iw2b";
+    sha256 = "0hi61cdihwwvz5jz1l7yq712j7ca1cj4bhr8x0x7c2vlb1s9biw9";
   };
 
   nativeBuildInputs = [ m4 ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/zchkzwsgsnl8aqbxzvi7hh93bdfl4759-netcdf-4.6.1/bin/nc-config --help` got 0 exit code
- ran `/nix/store/zchkzwsgsnl8aqbxzvi7hh93bdfl4759-netcdf-4.6.1/bin/nc-config --version` and found version 4.6.1
- found 4.6.1 with grep in /nix/store/zchkzwsgsnl8aqbxzvi7hh93bdfl4759-netcdf-4.6.1
- directory tree listing: https://gist.github.com/74ab9782611602d870caba813c09697e