### PR TITLE
Enable desktop notifications for keybase-gui

### DIFF
--- a/pkgs/tools/security/keybase-gui/default.nix
+++ b/pkgs/tools/security/keybase-gui/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, buildFHSUserEnv, writeTextFile, alsaLib, atk, cairo, cups
-, dbus, expat, fontconfig, freetype, gcc, gdk_pixbuf, glib, gnome2, gtk2, nspr
-, nss, pango, systemd, xorg, utillinuxMinimal }:
+, dbus, expat, fontconfig, freetype, gcc, gdk_pixbuf, glib, gnome2, gtk2
+, libnotify, nspr, nss, pango, systemd, xorg, utillinuxMinimal }:
 
 let
   libPath = stdenv.lib.makeLibraryPath [
@@ -17,6 +17,7 @@ let
     glib
     gnome2.GConf
     gtk2
+    libnotify
     nspr
     nss
     pango


### PR DESCRIPTION
###### Motivation for this change

Add `libnotify` as a build input to make message notifications work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

