### PR TITLE
coq: init at 8.8+beta1

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -22,6 +22,7 @@ let
    "8.7.0"     = "1h18b7xpnx3ix9vsi5fx4zdcbxy7bhra7gd5c5yzxmk53cgf1p9m";
    "8.7.1"     = "0gjn59jkbxwrihk8fx9d823wjyjh5m9gvj9l31nv6z6bcqhgdqi8";
    "8.7.2"     = "0a0657xby8wdq4aqb2xsxp3n7pmc2w4yxjmrb2l4kccs1aqvaj4w";
+   "8.8+beta1" = "19ipmx6bf8wjpk8y29hcginxk7hps4jh1bbihn5icx4qysm81165";
   }."${version}";
   coq-version = builtins.substring 0 3 version;
   camlp5 = ocamlPackages.camlp5_strict;
@@ -37,7 +38,7 @@ self = stdenv.mkDerivation {
   inherit camlp5;
   inherit (ocamlPackages) ocaml;
   passthru = {
-    inherit (ocamlPackages) findlib;
+    inherit (ocamlPackages) findlib num;
     emacsBufferSetup = pkgs: ''
       ; Propagate coq paths to children
       (inherit-local-permanent coq-prog-name "${self}/bin/coqtop")
@@ -92,7 +93,7 @@ self = stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ocamlPackages.ocaml ocamlPackages.findlib camlp5 ncurses ]
+  buildInputs = [ ocamlPackages.ocaml ocamlPackages.findlib camlp5 ncurses ocamlPackages.num ]
   ++ stdenv.lib.optional buildIde ocamlPackages.lablgtk;
 
   postPatch = ''
@@ -116,7 +117,6 @@ self = stdenv.mkDerivation {
 
   preConfigure = ''
     configureFlagsArray=(
-      -opt
       ${ideFlags}
     )
   '';

--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.6";
+    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" ];
   };
 }

--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, coq, ssreflect }:
 
-let param =
+let params =
   {
     "8.5" = {
       version = "20170512";
@@ -19,9 +19,9 @@ let param =
       rev = "195e550a1cf0810497734356437a1720ebb6d744";
       sha256 = "0zm23y89z0h4iamy74qk9qi2pz2cj3ga6ygav0w79n0qyqwhxcq1";
     };
-
-  }."${coq.coq-version}"
-; in
+  };
+  param = params."${coq.coq-version}";
+in
 
 stdenv.mkDerivation rec {
 
@@ -47,6 +47,10 @@ stdenv.mkDerivation rec {
     description = "Randomized property-based testing plugin for Coq; a clone of Haskell QuickCheck";
     maintainers = with maintainers; [ jwiegley ];
     platforms = coq.meta.platforms;
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.hasAttr v params;
   };
 
 }

--- a/pkgs/development/coq-modules/autosubst/default.nix
+++ b/pkgs/development/coq-modules/autosubst/default.nix
@@ -24,4 +24,6 @@ stdenv.mkDerivation rec {
     platforms = coq.meta.platforms;
   };
 
+  passthru = { inherit (mathcomp) compatibleCoqVersions; };
+
 }

--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -10,6 +10,10 @@ let param =
       rev = "V8.7.0";
       sha256 = "11c4sdmpd3l6jjl4v6k213z9fhrmmm1xnly3zmzam1wrrdif4ghl";
     };
+    "8.8" = {
+      rev = "V8.8+beta1";
+      sha256 = "1ymxyrvjygscxkfj3qkq66skl3vdjhb670rzvsvgmwrjkrakjnfg";
+    };
   }."${coq.coq-version}"
 ; in
 

--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchFromGitHub, coq }:
 
-let param =
+let params =
   {
     "8.5" = { version = "0.9.4"; sha256 = "1y66pamgsdxlq2w1338lj626ln70cwj7k53hxcp933g8fdsa4hp0"; };
     "8.6" = { version = "0.9.5"; sha256 = "1b4cvz3llxin130g13calw5n1zmvi6wdd5yb8a41q7yyn2hd3msg"; };
     "8.7" = { version = "0.9.5"; sha256 = "1b4cvz3llxin130g13calw5n1zmvi6wdd5yb8a41q7yyn2hd3msg"; };
-  }."${coq.coq-version}";
+  };
+  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {
@@ -34,4 +35,7 @@ stdenv.mkDerivation rec {
     platforms = coq.meta.platforms;
   };
 
+  passthru = {
+    compatibleCoqVersions = v: builtins.hasAttr v params;
+  };
 }

