### PR TITLE
opendylan: 2013.1 -> 2016.1pre

### DIFF
--- a/pkgs/development/compilers/opendylan/default.nix
+++ b/pkgs/development/compilers/opendylan/default.nix
@@ -2,18 +2,18 @@
 {stdenv, fetchgit, boehmgc, mps, gnused, opendylan-bootstrap, autoconf, automake, perl, makeWrapper, gcc }:
 
 stdenv.mkDerivation {
-  name = "opendylan-2013.2";
+  name = "opendylan-2016.1pre";
 
   src = fetchgit {
     url = https://github.com/dylan-lang/opendylan;
-    rev = "ce9b14dab6cb9ffedc69fae8c6df524c0c79abd3";
-    sha256 = "17jvhv0y63fj25ma05k70b7phcwgjyna5qkrirk48z3xapb8bknd";
+    rev = "cd9a8395586d33cc43a8611c1dc0513e69ee82dd";
+    sha256 = "00r1dm7mjy5p4hfm13vc4b6qryap40zinia3y15rhvalc3i2np4b";
     fetchSubmodules = true;
   };
 
   buildInputs = (if stdenv.system == "i686-linux" then [ mps ] else [ boehmgc ]) ++ [
     opendylan-bootstrap boehmgc gnused autoconf automake perl makeWrapper
-  ] ;
+  ];
 
   preConfigure = if stdenv.system == "i686-linux" then ''
     mkdir -p $TMPDIR/mps


### PR DESCRIPTION
###### Motivation for this change

1. easy resolution to build failure
2. update opendylan

questionable if updating to a "pre" release is OK. I tried the latest stable, 2014.1, but the build failed for the same as currently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

