### PR TITLE
libbitcoin-network: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/tools/misc/libbitcoin/libbitcoin-network.nix
+++ b/pkgs/tools/misc/libbitcoin/libbitcoin-network.nix
@@ -3,7 +3,7 @@
 
 let
   pname = "libbitcoin-network";
-  version = "3.4.0";
+  version = "3.5.0";
 
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "libbitcoin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1zlhyh5z0fla1yc6kwkx65ycwgmrcrkvzj8119wbkxy3xhzpwxpv";
+    sha256 = "0vqg3i40kwmbys4lyp82xvg2nx3ik4qhc66gcm8k66a86wpj9ji6";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/libbitcoin-network/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.5.0 with grep in /nix/store/mmrl1lvrc1p8ypclg2gf36n26vhyai04-libbitcoin-network-3.5.0
- directory tree listing: https://gist.github.com/05b992f0e86e04ef0e068c378b453f8b

cc @asymmetric for review