### PR TITLE
paraview: include numpy in python environment

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -1,5 +1,5 @@
 {
-stdenv, fetchFromGitHub, cmake
+stdenv, fetchFromGitHub, cmake, makeWrapper
 ,qtbase, qttools, python, libGLU_combined
 ,libXt, qtx11extras, qtxmlpatterns
 }:
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-   cmakeFlags = [
-     "-DPARAVIEW_ENABLE_PYTHON=ON"
-     "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON"
-     "-DPARAVIEW_ENABLE_EMBEDDED_DOCUMENTATION=OFF"
-   ];
+  cmakeFlags = [
+    "-DPARAVIEW_ENABLE_PYTHON=ON"
+    "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON"
+    "-DPARAVIEW_ENABLE_EMBEDDED_DOCUMENTATION=OFF"
+  ];
 
   # During build, binaries are called that rely on freshly built
   # libraries.  These reside in build/lib, and are not found by
@@ -35,10 +35,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    makeWrapper
   ];
 
   buildInputs = [
     python
+    python.pkgs.numpy
     libGLU_combined
     libXt
     qtbase
@@ -47,6 +49,16 @@ stdenv.mkDerivation rec {
     qtxmlpatterns
   ];
 
+  # Paraview links into the Python library, resolving symbolic links on the way,
+  # so we need to put the correct sitePackages (with numpy) back on the path
+  postInstall = ''
+    wrapProgram $out/bin/paraview \
+      --set PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
+    wrapProgram $out/bin/pvbatch \
+      --set PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
+    wrapProgram $out/bin/pvpython \
+      --set PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
+  '';
 
   meta = {
     homepage = http://www.paraview.org/;


### PR DESCRIPTION
###### Motivation for this change

The Python filter functionality in Paraview requires numpy, which is currently not included.
This PR aims to add numpy, based on the discussion in https://github.com/NixOS/nixpkgs/issues/37118 .

@dguibert @viric could you please review?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

