### PR TITLE
mpv: Add openal support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -32,6 +32,7 @@
 , youtubeSupport     ? true,  youtube-dl    ? null
 , vaapiSupport       ? true,  libva         ? null
 , drmSupport         ? true,  libdrm        ? null
+, openalSupport      ? true,  openalSoft   ? null
 , vapoursynthSupport ? false, vapoursynth   ? null
 , archiveSupport     ? false, libarchive    ? null
 , jackaudioSupport   ? false, libjack2      ? null
@@ -59,6 +60,7 @@ assert dvdnavSupport      -> available libdvdnav;
 assert bluraySupport      -> available libbluray;
 assert speexSupport       -> available speex;
 assert theoraSupport      -> available libtheora;
+assert openalSupport      -> available openalSoft;
 assert pulseSupport       -> available libpulseaudio;
 assert bs2bSupport        -> available libbs2b;
 assert cacaSupport        -> available libcaca;
@@ -113,6 +115,7 @@ in stdenv.mkDerivation rec {
     (enableFeature archiveSupport "libarchive")
     (enableFeature dvdreadSupport "dvdread")
     (enableFeature dvdnavSupport "dvdnav")
+    (enableFeature openalSupport "openal")
     (enableFeature vaapiSupport "vaapi")
     (enableFeature waylandSupport "wayland")
     (enableFeature stdenv.isLinux "dvbin")
@@ -143,6 +146,8 @@ in stdenv.mkDerivation rec {
     ++ optional vdpauSupport       libvdpau
     ++ optional speexSupport       speex
     ++ optional bs2bSupport        libbs2b
+    ++ optional openalSupport      openalSoft
+    ++ optional (openalSupport && stdenv.isDarwin) darwin.apple_sdk.frameworks.OpenAL
     ++ optional libpngSupport      libpng
     ++ optional youtubeSupport     youtube-dl
     ++ optional sdl2Support        SDL2


### PR DESCRIPTION
###### Motivation for this change

mpv no longer has HRTF support, which means it can't collapse positional (e.g. 5.1) audio to stereo (for headphones) while maintaining the surround effect. The recommended workaround is to use `-ao openal`, which does know how to do this.

(Assuming you put `hrtf = true` in ~/.alsoftrc.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

