### PR TITLE
gnome2.gtksourceview: fix build on Darwin

### DIFF
--- a/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
@@ -38,4 +38,6 @@ stdenv.mkDerivation rec {
   preConfigure = optionalString stdenv.isDarwin ''
     intltoolize --force
   '';
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 }


### PR DESCRIPTION
###### Motivation for this change

Build failure on darwin:

```
  CCLD     libgtksourceview-2.0.la
Undefined symbols for architecture x86_64:
  "_libintl_bind_textdomain_codeset", referenced from:
      __gtksourceview_gettext in gtksourceview-i18n.o
  "_libintl_bindtextdomain", referenced from:
      __gtksourceview_gettext in gtksourceview-i18n.o
  "_libintl_dgettext", referenced from:
      __gtksourceview_dgettext in gtksourceview-i18n.o
ld: symbol(s) not found for architecture x86_64
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

