### PR TITLE
perlPackages.GSSAPI: depend on krb5Full, fix misspelling

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6350,19 +6350,19 @@ let self = _self // overrides; _self = with self; {
   };
 
   GSSAPI = buildPerlPackage rec {
-    name = "GSSAPPI-0.28";
+    name = "GSSAPI-0.28";
     src = fetchurl {
-      url = "http://search.cpan.org/CPAN/authors/id/A/AG/AGROLMS/GSSAPI-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/A/AG/AGROLMS/${name}.tar.gz";
       sha256 = "1mkhwxjjlhr58pd770i9gnf7zy7jj092iv6jfbnb8bvnc5xjr3vx";
     };
     buildInputs = [ TestPod ];
-    propagatedBuildInputs = [ pkgs.heimdalFull ];
+    propagatedBuildInputs = [ pkgs.krb5Full.dev ];
     meta = {
       maintainers = [ maintainers.limeytexan ];
       description = "Perl extension providing access to the GSSAPIv2 library";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
-    makeMakerFlags = "--gssapiimpl ${pkgs.heimdalFull.out}";
+    makeMakerFlags = "--gssapiimpl ${pkgs.krb5Full.dev}";
   };
 
   Gtk2 = buildPerlPackage rec {


### PR DESCRIPTION
###### Motivation for this change
Updated GSSAPI to depend upon MIT krb5 rather than heimdal. I expect this
is safe as I only submitted the PR to add the GSSAPI module a few weeks back.

Also corrected a misspelling in the package name and updated the fetchurl
to match the convention employed by nix-generate-from-cpan.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

