### PR TITLE
treewide: remove placeholder usage

### DIFF
--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ duplicity ];
 
-  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";
+  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "lib/nautilus/extensions-3.0";
 
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas

--- a/pkgs/desktops/gnome-3/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome-3/apps/file-roller/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib gtk json-glib libarchive file gnome3.defaultIconTheme libnotify nautilus ];
 
-  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";
+  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "lib/nautilus/extensions-3.0";
 
   postPatch = ''
     chmod +x postinstall.py # patchShebangs requires executable file

--- a/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib gtk3 gjs pango gnome3.gsettings-desktop-schemas gnome3.defaultIconTheme libunistring ];
 
   mesonFlags = [
-    "-Ddbus_service_dir=${placeholder "out"}/share/dbus-1/services"
+    "-Ddbus_service_dir=share/dbus-1/services"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     "-DENABLE_VALA_BINDINGS=ON"
     "-DENABLE_INTROSPECTION=ON"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
-    "-DINCLUDE_INSTALL_DIR=${placeholder "dev"}/include"
   ];
 
 

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dudev_dir=${placeholder "out"}/lib/udev"
+    "-Dudev_dir=lib/udev"
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/libgee/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgee/default.nix
@@ -6,8 +6,6 @@ in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
-  outputs = [ "out" "dev" ];
-
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
     sha256 = "0c26x8gi3ivmhlbqcmiag4jwrkvcy28ld24j55nqr3jikb904a5v";
@@ -15,11 +13,10 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  patches = [ ./fix_introspection_paths.patch ];
+
   nativeBuildInputs = [ pkgconfig autoconf vala gobjectIntrospection ];
   buildInputs = [ glib ];
-
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/libgee/fix_introspection_paths.patch
+++ b/pkgs/desktops/gnome-3/core/libgee/fix_introspection_paths.patch
@@ -1,0 +1,13 @@
+--- fix_introspection_paths.patch/configure	2014-01-07 17:43:53.521339338 +0000
++++ fix_introspection_paths.patch/configure-fix	2014-01-07 17:45:11.068635069 +0000
+@@ -12085,8 +12085,8 @@
+        INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
+        INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+        INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+-       INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
+-       INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
++       INTROSPECTION_GIRDIR="${datadir}/gir-1.0"
++       INTROSPECTION_TYPELIBDIR="${libdir}/girepository-1.0"
+        INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+        INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+        INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  mesonFlags = [ "-Dwith-nautilusdir=${placeholder "out"}/lib/nautilus/extensions-3.0" ];
+  mesonFlags = [ "-Dwith-nautilusdir=lib/nautilus/extensions-3.0" ];
 
   wrapPrefixVariables = [ "PYTHONPATH" ];
 

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  PKG_CONFIG_GIO_2_0_GIOMODULEDIR = "${placeholder "out"}/lib/gio/modules";
+  PKG_CONFIG_GIO_2_0_GIOMODULEDIR = "lib/gio/modules";
 
   postPatch = ''
     chmod +x meson_post_install.py # patchShebangs requires executable file

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -42,9 +42,9 @@ stdenv.mkDerivation rec {
     ]);
 
   mesonFlags = [
-    "-Dgio_module_dir=${placeholder "out"}/lib/gio/modules"
-    "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
-    "-Ddbus_service_dir=${placeholder "out"}/share/dbus-1/services"
+    "-Dgio_module_dir=lib/gio/modules"
+    "-Dsystemduserunitdir=lib/systemd/user"
+    "-Ddbus_service_dir=share/dbus-1/services"
     "-Dtmpfilesdir=no"
   ] ++ stdenv.lib.optionals (!gnomeSupport) [
     "-Dgcr=false" "-Dgoa=false" "-Dkeyring=false" "-Dhttp=false"

--- a/pkgs/development/libraries/libwnck/3.x.nix
+++ b/pkgs/development/libraries/libwnck/3.x.nix
@@ -19,8 +19,8 @@ in stdenv.mkDerivation rec{
   nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ];
   propagatedBuildInputs = [ libX11 gtk3 ];
 
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "share/gir-1.0";
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "lib/girepository-1.0";
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext libsoup autoreconfHook vala gobjectIntrospection ];
 
-  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
+  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "share/polkit-1/actions";
 
   configureFlags = [
     "--with-gtk3"

--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ dbus glib linuxHeaders systemd ];
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "lib/systemd/system";
+  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "lib/systemd/user";
 
   postInstall = ''
     install -Dm644 ../README $out/share/doc/dbus-broker/README

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -29,11 +29,11 @@ stdenv.mkDerivation rec {
     glib-compile-schemas $out/share/glib-2.0/schemas
   '';
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
-  PKG_CONFIG_SYSTEMD_TMPFILESDIR = "${placeholder "out"}/lib/tmpfiles.d";
-  PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR= "${placeholder "out"}/share/bash-completion/completions";
-  PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
+  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "lib/systemd/system";
+  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "lib/systemd/user";
+  PKG_CONFIG_SYSTEMD_TMPFILESDIR = "lib/tmpfiles.d";
+  PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR= "share/bash-completion/completions";
+  PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
 
   postFixup = ''
     wrapProgram "$out/libexec/colord-session" \


### PR DESCRIPTION
###### Motivation for this change
I keep forgetting 17.03 is not released yet, see https://github.com/NixOS/nixpkgs/commit/2abac54c033778104533a269aaa08a1e75f677ad

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

