### PR TITLE
unixODBC: 2.3.5 -> 2.3.6

### DIFF
--- a/pkgs/development/libraries/unixODBC/default.nix
+++ b/pkgs/development/libraries/unixODBC/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unixODBC-${version}";
-  version = "2.3.5";
+  version = "2.3.6";
 
   src = fetchurl {
     url = "ftp://ftp.unixodbc.org/pub/unixODBC/${name}.tar.gz";
-    sha256 = "0ns93daph4wmk92d7m2w48x0yki4m1yznxnn97p1ldn6bkh742bn";
+    sha256 = "0sads5b8cmmj526gyjba7ccknl1vbhkslfqshv1yqln08zv3gdl8";
   };
 
   configureFlags = [ "--disable-gui" "--sysconfdir=/etc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/isql --help` got 0 exit code
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/isql --version` and found version 2.3.6
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/isql --help` and found version 2.3.6
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/odbcinst --help` got 0 exit code
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/odbcinst --version` and found version 2.3.6
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/odbcinst --help` and found version 2.3.6
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/iusql --help` got 0 exit code
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/iusql --version` and found version 2.3.6
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/iusql --help` and found version 2.3.6
- ran `/nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6/bin/odbc_config --version` and found version 2.3.6
- found 2.3.6 with grep in /nix/store/mmcxnlq2km3jcd0iwfnfrqr1v3g1k0ax-unixODBC-2.3.6
- directory tree listing: https://gist.github.com/09c59bac7a63f422b01e46272e81915b