### PR TITLE
gitAndTools.git-recent: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-recent/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-recent/default.nix
@@ -11,13 +11,13 @@ let
     ++ stdenv.lib.optional (utillinux != null) utillinux);
 in stdenv.mkDerivation rec {
   name = "git-recent-${version}";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "paulirish";
     repo = "git-recent";
     rev = "v${version}";
-    sha256 = "0rckjjrw2xmvmbqaf66i36x59vs1v4pfnmvbinx5iggp7vjly1a4";
+    sha256 = "0dbnm5b2v04fy0jgzphm3xvz9scx0n4p10fw8wjd0cy56308h79k";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/0qpj62pcv8gvlyimr7bmmhnq2y4kq59c-git-recent-1.0.4/bin/git-recent -h` got 0 exit code
- ran `/nix/store/0qpj62pcv8gvlyimr7bmmhnq2y4kq59c-git-recent-1.0.4/bin/git-recent --help` got 0 exit code
- ran `/nix/store/0qpj62pcv8gvlyimr7bmmhnq2y4kq59c-git-recent-1.0.4/bin/git-recent help` got 0 exit code
- ran `/nix/store/0qpj62pcv8gvlyimr7bmmhnq2y4kq59c-git-recent-1.0.4/bin/.git-recent-wrapped -h` got 0 exit code
- ran `/nix/store/0qpj62pcv8gvlyimr7bmmhnq2y4kq59c-git-recent-1.0.4/bin/.git-recent-wrapped --help` got 0 exit code
- ran `/nix/store/0qpj62pcv8gvlyimr7bmmhnq2y4kq59c-git-recent-1.0.4/bin/.git-recent-wrapped help` got 0 exit code
- found 1.0.4 with grep in /nix/store/0qpj62pcv8gvlyimr7bmmhnq2y4kq59c-git-recent-1.0.4
- directory tree listing: https://gist.github.com/a5c51e3598313240f56c2e95a8ddf85e

cc @jlesquembre for review