### PR TITLE
pants: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/tools/build-managers/pants/default.nix
+++ b/pkgs/development/tools/build-managers/pants/default.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 with pythonPackages;
 
 let
-  version = "1.3.0";
+  version = "1.4.0";
 in buildPythonApplication rec {
   inherit version;
   pname = "pantsbuild.pants";
@@ -12,7 +12,7 @@ in buildPythonApplication rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "18fcf9047l9k006wz21g525p1w5avyjabmabh0giyz22xnm8g5gp";
+    sha256 = "1jd041av1kipg4psbcwk70nwh0bsh5mkbjjcmnw4vrqdd09vg1gz";
   };
 
   prePatch = ''
@@ -24,10 +24,10 @@ in buildPythonApplication rec {
   dontStrip = true;
 
   propagatedBuildInputs = [
-    twitter-common-collections setproctitle setuptools six ansicolors
-    packaging pathspec scandir twitter-common-dirutil psutil requests
-    pystache pex docutils markdown pygments twitter-common-confluence
-    fasteners coverage pywatchman futures cffi
+    twitter-common-collections setproctitle ansicolors packaging pathspec
+    scandir twitter-common-dirutil psutil requests pystache pex docutils
+    markdown pygments twitter-common-confluence fasteners pywatchman
+    futures cffi subprocess32 contextlib2 faulthandler pyopenssl
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Upgrading to what was the latest release of pants. Note in meantime see that 1.5.0 was just released a couple days ago, but want to go one release at a time here.

###### Things done

Tested via running "nix-build -A pkgs.pants" on macOS (10.13.3)
