### PR TITLE
nvidiaLegacy304: fix build

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -62,7 +62,8 @@ in
     hardware.opengl.package = nvidiaPackage nvidia_x11 pkgs;
     hardware.opengl.package32 = nvidiaPackage nvidia_libs32 pkgs_i686;
 
-    environment.systemPackages = [ nvidia_x11.bin nvidia_x11.settings ]
+    environment.systemPackages = [ nvidia_x11.bin ]
+      ++ (if elem "nvidiaLegacy304" drivers then [ nvidia_libs32.settings ] else [ nvidia_x11.settings ])
       ++ lib.filter (p: p != null) [ nvidia_x11.persistenced ];
 
     boot.extraModulePackages = [ nvidia_x11.bin ];

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -50,8 +50,8 @@ rec {
     prePatch = let
       debPatches = fetchurl {
         url = "mirror://debian/pool/non-free/n/nvidia-graphics-drivers-legacy-304xx/"
-            + "nvidia-graphics-drivers-legacy-304xx_304.135-2.debian.tar.xz";
-        sha256 = "0mhji0ssn7075q5a650idigs48kzf11pzj2ca2n07rwxg3vj6pdr";
+            + "nvidia-graphics-drivers-legacy-304xx_304.137-5.debian.tar.xz";
+        sha256 = "0n8512mfcnvklfbg8gv4lzbkm3z6nncwj6ix2b8ngdkmc04f3b6l";
       };
       prefix = "debian/module/debian/patches";
       applyPatches = pnames: if pnames == [] then null else


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/37768 (dead link on debian.org)
Fixes https://github.com/NixOS/nixpkgs/issues/33395 (nvidia-setings in 32-bit only app in 304 version)
