### PR TITLE
emacsPackagesNg: lower priority of elpaPackages

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -385,9 +385,9 @@ let
 in
   lib.makeScope newScope (self:
     {}
+    // elpaPackages self
     // melpaStablePackages self
     // melpaPackages self
-    // elpaPackages self
     // orgPackages self
     // packagesFun self
   )


### PR DESCRIPTION
Lowering the priority of melpaStablePackages (#36423) leaves elpaPackages ahead
of melpaPackages; the former carries outdated dependencies which should be
overridden by melpaPackages.

See also: #36423

CC: @matthewbauer @mdorman 

### Testing 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

