### PR TITLE
oraclejdk: add version 10

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
@@ -29,7 +29,7 @@ assert stdenv.system == "x86_64-linux";
 assert swingSupport -> xorg != null;
 
 let
-  version = "9.0.4";
+  version = "10";
 
   downloadUrlBase = http://www.oracle.com/technetwork/java/javase/downloads;
 
@@ -51,20 +51,20 @@ let result = stdenv.mkDerivation rec {
     if packageType == "JDK" then
       requireFile {
         name = "jdk-${version}_linux-x64_bin.tar.gz";
-        url =  "${downloadUrlBase}/jdk9-downloads-3848520.html";
-        sha256 = "18nsjn64wkfmyb09wf2k7lvhazf83cs3dyichr038vl1gs3ymi4h";
+        url =  "${downloadUrlBase}/jdk10-downloads-4416644.html";
+        sha256 = "0338m0x5lka0xjsbcll70r1i308bjw3m42cm9dx9zmfk70kplj5c";
       }
     else if packageType == "JRE" then
       requireFile {
         name = "jre-${version}_linux-x64_bin.tar.gz";
-        url = "${downloadUrlBase}/jre9-downloads-3848532.html";
-        sha256 = "01fp079mr04nniyf06w8vd47qxr6rly1lbh8dqkddb8fp9h6a79k";
+        url = "${downloadUrlBase}/jre10-downloads-4417026.html";
+        sha256 = "1clawcahkla1h9pxnqfqzcgv51aqgq78v1ws5jygbk6fbbi7l54w";
       }
     else if packageType == "ServerJRE" then
       requireFile {
         name = "serverjre-${version}_linux-x64_bin.tar.gz";
-        url = "${downloadUrlBase}/server-jre9-downloads-3848530.html";
-        sha256 = "1jlpa4mn306hx0p9jcw3i6cpdvnng29dwjsymgcan56810q6p6yj";
+        url = "${downloadUrlBase}/sjre10-downloads-4417025.html";
+        sha256 = "0kiyg33fv29ad0nyl35r7y0bhyxivb2hxlds44m9l0259s55nwhw";
       }
     else abort "unknown package Type ${packageType}";
 
@@ -155,4 +155,4 @@ let result = stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ]; # some inherit jre.meta.platforms
   };
 
-}; in stdenv.lib.warn "Oracle JDK/JRE 9 is not updated anymore. Use 10." result
+}; in result

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6421,6 +6421,8 @@ with pkgs;
 
   oraclejdk9 = pkgs.oraclejdk9distro "JDK" false;
 
+  oraclejdk10 = pkgs.oraclejdk10distro "JDK" false;
+
   oraclejre = lowPrio (pkgs.jdkdistro false false);
 
   oraclejre8 = lowPrio (pkgs.oraclejdk8distro false false);
@@ -6429,7 +6431,11 @@ with pkgs;
 
   oraclejre9 = lowPrio (pkgs.oraclejdk9distro "JRE" false);
 
+  oraclejre10 = lowPrio (pkgs.oraclejdk10distro "JRE" false);
+
   oracleserverjre9 = lowPrio (pkgs.oraclejdk9distro "ServerJRE" false);
+
+  oracleserverjre10 = lowPrio (pkgs.oraclejdk10distro "ServerJRE" false);
 
   jrePlugin = jre8Plugin;
 
@@ -6448,6 +6454,10 @@ with pkgs;
   oraclejdk9distro = packageType: pluginSupport:
     (if pluginSupport then appendToName "with-plugin" else x: x)
       (callPackage ../development/compilers/oraclejdk/jdk9-linux.nix { inherit packageType pluginSupport; });
+
+  oraclejdk10distro = packageType: pluginSupport:
+    (if pluginSupport then appendToName "with-plugin" else x: x)
+      (callPackage ../development/compilers/oraclejdk/jdk10-linux.nix { inherit packageType pluginSupport; });
 
   jikes = callPackage ../development/compilers/jikes { };
 


### PR DESCRIPTION
###### Motivation for this change

- Local-variable type inference
- Additional Unicode language-tag extensions
- Time-based release versioning
- Better Docker support
- Parallel full GC for G1
- Removal of deprecated methods and features
- etc.

http://www.oracle.com/technetwork/java/javase/10-relnote-issues-4108729.html

Oracle JDK/JRE 9 is no longer updated. Should we remove nixexprs for those packages? 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

