### PR TITLE
gnustep.gui: 0.25.0 -> 0.26.2

### DIFF
--- a/pkgs/desktops/gnustep/gui/default.nix
+++ b/pkgs/desktops/gnustep/gui/default.nix
@@ -1,12 +1,12 @@
 { gsmakeDerivation, fetchurl, base }:
 let
-  version = "0.25.0";
+  version = "0.26.2";
 in
 gsmakeDerivation {
   name = "gnustep-gui-${version}";
   src = fetchurl {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-gui-${version}.tar.gz";
-    sha256 = "10jf3xir59qzbhhl0bvs9wdw40fsmvv6mdv5akdkia1rnck60xf5";
+    sha256 = "1dsbkifnjha3ghq8xx55bpsbbng0cjsni3yz71r7342ax2ixcvxc";
   };
   buildInputs = [ base ];
   patches = [ ./fixup-all.patch ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/gnustep-gui/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gclose -h` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gclose --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gclose help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gcloseall -h` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gcloseall --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gcloseall help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gopen -h` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gopen --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/gopen help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/make_services -h` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/make_services --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/make_services help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/set_show_service --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gclose-wrapped -h` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gclose-wrapped --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gclose-wrapped help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gcloseall-wrapped -h` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gcloseall-wrapped --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gcloseall-wrapped help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gopen-wrapped -h` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gopen-wrapped --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.gopen-wrapped help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.make_services-wrapped -h` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.make_services-wrapped --help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.make_services-wrapped help` got 0 exit code
- ran `/nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2/bin/.set_show_service-wrapped --help` got 0 exit code
- found 0.26.2 with grep in /nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2
- found 0.26.2 in filename of file in /nix/store/bma1fldnlpkx804zb7zxi9hqgkmv8ca5-gnustep-gui-0.26.2
- directory tree listing: https://gist.github.com/1f55420b15dcdd93eb98a06634b7fb25

cc @ashalkhakov @matthewbauer for review