### PR TITLE
gdal: 2.2.3 -> 2.2.4

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -8,12 +8,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "2.2.3";
+  version = "2.2.4";
   name = "gdal-${version}";
 
   src = fetchurl {
     url = "http://download.osgeo.org/gdal/${version}/${name}.tar.xz";
-    sha256 = "a328d63d476b3653f5a25b5f7971e87a15cdf8860ab0729d4b1157ba988b8d0b";
+    sha256 = "0y1237m2wilxgrsd0cdjpbf1zj9z954sd8518g53hlmkmk8v27j4";
   };
 
   buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.epsg_tr.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/epsg_tr.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gcps2vec.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gcps2vec.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal2tiles.py-wrapped -h` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal2tiles.py-wrapped --help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal2tiles.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal2tiles.py -h` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal2tiles.py --help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal2tiles.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal_auth.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_auth.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal_fillnodata.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_fillnodata.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal_merge.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_merge.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal_polygonize.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_polygonize.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal_proximity.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_proximity.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdal_sieve.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_sieve.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdalchksum.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalchksum.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdalcompare.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalcompare.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdalident.py-wrapped -h` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdalident.py-wrapped --help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdalident.py-wrapped help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdalident.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalident.py -h` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalident.py --help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalident.py help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalident.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdalimport.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalimport.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.gdalmove.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalmove.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.mkgraticule.py-wrapped help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/mkgraticule.py help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/.rgb2pct.py-wrapped --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/rgb2pct.py --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalinfo --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalserver --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_translate --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdaladdo --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalwarp --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/nearblack --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalmanage --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalenhance --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdaltransform --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdallocationinfo --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalsrsinfo help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalsrsinfo --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdaltindex --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_rasterize --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal_grid --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/ogrinfo help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/ogrinfo --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/ogr2ogr --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/ogrlineref --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/testepsg -h` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/testepsg --help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/testepsg help` got 0 exit code
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdalbuildvrt --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gnmmanage --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gnmanalyse --version` and found version 2.2.4
- ran `/nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4/bin/gdal-config --version` and found version 2.2.4
- found 2.2.4 with grep in /nix/store/jdbh08lrbarwcp1j656y02qqjlcv28xf-gdal-2.2.4
- directory tree listing: https://gist.github.com/9fbb0e6bcdf6a8ed1d3b5a8f20a84eca

cc @marcweber for review