### PR TITLE
kakoune: 2018-02-15 -> 2018-03-22

### DIFF
--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -4,12 +4,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "kakoune-unstable-${version}";
-  version = "2018-02-15";
+  version = "2018-03-22";
   src = fetchFromGitHub {
     repo = "kakoune";
     owner = "mawww";
-    rev = "f5e39972eb525166dc5b1d963067f79990991a75";
-    sha256 = "160a302xg6nfzx49dkis6ij20kyzr63kxvcv8ld3l07l8k69g80r";
+    rev = "f8e297acef1be0657b779fea5256f606a6c6a3a3";
+    sha256 = "14xmw3lkwzppm9bns55nmyb1lfihzhdyisf6xjqlszdj4mcf94jl";
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses asciidoc docbook_xsl libxslt ];


### PR DESCRIPTION
###### Motivation for this change

Newer version of the kakoune editor (2018-02-15 -> 2018-03-22)

###### Things done

Updated date, rev and sha fields of the corresponding default.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

