### PR TITLE
tdesktop: fixed GLib-GIO-ERROR

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/generic.nix
@@ -125,6 +125,7 @@ mkDerivation rec {
     # This is necessary to run Telegram in a pure environment.
     wrapProgram $out/bin/telegram-desktop \
       --prefix QT_PLUGIN_PATH : "${qtbase}/${qtbase.qtPluginPrefix}" \
+      --suffix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
       --set XDG_RUNTIME_DIR "XDG-RUNTIME-DIR"
     sed -i $out/bin/telegram-desktop \
       -e "s,'XDG-RUNTIME-DIR',\"\''${XDG_RUNTIME_DIR:-/run/user/\$(id --user)}\","


### PR DESCRIPTION
###### Motivation for this change

Fixes telegram-desktop crash with ```GLib-GIO-ERROR **: No GSettings schemas are installed on the system``` on choose-files dialogue. 
Fix taken here: https://github.com/NixOS/nixpkgs/pull/21700.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

