### PR TITLE
unifi, nixos/unifi: support LTS (5.6.36) and release (5.7.20)

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -4,22 +4,22 @@ let
   cfg = config.services.unifi;
   stateDir = "/var/lib/unifi";
   cmd = ''
-    @${pkgs.jre}/bin/java java \
+    @${cfg.jrePackage}/bin/java java \
         ${optionalString (cfg.initialJavaHeapSize != null) "-Xms${(toString cfg.initialJavaHeapSize)}m"} \
         ${optionalString (cfg.maximumJavaHeapSize != null) "-Xmx${(toString cfg.maximumJavaHeapSize)}m"} \
         -jar ${stateDir}/lib/ace.jar
   '';
   mountPoints = [
     {
-      what = "${pkgs.unifi}/dl";
+      what = "${cfg.unifiPackage}/dl";
       where = "${stateDir}/dl";
     }
     {
-      what = "${pkgs.unifi}/lib";
+      what = "${cfg.unifiPackage}/lib";
       where = "${stateDir}/lib";
     }
     {
-      what = "${pkgs.mongodb}/bin";
+      what = "${cfg.mongodbPackage}/bin";
       where = "${stateDir}/bin";
     }
     {
@@ -38,6 +38,33 @@ in
       default = false;
       description = ''
         Whether or not to enable the unifi controller service.
+      '';
+    };
+
+    services.unifi.jrePackage = mkOption {
+      type = types.package;
+      default = pkgs.jre8;
+      defaultText = "pkgs.jre8";
+      description = ''
+        The JRE package to use. Check the release notes to ensure it is supported.
+      '';
+    };
+
+    services.unifi.unifiPackage = mkOption {
+      type = types.package;
+      default = pkgs.unifiLTS;
+      defaultText = "pkgs.unifiLTS";
+      description = ''
+        The unifi package to use.
+      '';
+    };
+
+    services.unifi.mongodbPackage = mkOption {
+      type = types.package;
+      default = pkgs.mongodb;
+      defaultText = "pkgs.mongodb";
+      description = ''
+        The mongodb package to use.
       '';
     };
 
@@ -137,7 +164,7 @@ in
         rm -rf "${stateDir}/webapps"
         mkdir -p "${stateDir}/webapps"
         chown unifi "${stateDir}/webapps"
-        ln -s "${pkgs.unifi}/webapps/ROOT" "${stateDir}/webapps/ROOT"
+        ln -s "${cfg.unifiPackage}/webapps/ROOT" "${stateDir}/webapps/ROOT"
       '';
 
       postStop = ''

--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -2,21 +2,37 @@
 , dpkg
 , fetchurl
 , unzip
+, useLTS ? false
 }:
 
-stdenv.mkDerivation rec {
-  name = "unifi-controller-${version}";
-  version = "5.6.36";
 
-  src = fetchurl {
+let
+  versions = {
+    stable = {
+      version = "5.7.20";
+      sha256 = "1ylj4i5mcv6z9n32275ccdf1rqk74zilqsih3r6xzhm30pxrd8dd";
+    };
+    lts = {
+      version = "5.6.36";
+      sha256 = "075q7vm56fdsjwh72y2cb1pirl2pxdkvqnhvd3bf1c2n64mvp6bi";
+    };
+  };
+  selectedVersion =
+    let attr = if useLTS then "lts" else "stable";
+    in versions."${attr}";
+in
+
+stdenv.mkDerivation {
+  name = "unifi-controller-${selectedVersion.version}";
+  src = with selectedVersion; fetchurl {
     url = "https://dl.ubnt.com/unifi/${version}/unifi_sysvinit_all.deb";
-    sha256 = "075q7vm56fdsjwh72y2cb1pirl2pxdkvqnhvd3bf1c2n64mvp6bi";
+    inherit sha256;
   };
 
   buildInputs = [ dpkg ];
 
   unpackPhase = ''
-    dpkg-deb -x ${src} ./
+    dpkg-deb -x $src ./
   '';
 
   doConfigure = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12885,6 +12885,7 @@ with pkgs;
   axis2 = callPackage ../servers/http/tomcat/axis2 { };
 
   unifi = callPackage ../servers/unifi { };
+  unifiLTS = callPackage ../servers/unifi { useLTS=true; };
 
   virtuoso6 = callPackage ../servers/sql/virtuoso/6.x.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Ubiquiti has both a LTS and current version of their Unifi controller software.

The latter adds new features, but may drop support for some devices.

This adds the capability to use either for the `unifi` module but defaults to the LTS version, which was the previous behavior.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

