### PR TITLE
(krunner-pass): init at 1.3.0 on 17.09

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -658,6 +658,7 @@
   ylwghst = "Burim Augustin Berisa <ylwghst@onionmail.info>";
   yochai = "Yochai <yochai@titat.info>";
   yorickvp = "Yorick van Pelt <yorickvanpelt@gmail.com>";
+  ysndr = "Yannik Sander <me@ysndr.de>";
   yuriaisaka = "Yuri Aisaka <yuri.aisaka+nix@gmail.com>";
   yurrriq = "Eric Bailey <eric@ericb.me>";
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";

--- a/pkgs/tools/security/krunner-pass/default.nix
+++ b/pkgs/tools/security/krunner-pass/default.nix
@@ -1,0 +1,36 @@
+{ mkDerivation, stdenv,
+  fetchFromGitHub,
+  cmake, extra-cmake-modules, gnumake,
+
+  pass, pass-otp ? null, krunner,
+}:
+let
+  pname = "krunner-pass";
+  version = "1.3.0";
+in
+mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "akermu";
+    repo = "krunner-pass";
+    rev = "v1.3.0";
+    sha256 = "032fs2174ls545kjixbhzyd65wgxkw4s5vg8b20irc5c9ak3pxm0";
+  };
+
+  propagatedBuildInputs  = [
+    pass
+    pass-otp
+    krunner
+  ];
+
+  nativeBuildInputs = [cmake extra-cmake-modules gnumake];
+
+  meta = with stdenv.lib; {
+    description = "Integrates krunner with pass the unix standard password manager (https://www.passwordstore.org/)";
+    homepage = https://github.com/akermu/krunner-pass;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ysndr ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2849,6 +2849,8 @@ with pkgs;
 
   krename = libsForQt5.callPackage ../applications/misc/krename { };
 
+  krunner-pass = libsForQt5.callPackage ../tools/security/krunner-pass { };
+
   kronometer = libsForQt5.callPackage ../tools/misc/kronometer { };
 
   kdiff3 = libsForQt5.callPackage ../tools/text/kdiff3 { };


### PR DESCRIPTION
###### Motivation for this change
use krunner-pass on `17.09` after dding it to master (#374949)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

