### PR TITLE
networkmanager_strongswan: 1.4.1 -> 1.4.3

### DIFF
--- a/pkgs/tools/networking/network-manager/strongswan.nix
+++ b/pkgs/tools/networking/network-manager/strongswan.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
   name    = "${pname}-${version}";
   pname   = "NetworkManager-strongswan";
-  version = "1.4.1";
+  version = "1.4.3";
 
   src = fetchurl {
     url    = "https://download.strongswan.org/NetworkManager/${name}.tar.bz2";
-    sha256 = "0r5j8cr4x01d2cdy970990292n7p9v617cw103kdczw646xwcxs8";
+    sha256 = "0jzl52wmh2q2djb1s546kxliy7s6akhi5bx6rp2ppjfk3wbi2a2l";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.4.3 with grep in /nix/store/y2jkp10za0xpb7slalbfp3qyh9sgls70-NetworkManager-strongswan-1.4.3
- directory tree listing: https://gist.github.com/3d79a64230389ed5f84ff788ad4c56f1