### PR TITLE
talloc: 2.1.11 -> 2.1.12

### DIFF
--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "talloc-2.1.11";
+  name = "talloc-2.1.12";
 
   src = fetchurl {
     url = "mirror://samba/talloc/${name}.tar.gz";
-    sha256 = "1lzfxv2zjxap5snf9ydl1bqgjpz0kgkq7n644f8rkbx0arav77k3";
+    sha256 = "0jv0ri9vj93fczzgl7rn7xvnfgl2kfx4x85cr8h8v52yh7v0qz4q";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/talloc/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.1.12 with grep in /nix/store/scinsbqmcna4ch1d7yrmbi5zimxjbnzj-talloc-2.1.12
- found 2.1.12 in filename of file in /nix/store/scinsbqmcna4ch1d7yrmbi5zimxjbnzj-talloc-2.1.12
- directory tree listing: https://gist.github.com/741812f2d0252396e3ecb9ab86f33f66

cc @wkennington for review