### PR TITLE
wayland: 1.14.0 -> 1.14.92

### DIFF
--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -8,11 +8,11 @@ assert expat != null;
 
 stdenv.mkDerivation rec {
   name = "wayland-${version}";
-  version = "1.14.0";
+  version = "1.14.92";
 
   src = fetchurl {
     url = "https://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "1f3sla6h0bw15fz8pjc67jhwj7pwmfdc7qlj42j5k9v116ycm07d";
+    sha256 = "1wg789sy9w6807175j5imhz985yirqg7lvjc4cw8dx6p2kvs9gc0";
   };
 
   configureFlags = [ "--with-scanner" "--disable-documentation" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/wayland/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/f06b6sppm3wfx5b3qvw5lm896wc6jwf3-wayland-1.14.92/bin/wayland-scanner -h` got 0 exit code
- ran `/nix/store/f06b6sppm3wfx5b3qvw5lm896wc6jwf3-wayland-1.14.92/bin/wayland-scanner --help` got 0 exit code
- ran `/nix/store/f06b6sppm3wfx5b3qvw5lm896wc6jwf3-wayland-1.14.92/bin/wayland-scanner help` got 0 exit code
- ran `/nix/store/f06b6sppm3wfx5b3qvw5lm896wc6jwf3-wayland-1.14.92/bin/wayland-scanner -v` and found version 1.14.92
- ran `/nix/store/f06b6sppm3wfx5b3qvw5lm896wc6jwf3-wayland-1.14.92/bin/wayland-scanner --version` and found version 1.14.92
- found 1.14.92 with grep in /nix/store/f06b6sppm3wfx5b3qvw5lm896wc6jwf3-wayland-1.14.92
- directory tree listing: https://gist.github.com/00b5f69b529749572884bfc87de89c7a

cc @codyopel @wkennington for review