### PR TITLE
safeeyes: init at 2.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4130,4 +4130,9 @@
     github = "zzamboni";
     name = "Diego Zamboni";
   };
+  srghma = {
+    email = "srghma@gmail.com";
+    github = "srghma";
+    name = "Sergei Khoma";
+  };
 }

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -366,6 +366,7 @@
   ./services/misc/ripple-data-api.nix
   ./services/misc/rogue.nix
   ./services/misc/serviio.nix
+  ./services/misc/safeeyes.nix
   ./services/misc/siproxd.nix
   ./services/misc/snapper.nix
   ./services/misc/sonarr.nix

--- a/nixos/modules/services/misc/safeeyes.nix
+++ b/nixos/modules/services/misc/safeeyes.nix
@@ -39,8 +39,10 @@ in
         ExecStart = ''
           ${pkgs.safeeyes}/bin/safeeyes
         '';
+        Restart = "on-failure";
         RestartSec = 3;
-        Restart = "always";
+        StartLimitInterval = 350;
+        StartLimitBurst = 10;
       };
     };
 

--- a/nixos/modules/services/misc/safeeyes.nix
+++ b/nixos/modules/services/misc/safeeyes.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.safeeyes;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.safeeyes = {
+
+      enable = mkOption {
+        default = false;
+        description = "Whether to enable the safeeyes OSGi service";
+      };
+
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.user.services.safeeyes = {
+      description = "Safeeyes";
+
+      wantedBy = [ "graphical-session.target" ];
+      partOf   = [ "graphical-session.target" ];
+
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.safeeyes}/bin/safeeyes
+        '';
+        RestartSec = 3;
+        Restart = "always";
+      };
+    };
+
+  };
+}

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -30,11 +30,11 @@ in buildPythonApplication rec {
   # patch smartpause plugin
   postPatch = ''
     sed -i \
-      -e 's!xprintidle!${xprintidle-ng}/bin/xprintidle-ng!g' \
+      -e 's!xprintidle!xprintidle-ng!g' \
       safeeyes/plugins/smartpause/plugin.py
 
     sed -i \
-      -e 's!xprintidle!${xprintidle-ng}/bin/xprintidle-ng!g' \
+      -e 's!xprintidle!xprintidle-ng!g' \
       safeeyes/plugins/smartpause/config.json
   '';
 

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, gobjectIntrospection, libappindicator-gtk3, gtk3, gnome3, xprintidle-ng
+{ lib, python3Packages, gobjectIntrospection, libappindicator-gtk3, libnotify, gtk3, gnome3, xprintidle-ng
 }:
 
 let inherit (python3Packages) python buildPythonApplication fetchPypi;
@@ -24,6 +24,7 @@ in buildPythonApplication rec {
     dbus-python
 
     libappindicator-gtk3
+    libnotify
     xprintidle-ng
   ];
 

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, gobjectIntrospection, libappindicator-gtk3, libnotify, gtk3, gnome3, xprintidle-ng
+{ lib, python3Packages, gobjectIntrospection, libappindicator-gtk3, libnotify, gtk3, gnome3, xprintidle-ng, wrapGAppsHook, gdk_pixbuf, shared-mime-info, librsvg
 }:
 
 let inherit (python3Packages) python buildPythonApplication fetchPypi;
@@ -14,7 +14,16 @@ in buildPythonApplication rec {
     sha256 = "1fx6zd4hnbc7gdpac6r7smxwdl1bifaxx3mnx0wrqfvhpnwr1ybv";
   };
 
-  buildInputs = [ gtk3 gobjectIntrospection gnome3.defaultIconTheme ];
+  buildInputs = [
+    gtk3
+    gobjectIntrospection
+    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     Babel
@@ -39,14 +48,18 @@ in buildPythonApplication rec {
       safeeyes/plugins/smartpause/config.json
   '';
 
-  doCheck = false;
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${gdk_pixbuf}/share"
+      --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
+      --prefix XDG_DATA_DIRS : "${librsvg}/share"
 
-  makeWrapperArgs = [
-    ''--set GI_TYPELIB_PATH "$GI_TYPELIB_PATH"''
-    ''--set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"''
-    ''--suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"''
-    ''--prefix XDG_DATA_DIRS : "$out/lib/${python.libPrefix}/site-packages/usr/share"''
-  ];
+      # safeeyes images
+      --prefix XDG_DATA_DIRS : "$out/lib/${python.libPrefix}/site-packages/usr/share"
+    )
+  '';
+
+  doCheck = false; # no tests
 
   meta = {
     homepage = http://slgobinath.github.io/SafeEyes;

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -1,0 +1,57 @@
+{ lib, python3Packages, gobjectIntrospection, libappindicator-gtk3, gtk3, gnome3, xprintidle-ng
+}:
+
+let inherit (python3Packages) python buildPythonApplication fetchPypi;
+
+in buildPythonApplication rec {
+  name = "${pname}-${version}";
+  pname = "safeeyes";
+  version = "2.0.2";
+  namePrefix = "";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fx6zd4hnbc7gdpac6r7smxwdl1bifaxx3mnx0wrqfvhpnwr1ybv";
+  };
+
+  buildInputs = [ gtk3 gobjectIntrospection gnome3.defaultIconTheme ];
+
+  propagatedBuildInputs = with python3Packages; [
+    Babel
+    psutil
+    xlib
+    pygobject3
+    dbus-python
+
+    libappindicator-gtk3
+    xprintidle-ng
+  ];
+
+  # patch smartpause plugin
+  postPatch = ''
+    sed -i \
+      -e 's!xprintidle!${xprintidle-ng}/bin/xprintidle-ng!g' \
+      safeeyes/plugins/smartpause/plugin.py
+
+    sed -i \
+      -e 's!xprintidle!${xprintidle-ng}/bin/xprintidle-ng!g' \
+      safeeyes/plugins/smartpause/config.json
+  '';
+
+  doCheck = false;
+
+  makeWrapperArgs = [
+    "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\""
+    "--set GDK_PIXBUF_MODULE_FILE \"$GDK_PIXBUF_MODULE_FILE\""
+    "--prefix XDG_DATA_DIRS : \"$out/lib/${python.libPrefix}/site-packages/usr/share\""
+    "--suffix XDG_DATA_DIRS : \"$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH\""
+  ];
+
+  meta = {
+    homepage = http://slgobinath.github.io/SafeEyes;
+    description = "Protect your eyes from eye strain using this simple and beautiful, yet extensible break reminder. A Free and Open Source Linux alternative to EyeLeo";
+    license = lib.licenses.gpl3;
+    maintainers = [ ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -41,10 +41,10 @@ in buildPythonApplication rec {
   doCheck = false;
 
   makeWrapperArgs = [
-    "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\""
-    "--set GDK_PIXBUF_MODULE_FILE \"$GDK_PIXBUF_MODULE_FILE\""
-    "--prefix XDG_DATA_DIRS : \"$out/lib/${python.libPrefix}/site-packages/usr/share\""
-    "--suffix XDG_DATA_DIRS : \"$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH\""
+    ''--set GI_TYPELIB_PATH "$GI_TYPELIB_PATH"''
+    ''--set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"''
+    ''--suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"''
+    ''--prefix XDG_DATA_DIRS : "$out/lib/${python.libPrefix}/site-packages/usr/share"''
   ];
 
   meta = {

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -51,7 +51,7 @@ in buildPythonApplication rec {
     homepage = http://slgobinath.github.io/SafeEyes;
     description = "Protect your eyes from eye strain using this simple and beautiful, yet extensible break reminder. A Free and Open Source Linux alternative to EyeLeo";
     license = lib.licenses.gpl3;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ srghma ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4723,6 +4723,8 @@ with pkgs;
 
   safe-rm = callPackage ../tools/system/safe-rm { };
 
+  safeeyes = callPackage ../applications/misc/safeeyes { };
+
   salt = callPackage ../tools/admin/salt {};
 
   salut_a_toi = callPackage ../applications/networking/instant-messengers/salut-a-toi {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -629,9 +629,9 @@ with pkgs;
 
   encryptr = callPackage ../tools/security/encryptr {
     gconf = gnome2.GConf;
- };
+  };
 
- enchive = callPackage ../tools/security/enchive { };
+  enchive = callPackage ../tools/security/enchive { };
 
   enpass = callPackage ../tools/security/enpass { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

##### Known issues
1. 
```
ERROR:root:Error in loading the plugin: notification
```
 
2. 

```
(safeeyes:2448): Gtk-WARNING **: Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
This may indicate that pixbuf loaders or the mime database could not be found.
```


adding `"--prefix XDG_DATA_DIRS : \"${gnome3.defaultIconTheme}/share:$GSETTINGS_SCHEMAS_PATH\""` to `makeWrapperArgs` didnt help 