### PR TITLE
avrgcc: 5.4.0 -> 7.3.0

### DIFF
--- a/pkgs/development/misc/avr/gcc/default.nix
+++ b/pkgs/development/misc/avr/gcc/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, gmp, mpfr, libmpc, zlib, avrbinutils, texinfo }:
 
 let
-  version = "5.4.0";
+  version = "7.3.0";
 in
 stdenv.mkDerivation {
 
   name = "avr-gcc-${version}";
   src = fetchurl {
-    url = "mirror://gcc/releases/gcc-${version}/gcc-${version}.tar.bz2";
-    sha256 = "0fihlcy5hnksdxk0sn6bvgnyq8gfrgs8m794b1jxwd1dxinzg3b0";
+    url = "mirror://gcc/releases/gcc-${version}/gcc-${version}.tar.xz";
+    sha256 = "0p71bij6bfhzyrs8676a8jmpjsfz392s2rg862sdnsk30jpacb43";
   };
 
   patches = [
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
     description = "GNU Compiler Collection, version ${version} for AVR microcontrollers";
     homepage = http://gcc.gnu.org;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ mguentner ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Keeping it up to date. Also seems to work on macOS, so added darwin to platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

