### PR TITLE
wine: Unstable 3.3 -> 3.4 & reenable wineStaging

### DIFF
--- a/pkgs/misc/emulators/wine/default.nix
+++ b/pkgs/misc/emulators/wine/default.nix
@@ -56,12 +56,9 @@ let wine-build = build: release:
       });
 
 in if wineRelease == "staging" then
-  let wineUnstable = wine-build wineBuild "unstable"; in
-    # wine staging is not yet at 3.0, using unstable
-    # FIXME update winestaging sources
-    wineUnstable
-    # callPackage ./staging.nix {
-    #   inherit libtxc_dxtn_Name wineUnstable;
-    # }
+  callPackage ./staging.nix {
+    inherit libtxc_dxtn_Name;
+    wineUnstable = wine-build wineBuild "unstable";
+  }
 else
   wine-build wineBuild wineRelease

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -39,18 +39,16 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "3.3";
+    version = "3.4";
     url = "https://dl.winehq.org/wine/source/3.x/wine-${version}.tar.xz";
-    sha256 = "0cx31jsll7mxd9r7v0vpahajqwb6da6cpwybv06l5ydkgfrbv505";
+    sha256 = "14wf7536rkmhav9ibbvhqqkfqmbk1dckhd2679i5scizr5x290x4";
     inherit (stable) mono gecko32 gecko64;
   };
 
   staging = fetchFromGitHub rec {
     # https://github.com/wine-compholio/wine-staging/releases
     inherit (unstable) version;
-    # FIXME update winestaging sources, when 3.3 is released
-    # FIXME then revert the staging derivation in ./default.nix
-    sha256 = "0000000000000000000000000000000000000000000000000000000000000000";
+    sha256 = "11cdymdd0qf8khhrakzj7qz12gx19h2a30r8bimbx6rriqryhlc2";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change
wine unstable and staging are at 3.4 now

###### Things done
just updated wineUnstable and removed the workaround for wineStaging.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

