### PR TITLE
lua-{5.2,5.3}: cross fixups, drop crossAttrs

### DIFF
--- a/pkgs/development/interpreters/lua-5/5.2.nix
+++ b/pkgs/development/interpreters/lua-5/5.2.nix
@@ -19,17 +19,17 @@ stdenv.mkDerivation rec {
     sha256 = "0b8034v1s82n4dg5rzcn12067ha3nxaylp2vdp8gg08kjsbzphhk";
   };
 
-  nativeBuildInputs = [ readline ];
+  buildInputs = [ readline ];
 
   patches = if stdenv.isDarwin then [ ./5.2.darwin.patch ] else [ dsoPatch ];
 
   configurePhase =
     if stdenv.isDarwin
     then ''
-    makeFlagsArray=( INSTALL_TOP=$out INSTALL_MAN=$out/share/man/man1 PLAT=macosx CFLAGS="-DLUA_USE_LINUX -fno-common -O2 -fPIC${if compat then " -DLUA_COMPAT_ALL" else ""}" LDFLAGS="-fPIC" V=${luaversion} R=${version} )
+    makeFlagsArray=( INSTALL_TOP=$out INSTALL_MAN=$out/share/man/man1 PLAT=macosx CFLAGS="-DLUA_USE_LINUX -fno-common -O2 -fPIC${if compat then " -DLUA_COMPAT_ALL" else ""}" LDFLAGS="-fPIC" V=${luaversion} R=${version}  CC="$CC" )
     installFlagsArray=( TO_BIN="lua luac" TO_LIB="liblua.${version}.dylib" INSTALL_DATA='cp -d' )
   '' else ''
-    makeFlagsArray=( INSTALL_TOP=$out INSTALL_MAN=$out/share/man/man1 PLAT=linux CFLAGS="-DLUA_USE_LINUX -O2 -fPIC${if compat then " -DLUA_COMPAT_ALL" else ""}" LDFLAGS="-fPIC" V=${luaversion} R=${version} )
+    makeFlagsArray=( INSTALL_TOP=$out INSTALL_MAN=$out/share/man/man1 PLAT=linux CFLAGS="-DLUA_USE_LINUX -O2 -fPIC${if compat then " -DLUA_COMPAT_ALL" else ""}" LDFLAGS="-fPIC" V=${luaversion} R=${version} CC="$CC" AR="$AR q" RANLIB="$RANLIB" )
     installFlagsArray=( TO_BIN="lua luac" TO_LIB="liblua.a liblua.so liblua.so.${luaversion} liblua.so.${version}" INSTALL_DATA='cp -d' )
   '';
 
@@ -55,31 +55,6 @@ stdenv.mkDerivation rec {
     Cflags: -I$out/include
     EOF
   '';
-
-  crossAttrs = let
-    inherit (hostPlatform) isDarwin isMinGW;
-  in {
-    configurePhase = ''
-      makeFlagsArray=(
-        INSTALL_TOP=$out
-        INSTALL_MAN=$out/share/man/man1
-        V=${luaversion}
-        R=${version}
-        ${if isMinGW then "mingw" else stdenv.lib.optionalString isDarwin ''
-        ''}
-      )
-    '' + stdenv.lib.optionalString isMinGW ''
-      installFlagsArray=(
-        TO_BIN="lua.exe luac.exe"
-        TO_LIB="liblua.a lua52.dll"
-        INSTALL_DATA="cp -d"
-      )
-    '';
-  } // stdenv.lib.optionalAttrs isDarwin {
-    postPatch = ''
-      sed -i -e 's/-Wl,-soname[^ ]* *//' src/Makefile
-    '';
-  };
 
   meta = {
     homepage = http://www.lua.org;

--- a/pkgs/development/interpreters/lua-5/5.3.nix
+++ b/pkgs/development/interpreters/lua-5/5.3.nix
@@ -12,17 +12,17 @@ stdenv.mkDerivation rec {
     sha256 = "0320a8dg3aci4hxla380dx1ifkw8gj4gbw5c4dz41g1kh98sm0gn";
   };
 
-  nativeBuildInputs = [ readline ];
+  buildInputs = [ readline ];
 
   patches = if stdenv.isDarwin then [ ./5.2.darwin.patch ] else [];
 
   configurePhase =
     if stdenv.isDarwin
     then ''
-    makeFlagsArray=( INSTALL_TOP=$out INSTALL_MAN=$out/share/man/man1 PLAT=macosx CFLAGS="-DLUA_USE_LINUX -fno-common -O2 -fPIC${if compat then " -DLUA_COMPAT_ALL" else ""}" LDFLAGS="-fPIC" V=${luaversion} R=${version} )
+    makeFlagsArray=( INSTALL_TOP=$out INSTALL_MAN=$out/share/man/man1 PLAT=macosx CFLAGS="-DLUA_USE_LINUX -fno-common -O2 -fPIC${if compat then " -DLUA_COMPAT_ALL" else ""}" LDFLAGS="-fPIC" V=${luaversion} R=${version}  CC="$CC" )
     installFlagsArray=( TO_BIN="lua luac" TO_LIB="liblua.${version}.dylib" INSTALL_DATA='cp -d' )
   '' else ''
-    makeFlagsArray=( INSTALL_TOP=$out INSTALL_MAN=$out/share/man/man1 PLAT=linux CFLAGS="-DLUA_USE_LINUX -O2 -fPIC${if compat then " -DLUA_COMPAT_ALL" else ""}" LDFLAGS="-fPIC" V=${luaversion} R=${version})
+    makeFlagsArray=( INSTALL_TOP=$out INSTALL_MAN=$out/share/man/man1 PLAT=linux CFLAGS="-DLUA_USE_LINUX -O2 -fPIC${if compat then " -DLUA_COMPAT_ALL" else ""}" LDFLAGS="-fPIC" V=${luaversion} R=${version} CC="$CC" AR="$AR q" RANLIB="$RANLIB" )
     installFlagsArray=( TO_BIN="lua luac" TO_LIB="liblua.a liblua.so liblua.so.${luaversion} liblua.so.${version}" INSTALL_DATA='cp -d' )
     cat ${./lua-5.3-dso.make} >> src/Makefile
     sed -e 's/ALL_T *= */& $(LUA_SO)/' -i src/Makefile
@@ -54,31 +54,6 @@ stdenv.mkDerivation rec {
     Cflags: -I$out/include
     EOF
   '';
-
-  crossAttrs = let
-    inherit (hostPlatform) isDarwin isMinGW;
-  in {
-    configurePhase = ''
-      makeFlagsArray=(
-        INSTALL_TOP=$out
-        INSTALL_MAN=$out/share/man/man1
-        V=${luaversion}
-        R=${version}
-        ${if isMinGW then "mingw" else stdenv.lib.optionalString isDarwin ''
-        ''}
-      )
-    '' + stdenv.lib.optionalString isMinGW ''
-      installFlagsArray=(
-        TO_BIN="lua.exe luac.exe"
-        TO_LIB="liblua.a lua52.dll"
-        INSTALL_DATA="cp -d"
-      )
-    '';
-  } // stdenv.lib.optionalAttrs isDarwin {
-    postPatch = ''
-      sed -i -e 's/-Wl,-soname[^ ]* *//' src/Makefile
-    '';
-  };
 
   meta = {
     homepage = http://www.lua.org;


### PR DESCRIPTION
mostly just forward environment variables to make arguments,
this partially reverts 5d1e51a199917fa945cb59567597e354c6e4f56d
which removed them because they're already set in env--
but that's not enough to override make vars.

Also, readline is buildInput not nativeBuildInput

(we need headers and to link against it)




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---