### PR TITLE
qpid-cpp: fix build

### DIFF
--- a/pkgs/servers/amqp/qpid-cpp/default.nix
+++ b/pkgs/servers/amqp/qpid-cpp/default.nix
@@ -1,8 +1,7 @@
-{ stdenv, fetchurl, cmake, python2, boost, libuuid, ruby }:
+{ stdenv, fetchurl, cmake, python2, boost, libuuid, ruby, buildEnv, buildPythonPackage, qpid-python }:
 
-stdenv.mkDerivation rec {
+let
   name = "qpid-cpp-${version}";
-
   version = "1.37.0";
 
   src = fetchurl {
@@ -10,24 +9,45 @@ stdenv.mkDerivation rec {
     sha256 = "1s4hyi867i0lqn81c1crrk6fga1gmsv61675vjv5v41skz56lrsb";
   };
 
-  buildInputs = [ cmake python2 boost libuuid ruby ];
-
-  # the subdir managementgen wants to install python stuff in ${python} and
-  # the installation tries to create some folders in /var
-  patchPhase = ''
-    sed -i '/managementgen/d' CMakeLists.txt
-    sed -i '/ENV/d' src/CMakeLists.txt
-  '';
-
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations -Wno-error=unused-function";
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://qpid.apache.org;
     repositories.git = git://git.apache.org/qpid.git;
     repositories.svn = http://svn.apache.org/repos/asf/qpid;
     description = "An AMQP message broker and a C++ messaging API";
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.cpages ];
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cpages ma27 ];
   };
+
+  qpid-cpp = stdenv.mkDerivation {
+    inherit src meta name;
+
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ boost libuuid ruby python2 ];
+
+    # the subdir managementgen wants to install python stuff in ${python} and
+    # the installation tries to create some folders in /var
+    postPatch = ''
+      sed -i '/managementgen/d' CMakeLists.txt
+      sed -i '/ENV/d' src/CMakeLists.txt
+      sed -i '/management/d' CMakeLists.txt
+    '';
+
+    NIX_CFLAGS_COMPILE = [
+      "-Wno-error=deprecated-declarations"
+      "-Wno-error=unused-function"
+      "-Wno-error=int-in-bool-context"
+    ];
+  };
+
+  python-frontend = buildPythonPackage {
+    inherit name meta src;
+
+    sourceRoot = "${name}/management/python";
+
+    propagatedBuildInputs = [ qpid-python ];
+  };
+in buildEnv {
+  name = "${name}-env";
+  paths = [ qpid-cpp python-frontend ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12714,6 +12714,7 @@ with pkgs;
 
   qpid-cpp = callPackage ../servers/amqp/qpid-cpp {
     boost = boost155;
+    inherit (pythonPackages) buildPythonPackage qpid-python;
   };
 
   quagga = callPackage ../servers/quagga { };


### PR DESCRIPTION
###### Motivation for this change

The compilation broke due to the flag `-Werror=int-in-bool-context`
which caused several compilation errors with GCC v7. Disabling this
warning manually with `-Wno-error` in `NIX_CFLAGS_COMPILE` should be
fine.

This package experienced several radical changes as the entire python
build in `$src/management/python` was broken since the given Python
interpreter missed several needed modules (including
`pythonPackages.qpid-python`). As the CMake build tried to invoke the
affected `setup.py` manually and patched the shebangs with `disutil` and
caused non-functional executables, I split the package up into two
parts, the actual `qpid-cpp` lib and the Python module that will be
composed using `buildEnv`.

Furthermore I added myself as maintainer for the package as the diff
became quite huge and we should have more folks available to maintain
this.

See https://hydra.nixos.org/build/71519082/log
See tickets #36453 and #31747

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

