### PR TITLE
neomutt: 20180223 -> 20180323

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -15,14 +15,14 @@ let
   '';
 
 in stdenv.mkDerivation rec {
-  version = "20180223";
+  version = "20180323";
   name = "neomutt-${version}";
 
   src = fetchFromGitHub {
     owner  = "neomutt";
     repo   = "neomutt";
     rev    = "neomutt-${version}";
-    sha256 = "1q0zwm8p2mk85icrbq42z4235mpqfra38pigd064kharx54k36sb";
+    sha256 = "0wxk1fqxk9pf2s43mw7diixv3hpwdry1cyr2xh119gqjc27lrc5w";
   };
 
   buildInputs = [
@@ -53,7 +53,7 @@ in stdenv.mkDerivation rec {
       --replace /etc/mime.types ${mime-types}/etc/mime.types
 
     # The string conversion tests all fail with the first version of neomutt
-    # that has tests (20180223) so we disable them for now.
+    # that has tests (20180323) so we disable them for now.
     # I don't know if that is related to the tests or our build environment.
     # Try again with a later release.
     sed -i '/rfc2047/d' test/Makefile.autosetup test/main.c


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/neomutt/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/neomutt -h` got 0 exit code
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/neomutt --help` got 0 exit code
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/neomutt -V` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/neomutt -v` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/neomutt --version` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/neomutt -h` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/neomutt --help` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/.neomutt-wrapped -h` got 0 exit code
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/.neomutt-wrapped --help` got 0 exit code
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/.neomutt-wrapped -V` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/.neomutt-wrapped -v` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/.neomutt-wrapped --version` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/.neomutt-wrapped -h` and found version 20180323
- ran `/nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323/bin/.neomutt-wrapped --help` and found version 20180323
- found 20180323 with grep in /nix/store/fznjp6nlh84knadpczkbqv3fm8rhxy7l-neomutt-20180323
- directory tree listing: https://gist.github.com/71a82f349ab996e34b0dfb7ab0708c4e

cc @cstrahan @erikryb @jfrankenau @vrthra for review