### PR TITLE
gst-rtsp-server: Init at 1.12.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -591,6 +591,11 @@
     github = "bjornfor";
     name = "Bjørn Forsman";
   };
+  bkchr = {
+    email = "nixos@kchr.de";
+    github = "bkchr";
+    name = "Bastian Köcher";
+  };
   bluescreen303 = {
     email = "mathijs@bluescreen303.nl";
     github = "bluescreen303";

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -13,6 +13,8 @@ rec {
 
   gst-plugins-ugly = callPackage ./ugly { inherit gst-plugins-base; };
 
+  gst-rtsp-server = callPackage ./rtsp-server { inherit gst-plugins-base; };
+
   gst-libav = callPackage ./libav { inherit gst-plugins-base; };
 
   gnonlin = callPackage ./gnonlin { inherit gst-plugins-base; };

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pkgconfig, gst-plugins-base }:
+
+stdenv.mkDerivation rec {
+  name = "gst-rtsp-server-1.12.3";
+
+  meta = with stdenv.lib; {
+    description = "Gstreamer RTSP server";
+    homepage    = "https://gstreamer.freedesktop.org";
+    longDescription = ''
+      a library on top of GStreamer for building an RTSP server.
+    '';
+    license     = licenses.lgpl2Plus;
+    platforms   = platforms.linux ++ platforms.darwin;
+  };
+
+  src = fetchurl {
+    url = "${meta.homepage}/src/gst-rtsp-server/${name}.tar.xz";
+    sha256 = "1v3lghx75l05hssgwxdxsgrxpn10gxlgkfb6vq0rl0hnpdqmj9b7";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ gst-plugins-base ];
+}

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
     '';
     license     = licenses.lgpl2Plus;
     platforms   = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ bkchr ];
   };
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

