### PR TITLE
xfce.xfce4-hardware-monitor-plugin: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
@@ -5,11 +5,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname  = "xfce4-hardware-monitor-plugin";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://git.xfce.org/panel-plugins/${pname}/snapshot/${name}.tar.bz2";
-    sha256 = "0sqvisr8gagpywq9sfyzqw37hxmj54ii89j5s2g8hx8bng5a98z1";
+    sha256 = "0xg5har11fk1wmdymydxlbk1z8aa39j8k0p4gzw2iqslv3n0zf7b";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.6.0 with grep in /nix/store/7c7lfqhq2ml0a8snjsvdrhahg8idpvs1-xfce4-hardware-monitor-plugin-1.6.0
- directory tree listing: https://gist.github.com/fc22e9e1afe29538412962283a639129

cc @romildo for review