### PR TITLE
streamripper: Enable darwin build

### DIFF
--- a/pkgs/applications/audio/streamripper/default.nix
+++ b/pkgs/applications/audio/streamripper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl , glib, pkgconfig, libogg, libvorbis }:
+{ stdenv, fetchurl , glib, pkgconfig, libogg, libvorbis, libmad }:
 
 stdenv.mkDerivation rec {
   name = "streamripper-${version}";
@@ -10,13 +10,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libogg libvorbis ];
+  buildInputs = [ glib libogg libvorbis libmad ];
 
   meta = with stdenv.lib; {
     homepage = http://streamripper.sourceforge.net/;
     description = "Application that lets you record streaming mp3 to your hard drive";
     license = licenses.gpl2;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ the-kenny ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)

streamripper ships its own version of libmad, which does not compile on
clang, due to the usage of incompatible compiler flags. We can get the
build working by using the already packaged libmad, which includes
patches for clang.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

