### PR TITLE
pythonPackages.face_recognition: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/face_recognition/default.nix
+++ b/pkgs/development/python-modules/face_recognition/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage, fetchFromGitHub, pillow, click, dlib, numpy
+, face_recognition_models, scipy, stdenv, flake8, tox, pytest, glibcLocales
+}:
+
+buildPythonPackage rec {
+  pname = "face_recognition";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "ageitgey";
+    rev = "fe421d4acd76e8a19098e942b7bd9c3bbef6ebc4"; # no tags available in Git, pure revs are pushed to pypi
+    sha256 = "0wv5qxkg7xv1cr43zhhbixaqgj08xw2l7yvwl8g3fb2kdxyndw1c";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "flake8==2.6.0" "flake8"
+  '';
+
+  propagatedBuildInputs = [ pillow click dlib numpy face_recognition_models scipy ];
+
+  checkInputs = [ flake8 tox pytest glibcLocales ];
+  checkPhase = ''
+    LC_ALL="en_US.UTF-8" py.test
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    homepage = https://github.com/ageitgey/face_recognition;
+    maintainers = with maintainers; [ ma27 ];
+    description = "The world's simplest facial recognition api for Python and the command line";
+  };
+}

--- a/pkgs/development/python-modules/face_recognition_models/default.nix
+++ b/pkgs/development/python-modules/face_recognition_models/default.nix
@@ -1,0 +1,21 @@
+{ buildPythonPackage, stdenv, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "face_recognition_models";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kwnv3qpy5bhspk780bkyg8jd9n5f6p91ja6sjlwk1wcm00d56xp";
+  };
+
+  # no module named `tests` as no tests are available
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ageitgey/face_recognition_models;
+    license = licenses.cc0;
+    maintainers = with maintainers; [ ma27 ];
+    description = "Trained models for the face_recognition python library";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4209,6 +4209,10 @@ in {
     };
   };
 
+  face_recognition = callPackage ../development/python-modules/face_recognition { };
+
+  face_recognition_models = callPackage ../development/python-modules/face_recognition_models { };
+
   faker = callPackage ../development/python-modules/faker { };
 
   fake_factory = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Adds the python package `face_recognition` and its dependency
`face_recognition_models`.

This package is a wrapper for `dlib` which is able to detect faces in a
given image. I checked the package with the following expression:

```
with import ./. { };

stdenv.mkDerivation {
  name = "facetest";
  src = null;
  buildInputs = with pythonPackages; [ face_recognition ];
}
```

The package works perfectly fine in a `nix-shell`:

```
$ nix-shell
[nix-shell:~]$ python
Python 2.7.14 (default, Sep 16 2017, 17:49:51)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import face_recognition
>>> img = face_recognition.load_image_file("/home/ma27/me.jpg")
>>> print(face_recognition.face_locations(img))
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

