### PR TITLE
ocamlPackages.ocaml_extlib: 1.7.2 -> 1.7.4

### DIFF
--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -3,11 +3,11 @@
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.11";
 
 stdenv.mkDerivation {
-  name = "ocaml-extlib-1.7.2";
+  name = "ocaml-extlib-1.7.4";
 
   src = fetchurl {
-    url = http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.2.tar.gz;
-    sha256 = "0r7mhfgh6n5chj9r12s2x1fxrzvh6nm8h80ykl1mr75j86za41bm";
+    url = http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.4.tar.gz;
+    sha256 = "18jb4rvkk6p3mqnkamwb41x8q49shgn43h020bs4cp4vac7nrhnr";
   };
 
   buildInputs = [ ocaml findlib cppo ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/ocaml-extlib/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.7.4 with grep in /nix/store/dvi3qa5d9bkfr31vdwf1q87bh79jjh0n-ocaml-extlib-1.7.4
- directory tree listing: https://gist.github.com/7757241c8441089d6d514b9245f26bfd