### PR TITLE
godot: 2.1.4 -> 3.0.2

### DIFF
--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -1,22 +1,23 @@
 { stdenv, fetchFromGitHub, gcc5, scons, pkgconfig, libX11, libXcursor
-, libXinerama, libXrandr, libXrender, freetype, openssl, alsaLib
-, libpulseaudio, libGLU, zlib }:
+, libXinerama, libXrandr, libXrender, libXi, libXext, libXfixes
+, freetype, openssl, alsaLib, libpulseaudio, libGLU, zlib }:
 
 stdenv.mkDerivation rec {
   name    = "godot-${version}";
-  version = "2.1.4";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner  = "godotengine";
     repo   = "godot";
     rev    = "${version}-stable";
-    sha256 = "0d2zczn5k7296sky5gllq55cxd586nx134y2iwjpkqqjr62g0h48";
+    sha256 = "1ca1zznb7qqn4vf2nfwb8nww5x0k8fc4lwjvgydr6nr2mn70xka4";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     gcc5 scons libX11 libXcursor libXinerama libXrandr libXrender
-    freetype openssl alsaLib libpulseaudio libGLU zlib
+    libXi libXext libXfixes freetype openssl alsaLib libpulseaudio
+    libGLU zlib
   ];
 
   patches = [ ./pkg_config_additions.patch ];

--- a/pkgs/development/tools/godot/pkg_config_additions.patch
+++ b/pkgs/development/tools/godot/pkg_config_additions.patch
@@ -1,12 +1,12 @@
 +++ build/platform/x11/detect.py
-@@ -139,6 +139,10 @@
-     env.ParseConfig('pkg-config xinerama --cflags --libs')
+@@ -142,6 +142,10 @@
      env.ParseConfig('pkg-config xcursor --cflags --libs')
+     env.ParseConfig('pkg-config xinerama --cflags --libs')
      env.ParseConfig('pkg-config xrandr --cflags --libs')
 +    env.ParseConfig('pkg-config xrender --cflags --libs')
-+    env.ParseConfig('pkg-config oslibGLU_combined --cflags')
++    env.ParseConfig('pkg-config xext --cflags --libs')
++    env.ParseConfig('pkg-config xfixes --cflags --libs')
 +    env.ParseConfig('pkg-config glu --cflags --libs')
-+    env.ParseConfig('pkg-config zlib --cflags --libs')
 
-     if (env['builtin_openssl'] == 'no'):
-         # Currently not compatible with OpenSSL 1.1.0+
+     if (env['touch']):
+         x11_error = os.system("pkg-config xi --modversion > /dev/null "


### PR DESCRIPTION
###### Motivation for this change
Make available the version 3, version 2 is considered as legacy.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

