### PR TITLE
netcdffortran: 4.4.3 -> 4.4.4

### DIFF
--- a/pkgs/development/libraries/netcdf-fortran/default.nix
+++ b/pkgs/development/libraries/netcdf-fortran/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, netcdf, hdf5, curl, gfortran }:
 stdenv.mkDerivation rec {
   name = "netcdf-fortran-${version}";
-  version = "4.4.3";
+  version = "4.4.4";
 
   src = fetchurl {
     url = "https://github.com/Unidata/netcdf-fortran/archive/v${version}.tar.gz";
-    sha256 = "4170fc018c9ee8222e317215c6a273542623185f5f6ee00d37bbb4e024e4e998";
+    sha256 = "0rwybszj1jjb25cx8vfyrd77x5qsdjzwspcjz56n12br89n9ica4";
   };
 
   buildInputs = [ netcdf hdf5 curl gfortran ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/iab00yc7zgj1q5cdazbnfbx2gc9f6zi0-netcdf-fortran-4.4.4/bin/nf-config -h` got 0 exit code
- ran `/nix/store/iab00yc7zgj1q5cdazbnfbx2gc9f6zi0-netcdf-fortran-4.4.4/bin/nf-config --help` got 0 exit code
- ran `/nix/store/iab00yc7zgj1q5cdazbnfbx2gc9f6zi0-netcdf-fortran-4.4.4/bin/nf-config help` got 0 exit code
- ran `/nix/store/iab00yc7zgj1q5cdazbnfbx2gc9f6zi0-netcdf-fortran-4.4.4/bin/nf-config --version` and found version 4.4.4
- found 4.4.4 with grep in /nix/store/iab00yc7zgj1q5cdazbnfbx2gc9f6zi0-netcdf-fortran-4.4.4
- directory tree listing: https://gist.github.com/c28218d35636f05cac88796c8fe27ec1

cc @bzizou for review