### PR TITLE
openisns: 0.97 -> 0.98

### DIFF
--- a/pkgs/os-specific/linux/open-isns/default.nix
+++ b/pkgs/os-specific/linux/open-isns/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "open-isns-${version}";
-  version = "0.97";
+  version = "0.98";
 
   src = fetchFromGitHub {
     owner = "gonzoleeman";
     repo = "open-isns";
     rev = "v${version}";
-    sha256 = "17aichjgkwjfp9dx1piw7dw8ddz1bgm5mk3laid2zvjks1h739k3";
+    sha256 = "055gjwz5hxaj5jk23bf7dy9wbxk9m8cfgl1msbzjc60gr2mmcbdg";
   };
 
   propagatedBuildInputs = [ openssl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/fabx95vlf0nyw2dvsq2zjsv8j2vdqs12-open-isns-0.98/bin/isnsadm -h` got 0 exit code
- ran `/nix/store/fabx95vlf0nyw2dvsq2zjsv8j2vdqs12-open-isns-0.98/bin/isnsadm --help` got 0 exit code
- ran `/nix/store/fabx95vlf0nyw2dvsq2zjsv8j2vdqs12-open-isns-0.98/bin/isnsd -h` got 0 exit code
- ran `/nix/store/fabx95vlf0nyw2dvsq2zjsv8j2vdqs12-open-isns-0.98/bin/isnsd --help` got 0 exit code
- ran `/nix/store/fabx95vlf0nyw2dvsq2zjsv8j2vdqs12-open-isns-0.98/bin/isnsdd -h` got 0 exit code
- ran `/nix/store/fabx95vlf0nyw2dvsq2zjsv8j2vdqs12-open-isns-0.98/bin/isnsdd --help` got 0 exit code
- found 0.98 with grep in /nix/store/fabx95vlf0nyw2dvsq2zjsv8j2vdqs12-open-isns-0.98
- directory tree listing: https://gist.github.com/1ad3d6e680af4f1462bda181b2cdc43e