### PR TITLE
xmlrpc_c: 1.33.17 -> 1.39.12

### DIFF
--- a/pkgs/development/libraries/xmlrpc-c/default.nix
+++ b/pkgs/development/libraries/xmlrpc-c/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, curl, libxml2 }:
 
 stdenv.mkDerivation rec {
-  name = "xmlrpc-c-1.33.17";
+  name = "xmlrpc-c-1.39.12";
 
   src = fetchurl {
     url = "mirror://sourceforge/xmlrpc-c/${name}.tgz";
-    sha256 = "0makq1zpfqnrj6xx1xc7wi4mh115ri9p4yz2rbvjhj0il4y8l4ah";
+    sha256 = "026fh7w7y3q9pvxd09i5d4hq3l6gd81n9k19yq4zwbc398kg6c6q";
   };
 
   buildInputs = [ curl libxml2 ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/4cdb0kvm05d8390pg3agfy7hjm9ygd9s-xmlrpc-c-1.39.12/bin/xmlrpc-c-config --help` got 0 exit code
- ran `/nix/store/4cdb0kvm05d8390pg3agfy7hjm9ygd9s-xmlrpc-c-1.39.12/bin/xmlrpc-c-config --version` and found version 1.39.12
- ran `/nix/store/4cdb0kvm05d8390pg3agfy7hjm9ygd9s-xmlrpc-c-1.39.12/bin/xmlrpc-c-config --help` and found version 1.39.12
- found 1.39.12 with grep in /nix/store/4cdb0kvm05d8390pg3agfy7hjm9ygd9s-xmlrpc-c-1.39.12
- directory tree listing: https://gist.github.com/02ef530309005ffeedbc4af16ffd467c

cc @bjornfor for review