### PR TITLE
owncloud91: 9.1.3 -> 10.0.7

### DIFF
--- a/pkgs/servers/owncloud/default.nix
+++ b/pkgs/servers/owncloud/default.nix
@@ -58,8 +58,8 @@ in {
   };
 
   owncloud91 = common {
-    versiona = "9.1.3";
-    sha256 = "1sgnsj2ng14lh05n5kc3jv03xk6xnkyx7xj1rasxlqgvzwsyp8g0";
+    versiona = "10.0.7";
+    sha256 = "1c0gklk1iqfql1fk2rh6k787vk6pa58ld98k6ap928qqcfhjm0kw";
   };
 
 }


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 10.0.7 with grep in /nix/store/c8p81wv8afhs19jca5vlcp0fjkvc9wkl-owncloud-10.0.7
- directory tree listing: https://gist.github.com/9231813b33fae2850c53e5bac08234de

cc @matejc for review