### PR TITLE
pythonPackages.hdbscan: init at 0.8.12

### DIFF
--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, cython
+, numpy
+, nose
+, scipy
+, scikitlearn
+, pythonOlder
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "hdbscan";
+  version = "0.8.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0yxi34frg2jwyvjl942qy4gq5pbx8dq4pf4p28d1xah8njchfqir";
+  };
+
+  checkInputs = [ nose ];
+
+  propagatedBuildInputs = [ cython numpy scipy scikitlearn ];
+
+  meta = with lib; {
+    description = "Hierarchical Density-Based Spatial Clustering of Applications with Noise, a clustering algorithm with a scikit-learn compatible API";
+    homepage =  http://github.com/scikit-learn-contrib/hdbscan;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ixxie ];
+  };
+}

--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -5,7 +5,6 @@
 , nose
 , scipy
 , scikitlearn
-, pythonOlder
 , fetchPypi
 }:
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6342,6 +6342,8 @@ in {
     propagatedBuildInputs = with self; [ requests webob ];
   };
 
+  hdbscan = callPackage ../development/python-modules/hdbscan { };
+
   hmmlearn = callPackage ../development/python-modules/hmmlearn { };
 
   hcs_utils = callPackage ../development/python-modules/hcs_utils { };


### PR DESCRIPTION
Initial packaging of the python HDBSCAN module and the related variant HDBSCAN with cosine distance.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

