### PR TITLE
netsurf.buildsystem: 1.5 -> 1.6

### DIFF
--- a/pkgs/applications/misc/netsurf/buildsystem/default.nix
+++ b/pkgs/applications/misc/netsurf/buildsystem/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   name = "netsurf-buildsystem-${version}";
-  version = "1.5";
+  version = "1.6";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/buildsystem-${version}.tar.gz";
-    sha256 = "0wdgvasrjik1dgvvpqbppbpyfzkqd1v45x3g9rq7p67n773azinv";
+    sha256 = "0p5k708lcq8dip9xxck6hml32bjrbyipprm22bbsvdnsc0pqm71x";
   };
 
   makeFlags = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/8d2bc8fda08696882cec0fd25ff22ac3

cc @vrthra for review