### PR TITLE
compactor: init at 0.11.0

### DIFF
--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -1,0 +1,52 @@
+{ autoconf, automake, boost, cbor-diag, cddl, fetchFromGitHub, file, gcc, libpcap, libtins, libtool, lzma, openssl, pkgconfig, stdenv, tcpdump, wireshark-cli }:
+
+stdenv.mkDerivation rec {
+  name = "compactor-${version}";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "dns-stats";
+    repo = "compactor";
+    rev = "${version}";
+    sha256 = "1zn6w99xqq5igaz0n89429i78a5pj4nnfn1mm5yv1yfbn1lm0y3l";
+  };
+
+  # cbor-diag, cddl and wireshark-cli are only used for tests.
+  nativeBuildInputs = [ autoconf automake libtool pkgconfig cbor-diag cddl wireshark-cli ];
+  buildInputs = [
+    boost
+    libpcap
+    openssl
+    libtins
+    lzma
+  ];
+
+  patchPhase = ''
+    patchShebangs test-scripts/
+  '';
+
+  preConfigure = ''
+    sh autogen.sh
+    substituteInPlace configure \
+      --replace "/usr/bin/file" "${file}/bin/file"
+  '';
+  CXXFLAGS = "-std=c++11";
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--with-boost=${boost.dev}"
+  ];
+
+  doCheck = true;
+  preCheck = ''
+    substituteInPlace test-scripts/check-live-pcap.sh \
+      --replace "/usr/sbin/tcpdump" "${tcpdump}/bin/tcpdump"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tools to capture DNS traffic and record it in C-DNS files";
+    homepage    = http://dns-stats.org/;
+    license     = [ licenses.boost licenses.mpl20 licenses.openssl ];
+    maintainers = with maintainers; [ fdns ];
+    platforms   = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/tools/cbor-diag/Gemfile
+++ b/pkgs/development/tools/cbor-diag/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'cbor-diag'

