### PR TITLE
ocamlPackages.pa_ounit: 112.24.00 -> 113.00.00

### DIFF
--- a/pkgs/development/ocaml-modules/pa_ounit/default.nix
+++ b/pkgs/development/ocaml-modules/pa_ounit/default.nix
@@ -2,11 +2,11 @@
 
 buildOcaml rec {
   name = "pa_ounit";
-  version = "112.24.00";
+  version = "113.00.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/pa_ounit/archive/${version}.tar.gz";
-    sha256 = "fa04e72fe1db41e6dc64f9707cf5705cb9b957aa93265120c875c808eb9b9b96";
+    sha256 = "0vi0p2hxcrdsl0319c9s8mh9hmk2i4ir6c6vrj8axkc37zkgc437";
   };
 
   propagatedBuildInputs = [ ounit ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 113.00.00 with grep in /nix/store/rpbwnyaisfm27cf36hb7scsa833r1lkb-ocaml-pa_ounit-113.00.00
- directory tree listing: https://gist.github.com/7284ca806fd00f73984a14b088879e92

cc @ericbmerritt for review