### PR TITLE
home-assistant: backport of a number of python packages

### DIFF
--- a/pkgs/development/python-modules/deluge-client/default.nix
+++ b/pkgs/development/python-modules/deluge-client/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "deluge-client";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "048zfidv08sr4hivdd3xxf1pywhqbnszj5qcn51h2f4y1588fhpf";
+  };
+
+  # it will try to connect to a running instance
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Lightweight pure-python rpc client for deluge";
+    homepage = https://github.com/JohnDoee/deluge-client;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/ha-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/ha-ffmpeg/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, ffmpeg, async-timeout }:
+
+buildPythonPackage rec {
+  pname = "ha-ffmpeg";
+  version = "1.9";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0644j5fqw8p6li6nrnm1rw7nhvsixq1c7gik3f1yx50776yg05i8";
+  };
+
+  buildInputs = [ ffmpeg ];
+
+  propagatedBuildInputs = [ async-timeout ];
+
+  # only manual tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pvizeli/ha-ffmpeg;
+    description = "Library for home-assistant to handle ffmpeg";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/miniupnpc/default.nix
+++ b/pkgs/development/python-modules/miniupnpc/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "miniupnpc";
+  version = "2.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ca94zz7sr2x57j218aypxqcwkr23n8js30f3yrvvqbg929nr93y";
+  };
+
+  meta = with stdenv.lib; {
+    description = "miniUPnP client";
+    homepage = http://miniupnp.free.fr/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/sseclient/default.nix
+++ b/pkgs/development/python-modules/sseclient/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, requests, six
+, backports_unittest-mock, pluggy, pytest, pytestrunner }:
+
+buildPythonPackage rec {
+  pname = "sseclient";
+  version = "0.0.19";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7a2ea3f4c8525ae9a677bc8193df5db88e23bcaafcc34938a1ee665975703a9f";
+  };
+
+  propagatedBuildInputs = [ requests six ];
+
+  checkInputs = [ backports_unittest-mock pytest pytestrunner ];
+
+  meta = with stdenv.lib; {
+    description = "Client library for reading Server Sent Event streams";
+    homepage = https://github.com/btubbs/sseclient;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/yahooweather/default.nix
+++ b/pkgs/development/python-modules/yahooweather/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "yahooweather";
+  version = "0.10";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bsxmngkpzvqm50i2cnxjzhpbdhb8s10ly8h5q08696cjihqdkpa";
+  };
+
+  # Tests require network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Provide an interface to the Yahoo! Weather RSS feed";
+    homepage = https://github.com/pvizeli/yahooweather;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -99,7 +99,7 @@
     "envisalink" = ps: with ps; [  ];
     "fan.xiaomi_miio" = ps: with ps; [  ];
     "feedreader" = ps: with ps; [ feedparser ];
-    "ffmpeg" = ps: with ps; [  ];
+    "ffmpeg" = ps: with ps; [ ha-ffmpeg ];
     "frontend" = ps: with ps; [  ];
     "gc100" = ps: with ps; [  ];
     "goalfeed" = ps: with ps; [  ];
@@ -280,7 +280,7 @@
     "sensor.crimereports" = ps: with ps; [  ];
     "sensor.cups" = ps: with ps; [  ];
     "sensor.darksky" = ps: with ps; [  ];
-    "sensor.deluge" = ps: with ps; [  ];
+    "sensor.deluge" = ps: with ps; [ deluge-client ];
     "sensor.deutsche_bahn" = ps: with ps; [  ];
     "sensor.dht" = ps: with ps; [  ];
     "sensor.discogs" = ps: with ps; [ discogs_client ];
@@ -376,7 +376,7 @@
     "sensor.xbox_live" = ps: with ps; [  ];
     "sensor.yahoo_finance" = ps: with ps; [  ];
     "sensor.yr" = ps: with ps; [ xmltodict ];
