### PR TITLE
mbuffer: 20171011 -> 20180318

### DIFF
--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -3,12 +3,12 @@
  } :
 
 stdenv.mkDerivation rec {
-  version = "20171011";
+  version = "20180318";
   name = "mbuffer-${version}";
 
   src = fetchurl {
     url = "http://www.maier-komor.de/software/mbuffer/mbuffer-${version}.tgz";
-    sha256 = "1z6is359dnlf61n6ida9ivghafzz5m8cf4hzdhma8nxv12brfbzb";
+    sha256 = "1sh0ipf77aav1k17dgl9dcjlb17zygs07x01g0nn0cg7yw5y5hfk";
   };
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mbuffer/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/sjlbs2k9114xlxalqcz2n0jj90lvik07-mbuffer-20180318/bin/mbuffer -h` got 0 exit code
- ran `/nix/store/sjlbs2k9114xlxalqcz2n0jj90lvik07-mbuffer-20180318/bin/mbuffer --help` got 0 exit code
- ran `/nix/store/sjlbs2k9114xlxalqcz2n0jj90lvik07-mbuffer-20180318/bin/mbuffer -V` and found version 20180318
- ran `/nix/store/sjlbs2k9114xlxalqcz2n0jj90lvik07-mbuffer-20180318/bin/mbuffer --version` and found version 20180318
- found 20180318 with grep in /nix/store/sjlbs2k9114xlxalqcz2n0jj90lvik07-mbuffer-20180318
- directory tree listing: https://gist.github.com/5b88f842903984d6134c96d89c2169de

cc @tokudan for review