### PR TITLE
xineUI: 0.99.9 -> 0.99.10

### DIFF
--- a/pkgs/applications/video/xine-ui/default.nix
+++ b/pkgs/applications/video/xine-ui/default.nix
@@ -2,11 +2,11 @@
 , lirc, shared-mime-info, libjpeg }:
 
 stdenv.mkDerivation rec {
-  name = "xine-ui-0.99.9";
+  name = "xine-ui-0.99.10";
   
   src = fetchurl {
     url = "mirror://sourceforge/xine/${name}.tar.xz";
-    sha256 = "18liwmkbj75xs9bipw3vr67a7cwmdfcp04v5lph7nsjlkwhq1lcd";
+    sha256 = "0i3jzhiipfs5p1jbxviwh42zcfzag6iqc6yycaan0vrqm90an86a";
   };
   
   nativeBuildInputs = [ pkgconfig shared-mime-info ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check -h` got 0 exit code
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check --help` got 0 exit code
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check help` got 0 exit code
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check -V` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check --version` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check version` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check -h` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check --help` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-check help` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport -h` got 0 exit code
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport --help` got 0 exit code
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport help` got 0 exit code
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport -V` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport --version` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport version` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport -h` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport --help` and found version 0.99.10
- ran `/nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10/bin/xine-bugreport help` and found version 0.99.10
- found 0.99.10 with grep in /nix/store/zca8nmwqrr97lpvmprr5hqglxlqig2d4-xine-ui-0.99.10
- directory tree listing: https://gist.github.com/38a0309d9443aca1e54f071937c1e1cc