### PR TITLE
wrapper.c: fixup includes to work w/musl

### DIFF
--- a/nixos/modules/security/wrappers/wrapper.c
+++ b/nixos/modules/security/wrappers/wrapper.c
@@ -10,8 +10,8 @@
 #include <errno.h>
 #include <linux/capability.h>
 #include <sys/capability.h>
-#include <linux/prctl.h>
 #include <sys/prctl.h>
+#include <limits.h>
 #include <cap-ng.h>
 
 // Make sure assertions are not compiled out, we use them to codify


### PR DESCRIPTION
don't use <linux/*> headers after <sys/*>,
although it's generally a bit tricky to avoid conflicts
and the above might not always work.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---