### PR TITLE
ptlib: fix build

### DIFF
--- a/pkgs/development/libraries/ptlib/default.nix
+++ b/pkgs/development/libraries/ptlib/default.nix
@@ -24,11 +24,15 @@ stdenv.mkDerivation rec {
     (fetchpatch { url = http://sources.debian.net/data/main/p/ptlib/2.10.11~dfsg-2.1/debian/patches/no-sslv3;
       sha256 = "172s1dnnrl54p9sf1nl7s475sm78rpw3p8jxi0pdx6izzl8hcdr0";
     })
-    (fetchpatch { url = http://sources.debian.net/data/main/p/ptlib/2.10.11~dfsg-2.1/debian/patches/gcc-5_support;
-      sha256 = "0pf2yj0150r4cnc6nv65mclrm3dillqh1xjk7m6gsjnk9b96i5d4";
-    })
     ./ptlib-2.10.11-glibc-2.26.patch
   ];
+
+  # fix typedef clashes with unixODBC>=2.3.5
+  postPatch = ''
+    substituteInPlace include/ptlib/unix/ptlib/contain.h \
+      --replace "typedef uintptr_t    UINT" "typedef unsigned int    UINT" \
+      --replace "typedef wchar_t                 WCHAR" "typedef unsigned short          WCHAR"
+  '';
 
   meta = with stdenv.lib; {
     description = "Portable Tools from OPAL VoIP";


### PR DESCRIPTION
###### Motivation for this change

Didn't build with unixODBC>=2.3.5 due to typedef clashes.
Fix these and remove an obsolete patch.

/cc ZHF #36453 
/cc maintainer @7c6f434c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

