### PR TITLE
linux_riscv: 4.16-rc2 -> 4.16-rc6.

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-riscv.nix
+++ b/pkgs/os-specific/linux/kernel/linux-riscv.nix
@@ -1,15 +1,15 @@
 { stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.16-rc2";
-  modDirVersion = "4.16.0-rc2";
+  version = "4.16-rc6";
+  modDirVersion = "4.16.0-rc6";
   extraMeta.branch = "4.16";
 
   src = fetchFromGitHub {
     owner = "shlevy";
     repo ="riscv-linux";
-    rev = "f0c42cff9292c0a8e6ca702a54aafa04b35758a6";
-    sha256 = "050mdciyz1595z81zsss0v9vqsaysppyzqaqpfs5figackifv3iv";
+    rev = "a54f259c2adce68e3bd7600be8989bf1ddf9ea3a";
+    sha256 = "140w6mj4hm1vf4zsmcr2w5cghcaalbvw5d4m9z57dmq1z5plsl4q";
   };
 
   # Should the testing kernels ever be built on Hydra?


### PR DESCRIPTION
Also moves most of our patches upstream.