### PR TITLE
rofi-pass: 1.5.3 -> 2.0.1

### DIFF
--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "rofi-pass-${version}";
-  version = "1.5.3";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "carnager";
     repo = "rofi-pass";
     rev = version;
-    sha256 = "1fn1j2rf3abc5qb44zfc8z8ffw6rva4xfp7597hwr1g3szacazpq";
+    sha256 = "1r5z9g2kc6qf9r2d7vanzdc594apf8fgyn1rh30fvxygl2976yrw";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/rofi-pass/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped -h` got 0 exit code
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped --help` got 0 exit code
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped help` got 0 exit code
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped -V` and found version 2.0.1
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped -v` and found version 2.0.1
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped --version` and found version 2.0.1
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped version` and found version 2.0.1
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped -h` and found version 2.0.1
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped --help` and found version 2.0.1
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/.rofi-pass-wrapped help` and found version 2.0.1
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/rofi-pass -h` got 0 exit code
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/rofi-pass --help` got 0 exit code
- ran `/nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1/bin/rofi-pass help` got 0 exit code
- found 2.0.1 with grep in /nix/store/wzb6gvnk6sxf2kda842p8bsy9hrf9ccw-rofi-pass-2.0.1
- directory tree listing: https://gist.github.com/b535484b83f99920256e8f30a2b337f6

cc @the-kenny @garbas for review