### PR TITLE
openrct2: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -5,20 +5,20 @@
 
 let
   name = "openrct2-${version}";
-  version = "0.1.1";
+  version = "0.1.2";
 
   openrct2-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenRCT2";
     rev = "v${version}";
-    sha256 = "1xxwqx2gzvsdrsy76rz3sys9m4pyn9q25nbnkba3cw1z4l2b73lg";
+    sha256 = "1zqrdxr79c9yx4bdxz1r5866hhwq0lcs9qpv3vhisr56ar5n5wk3";
   };
 
   title-sequences-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "title-sequences";
-    rev = "v0.1.0";
-    sha256 = "17c926lhby90ilvyyl6jsiy0df8dw5jws97xigp3x8hddhvv7c16";
+    rev = "v0.1.2";
+    sha256 = "1yb1ynkfmiankii3fngr9km5wbc07rp30nh0apkj6wryrhy7imgm";
   };
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2 -h` got 0 exit code
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2 --help` got 0 exit code
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2 -v` and found version 0.1.2
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2 --version` and found version 0.1.2
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2-cli -h` got 0 exit code
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2-cli --help` got 0 exit code
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2-cli help` got 0 exit code
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2-cli -v` and found version 0.1.2
- ran `/nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2/bin/openrct2-cli --version` and found version 0.1.2
- found 0.1.2 with grep in /nix/store/qza712wxad8v4scd06gb2jisl0cl9vf6-openrct2-0.1.2
- directory tree listing: https://gist.github.com/dfc357796fabf91024a21e322be78e5f

cc @geistesk for review