### PR TITLE
bundler 1.14.6 -> 1.16.1

### DIFF
--- a/pkgs/development/ruby-modules/bundler/default.nix
+++ b/pkgs/development/ruby-modules/bundler/default.nix
@@ -4,8 +4,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "bundler";
-  version = "1.14.6";
-  source.sha256 = "0h3x2csvlz99v2ryj1w72vn6kixf7rl35lhdryvh7s49brnj0cgl";
+  version = "1.16.1";
+  source.sha256 = "42b8e0f57093e1d10c15542f956a871446b759e7969d99f91caf3b6731c156e8";
   dontPatchShebangs = true;
 
   postFixup = ''

--- a/pkgs/development/tools/vagrant/Gemfile.lock
+++ b/pkgs/development/tools/vagrant/Gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webmock (~> 2.3.1)
 
 BUNDLED WITH
-   1.16.1
+   1.14.6

--- a/pkgs/development/tools/vagrant/Gemfile.lock
+++ b/pkgs/development/tools/vagrant/Gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webmock (~> 2.3.1)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/pkgs/development/tools/vagrant/gemset.nix
+++ b/pkgs/development/tools/vagrant/gemset.nix
@@ -70,10 +70,10 @@
   ffi = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "034f52xf7zcqgbvwbl20jwdyjwznvqnwpbaps9nk18v9lgb1dpx0";
+      sha256 = "0zw6pbyvmj8wafdc7l5h7w20zkp1vbr2805ql5d941g2b20pk4zr";
       type = "gem";
     };
-    version = "1.9.18";
+    version = "1.9.23";
   };
   gssapi = {
     dependencies = ["ffi"];
@@ -238,10 +238,10 @@
   public_suffix = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0mvzd9ycjw8ydb9qy3daq3kdzqs2vpqvac4dqss6ckk4rfcjc637";
+      sha256 = "1x5h1dh1i3gwc01jbg01rly2g6a1qwhynb1s8a30ic507z1nh09s";
       type = "gem";
     };
-    version = "3.0.1";
+    version = "3.0.2";
   };
   rake = {
     source = {
@@ -403,10 +403,10 @@
     dependencies = ["childprocess" "log4r" "rspec" "thor"];
     source = {
       fetchSubmodules = false;
-      rev = "7ac8b4191de578e345b29acaf62ecc72c8e73be1";
-      sha256 = "0qybgxdnndx7xfmhyjcj46b2mv78d98yk30d68ppmfnmm3jx590h";
+      rev = "f3daedaac493ebc0ba1a96c915423a329e09e84a";
+      sha256 = "073wwapd9n13w23mnhrgh9bd80wkbcj8fl06k03ngy7cyn5r71d2";
       type = "git";
-      url = "https://github.com/mitchellh/vagrant-spec.git";
+      url = "https://github.com/hashicorp/vagrant-spec.git";
     };
     version = "0.0.1";
   };


### PR DESCRIPTION
###### Motivation for this change

I was trying to use `vagrant plugin install vagrant-aws` which was failing with:
```
Installing the 'vagrant-aws' plugin. This can take a few minutes...
Bundler, the underlying system Vagrant uses to install plugins,
reported an error. The error is shown below. These errors are usually
caused by misconfigured plugin installations or transient network
issues. The error from Bundler is:

conflicting dependencies bundler (= 1.14.6) and bundler (= 1.16.1)
  Activated bundler-1.16.1
  which does not match conflicting dependency (= 1.14.6)

  Conflicting dependency chains:
    bundler (= 1.16.1), 1.16.1 activated

  versus:
    bundler (= 1.14.6)

  Gems matching bundler (= 1.14.6):
    bundler-1.14.6
```

###### Things done
I used bundix to create a new gemset.nix and then updated the version of bundler to match what I think ruby expects:
```
$ git clone git@github.com:hashicorp/vagrant.git
$ cd vagrant
$ bundix -l
$ cp gemset.nix /path/to/nixpkgs/pkgs/development/tools/vagrant
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

