### PR TITLE
signal-desktop: 1.5.2 -> 1.6.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,13 +40,13 @@ in
   stdenv.mkDerivation rec {
     name = "signal-desktop-${version}";
 
-    version = "1.5.2";
+    version = "1.6.1";
 
     src =
       if stdenv.system == "x86_64-linux" then
         fetchurl {
           url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-          sha256 = "1h4qa5i7axkmsai854yvlyh5r038mmjl4pj2rd27mz11if7yf067";
+          sha256 = "0q2qzl84ifnhcn1qbq38fdpj8ry748h6dlzp2mdpkslsh8mc46as";
         }
       else
         throw "Signal for Desktop is not currently supported on ${stdenv.system}";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/signal-desktop/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.6.1 with grep in /nix/store/pvdn1xmg25m71qciqgin0flihwbvf7p3-signal-desktop-1.6.1
- directory tree listing: https://gist.github.com/5e549f57e17894ca01ff108753e073e6

cc @ixmatus for review