### PR TITLE
Add a derefPath function that copies a path to the store

### DIFF
--- a/pkgs/build-support/deref-path.nix
+++ b/pkgs/build-support/deref-path.nix
@@ -1,0 +1,3 @@
+{ runCommand }:
+{ name, src }:
+runCommand name {} "cp -aL ${toString src}/ $out/"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -113,6 +113,8 @@ with pkgs;
 
   cmark = callPackage ../development/libraries/cmark { };
 
+  derefPath = callPackage ../build-support/deref-path.nix { };
+
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {
     inherit dhall-nix;
   };


### PR DESCRIPTION
This function will copy a path to the nix store. The difference with
using `src = ./.` is how symbolic links are handled. Nix normally just copies those links as-is into the store.
This function can be used to dereference all symbolic links.

## Example
```nix
{ stdenv, derefPath }:
stdenv.mkDerivation rec {
  name = "hello";

  src = derefPath {
    name = "${name}-src";
    src = ./.;
  };
}
```

This is a quick and dirty fix for the following issues in `NixOS/nix`:
* https://github.com/NixOS/nix/issues/1232
* https://github.com/NixOS/nix/issues/897

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

