### PR TITLE
ircdHybrid: 8.2.21 -> 8.2.22

### DIFF
--- a/pkgs/servers/irc/ircd-hybrid/default.nix
+++ b/pkgs/servers/irc/ircd-hybrid/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, openssl, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "ircd-hybrid-8.2.21";
+  name = "ircd-hybrid-8.2.22";
 
   src = fetchurl {
     url = "mirror://sourceforge/ircd-hybrid/${name}.tgz";
-    sha256 = "19cgrgmmz1c72x4gxpd39f9ckm4j9cp1gpgvlkk73d3v13znfzy3";
+    sha256 = "1i5iv5hc8gbaw74mz18zdjzv3dsvyvr8adldj8p1726h4i2xzn6p";
   };
 
   buildInputs = [ openssl zlib ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/mkpasswd -h` got 0 exit code
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/mkpasswd --help` got 0 exit code
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/mkpasswd -V` and found version 8.2.22
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/mkpasswd -v` and found version 8.2.22
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/mkpasswd --version` and found version 8.2.22
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/mkpasswd --help` and found version 8.2.22
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/ircd help` got 0 exit code
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/ircd version` and found version 8.2.22
- ran `/nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22/bin/ircd help` and found version 8.2.22
- found 8.2.22 with grep in /nix/store/z0r8fy3q89hq2dp62h084q6s5m9bpxi6-ircd-hybrid-8.2.22
- directory tree listing: https://gist.github.com/4a91920bc15a662018a588fbd3e819d1