### PR TITLE
bird2: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -48,7 +48,7 @@ in
   };
 
   bird2 = generic {
-    version = "2.0.1";
-    sha256 = "0qyh2cxj7hfz90x3fnczjdm3i9g7vr0nc4l4wjkj9qm0646vc52n";
+    version = "2.0.2";
+    sha256 = "03s8hcl761y3489j1krarm3r3iy5qid26508i91yvy38ypb92pq3";
   };
 }


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/bird/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/b6040kgjb2ndh4sznwnd30inslcf0ngi-bird-2.0.2/bin/bird -h` got 0 exit code
- ran `/nix/store/b6040kgjb2ndh4sznwnd30inslcf0ngi-bird-2.0.2/bin/bird --help` got 0 exit code
- ran `/nix/store/b6040kgjb2ndh4sznwnd30inslcf0ngi-bird-2.0.2/bin/bird --version` and found version 2.0.2
- found 2.0.2 with grep in /nix/store/b6040kgjb2ndh4sznwnd30inslcf0ngi-bird-2.0.2
- directory tree listing: https://gist.github.com/b5a31c5299059545befb8209b15fef9d

cc @viric @fpletz for review