### PR TITLE
python2Packages.notebook: fix tests

### DIFF
--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
 
   # disable warning_filters
   preCheck = lib.optionalString (!isPy3k) ''
-    touch setup.cfg
+    echo "" > setup.cfg
   '';
 
   checkPhase = ''


### PR DESCRIPTION
These were accidentally broken by #37615.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

