### PR TITLE
openimageio: 1.8.8 -> 1.8.9

### DIFF
--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "openimageio-${version}";
-  version = "1.8.8";
+  version = "1.8.9";
 
   src = fetchFromGitHub {
     owner = "OpenImageIO";
     repo = "oiio";
     rev = "Release-${version}";
-    sha256 = "1jn4ph7giwxr65xxbm59i03wywnmxkqnpvqp0kcajl4k48vq3wkr";
+    sha256 = "0xyfb41arvi3cc5jvgj2m8skzjrb0xma8sml74svygjgagxfj65h";
   };
 
   outputs = [ "bin" "out" "dev" "doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/openimageio/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/2wwk85adfbywas17rirv6qmqwj2imy6i-openimageio-1.8.9-bin/bin/iinfo help` got 0 exit code
- ran `/nix/store/2wwk85adfbywas17rirv6qmqwj2imy6i-openimageio-1.8.9-bin/bin/maketx -v` and found version 1.8.9
- ran `/nix/store/2wwk85adfbywas17rirv6qmqwj2imy6i-openimageio-1.8.9-bin/bin/oiiotool --help` got 0 exit code
- ran `/nix/store/2wwk85adfbywas17rirv6qmqwj2imy6i-openimageio-1.8.9-bin/bin/oiiotool --help` and found version 1.8.9
- found 1.8.9 with grep in /nix/store/2wwk85adfbywas17rirv6qmqwj2imy6i-openimageio-1.8.9-bin
- directory tree listing: https://gist.github.com/70525af4a49db9639e7267a05d2d934e

cc @cillianderoiste for review