### PR TITLE
gettext, libiconv: Make setup hook work for cross

### DIFF
--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -9,7 +9,18 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 # libintl must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
 gettextLdflags() {
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lintl"
+    # The `depHostOffset` describes how the host platform of the dependencies
+    # are slid relative to the depending package. It is brought into scope of
+    # the environment hook defined as the role of the dependency being applied.
+    case $depHostOffset in
+        -1) local role='BUILD_' ;;
+        0)  local role='' ;;
+        1)  local role='TARGET_' ;;
+        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
+            return 1 ;;
+    esac
+
+    export NIX_${role}LDFLAGS+=" -lintl"
 }
 
 if [ ! -z "@gettextNeedsLdflags@" ]; then

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -1,7 +1,18 @@
 # libiconv must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
 iconvLdflags() {
-    export NIX_LDFLAGS="$NIX_LDFLAGS -liconv"
+    # The `depHostOffset` describes how the host platform of the dependencies
+    # are slid relative to the depending package. It is brought into scope of
+    # the environment hook defined as the role of the dependency being applied.
+    case $depHostOffset in
+        -1) local role='BUILD_' ;;
+        0)  local role='' ;;
+        1)  local role='TARGET_' ;;
+        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
+            return 1 ;;
+    esac
+
+    export NIX_${role}LDFLAGS+=" -liconv"
 }
 
 addEnvHooks "$hostOffset" iconvLdflags


### PR DESCRIPTION
###### Motivation for this change

Fixing my concern from https://github.com/NixOS/nixpkgs/pull/37012/files#r174660554. The method and comment is taken from the cc-wrapper and binutils-wrappers setup hooks. (Should we abstract it instead?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

