### PR TITLE
libhttpseverywhere: fix build (tests)

### DIFF
--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  checkPhase = "./httpseverywhere_test";
+  checkPhase = "(cd test && ./httpseverywhere_test)";
 
   outputs = [ "out" "devdoc" ];
 


### PR DESCRIPTION
###### Motivation for this change

Tests failed after update to v0.8 (wrong directory).

/cc ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

