### PR TITLE
vulkan-loader: 1.0.61.1 -> 1.1.70.0

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -1,20 +1,34 @@
-{ stdenv, fetchFromGitHub, cmake, bison }:
+{ stdenv, fetchFromGitHub, cmake, bison, spirv-tools, jq }:
 
 stdenv.mkDerivation rec {
   name = "glslang-git-${version}";
-  version = "2017-08-31";
+  version = "2018-02-05";
 
   # `vulkan-loader` requires a specific version of `glslang` as specified in
   # `<vulkan-loader-repo>/external_revisions/glslang_revision`.
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "3a21c880500eac21cdf79bef5b80f970a55ac6af";
-    sha256 = "1i15m17r0acmzjrkybris2rgw15il05a4w5h7vhhsiyngcvajcyn";
+    rev = "2651ccaec8";
+    sha256 = "0x5x5i07n9g809rzf5jgw70mmwck31ishdmxnmi0wxx737jjqwaq";
   };
 
-  buildInputs = [ cmake bison ];
+  buildInputs = [ cmake bison jq ] ++ spirv-tools.buildInputs;
   enableParallelBuilding = true;
+
+  patchPhase = ''
+    cp --no-preserve=mode -r "${spirv-tools.src}" External/spirv-tools
+    ln -s "${spirv-tools.headers}" External/spirv-tools/external/spirv-headers
+  '';
+
+  preConfigure = ''
+    HEADERS_COMMIT=$(jq -r < known_good.json '.commits|map(select(.name=="spirv-tools/external/spirv-headers"))[0].commit')
+    TOOLS_COMMIT=$(jq -r < known_good.json '.commits|map(select(.name=="spirv-tools"))[0].commit')
+    if [ "$HEADERS_COMMIT" != "${spirv-tools.headers.rev}" ] || [ "$TOOLS_COMMIT" != "${spirv-tools.src.rev}" ]; then
+      echo "ERROR: spirv-tools commits do not match expected versions";
+      exit 1;
+    fi
+  '';
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -3,12 +3,12 @@
   libXext, wayland, libGL, makeWrapper }:
 
 let
-  version = "1.0.61.1";
+  version = "1.1.70.0";
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-LoaderAndValidationLayers";
     rev = "sdk-${version}";
-    sha256 = "043kw6wnrpdplnb40x6n9rgf3gygsn9jiv91y458sydbhalfr945";
+    sha256 = "1a7xwl65bi03l4zbjq54qkxjb8kb4m78qvw8bas5alhf9v6i6yqp";
   };
 in
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs = [ cmake git python3 python3Packages.lxml
-                  glslang spirv-tools x11 libxcb libXrandr libXext wayland
+                  glslang x11 libxcb libXrandr libXext wayland
                 ];
   enableParallelBuilding = true;
 
@@ -28,13 +28,18 @@ stdenv.mkDerivation rec {
   ];
 
   outputs = [ "out" "dev" "demos" ];
+  patches = [ ./rev-file.patch ];
+
+  postUnpack = ''
+    # Hack so a version header can be generated. Relies on ./rev-file.patch to work.
+    mkdir -p "$sourceRoot/external/glslang/External"
+    echo "${spirv-tools.src.rev}" > "$sourceRoot/external/glslang/External/spirv-tools"
+  '';
 
   preConfigure = ''
     checkRev() {
       [ "$2" = $(cat "external_revisions/$1_revision") ] || (echo "ERROR: dependency $1 is revision $2 but should be revision" $(cat "external_revisions/$1_revision") && exit 1)
     }
-    checkRev spirv-tools "${spirv-tools.src.rev}"
-    checkRev spirv-headers "${spirv-tools.headers.rev}"
     checkRev glslang "${glslang.src.rev}"
   '';
 

--- a/pkgs/development/libraries/vulkan-loader/rev-file.patch
+++ b/pkgs/development/libraries/vulkan-loader/rev-file.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c9f73ce96..d14ffeed9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -339,13 +339,13 @@ macro(run_vk_xml_generate dependency output)
+ endmacro()
+ 
+ # Define macro used for generating header files containing commit IDs for external dependencies
+-macro(run_external_revision_generate source_dir symbol_name output)
++macro(run_external_revision_generate rev_file symbol_name output)
+     add_custom_command(OUTPUT ${output}
+     # NOTE: If you modify this call to use --rev_file instead of --git_dir (to read the commit ID from a file instead of
+     # parsing from a Git repository), you probably also want to add the revision file to the list of DEPENDS on the
+     # subsequent line (to ensure that the script is re-run when the revision file is modified).
+-    COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/external_revision_generator.py --git_dir ${source_dir} -s ${symbol_name} -o ${output}
+-    DEPENDS ${SCRIPTS_DIR}/external_revision_generator.py ${source_dir}/.git/HEAD ${source_dir}/.git/index
++    COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/external_revision_generator.py --rev_file ${rev_file} -s ${symbol_name} -o ${output}
++    DEPENDS ${SCRIPTS_DIR}/external_revision_generator.py ${rev_file}
+     )
+ endmacro()
+ 

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -3,19 +3,18 @@
 let
 
 spirv_sources = {
-  # `vulkan-loader` requires a specific version of `spirv-tools` and `spirv-headers` as specified in
-  # `<vulkan-loader-repo>/external_revisions/spirv-tools_revision`.
+  # `glslang` requires a specific version of `spirv-tools` and `spirv-headers` as specified in `known-good.json`.
   tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "7e2d26c77b606b21af839b37fd21381c4a669f23";
-    sha256 = "1nlzj081v1xdyfz30nfs8hfcnqd072fra127h46gav179f04kss2";
+    rev = "9e19fc0f31ceaf1f6bc907dbf17dcfded85f2ce8";
+    sha256 = "1zpwznq0fyvkzs5h9nnkr7g6svr0w8z6zx62xgnss17c2a5cz0lk";
   };
   headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "2bb92e6fe2c6aa410152fc6c63443f452acb1a65";
-    sha256 = "1rgjd7kpa7xpbwpzd6m3f6yq44s9xn5ddhz135213pxwbi5c0c26";
+    rev = "ce309203d7eceaf908bea8862c27f3e0749f7d00";
+    sha256 = "1sv1iy2d46sg7r3xy591db6fn9h78wd079yvfa87vwmwsdkhiqhm";
   };
 };
 
@@ -23,7 +22,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "spirv-tools-${version}";
-  version = "2017-09-01";
+  version = "2018-02-05";
 
   src = spirv_sources.tools;
   patchPhase = ''ln -sv ${spirv_sources.headers} external/spirv-headers'';


### PR DESCRIPTION
Lockstep glslang and spirv-tools updates included.

These packages are getting progressively more annoying to manage. I tried to update shaderc while I was at it, but it seems like it requires a *different* set of seemingly arbitrary revisions of `spirv-tools`, so I'm leaving it broken for now. Might be best to give up on reusing the standalone spirv-tools package; it's not like glslang or shaderc make any effort to reuse existing build products anyway.

###### Motivation for this change
This allows development of Vulkan 1.1 applications with Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

