### PR TITLE
telepathy-gabble: fix source URL

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "telepathy-gabble-0.18.3";
 
   src = fetchurl {
-    url = "${meta.homepage}/releases/telepathy-gabble/${name}.tar.gz";
+    url = "http://telepathy.freedesktop.org/releases/telepathy-gabble/${name}.tar.gz";
     sha256 = "1hl9k6jwn2afwwv7br16wfw5szdhwxqziba47xd8vjwvgrh19iwf";
   };
 


### PR DESCRIPTION
###### Motivation for this change

didn't build after upstream changed the source URL.

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

