### PR TITLE
xorg.xf86videovesa: 2.3.4 -> 2.4.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2264,11 +2264,11 @@ let
   }) // {inherit randrproto videoproto xorgserver xproto ;};
 
   xf86videovesa = (mkDerivation "xf86videovesa" {
-    name = "xf86-video-vesa-2.3.4";
+    name = "xf86-video-vesa-2.4.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/driver/xf86-video-vesa-2.3.4.tar.bz2;
-      sha256 = "1haiw8r1z8ihk68d0jqph2wsld13w4qkl86biq46fvyxg7cg9pbv";
+      url = mirror://xorg/individual/driver/xf86-video-vesa-2.4.0.tar.bz2;
+      sha256 = "1373vsxn6qh00na0s9c09kf09gj78rzi98zq93id8v5zsya3qi5z";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ fontsproto libpciaccess randrproto renderproto xextproto xorgserver xproto ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.4.0 with grep in /nix/store/61y7ka641q9l5ykkfdilk1507xqv8gnl-xf86-video-vesa-2.4.0
- directory tree listing: https://gist.github.com/148425747ac738aa905b76186c75afc4