### PR TITLE
libretro.mame: 2017-06-04 -> 2017-03-02

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -232,10 +232,11 @@ in with stdenv.lib.licenses;
 
   mame = (mkLibRetroCore {
     core = "mame";
+    version = "2018-03-02";
     src = fetchRetro {
       repo = "mame";
-      rev = "9f8a36adeb4dc54ec2ecac992ce91bcdb377519e";
-      sha256 = "0blfvq28hgv9kkpijd8c9d9sa5g2qr448clwi7wrj8kqfdnrr8m1";
+      rev = "893f1ac2231b348b63209fd5b2545f770458ae8f";
+      sha256 = "1j9p82q9jhf5lf4w392zd09bq0j4iw1afhznymg0v60jv592h3gz";
     };
     description = "Port of MAME to libretro";
     license = gpl2Plus;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

