### PR TITLE
rawtherapee: 5.3 -> 5.4

### DIFF
--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -4,14 +4,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "5.3";
+  version = "5.4";
   name = "rawtherapee-" + version;
 
   src = fetchFromGitHub {
     owner = "Beep6581";
     repo = "RawTherapee";
     rev = version;
-    sha256 = "1r6sx9zl1wkykgfx6k26268xadair6hzl15v5hmiri9sdhrn33q7";
+    sha256 = "1h2x5biqsb4kfwsffqkyk8ky22qv2a0cjs1s445x9farcr3kwk99";
   };
 
   nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools. These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 5.4 with grep in /nix/store/p24xccx2wm6dls7g36pzdl1m1r3p1x5l-rawtherapee-5.4
- directory tree listing: https://gist.github.com/ea61efad6dd7afad2c60614dd433534d

cc @viric @2chilled @the-kenny for review