### PR TITLE
pycurl: 7.19.5.1 -> 7.43.0.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12645,17 +12645,19 @@ in {
   pycups = callPackage ../development/python-modules/pycups { };
 
   pycurl = buildPythonPackage (rec {
-    name = "pycurl-7.19.5.1";
+    pname = "pycurl";
+    version = "7.43.0.1";
     disabled = isPyPy; # https://github.com/pycurl/pycurl/issues/208
 
-    src = pkgs.fetchurl {
-      url = "http://pycurl.sourceforge.net/download/${name}.tar.gz";
-      sha256 = "0v5w66ir3siimfzg3kc8hfrrilwwnbxq5bvipmrpyxar0kw715vf";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1ali1gjs9iliwjra7w0y5hwg79a2fd0f4ydvv6k27sgxpbr1n8s3";
     };
 
     buildInputs = with self; [ pkgs.curl pkgs.openssl.out ];
 
-    checkInputs = with self; [ bottle pytest nose ];
+    checkInputs = with self; [ bottle pytest nose flaky ];
+
     checkPhase = ''
       py.test -k "not ssh_key_cb_test \
                   and not test_libcurl_ssl_gnutls \


### PR DESCRIPTION
###### Motivation for this change
This unbreaks the release-18.03 for me, as otherwise pycurl is broken and doesn't compile.

###### Things done
nixos-rebuild

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

