### PR TITLE
pythonPackages.libais: 0.16 -> 0.17

### DIFF
--- a/pkgs/development/python-modules/libais/default.nix
+++ b/pkgs/development/python-modules/libais/default.nix
@@ -1,20 +1,19 @@
-{ stdenv, buildPythonPackage, fetchurl,
+{ stdenv, buildPythonPackage, fetchPypi,
   six, pytest, pytestrunner, pytestcov, coverage
 }:
 buildPythonPackage rec {
   pname = "libais";
-  name = "${pname}-${version}";
-  version = "0.16";
+  version = "0.17";
 
-  src = fetchurl {
-    url = "mirror://pypi/l/libais/${name}.tar.bz2";
-    sha256 = "14dsh5k32ryszwdn6p45wrqp4ska6cc9qpm6lk5c5d1p4rc7wnhq";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pyka09h8nb0vlzh14npq4nxmzg1046lr3klgn97dsf5k0iflapb";
   };
 
   # data files missing
   doCheck = false;
 
-  buildInputs = [ pytest pytestrunner pytestcov coverage ];
+  checkInputs = [ pytest pytestrunner pytestcov coverage ];
   propagatedBuildInputs = [ six ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

