### PR TITLE
ghc-{8.2.2,8.4.2}: fixups mostly for 2-stage cross, musl

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -53,7 +53,8 @@ let
   '' + stdenv.lib.optionalString enableIntegerSimple ''
     INTEGER_LIBRARY = integer-simple
   '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
-    Stage1Only = YES
+    Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
+    CrossCompilePrefix = ${targetPrefix}
     HADDOCK_DOCS = NO
     BUILD_SPHINX_HTML = NO
     BUILD_SPHINX_PDF = NO
@@ -95,6 +96,27 @@ stdenv.mkDerivation rec {
       sha256 = "03253ci40np1v6k0wmi4aypj3nmj3rdyvb1k6rwqipb30nfc719f";
     })
     (import ./abi-depends-determinism.nix { inherit fetchpatch runCommand; })
+  ] ++ stdenv.lib.optionals (hostPlatform != targetPlatform && targetPlatform.system == hostPlatform.system) [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/08a41d2dff99645af6ac5a7bb4774f5f193b6f20/dev-lang/ghc/files/ghc-8.2.1_rc1-unphased-cross.patch";
+      sha256 = "1hxj80bjx0x3w0f35cj3k2wipppr1ald03jwfy5q0xlxygdha17w";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/08a41d2dff99645af6ac5a7bb4774f5f193b6f20/dev-lang/ghc/files/ghc-8.2.1_rc1-staged-cross.patch";
+      sha256 = "12xsln3zyfpvml8bwdpbc003h6zl1qh2qcq1rhdrw02n45dz8lvc";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/08a41d2dff99645af6ac5a7bb4774f5f193b6f20/dev-lang/ghc/files/ghc-8.2.1_rc1-ghci-cross.patch";
+      sha256 = "03dcqf5af3vjhrky3f2z26j4d9h8qd9nkv76xp0l97h4cqk7vfqb";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/08a41d2dff99645af6ac5a7bb4774f5f193b6f20/dev-lang/ghc/files/ghc-8.2.1_rc1-stage2-cross.patch";
+      sha256 = "0pi2m85wjxaaablq6n4q5vyn9qxvry5d7nmja4b28i68yb4ly9g1";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/08a41d2dff99645af6ac5a7bb4774f5f193b6f20/dev-lang/ghc/files/ghc-8.2.1_rc1-hp2ps-cross.patch";
+      sha256 = "1fszfavf1cvrf02x500mi7jykcpvpl2i7i4qzr2qz9sbmyq063f0";
+    })
   ] ++ stdenv.lib.optional deterministicProfiling
     (fetchpatch { # Backport of https://phabricator.haskell.org/D4388 for more determinism
       url = "https://github.com/shlevy/ghc/commit/fec1b8d3555c447c0d8da0e96b659be67c8bb4bc.patch";
@@ -136,6 +158,7 @@ stdenv.mkDerivation rec {
   # `--with` flags for libraries needed for RTS linker
   configureFlags = [
     "--datadir=$doc/share/doc/ghc"
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform) [
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"

--- a/pkgs/development/compilers/ghc/8.4.2.nix
+++ b/pkgs/development/compilers/ghc/8.4.2.nix
@@ -51,7 +51,8 @@ let
   '' + stdenv.lib.optionalString enableIntegerSimple ''
     INTEGER_LIBRARY = integer-simple
   '' + stdenv.lib.optionalString (targetPlatform != hostPlatform) ''
-    Stage1Only = YES
+    Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
+    CrossCompilePrefix = ${targetPrefix}
     HADDOCK_DOCS = NO
     BUILD_SPHINX_HTML = NO
     BUILD_SPHINX_PDF = NO
@@ -131,6 +132,7 @@ stdenv.mkDerivation rec {
   # `--with` flags for libraries needed for RTS linker
   configureFlags = [
     "--datadir=$doc/share/doc/ghc"
+  ] ++ stdenv.lib.optional (targetPlatform == hostPlatform) [
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && ! enableIntegerSimple) [
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"


### PR DESCRIPTION
* grab patches from gentoo to fix various 2-stage cross build system
  bugs
* explicitly set CrossCompilePrefix to the expected targetPrefix
  -- ensures everything has expected name and location
  -- fixes lack of prefix'ing when doing glibc -> musl "cross"
* Stage1Only: only set if doing "true" cross
* don't try to specify include/lib dirs for ncurses on cross
  -- only used by terminfo which actually removed the include option,
  and the lib option doesn't seem to do anything other than
  confuse the situation re:cross.


Fixes #37522




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested native x86_64, aarch64, cross-to-musl on those platforms,
and 'hello' :).