### PR TITLE
gitAndTools.git-extras: 4.4.0 -> 4.5.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-extras/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-extras/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "git-extras-${version}";
-  version = "4.4.0";
+  version = "4.5.0";
 
   src = fetchurl {
     url = "https://github.com/tj/git-extras/archive/${version}.tar.gz";
-    sha256 = "0vb8syyr5nbvmkj5g4rb1p8rqxb2hyl25gbyf4rd0b972d7iihhn";
+    sha256 = "059680bvblbhrlkybg1yisr5zq62pir1rnaxz5izhfsw2ng9s2fb";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/5f91kx2c84gnfkvaw7lfs73ziwfih3y3-git-extras-4.5.0/bin/git-extras -v` and found version 4.5.0
- ran `/nix/store/5f91kx2c84gnfkvaw7lfs73ziwfih3y3-git-extras-4.5.0/bin/git-extras --version` and found version 4.5.0
- ran `/nix/store/5f91kx2c84gnfkvaw7lfs73ziwfih3y3-git-extras-4.5.0/bin/git-standup -h` got 0 exit code
- ran `/nix/store/5f91kx2c84gnfkvaw7lfs73ziwfih3y3-git-extras-4.5.0/bin/git-standup help` got 0 exit code
- found 4.5.0 with grep in /nix/store/5f91kx2c84gnfkvaw7lfs73ziwfih3y3-git-extras-4.5.0
- directory tree listing: https://gist.github.com/a7a8d5fdc1d2b452c08a12f2319907dd

cc @spwhitt @cko for review