### PR TITLE
pius: 2.2.4 -> 2.2.6

### DIFF
--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -1,6 +1,6 @@
 { fetchFromGitHub, stdenv, pythonPackages, gnupg }:
 
-let version = "2.2.4"; in
+let version = "2.2.6"; in
 pythonPackages.buildPythonApplication {
   name = "pius-${version}";
   namePrefix = "";
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication {
     owner = "jaymzh";
     repo = "pius";
     rev = "v${version}";
-    sha256 = "1yk6ngpk55yjdnzhm5sj675xbzwp7rir816a3aris647gsph1vlx";
+    sha256 = "1rffwyjd84rwx1w5yyqckirm1kdj80ldfwjlw91kk74swhpbpzzj";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.2.6 with grep in /nix/store/q9ca3k22liz3dsaipnlnw8fmggpqx1n1-pius-2.2.6
- directory tree listing: https://gist.github.com/0d14ff30c172f091a342653aae676f55

cc @fuuzetsu @kierdavis for review