### PR TITLE
libdvdread: 5.0.3 -> 6.0.0

### DIFF
--- a/pkgs/development/libraries/libdvdnav/default.nix
+++ b/pkgs/development/libraries/libdvdnav/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libdvdnav-${version}";
-  version = "5.0.3";
+  version = "6.0.0";
 
   src = fetchurl {
     url = "http://get.videolan.org/libdvdnav/${version}/${name}.tar.bz2";
-    sha256 = "5097023e3d2b36944c763f1df707ee06b19dc639b2b68fb30113a5f2cbf60b6d";
+    sha256 = "062njcksmpgw9yv3737qkf93r2pzhaxi9szqjabpa8d010dp38ph";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/libdvdread/default.nix
+++ b/pkgs/development/libraries/libdvdread/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libdvdread-${version}";
-  version = "5.0.3";
+  version = "6.0.0";
 
   src = fetchurl {
     url = "http://get.videolan.org/libdvdread/${version}/${name}.tar.bz2";
-    sha256 = "0ayqiq0psq18rcp6f5pz82sxsq66v0kwv0y55dbrcg68plnxy71j";
+    sha256 = "0dgr23fzcjhb7ck54xkr9zmf4jcq3ph0dz3fbyvla1c6ni9ijfxk";
   };
 
   buildInputs = [libdvdcss];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 6.0.0 with grep in /nix/store/dr0ps08716fhniggawzg9f9s7d74r8v7-libdvdread-6.0.0
- directory tree listing: https://gist.github.com/63bc02c878936a5428bbd234fd6c26c8

cc @wmertens for review