### PR TITLE
librsync: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/development/libraries/librsync/default.nix
+++ b/pkgs/development/libraries/librsync/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "librsync-${version}";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "librsync";
     repo = "librsync";
     rev = "v${version}";
-    sha256 = "0wihjinqbjl4hnvrgsk4ca1zy5v6bj7vjm6wlygwvgbn5yh3yq0x";
+    sha256 = "1qnr4rk93mhggqjh2025clmlhhgnjhq983p1vbh8i1g8aiqdnapi";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/w6nqi0pjm3bm0v1kcxk9v1ndj0qnjg6z-librsync-2.0.2/bin/rdiff -h` got 0 exit code
- ran `/nix/store/w6nqi0pjm3bm0v1kcxk9v1ndj0qnjg6z-librsync-2.0.2/bin/rdiff --help` got 0 exit code
- ran `/nix/store/w6nqi0pjm3bm0v1kcxk9v1ndj0qnjg6z-librsync-2.0.2/bin/rdiff -V` and found version 2.0.2
- ran `/nix/store/w6nqi0pjm3bm0v1kcxk9v1ndj0qnjg6z-librsync-2.0.2/bin/rdiff --version` and found version 2.0.2
- found 2.0.2 with grep in /nix/store/w6nqi0pjm3bm0v1kcxk9v1ndj0qnjg6z-librsync-2.0.2
- found 2.0.2 in filename of file in /nix/store/w6nqi0pjm3bm0v1kcxk9v1ndj0qnjg6z-librsync-2.0.2
- directory tree listing: https://gist.github.com/aef3b835949789ba889040112d401160

cc @wkennington for review