### PR TITLE
syslog-ng: enable SMTP destination

### DIFF
--- a/pkgs/development/libraries/libesmtp/default.nix
+++ b/pkgs/development/libraries/libesmtp/default.nix
@@ -1,0 +1,12 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libESMTP-${version}";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "http://brianstafford.info/libesmtp/libesmtp-1.0.6.tar.bz2";
+    sha256 = "02zbniyz7qys1jmx3ghx21kxmns1wc3hmv80gp7ag7yra9f1m9nh";
+  };
+}
+

--- a/pkgs/development/libraries/libesmtp/default.nix
+++ b/pkgs/development/libraries/libesmtp/default.nix
@@ -8,5 +8,11 @@ stdenv.mkDerivation rec {
     url = "http://brianstafford.info/libesmtp/libesmtp-1.0.6.tar.bz2";
     sha256 = "02zbniyz7qys1jmx3ghx21kxmns1wc3hmv80gp7ag7yra9f1m9nh";
   };
+
+  meta = {
+    homepage = http://brianstafford.info/libesmtp/index.html;
+    description = "A Library for Posting Electronic Mail";
+    licenses = stdenv.licenses.lgpl3Plus;
+  };
 }
 

--- a/pkgs/development/libraries/libesmtp/default.nix
+++ b/pkgs/development/libraries/libesmtp/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://brianstafford.info/libesmtp/index.html;
     description = "A Library for Posting Electronic Mail";
-    license = licenses.gpl3;
+    license = licenses.lgpl21;
   };
 }
 

--- a/pkgs/development/libraries/libesmtp/default.nix
+++ b/pkgs/development/libraries/libesmtp/default.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "02zbniyz7qys1jmx3ghx21kxmns1wc3hmv80gp7ag7yra9f1m9nh";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://brianstafford.info/libesmtp/index.html;
     description = "A Library for Posting Electronic Mail";
-    licenses = stdenv.licenses.lgpl3Plus;
+    license = licenses.gpl3;
   };
 }
 

--- a/pkgs/tools/system/syslog-ng/default.nix
+++ b/pkgs/tools/system/syslog-ng/default.nix
@@ -1,7 +1,9 @@
 { stdenv, fetchurl, openssl, libcap, curl, which
 , eventlog, pkgconfig, glib, python, systemd, perl
 , riemann_c_client, protobufc, pcre, libnet
-, json_c, libuuid, libivykis, mongoc, rabbitmq-c }:
+, json_c, libuuid, libivykis, mongoc, rabbitmq-c
+, libesmtp
+}:
 
 let
   pname = "syslog-ng";
@@ -36,12 +38,14 @@ stdenv.mkDerivation rec {
     libivykis
     mongoc
     rabbitmq-c
+    libesmtp
   ];
 
   configureFlags = [
     "--enable-manpages"
     "--enable-dynamic-linking"
     "--enable-systemd"
+    "--enable-smtp"
     "--with-ivykis=system"
     "--with-librabbitmq-client=system"
     "--with-mongoc=system"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8683,6 +8683,8 @@ with pkgs;
 
   esdl = callPackage ../development/libraries/esdl { };
 
+  libesmtp = callPackage ../development/libraries/libesmtp { };
+
   exiv2 = callPackage ../development/libraries/exiv2 { };
 
   expat = callPackage ../development/libraries/expat { };


### PR DESCRIPTION
###### Motivation for this change

Enable the SMTP Destination

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

