### PR TITLE
ocamlPackages.pa_bench: 112.06.00 -> 113.00.00

### DIFF
--- a/pkgs/development/ocaml-modules/pa_bench/default.nix
+++ b/pkgs/development/ocaml-modules/pa_bench/default.nix
@@ -2,13 +2,13 @@
 
 buildOcaml rec {
   name = "pa_bench";
-  version = "112.06.00";
+  version = "113.00.00";
 
   minimumSupportedOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/pa_bench/archive/${version}.tar.gz";
-    sha256 = "e3401e37f1d3d4acb957fd46a192d0ffcefeb0bedee63bbeb26969af1d540870";
+    sha256 = "1cd6291gdnk6h8ziclg6x3if8z5xy67nfz9gx8sx4k2cwv0j29k5";
   };
 
   buildInputs = [ pa_ounit ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 113.00.00 with grep in /nix/store/z75i3hc6a7yn9jciri3zwpzrzmcxfs9y-ocaml-pa_bench-113.00.00
- directory tree listing: https://gist.github.com/81cbcb6edb9964f7b33a8fd163ad6e30

cc @ericbmerritt for review