### PR TITLE
mp3blaster: fix darwin build

### DIFF
--- a/pkgs/applications/audio/mp3blaster/default.nix
+++ b/pkgs/applications/audio/mp3blaster/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ncurses, libvorbis }:
+{ stdenv, fetchFromGitHub, ncurses, libvorbis, SDL }:
 stdenv.mkDerivation rec {
 
   version = "3.2.6";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ncurses
     libvorbis
-  ];
+  ] ++ stdenv.lib.optional stdenv.isDarwin SDL;
 
   buildFlags = [ "CXXFLAGS=-Wno-narrowing" ];
 


### PR DESCRIPTION
###### Motivation for this change
18.03 ZHF darwin edition: #36454 (Please backport to 18.03!)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

