### PR TITLE
mopidy-iris: 3.14.0 -> 3.14.2

### DIFF
--- a/pkgs/applications/audio/mopidy-iris/default.nix
+++ b/pkgs/applications/audio/mopidy-iris/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "Mopidy-Iris";
-  version = "3.14.0";
+  version = "3.14.2";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "2c0ec5138e554e91d299ac72a7049bc00d77770a08c16c17e1a9df7f8ef42feb";
+    sha256 = "19affzk45wby50gwxwzqgwa7h7618lcs48ngdsa06sd66s8x2fza";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.14.2 with grep in /nix/store/anzim7y47xa3m530qzq91n9wl8ys1kk2-Mopidy-Iris-3.14.2
- directory tree listing: https://gist.github.com/96a0fc1d9812e5c4e6659fd37c7b21c6

cc @rvolosatovs for review