### PR TITLE
xpointerbarrier: 17.10 -> 17.11

### DIFF
--- a/pkgs/tools/X11/xpointerbarrier/default.nix
+++ b/pkgs/tools/X11/xpointerbarrier/default.nix
@@ -1,13 +1,13 @@
 { stdenv, xorg, fetchFromGitHub }:
 stdenv.mkDerivation rec {
   name = "xpointerbarrier-${version}";
-  version = "17.10";
+  version = "17.11";
 
   src = fetchFromGitHub {
     owner = "vain";
     repo = "xpointerbarrier";
     rev = "v${version}";
-    sha256 = "0p4qc7ggndf74d2xdf38659prx3r3lfi5jc8nmqx52c9fqdshcrk";
+    sha256 = "0s6bd58xjyc2nqzjq6aglx6z64x9xavda3i6p8vrmxqmcpik54nm";
   };
 
   buildInputs = [ xorg.libX11 xorg.libXfixes xorg.libXrandr ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

