### PR TITLE
terraform: Wrap PATH of propagatedBuildInputs

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -45,10 +45,7 @@ let
           actualPlugins = plugins terraform.plugins;
 
           # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
-          wrapperInputs = lib.unique (lib.flatten
-            (lib.catAttrs "propagatedBuildInputs"
-            (builtins.filter (x: x != null )
-            (lib.attrValues terraform.plugins))));
+          wrapperInputs = lib.unique (lib.flatten (lib.catAttrs "propagatedBuildInputs" actualPlugins));
 
           passthru = {
             withPlugins = newplugins: withPlugins (x: newplugins x ++ actualPlugins);

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -45,7 +45,7 @@ let
           actualPlugins = plugins terraform.plugins;
 
           # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
-          wrapperInputs = lib.unique (lib.flatten (lib.catAttrs "propagatedBuildInputs" actualPlugins));
+          wrapperInputs = lib.unique (lib.flatten (builtins.filter (x: x != null) (lib.catAttrs "propagatedBuildInputs" actualPlugins)));
 
           passthru = {
             withPlugins = newplugins: withPlugins (x: newplugins x ++ actualPlugins);

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -45,7 +45,7 @@ let
           actualPlugins = plugins terraform.plugins;
 
           # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
-          wrapperInputs = lib.unique (lib.flatten (builtins.filter (x: x != null) (lib.catAttrs "propagatedBuildInputs" actualPlugins)));
+          wrapperInputs = lib.unique (lib.flatten (lib.catAttrs "propagatedBuildInputs" (builtins.filter (x: x != null) actualPlugins)));
 
           passthru = {
             withPlugins = newplugins: withPlugins (x: newplugins x ++ actualPlugins);

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -44,6 +44,12 @@ let
         let
           actualPlugins = plugins terraform.plugins;
 
+          # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
+          wrapperInputs = lib.unique (lib.flatten
+            (lib.catAttrs "propagatedBuildInputs"
+            (builtins.filter (x: x != null )
+            (lib.attrValues terraform.plugins))));
+
           passthru = {
             withPlugins = newplugins: withPlugins (x: newplugins x ++ actualPlugins);
 
@@ -64,7 +70,8 @@ let
               buildCommand = ''
                 mkdir -p $out/bin/
                 makeWrapper "${terraform.bin}/bin/terraform" "$out/bin/terraform" \
-                  --set NIX_TERRAFORM_PLUGIN_DIR "${buildEnv { name = "tf-plugin-env"; paths = actualPlugins; }}/bin"
+                  --set NIX_TERRAFORM_PLUGIN_DIR "${buildEnv { name = "tf-plugin-env"; paths = actualPlugins; }}/bin" \
+                  --prefix PATH : "${lib.makeBinPath wrapperInputs}"
               '';
 
               inherit passthru;


### PR DESCRIPTION
###### Motivation for this change
Plugins (namely terraform-provider-libvirt) may have a run time
dependency on external binaries.

See https://github.com/NixOS/nixpkgs/pull/37852

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Mic92 @zimbatm @peterhoeg @jgeerds 