### PR TITLE
procps-ng: updated project location

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3660,6 +3660,11 @@
     github = "twey";
     name = "James ‘Twey’ Kay";
   };
+  typetetris = {
+    email = "ericwolf42@mail.com";
+    github = "typetetris";
+    name = "Eric Wolf";
+  };
   unode = {
     email = "alves.rjc@gmail.com";
     github = "unode";

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -1,15 +1,24 @@
-{ lib, stdenv, fetchurl, ncurses }:
+{ lib, stdenv, fetchFromGitLab, ncurses, libtool, gettext, autoconf, automake, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "procps-${version}";
   version = "3.3.12";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/procps-ng/procps-ng-${version}.tar.xz";
-    sha256 = "1m57w6jmry84njd5sgk5afycbglql0al80grx027kwqqcfw5mmkf";
+  src = fetchFromGitLab {
+    owner ="procps-ng";
+    repo = "procps";
+    rev = "v${version}";
+    sha256 = "0k5vvvjn954xqnhk97j62ilwmipbi4gqjcznllmk6ilfmszqczzz";
   };
 
   buildInputs = [ ncurses ];
+  nativeBuildInputs = [ libtool gettext autoconf automake pkgconfig ];
+
+  # autoreconfHook doesn't quite get, what procps-ng buildprocss does
+  # with po/Makefile.in.in and stuff.
+  preConfigure = ''
+    ./autogen.sh
+  '';
 
   makeFlags = "usrbin_execdir=$(out)/bin";
 
@@ -22,7 +31,7 @@ stdenv.mkDerivation rec {
       "ac_cv_func_realloc_0_nonnull=yes" ];
 
   meta = {
-    homepage = https://sourceforge.net/projects/procps-ng/;
+    homepage = https://gitlab.com/procps-ng/procps;
     description = "Utilities that give information about processes using the /proc filesystem";
     priority = 10; # less than coreutils, which also provides "kill" and "uptime"
     license = lib.licenses.gpl2;

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     priority = 10; # less than coreutils, which also provides "kill" and "uptime"
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux ++ lib.platforms.cygwin;
+    maintainers = [ lib.maintainers.typetetris ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- use the real project location and not some sf.net mirror
- the meta attribute shouldn't point users to a website cluttered
  with ads (sf.net) where they probably just follow the link
  to the real project location
- adapted the build to the new archive

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  My box didn't have nix 2 and with some `nix-shell -p nixUnstable` tried to build all derivations, which
  seemed unlikely to be caused by this.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I also offer to take maintainership of procps-ng, if so desired.