### PR TITLE
kotlin: 1.2.30 -> 1.2.31

### DIFF
--- a/pkgs/development/compilers/kotlin/default.nix
+++ b/pkgs/development/compilers/kotlin/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, makeWrapper, jre, unzip }:
 
 let
-  version = "1.2.30";
+  version = "1.2.31";
 in stdenv.mkDerivation rec {
   inherit version;
   name = "kotlin-${version}";
 
   src = fetchurl {
     url = "https://github.com/JetBrains/kotlin/releases/download/v${version}/kotlin-compiler-${version}.zip";
-    sha256 = "0wg08cncwfajxfx8860wdf5dr4h92j069qvdr90l5m01ff3nasad";
+    sha256 = "09l0vjff9kkiprf5irgq1sb9cils8plbzbrf55ajj8m5fyxcd6fs";
   };
 
   propagatedBuildInputs = [ jre ] ;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/kotlin/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/kotlin -h` got 0 exit code
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/kotlin-dce-js -h` got 0 exit code
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/kotlinc -h` got 0 exit code
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/kotlinc-js -h` got 0 exit code
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/kotlinc-jvm -h` got 0 exit code
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/.kotlin-wrapped -h` got 0 exit code
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/.kotlin-dce-js-wrapped -h` got 0 exit code
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/.kotlinc-js-wrapped -h` got 0 exit code
- ran `/nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31/bin/.kotlinc-jvm-wrapped -h` got 0 exit code
- found 1.2.31 with grep in /nix/store/c8gxcm1qd27rc1q7m164vwys12rr7kzj-kotlin-1.2.31
- directory tree listing: https://gist.github.com/2abc86ffb8a29b93e0ee8cdc45c72125

cc @nequissimus for review