### PR TITLE
lightdm_gtk_greeter: 2.0.4 -> 2.0.5

### DIFF
--- a/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
@@ -9,14 +9,14 @@
 
 let
   ver_branch = "2.0";
-  version = "2.0.4";
+  version = "2.0.5";
 in
 stdenv.mkDerivation rec {
   name = "lightdm-gtk-greeter-${version}";
 
   src = fetchurl {
     url = "${meta.homepage}/${ver_branch}/${version}/+download/${name}.tar.gz";
-    sha256 = "1svbyq2l3l2d72k10nw79jz940rqsskryaim2viy6jfpv9k5jfv1";
+    sha256 = "1pw70db8320wvkhkrw4i2qprxlrqy3jmb6yrr4bm3lgrizahiijx";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.0.5 with grep in /nix/store/w1whi2qkvm97pbk0mjigs7xhnd2vgczx-lightdm-gtk-greeter-2.0.5
- directory tree listing: https://gist.github.com/7fa4fc4e3d6e3d17e75f94d3a9798382

cc @ocharles @wkennington for review