### PR TITLE
lib.types: fix loaOf behavior of long lists and many merges

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -138,6 +138,12 @@ checkConfigOutput "\"42\"" config.value ./declare-coerced-value.nix
 checkConfigOutput "\"24\"" config.value ./declare-coerced-value.nix ./define-value-string.nix
 checkConfigError 'The option value .* in .* is not.*string or signed integer.*' config.value ./declare-coerced-value.nix ./define-value-list.nix
 
+# Check loaOf with long list.
+checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-long-list.nix
+
+# Check loaOf with many merges of lists.
+checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-many-list-merges.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/loaOf-with-long-list.nix
+++ b/lib/tests/modules/loaOf-with-long-list.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+
+{
+  options = {
+    loaOfInt = lib.mkOption {
+      type = lib.types.loaOf lib.types.int;
+    };
+
+    result = lib.mkOption {
+      type = lib.types.str;
+    };
+  };
+
+  config = {
+    loaOfInt = [ 1 2 3 4 5 6 7 8 9 10 ];
+
+    result = toString (lib.attrValues config.loaOfInt);
+  };
+}

--- a/lib/tests/modules/loaOf-with-many-list-merges.nix
+++ b/lib/tests/modules/loaOf-with-many-list-merges.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+
+{
+  options = {
+    loaOfInt = lib.mkOption {
+      type = lib.types.loaOf lib.types.int;
+    };
+
+    result = lib.mkOption {
+      type = lib.types.str;
+    };
+  };
+
+  config = {
+    loaOfInt = lib.mkMerge (map lib.singleton [ 1 2 3 4 5 6 7 8 9 10 ]);
+
+    result = toString (lib.attrValues config.loaOfInt);
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Assigning a list of 10 or more elements to an option having the type `loaOf a` produces a configuration value that is not honoring the order of the original list. This commit fixes this and a related issue arising when 10 or more lists are merged into this type of option.

###### Things done

Works for me™