### PR TITLE
treewide: replace deprecated alias s/mssys/ms-sys/g

### DIFF
--- a/nixos/modules/installer/cd-dvd/system-tarball-fuloong2f.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-fuloong2f.nix
@@ -54,7 +54,7 @@ in
   environment.systemPackages =
     [ pkgs.w3m # needed for the manual anyway
       pkgs.testdisk # useful for repairing boot problems
-      pkgs.mssys # for writing Microsoft boot sectors / MBRs
+      pkgs.ms-sys # for writing Microsoft boot sectors / MBRs
       pkgs.parted
       pkgs.ddrescue
       pkgs.ccrypt

--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -9,7 +9,7 @@
   environment.systemPackages = [
     pkgs.w3m-nox # needed for the manual anyway
     pkgs.testdisk # useful for repairing boot problems
-    pkgs.mssys # for writing Microsoft boot sectors / MBRs
+    pkgs.ms-sys # for writing Microsoft boot sectors / MBRs
     pkgs.efibootmgr
     pkgs.efivar
     pkgs.parted


### PR DESCRIPTION
###### Motivation for this change

replace deprecated alias s/mssys/ms-sys/g