### PR TITLE
xercesc: 3.1.4 -> 3.2.1

### DIFF
--- a/pkgs/development/libraries/xercesc/default.nix
+++ b/pkgs/development/libraries/xercesc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "xerces-c-${version}";
-  version = "3.1.4";
+  version = "3.2.1";
 
   src = fetchurl {
     url = "mirror://apache/xerces/c/3/sources/${name}.tar.gz";
-    sha256 = "1xpccqzykpd3806kd788lgkl01pk7v5lklva6q4kp9zq9jnfv3n9";
+    sha256 = "18045nyjkr2hygkjc43pi2fmz6qcbn9p00kf42my3aa4i0mn1m3d";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/hlkw8kda3fc03mr4j8pcz11cj19rlls2-xerces-c-3.2.1/bin/MemParse -h` got 0 exit code
- ran `/nix/store/hlkw8kda3fc03mr4j8pcz11cj19rlls2-xerces-c-3.2.1/bin/MemParse --help` got 0 exit code
- ran `/nix/store/hlkw8kda3fc03mr4j8pcz11cj19rlls2-xerces-c-3.2.1/bin/PSVIWriter help` got 0 exit code
- ran `/nix/store/hlkw8kda3fc03mr4j8pcz11cj19rlls2-xerces-c-3.2.1/bin/SCMPrint help` got 0 exit code
- ran `/nix/store/hlkw8kda3fc03mr4j8pcz11cj19rlls2-xerces-c-3.2.1/bin/SEnumVal help` got 0 exit code
- found 3.2.1 with grep in /nix/store/hlkw8kda3fc03mr4j8pcz11cj19rlls2-xerces-c-3.2.1
- directory tree listing: https://gist.github.com/b0e7f99274b68686c5e81ab68cf510ba