### PR TITLE
i3-gaps: 4.14.1 -> 4.15.0.1

### DIFF
--- a/pkgs/applications/window-managers/i3/gaps.nix
+++ b/pkgs/applications/window-managers/i3/gaps.nix
@@ -3,12 +3,12 @@
 i3.overrideDerivation (super : rec {
 
   name = "i3-gaps-${version}";
-  version = "4.14.1";
-  releaseDate = "2017-09-24";
+  version = "4.15.0.1";
+  releaseDate = "2018-03-13";
 
   src = fetchurl {
     url = "https://github.com/Airblader/i3/archive/${version}.tar.gz";
-    sha256 = "11fnkg4halplcnannfw3ishzwwbxbnjafmkxsim199jhlyjjd8j7";
+    sha256 = "16s6bink8yj3zix4vww64b745d5drf2vqjg8vz3pwzrark09hfal";
   };
 
   nativeBuildInputs = super.nativeBuildInputs ++ [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

