### PR TITLE
xorg.xbacklight: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -92,10 +92,10 @@ let
   }) // {inherit ;};
 
   damageproto = (mkDerivation "damageproto" {
-    name = "damageproto-1.2.1";
+    name = "damageproto-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/X11R7.7/src/everything/damageproto-1.2.1.tar.bz2;
+      url = mirror://xorg/X11R7.7/src/everything/damageproto-1.2.2.tar.bz2;
       sha256 = "0nzwr5pv9hg7c21n995pdiv0zqhs91yz3r8rn3aska4ykcp12z2w";
     };
     nativeBuildInputs = [ pkgconfig ];
@@ -1424,11 +1424,11 @@ let
   }) // {inherit libX11 libXau libXext libXmu xproto ;};
 
   xbacklight = (mkDerivation "xbacklight" {
-    name = "xbacklight-1.2.1";
+    name = "xbacklight-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/app/xbacklight-1.2.1.tar.bz2;
-      sha256 = "0arnd1j8vzhzmw72mqhjjcb2qwcbs9qphsy3ps593ajyld8wzxhp";
+      url = mirror://xorg/individual/app/xbacklight-1.2.2.tar.bz2;
+      sha256 = "0pmzaz4kp38qv2lqiw5rnqhwzmwrq65m1x5j001mmv99wh9isnk1";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ libxcb xcbutil ];
@@ -2384,10 +2384,10 @@ let
   }) // {inherit libX11 libXau libXmu xproto ;};
 
   xineramaproto = (mkDerivation "xineramaproto" {
-    name = "xineramaproto-1.2.1";
+    name = "xineramaproto-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/X11R7.7/src/everything/xineramaproto-1.2.1.tar.bz2;
+      url = mirror://xorg/X11R7.7/src/everything/xineramaproto-1.2.2.tar.bz2;
       sha256 = "0ns8abd27x7gbp4r44z3wc5k9zqxxj8zjnazqpcyr4n17nxp8xcp";
     };
     nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.2.2 with grep in /nix/store/y023vl1iizdkqp59dhk0s56dd3qx7y7p-xbacklight-1.2.2
- directory tree listing: https://gist.github.com/fced4656541c4188f59d3b238c2736d2