### PR TITLE
mdds: 1.2.2 -> 1.3.1

### DIFF
--- a/pkgs/development/libraries/mdds/default.nix
+++ b/pkgs/development/libraries/mdds/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.2";
+  version = "1.3.1";
   name = "mdds-${version}";
 
   src = fetchurl {
     url = "http://kohei.us/files/mdds/src/mdds-${version}.tar.bz2";
-    sha256 = "17fcjhsq3bzqm7ba9sgp6my3y4226jnwai6q5jq3810i745p67hl";
+    sha256 = "18g511z1lgfxrga2ld9yr95phmyfbd3ymbv4q5g5lyjn4ljcvf6w";
   };
 
   postInstall = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.3.1 with grep in /nix/store/1jh7ran6gm77rksnm74kix37b44b1ni9-mdds-1.3.1
- directory tree listing: https://gist.github.com/bd00a4a5fa8495574a863ebf42d43a9a