### PR TITLE
geogebra: add archive.org link for 5-0-444-0

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -7,7 +7,10 @@ stdenv.mkDerivation rec {
   preferLocalBuild = true;
 
   src = fetchurl {
-    urls = "https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2";
+    urls = [
+      "https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
+      "http://web.archive.org/web/20180325075100/http://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
+    ];
     sha256 = "1x2h40m62zbhmy42hln5gjj3fwk4b6803v3k9agpv5c6j468sq0p";
   };
 


### PR DESCRIPTION
###### Motivation for this change

The `geogebra` package is subject to break as upstream removes versioned
packages from their download server when five new releases are comming.

This is why I had to fix almost monthly the package by bumping the
version (these can be found by running `git log --online | grep
geogebra:`). As the package didn't cause any issues for several months
now I guess that using `archive.org` seems to be a suitable solution for
now.

/cc @sternenseemann @matthewbauer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

