### PR TITLE
nixos/xserver.windowManager.session: handle duplicate names

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -27,6 +27,15 @@ let
     Xft.hintstyle: hintslight
   '';
 
+  mkCases = session:
+    concatStrings (
+      mapAttrsToList (name: starts: ''
+                       (${name})
+                         ${concatMapStringsSep "\n  " (n: n.start) starts}
+                         ;;
+                     '') (lib.groupBy (n: n.name) session)
+    );
+
   # file provided by services.xserver.displayManager.session.wrapper
   xsessionWrapper = pkgs.writeScript "xsession-wrapper"
     ''
@@ -139,21 +148,13 @@ let
 
       # Start the window manager.
       case "$windowManager" in
-        ${concatMapStrings (s: ''
-          (${s.name})
-            ${s.start}
-            ;;
-        '') wm}
+        ${mkCases wm}
         (*) echo "$0: Window manager '$windowManager' not found.";;
       esac
 
       # Start the desktop manager.
       case "$desktopManager" in
-        ${concatMapStrings (s: ''
-          (${s.name})
-            ${s.start}
-            ;;
-        '') dm}
+        ${mkCases dm}
         (*) echo "$0: Desktop manager '$desktopManager' not found.";;
       esac
 


### PR DESCRIPTION
###### Motivation for this change

It fixes the following issue:

Adding programs to a WM session, for example the programs to run in tray area:
```
services.xserver.windowManager.session = [{
  name = "icewm";
  start = ''
    ${pkgs.icewm}/bin/icewmbg &
    ${pkgs.yubioath-desktop}/bin/yubioath-gui -t &  # TOTP passwords
    ${pkgs.pasystray}/bin/pasystray &               # Volume control
  '';
}];
```

results in duplicated cases in ```xsession```
```bash
export windowManager="icewm"
case "$windowManager" in
  (icewm)
    .../bin/icewmbg &
    .../yubioath-gui -t &
    .../pasystray &
  ;;
  (none)
    ...
  ;;
  (icewm)
    .../bin/icewm &
    waitPID=$!
  ;;

  (*) echo "$0: Window manager '$windowManager' not found.";;
esac
```

which obviously does not work because there are two ```(icewm)``` cases

