### PR TITLE
dlib: 19.9 -> 19.10

### DIFF
--- a/pkgs/development/libraries/dlib/default.nix
+++ b/pkgs/development/libraries/dlib/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "19.9";
+  version = "19.10";
   name = "dlib-${version}";
 
   src = fetchFromGitHub {
     owner = "davisking";
     repo = "dlib";
     rev ="v${version}";
-    sha256 = "0lc54r928j9dg7f2wn25m887z24d31wrc14v2hn6aknp1z084lrc";
+    sha256 = "0sgxblf4n33b8wgblyblmrkwydvy1yh7fzll1b6c4zgkz675w0m5";
   };
 
   postPatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 19.10 with grep in /nix/store/3h9m66pcyc428v616z3ls200aidd12wz-dlib-19.10
- directory tree listing: https://gist.github.com/7c3e568146e46ccdaed28be2916bd0a9

cc @christopherpoole for review