### PR TITLE
opencv3: don't download ippicv if not enabled

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -167,7 +167,7 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure =
-    installExtraFiles ippicv + (
+    lib.optionalString enableIpp (installExtraFiles ippicv) + (
     lib.optionalString buildContrib ''
       cmakeFlagsArray+=("-DOPENCV_EXTRA_MODULES_PATH=$NIX_BUILD_TOP/opencv_contrib")
 


### PR DESCRIPTION
On aarch64 ipp is not available but the derivation still tries to download it
leading to an error that the platform is not supported.

There is already an option to enable ipp which is disabled by default.
So the sensitive thing to do is to only download the ippicv package if
the option is enabled.

This should make opencv3 build on aarch64.

###### Motivation for this change

Use `python3Packages.opencv3` on raspberry pi.

###### Things done

I built `python3Packages.opencv3` and `opencv3` on my x86_64 machine. But I was unable to build opencv3 on my RaspberryPi 3. It always produces a compile segmentation fault, I assume due the lack of resources of the device.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

