### PR TITLE
virtuoso7: 7.0.0 -> 7.2.4.2

### DIFF
--- a/pkgs/servers/sql/virtuoso/7.x.nix
+++ b/pkgs/servers/sql/virtuoso/7.x.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libxml2, openssl, readline, gawk }:
 
 stdenv.mkDerivation rec {
-  name = "virtuoso-opensource-7.0.0";
+  name = "virtuoso-opensource-7.2.4.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/virtuoso/${name}.tar.gz";
-    sha256 = "1z0jdzayv45y57jj8kii6csqfjhswcs8s2krqqfhab54xy6gynbl";
+    sha256 = "12dqam1gc1v93l0bj0vlpvjqppki6y1hqrlznywxnw0rrz9pb002";
   };
 
   buildInputs = [ libxml2 openssl readline gawk ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/xlf49a3742xgl9zhl6v5s31fc6gv2k9h-virtuoso-opensource-7.2.4.2/bin/virtuoso-t help` got 0 exit code
- ran `/nix/store/xlf49a3742xgl9zhl6v5s31fc6gv2k9h-virtuoso-opensource-7.2.4.2/bin/isql --help` got 0 exit code
- ran `/nix/store/xlf49a3742xgl9zhl6v5s31fc6gv2k9h-virtuoso-opensource-7.2.4.2/bin/isqlw --help` got 0 exit code
- ran `/nix/store/xlf49a3742xgl9zhl6v5s31fc6gv2k9h-virtuoso-opensource-7.2.4.2/bin/inifile help` got 0 exit code
- found 7.2.4.2 with grep in /nix/store/xlf49a3742xgl9zhl6v5s31fc6gv2k9h-virtuoso-opensource-7.2.4.2
- directory tree listing: https://gist.github.com/dcd661201732277a82f8e3f4e4263587