### PR TITLE
celt-0.5.1: disable tests that fail to build due to bad code

### DIFF
--- a/pkgs/development/libraries/celt/0.5.1.nix
+++ b/pkgs/development/libraries/celt/0.5.1.nix
@@ -7,4 +7,11 @@ callPackage ./generic.nix (args // rec{
     url = "http://downloads.xiph.org/releases/celt/celt-${version}.tar.gz";
     sha256 = "0bkam9z5vnrxpbxkkh9kw6yzjka9di56h11iijikdd1f71l5nbpw";
   };
+
+  # Don't build tests due to badness with ec_ilog
+  prePatch = ''
+    substituteInPlace Makefile.in \
+      --replace 'SUBDIRS = libcelt tests' \
+                'SUBDIRS = libcelt'
+  '';
 })

--- a/pkgs/development/libraries/celt/generic.nix
+++ b/pkgs/development/libraries/celt/generic.nix
@@ -1,5 +1,6 @@
 { stdenv, version, src
 , liboggSupport ? true, libogg ? null # if disabled only the library will be built
+, prePatch ? ""
 , ...
 }:
 
@@ -9,6 +10,8 @@ stdenv.mkDerivation rec {
   name = "celt-${version}";
 
   inherit src;
+
+  inherit prePatch;
 
   buildInputs = []
     ++ stdenv.lib.optional liboggSupport libogg;


### PR DESCRIPTION
These were fixed upstream, but patches don't apply to
0.5.1 which we need to use for spice.

Instead of maintaining backported patches for very deprecated
software, just don't build the tests in the first place.


http://lists.xiph.org/pipermail/opus/2011-March/001423.html
http://lists.xiph.org/pipermail/opus/2011-March/001429.html


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---