### PR TITLE
libcec_platform: 2.0.1 -> 2.1.0.1

### DIFF
--- a/pkgs/development/libraries/libcec/platform.nix
+++ b/pkgs/development/libraries/libcec/platform.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, cmake }:
 
-let version = "2.0.1"; in
+let version = "2.1.0.1"; in
 
 stdenv.mkDerivation {
   name = "p8-platform-${version}";
 
   src = fetchurl {
     url = "https://github.com/Pulse-Eight/platform/archive/p8-platform-${version}.tar.gz";
-    sha256 = "1kslq24p2zams92kc247qcczbxb2n89ykk9jfyiilmwh7qklazp9";
+    sha256 = "18381y54f7d18ckpzf9cfxbz1ws6imprbbm9pvhcg5c86ln8skq6";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.1.0.1 with grep in /nix/store/klb1bvsf1az785f2jzvsg5g0sxs8g4l3-p8-platform-2.1.0.1
- directory tree listing: https://gist.github.com/be00d099a69bdff53bd6e138cf5d6877

cc @titanous for review