### PR TITLE
libgpg-error: fix on ARM

### DIFF
--- a/pkgs/development/libraries/libgpg-error/default.nix
+++ b/pkgs/development/libraries/libgpg-error/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, buildPackages, fetchurl, gettext
-, hostPlatform, genPosixLockObjOnly ? false
+{ stdenv, lib, fetchpatch, buildPackages, fetchurl, gettext
+, genPosixLockObjOnly ? false
 }: let
-  genPosixLockObjOnlyAttrs = stdenv.lib.optionalAttrs genPosixLockObjOnly {
+  genPosixLockObjOnlyAttrs = lib.optionalAttrs genPosixLockObjOnly {
     buildPhase = ''
       cd src
       make gen-posix-lock-obj
@@ -24,9 +24,17 @@ in stdenv.mkDerivation (rec {
     sha256 = "0jfsfnh9bxlxiwxws60yah4ybjw2hshmvqp31pri4m4h8ivrbnry";
   };
 
+  patches = [
+    # Fix builds on ARM, AArch64
+    (fetchpatch {
+      url = "https://github.com/gpg/libgpg-error/commit/791177de023574223eddf7288eb7c5a0721ac623.patch";
+      sha256 = "0vqfw0ak1j37wf6sk9y9vmdyk3kxdxkldhs0bv2waa76s11cmdx0";
+    })
+  ];
+
   postPatch = ''
     sed '/BUILD_TIMESTAMP=/s/=.*/=1970-01-01T00:01+0000/' -i ./configure
-  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+  '' + lib.optionalString stdenv.hostPlatform.isMusl ''
     ln -s lock-obj-pub.x86_64-pc-linux-musl.h src/syscfg/lock-obj-pub.linux-musl.h
   '';
 
@@ -39,7 +47,7 @@ in stdenv.mkDerivation (rec {
   nativeBuildInputs = [ gettext ];
 
   postConfigure =
-    stdenv.lib.optionalString stdenv.isSunOS
+    lib.optionalString stdenv.isSunOS
     # For some reason, /bin/sh on OpenIndiana leads to this at the end of the
     # `config.status' run:
     #   ./config.status[1401]: shift: (null): bad number


### PR DESCRIPTION
###### Motivation for this change

Fix staging on ARM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build libgpgerror