### PR TITLE
nixos/acme: Fix letsencrypt test nginx servernames

### DIFF
--- a/nixos/tests/common/letsencrypt.nix
+++ b/nixos/tests/common/letsencrypt.nix
@@ -386,6 +386,7 @@ in {
 
     services.nginx.enable = true;
     services.nginx.recommendedProxySettings = true;
+    services.nginx.appendHttpConfig = "server_names_hash_bucket_size 64;";
     services.nginx.virtualHosts.${wfeDomain} = {
       onlySSL = true;
       enableACME = false;


### PR DESCRIPTION
###### Motivation for this change
NixOS test died with: `letsencrypt# [   37.455263] nginx-pre-start[910]: nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size: 32`

Apparently, nginx defaults it based on the cpu advertised on the system.

###### Things done
Increased `server_names_hash_bucket_size` to 64 on the letsencrypt host.

I think this is sufficient to fix the issue on 18.03, but something else is also breaking the test on master. This change should be sensible either way.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---