### PR TITLE
googleearth: 7.1.4.1529 -> 7.1.8.3036-r0

### DIFF
--- a/pkgs/applications/misc/googleearth/default.nix
+++ b/pkgs/applications/misc/googleearth/default.nix
@@ -34,11 +34,11 @@ let
   ];
 in
 stdenv.mkDerivation rec {
-  version = "7.1.4.1529";
+  version = "7.1.8.3036-r0";
   name = "googleearth-${version}";
 
   src = fetchurl {
-    url = "https://dl.google.com/earth/client/current/google-earth-stable_current_${arch}.deb";
+    url = "https://dl.google.com/linux/earth/deb/pool/main/g/google-earth-stable/google-earth-stable_${version}_${arch}.deb";
     inherit sha256;
   };
 
@@ -55,8 +55,8 @@ stdenv.mkDerivation rec {
     mv usr/* $out/
     rmdir usr
     mv * $out/
-    rm $out/bin/google-earth $out/opt/google/earth/free/google-earth
-    ln -s $out/opt/google/earth/free/googleearth $out/bin/google-earth
+    rm $out/bin/google-earth $out/opt/google/earth/free/google-earth $out/opt/google/earth/free/googleearth
+    ln -s $out/opt/google/earth/free/googleearth-bin $out/bin/google-earth
 
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "${fullPath}:\$ORIGIN" \


### PR DESCRIPTION
###### Motivation for this change

Fixes broken URL and broken start script (sha256 of the debs remains the same)
Tested on NixOS 17.09, it builds, but the program hangs at the splash screen.
Not sure if it's just my system or happens to others as well, testing/feedback welcome.

See also #30491
cc @viric  @peterhoeg @chris-martin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

