### PR TITLE
fflas-ffpack: 2.2.2 -> 2.3.2

### DIFF
--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -2,12 +2,12 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "fflas-ffpack";
-  version = "2.2.2";
+  version = "2.3.2";
   src = fetchFromGitHub {
     owner = "linbox-team";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "0k1f4pb7azrm6ajncvg7vni7ixfmn6fssd5ld4xddbi6jqbsf9rd";
+    sha256 = "1cqhassj2dny3gx0iywvmnpq8ca0d6m82xl5rz4mb8gaxr2kwddl";
   };
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ givaro (liblapack.override {shared = true;}) openblas];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config -h` got 0 exit code
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config --help` got 0 exit code
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config help` got 0 exit code
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config -V` and found version 2.3.2
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config -v` and found version 2.3.2
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config --version` and found version 2.3.2
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config version` and found version 2.3.2
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config -h` and found version 2.3.2
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config --help` and found version 2.3.2
- ran `/nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2/bin/fflas-ffpack-config help` and found version 2.3.2
- found 2.3.2 with grep in /nix/store/10g4cklvbc5d7hkymlzbgnn7yw7mgdkp-fflas-ffpack-2.3.2
- directory tree listing: https://gist.github.com/e66f5e5926034e2f224c064aba1c3613

cc @7c6f434c for review