### PR TITLE
librelp: 1.2.14 -> 1.2.15

### DIFF
--- a/pkgs/development/libraries/librelp/default.nix
+++ b/pkgs/development/libraries/librelp/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, gnutls, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "librelp-1.2.14";
+  name = "librelp-1.2.15";
 
   src = fetchurl {
     url = "http://download.rsyslog.com/librelp/${name}.tar.gz";
-    sha256 = "0marms2np729ck0x0hsj1bdmi0ly57pl7pfspwrqld9n8cd29xhi";
+    sha256 = "16d9km99isa4mwk6psf8brny1sfl45dijlkdwzp0yrjnj0nq6cd9";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/librelp/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.2.15 with grep in /nix/store/cjbd6mqjf4lgxl73dkvs9xc03yvdcwwv-librelp-1.2.15
- directory tree listing: https://gist.github.com/bc4e1fc397536ead26ce0d2df2c25296

cc @wkennington for review