### PR TITLE
freeciv_gtk: 2.5.10 -> 2.5.11

### DIFF
--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -12,7 +12,7 @@ let
   gtkName = if gtkClient then "-gtk" else "";
 
   name = "freeciv";
-  version = "2.5.10";
+  version = "2.5.11";
 in
 stdenv.mkDerivation {
   name = "${name}${sdlName}${gtkName}-${version}";
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/freeciv/${name}-${version}.tar.bz2";
-    sha256 = "00mkzhfcbc27d8m7hj644h8lyc9mb8nhqfcngc52zkidarb438f8";
+    sha256 = "1bcs4mj4kzkpyrr0yryydmn0dzcqazvwrf02nfs7r5zya9lm572c";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/freeciv-gtk/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server -h` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server --help` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server help` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server -V` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server -v` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server --version` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server version` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server -h` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server --help` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-server help` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-gtk2 -h` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-gtk2 --help` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-gtk2 -v` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-gtk2 --version` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-manual -h` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-manual --help` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-manual -v` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-manual --version` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-mp-gtk2 -h` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-mp-gtk2 --help` got 0 exit code
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-mp-gtk2 -v` and found version 2.5.11
- ran `/nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11/bin/freeciv-mp-gtk2 --version` and found version 2.5.11
- found 2.5.11 with grep in /nix/store/h5yjw60axfcj1qiva25shmxdh0b4h6xy-freeciv-gtk-2.5.11
- directory tree listing: https://gist.github.com/02a6a0c73fce1c016f7e3dc7111c76b3

cc @nbp for review