### PR TITLE
WIP: GHCJS: Bump GHCJS 8.0 branch

### DIFF
--- a/pkgs/development/compilers/ghcjs/head.nix
+++ b/pkgs/development/compilers/ghcjs/head.nix
@@ -1,15 +1,15 @@
 { fetchgit, fetchFromGitHub, bootPkgs, cabal-install }:
 
 bootPkgs.callPackage ./base.nix {
-  version = "0.2.020170323";
+  version = "0.2.120171220";
 
   inherit bootPkgs cabal-install;
 
   ghcjsSrc = fetchFromGitHub {
     owner = "ghcjs";
     repo = "ghcjs";
-    rev = "2b3759942fb5b2fc1a58d314d9b098d4622fa6b6";
-    sha256 = "15asapg0va8dvcdycsx8dgk4xcpdnhml4h31wka6vvxf5anzz8aw";
+    rev = "665624644d5d476f9e4e4c89a2717b9d84151e39";
+    sha256 = "1ar8x86h7qy7hk1gckv8vbmc2abqyj7ma1mk1ndbyja83bvqaxs4";
   };
   ghcjsBootSrc = fetchgit {
     url = git://github.com/ghcjs/ghcjs-boot.git;

--- a/pkgs/development/compilers/ghcjs/shims.nix
+++ b/pkgs/development/compilers/ghcjs/shims.nix
@@ -2,6 +2,6 @@
 fetchFromGitHub {
   owner = "ghcjs";
   repo = "shims";
-  rev = "b97015229c58eeab7c1d0bb575794b14a9f6efca";
-  sha256 = "1p5adkqvmb1gsv9hnn3if0rdpnaq3v9a1zkfdy282yw05jaaaggz";
+  rev = "d3c579d05154a23fd4ea5f6ecf622ae5df129167";
+  sha256 = "0zm6ihpxgzvrpzlw2qybb7j2ylqg6wcm4jkr9aak0h42kq61p945";
 }


### PR DESCRIPTION
###### Motivation for this change

Update GHCJS to latest 8.0 branch. This will successfully build when #37842 is done.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

