### PR TITLE
ocamlPackages.herelib: 109.35.02 -> 112.35.00

### DIFF
--- a/pkgs/development/ocaml-modules/herelib/default.nix
+++ b/pkgs/development/ocaml-modules/herelib/default.nix
@@ -1,14 +1,14 @@
 {stdenv, buildOcaml, fetchurl}:
 
 buildOcaml rec {
-  version = "109.35.02";
+  version = "112.35.00";
   name = "herelib";
 
   minimumSupportedOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/herelib/archive/${version}.tar.gz";
-    sha256 = "7f8394169cb63f6d41e91c9affa1b8ec240d5f6e9dfeda3fbb611df521d4b05a";
+    sha256 = "03rrlpjmnd8d1rzzmd112355m7a5bwn3vf90xkbc6gkxlad9cxbs";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 112.35.00 with grep in /nix/store/fi8xvwsqw6c7fjn524ikskpdpi36gb6f-ocaml-herelib-112.35.00
- directory tree listing: https://gist.github.com/ed38197efceac2aed2e22c37ba8992c2

cc @ericbmerritt for review