### PR TITLE
links: 2.14 -> 2.15

### DIFF
--- a/pkgs/applications/networking/browsers/links2/default.nix
+++ b/pkgs/applications/networking/browsers/links2/default.nix
@@ -8,12 +8,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.14";
+  version = "2.15";
   name = "links2-${version}";
 
   src = fetchurl {
     url = "${meta.homepage}/download/links-${version}.tar.bz2";
-    sha256 = "1f24y83wa1vzzjq5kp857gjqdpnmf8pb29yw7fam0m8wxxw0c3gp";
+    sha256 = "1jp3xyvp87a188b4kg5ycqahrazj7928zncgsznzn54w8d5iqahy";
   };
 
   buildInputs = with stdenv.lib;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/links2/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.15 with grep in /nix/store/sv2bhipkaba7wbgkwinbq1xs430zmvra-links2-2.15
- directory tree listing: https://gist.github.com/c94bde5e3281eca9ed30751401d14020

cc @7c6f434c @viric for review