### PR TITLE
bazel: 0.10.1 -> 0.11.1

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
 
-  version = "0.10.1";
+  version = "0.11.1";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "0rz6zvkzyglf0mmc178avf52zynz487m4v0089ilsbrgv7v4i0kh";
+    sha256 = "0grkbfr37pyns2hb7kmq75d59rzvbklji01cjm8glrhmq2y65mz8";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.11.1 with grep in /nix/store/x5y0fs17z8xayw1lplp1hbl8ny6jxpqp-bazel-0.11.1
- directory tree listing: https://gist.github.com/ac19a0e0ea728fcb73ca6819bcbba7ea

cc @philandstuff for review