### PR TITLE
freecell-solver: 4.16.0 -> 4.18.0

### DIFF
--- a/pkgs/games/freecell-solver/default.nix
+++ b/pkgs/games/freecell-solver/default.nix
@@ -6,11 +6,11 @@ with stdenv.lib;
 stdenv.mkDerivation rec{
 
   name = "freecell-solver-${version}";
-  version = "4.16.0";
+  version = "4.18.0";
 
   src = fetchurl {
     url = "http://fc-solve.shlomifish.org/downloads/fc-solve/${name}.tar.xz";
-    sha256 = "1ihrmxbsli7c1lm5gw9xgrakyn4nsmaj1zgk5gza2ywnfpgdb0ac";
+    sha256 = "1cmaib69pijmcpvgjvrdry8j4xys8l906l80b8z21vvyhdwrfdnn";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/freecell-solver/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/fc-solve -h` got 0 exit code
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/fc-solve --help` got 0 exit code
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/fc-solve --version` and found version 4.18.0
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/pi-make-microsoft-freecell-board -h` got 0 exit code
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/pi-make-microsoft-freecell-board --help` got 0 exit code
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/pi-make-microsoft-freecell-board help` got 0 exit code
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/fc_solve_find_index_s2ints.py -h` got 0 exit code
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/fc_solve_find_index_s2ints.py --help` got 0 exit code
- ran `/nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0/bin/fc_solve_find_index_s2ints.py help` got 0 exit code
- found 4.18.0 with grep in /nix/store/k186rg37jwk63hvw2h1nmpmssa3cwrj4-freecell-solver-4.18.0
- directory tree listing: https://gist.github.com/2c22e8a4355b2da3c90bfde6c8d92c13

cc @AndersonTorres for review