### PR TITLE
libmediainfo: 17.12 -> 18.03

### DIFF
--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "17.12";
+  version = "18.03";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "0lm4454ynp0msgqm3s0mnxqxql6i1ank35jvff5swnaxvwsbp0ml";
+    sha256 = "1d4zqik9sm8fsr26w5jsp0rgczlh5vh3gwknxy4g3gd6pqri4igv";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 18.03 with grep in /nix/store/zs2mqa4yzrcy89x12hpz445b5lf8v618-libmediainfo-18.03
- directory tree listing: https://gist.github.com/647416634a701d34570d8a26d64689e7

cc @devhell for review