### PR TITLE
smplayer: 18.2.2 -> 18.3.0

### DIFF
--- a/pkgs/applications/video/smplayer/default.nix
+++ b/pkgs/applications/video/smplayer/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, qmake, qtscript }:
 
 stdenv.mkDerivation rec {
-  name = "smplayer-18.2.2";
+  name = "smplayer-18.3.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/smplayer/${name}.tar.bz2";
-    sha256 = "0q0m9q643z6ih5gkf1fq3d6y99d62yxkhfgap98h251q6kd7dhis";
+    sha256 = "0y7kwcngd0d2d863wnppfvjm1n1l60nn6lsf9r0g4hsf19gkrd46";
   };
 
   buildInputs = [ qtscript ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/smplayer/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 18.3.0 with grep in /nix/store/39n4zv5ynkjwhjcfs479fz6jj0pqfwvp-smplayer-18.3.0
- directory tree listing: https://gist.github.com/72db17f9f10b4ea51b5b470cfef842cf