### PR TITLE
gettext: fix dep on libiconv w/musl

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ xz xz.bin ];
   # HACK, see #10874 (and 14664)
-  buildInputs = stdenv.lib.optional (!stdenv.isLinux && !hostPlatform.isCygwin) libiconv;
+  buildInputs = stdenv.lib.optional (stdenv.hostPlatform.libc != "glibc" && !hostPlatform.isCygwin) libiconv;
 
   setupHook = ./gettext-setup-hook.sh;
   gettextNeedsLdflags = hostPlatform.libc != "glibc" && !hostPlatform.isMusl;


### PR DESCRIPTION
AFAICT this should "always" be provided (gettext dep on libiconv)
but the conditions present are used to avoid a bootstrapping problem
on Linux/glibc since there `iconv == stdenv.cc.libc`.
(see issues linked in expression above modified line)

Fix this on musl by narrowing the check to glibc.

I'm not sure what the Cygwin situation is about, so leaving it alone.


Fixes musl-native build of things requiring gettext...
for example `gobjectIntrospection`.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---