### PR TITLE
perlPackages.perlldap: init at 0.65

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10502,14 +10502,7 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
-  NetLDAP = buildPerlPackage {
-    name = "Net-LDAP-0.4001";
-    propagatedBuildInputs = [ ConvertASN1 ];
-    src = fetchurl {
-      url = mirror://cpan/authors/id/G/GB/GBARR/perl-ldap-0.4001.tar.gz;
-      sha256 = "0spwid70yxkh5zbad3ldw8yb2m5shkm59a7f0kllw8bb7ccczqps";
-    };
-  };
+  NetLDAP = perlldap;
 
   NetOAuth = buildPerlPackage {
     name = "Net-OAuth-0.28";
@@ -11241,6 +11234,22 @@ let self = _self // overrides; _self = with self; {
       description = "A PerlIO layer that adds read & write timeout to a handle";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.rycee ];
+    };
+  };
+
+  perlldap = buildPerlPackage rec {
+    name = "perl-ldap-0.65";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARSCHAP/${name}.tar.gz";
+      sha256 = "5f57dd261dc16ebf942a272ddafe69526598df71151a51916edc37a4f2f23834";
+    };
+    buildInputs = [ TextSoundex ];
+    propagatedBuildInputs = [ ConvertASN1 ];
+    meta = {
+      homepage = http://ldap.perl.org/;
+      description = "LDAP client library";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.limeytexan ];
     };
   };
 


### PR DESCRIPTION

###### Motivation for this change
This package provides version 0.65 of the Net::LDAP module and
replaces the old version 0.4001 NetLDAP package which was
broken with respect to the use of hostnames in SASL bindings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

