### PR TITLE
ocamlPackages.comparelib: 109.60.00 -> 113.00.00

### DIFF
--- a/pkgs/development/ocaml-modules/comparelib/default.nix
+++ b/pkgs/development/ocaml-modules/comparelib/default.nix
@@ -2,13 +2,13 @@
 
 buildOcaml rec {
   name = "comparelib";
-  version = "109.60.00";
+  version = "113.00.00";
 
   minimumSupportedOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/comparelib/archive/${version}.tar.gz";
-    sha256 = "1075fb05e0d1e290f71ad0f6163f32b2cb4cebdc77568491c7eb38ba91f5db7e";
+    sha256 = "02l343drgi4200flfx73nzdk61zajwidsqjk9n80b2d37lvhazlf";
   };
 
   propagatedBuildInputs = [ type_conv ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 113.00.00 with grep in /nix/store/gdvngw3bv43p5ms1r0z6mfyz44pds5ck-ocaml-comparelib-113.00.00
- directory tree listing: https://gist.github.com/e2bf9625e7cfaca3ffe5d8077977c36c

cc @ericbmerritt for review