### PR TITLE
translate-shell: 0.9.6.6 -> 0.9.6.7, fix packaging

### DIFF
--- a/pkgs/applications/misc/translate-shell/default.nix
+++ b/pkgs/applications/misc/translate-shell/default.nix
@@ -1,101 +1,38 @@
-{ stdenv, fetchFromGitHub, curl, fribidi, mpv, less, rlwrap, gawk, bash, emacs, groff, ncurses, pandoc }:
+{ stdenv, fetchFromGitHub, makeWrapper, curl, fribidi, rlwrap, gawk, groff, ncurses }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "translate-shell";
-  version = "0.9.6.6";
+  version = "0.9.6.7";
 
   src = fetchFromGitHub {
     owner = "soimort";
     repo = "translate-shell";
-    rev = "v" + version;
-    sha256 = "0hbwvc554v6fi4ardidwsnn8hk7p68p155yjllvljjawkbq4qljq";
+    rev = "v${version}";
+    sha256 = "0krcidjh32xwybr1v4nykgf0jjnffjqx125bvn3jh2a44cikyq3n";
   };
 
-  phases = [ "buildPhase" "installPhase" "postFixup" ];
+  buildInputs = [ makeWrapper ];
 
-  buildPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share
-    mkdir -p $out/share/man/man1
-  '';
+  installFlags = [ "PREFIX=$(out)" ];
 
-  installPhase = ''
-    cp $src/translate $out/bin/trans
-    cp $src/translate $out/bin/translate
-    cp $src/translate $out/bin/translate-shell
-
-    cp $src/translate.awk $out/share/translate.awk
-    cp $src/build.awk $out/share/build.awk
-    cp $src/metainfo.awk $out/share/metainfo.awk
-    cp $src/test.awk $out/share/test.awk
-
-    cp -r $src/include $out/share
-    cp -r $src/test $out/share
-    cp $src/man/trans.1 $out/share/man/man1
-
-    chmod +x $out/bin/translate
-    chmod +x $out/share/translate.awk
-    chmod +x $out/share/build.awk
-    chmod +x $out/share/metainfo.awk
-    chmod +x $out/share/test.awk
-  '';
-
-  postFixup = ''
-    substituteInPlace $out/bin/trans --replace "/bin/sh" "${bash}/bin/bash"
-    substituteInPlace $out/bin/trans --replace "gawk " "${gawk}/bin/gawk "
-    substituteInPlace $out/bin/trans --replace "translate.awk" "$out/share/translate.awk"
-
-    substituteInPlace $out/bin/translate --replace "/bin/sh" "${bash}/bin/bash"
-    substituteInPlace $out/bin/translate --replace "gawk " "${gawk}/bin/gawk "
-    substituteInPlace $out/bin/translate --replace "translate.awk" "$out/share/translate.awk"
-
-    substituteInPlace $out/bin/translate-shell --replace "/bin/sh" "${bash}/bin/bash"
-    substituteInPlace $out/bin/translate-shell --replace "gawk " "${gawk}/bin/gawk "
-    substituteInPlace $out/bin/translate-shell --replace "translate.awk" "$out/share/translate.awk"
-
-    substituteInPlace $out/share/translate.awk --replace "/usr/bin/gawk" "${gawk}/bin/gawk"
-    substituteInPlace $out/share/translate.awk --replace "metainfo" "$out/share/metainfo"
-    substituteInPlace $out/share/translate.awk --replace "include/" "$out/share/include/"
-
-    substituteInPlace $out/share/build.awk --replace "/usr/bin/gawk" "${gawk}/bin/gawk"
-    substituteInPlace $out/share/build.awk --replace "include/" "$out/share/include/"
-    substituteInPlace $out/share/build.awk --replace "metainfo.awk" "$out/share/metainfo.awk"
-
-    substituteInPlace $out/share/metainfo.awk --replace "translate.awk" "$out/share/translate.awk"
-
-    substituteInPlace $out/share/test.awk --replace "/usr/bin/gawk" "${gawk}/bin/gawk"
-    substituteInPlace $out/share/test.awk --replace "include/" "$out/share/include/"
-    substituteInPlace $out/share/test.awk --replace "test/" "$out/share/test/"
-
-    substituteInPlace $out/share/include/Translators/\*.awk --replace "include/" "$out/share/include/"
-
-    substituteInPlace $out/share/test/Test.awk --replace "test/" "$out/share/test/"
-    substituteInPlace $out/share/test/TestUtils.awk --replace "include/" "$out/share/include/"
-    substituteInPlace $out/share/test/TestParser.awk --replace "include/" "$out/share/include/"
-    substituteInPlace $out/share/test/TestCommons.awk --replace "\"gawk\"" "\"${gawk}/bin/gawk\""
-    substituteInPlace $out/share/test/TestCommons.awk --replace "Commons.awk" "$out/share/include/Commons.awk"
-
-    substituteInPlace $out/share/include/Main.awk --replace "\"tput\"" "\"${ncurses.out}/bin/tput\""
-    substituteInPlace $out/share/include/Help.awk --replace "\"groff\"" "\"${groff}/bin/groff\""
-    substituteInPlace $out/share/include/Utils.awk --replace "\"fribidi\"" "\"${fribidi}/bin/fribidi\""
-    substituteInPlace $out/share/include/Utils.awk --replace "\"fribidi " "\"${fribidi}/bin/fribidi "
-    substituteInPlace $out/share/include/Utils.awk --replace "\"rlwrap\"" "\"${rlwrap}/bin/rlwrap\""
-    substituteInPlace $out/share/include/Utils.awk --replace "\"emacs\"" "\"${emacs}/bin/emacs\""
-    substituteInPlace $out/share/include/Utils.awk --replace "\"curl\"" "\"${curl.bin}/bin/curl\""
-
-    substituteInPlace $out/share/build.awk --replace "\"pandoc " "\"${pandoc}/bin/pandoc "
-
-    substituteInPlace $out/share/include/Translate.awk --replace "\"mpv " "\"${mpv}/bin/mpv "
-    substituteInPlace $out/share/include/Translate.awk --replace "\"less " "\"${less}/bin/less "
-
+  postInstall = ''
+    wrapProgram $out/bin/trans \
+      --prefix PATH : ${stdenv.lib.makeBinPath [
+        gawk
+        curl
+        ncurses
+        rlwrap
+        groff
+        fribidi
+      ]}
   '';
 
   meta = with stdenv.lib; {
     homepage = https://www.soimort.org/translate-shell;
     description = "Command-line translator using Google Translate, Bing Translator, Yandex.Translate, and Apertium";
-    license = licenses.publicDomain;
-    maintainers = [ maintainers.ebzzry ];
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ ebzzry infinisil ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The packaging of this was a mess before, I'm wondering why it got merged in the first place. I cleaned it up and removed unnecessary dependencies (including pandoc), which reduced the closure size from just below 1GB to just 40MB. Also fixed the license.

#37549 should be closed in favor of this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

