### PR TITLE
darktable: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -6,12 +6,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.1";
+  version = "2.4.2";
   name = "darktable-${version}";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "014pq80i5k1kdvvrl7xrgaaq3i4fzv09h7a3pwzlp2ahkczwcm32";
+    sha256 = "10asz918kv2248px3w9bn5k8cfrad5xrci58x9y61l0yf5hcpk0r";
   };
 
   nativeBuildInputs = [ cmake ninja llvm pkgconfig intltool perl desktop-file-utils wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/darktable/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/36vw0ki4wqgvwj1f0xgb17qpdxpzijm7-darktable-2.4.2/bin/darktable-cltest help` got 0 exit code
- found 2.4.2 with grep in /nix/store/36vw0ki4wqgvwj1f0xgb17qpdxpzijm7-darktable-2.4.2
- directory tree listing: https://gist.github.com/2fb5b4b7836751e43911e4337febf1ab

cc @cillianderoiste @rickynils @flosse @mrVanDalo for review