### PR TITLE
libguestfs: fix path to appliance

### DIFF
--- a/pkgs/development/libraries/libguestfs/appliance.nix
+++ b/pkgs/development/libraries/libguestfs/appliance.nix
@@ -1,0 +1,7 @@
+{ fetchzip }:
+
+fetchzip {
+  name = "libguestfs-appliance-1.38.0";
+  url = "http://libguestfs.org/download/binaries/appliance/appliance-1.38.0.tar.xz";
+  sha256 = "15rxwj5qjflizxk7slpbrj9lcwkd2lgm52f5yv101qba4yyn3g76";
+}

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -3,18 +3,15 @@
 , acl, libcap, libcap_ng, libconfig, systemd, fuse, yajl, libvirt, hivex
 , gmp, readline, file, libintlperl, GetoptLong, SysVirt, numactl, xen, libapparmor
 , getopt, perlPackages, ocamlPackages
+, appliance ? null
 , javaSupport ? false, jdk ? null }:
 
+assert appliance == null || stdenv.lib.isDerivation appliance;
 assert javaSupport -> jdk != null;
 
 stdenv.mkDerivation rec {
   name = "libguestfs-${version}";
   version = "1.38.0";
-
-  appliance = fetchurl {
-    url = "http://libguestfs.org/download/binaries/appliance/appliance-1.38.0.tar.xz";
-    sha256 = "05481qxgidakga871yb5rgpyci2jaxmplmkh6y79anfh5m19nzhy";
-  };
 
   src = fetchurl {
     url = "http://libguestfs.org/download/1.38-stable/libguestfs-${version}.tar.gz";
@@ -54,14 +51,31 @@ stdenv.mkDerivation rec {
   postInstall = ''
     for bin in $out/bin/*; do
       wrapProgram "$bin" \
-        --prefix "PATH" : "$out/bin:${hivex}/bin:${qemu}/bin" \
-        --prefix "PERL5LIB" : "$PERL5LIB:$out/lib/perl5/site_perl"
+        --prefix PATH     : "$out/bin:${hivex}/bin:${qemu}/bin" \
+        --prefix PERL5LIB : "$out/lib/perl5/site_perl"
     done
   '';
 
-  postFixup = ''
-    mkdir -p "$out/lib/guestfs"
-    tar -Jxvf "$appliance" --strip 1 -C "$out/lib/guestfs"
+  postFixup = stdenv.lib.optionalString (appliance != null) ''
+    mkdir -p $out/{lib,lib64}
+    ln -s ${appliance} $out/lib64/guestfs
+    ln -s ${appliance} $out/lib/guestfs
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export HOME=$(mktemp -d) # avoid access to /homeless-shelter/.guestfish
+
+    ${qemu}/bin/qemu-img create -f qcow2 disk1.img 10G
+
+    $out/bin/guestfish <<'EOF'
+    add-drive disk1.img
+    run
+    list-filesystems
+    part-disk /dev/sda mbr
+    mkfs ext2 /dev/sda1
+    list-filesystems
+    EOF
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9825,8 +9825,10 @@ with pkgs;
 
   libgudev = callPackage ../development/libraries/libgudev { };
 
+  libguestfs-appliance = callPackage ../development/libraries/libguestfs/appliance.nix {};
   libguestfs = callPackage ../development/libraries/libguestfs {
     inherit (perlPackages) libintlperl GetoptLong SysVirt;
+    appliance = libguestfs-appliance;
   };
 
   libhangul = callPackage ../development/libraries/libhangul { };


### PR DESCRIPTION
###### Motivation for this change

1. Fixes #37540 (path to appliance)
2. Added possibility to build ```libguestfs``` without appliance to reduce closure size, as the default appliance is about 4GB (it can be passed in runtime ```$LIBGUESTFS_PATH```)
3. added ```installCheckPhase```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

