### PR TITLE
kid3: 3.5.1 -> 3.6.0

### DIFF
--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -10,11 +10,11 @@
 stdenv.mkDerivation rec {
 
   name = "kid3-${version}";
-  version = "3.5.1";
+  version = "3.6.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/kid3/kid3/${version}/${name}.tar.gz";
-    sha256 = "09iryxnhg8d9q36a4brb25bqkjprkx5kl0x7vyy82gxivqk0ihl8";
+    sha256 = "1kv795prc4d3f2cbzskvdi73l6nx4cfcd32x255wq1s74zp1k73p";
   };
 
   buildInputs = with stdenv.lib;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/b7qyswz8glvmami13ij30d7xxsi6631n-kid3-3.6.0/bin/kid3-cli -h` got 0 exit code
- ran `/nix/store/b7qyswz8glvmami13ij30d7xxsi6631n-kid3-3.6.0/bin/kid3-cli --help` got 0 exit code
- ran `/nix/store/b7qyswz8glvmami13ij30d7xxsi6631n-kid3-3.6.0/bin/kid3-cli -h` and found version 3.6.0
- ran `/nix/store/b7qyswz8glvmami13ij30d7xxsi6631n-kid3-3.6.0/bin/kid3-cli --help` and found version 3.6.0
- found 3.6.0 with grep in /nix/store/b7qyswz8glvmami13ij30d7xxsi6631n-kid3-3.6.0
- found 3.6.0 in filename of file in /nix/store/b7qyswz8glvmami13ij30d7xxsi6631n-kid3-3.6.0
- directory tree listing: https://gist.github.com/55e96f99bdc127e8e0ab453dc59880e8

cc @AndersonTorres for review