### PR TITLE
helmholtz: fix failing build

### DIFF
--- a/pkgs/applications/audio/pd-plugins/helmholtz/default.nix
+++ b/pkgs/applications/audio/pd-plugins/helmholtz/default.nix
@@ -20,13 +20,16 @@ stdenv.mkDerivation rec {
     mv helmholtz~/src/Makefile .
     rm -rf helmholtz~/src/
     rm helmholtz~/helmholtz~.pd_darwin
+    rm helmholtz~/helmholtz~.pd_linux
     rm helmholtz~/helmholtz~.dll
     rm -rf __MACOSX
   '';
 
   patchPhase = ''
+    mkdir -p $out/helmholtz~
     sed -i "s@current: pd_darwin@current: pd_linux@g" Makefile
     sed -i "s@-Wl@@g" Makefile
+    sed -i "s@\$(NAME).pd_linux \.\./\$(NAME).pd_linux@helmholtz~.pd_linux $out/helmholtz~/@g" Makefile
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

