### PR TITLE
ocamlPackages.js_of_ocaml: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -8,13 +8,13 @@ else
 
 stdenv.mkDerivation rec {
 	name = "js_of_ocaml-compiler-${version}";
-	version = "3.0.0";
+	version = "3.1.0";
 
 	src = fetchFromGitHub {
 		owner = "ocsigen";
 		repo = "js_of_ocaml";
 		rev = version;
-		sha256 = "17w1pqjk521jd4yp34miyif0cxjxchnw59xhj188qfl635ykb4k8";
+		sha256 = "17a0kb39bcx2qq41cq7kjrxghm67l1yahrs47yakgb1avna0pqd9";
 	};
 
 	buildInputs = [ ocaml findlib jbuilder cmdliner cppo ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.1.0 with grep in /nix/store/rg3dh55klmmy5gffvv353nbgwjg0mh11-js_of_ocaml-3.1.0
- directory tree listing: https://gist.github.com/4afbe9caa678f6e8124185a1cc5d2a9c

cc @vbgl for review