### PR TITLE
exrdisplay: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/applications/graphics/exrdisplay/default.nix
+++ b/pkgs/applications/graphics/exrdisplay/default.nix
@@ -3,11 +3,11 @@
 assert fltk.glSupport;
 
 stdenv.mkDerivation {
-  name ="openexr_viewers-2.2.0";
+  name ="openexr_viewers-2.2.1";
 
   src = fetchurl {
-    url =  "mirror://savannah/openexr/openexr_viewers-2.2.0.tar.gz";
-    sha256 = "1s84vnas12ybx8zz0jcmpfbk9m4ab5bg2d3cglqwk3wys7jf4gzp";
+    url =  "mirror://savannah/openexr/openexr_viewers-2.2.1.tar.gz";
+    sha256 = "1ixx2wbjp4rvsf7h3bkja010gl1ihjrcjzy7h20jnn47ikg12vj8";
   };
 
   configurePhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.2.1 with grep in /nix/store/kpbzkj0s48h5mvvsvprqfqpah2kispil-openexr_viewers-2.2.1
- directory tree listing: https://gist.github.com/946b2664eb02e90d8d73194ffd04ac5f