### PR TITLE
imagemagick7: 7.0.7-22 -> 7.0.7-27

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -14,8 +14,8 @@ let
     else throw "ImageMagick is not supported on this platform.";
 
   cfg = {
-    version = "7.0.7-22";
-    sha256 = "1ad7mwx48xrkvm3v060n2f67kmi0qk7gfql1shiwbkkjvzzaaiam";
+    version = "7.0.7-27";
+    sha256 = "04v7m1s2a89xi57fpxbq30hzxqg3fawr3lms6wfmaq4j2ax0qw6k";
     patches = [];
   };
 in


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/8n4a2v0wfmzlk9n2bdv919ybg17bai8c-imagemagick-7.0.7-27/bin/magick -h` got 0 exit code
- ran `/nix/store/8n4a2v0wfmzlk9n2bdv919ybg17bai8c-imagemagick-7.0.7-27/bin/magick --help` got 0 exit code
- ran `/nix/store/8n4a2v0wfmzlk9n2bdv919ybg17bai8c-imagemagick-7.0.7-27/bin/magick help` got 0 exit code
- ran `/nix/store/8n4a2v0wfmzlk9n2bdv919ybg17bai8c-imagemagick-7.0.7-27/bin/magick --version` and found version 7.0.7-27
- found 7.0.7-27 with grep in /nix/store/8n4a2v0wfmzlk9n2bdv919ybg17bai8c-imagemagick-7.0.7-27
- directory tree listing: https://gist.github.com/4c89cc9d32b6739922d277619629d087

cc @the-kenny @wkennington for review