### PR TITLE
gitAndTools.git-open: 1.3.1 -> 2.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-open/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-open/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "git-open-${version}";
-  version = "1.3.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "paulirish";
     repo = "git-open";
     rev = "v${version}";
-    sha256 = "1klj41vqgyyigqzi6s1ykz9vd8wvaq3skin63pi989dlsjf7igyr";
+    sha256 = "0lprzrjsqrg83gixfaiw26achgd8l7s56jknsjss4p7y0w1fxm05";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.0.0 with grep in /nix/store/bl1bdnjxn6k22is2w6qvdjl7kvhzjv2s-git-open-2.0.0
- directory tree listing: https://gist.github.com/7c26064e56c054ea6ba2b4d9162267cd

cc @jlesquembre for review