### PR TITLE
pythonPackages.notebook: cleanup

### DIFF
--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   LC_ALL = "en_US.utf8";
 
-  buildInputs = [ nose glibcLocales ]
+  checkInputs = [ nose glibcLocales ]
     ++ (if isPy3k then [ nose_warnings_filters ] else [ mock ]);
 
   propagatedBuildInputs = [
@@ -43,9 +43,9 @@ buildPythonPackage rec {
 
   # disable warning_filters
   preCheck = lib.optionalString (!isPy3k) ''
-    echo "" > setup.cfg
-    cat setup.cfg
+    touch setup.cfg
   '';
+
   checkPhase = ''
     runHook preCheck
     mkdir tmp


### PR DESCRIPTION
As discussed in https://github.com/NixOS/nixpkgs/pull/37607#issuecomment-375226186.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

