### PR TITLE
ocamlPackages.bitstring: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/bitstring/default.nix
+++ b/pkgs/development/ocaml-modules/bitstring/default.nix
@@ -2,10 +2,10 @@
 
 buildOcaml rec {
   name = "bitstring";
-  version = "2.1.0";
+  version = "2.1.1";
   src = fetchurl {
-    url = http://github.com/xguerin/bitstring/archive/v2.1.0.tar.gz;
-    sha256 = "0miw4banfpmx4kxrckpqr57b1fcmsqdmspyjx6gqjd4kghm4l7xj";
+    url = http://github.com/xguerin/bitstring/archive/v2.1.1.tar.gz;
+    sha256 = "0vy8ibrxccii1jbsk5q6yh1kxjigqvi7lhhcmizvd5gfhf7mfyc8";
   };
 
   patches = [ ./camlp4-git.patch ./srcdir.patch ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.1.1 with grep in /nix/store/82mvh5s9b7njvwvf2a0c3bw27qm0af4n-ocaml-bitstring-2.1.1
- directory tree listing: https://gist.github.com/6a7bc29539027df0f0f45f8f9e9c1b45

cc @maurer for review