### PR TITLE
ocamlPackages.type_conv: 112.01.01 -> 113.00.02

### DIFF
--- a/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
@@ -4,11 +4,11 @@ buildOcaml rec {
   minimumSupportedOcamlVersion = "4.02";
 
   name = "type_conv";
-  version = "112.01.01";
+  version = "113.00.02";
 
   src = fetchurl {
     url = "https://github.com/janestreet/type_conv/archive/${version}.tar.gz";
-    sha256 = "dbbc33b7ab420e8442d79ba4308ea6c0c16903b310d33525be18841159aa8855";
+    sha256 = "1718yl2q8zandrs4xqffkfmssfld1iz62dzcqdm925735c1x01fk";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 113.00.02 with grep in /nix/store/ph9bs0vwwgpm1gcypd37ia7h3iybrzlf-ocaml-type_conv-113.00.02
- directory tree listing: https://gist.github.com/e0e5582781203fe8077a8ede54af0ef6

cc @maggesi @ericbmerritt for review