### PR TITLE
slstatus: init at unstable-2018-03-28

### DIFF
--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit, pkgconfig, writeText, libX11, conf ? null }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "slstatus-${version}";
+  version = "unstable-2018-03-28";
+
+  src = fetchgit {
+    url = https://git.suckless.org/slstatus;
+    rev = "faa52bdcc0221de2d8fae950e409a8ac5e05bfcd";
+    sha256 = "0i8k7gjvx51y0mwxjlqhyk2dpvkb2d3y8x4l6ckdnyiy5632pn76";
+  };
+
+  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libX11 ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    homepage = https://tools.suckless.org/slstatus/;
+    description = "status monitor for window managers that use WM_NAME like dwm";
+    license = licenses.isc;
+    maintainers = with maintainers; [ geistesk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4802,6 +4802,10 @@ with pkgs;
 
   slsnif = callPackage ../tools/misc/slsnif { };
 
+  slstatus = callPackage ../applications/misc/slstatus {
+    conf = config.slstatus.conf or null;
+  };
+
   smartmontools = callPackage ../tools/system/smartmontools {
     inherit (darwin.apple_sdk.frameworks) IOKit ApplicationServices;
   };


### PR DESCRIPTION
###### Motivation for this change
This PR adds the [`slstatus`](https://tools.suckless.org/slstatus/) software to display status information for display managers like `dwm`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

