### PR TITLE
gitAndTools.gitRemoteGcrypt: 1.0.0 -> 1.0.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "git-remote-gcrypt-${version}";
-  version = "1.0.0";
+  version = "1.0.3";
   rev = version;
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "spwhitton";
     repo = "git-remote-gcrypt";
-    sha256 = "0c8ig1pdqj7wjwldnf62pmm2x29ri62x6b24mbsl2nxzkqbwh379";
+    sha256 = "1vay3204729c7wajgn3nxf0s0hzwpdrw14pl6kd8w2ss25gvw2k1";
   };
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.0.3 with grep in /nix/store/y4rmp0i9bslzh2izpjhl9glklwhd9ypn-git-remote-gcrypt-1.0.3
- directory tree listing: https://gist.github.com/4dd37ba2fc098537882e10e0c38823bb

cc @ellis @montag451 for review