### PR TITLE
swiften: 3.0beta2 -> 4.0

### DIFF
--- a/pkgs/development/libraries/swiften/default.nix
+++ b/pkgs/development/libraries/swiften/default.nix
@@ -1,14 +1,14 @@
 { stdenv, python, fetchurl, openssl, boost }:
 stdenv.mkDerivation rec {
   name    = "swiften-${version}";
-  version = "3.0beta2";
+  version = "4.0";
 
   buildInputs           = [ python ];
   propagatedBuildInputs = [ openssl boost ];
 
   src = fetchurl {
     url    = "http://swift.im/downloads/releases/swift-${version}/swift-${version}.tar.gz";
-    sha256 = "0i6ks122rry9wvg6qahk3yiggi7nlkpgws1z0r41vi4i1siq0ls0";
+    sha256 = "06bk45hxqmny8z7x78ycrfrazq6xdzv5c28i8x0lgc85j03b5dsh";
   };
   
   buildPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/swiften/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/pfiq18ki0dzdd0zsbvv04sppr4f28fl5-swiften-4.0/bin/swiften-config -h` got 0 exit code
- ran `/nix/store/pfiq18ki0dzdd0zsbvv04sppr4f28fl5-swiften-4.0/bin/swiften-config --help` got 0 exit code
- ran `/nix/store/pfiq18ki0dzdd0zsbvv04sppr4f28fl5-swiften-4.0/bin/swiften-config help` got 0 exit code
- ran `/nix/store/pfiq18ki0dzdd0zsbvv04sppr4f28fl5-swiften-4.0/bin/swiften-config --version` and found version 4.0
- found 4.0 with grep in /nix/store/pfiq18ki0dzdd0zsbvv04sppr4f28fl5-swiften-4.0
- directory tree listing: https://gist.github.com/bf18dc85d27b684315737f90db4a6b64

cc @twey for review