### PR TITLE
haskell.compiler.ghc8{22,41}: Fix abi-depends non-determinism.

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -4,6 +4,7 @@
 # build-tools
 , bootPkgs, alex, happy, hscolour
 , autoconf, autoreconfHook, automake, coreutils, fetchurl, fetchpatch, perl, python3, sphinx
+, runCommand
 
 , libffi, libiconv ? null, ncurses
 
@@ -89,6 +90,7 @@ stdenv.mkDerivation rec {
       url = "https://git.haskell.org/ghc.git/commitdiff_plain/2fc8ce5f0c8c81771c26266ac0b150ca9b75c5f3";
       sha256 = "03253ci40np1v6k0wmi4aypj3nmj3rdyvb1k6rwqipb30nfc719f";
     })
+    (import ./abi-depends-determinism.nix { inherit fetchpatch runCommand; })
   ] ++ stdenv.lib.optional deterministicProfiling
     (fetchpatch { # Backport of https://phabricator.haskell.org/D4388 for more determinism
       url = "https://github.com/shlevy/ghc/commit/fec1b8d3555c447c0d8da0e96b659be67c8bb4bc.patch";

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -4,6 +4,7 @@
 # build-tools
 , bootPkgs, alex, happy
 , autoconf, automake, coreutils, fetchgit, fetchpatch, perl, python3
+, runCommand
 
 , libffi, libiconv ? null, ncurses
 
@@ -85,7 +86,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "doc" ];
 
-  patches = stdenv.lib.optional deterministicProfiling
+  patches = [
+    (import ./abi-depends-determinism.nix { inherit fetchpatch runCommand; })
+  ] ++ stdenv.lib.optional deterministicProfiling
     (fetchpatch { # https://phabricator.haskell.org/D4388 for more determinism
       url = "https://github.com/shlevy/ghc/commit/8b2dbd869d1a64de3e99fa8b1c9bb1140eee7099.patch";
       sha256 = "0hxpiwhbg64rsyjdr4psh6dwyp58b96mad3adccvfr0x8hc6ba2m";

--- a/pkgs/development/compilers/ghc/abi-depends-determinism.nix
+++ b/pkgs/development/compilers/ghc/abi-depends-determinism.nix
@@ -1,0 +1,10 @@
+# https://phabricator.haskell.org/D4159 to fix non-determinism in
+# cached abi-depends fields in package databases, modified to only
+# contain hunks that exist in distribution tarballs.
+{ fetchpatch, runCommand }: let
+  base = fetchpatch { # Non-determinism in cached abi-depends fields
+    url = https://phabricator-files.haskell.org/file/data/4pqrbo5b62sifktfbrls/PHID-FILE-4g4zjiqlfxmmlaos7lz7/D4159.diff;
+    sha256 = "0b8a08sisf1swmarm6nh9rgw7cpzi2rwdzvrd6ny49c7wk0f7x4b";
+  };
+in runCommand base.name {}
+  "sed -n '/utils\\/ghc-pkg/,$p' ${base} >$out"


### PR DESCRIPTION
See https://github.com/haskell/cabal/issues/4728 for symptoms,
https://phabricator.haskell.org/D4159 for the base of the fix.