### PR TITLE
ibus-engines.anthy: 1.5.9 -> 1.5.10

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "ibus-anthy-${version}";
-  version = "1.5.9";
+  version = "1.5.10";
 
   meta = with stdenv.lib; {
     isIbusEngine = true;
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/ibus/ibus-anthy/releases/download/${version}/${name}.tar.gz";
-    sha256 = "1y8sf837rmp662bv6zakny0xcm7c9c5qda7f9kq9riv9ywpcbw6x";
+    sha256 = "0jpqz7pb9brlqiwrbr3i6wvj3b39a9bs9lljl3qa3r77mz8y0cyc";
   };
 }


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.5.10 with grep in /nix/store/3h4a30xh4ddij4i5nmyi8p478y804jv7-ibus-anthy-1.5.10
- directory tree listing: https://gist.github.com/2a6dbfad474173b76f5f0d7aa35964f6

cc @gebner @ericsagnes for review