### PR TITLE
ocamlPackages.pipebang: 110.01.00 -> 113.00.00

### DIFF
--- a/pkgs/development/ocaml-modules/pipebang/default.nix
+++ b/pkgs/development/ocaml-modules/pipebang/default.nix
@@ -2,13 +2,13 @@
 
 buildOcaml rec {
   name = "pipebang";
-  version = "110.01.00";
+  version = "113.00.00";
 
   minimumSupportedOcamlVersion = "4.00";
 
   src = fetchurl {
     url = "https://github.com/janestreet/pipebang/archive/${version}.tar.gz";
-    sha256 = "a8858d9607c15cdf0a775196be060c8d91de724fc80a347d7a76ef1d38329096";
+    sha256 = "0acm2y8wxvnapa248lkgm0vcc44hlwhrjxqkx1awjxzcmarnxhfk";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 113.00.00 with grep in /nix/store/kq6az2hq7xjwwsk5zaqvsxk404fkwxib-ocaml-pipebang-113.00.00
- directory tree listing: https://gist.github.com/f574e3b8aec1bc7c22f6688c2a1afed4

cc @ericbmerritt for review