### PR TITLE
Update systemd and unbreak staging

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -137,7 +137,6 @@ let
 
       # Slices / containers.
       "slices.target"
-      "system.slice"
       "user.slice"
       "machine.slice"
       "machines.target"
@@ -821,7 +820,8 @@ in
 
     system.requiredKernelConfig = map config.lib.kernelConfig.isEnabled
       [ "DEVTMPFS" "CGROUPS" "INOTIFY_USER" "SIGNALFD" "TIMERFD" "EPOLL" "NET"
-        "SYSFS" "PROC_FS" "FHANDLE" "DMIID" "AUTOFS4_FS" "TMPFS_POSIX_ACL"
+        "SYSFS" "PROC_FS" "FHANDLE" "CRYPTO_USER_API_HASH" "CRYPTO_HMAC"
+        "CRYPTO_SHA256" "DMIID" "AUTOFS4_FS" "TMPFS_POSIX_ACL"
         "TMPFS_XATTR" "SECCOMP"
       ];
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -135,6 +135,7 @@ with stdenv.lib;
   NETFILTER y
   NETFILTER_ADVANCED y
   CGROUP_BPF? y # Required by systemd per-cgroup firewalling
+  CGROUP_NET_PRIO y # Required by systemd
   IP_ROUTE_VERBOSE y
   IP_MROUTE_MULTIPLE_TABLES y
   IP_VS_PROTO_TCP y

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -18,14 +18,14 @@ let
   pythonLxmlEnv = buildPackages.python3Packages.python.withPackages ( ps: with ps; [ python3Packages.lxml ]);
 
 in stdenv.mkDerivation rec {
-  version = "237";
+  version = "238";
   name = "systemd-${version}";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "systemd";
-    rev = "98067cc806ae0d2759cdd2334f230cd8548e5317";
-    sha256 = "077svfs2xy3g30s62q69wcv5pb9vfhzh8i7lhfri73vvhwbpzd5q";
+    rev = "243d65d38f2df82d4a39f6a9970337803dff65a1";
+    sha256 = "098hxlkh6q17rxa178adylksxnnd4x9rxb8amjnlbiydcc6kaa5n";
   };
 
   outputs = [ "out" "lib" "man" "dev" ];
@@ -176,13 +176,6 @@ in stdenv.mkDerivation rec {
     mv $out/lib/systemd/{system,user} $out/example/systemd
 
     rm -rf $out/etc/systemd/system
-
-    # Install SysV compatibility commands.
-    mkdir -p $out/sbin
-    ln -s $out/lib/systemd/systemd $out/sbin/telinit
-    for i in init halt poweroff runlevel reboot shutdown; do
-      ln -s $out/bin/systemctl $out/sbin/$i
-    done
 
     # Fix reference to /bin/false in the D-Bus services.
     for i in $out/share/dbus-1/system-services/*.service; do

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -1,16 +1,23 @@
-{ stdenv, fetchurl, pkgconfig, attr, acl, zlib, libuuid, e2fsprogs, lzo
+{ stdenv, fetchurl, fetchpatch, pkgconfig, attr, acl, zlib, libuuid, e2fsprogs, lzo
 , asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, libxslt, zstd
 }:
 
-let version = "4.15.1"; in
-
 stdenv.mkDerivation rec {
   name = "btrfs-progs-${version}";
+  version = "4.15.1";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v${version}.tar.xz";
     sha256 = "15izak6jg6pqr6ha9447cdrdj9k6kfiarvwlrj53cpvrsv02l437";
   };
+
+  patches = [
+    # Fix build with e2fsprogs 1.44.0
+    (fetchpatch {
+      url = "https://patchwork.kernel.org/patch/10281327/raw/";
+      sha256 = "016124hjms220809zjvvr7l1gq23j419d3piaijsaw8n7yd3kksf";
+    })
+  ];
 
   nativeBuildInputs = [
     pkgconfig asciidoc xmlto docbook_xml_dtd_45 docbook_xsl libxslt
@@ -20,7 +27,7 @@ stdenv.mkDerivation rec {
 
   # gcc bug with -O1 on ARM with gcc 4.8
   # This should be fine on all platforms so apply universally
-  patchPhase = "sed -i s/-O1/-O2/ configure";
+  postPatch = "sed -i s/-O1/-O2/ configure";
 
   postInstall = ''
     install -v -m 444 -D btrfs-completion $out/etc/bash_completion.d/btrfs


### PR DESCRIPTION
###### Motivation for this change

Fix current staging problems by updating systemd and fix other packages around.

Fixes https://github.com/NixOS/nixpkgs/issues/36918.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested by building a near-empty VM. Upstream systemd bug report related to `CGROUP_NET_PRIO` is coming.