### PR TITLE
erlang R18-20: updates

### DIFF
--- a/pkgs/development/interpreters/erlang/R18.nix
+++ b/pkgs/development/interpreters/erlang/R18.nix
@@ -12,8 +12,8 @@ let
   };
 
 in mkDerivation rec {
-  version = "18.3.4.7";
-  sha256 = "1l66vzbb1vidrmf6gr84l34kgrpb9k7z2170bac4c6aviah9r02l";
+  version = "18.3.4.8";
+  sha256 = "16c0h25hh5yvkv436ks5jbd7qmxzb6ndvk64mr404347a20iib0g";
 
   patches = [
     rmAndPwdPatch

--- a/pkgs/development/interpreters/erlang/R19.nix
+++ b/pkgs/development/interpreters/erlang/R19.nix
@@ -1,8 +1,8 @@
 { mkDerivation, fetchurl, fetchpatch }:
 
 mkDerivation rec {
-  version = "19.3.6.4";
-  sha256 = "1w0h3wj2h58m3jrfgw56xab2352na3i9ccrbpfs4420dn7igf071";
+  version = "19.3.6.6";
+  sha256 = "05l81gig0hmr951pjvwknc9x2qvpm95ph9z072hn4jqg13rzbgvg";
 
   patches = [
     # macOS 10.13 crypto fix from OTP-20.1.2

--- a/pkgs/development/interpreters/erlang/R20.nix
+++ b/pkgs/development/interpreters/erlang/R20.nix
@@ -1,8 +1,8 @@
 { mkDerivation, fetchurl }:
 
 mkDerivation rec {
-  version = "20.2.2";
-  sha256 = "1cns1qcmmr00nyvcvcj4p4n2gvliyjynlwfqc7qzpkjjnkb7fzl6";
+  version = "20.3.1";
+  sha256 = "13qh3an98qm477zr1dvcklbhar001cikp177295llcqpchamgzx3";
 
   prePatch = ''
     substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'


### PR DESCRIPTION
Noticed various updates available, thought I'd submit bumps :).

Also forces rebuild which may be significant re:testing
and hopefully fixing #https://github.com/NixOS/nixpkgs/issues/36853.


Not sure how folks generally test erlang, I defer to your wisdom!


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---