### PR TITLE
libvpx: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -58,13 +58,13 @@ assert isCygwin -> unitTestsSupport && webmIOSupport && libyuvSupport;
 
 stdenv.mkDerivation rec {
   name = "libvpx-${version}";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "webmproject";
     repo = "libvpx";
     rev = "v${version}";
-    sha256 = "10fs7xilf2bsj5bqw206lb5r5dgl84p5m6nibiirk28lmjx1i3l0";
+    sha256 = "0vvh89hvp8qg9an9vcmwb7d9k3nixhxaz6zi65qdjnd0i56kkcz6";
   };
 
   patchPhase = ''patchShebangs .'';


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/q26np2w8fjj2cjsgkhklbywd4vvykq67-libvpx-1.7.0-bin/bin/vpxdec --help` got 0 exit code
- ran `/nix/store/q26np2w8fjj2cjsgkhklbywd4vvykq67-libvpx-1.7.0-bin/bin/vpxdec --help` and found version 1.7.0
- ran `/nix/store/q26np2w8fjj2cjsgkhklbywd4vvykq67-libvpx-1.7.0-bin/bin/vpxenc --help` got 0 exit code
- ran `/nix/store/q26np2w8fjj2cjsgkhklbywd4vvykq67-libvpx-1.7.0-bin/bin/vpxenc --help` and found version 1.7.0
- found 1.7.0 with grep in /nix/store/q26np2w8fjj2cjsgkhklbywd4vvykq67-libvpx-1.7.0-bin
- directory tree listing: https://gist.github.com/feae181f96e3cbf1235f1f3b9503500c

cc @codyopel for review