### PR TITLE
translate-shell: 0.9.6.6 -> 0.9.6.7

### DIFF
--- a/pkgs/applications/misc/translate-shell/default.nix
+++ b/pkgs/applications/misc/translate-shell/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "translate-shell";
-  version = "0.9.6.6";
+  version = "0.9.6.7";
 
   src = fetchFromGitHub {
     owner = "soimort";
     repo = "translate-shell";
     rev = "v" + version;
-    sha256 = "0hbwvc554v6fi4ardidwsnn8hk7p68p155yjllvljjawkbq4qljq";
+    sha256 = "0krcidjh32xwybr1v4nykgf0jjnffjqx125bvn3jh2a44cikyq3n";
   };
 
   phases = [ "buildPhase" "installPhase" "postFixup" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.6.7 with grep in /nix/store/2bsfjdnyfz64kw4gp3sk3bky4wnhz001-translate-shell-0.9.6.7
- directory tree listing: https://gist.github.com/8933394593c7e7f5cf6ec5f813614e43

cc @ebzzry for review