### PR TITLE
ceph: Add makeWrapper to dependencies and nativeBuildInputs

### DIFF
--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -5,7 +5,7 @@
 , openldap, lttngUst
 , babeltrace, gperf
 , cunit, snappy
-, rocksdb
+, rocksdb, makeWrapper
 
 # Optional Dependencies
 , yasm ? null, fcgi ? null, expat ? null
@@ -97,6 +97,7 @@ let
     ps.pecan
     ps.prettytable
     ps.webob
+    ps.cherrypy
 	]);
 
 in
@@ -114,7 +115,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     cmake
-    pkgconfig which git python2Packages.wrapPython
+    pkgconfig which git python2Packages.wrapPython makeWrapper
     (ensureNewerSourcesHook { year = "1980"; })
   ];
   
@@ -159,6 +160,7 @@ stdenv.mkDerivation {
 
   postFixup = ''
     wrapPythonPrograms
+    wrapProgram $out/bin/ceph-mgr --set PYTHONPATH $out/lib/python2.7/site-packages
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -160,7 +160,7 @@ stdenv.mkDerivation {
 
   postFixup = ''
     wrapPythonPrograms
-    wrapProgram $out/bin/ceph-mgr --set PYTHONPATH $out/lib/python2.7/site-packages
+    wrapProgram $out/bin/ceph-mgr --set PYTHONPATH $out/${python2Packages.python.sitePackages}
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

The ceph-mgr daemon needs to know the location of cephs own-made python modules for some of the modules that you can enable for it.
With wrapProgram, a wrapper is added that sets the proper pythonpath environment variable for the ceph-mgr daemon so its modules can find the ceph python modules.

It also adds cherrypy to the python env used by the python scripts, as its needed for the dashboard module for ceph-mgr.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

