### PR TITLE
pam_krb5: 4.7 -> 4.8

### DIFF
--- a/pkgs/os-specific/linux/pam_krb5/default.nix
+++ b/pkgs/os-specific/linux/pam_krb5/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pam, kerberos }:
 
 stdenv.mkDerivation rec {
-  name = "pam-krb5-4.7";
+  name = "pam-krb5-4.8";
 
   src = fetchurl {
     url = "http://archives.eyrie.org/software/kerberos/${name}.tar.gz";
-    sha256 = "04klg9a2rhdz0a2dw4f0ybcm28vcbab6lrynwq7rm4sn0hnzakwv";
+    sha256 = "0j96jfaxzkj1ifc3qxagjmaxvgda7ndqaaxx2ka018is9f5lbfrs";
   };
 
   buildInputs = [ pam kerberos ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 4.8 with grep in /nix/store/lbmm10zm3yif6n33xvw5irzhzsqkwk7b-pam-krb5-4.8
- directory tree listing: https://gist.github.com/8511cb10102508ce5701ed7e0830e60c

cc @wkennington for review