### PR TITLE
hologram-server module: add cache timeout option

### DIFF
--- a/nixos/modules/services/security/hologram-server.nix
+++ b/nixos/modules/services/security/hologram-server.nix
@@ -23,8 +23,9 @@ let
       account     = cfg.awsAccount;
       defaultrole = cfg.awsDefaultRole;
     };
-    stats  = cfg.statsAddress;
-    listen = cfg.listenAddress;
+    stats        = cfg.statsAddress;
+    listen       = cfg.listenAddress;
+    cachetimeout = cfg.cacheTimeoutSeconds;
   });
 in {
   options = {
@@ -105,6 +106,12 @@ in {
         type        = types.str;
         default     = "";
         description = "Address of statsd server";
+      };
+
+      cacheTimeoutSeconds = mkOption {
+        type        = types.int;
+        default     = 3600;
+        description = "How often (in seconds) to refresh the LDAP cache";
       };
     };
   };


### PR DESCRIPTION
The version of hologram we're using has supported this option for a while, but we didn't expose it through the NixOS module

###### Motivation for this change

I want to adjust the LDAP cache timeout 😄 
