### PR TITLE
wrapFirefox: update icon location

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -130,9 +130,11 @@ let
             mkdir -p "$out/share"
             ln -s "${browser}/share/icons" "$out/share/icons"
         else
-            mkdir -p "$out/share/icons/hicolor/128x128/apps"
-            ln -s "${browser}/lib/${browserName}-"*"/browser/icons/mozicon128.png" \
-                "$out/share/icons/hicolor/128x128/apps/${browserName}.png"
+            for res in 16 32 48 64 128; do
+            mkdir -p "$out/share/icons/hicolor/''${res}x''${res}/apps"
+            ln -s "${browser}/lib/${browserName}/browser/chrome/icons/default/default''${res}.png" \
+                "$out/share/icons/hicolor/''${res}x''${res}/apps/${browserName}.png"
+            done
         fi
 
         install -D -t $out/share/applications $desktopItem/share/applications/*


### PR DESCRIPTION
The icons for Firefox are in a new location in the unwrapped package; the
wrapper is updated to reflect that. This should have no effect on other browers
that provide their own icons in the default XDG location.

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

