### PR TITLE
xineLib: 1.2.6 -> 1.2.9

### DIFF
--- a/pkgs/development/libraries/xine-lib/default.nix
+++ b/pkgs/development/libraries/xine-lib/default.nix
@@ -5,11 +5,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "xine-lib-1.2.6";
+  name = "xine-lib-1.2.9";
 
   src = fetchurl {
     url = "mirror://sourceforge/xine/${name}.tar.xz";
-    sha256 = "01d0nv4zhr4k8id5n4rmw13llrjsv9dhwg1a773c1iqpi1ris15x";
+    sha256 = "13clir4qxl2zvsvvjd9yv3yrdhsnvcn5s7ambbbn5dzy9604xcrj";
   };
 
   nativeBuildInputs = [ pkgconfig perl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/hnckr7rw59jim490swa9xq3nbn98c411-xine-lib-1.2.9/bin/xine-list-1.2 -h` got 0 exit code
- ran `/nix/store/hnckr7rw59jim490swa9xq3nbn98c411-xine-lib-1.2.9/bin/xine-list-1.2 --help` got 0 exit code
- ran `/nix/store/hnckr7rw59jim490swa9xq3nbn98c411-xine-lib-1.2.9/bin/xine-list-1.2 help` got 0 exit code
- ran `/nix/store/hnckr7rw59jim490swa9xq3nbn98c411-xine-lib-1.2.9/bin/xine-list-1.2 -v` and found version 1.2.9
- ran `/nix/store/hnckr7rw59jim490swa9xq3nbn98c411-xine-lib-1.2.9/bin/xine-list-1.2 --version` and found version 1.2.9
- ran `/nix/store/hnckr7rw59jim490swa9xq3nbn98c411-xine-lib-1.2.9/bin/xine-list-1.2 -h` and found version 1.2.9
- ran `/nix/store/hnckr7rw59jim490swa9xq3nbn98c411-xine-lib-1.2.9/bin/xine-list-1.2 --help` and found version 1.2.9
- found 1.2.9 with grep in /nix/store/hnckr7rw59jim490swa9xq3nbn98c411-xine-lib-1.2.9
- directory tree listing: https://gist.github.com/0b66f70c336b62519465be16269e2cce