### PR TITLE
babelstone-han: 10.0.2 -> 11.0.0

### DIFF
--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,16 +1,16 @@
 {stdenv, fetchzip}:
 
 let
-  version = "10.0.2";
+  version = "11.0.0";
 in fetchzip {
   name = "babelstone-han-${version}";
 
-  url = http://www.babelstone.co.uk/Fonts/7932/BabelStoneHan.zip;
+  url = http://www.babelstone.co.uk/Fonts/3902/BabelStoneHan.zip;
   postFetch = ''
     mkdir -p $out/share/fonts/truetype
     unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
   '';
-  sha256 = "17r5cf028v66yzjf9qbncn4rchv2xxkl2adxr35ppg1l7zssz9v6";
+  sha256 = "1w3v69lacsy0nha20rkbs6f0dskf5xm6p250qx4a1m69d4a1gx7v";
 
   meta = with stdenv.lib; {
     description = "Unicode CJK font with over 32600 Han characters";


### PR DESCRIPTION
new font version; old link answers with 404