--- a/pkgs/development/coq-modules/coq-haskell/default.nix
+++ b/pkgs/development/coq-modules/coq-haskell/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, coq, ssreflect }:
 
-let param =
+let params =
   {
     "8.5" = {
       version = "20171215";
@@ -19,9 +19,9 @@ let param =
       rev = "e2cf8b270c2efa3b56fab1ef6acc376c2c3de968";
       sha256 = "09dq1vvshhlhgjccrhqgbhnq2hrys15xryfszqq11rzpgvl2zgdv";
     };
-
-  }."${coq.coq-version}"
-; in
+  };
+  param = params."${coq.coq-version}";
+in
 
 stdenv.mkDerivation rec {
 
@@ -48,4 +48,7 @@ stdenv.mkDerivation rec {
     platforms = coq.meta.platforms;
   };
 
+  passthru = {
+    compatibleCoqVersions = v: builtins.hasAttr v params;
+  };
 }

--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -22,4 +22,7 @@ stdenv.mkDerivation {
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     inherit (coq.meta) platforms;
   };
+
+  passthru = { inherit (ssreflect) compatibleCoqVersions; };
+
 }

--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook, coq, ocamlPackages }:
 
-let param = {
+let params = {
   "8.7" = {
     version = "0.6.2";
     rev = "d76ddde37d918569945774733b7997e8b24daf51";
@@ -16,7 +16,9 @@ let param = {
     rev = "v0.6";
     sha256 = "0qvar8gfbrcs9fmvkph5asqz4l5fi63caykx3bsn8zf0xllkwv0n";
   };
-}."${coq.coq-version}"; in
+};
+param = params."${coq.coq-version}";
+in
 
 stdenv.mkDerivation {
   name = "coq${coq.coq-version}-dpdgraph-${param.version}";
@@ -46,4 +48,9 @@ stdenv.mkDerivation {
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
     platforms = coq.meta.platforms;
   };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.hasAttr v params;
+  };
+
 }

--- a/pkgs/development/coq-modules/heq/default.nix
+++ b/pkgs/development/coq-modules/heq/default.nix
@@ -24,4 +24,7 @@ stdenv.mkDerivation rec {
     platforms = coq.meta.platforms;
   };
 
+  passthru = {
+    compatibleCoqVersions = v: !stdenv.lib.versionAtLeast v "8.8";
+  };
 }

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -24,4 +24,7 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ vbgl ];
     platforms = coq.meta.platforms;
   };
+
+  passthru = { inherit (mathcomp) compatibleCoqVersions; };
+
 }

--- a/pkgs/development/coq-modules/mathcomp/generic.nix
+++ b/pkgs/development/coq-modules/mathcomp/generic.nix
@@ -35,4 +35,8 @@ stdenv.mkDerivation {
     platforms = coq.meta.platforms;
   };
 
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+  };
+
 }

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -28,4 +28,8 @@ stdenv.mkDerivation rec {
     platforms = coq.meta.platforms;
   };
 
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+  };
+
 }

--- a/pkgs/development/coq-modules/ssreflect/generic.nix
+++ b/pkgs/development/coq-modules/ssreflect/generic.nix
@@ -42,4 +42,8 @@ stdenv.mkDerivation {
     platforms = coq.meta.platforms;
   };
 
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+  };
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19727,8 +19727,8 @@ with pkgs;
 
   inherit (callPackage ./coq-packages.nix {})
     mkCoqPackages
-    coq_8_3 coq_8_4 coq_8_5 coq_8_6 coq_8_7
-    coqPackages_8_5 coqPackages_8_6 coqPackages_8_7
+    coq_8_3 coq_8_4 coq_8_5 coq_8_6 coq_8_7 coq_8_8
+    coqPackages_8_5 coqPackages_8_6 coqPackages_8_7 coqPackages_8_8
     coqPackages coq
   ;
 

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -71,10 +71,14 @@ in rec {
   coq_8_7 = callPackage ../applications/science/logic/coq {
     version = "8.7.2";
   };
+  coq_8_8 = callPackage ../applications/science/logic/coq {
+    version = "8.8+beta1";
+  };
 
   coqPackages_8_5 = mkCoqPackages coq_8_5;
   coqPackages_8_6 = mkCoqPackages coq_8_6;
   coqPackages_8_7 = mkCoqPackages coq_8_7;
+  coqPackages_8_8 = mkCoqPackages coq_8_8;
   coqPackages = coqPackages_8_7;
   coq = coqPackages.coq;
 


### PR DESCRIPTION
Tested on darwin and debian.

Drops the `-opt` configure flag, which has been deprecated (and a no-op) since at least Coq 8.5.