### PR TITLE
gtkspell3: add missing isocodes dep

### DIFF
--- a/pkgs/development/libraries/gtkspell/3.nix
+++ b/pkgs/development/libraries/gtkspell/3.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk3, aspell, pkgconfig, enchant, intltool}:
+{stdenv, fetchurl, gtk3, aspell, pkgconfig, enchant, isocodes, intltool}:
 
 stdenv.mkDerivation rec {
   name = "gtkspell-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];
-  buildInputs = [ aspell gtk3 enchant ];
+  buildInputs = [ aspell gtk3 enchant isocodes ];
   propagatedBuildInputs = [ enchant ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Otherwise (as-is) gtkspell3 tries to find isocodes
at runtime by looking in `/usr`.

(configure phase nicely reports this search path
 for easy comparison before/after)

Fixes problems at runtime when they can't be found:
warnings and presumably functionality loss.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---