### PR TITLE
hpx: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/hpx/default.nix
+++ b/pkgs/development/libraries/hpx/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "hpx-${version}";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "STEllAR-GROUP";
     repo = "hpx";
     rev = "${version}";
-    sha256 = "0k79gw4c0v4i7ps1hw6x4m7svxbfml5xm6ly7p00dvg7z9521zsk";
+    sha256 = "0xlhnycmpy2jgiqyzpwmkdrl6drf46ywdsl0qm4vksvjxqfgk9z3";
   };
 
   buildInputs = [ boost hwloc gperftools ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/hpx/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/xg48bc9gkcq2hyk51hxy5s7x8l0s70r9-hpx-1.1.0/bin/hpxrun.py -h` got 0 exit code
- ran `/nix/store/xg48bc9gkcq2hyk51hxy5s7x8l0s70r9-hpx-1.1.0/bin/hpxrun.py --help` got 0 exit code
- found 1.1.0 with grep in /nix/store/xg48bc9gkcq2hyk51hxy5s7x8l0s70r9-hpx-1.1.0
- found 1.1.0 in filename of file in /nix/store/xg48bc9gkcq2hyk51hxy5s7x8l0s70r9-hpx-1.1.0
- directory tree listing: https://gist.github.com/377d8c673231332bb40acb55fed39e53

cc @bobakker for review