### PR TITLE
gegl_0_3: 0.3.28 -> 0.3.30

### DIFF
--- a/pkgs/development/libraries/gegl/3.0.nix
+++ b/pkgs/development/libraries/gegl/3.0.nix
@@ -3,11 +3,11 @@
 , libwebp, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "gegl-0.3.28";
+  name = "gegl-0.3.30";
 
   src = fetchurl {
     url = "http://download.gimp.org/pub/gegl/0.3/${name}.tar.bz2";
-    sha256 = "1zr3gmmzjhp2d3d3h51x80r5q7gs9rv67ywx69sif6as99h8fbqm";
+    sha256 = "0lg5j5kn24qvyb6fn7khxf3jadkacbpnb9nrqzy7w665s8xakd7q";
   };
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/gegl/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/fn6gs9ss2l0qpxyg3w5y76bx4wlgr9q6-gegl-0.3.30/bin/gegl -h` got 0 exit code
- ran `/nix/store/fn6gs9ss2l0qpxyg3w5y76bx4wlgr9q6-gegl-0.3.30/bin/gegl --help` got 0 exit code
- ran `/nix/store/fn6gs9ss2l0qpxyg3w5y76bx4wlgr9q6-gegl-0.3.30/bin/gegl -V` and found version 0.3.30
- ran `/nix/store/fn6gs9ss2l0qpxyg3w5y76bx4wlgr9q6-gegl-0.3.30/bin/gegl --version` and found version 0.3.30
- ran `/nix/store/fn6gs9ss2l0qpxyg3w5y76bx4wlgr9q6-gegl-0.3.30/bin/gegl -h` and found version 0.3.30
- ran `/nix/store/fn6gs9ss2l0qpxyg3w5y76bx4wlgr9q6-gegl-0.3.30/bin/gegl --help` and found version 0.3.30
- found 0.3.30 with grep in /nix/store/fn6gs9ss2l0qpxyg3w5y76bx4wlgr9q6-gegl-0.3.30
- directory tree listing: https://gist.github.com/d252f515654f002ddf4d8f3301559e56

cc @jtojnar for review