### PR TITLE
gnulib: symlink include/ to lib/

### DIFF
--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -9,8 +9,12 @@ stdenv.mkDerivation {
     sha256 = "0sifr3bkmhyr5s6ljgfyr0fw6w49ajf11rlp1r797f3r3r6j9w4k";
   };
 
-  installPhase = "mkdir -p $out; mv * $out/";
   dontFixup = true;
+  # no "make install", gnulib is a collection of source code
+  installPhase = ''
+    mkdir -p $out; mv * $out/
+    ln -s $out/lib $out/include
+  '';
 
   meta = {
     homepage = http://www.gnu.org/software/gnulib/;


### PR DESCRIPTION
so that some programs can find the headers automatically instead of
adding -I${gnulib}/lib



- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

