### PR TITLE
preview: add Shenandoah GC to openjdk packages by default

### DIFF
--- a/pkgs/development/compilers/openjdk/10.nix
+++ b/pkgs/development/compilers/openjdk/10.nix
@@ -26,8 +26,9 @@ let
     name = "openjdk-${update}-b${build}";
 
     src = fetchurl {
-      url = "http://hg.openjdk.java.net/jdk-updates/jdk10u/archive/${repover}.tar.gz";
-      sha256 = "1a2cjad816qilsigkq035rqzfhzmq5vaz1klilrrws456flbsjlg";
+      # NOTE: this is Shenandoah at jdk-10+46 with backported patches
+      url = "http://hg.openjdk.java.net/shenandoah/jdk10/archive/f45781c7e1da.tar.gz";
+      sha256 = "0mrpsz80b6czyi2sayakazlbicd4f7qf28vzlji65jj31pzlc0qa";
     };
 
     outputs = [ "out" "jre" ];


### PR DESCRIPTION
###### Motivation for this change

Shenandoah is a new, ultra-low pause time garbage collector for the JVM that collects garbage concurrently as the program runs, allowing GC times that do not scale proportional to the heap size: collecting a heap with a size of of 100GB or a 2GB size has the same pause behavior, which should be predictable.

###### Background

Shenandoah is enabled by updating the `hotspot` component of the OpenJDK build to
point to the Shenandoah fork -- thanks to a JDK 9 backport from the developers that is continuously kept up to date with the latest JDK versions, this is viable without bitrotting the packages, or having to put them under separate names.

While the `hotspot` component comes from the Shenandoah fork, it is not the default GC in this branch -- G1 still reigns by default on x86_64 Linux, and as the branch is kept up to date, still gets all the latest fixes.

This change was based on the Gentoo IcedTea build (which features Shenandoah support as a USE flag).

###### User impact

None by default; Shenandoah is opt-in only. This can be enabled with `-XX:+UseShenandoahGC`, e.g.

    $ ./result/bin/java -XX:+UseShenandoahGC -Xlog:gc -version
    [0.014s][info][gc] Using Shenandoah
    openjdk version "9.0.4-internal"
    OpenJDK Runtime Environment (build 9.0.4-internal+0-adhoc..jdk9u-jdk-9.0.412)
    OpenJDK 64-Bit Server VM (build 9.0.4-internal+0-adhoc..jdk9u-jdk-9.0.412, mixed mode)
    [0.076s][info][gc] Cancelling concurrent GC: Stopping VM

###### Still not done

The developers also keep backports of Shenandoah to JDK8 and (the new) JDK10. I would like it to be added to all these packages as well, to give a consistent preview feature set to all `openjdk*` package users. Currently, for JDK 8, I'm waiting on a new merge with the upstream `jdk8u-updates` branch (the fork is a tiny bit behind), while JDK10 is still not yet packaged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] ~macOS~
   - [x] other Linux distributions (Fedora 25 with Sandboxing)
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)).~ `openjdk9` is not the default JDK (`openjdk8` is), so almost nothing is tested by it now. I have done my own testing.
- [ ] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`.~ `openjdk9` is not the default JDK (`openjdk8` is), so almost nothing is rebuilt by changing this. I have done my own testing.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

