### PR TITLE
snd: 18.1 -> 18.2

### DIFF
--- a/pkgs/applications/audio/snd/default.nix
+++ b/pkgs/applications/audio/snd/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "snd-18.1";
+  name = "snd-18.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/snd/${name}.tar.gz";
-    sha256 = "0wdifvpm54j5fxxp867jnrfdy3jb8iff2mxqvp08plp45zfjv6xh";
+    sha256 = "0b0ija3cf2c9sqh3cclk5a7i73vagfkyw211aykfd76w7ibirs3r";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/snd/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/caxkfgbcv6kplihpx8gbivz6l5sisnv5-snd-18.2/bin/snd --help` got 0 exit code
- ran `/nix/store/caxkfgbcv6kplihpx8gbivz6l5sisnv5-snd-18.2/bin/snd --version` and found version 18.2
- ran `/nix/store/caxkfgbcv6kplihpx8gbivz6l5sisnv5-snd-18.2/bin/snd --help` and found version 18.2
- found 18.2 with grep in /nix/store/caxkfgbcv6kplihpx8gbivz6l5sisnv5-snd-18.2
- directory tree listing: https://gist.github.com/549e1eef8a929e09d72499dc97a47aa2

cc @fuuzetsu for review