### PR TITLE
avrdude: add darwin platform (including libftdi1 dependency)

### DIFF
--- a/pkgs/development/libraries/libftdi/1.x.nix
+++ b/pkgs/development/libraries/libftdi/1.x.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "A library to talk to FTDI chips using libusb";
     homepage = https://www.intra2net.com/en/developer/libftdi/;
     license = with licenses; [ lgpl2 gpl2 ];
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/tools/misc/avrdude/default.nix
+++ b/pkgs/development/tools/misc/avrdude/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.nongnu.org/avrdude/;
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Flash AVRs from macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

