### PR TITLE
gettext: don't add -lintl on musl, either

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   buildInputs = stdenv.lib.optional (!stdenv.isLinux && !hostPlatform.isCygwin) libiconv;
 
   setupHook = ./gettext-setup-hook.sh;
-  gettextNeedsLdflags = hostPlatform.libc != "glibc";
+  gettextNeedsLdflags = hostPlatform.libc != "glibc" && !hostPlatform.isMusl;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
gettext won't actually provide libintl unless we go out of
our way to tell it to do so [1][2].

We could add those flags on musl (as I initially did in [3]),
but then we have two different libintl.h files and generally
some confusion about which gettext is being used.

Instead of sorting that out, for now let's just continue on
without gettext providing libintl-- it's worked well enough so far.

Only change that needs to be made, then, is to avoid
adding -lintl on musl since there is no libintl.

[1] https://github.com/pullmoll/void-packages/commit/c739240fd25e8378fe0467cd51ab483427337410
[2] https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-libs/libintl/libintl-0.19.8.1.ebuild?id=332e48712b6521697f992f923c9c985482dd1c36#n41
[3] https://github.com/dtzWill/nixpkgs/commit/729302f29aea8d380196d114e7d2f904add40711




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Sorry for not catching this earlier during review!

This unbreaks musl builds, and should be "safe" in that it preserves
prior behavior (rather than wrangling with the problem just yet).