### PR TITLE
accounts-qt: 1.13 -> 1.15

### DIFF
--- a/pkgs/development/libraries/accounts-qt/default.nix
+++ b/pkgs/development/libraries/accounts-qt/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "accounts-qt-${version}";
-  version = "1.13";
+  version = "1.15";
 
   src = fetchFromGitLab {
-    sha256 = "1gpkgw05dwsf2wk5cy3skgss3kw6mqh7iv3fadrxqxfc1za1xmyl";
-    rev = version;
+    sha256 = "0cnra7g2mcgzh8ykrj1dpb4khkx676pzdr4ia1bvsp0cli48691w";
+    rev = "VERSION_${version}";
     repo = "libaccounts-qt";
     owner = "accounts-sso";
   };


### PR DESCRIPTION
accounts-qt changed their tag naming scheme.

- Built on NixOS
- ran `/nix/store/790jpjbv7n4ccfwbnp2hpxi6xnh0rp4m-accounts-qt-1.15/bin/accountstest --help` got 0 exit code
- ran `/nix/store/790jpjbv7n4ccfwbnp2hpxi6xnh0rp4m-accounts-qt-1.15/bin/accountstest --help` and found version 1.15
- found 1.15 with grep in /nix/store/790jpjbv7n4ccfwbnp2hpxi6xnh0rp4m-accounts-qt-1.15
- directory tree listing: https://gist.github.com/5d6d729f133d93d11e63e456638fd32e

Also, I ran the accountstest suite on 1.13 and 1.15. Fewer tests fail on 1.15 than 1.13. 