### PR TITLE
neopg: Init at 0.0.4

### DIFF
--- a/pkgs/tools/security/neopg/default.nix
+++ b/pkgs/tools/security/neopg/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchgit
+, cmake
+, sqlite
+, botan2
+, boost164
+, curl
+, gettext
+, pkgconfig
+, libusb
+, gnutls }:
+
+stdenv.mkDerivation rec {
+  name = "neopg";
+  version = "0.0.4";
+
+  # no fetchFromGitHub, as repo contains submodules
+  src = fetchgit {
+    url = "https://github.com/das-labor/neopg.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "0hhkl326ff6f76k8pwggpzmivbm13fz497nlyy6ybn5bmi9xfblm";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ cmake sqlite botan2 boost164 curl gettext libusb gnutls ]; 
+
+  doCheck = true;
+  checkTarget = "test";
+
+  postInstall = ''
+    mkdir -p $out/bin
+    cp src/neopg $out/bin/neopg
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://neopg.io/;
+    description = "Modern replacement for GnuPG 2";
+    license = licenses.gpl3;
+    longDescription = ''
+      NeoPG starts as an opiniated fork of GnuPG 2 to clean up the code and make it easier to develop.
+      It is written in C++11.
+    '';
+    maintainers = with maintainers; [ erictapen ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3812,6 +3812,8 @@ with pkgs;
 
   ndisc6 = callPackage ../tools/networking/ndisc6 { };
 
+  neopg = callPackage ../tools/security/neopg { };
+
   netboot = callPackage ../tools/networking/netboot {};
 
   netcat = netcat-openbsd;


### PR DESCRIPTION
###### Motivation for this change

NeoPG is a fork of GnuPG. See the [website](https://neopg.io/) for further information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

