### PR TITLE
pcmciaUtils: 017 -> 018

### DIFF
--- a/pkgs/os-specific/linux/pcmciautils/default.nix
+++ b/pkgs/os-specific/linux/pcmciautils/default.nix
@@ -8,11 +8,11 @@
 
 # FIXME: should add an option to choose between hotplug and udev.
 stdenv.mkDerivation rec {
-  name = "pcmciautils-017";
+  name = "pcmciautils-018";
 
   src = fetchurl {
     url = "https://kernel.org/pub/linux/utils/kernel/pcmcia/${name}.tar.gz";
-    sha256 = "5d8e2efad8a7f692129610603da232f2144851753d8d49a70eeb8eb1be6f6bc3";
+    sha256 = "0sfm3w2n73kl5w7gb1m6q8gy5k4rgwvzz79n6yhs9w3sag3ix8sk";
   };
 
   buildInputs = [udev yacc sysfsutils kmod flex];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/d7b3p8gcfc0qmfmi5rz3igycjbllkpgq-pcmciautils-018/bin/pccardctl -h` got 0 exit code
- ran `/nix/store/d7b3p8gcfc0qmfmi5rz3igycjbllkpgq-pcmciautils-018/bin/pccardctl --help` got 0 exit code
- ran `/nix/store/d7b3p8gcfc0qmfmi5rz3igycjbllkpgq-pcmciautils-018/bin/pccardctl -V` and found version 018
- ran `/nix/store/d7b3p8gcfc0qmfmi5rz3igycjbllkpgq-pcmciautils-018/bin/pccardctl --version` and found version 018
- ran `/nix/store/d7b3p8gcfc0qmfmi5rz3igycjbllkpgq-pcmciautils-018/bin/pccardctl -h` and found version 018
- ran `/nix/store/d7b3p8gcfc0qmfmi5rz3igycjbllkpgq-pcmciautils-018/bin/pccardctl --help` and found version 018
- found 018 with grep in /nix/store/d7b3p8gcfc0qmfmi5rz3igycjbllkpgq-pcmciautils-018
- directory tree listing: https://gist.github.com/0340af0c6b28001bbca26c8b5ecf3638