-    "sensor.yweather" = ps: with ps; [  ];
+    "sensor.yweather" = ps: with ps; [ yahooweather ];
     "sensor.zestimate" = ps: with ps; [ xmltodict ];
     "shiftr" = ps: with ps; [ paho-mqtt ];
     "skybell" = ps: with ps; [  ];
@@ -387,7 +387,7 @@
     "switch.acer_projector" = ps: with ps; [ pyserial ];
     "switch.anel_pwrctrl" = ps: with ps; [  ];
     "switch.broadlink" = ps: with ps; [  ];
-    "switch.deluge" = ps: with ps; [  ];
+    "switch.deluge" = ps: with ps; [ deluge-client ];
     "switch.digitalloggers" = ps: with ps; [  ];
     "switch.dlink" = ps: with ps; [  ];
     "switch.edimax" = ps: with ps; [  ];
@@ -423,7 +423,7 @@
     "twilio" = ps: with ps; [ twilio ];
     "upcloud" = ps: with ps; [  ];
     "updater" = ps: with ps; [ distro ];
-    "upnp" = ps: with ps; [  ];
+    "upnp" = ps: with ps; [ miniupnpc ];
     "usps" = ps: with ps; [  ];
     "vacuum.roomba" = ps: with ps; [  ];
     "vacuum.xiaomi_miio" = ps: with ps; [  ];
@@ -439,7 +439,7 @@
     "weather.darksky" = ps: with ps; [  ];
     "weather.metoffice" = ps: with ps; [  ];
     "weather.openweathermap" = ps: with ps; [  ];
-    "weather.yweather" = ps: with ps; [  ];
+    "weather.yweather" = ps: with ps; [ yahooweather ];
     "wemo" = ps: with ps; [  ];
     "wink" = ps: with ps; [  ];
     "xiaomi_aqara" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -257,6 +257,8 @@ in {
     hdf5 = pkgs.hdf5-mpi;
   };
 
+  ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };
+
   habanero = callPackage ../development/python-modules/habanero { };
 
   i3ipc = callPackage ../development/python-modules/i3ipc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20472,6 +20472,8 @@ EOF
 
   thinc = callPackage ../development/python-modules/thinc { };
 
+  yahooweather = callPackage ../development/python-modules/yahooweather { };
+
   spacy = callPackage ../development/python-modules/spacy { };
 
   spacy_models = callPackage ../development/python-modules/spacy/models.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2791,6 +2791,8 @@ in {
     };
   };
 
+  miniupnpc = callPackage ../development/python-modules/miniupnpc {};
+
   mixpanel = buildPythonPackage rec {
     version = "4.0.2";
     name = "mixpanel-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20479,6 +20479,8 @@ EOF
 
   spacy_models = callPackage ../development/python-modules/spacy/models.nix { };
 
+  sseclient = callPackage ../development/python-modules/sseclient { };
+
   textacy = callPackage ../development/python-modules/textacy { };
 
   pyemd  = callPackage ../development/python-modules/pyemd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -642,6 +642,7 @@ in {
     gui = false;
   };
 
+  deluge-client = callPackage ../development/python-modules/deluge-client { };
 
   arrow = callPackage ../development/python-modules/arrow { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -648,20 +648,6 @@ in {
 
   arrow = callPackage ../development/python-modules/arrow { };
 
-  async = buildPythonPackage rec {
-    name = "async-0.6.1";
-    disabled = isPy3k;
-    meta.maintainers = with maintainers; [ ];
-
-    buildInputs = with self; [ pkgs.zlib ];
-    doCheck = false;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/async/${name}.tar.gz";
-      sha256 = "1lfmjm8apy9qpnpbq8g641fd01qxh9jlya5g2d6z60vf8p04rla1";
-    };
-  };
-
   asynctest = callPackage ../development/python-modules/asynctest { };
 
   async-timeout = callPackage ../development/python-modules/async_timeout { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

