### PR TITLE
xdg-user-dirs: 0.16 -> 0.17

### DIFF
--- a/pkgs/tools/X11/xdg-user-dirs/default.nix
+++ b/pkgs/tools/X11/xdg-user-dirs/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libxslt, docbook_xsl, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "xdg-user-dirs-0.16";
+  name = "xdg-user-dirs-0.17";
 
   src = fetchurl {
     url = "http://user-dirs.freedesktop.org/releases/${name}.tar.gz";
-    sha256 = "1rp3c94hxjlfsryvwajklynfnrcvxplhwnjqc7395l89i0nb83vp";
+    sha256 = "13216b8rfkzak5k6bvpx6jvqv3cnbgpijnjwj8a8d3kq4cl0a1ra";
   };
 
   buildInputs = [ libxslt docbook_xsl makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/2isrxm5fr9kgxkh0pbzb5d77jpip1vvd-xdg-user-dirs-0.17/bin/xdg-user-dirs-update --help` got 0 exit code
- ran `/nix/store/2isrxm5fr9kgxkh0pbzb5d77jpip1vvd-xdg-user-dirs-0.17/bin/.xdg-user-dirs-update-wrapped --help` got 0 exit code
- ran `/nix/store/2isrxm5fr9kgxkh0pbzb5d77jpip1vvd-xdg-user-dirs-0.17/bin/xdg-user-dir -h` got 0 exit code
- ran `/nix/store/2isrxm5fr9kgxkh0pbzb5d77jpip1vvd-xdg-user-dirs-0.17/bin/xdg-user-dir --help` got 0 exit code
- ran `/nix/store/2isrxm5fr9kgxkh0pbzb5d77jpip1vvd-xdg-user-dirs-0.17/bin/xdg-user-dir help` got 0 exit code
- found 0.17 with grep in /nix/store/2isrxm5fr9kgxkh0pbzb5d77jpip1vvd-xdg-user-dirs-0.17
- directory tree listing: https://gist.github.com/e8c151156e7a65f9f958a9a64e1e5a86

cc @lethalman for review