### PR TITLE
supercollider: 3.9.1 -> 3.9.2

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -9,12 +9,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "supercollider-${version}";
-  version = "3.9.1";
+  version = "3.9.2";
 
 
   src = fetchurl {
     url = "https://github.com/supercollider/supercollider/releases/download/Version-${version}/SuperCollider-${version}-Source-linux.tar.bz2";
-    sha256 = "150fgnjcmb06r3pa3mbsvb4iwnqlimjwdxgbs6p55zz6g8wbln7a";
+    sha256 = "0d3cb6dw8jz7ijriqn3rlwin24gffczp69hl17pzxj1d5w57yj44";
   };
 
   hardeningDisable = [ "stackprotector" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/supercollider/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/a6z8q6az7fzhh0sp4llp4fzp8c95bm6y-supercollider-3.9.2/bin/scsynth -v` and found version 3.9.2
- ran `/nix/store/a6z8q6az7fzhh0sp4llp4fzp8c95bm6y-supercollider-3.9.2/bin/supernova -h` got 0 exit code
- ran `/nix/store/a6z8q6az7fzhh0sp4llp4fzp8c95bm6y-supercollider-3.9.2/bin/supernova --help` got 0 exit code
- ran `/nix/store/a6z8q6az7fzhh0sp4llp4fzp8c95bm6y-supercollider-3.9.2/bin/supernova -v` and found version 3.9.2
- ran `/nix/store/a6z8q6az7fzhh0sp4llp4fzp8c95bm6y-supercollider-3.9.2/bin/supernova --version` and found version 3.9.2
- ran `/nix/store/a6z8q6az7fzhh0sp4llp4fzp8c95bm6y-supercollider-3.9.2/bin/sclang -h` got 0 exit code
- ran `/nix/store/a6z8q6az7fzhh0sp4llp4fzp8c95bm6y-supercollider-3.9.2/bin/sclang -v` and found version 3.9.2
- found 3.9.2 with grep in /nix/store/a6z8q6az7fzhh0sp4llp4fzp8c95bm6y-supercollider-3.9.2
- directory tree listing: https://gist.github.com/5b90384fd1df273cba0757c752a352d6