### PR TITLE
ngspice: Move shared library to a new derivation

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -572,6 +572,11 @@
     github = "bergey";
     name = "Daniel Bergey";
   };
+  bgamari = {
+    email = "ben@smart-cactus.org";
+    github = "bgamari";
+    name = "Ben Gamari";
+  };
   bhipple = {
     email = "bhipple@protonmail.com";
     github = "bhipple";

--- a/pkgs/applications/science/electronics/kicad/unstable.nix
+++ b/pkgs/applications/science/electronics/kicad/unstable.nix
@@ -3,9 +3,11 @@
 , doxygen, pcre, libpthreadstubs, libXdmcp
 
 , oceSupport ? true, opencascade_oce
-, ngspiceSupport ? true, ngspice
+, ngspiceSupport ? true, libngspice
 , scriptingSupport ? true, swig, python, wxPython
 }:
+
+assert ngspiceSupport -> libngspice != null;
 
 with lib;
 stdenv.mkDerivation rec {
@@ -41,7 +43,7 @@ stdenv.mkDerivation rec {
     libGLU_combined zlib libX11 wxGTK pcre libXdmcp gettext glew glm libpthreadstubs
     cairo curl openssl boost
   ] ++ optional (oceSupport) opencascade_oce
-    ++ optional (ngspiceSupport) ngspice
+    ++ optional (ngspiceSupport) libngspice
     ++ optionals (scriptingSupport) [ swig python wxPython ];
 
   meta = {

--- a/pkgs/applications/science/electronics/ngspice/default.nix
+++ b/pkgs/applications/science/electronics/ngspice/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, readline, bison, flex, libX11, libICE, libXaw, libXext}:
+{stdenv, fetchurl, readline, bison, flex, libX11, libICE, libXaw, libXext, fftw}:
 
 stdenv.mkDerivation {
   name = "ngspice-27";
@@ -8,15 +8,16 @@ stdenv.mkDerivation {
     sha256 = "15862npsy5sj56z5yd1qiv3y0fgicrzj7wwn8hbcy89fgbawf20c";
   };
 
-  buildInputs = [ readline libX11 flex bison libICE libXaw libXext ];
+  nativeBuildInputs = [ flex bison ];
+  buildInputs = [ readline libX11 libICE libXaw libXext fftw ];
 
-  configureFlags = [ "--enable-x" "--with-x" "--with-readline" "--enable-xspice" "--enable-cider" "--with-ngshared" ];
+  configureFlags = [ "--enable-x" "--with-x" "--with-readline" "--enable-xspice" "--enable-cider" ];
 
   meta = with stdenv.lib; {
     description = "The Next Generation Spice (Electronic Circuit Simulator)";
     homepage = http://ngspice.sourceforge.net;
     license = with licenses; [ "BSD" gpl2 ];
-    maintainers = with maintainers; [ viric rongcuid ];
+    maintainers = with maintainers; [ bgamari viric rongcuid ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libngspice/default.nix
+++ b/pkgs/development/libraries/libngspice/default.nix
@@ -1,0 +1,25 @@
+{stdenv, fetchurl, bison, flex, fftw}:
+
+# Note that this does not provide the ngspice command-line utility. For that see
+# the ngspice derivation.
+stdenv.mkDerivation {
+  name = "libngspice-26";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/ngspice/ngspice-26.tar.gz";
+    sha256 = "51e230c8b720802d93747bc580c0a29d1fb530f3dd06f213b6a700ca9a4d0108";
+  };
+
+  nativeBuildInputs = [ flex bison ];
+  buildInputs = [ fftw ];
+
+  configureFlags = [ "--with-ngshared" "--enable-xspice" "--enable-cider" ];
+
+  meta = with stdenv.lib; {
+    description = "The Next Generation Spice (Electronic Circuit Simulator)";
+    homepage = http://ngspice.sourceforge.net;
+    license = with licenses; [ "BSD" gpl2 ];
+    maintainers = with maintainers; [ bgamari ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3434,6 +3434,8 @@ with pkgs;
 
   libnabo = callPackage ../development/libraries/libnabo { };
 
+  libngspice = callPackage ../development/libraries/libngspice { };
+
   libpointmatcher = callPackage ../development/libraries/libpointmatcher { };
 
   libtorrent = callPackage ../tools/networking/p2p/libtorrent { };


### PR DESCRIPTION
###### Motivation for this change

It turns out that the build system does not support building both the
command-line tool and the shared library at the same time. Consequently
the ngspice derivation has not provided the command-line tools since the
shared library was enabled in #31166.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

