### PR TITLE
yate: 5.4.2 -> 6.0.0

### DIFF
--- a/pkgs/applications/misc/yate/default.nix
+++ b/pkgs/applications/misc/yate/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "yate-${version}";
-  version = "5.4.2-1";
+  version = "6.0.0-1";
 
   src = fetchurl {
-    url = "http://voip.null.ro/tarballs/yate5/${name}.tar.gz";
-    sha256 = "08gwz0gipc5v75jv46p2yg8hg31xjp6x7jssd0rrgsa3szi5697n";
+    url = "http://voip.null.ro/tarballs/yate${lib.versions.major version}/${name}.tar.gz";
+    sha256 = "05qqdhi3rp5660gq1484jkmxkm9vq81j0yr765h0gf0xclan1dqa";
   };
 
   # TODO zaptel ? postgres ?


### PR DESCRIPTION
- built on NixOS
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate -h` got 0 exit code
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate --help` got 0 exit code
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate -V` and found version 6.0.0
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate --version` and found version 6.0.0
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate -h` and found version 6.0.0
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate --help` and found version 6.0.0
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate-qt4 -h` got 0 exit code
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate-qt4 --help` got 0 exit code
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate-qt4 -V` and found version 6.0.0
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate-qt4 --version` and found version 6.0.0
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate-qt4 -h` and found version 6.0.0
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate-qt4 --help` and found version 6.0.0
- ran `/nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1/bin/yate-config --version` and found version 6.0.0
- found 6.0.0 with grep in /nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1
- found 6.0.0 in filename of file in /nix/store/prjhgn0ps0ywpjfpb64dy0j332dci2xd-yate-6.0.0-1
- directory tree listing: https://gist.github.com/b8b0469c23ed9c02dd5173ba822bdf57

cc @MarcWeber  as maintainer for review