### PR TITLE
mediainfo: 17.12 -> 18.03

### DIFF
--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "17.12";
+  version = "18.03";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1pxdf0ny3c38gl513zdiaagpvk4bqnsc2fn7476yjdpv2lxsw56f";
+    sha256 = "171xv1qn6lbzybhx471j5a3rdqdj3xn0xc7gs181624r1kslxyn1";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- ran `/nix/store/dykj39kcyb4rj6pm347q0djry1q5gh2y-mediainfo-18.03/bin/mediainfo -h` got 0 exit code
- ran `/nix/store/dykj39kcyb4rj6pm347q0djry1q5gh2y-mediainfo-18.03/bin/mediainfo --help` got 0 exit code
- directory tree listing: https://gist.github.com/f5a53e7a582604e5913226a02b977dc6

cc @devhell for review