### PR TITLE
treewide: use more HTTPS URLs

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -284,7 +284,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
 
   gpl2Oss = {
     fullName = "GNU General Public License version 2 only (with OSI approved licenses linking exception)";
-    url = http://www.mysql.com/about/legal/licensing/foss-exception;
+    url = https://www.mysql.com/about/legal/licensing/foss-exception;
   };
 
   gpl2Plus = spdx {

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -279,7 +279,7 @@ in {
       tokenAuthFile = mkOption {
         description = ''
           Kubernetes apiserver token authentication file. See
-          <link xlink:href="http://kubernetes.io/docs/admin/authentication.html"/>
+          <link xlink:href="https://kubernetes.io/docs/admin/authentication.html"/>
         '';
         default = null;
         type = types.nullOr types.path;
@@ -288,7 +288,7 @@ in {
       basicAuthFile = mkOption {
         description = ''
           Kubernetes apiserver basic authentication file. See
-          <link xlink:href="http://kubernetes.io/docs/admin/authentication.html"/>
+          <link xlink:href="https://kubernetes.io/docs/admin/authentication.html"/>
         '';
         default = pkgs.writeText "users" ''
           kubernetes,admin,0
@@ -299,7 +299,7 @@ in {
       authorizationMode = mkOption {
         description = ''
           Kubernetes apiserver authorization mode (AlwaysAllow/AlwaysDeny/ABAC/RBAC). See
-          <link xlink:href="http://kubernetes.io/docs/admin/authorization.html"/>
+          <link xlink:href="https://kubernetes.io/docs/admin/authorization.html"/>
         '';
         default = ["RBAC" "Node"];
         type = types.listOf (types.enum ["AlwaysAllow" "AlwaysDeny" "ABAC" "RBAC" "Node"]);
@@ -308,7 +308,7 @@ in {
       authorizationPolicy = mkOption {
         description = ''
           Kubernetes apiserver authorization policy file. See
-          <link xlink:href="http://kubernetes.io/docs/admin/authorization.html"/>
+          <link xlink:href="https://kubernetes.io/docs/admin/authorization.html"/>
         '';
         default = [];
         type = types.listOf types.attrs;
@@ -332,7 +332,7 @@ in {
       runtimeConfig = mkOption {
         description = ''
           Api runtime configuration. See
-          <link xlink:href="http://kubernetes.io/docs/admin/cluster-management.html"/>
+          <link xlink:href="https://kubernetes.io/docs/admin/cluster-management.html"/>
         '';
         default = "authentication.k8s.io/v1beta1=true";
         example = "api/all=false,api/v1=true";
@@ -342,7 +342,7 @@ in {
       admissionControl = mkOption {
         description = ''
           Kubernetes admission control plugins to use. See
-          <link xlink:href="http://kubernetes.io/docs/admin/admission-controllers/"/>
+          <link xlink:href="https://kubernetes.io/docs/admin/admission-controllers/"/>
         '';
         default = ["NamespaceLifecycle" "LimitRanger" "ServiceAccount" "ResourceQuota" "DefaultStorageClass" "DefaultTolerationSeconds" "NodeRestriction"];
         example = [

--- a/pkgs/applications/altcoins/ethsign/default.nix
+++ b/pkgs/applications/altcoins/ethsign/default.nix
@@ -52,7 +52,7 @@ buildGoPackage rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/dapphub/ethsign;
+    homepage = https://github.com/dapphub/ethsign;
     description = "Make raw signed Ethereum transactions";
     license = [licenses.gpl3];
   };

--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Audio player";
-    homepage = http://audacious-media-player.org/;
+    homepage = https://audacious-media-player.org/;
     maintainers = with maintainers; [ eelco ramkromberg ];
     platforms = with platforms; linux;
     license = with licenses; [

--- a/pkgs/applications/audio/audacious/qt-5.nix
+++ b/pkgs/applications/audio/audacious/qt-5.nix
@@ -81,7 +81,7 @@ mkDerivation {
 
   meta = with lib; {
     description = "Audio player";
-    homepage = http://audacious-media-player.org/;
+    homepage = https://audacious-media-player.org/;
     maintainers = with maintainers; [ ttuegel ];
     platforms = with platforms; linux;
     license = with licenses; [

--- a/pkgs/applications/audio/lastfmsubmitd/default.nix
+++ b/pkgs/applications/audio/lastfmsubmitd/default.nix
@@ -6,7 +6,7 @@ pythonPackages.buildPythonApplication rec {
   version = "1.0.6";
 
   src = fetchurl {
-    url = "http://www.red-bean.com/decklin/lastfmsubmitd/lastfmsubmitd-${version}.tar.gz";
+    url = "https://www.red-bean.com/decklin/lastfmsubmitd/lastfmsubmitd-${version}.tar.gz";
     sha256 = "c2636d5095a95167366bacd458624d67b046e060244fa54ba2c2e3efb79f9b0e";
   };
 
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
   installCommand = "python setup.py install --prefix=$out";
 
   meta = {
-    homepage = http://www.red-bean.com/decklin/lastfmsubmitd/;
+    homepage = https://www.red-bean.com/decklin/lastfmsubmitd/;
     description = "An last.fm audio scrobbler and daemon";
   };
 }

--- a/pkgs/applications/audio/mopidy-gmusic/default.nix
+++ b/pkgs/applications/audio/mopidy-gmusic/default.nix
@@ -19,7 +19,7 @@ pythonPackages.buildPythonApplication rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://www.mopidy.com/;
+    homepage = https://www.mopidy.com/;
     description = "Mopidy extension for playing music from Google Play Music";
     license = licenses.asl20;
     maintainers = [ maintainers.jgillich ];

--- a/pkgs/applications/audio/mopidy-spotify/default.nix
+++ b/pkgs/applications/audio/mopidy-spotify/default.nix
@@ -14,7 +14,7 @@ pythonPackages.buildPythonApplication rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://www.mopidy.com/;
+    homepage = https://www.mopidy.com/;
     description = "Mopidy extension for playing music from Spotify";
     license = licenses.asl20;
     maintainers = [ maintainers.rickynils ];

--- a/pkgs/applications/graphics/leocad/default.nix
+++ b/pkgs/applications/graphics/leocad/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "CAD program for creating virtual LEGO models";
-    homepage = http://www.leocad.org/;
+    homepage = https://www.leocad.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     mupdf_modded = mupdf.overrideAttrs (attrs: {
       name = "mupdf-1.10a";
       src = fetchurl {
-        url = "http://mupdf.com/downloads/archive/mupdf-1.10a-source.tar.gz";
+        url = "https://mupdf.com/downloads/archive/mupdf-1.10a-source.tar.gz";
         sha256 = "0dm8wcs8i29aibzkqkrn8kcnk4q0kd1v66pg48h5c3qqp4v1zk5a";
       };
       # Excluded the pdf-*.c files, since they mostly just broke the #includes

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
   name = "mupdf-${version}";
 
   src = fetchurl {
-    url = "http://mupdf.com/downloads/archive/${name}-source.tar.gz";
+    url = "https://mupdf.com/downloads/archive/${name}-source.tar.gz";
     sha256 = "0mc7a92zri27lk17wdr2iffarbfi4lvrmxhc53sz84hm5yl56qsw";
   };
 

--- a/pkgs/applications/misc/mupdf/default.upstream
+++ b/pkgs/applications/misc/mupdf/default.upstream
@@ -1,4 +1,4 @@
-url http://mupdf.com/downloads/archive/
+url https://mupdf.com/downloads/archive/
 do_overwrite(){
   ensure_hash
   ensure_version

--- a/pkgs/applications/misc/wordnet/default.nix
+++ b/pkgs/applications/misc/wordnet/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
          for computational linguistics and natural language processing.
       '';
 
-    homepage = http://wordnet.princeton.edu/;
+    homepage = https://wordnet.princeton.edu/;
 
     maintainers = [ ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;

--- a/pkgs/applications/networking/firehol/default.nix
+++ b/pkgs/applications/networking/firehol/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
       FireHOL, an iptables stateful packet filtering firewall for humans!
       FireQOS, a TC based bandwidth shaper for humans!
     '';
-    homepage = http://firehol.org/;
+    homepage = https://firehol.org/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ geistesk ];
     platforms = platforms.linux;

--- a/pkgs/applications/networking/ostinato/default.nix
+++ b/pkgs/applications/networking/ostinato/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   ostinatoIcon = fetchurl {
-    url = "http://ostinato.org/images/site-logo.png";
+    url = "https://ostinato.org/images/site-logo.png";
     sha256 = "f5c067823f2934e4d358d76f65a343efd69ad783a7aeabd7ab4ce3cd03490d70";
   };
 

--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   name = "pulseview-0.4.0";
 
   src = fetchurl {
-    url = "http://sigrok.org/download/source/pulseview/${name}.tar.gz";
+    url = "https://sigrok.org/download/source/pulseview/${name}.tar.gz";
     sha256 = "1f8f2342d5yam98mmcb8f9g2vslcwv486bmi4x45pxn68l82ky3q";
   };
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Qt-based LA/scope/MSO GUI for sigrok (a signal analysis software suite)";
-    homepage = http://sigrok.org/;
+    homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "4.15";
 
   src = fetchurl {
-    url = "http://i3wm.org/downloads/${name}.tar.bz2";
+    url = "https://i3wm.org/downloads/${name}.tar.bz2";
     sha256 = "09jk70hsdxab24lqvj2f30ijrkbv3f6q9xi5dcsax1dw3x6m4z91";
   };
 

--- a/pkgs/applications/window-managers/i3/status.nix
+++ b/pkgs/applications/window-managers/i3/status.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "i3status-2.11";
 
   src = fetchurl {
-    url = "http://i3wm.org/i3status/${name}.tar.bz2";
+    url = "https://i3wm.org/i3status/${name}.tar.bz2";
     sha256 = "0pwcy599fw8by1a1sf91crkqba7679qhvhbacpmhis8c1xrpxnwq";
   };
 

--- a/pkgs/data/fonts/gentium-book-basic/default.nix
+++ b/pkgs/data/fonts/gentium-book-basic/default.nix
@@ -19,7 +19,7 @@ in fetchzip rec {
   sha256 = "0598zr5f7d6ll48pbfbmmkrybhhdks9b2g3m2g67wm40070ffzmd";
 
   meta = with stdenv.lib; {
-    homepage = http://software.sil.org/gentium/;
+    homepage = https://software.sil.org/gentium/;
     description = "A high-quality typeface family for Latin, Cyrillic, and Greek";
     maintainers = with maintainers; [ ];
     license = licenses.ofl;

--- a/pkgs/data/sgml+xml/schemas/docbook-5.0/default.nix
+++ b/pkgs/data/sgml+xml/schemas/docbook-5.0/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Schemas for DocBook 5.0, a semantic markup language for technical documentation";
-    homepage = http://docbook.org/xml/5.0/;
+    homepage = https://docbook.org/xml/5.0/;
     maintainers = [ lib.maintainers.eelco ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/desktops/lxde/core/lxmenu-data.nix
+++ b/pkgs/desktops/lxde/core/lxmenu-data.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool ];
 
   meta = {
-    homepage = http://lxde.org/;
+    homepage = https://lxde.org/;
     license = stdenv.lib.licenses.gpl2;
     description = "Freedesktop.org desktop menus for LXDE";
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/lxde/core/lxpanel/default.nix
+++ b/pkgs/desktops/lxde/core/lxpanel/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Lightweight X11 desktop panel for LXDE";
-    homepage = http://lxde.org/;
+    homepage = https://lxde.org/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.ryneeverett ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/compilers/adobe-flex-sdk/default.nix
+++ b/pkgs/development/compilers/adobe-flex-sdk/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Flex SDK for Adobe Flash / ActionScript";
-    homepage = "http://www.adobe.com/products/flex.html";
+    homepage = "https://www.adobe.com/products/flex.html";
     license = stdenv.lib.licenses.mpl11;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/compilers/neko/default.nix
+++ b/pkgs/development/compilers/neko/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "2.2.0";
 
   src = fetchurl {
-    url = "http://nekovm.org/media/neko-${version}-src.tar.gz";
+    url = "https://nekovm.org/media/neko-${version}-src.tar.gz";
     sha256 = "1qv47zaa0vzhjlq5wb71627n7dbsxpc1gqpg0hsngjxnbnh1q46g";
   };
 

--- a/pkgs/development/compilers/opendylan/bin.nix
+++ b/pkgs/development/compilers/opendylan/bin.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation {
   name = "opendylan-2013.2";
 
   src = if stdenv.system == "x86_64-linux" then fetchurl {
-      url = http://opendylan.org/downloads/opendylan/2013.2/opendylan-2013.2-x86_64-linux.tar.bz2;
+      url = https://opendylan.org/downloads/opendylan/2013.2/opendylan-2013.2-x86_64-linux.tar.bz2;
       sha256 = "035brbw3hm7zrs593q4zc42yglj1gmmkw3b1r7zzlw3ks4i2lg7h";
     }
     else if stdenv.system == "i686-linux" then fetchurl {
-      url = http://opendylan.org/downloads/opendylan/2013.2/opendylan-2013.2-x86-linux.tar.bz2;
+      url = https://opendylan.org/downloads/opendylan/2013.2/opendylan-2013.2-x86-linux.tar.bz2;
       sha256 = "0c61ihvblcsjrw6ncr8x8ylhskcrqs8pajs4mg5di36cvqw12nq5";
     }
     else throw "platform ${stdenv.system} not supported.";

--- a/pkgs/development/java-modules/junit/default.nix
+++ b/pkgs/development/java-modules/junit/default.nix
@@ -19,7 +19,7 @@ in rec {
     m2Path = "/junit/junit/${version}";
 
     meta = {
-      homepage = http://junit.org/junit4/;
+      homepage = https://junit.org/junit4/;
       description = "Simple framework to write repeatable tests. It is an instance of the xUnit architecture for unit testing frameworks";
       license = stdenv.lib.licenses.epl10;
       platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/libraries/gamin/default.nix
+++ b/pkgs/development/libraries/gamin/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation (rec {
   name = "gamin-0.1.10";
 
   src = fetchurl {
-    url = "http://www.gnome.org/~veillard/gamin/sources/${name}.tar.gz";
+    url = "https://www.gnome.org/~veillard/gamin/sources/${name}.tar.gz";
     sha256 = "18cr51y5qacvs2fc2p1bqv32rs8bzgs6l67zhasyl45yx055y218";
   };
 

--- a/pkgs/development/libraries/ignition-transport/generic.nix
+++ b/pkgs/development/libraries/ignition-transport/generic.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://ignitionrobotics.org/libraries/math;
+    homepage = https://ignitionrobotics.org/libraries/math;
     description = "Math library by Ingition Robotics, created for the Gazebo project";
     license = licenses.asl20;
     maintainers = with maintainers; [ pxc ];

--- a/pkgs/development/libraries/isl/0.11.1.nix
+++ b/pkgs/development/libraries/isl/0.11.1.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://www.kotnet.org/~skimo/isl/;
+    homepage = https://www.kotnet.org/~skimo/isl/;
     license = stdenv.lib.licenses.lgpl21;
     description = "A library for manipulating sets and relations of integer points bounded by linear constraints";
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/libraries/isl/0.12.2.nix
+++ b/pkgs/development/libraries/isl/0.12.2.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://www.kotnet.org/~skimo/isl/;
+    homepage = https://www.kotnet.org/~skimo/isl/;
     license = stdenv.lib.licenses.lgpl21;
     description = "A library for manipulating sets and relations of integer points bounded by linear constraints";
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/libraries/isl/0.14.1.nix
+++ b/pkgs/development/libraries/isl/0.14.1.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://www.kotnet.org/~skimo/isl/;
+    homepage = https://www.kotnet.org/~skimo/isl/;
     license = stdenv.lib.licenses.lgpl21;
     description = "A library for manipulating sets and relations of integer points bounded by linear constraints";
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/libraries/isl/0.15.0.nix
+++ b/pkgs/development/libraries/isl/0.15.0.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://www.kotnet.org/~skimo/isl/;
+    homepage = https://www.kotnet.org/~skimo/isl/;
     license = stdenv.lib.licenses.lgpl21;
     description = "A library for manipulating sets and relations of integer points bounded by linear constraints";
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/libraries/isl/0.17.1.nix
+++ b/pkgs/development/libraries/isl/0.17.1.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://www.kotnet.org/~skimo/isl/;
+    homepage = https://www.kotnet.org/~skimo/isl/;
     license = stdenv.lib.licenses.lgpl21;
     description = "A library for manipulating sets and relations of integer points bounded by linear constraints";
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/libraries/jama/default.nix
+++ b/pkgs/development/libraries/jama/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.2.5";
   
   src = fetchurl {
-    url = http://math.nist.gov/tnt/jama125.zip;
+    url = https://math.nist.gov/tnt/jama125.zip;
     sha256 = "031ns526fvi2nv7jzzv02i7i5sjcyr0gj884i3an67qhsx8vyckl";
   };
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://math.nist.gov/tnt/;
+    homepage = https://math.nist.gov/tnt/;
     description = "JAMA/C++ Linear Algebra Package: Java-like matrix C++ templates";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libaudclient/default.nix
+++ b/pkgs/development/libraries/libaudclient/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Legacy D-Bus client library for Audacious";
-    homepage = http://audacious-media-player.org/;
+    homepage = https://audacious-media-player.org/;
     license = licenses.bsd2;
     maintainers = with maintainers; [ pSub ];
     platforms = with platforms; unix;

--- a/pkgs/development/libraries/libmnl/default.nix
+++ b/pkgs/development/libraries/libmnl/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       This library aims to provide simple helpers that allows you to re-use code and to avoid
       re-inventing the wheel.
     '';
-    homepage = http://netfilter.org/projects/libmnl/index.html;
+    homepage = https://netfilter.org/projects/libmnl/index.html;
     license = stdenv.lib.licenses.lgpl21Plus;
 
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/libnetfilter_conntrack/default.nix
+++ b/pkgs/development/libraries/libnetfilter_conntrack/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.0.6";
 
   src = fetchurl {
-    url = "http://netfilter.org/projects/libnetfilter_conntrack/files/${name}.tar.bz2";
+    url = "https://netfilter.org/projects/libnetfilter_conntrack/files/${name}.tar.bz2";
     sha256 = "1svzyf3rq9nbrcw1jsricgyhh7x1am8iqn6kjr6mzrw42810ik7g";
   };
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       previously known as libnfnetlink_conntrack and libctnetlink. This library is currently used
       by conntrack-tools among many other applications
     '';
-    homepage = http://netfilter.org/projects/libnetfilter_conntrack/;
+    homepage = https://netfilter.org/projects/libnetfilter_conntrack/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/libnetfilter_cttimeout/default.nix
+++ b/pkgs/development/libraries/libnetfilter_cttimeout/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.0.0";
 
   src = fetchurl {
-    url = "http://netfilter.org/projects/libnetfilter_cttimeout/files/${name}.tar.bz2";
+    url = "https://netfilter.org/projects/libnetfilter_cttimeout/files/${name}.tar.bz2";
     sha256 = "aeab12754f557cba3ce2950a2029963d817490df7edb49880008b34d7ff8feba";
   };
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       With this library, you can create, update and delete timeout policies that can
       be attached to traffic flows. This library is used by conntrack-tools.
     '';
-    homepage = http://netfilter.org/projects/libnetfilter_cttimeout/;
+    homepage = https://netfilter.org/projects/libnetfilter_cttimeout/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/libraries/libnetfilter_log/default.nix
+++ b/pkgs/development/libraries/libnetfilter_log/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.0.1";
 
   src = fetchurl {
-    url = "http://netfilter.org/projects/libnetfilter_log/files/${name}.tar.bz2";
+    url = "https://netfilter.org/projects/libnetfilter_log/files/${name}.tar.bz2";
     sha256 = "089vjcfxl5qjqpswrbgklf4wflh44irmw6sk2k0kmfixfmszxq3l";
   };
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       system that deprecates the old syslog/dmesg based packet logging. This
       library has been previously known as libnfnetlink_log.
     '';
-    homepage = http://netfilter.org/projects/libnetfilter_log/;
+    homepage = https://netfilter.org/projects/libnetfilter_log/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ orivej ];

--- a/pkgs/development/libraries/libtheora/default.nix
+++ b/pkgs/development/libraries/libtheora/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.theora.org/;
+    homepage = https://www.theora.org/;
     description = "Library for Theora, a free and open video compression format";
     license = licenses.bsd3;
     maintainers = with maintainers; [ spwhitt wkennington ];

--- a/pkgs/development/libraries/liburcu/default.nix
+++ b/pkgs/development/libraries/liburcu/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "liburcu-${version}";
 
   src = fetchurl {
-    url = "http://lttng.org/files/urcu/userspace-rcu-${version}.tar.bz2";
+    url = "https://lttng.org/files/urcu/userspace-rcu-${version}.tar.bz2";
     sha256 = "01pbg67qy5hcssy2yi0ckqapzfclgdq93li2rmzw4pa3wh5j42cw";
   };
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Userspace RCU (read-copy-update) library";
-    homepage = http://lttng.org/urcu;
+    homepage = https://lttng.org/urcu;
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/libraries/libvpx/git.nix
+++ b/pkgs/development/libraries/libvpx/git.nix
@@ -180,7 +180,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "WebM VP8/VP9 codec SDK";
-    homepage    = http://www.webmproject.org/;
+    homepage    = https://www.webmproject.org/;
     license     = licenses.bsd3;
     maintainers = with maintainers; [ codyopel ];
     platforms   = platforms.all;

--- a/pkgs/development/libraries/log4cxx/default.nix
+++ b/pkgs/development/libraries/log4cxx/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ libtool ];
 
   meta = {
-    homepage = http://logging.apache.org/log4cxx/index.html;
+    homepage = https://logging.apache.org/log4cxx/index.html;
     description = "A logging framework for C++ patterned after Apache log4j";
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/movit/default.nix
+++ b/pkgs/development/libraries/movit/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.5.1";
 
   src = fetchurl {
-    url = "http://movit.sesse.net/${name}.tar.gz";
+    url = "https://movit.sesse.net/${name}.tar.gz";
     sha256 = "1259iq2ixiprk4mn7ypapinbg2w1sjq1aivzzbbch9i23kcfsd44";
   };
 

--- a/pkgs/development/libraries/netcdf-fortran/default.nix
+++ b/pkgs/development/libraries/netcdf-fortran/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Fortran API to manipulate netcdf files";
-    homepage = http://www.unidata.ucar.edu/software/netcdf/;
+    homepage = https://www.unidata.ucar.edu/software/netcdf/;
     license = licenses.free;
     maintainers = [ maintainers.bzizou ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/ogre/1.9.x.nix
+++ b/pkgs/development/libraries/ogre/1.9.x.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A 3D engine";
-    homepage = http://www.ogre3d.org/;
+    homepage = https://www.ogre3d.org/;
     maintainers = [ stdenv.lib.maintainers.raskin ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -260,7 +260,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Open Computer Vision Library with more than 500 algorithms";
-    homepage = http://opencv.org/;
+    homepage = https://opencv.org/;
     license = with stdenv.lib.licenses; if enableUnfree then unfree else bsd3;
     maintainers = with stdenv.lib.maintainers; [viric mdaiter basvandijk];
     platforms = with stdenv.lib.platforms; linux ++ darwin;

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Server and user space API to deal with multimedia pipelines";
-    homepage = http://pipewire.org/;
+    homepage = https://pipewire.org/;
     license = licenses.lgpl21;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jtojnar ];

--- a/pkgs/development/libraries/tnt/default.nix
+++ b/pkgs/development/libraries/tnt/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.0.12";
   
   src = fetchurl {
-    url = http://math.nist.gov/tnt/tnt_3_0_12.zip;
+    url = https://math.nist.gov/tnt/tnt_3_0_12.zip;
     sha256 = "1bzkfdb598584qlc058n8wqq9vbz714gr5r57401rsa9qaxhk5j7";
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://math.nist.gov/tnt/;
+    homepage = https://math.nist.gov/tnt/;
     description = "Template Numerical Toolkit: C++ headers for array and matrices";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/misc/amdapp-sdk/default.nix
+++ b/pkgs/development/misc/amdapp-sdk/default.nix
@@ -99,7 +99,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "AMD Accelerated Parallel Processing (APP) SDK, with OpenCL 1.2 support";
-    homepage = http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/;
+    homepage = https://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/;
     license = licenses.amd;
     maintainers = [ maintainers.offline ];
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/development/python-modules/GeoIP/default.nix
+++ b/pkgs/development/python-modules/GeoIP/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "MaxMind GeoIP Legacy Database - Python API";
-    homepage = http://www.maxmind.com/;
+    homepage = https://www.maxmind.com/;
     maintainers = with lib.maintainers; [ jluttine ];
     license = lib.licenses.lgpl21Plus;
   };

--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "WebSocket and WAMP in Python for Twisted and asyncio.";
-    homepage    = "http://crossbar.io/autobahn";
+    homepage    = "https://crossbar.io/autobahn";
     license     = licenses.mit;
     maintainers = with maintainers; [ nand0p ];
     platforms   = platforms.all;

--- a/pkgs/development/python-modules/cytoolz/default.nix
+++ b/pkgs/development/python-modules/cytoolz/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    homepage = "http://github.com/pytoolz/cytoolz/";
+    homepage = "https://github.com/pytoolz/cytoolz/";
     description = "Cython implementation of Toolz: High performance functional utilities";
     license = "licenses.bsd3";
     maintainers = with lib.maintainers; [ fridh ];

--- a/pkgs/development/python-modules/flask-assets/default.nix
+++ b/pkgs/development/python-modules/flask-assets/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ flask webassets flask_script nose ];
 
   meta = with lib; {
-    homepage = http://github.com/miracle2k/flask-assets;
+    homepage = https://github.com/miracle2k/flask-assets;
     description = "Asset management for Flask, to compress and merge CSS and Javascript files";
     license = licenses.bsd2;
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/development/python-modules/flask-script/default.nix
+++ b/pkgs/development/python-modules/flask-script/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage = http://github.com/smurfix/flask-script;
+    homepage = https://github.com/smurfix/flask-script;
     description = "Scripting support for Flask";
     license = licenses.bsd3;
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/development/python-modules/graph-tool/2.x.x.nix
+++ b/pkgs/development/python-modules/graph-tool/2.x.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Python module for manipulation and statistical analysis of graphs";
-    homepage    = http://graph-tool.skewed.de/;
+    homepage    = https://graph-tool.skewed.de/;
     license     = licenses.gpl3;
     platforms   = platforms.all;
     maintainers = [ stdenv.lib.maintainers.joelmo ];

--- a/pkgs/development/python-modules/idna/default.nix
+++ b/pkgs/development/python-modules/idna/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   meta = {
-    homepage = "http://github.com/kjd/idna/";
+    homepage = "https://github.com/kjd/idna/";
     description = "Internationalized Domain Names in Applications (IDNA)";
     license = lib.licenses.bsd3;
   };

--- a/pkgs/development/python-modules/jsonref/default.nix
+++ b/pkgs/development/python-modules/jsonref/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "An implementation of JSON Reference for Python";
-    homepage    = "http://github.com/gazpachoking/jsonref";
+    homepage    = "https://github.com/gazpachoking/jsonref";
     license     = licenses.mit;
     maintainers = with maintainers; [ nand0p ];
     platforms   = platforms.all;

--- a/pkgs/development/python-modules/jsonrpc-async/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-async/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A JSON-RPC client library for asyncio";
-    homepage = http://github.com/armills/jsonrpc-async;
+    homepage = https://github.com/armills/jsonrpc-async;
     license = licenses.bsd3;
     maintainers = with maintainers; [ peterhoeg ];
   };

--- a/pkgs/development/python-modules/locustio/default.nix
+++ b/pkgs/development/python-modules/locustio/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   buildInputs = [ mock unittest2 ];
 
   meta = {
-    homepage = http://locust.io/;
+    homepage = https://locust.io/;
     description = "A load testing tool";
   };
 }

--- a/pkgs/development/python-modules/logilab/constraint.nix
+++ b/pkgs/development/python-modules/logilab/constraint.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "logilab-database provides some classes to make unified access to different";
-    homepage = "http://www.logilab.org/project/logilab-database";
+    homepage = "https://www.logilab.org/project/logilab-database";
   };
 }
 

--- a/pkgs/development/python-modules/meliae/default.nix
+++ b/pkgs/development/python-modules/meliae/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Python Memory Usage Analyzer";
-    homepage = http://launchpad.net/meliae;
+    homepage = https://launchpad.net/meliae;
     license = licenses.gpl3;
     maintainers = with maintainers; [ xvapx ];
   };

--- a/pkgs/development/python-modules/moinmoin/default.nix
+++ b/pkgs/development/python-modules/moinmoin/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Advanced, easy to use and extensible WikiEngine";
 
-    homepage = "http://moinmo.in/";
+    homepage = "https://moinmo.in/";
 
     license = licenses.gpl2Plus;
   };

--- a/pkgs/development/python-modules/pecan/default.nix
+++ b/pkgs/development/python-modules/pecan/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Pecan";
-    homepage = "http://github.com/pecan/pecan";
+    homepage = "https://github.com/pecan/pecan";
   };
 }

--- a/pkgs/development/tools/database/pyrseas/default.nix
+++ b/pkgs/development/tools/database/pyrseas/default.nix
@@ -38,7 +38,7 @@ pythonPackages.buildPythonApplication rec {
   ];
   meta = {
     description = "A declarative language to describe PostgreSQL databases";
-    homepage = http://perseas.github.io/;
+    homepage = https://perseas.github.io/;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ pmeunier ];
   };

--- a/pkgs/development/tools/jbake/default.nix
+++ b/pkgs/development/tools/jbake/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "jbake-${version}";
 
   src = fetchzip {
-    url = "http://jbake.org/files/jbake-${version}-bin.zip";
+    url = "https://dl.bintray.com/jbake/binary/${name}-bin.zip";
     sha256 = "1ib5gvz6sl7k0ywx22anhz69i40wc6jj5lxjxj2aa14qf4lrw912";
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "JBake is a Java based, open source, static site/blog generator for developers & designers";
-    homepage = "http://jbake.org/";
+    homepage = "https://jbake.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ moaxcp ];
   };

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -8,12 +8,12 @@ stdenv.mkDerivation rec {
   name = "libsigrok-${version}";
 
   src = fetchurl {
-    url = "http://sigrok.org/download/source/libsigrok/${name}.tar.gz";
+    url = "https://sigrok.org/download/source/libsigrok/${name}.tar.gz";
     inherit sha256;
   };
 
   firmware = fetchurl {
-    url = "http://sigrok.org/download/binary/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-bin-0.1.3.tar.gz";
+    url = "https://sigrok.org/download/binary/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-bin-0.1.3.tar.gz";
     sha256 = "1qr02ny97navqxr56xq1a227yzf6h09m8jlvc9bnjl0bsk6887bl";
   };
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Core library of the sigrok signal analysis software suite";
-    homepage = http://sigrok.org/;
+    homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/tools/libsigrokdecode/default.nix
+++ b/pkgs/development/tools/libsigrokdecode/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libsigrokdecode-0.5.0";
 
   src = fetchurl {
-    url = "http://sigrok.org/download/source/libsigrokdecode/${name}.tar.gz";
+    url = "https://sigrok.org/download/source/libsigrokdecode/${name}.tar.gz";
     sha256 = "1hfigfj1976qk11kfsgj75l20qvyq8c9p2h4mjw23d59rsg5ga2a";
   };
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Protocol decoding library for the sigrok signal analysis software suite";
-    homepage = http://sigrok.org/;
+    homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/tools/misc/lttng-tools/default.nix
+++ b/pkgs/development/tools/misc/lttng-tools/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tracing tools (kernel + user space) for Linux";
-    homepage = http://lttng.org/;
+    homepage = https://lttng.org/;
     license = licenses.lgpl21;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/tools/misc/lttng-ust/default.nix
+++ b/pkgs/development/tools/misc/lttng-ust/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "LTTng Userspace Tracer libraries";
-    homepage = http://lttng.org/;
+    homepage = https://lttng.org/;
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/tools/misc/lttv/default.nix
+++ b/pkgs/development/tools/misc/lttv/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "lttv-1.5";
 
   src = fetchurl {
-    url = "http://lttng.org/files/packages/${name}.tar.bz2";
+    url = "https://lttng.org/files/packages/${name}.tar.bz2";
     sha256 = "1faldxnh9dld5k0vxckwpqw241ya1r2zv286l6rpgqr500zqw7r1";
   };
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Graphical trace viewer for LTTng trace files";
-    homepage = http://lttng.org/;
+    homepage = https://lttng.org/;
     # liblttvtraceread (ltt/ directory) is distributed under the GNU LGPL v2.1.
     # The rest of the LTTV package is distributed under the GNU GPL v2.
     license = with licenses; [ gpl2 lgpl21 ];

--- a/pkgs/development/tools/sigrok-cli/default.nix
+++ b/pkgs/development/tools/sigrok-cli/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "sigrok-cli-0.7.0";
 
   src = fetchurl {
-    url = "http://sigrok.org/download/source/sigrok-cli/${name}.tar.gz";
+    url = "https://sigrok.org/download/source/sigrok-cli/${name}.tar.gz";
     sha256 = "072ylscp0ppgii1k5j07hhv7dfmni4vyhxnsvxmgqgfyq9ldjsan";
   };
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Command-line frontend for the sigrok signal analysis software suite";
-    homepage = http://sigrok.org/;
+    homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
       substances or radiation, now more closely resemble insects, birds or fish
       than their original form.
     '';
-    homepage = http://cataclysmdda.org/;
+    homepage = https://cataclysmdda.org/;
     license = licenses.cc-by-sa-30;
     maintainers = [ maintainers.skeidel ];
     platforms = platforms.unix;

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
       substances or radiation, now more closely resemble insects, birds or fish
       than their original form.
     '';
-    homepage = http://cataclysmdda.org/;
+    homepage = https://cataclysmdda.org/;
     license = licenses.cc-by-sa-30;
     platforms = platforms.unix;
   };

--- a/pkgs/games/dxx-rebirth/assets.nix
+++ b/pkgs/games/dxx-rebirth/assets.nix
@@ -42,7 +42,7 @@ let
 
     meta = with stdenv.lib; {
       description = "Descent ${toString ver} assets from GOG";
-      homepage    = http://www.dxx-rebirth.com/;
+      homepage    = https://www.dxx-rebirth.com/;
       license     = licenses.unfree;
       maintainers = with maintainers; [ peterhoeg ];
       hydraPlatforms = [];

--- a/pkgs/games/dxx-rebirth/default.nix
+++ b/pkgs/games/dxx-rebirth/default.nix
@@ -4,7 +4,7 @@
 
 let
   music = fetchurl {
-    url = "http://www.dxx-rebirth.com/download/dxx/res/d2xr-sc55-music.dxa";
+    url = "https://www.dxx-rebirth.com/download/dxx/res/d2xr-sc55-music.dxa";
     sha256 = "05mz77vml396mff43dbs50524rlm4fyds6widypagfbh5hc55qdc";
   };
 
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
   version = "0.59.100";
 
   src = fetchurl {
-    url = "http://www.dxx-rebirth.com/download/dxx/dxx-rebirth_v${version}-src.tar.gz";
+    url = "https://www.dxx-rebirth.com/download/dxx/dxx-rebirth_v${version}-src.tar.gz";
     sha256 = "0m9k34zyr8bbni9szip407mffdpwbqszgfggavgqjwq0k9c1w7ka";
   };
 
@@ -57,7 +57,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Source Port of the Descent 1 and 2 engines";
-    homepage = http://www.dxx-rebirth.com/;
+    homepage = https://www.dxx-rebirth.com/;
     license = licenses.free;
     maintainers = with maintainers; [ viric peterhoeg ];
     platforms = with platforms; linux;

--- a/pkgs/games/dxx-rebirth/full.nix
+++ b/pkgs/games/dxx-rebirth/full.nix
@@ -16,7 +16,7 @@ let
 
     meta = with stdenv.lib; {
       description = "Descent ${toString ver} using the DXX-Rebirth project engine and game assets from GOG";
-      homepage    = http://www.dxx-rebirth.com/;
+      homepage    = https://www.dxx-rebirth.com/;
       license     = with licenses; [ free unfree ];
       maintainers = with maintainers; [ peterhoeg ];
       platforms   = with platforms; linux;

--- a/pkgs/misc/emulators/fs-uae/default.nix
+++ b/pkgs/misc/emulators/fs-uae/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "2.8.3";
 
   src = fetchurl {
-    url = "http://fs-uae.net/fs-uae/stable/${version}/${name}.tar.gz";
+    url = "https://fs-uae.net/fs-uae/stable/${version}/${name}.tar.gz";
     sha256 = "14k2p324sdr662f49299mv0bw5jmpj1i2iqn0xs5pgf80x6l3mg2";
   };
 

--- a/pkgs/misc/emulators/pcsxr/default.nix
+++ b/pkgs/misc/emulators/pcsxr/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Playstation 1 emulator";
-    homepage = http://pcsxr.codeplex.com/;
+    homepage = https://pcsxr.codeplex.com/;
     maintainers = with maintainers; [ rardiol ];
     license = licenses.gpl2Plus;
     platforms = platforms.all;

--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "2.10.5";
 
   src = fetchurl {
-    url = "http://lttng.org/files/lttng-modules/lttng-modules-${version}.tar.bz2";
+    url = "https://lttng.org/files/lttng-modules/lttng-modules-${version}.tar.bz2";
     sha256 = "07rs01zwr4bmjamplix5qz1c6mb6wdawb68vyn0w6wx68ppbpnxq";
   };
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Linux kernel modules for LTTng tracing";
-    homepage = http://lttng.org/;
+    homepage = https://lttng.org/;
     license = with licenses; [ lgpl21 gpl2 mit ];
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/servers/dict/dictd-wordnet.nix
+++ b/pkgs/servers/dict/dictd-wordnet.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
          the wordnet data available to dictd and by extension for lookup with
          the dict command. '';
 
-    homepage = http://wordnet.princeton.edu/;
+    homepage = https://wordnet.princeton.edu/;
 
     maintainers = [ ];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   name = "gpm-1.20.7";
 
   src = fetchurl {
-    url = "http://www.nico.schottelius.org/software/gpm/archives/${name}.tar.bz2";
+    url = "https://www.nico.schottelius.org/software/gpm/archives/${name}.tar.bz2";
     sha256 = "13d426a8h403ckpc8zyf7s2p5rql0lqbg2bv0454x0pvgbfbf4gh";
   };
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.nico.schottelius.org/software/gpm/;
+    homepage = https://www.nico.schottelius.org/software/gpm/;
     description = "A daemon that provides mouse support on the Linux console";
     license = licenses.gpl2;
     platforms = platforms.linux ++ platforms.cygwin;

--- a/pkgs/servers/irc/ngircd/default.nix
+++ b/pkgs/servers/irc/ngircd/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "ngircd-24";
 
   src = fetchurl {
-    url = "http://ngircd.barton.de/pub/ngircd/${name}.tar.xz";
+    url = "https://ngircd.barton.de/pub/ngircd/${name}.tar.xz";
     sha256 = "020h9d1awyxqr0l42x1fhs47q7cmm17fdxzjish8p2kq23ma0gqp";
   };
 

--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -71,7 +71,7 @@ self = stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = http://www.mysql.com/;
+    homepage = https://www.mysql.com/;
     description = "The world's most popular open source database";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/tools/filesystems/bindfs/default.nix
+++ b/pkgs/tools/filesystems/bindfs/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name    = "bindfs-${version}";
 
   src = fetchurl {
-    url    = "http://bindfs.org/downloads/${name}.tar.gz";
+    url    = "https://bindfs.org/downloads/${name}.tar.gz";
     sha256 = "1dgqjq2plpds442ygpv8czr5v199ljscp33m89y19x04ssljrymc";
   };
 

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -165,7 +165,7 @@ stdenv.mkDerivation {
   outputs = [ "dev" "lib" "out" "doc" ];
 
   meta = {
-    homepage = http://ceph.com/;
+    homepage = https://ceph.com/;
     description = "Distributed storage system";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ adev ak wkennington ];

--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = http://github.com/fcitx/fcitx-qt5;
+    homepage    = https://github.com/fcitx/fcitx-qt5;
     description = "Qt5 IM Module for Fcitx";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/tools/inputmethods/fcitx/unwrapped.nix
+++ b/pkgs/tools/inputmethods/fcitx/unwrapped.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    homepage    = http://github.com/fcitx/fcitx;
+    homepage    = https://github.com/fcitx/fcitx;
     description = "A Flexible Input Method Framework";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/tools/misc/argtable/default.nix
+++ b/pkgs/tools/misc/argtable/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.argtable.org/;
+    homepage = https://www.argtable.org/;
     description = "A Cross-Platform, Single-File, ANSI C Command-Line Parsing Library";
     license = licenses.bsd3;
     maintainers = with maintainers; [ artuuge ];

--- a/pkgs/tools/misc/edid-decode/default.nix
+++ b/pkgs/tools/misc/edid-decode/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
 
   meta = {
     description = "EDID decoder and conformance tester";
-    homepage = http://cgit.freedesktop.org/xorg/app/edid-decode/;
+    homepage = https://cgit.freedesktop.org/xorg/app/edid-decode/;
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.chiiruno ];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -775,7 +775,7 @@ in {
 
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -790,7 +790,7 @@ in {
     };
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -810,7 +810,7 @@ in {
     '';
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -830,7 +830,7 @@ in {
     '';
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -855,7 +855,7 @@ in {
     propagatedBuildInputs = with self; [ azure-mgmt-common ];
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -880,7 +880,7 @@ in {
     propagatedBuildInputs = with self; [ azure-mgmt-common ];
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -896,7 +896,7 @@ in {
     propagatedBuildInputs = with self; [ azure-nspkg ];
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -921,7 +921,7 @@ in {
     propagatedBuildInputs = with self; [ azure-mgmt-common ];
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -946,7 +946,7 @@ in {
     propagatedBuildInputs = with self; [ azure-mgmt-common ];
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -965,7 +965,7 @@ in {
     '';
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -984,7 +984,7 @@ in {
     '';
     meta = {
       description = "Microsoft Azure SDK for Python";
-      homepage = "http://azure.microsoft.com/en-us/develop/python/";
+      homepage = "https://azure.microsoft.com/en-us/develop/python/";
       license = licenses.asl20;
       maintainers = with maintainers; [ olcai ];
     };
@@ -1750,7 +1750,7 @@ in {
 
     meta = {
       description = "Python bindings for Oracle Berkeley DB";
-      homepage = http://www.jcea.es/programacion/pybsddb.htm;
+      homepage = https://www.jcea.es/programacion/pybsddb.htm;
       license = with licenses; [ agpl3 ]; # License changed from bsd3 to agpl3 since 6.x
     };
   };
@@ -1861,7 +1861,7 @@ in {
     doCheck = false;
 
     meta = {
-      homepage =  http://github.com/ralphbean/bugwarrior;
+      homepage =  https://github.com/ralphbean/bugwarrior;
       description = "Sync github, bitbucket, bugzilla, and trac issues with taskwarrior";
       license = licenses.gpl3Plus;
       platforms = platforms.all;
@@ -4686,7 +4686,7 @@ in {
 
     meta = {
       description = "A small Gtk+ app for keeping track of your time. It's main goal is to be as unintrusive as possible";
-      homepage = http://mg.pov.lt/gtimelog/;
+      homepage = https://mg.pov.lt/gtimelog/;
       license = licenses.gpl2Plus;
       maintainers = with maintainers; [ ocharles ];
       platforms = platforms.unix;
@@ -5512,7 +5512,7 @@ in {
 
     meta = {
       description = "PAM interface using ctypes";
-      homepage = "http://github.com/minrk/pamela";
+      homepage = "https://github.com/minrk/pamela";
       license = licenses.mit;
     };
   };
@@ -5561,7 +5561,7 @@ in {
 
     meta = {
       description = "A Python-based build/distribution/deployment scripting tool";
-      homepage    = http://github.com/paver/paver;
+      homepage    = https://github.com/paver/paver;
       maintainers = with maintainers; [ lovek323 ];
       platforms   = platforms.unix;
     };
@@ -7640,7 +7640,7 @@ in {
 
     meta = {
       description = "Filesystem abstraction";
-      homepage    = http://pypi.python.org/pypi/fs;
+      homepage    = https://pypi.python.org/pypi/fs;
       license     = licenses.bsd3;
       maintainers = with maintainers; [ lovek323 ];
       platforms   = platforms.unix;
@@ -8398,7 +8398,7 @@ in {
     '';
 
     meta = {
-      homepage = "http://falcao.it/HTTPretty/";
+      homepage = "https://falcao.it/HTTPretty/";
       description = "HTTP client request mocking tool";
       license = licenses.mit;
     };
@@ -8838,7 +8838,7 @@ in {
 
     meta = {
       description = "Messaging library for Python";
-      homepage    = "http://github.com/celery/kombu";
+      homepage    = "https://github.com/celery/kombu";
       license     = licenses.bsd3;
     };
   };
@@ -9076,7 +9076,7 @@ in {
     '';
 
     meta = {
-      homepage = http://launchpad.net/pylockfile;
+      homepage = https://launchpad.net/pylockfile;
       description = "Platform-independent advisory file locking capability for Python applications";
       license = licenses.asl20;
     };
@@ -10383,7 +10383,7 @@ in {
     };
 
     meta = {
-      homepage = http://alastairs-place.net/projects/netifaces/;
+      homepage = https://alastairs-place.net/projects/netifaces/;
       description = "Portable access to network interfaces from Python";
     };
   };
@@ -10937,7 +10937,7 @@ in {
 
     meta = {
       description = "Draws Python object reference graphs with graphviz";
-      homepage = http://mg.pov.lt/objgraph/;
+      homepage = https://mg.pov.lt/objgraph/;
       license = licenses.mit;
     };
   };
@@ -18924,7 +18924,7 @@ EOF
     doCheck = false;
 
     meta = {
-      homepage = "http://matplotlib.org/basemap/";
+      homepage = "https://matplotlib.org/basemap/";
       description = "Plot data on map projections with matplotlib";
       longDescription = ''
         An add-on toolkit for matplotlib that lets you plot data on map projections with
@@ -19084,7 +19084,7 @@ EOF
 
     meta = {
       description = "Copy your docs directly to the gh-pages branch";
-      homepage = "http://github.com/davisp/ghp-import";
+      homepage = "https://github.com/davisp/ghp-import";
       license = "Tumbolia Public License";
       maintainers = with maintainers; [ garbas ];
     };
@@ -19200,7 +19200,7 @@ EOF
 
     meta = {
       description = "Jenkins Job Builder is a system for configuring Jenkins jobs using simple YAML files stored in Git";
-      homepage = "http://docs.openstack.org/infra/system-config/jjb.html";
+      homepage = "https://docs.openstack.org/infra/system-config/jjb.html";
       license = licenses.asl20;
       maintainers = with maintainers; [ garbas ];
     };


### PR DESCRIPTION
Uses the HTTPS url for cases where the existing URL has a permanent
redirect. For each domain, at least one fixed derivation URL was
downloaded to test the domain is properly serving downloads.

Also fixes jbake source URL, which was broken.