### PR TITLE
libcdio-paranoia: fix darwin build

### DIFF
--- a/pkgs/development/libraries/libcdio-paranoia/default.nix
+++ b/pkgs/development/libraries/libcdio-paranoia/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, libcdio, pkgconfig }:
+{ stdenv, fetchFromGitHub, autoreconfHook, libcdio, pkgconfig,
+  libiconv, IOKit, DiskArbitration}:
 
 stdenv.mkDerivation {
   name = "libcdio-paranoia-0.94+2";
@@ -11,7 +12,14 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ libcdio ];
+  buildInputs = [ libcdio ] ++
+    stdenv.lib.optionals stdenv.isDarwin [ libiconv IOKit DiskArbitration ];
+
+  propagatedBuildInputs = stdenv.lib.optional stdenv.isDarwin DiskArbitration;
+
+  configureFlags = stdenv.lib.optionals stdenv.isDarwin [
+    "--disable-ld-version-script"
+  ];
 
   meta = with stdenv.lib; {
     description = "CD paranoia on top of libcdio";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9601,7 +9601,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Carbon IOKit;
   };
 
-  libcdio-paranoia = callPackage ../development/libraries/libcdio-paranoia { };
+  libcdio-paranoia = callPackage ../development/libraries/libcdio-paranoia {
+    inherit (darwin.apple_sdk.frameworks) DiskArbitration IOKit;
+  };
 
   libcdr = callPackage ../development/libraries/libcdr { lcms = lcms2; };
 


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)
I also ran `result/bin/cd-paranoia -A` with a CD inserted, and it worked fine.
I put `DiskArbitration` in the `propagatedBuildInputs` to fix the `cmus` build. Now cmus should also build fine. I haven't however figured out how to play a CD using cmus.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

