### PR TITLE
oniguruma: 6.6.1 -> 6.7.1

### DIFF
--- a/pkgs/development/libraries/oniguruma/default.nix
+++ b/pkgs/development/libraries/oniguruma/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "onig-${version}";
-  version = "6.6.1";
+  version = "6.7.1";
 
   src = fetchFromGitHub {
     owner = "kkos";
     repo = "oniguruma";
     rev = "v${version}";
-    sha256 = "062g5443dyxsraq346panfqvbd6wal6nmb336n4dw1rszx576sxz";
+    sha256 = "07xbx4f3h1aqvy6587xbr8fgcn679ph3bd86pp144y0agzw0d0q2";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 6.7.1 with grep in /nix/store/adypaqqfpnmali0662725r7xdzgyqqh0-onig-6.7.1
- directory tree listing: https://gist.github.com/b40671987a847be6597a16cb977ff6a4

cc @fuuzetsu for review