### PR TITLE
dockerTools.tarsum: Fix upstream import

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -44,8 +44,8 @@ rec {
 
     cp ${./tarsum.go} tarsum.go
     export GOPATH=$(pwd)
-    mkdir src
-    ln -sT ${docker.src}/components/engine/pkg/tarsum src/tarsum
+    mkdir -p src/github.com/docker/docker/pkg
+    ln -sT ${docker.src}/components/engine/pkg/tarsum src/github.com/docker/docker/pkg/tarsum
     go build
 
     cp tarsum $out

--- a/pkgs/build-support/docker/tarsum.go
+++ b/pkgs/build-support/docker/tarsum.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"tarsum"
+	"github.com/docker/docker/pkg/tarsum"
 )
 
 func main() {


### PR DESCRIPTION
###### Motivation for this change

Recently, ...

```
building '/nix/store/72nalbxv6bwpah2w1v18brm8yfzv9lm0-tarsum.drv'...
tarsum.go:8:2: code in directory /build/tarsum/src/tarsum expects import "github.com/docker/docker/pkg/tarsum"
```


###### Things done
Add the import paths as specified in the upstream pkg.

A better solution would probably be to split out our "tarsum" entirely and have it properly depend on upstream as a gopkg.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

