### PR TITLE
rdma-core: 17 -> 17.1

### DIFF
--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -3,7 +3,7 @@
 } :
 
 let
-  version = "17";
+  version = "17.1";
 
 in stdenv.mkDerivation {
   name = "rdma-core-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "linux-rdma";
     repo = "rdma-core";
     rev = "v${version}";
-    sha256 = "1xql46favv8i4ni4zqkk9ra2kcqq2dyn7jyi940c869lndmjw9ni";
+    sha256 = "019h5q0szjccdgfk13qy0f2dxd0n1fr407b3qqq1vcmx41w9b6vz";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/ibv_asyncwatch -h` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/ibv_asyncwatch --help` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/ibv_asyncwatch -h` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/ibv_asyncwatch --help` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rxe_cfg -h` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rxe_cfg --help` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rxe_cfg help` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/ibacm help` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/iwpmd -h` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/iwpmd --help` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/iwpmd help` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/iwpmd -V` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/iwpmd -v` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/iwpmd --version` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/iwpmd -h` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/iwpmd --help` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rdma-ndd -h` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rdma-ndd --help` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rdma-ndd help` got 0 exit code
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rdma-ndd -V` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rdma-ndd -v` and found version 17.1
- ran `/nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1/bin/rdma-ndd --version` and found version 17.1
- found 17.1 with grep in /nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1
- found 17.1 in filename of file in /nix/store/2c9wjl45czzxkjdg6gggnqz19jky6ml6-rdma-core-17.1
- directory tree listing: https://gist.github.com/bc45415978e0954a49f501d71dead508

cc @markuskowa for review