### PR TITLE
fail2ban: install docs to $out/share/doc

### DIFF
--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -26,6 +26,8 @@ pythonPackages.buildPythonApplication {
   doCheck = false;
 
   preInstall = ''
+    substituteInPlace setup.py --replace /usr/share/doc/ share/doc/
+  
     # see https://github.com/NixOS/nixpkgs/issues/4968
     ${python}/bin/${python.executable} setup.py install_data --install-dir=$out --root=$out
   '';


### PR DESCRIPTION
###### Motivation for this change
Currently fail2ban docs are installed to $out/usr/share/doc. This fixes issue #28145. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---
cc maintainers @edolstra @lovek323 @fpletz
