### PR TITLE
xpraGtk3: 2.1.3 -> 2.2.5

### DIFF
--- a/pkgs/tools/X11/xpra/gtk3.nix
+++ b/pkgs/tools/X11/xpra/gtk3.nix
@@ -7,11 +7,11 @@
 
 buildPythonApplication rec {
   name = "xpra-${version}";
-  version = "2.1.3";
+  version = "2.2.5";
 
   src = fetchurl {
     url = "http://xpra.org/src/${name}.tar.xz";
-    sha256 = "0r0l3p59q05fmvkp3jv8vmny2v8m1vyhqkg6b9r2qgxn1kcxx7rm";
+    sha256 = "1q2l00nc3bgwlhjzkbk4a8x2l8z9w1799yn31icsx5hrgh98a1js";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/xpra -h` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/xpra --help` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/xpra --version` and found version 2.2.5
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/udev_product_version -h` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/udev_product_version --help` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/udev_product_version help` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/..xpra-wrapped-wrapped -h` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/..xpra-wrapped-wrapped --help` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/..xpra-wrapped-wrapped --version` and found version 2.2.5
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/.xpra-wrapped -h` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/.xpra-wrapped --help` got 0 exit code
- ran `/nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5/bin/.xpra-wrapped --version` and found version 2.2.5
- found 2.2.5 with grep in /nix/store/raq8vylxav1gm8v4gsphfmpbq6mw9362-xpra-2.2.5
- directory tree listing: https://gist.github.com/78f0907352399b3a9966fb6f71f1f0d4