### PR TITLE
ahoviewer: 1.4.9 -> 1.5.0; add useUnrar option

### DIFF
--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "ahoviewer-${version}";
-  version = "1.4.9";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "ahodesuka";
     repo = "ahoviewer";
     rev = version;
-    sha256 = "194h3k5zvd8gjrbs91qba7d9h7i30yh4rjk4w3aa1vwvv0qm2amx";
+    sha256 = "1adzxp30fwh41y339ha8i5qp89zf21dw18vcicqqnzvyxbk5r3ig";
   };
 
   enableParallelBuilding = true; 
@@ -20,9 +20,13 @@ stdenv.mkDerivation rec {
                   libsecret curl unrar libzip librsvg 
                   gst_all_1.gstreamer
                   gst_all_1.gst-plugins-good 
-                  gst_all_1.gst-plugins-bad 
                   gst_all_1.gst-libav
                   gst_all_1.gst-plugins-base ];
+
+  # https://github.com/ahodesuka/ahoviewer/issues/60
+  # Already fixed in the master branch
+  # TODO: remove this next release
+  makeFlags = [ ''LIBS=-lssl -lcrypto'' ];
   
   postPatch = ''patchShebangs version.sh'';
   

--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -1,6 +1,10 @@
-{ stdenv, pkgs, fetchurl, fetchFromGitHub, pkgconfig, libconfig, 
-  gtkmm2, glibmm, libxml2, libsecret, curl, unrar, libzip,
-  librsvg, gst_all_1, autoreconfHook, makeWrapper }:
+{ stdenv, pkgs, fetchurl, fetchFromGitHub, pkgconfig, libconfig,
+  gtkmm2, glibmm, libxml2, libsecret, curl, libzip,
+  librsvg, gst_all_1, autoreconfHook, makeWrapper,
+  useUnrar ? false, unrar
+}:
+
+assert useUnrar -> unrar != null;
 
 stdenv.mkDerivation rec {
   name = "ahoviewer-${version}";
@@ -13,23 +17,25 @@ stdenv.mkDerivation rec {
     sha256 = "1adzxp30fwh41y339ha8i5qp89zf21dw18vcicqqnzvyxbk5r3ig";
   };
 
-  enableParallelBuilding = true; 
-  
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
-  buildInputs = [ glibmm libconfig gtkmm2 glibmm libxml2
-                  libsecret curl unrar libzip librsvg 
-                  gst_all_1.gstreamer
-                  gst_all_1.gst-plugins-good 
-                  gst_all_1.gst-libav
-                  gst_all_1.gst-plugins-base ];
+  buildInputs = [
+    glibmm libconfig gtkmm2 glibmm libxml2
+    libsecret curl libzip librsvg
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-base
+  ] ++ stdenv.lib.optional useUnrar unrar;
 
   # https://github.com/ahodesuka/ahoviewer/issues/60
   # Already fixed in the master branch
   # TODO: remove this next release
   makeFlags = [ ''LIBS=-lssl -lcrypto'' ];
-  
+
   postPatch = ''patchShebangs version.sh'';
-  
+
   postInstall = ''
     wrapProgram $out/bin/ahoviewer \
     --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14612,7 +14612,9 @@ with pkgs;
     stdenv = overrideCC stdenv gcc49;
   };
 
-  ahoviewer = callPackage ../applications/graphics/ahoviewer { };
+  ahoviewer = callPackage ../applications/graphics/ahoviewer {
+    useUnrar = config.ahoviewer.useUnrar or false;
+  };
 
   airwave = callPackage ../applications/audio/airwave/default.nix { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

