### PR TITLE
ocamlPackages.ppx_tools_versioned: 5.0.1 -> 5.1

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
@@ -2,7 +2,7 @@
 
 buildOcaml rec {
   name = "ppx_tools_versioned";
-  version = "5.0.1";
+  version = "5.1";
 
   minimumSupportedOcamlVersion = "4.02";
 
@@ -10,7 +10,7 @@ buildOcaml rec {
     owner = "let-def";
     repo = "ppx_tools_versioned";
     rev = version;
-    sha256 = "1rpbxbhk3k7f61h7lr4qkllkc12gjpq0rg52q7i6hcrg2dxkhwh6";
+    sha256 = "1c7kvca67qpyr4hiy492yik5x31lmkhyhy5wpl0l0fbx7fr7l624";
   };
 
   propagatedBuildInputs = [ ocaml-migrate-parsetree ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 5.1 with grep in /nix/store/6bf2nw21lnwsmdy72z7vcwsx7ipvsmmy-ocaml-ppx_tools_versioned-5.1
- directory tree listing: https://gist.github.com/769030f036fe6d5816eb1c77cdd9ecd0

cc @volth for review