### PR TITLE
xf86_input_wacom: 0.35.0 -> 0.36.0

### DIFF
--- a/pkgs/os-specific/linux/xf86-input-wacom/default.nix
+++ b/pkgs/os-specific/linux/xf86-input-wacom/default.nix
@@ -3,11 +3,11 @@
 , ncurses, pkgconfig, randrproto, xorgserver, xproto, udev, libXinerama, pixman }:
 
 stdenv.mkDerivation rec {
-  name = "xf86-input-wacom-0.35.0";
+  name = "xf86-input-wacom-0.36.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/linuxwacom/${name}.tar.bz2";
-    sha256 = "0za44snc0zirq65a4lxsmg7blp1bynj6j835hm459x8yx1qhmxjm";
+    sha256 = "1xi39hl8ddgj9m7m2k2ll2r3wh0k0aq45fvrsv43651bhz9cbrza";
   };
 
   buildInputs = [ inputproto libX11 libXext libXi libXrandr libXrender


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/xsetwacom -h` got 0 exit code
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/xsetwacom --help` got 0 exit code
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/xsetwacom -V` and found version 0.36.0
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/xsetwacom --version` and found version 0.36.0
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-debugger -h` got 0 exit code
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-debugger --help` got 0 exit code
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-debugger -V` and found version 0.36.0
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-debugger --version` and found version 0.36.0
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-inputattach -h` got 0 exit code
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-inputattach --help` got 0 exit code
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-inputattach -V` and found version 0.36.0
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-inputattach -v` and found version 0.36.0
- ran `/nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0/bin/isdv4-serial-inputattach --version` and found version 0.36.0
- found 0.36.0 with grep in /nix/store/ipx3qfwcd0g7wnmnqxq008fws2n8ldg4-xf86-input-wacom-0.36.0
- directory tree listing: https://gist.github.com/ceac89f2f9f39c6b3da0882790d97699

cc @cillianderoiste for review