### PR TITLE
systemd: use stable tree

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -21,11 +21,13 @@ in stdenv.mkDerivation rec {
   version = "238";
   name = "systemd-${version}";
 
+  # When updating, use https://github.com/systemd/systemd-stable tree, not the development one!
+  # Also fresh patches should be cherry-picked from that tree to our current one.
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "systemd";
-    rev = "243d65d38f2df82d4a39f6a9970337803dff65a1";
-    sha256 = "098hxlkh6q17rxa178adylksxnnd4x9rxb8amjnlbiydcc6kaa5n";
+    rev = "3a439bcdb5706dbb44215ef4e70f07b09aaac040";
+    sha256 = "0qkk5891068pkxmxqvm07bwl597i8lfp89c23yxp11m21cjq0f4b";
   };
 
   outputs = [ "out" "lib" "man" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

This fixes a bug with changed qemu network interface names and also generally
should be preferred to using a release tag. It seems we were doing systemd the wrong way all this time! There is a [stable tree](https://github.com/systemd/systemd-stable/) which we didn't use at least for v237 and v230 (I think never!).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also patches should be cherry-picked from it to our fork from time to time (I've documented it).

@fpletz probably we should rename current tree `nixos-v238-old` and name mine new one `nixos-v238`, or we can just force-push.