### PR TITLE
GHCJS: Fix GHCJS with haddock-library-1.4.3

### DIFF
--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -47,6 +47,4 @@ bootPkgs.callPackage ./base.nix {
   stage2 = import ./head_stage2.nix;
 
   patches = [ ./ghcjs-head.patch ];
-
-  broken = true;  # https://hydra.nixos.org/build/71923242
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -74,6 +74,7 @@ self: super: {
   indents = dontCheck super.indents;
 
   # Newer versions require GHC 8.2.
+  haddock-library = self.haddock-library_1_4_3;
   haddock-api = self.haddock-api_2_17_4;
   haddock = self.haddock_2_17_5;
 }


### PR DESCRIPTION
###### Motivation for this change

This is a placeholder. Once hackage-packages are regenerated after #37834, this will use `haddock-library_1_4_3` to fix the GHCJS 8.0 builds

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

