### PR TITLE
xpdf: Don't try to wrap xpdf binary on Darwin if it wasn't requested (enableGUI = false)

### DIFF
--- a/pkgs/applications/misc/xpdf/default.nix
+++ b/pkgs/applications/misc/xpdf/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = stdenv.lib.optionalString (stdenv.isDarwin && enableGUI) ''
     wrapProgram $out/bin/xpdf \
       --set QT_PLUGIN_PATH ${qtbase.bin}/${qtbase.qtPluginPrefix}:${qtsvg.bin}/${qtbase.qtPluginPrefix}
   '';


### PR DESCRIPTION
###### Motivation for this change
The postInstall clause wants to wrap xpdf on Darwin even if it was't built (enableGUI = false)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
