### PR TITLE
netcat-openbsd: fix w/musl by providing b64_ntop

### DIFF
--- a/pkgs/tools/networking/netcat-openbsd/default.nix
+++ b/pkgs/tools/networking/netcat-openbsd/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, libbsd}:
+{stdenv, fetchurl, fetchpatch, pkgconfig, libbsd}:
 
 stdenv.mkDerivation rec {
   version = "1.187";
@@ -26,6 +26,13 @@ stdenv.mkDerivation rec {
       patch -p1 < "../debian/patches/$i"
     done
   '';
+
+  patches = stdenv.lib.optional stdenv.hostPlatform.isMusl [
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/proj/musl.git/plain/net-analyzer/openbsd-netcat/files/openbsd-netcat-1.105-b64_ntop.patch?id=4a5864922232c7df550c21f2a7b77fe6f8ffc6d6";
+      sha256 = "1cgqb6fxas5yiwf26hq57v627hhmcskl5j6rx30090ha2ksjqyvr";
+    })
+  ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Patch from gentoo-musl, implementation is from ISC (all known implementations are from ISC as far as I can tell).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---