### PR TITLE
cmakeWithQt4Gui: 3.10.2 -> 3.10.3

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -19,7 +19,7 @@ with (
   {
     "3.10" = {
       minorVersion = "2";
-      sha256 = "80d0faad4ab56de07aa21a7fc692c88c4ce6156d42b0579c6962004a70a3218b";
+      sha256 = "12r1ldq4l032d6f5gc22dlayck4cr29cczqsl9xf0vdm9anzml40";
     };
     "3.9" = {
       minorVersion = "6";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}files/v${majorVersion}/cmake-${version}.tar.gz";
-    # from https://cmake.org/files/v3.10/cmake-3.10.2-SHA-256.txt
+    # from https://cmake.org/files/v3.10/cmake-3.10.3-SHA-256.txt
     inherit sha256;
   };
 


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/ccmake -h` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/ccmake --help` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/cmake -h` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/cmake --help` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/cmake-gui -h` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/cmake-gui --help` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/cpack -h` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/cpack --help` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/ctest -h` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/ctest --help` got 0 exit code
- ran `/nix/store/sgglmrmm9k02zcgkb7z06v4sxl12bfdy-cmake-cursesUI-qt4UI-3.10.2/bin/ctest help` got 0 exit code
- directory tree listing: https://gist.github.com/1cc16386b81e0fedc5a9a4c27b14c198

cc @ttuegel @lnl7 for review