### PR TITLE
verilator: 3.920 -> 3.922

### DIFF
--- a/pkgs/applications/science/electronics/verilator/default.nix
+++ b/pkgs/applications/science/electronics/verilator/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "verilator-${version}";
-  version = "3.920";
+  version = "3.922";
 
   src = fetchurl {
     url    = "http://www.veripool.org/ftp/${name}.tgz";
-    sha256 = "1zs3d6h5sbz455fwpgg89h81hkfn92ary8bmhjinc1rd8fm3hp1b";
+    sha256 = "1srv8d1w3mwblfydznl3frswg98i3dkylx8x18c4807wsjk8vflg";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_bin -V` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_bin --version` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_bin_dbg -V` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_bin_dbg --version` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_coverage_bin_dbg -V` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_coverage_bin_dbg --version` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator -V` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator --version` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_coverage -V` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_coverage --version` and found version 3.922
- ran `/nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922/bin/verilator_profcfunc help` got 0 exit code
- found 3.922 with grep in /nix/store/fnypnfihpivkzgwrpi3g6r7ag5psfdim-verilator-3.922
- directory tree listing: https://gist.github.com/04b5044a54bb4ff549696cbcd57cd88e

cc @thoughtpolice for review