### PR TITLE
update of displaycal to 3.5.0.0

### DIFF
--- a/pkgs/applications/graphics/displaycal/default.nix
+++ b/pkgs/applications/graphics/displaycal/default.nix
@@ -1,15 +1,15 @@
 {buildPythonPackage, stdenv, fetchurl, pkgconfig
- , libXext, libXxf86vm, libX11, libXrandr, libXinerama
+ , libXext, libXxf86vm, libX11, libXrandr, libXinerama, libXScrnSaver
  , argyllcms, wxPython, numpy
  }:
 buildPythonPackage {
-  name = "displaycal-3.2.4.0";
+  name = "displaycal-3.5.0.0";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
-    url = mirror://sourceforge/project/dispcalgui/release/3.2.4.0/DisplayCAL-3.2.4.0.tar.gz;
-    sha256 = "0swkhv338d1kmfxyf30zzdjs5xpbha40pg2zysiipcbasc0xhlb8";
+    url = mirror://sourceforge/project/dispcalgui/release/3.5.0.0/DisplayCAL-3.5.0.0.tar.gz;
+    sha256 = "1j496sv8pbhby5hkkbp07k6bs3f7mb1l3dijmn2iga3kmix0fn5q";
   };
 
   propagatedBuildInputs = [
@@ -18,6 +18,7 @@ buildPythonPackage {
     libX11
     libXrandr
     libXinerama
+    libXScrnSaver
     argyllcms
     wxPython
     numpy


### PR DESCRIPTION
###### Motivation for this change

Upgrade displaycal (color management and display profiling) to version 3.5.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

