### PR TITLE
libdvdnav: 5.0.3 -> 6.0.0

### DIFF
--- a/pkgs/development/libraries/libdvdnav/default.nix
+++ b/pkgs/development/libraries/libdvdnav/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libdvdnav-${version}";
-  version = "5.0.3";
+  version = "6.0.0";
 
   src = fetchurl {
     url = "http://get.videolan.org/libdvdnav/${version}/${name}.tar.bz2";
-    sha256 = "5097023e3d2b36944c763f1df707ee06b19dc639b2b68fb30113a5f2cbf60b6d";
+    sha256 = "062njcksmpgw9yv3737qkf93r2pzhaxi9szqjabpa8d010dp38ph";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 6.0.0 with grep in /nix/store/9hclm5126babak424wlc0bflzp5w8wxg-libdvdnav-6.0.0
- directory tree listing: https://gist.github.com/ac1677320d622ed0b03422144cbbc5e4

cc @wmertens for review