### PR TITLE
glyr: enable darwin build

### DIFF
--- a/pkgs/tools/audio/glyr/default.nix
+++ b/pkgs/tools/audio/glyr/default.nix
@@ -15,16 +15,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ sqlite glib curl ];
 
-  configurePhase = ''
-    cmake -DCMAKE_INSTALL_PREFIX=$out
-  '';
-
   meta = with stdenv.lib; {
     license = licenses.lgpl3;
     description = "A music related metadata searchengine";
     homepage = https://github.com/sahib/glyr;
     maintainers = [ maintainers.sternenseemann ];
-    platforms = platforms.linux; # TODO macOS would be possible
+    platforms = platforms.unix;
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

