### PR TITLE
blender: 2.79a -> 2.79b

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -11,11 +11,11 @@
 with lib;
 
 stdenv.mkDerivation rec {
-  name = "blender-2.79a";
+  name = "blender-2.79b";
 
   src = fetchurl {
     url = "http://download.blender.org/source/${name}.tar.gz";
-    sha256 = "1mw45mvfk9f0fhn12vp3g2vwqzinrp3by0m3w01wj87h9ri5zkwc";
+    sha256 = "1g4kcdqmf67srzhi3hkdnr4z1ph4h9sza1pahz38mrj998q4r52c";
   };
 
   buildInputs =


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/blender/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/v357w3cwwln6lprqr3xss3jvgpp9gsm8-blender-2.79b/bin/blender -h` got 0 exit code
- ran `/nix/store/v357w3cwwln6lprqr3xss3jvgpp9gsm8-blender-2.79b/bin/blender --help` got 0 exit code
- ran `/nix/store/v357w3cwwln6lprqr3xss3jvgpp9gsm8-blender-2.79b/bin/blender-thumbnailer.py -h` got 0 exit code
- ran `/nix/store/v357w3cwwln6lprqr3xss3jvgpp9gsm8-blender-2.79b/bin/blender-thumbnailer.py --help` got 0 exit code
- ran `/nix/store/v357w3cwwln6lprqr3xss3jvgpp9gsm8-blender-2.79b/bin/blender-thumbnailer.py help` got 0 exit code
- found 2.79b with grep in /nix/store/v357w3cwwln6lprqr3xss3jvgpp9gsm8-blender-2.79b
- directory tree listing: https://gist.github.com/31e73f72bba2c0103ef5f038b4346d34

cc @cillianderoiste for review