### PR TITLE
init cconv at 0.6.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2974,6 +2974,11 @@
     github = "redbaron";
     name = "Maxim Ivanov";
   };
+  redfish64 = {
+    email = "engler@gmail.com";
+    github = "redfish64";
+    name = "Tim Engler";
+  };
   redvers = {
     email = "red@infect.me";
     github = "redvers";

--- a/pkgs/tools/text/cconv/default.nix
+++ b/pkgs/tools/text/cconv/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, autoreconfHook }:
+let version = "0.6.3"; in
+  stdenv.mkDerivation {
+  name = "cconv-${version}";
+  
+  src = fetchurl {
+    url = "https://github.com/xiaoyjy/cconv/archive/v${version}.tar.gz";
+    sha256 = "82f46a94829f5a8157d6f686e302ff5710108931973e133d6e19593061b81d84";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  
+  meta = with stdenv.lib; {
+    description = "A iconv based simplified-traditional chinese conversion tool";
+    homepage = https://github.com/xiaoyjy/cconv;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.redfish64 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -611,6 +611,8 @@ with pkgs;
 
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };
 
+  cconv = callPackage ../tools/text/cconv { };
+  
   chkcrontab = callPackage ../tools/admin/chkcrontab { };
 
   djmount = callPackage ../tools/filesystems/djmount { };


### PR DESCRIPTION
###### Motivation for this change

add cconv tool for conversion between simplified and traditional chinese text

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

