### PR TITLE
ocamlPackages.ocamlbuild: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, ocaml, findlib }:
 let
-  version = "0.11.0";
+  version = "0.12.0";
 in
 stdenv.mkDerivation {
   name = "ocamlbuild-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     owner = "ocaml";
     repo = "ocamlbuild";
     rev = version;
-    sha256 = "0c8lv15ngmrc471jmkv0jp3d573chibwnjlavps047d9hd8gwxak";
+    sha256 = "1shyim50ms0816fphc4mk0kldcx3pnba2i6m10q0cbm18m9d7chq";
   };
 
   createFindlibDestdir = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/b1b0f9iyawv0rm483q2fbbfhgjgpjdik-ocamlbuild-0.12.0/bin/ocamlbuild --help` got 0 exit code
- ran `/nix/store/b1b0f9iyawv0rm483q2fbbfhgjgpjdik-ocamlbuild-0.12.0/bin/ocamlbuild --version` and found version 0.12.0
- ran `/nix/store/b1b0f9iyawv0rm483q2fbbfhgjgpjdik-ocamlbuild-0.12.0/bin/ocamlbuild --help` and found version 0.12.0
- ran `/nix/store/b1b0f9iyawv0rm483q2fbbfhgjgpjdik-ocamlbuild-0.12.0/bin/ocamlbuild.native --help` got 0 exit code
- ran `/nix/store/b1b0f9iyawv0rm483q2fbbfhgjgpjdik-ocamlbuild-0.12.0/bin/ocamlbuild.native --version` and found version 0.12.0
- ran `/nix/store/b1b0f9iyawv0rm483q2fbbfhgjgpjdik-ocamlbuild-0.12.0/bin/ocamlbuild.native --help` and found version 0.12.0
- found 0.12.0 with grep in /nix/store/b1b0f9iyawv0rm483q2fbbfhgjgpjdik-ocamlbuild-0.12.0
- directory tree listing: https://gist.github.com/3b75d2c602f455856f9642228b53d2e7

cc @vbgl for review