--- a/pkgs/development/tools/cbor-diag/Gemfile.lock
+++ b/pkgs/development/tools/cbor-diag/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cbor-diag (0.5.2)
+      json
+      treetop (~> 1)
+    json (2.1.0)
+    polyglot (0.3.5)
+    treetop (1.6.10)
+      polyglot (~> 0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cbor-diag
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/development/tools/cbor-diag/default.nix
+++ b/pkgs/development/tools/cbor-diag/default.nix
@@ -1,0 +1,30 @@
+{ lib, bundlerApp, ruby }:
+
+bundlerApp {
+  pname = "cbor-diag";
+
+  inherit ruby;
+  gemdir = ./.;
+
+  exes = [
+    "cbor2diag.rb"
+    "cbor2json.rb"
+    "cbor2pretty.rb"
+    "cbor2yaml.rb"
+    "diag2cbor.rb"
+    "diag2pretty.rb"
+    "json2cbor.rb"
+    "json2pretty.rb"
+    "pretty2cbor.rb"
+    "pretty2diag.rb"
+    "yaml2cbor.rb"
+  ];
+
+  meta = with lib; {
+    description = "CBOR diagnostic utilities";
+    homepage    = https://github.com/cabo/cbor-diag;
+    license     = with licenses; asl20;
+    maintainers = with maintainers; [ fdns ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/cbor-diag/gemset.nix
+++ b/pkgs/development/tools/cbor-diag/gemset.nix
@@ -1,0 +1,36 @@
+{
+  cbor-diag = {
+    dependencies = ["json" "treetop"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g4pxf1ag4pyb351m06l08ig1smnf8w27ynqfxkgmwak5mh1z7w1";
+      type = "gem";
+    };
+    version = "0.5.2";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  polyglot = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  treetop = {
+    dependencies = ["polyglot"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0g31pijhnv7z960sd09lckmw9h8rs3wmc8g4ihmppszxqm99zpv7";
+      type = "gem";
+    };
+    version = "1.6.10";
+  };
+}

--- a/pkgs/development/tools/cddl/Gemfile
+++ b/pkgs/development/tools/cddl/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'cddl'

--- a/pkgs/development/tools/cddl/Gemfile.lock
+++ b/pkgs/development/tools/cddl/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abnc (0.1.0)
+    cbor-diag (0.5.2)
+      json
+      treetop (~> 1)
+    cddl (0.8.5)
+      abnc
+      cbor-diag
+      colorize
+      json
+      regexp-examples
+    colorize (0.8.1)
+    json (2.1.0)
+    polyglot (0.3.5)
+    regexp-examples (1.4.2)
+    treetop (1.6.10)
+      polyglot (~> 0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cddl
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/development/tools/cddl/default.nix
+++ b/pkgs/development/tools/cddl/default.nix
@@ -1,0 +1,17 @@
+{ lib, bundlerApp, ruby }:
+
+bundlerApp {
+  pname = "cddl";
+
+  inherit ruby;
+  gemdir = ./.;
+  exes = [ "cddl" ];
+
+  meta = with lib; {
+    description = "A parser, generator, and validator for CDDL";
+    homepage    = https://rubygems.org/gems/cddl;
+    license     = with licenses; mit;
+    maintainers = with maintainers; [ fdns ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/cddl/gemset.nix
+++ b/pkgs/development/tools/cddl/gemset.nix
@@ -1,0 +1,69 @@
+{
+  abnc = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13nvzrk72nj130fs8bq8q3cfm48939rdzh7l31ncj5c4969hrbig";
+      type = "gem";
+    };
+    version = "0.1.0";
+  };
+  cbor-diag = {
+    dependencies = ["json" "treetop"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g4pxf1ag4pyb351m06l08ig1smnf8w27ynqfxkgmwak5mh1z7w1";
+      type = "gem";
+    };
+    version = "0.5.2";
+  };
+  cddl = {
+    dependencies = ["abnc" "cbor-diag" "colorize" "json" "regexp-examples"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pg91wrby0qgrdnf089ddy5yy2jalxd3bb9dljj16cpwv4gjx047";
+      type = "gem";
+    };
+    version = "0.8.5";
+  };
+  colorize = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "133rqj85n400qk6g3dhf2bmfws34mak1wqihvh3bgy9jhajw580b";
+      type = "gem";
+    };
+    version = "0.8.1";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  polyglot = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  regexp-examples = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "104f0j0h2x5ijly7kyaj7zz0md65r2c03cpbi5cngm0hs2sr1qkz";
+      type = "gem";
+    };
+    version = "1.4.2";
+  };
+  treetop = {
+    dependencies = ["polyglot"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0g31pijhnv7z960sd09lckmw9h8rs3wmc8g4ihmppszxqm99zpv7";
+      type = "gem";
+    };
+    version = "1.6.10";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1009,6 +1009,8 @@ with pkgs;
 
   colpack = callPackage ../applications/science/math/colpack { };
 
+  compactor = callPackage ../applications/networking/compactor { };
+
   consul = callPackage ../servers/consul { };
 
   consul-ui = callPackage ../servers/consul/ui.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -977,6 +977,8 @@ with pkgs;
 
   image-analyzer = callPackage ../misc/emulators/cdemu/analyzer.nix { };
 
+  cbor-diag = callPackage ../development/tools/cbor-diag { };
+
   ccnet = callPackage ../tools/networking/ccnet { };
 
   cddl = callPackage ../development/tools/cddl { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -979,6 +979,8 @@ with pkgs;
 
   ccnet = callPackage ../tools/networking/ccnet { };
 
+  cddl = callPackage ../development/tools/cddl { };
+
   cfdyndns = callPackage ../applications/networking/dyndns/cfdyndns { };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };


### PR DESCRIPTION
###### Motivation for this change
Adding compactor, a DNS traffic capturer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

