### PR TITLE
linuxPackages.evdi: 1.5.0 -> 1.5.0.2

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "evdi-${version}";
-  version = "1.5.0";
+  version = "1.5.0.2";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = "evdi";
     rev = "v${version}";
-    sha256 = "01z7bx5rgpb5lc4c6dxfiv52ni25564djxmvmgy3d7r1x1mqhxgs";
+    sha256 = "1wjk023lpjxnspfl34c6rzkrixahfdzdkmc3hnmrdw12s3i6ca5x";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/evdi/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.5.0.2 with grep in /nix/store/hngckzkz4hn1qx4v6j50kdxkd775nfhr-evdi-1.5.0.2
- directory tree listing: https://gist.github.com/47526fd1bae00c70366d3fceb27b8b49