### PR TITLE
pythonPackages.grpcio: 1.9.1 -> 1.10.0; fix build

### DIFF
--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -3,12 +3,16 @@
 
 buildPythonPackage rec {
   pname = "grpcio";
-  version = "1.9.1";
+  version = "1.10.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e7c43b5619deff48cc177c1b0618c4beeb2797f910f160e3c2035d5baf790a5d";
+    sha256 = "1075abnm2nrs69dycsiyi5h84g47yx389xiy9h96zwlvsdr589h3";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "'protobuf>=3.5.0.post1'" "'protobuf'"
+  '';
 
   propagatedBuildInputs = [ six protobuf ]
                         ++ lib.optionals (isPy26 || isPy27 || isPy34) [ enum34 ]


### PR DESCRIPTION
###### Motivation for this change

A slight dependency bump was needed in order to fix the build again.
Furthermore the dependency constraint for `protobuf` has been dropped in
order to support `pythonPackages.protobuf` properly.

See https://hydra.nixos.org/build/70683027/log
See ticket #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

