### PR TITLE
fmit: 1.1.13 -> 1.1.14

### DIFF
--- a/pkgs/applications/audio/fmit/default.nix
+++ b/pkgs/applications/audio/fmit/default.nix
@@ -11,10 +11,10 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "fmit-${version}";
-  version = "1.1.13";
+  version = "1.1.14";
 
   src = fetchFromGitHub {
-    sha256 = "1p374gf7iksrlyvddm3w4qk3l0rxsiyymz5s8dmc447yvin8ykfq";
+    sha256 = "18gvl8smcnigzldy1acs5h8rscf287b39xi4y2cl5armqbj0y38x";
     rev = "v${version}";
     repo = "fmit";
     owner = "gillesdegottex";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/fmit/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.1.14 with grep in /nix/store/3n6m5ipvpy4wkxaagzq2gwx7w3zvk6m1-fmit-1.1.14
- directory tree listing: https://gist.github.com/1f691b378929e55b2019578fa597a792