### PR TITLE
neo4j: 3.3.2 -> 3.3.4

### DIFF
--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "neo4j-${version}";
-  version = "3.3.2";
+  version = "3.3.4";
 
   src = fetchurl {
     url = "http://dist.neo4j.org/neo4j-community-${version}-unix.tar.gz";
-    sha256 = "0vjzc38sacnbcw781qzng9lqwwahndfc3wia5yvxji094zqp8ala";
+    sha256 = "072pk0x1iyg6kasjah8qpki2z462qp0rvgn93y6ngi6zvrpdlbyc";
   };
 
   buildInputs = [ makeWrapper jre8 which gawk ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/neo4j/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j help` got 0 exit code
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j --version` and found version 3.3.4
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j version` and found version 3.3.4
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j help` and found version 3.3.4
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j-admin help` got 0 exit code
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j-admin --version` and found version 3.3.4
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j-import --help` got 0 exit code
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j-import help` got 0 exit code
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j-shell -h` got 0 exit code
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j-shell --help` got 0 exit code
- ran `/nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4/bin/neo4j-shell --version` and found version 3.3.4
- found 3.3.4 with grep in /nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4
- found 3.3.4 in filename of file in /nix/store/32bqjcjflqrpn65r5fw0si7hd5ps826s-neo4j-3.3.4
- directory tree listing: https://gist.github.com/06dd1dc492c20ed7b979e977cbfed538

cc @offlinehacker for review