### PR TITLE
CODEOWNERS: Add Profpatsch to /lib/generators.nix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 # Libraries
 /lib                        @edolstra @nbp
 /lib/systems                @nbp @ericson2314
+/lib/generators.nix         @edolstra @nbp @Profpatsch
 
 # Nixpkgs Internals
 /default.nix                          @nbp


### PR DESCRIPTION
I’d like to be notified of changes so I can ensure the API always follows the same patterns.

Later (more specific) files replace more general codeowners [according to the documentation](https://help.github.com/articles/about-codeowners/), so I also listed `edolstra` and `nbp` again.