### PR TITLE
nixpkgs docs: Use SVGs for callouts

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -23,6 +23,7 @@ out/html/index.html: manual-full.xml style.css
 		"$$XSL/docbook/xhtml/docbook.xsl" \
 		./manual-full.xml
 
+	cp ./overrides.css out/html/
 	cp ./style.css out/html/style.css
 
 	mkdir -p out/html/images/callouts
@@ -36,6 +37,7 @@ out/epub/manual.epub: manual-full.xml
 		"$$XSL/docbook/epub/docbook.xsl" \
 		./manual-full.xml
 
+	cp ./overrides.css out/epub/scratch/OEBPS
 	cp ./style.css out/epub/scratch/OEBPS
 	mkdir -p out/epub/scratch/OEBPS/images/callouts/
 	cp "$$XSL/docbook/images/callouts/"*.svg out/epub/scratch/OEBPS/images/callouts/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,7 +17,7 @@ validate: manual-full.xml
 
 out/html/index.html: manual-full.xml style.css
 	mkdir -p out/html
-	xsltproc $$xsltFlags \
+	xsltproc ${xsltFlags} \
 		--nonet --xinclude \
 		--output $@ \
 		"$$XSL/docbook/xhtml/docbook.xsl" \
@@ -26,17 +26,19 @@ out/html/index.html: manual-full.xml style.css
 	cp ./style.css out/html/style.css
 
 	mkdir -p out/html/images/callouts
-	cp "$$XSL/docbook/images/callouts/"*.gif out/html/images/callouts/
+	cp "$$XSL/docbook/images/callouts/"*.svg out/html/images/callouts/
 	chmod u+w -R out/html/images/
 
 out/epub/manual.epub: manual-full.xml
 	mkdir -p out/epub/scratch
-	xsltproc $$xsltFlags --nonet \
+	xsltproc ${xsltFlags} --nonet \
 		--output out/epub/scratch/ \
 		"$$XSL/docbook/epub/docbook.xsl" \
 		./manual-full.xml
 
-	cp "$$XSL/docbook/images/callouts/"*.gif out/epub/scratch/OEBPS
+	cp ./style.css out/epub/scratch/OEBPS
+	mkdir -p out/epub/scratch/OEBPS/images/callouts/
+	cp "$$XSL/docbook/images/callouts/"*.svg out/epub/scratch/OEBPS/images/callouts/
 	echo "application/epub+zip" > mimetype
 	zip -0Xq "out/epub/manual.epub" mimetype
 	rm mimetype

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -16,11 +16,11 @@ pkgs.stdenv.mkDerivation {
   xsltFlags = lib.concatStringsSep " " [
     "--param section.autolabel 1"
     "--param section.label.includes.component.label 1"
-    "--param html.stylesheet 'style.css'"
+    "--stringparam html.stylesheet 'style.css'"
     "--param xref.with.number.and.title 1"
     "--param toc.section.depth 3"
-    "--param admon.style ''"
-    "--param callout.graphics.extension '.gif'"
+    "--stringparam admon.style ''"
+    "--stringparam callout.graphics.extension .svg"
   ];
 
   postPatch = ''

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -16,7 +16,7 @@ pkgs.stdenv.mkDerivation {
   xsltFlags = lib.concatStringsSep " " [
     "--param section.autolabel 1"
     "--param section.label.includes.component.label 1"
-    "--stringparam html.stylesheet 'style.css'"
+    "--stringparam html.stylesheet 'style.css overrides.css'"
     "--param xref.with.number.and.title 1"
     "--param toc.section.depth 3"
     "--stringparam admon.style ''"

--- a/doc/overrides.css
+++ b/doc/overrides.css
@@ -1,0 +1,8 @@
+
+.programlisting img {
+    width: 1em;
+}
+
+.calloutlist img {
+    width: 1.5em;
+}

--- a/doc/style.css
+++ b/doc/style.css
@@ -118,15 +118,6 @@ div.example pre.programlisting
     margin: 0 0 0 0;
 }
 
-.programlisting img {
-    width: 1em;
-}
-
-
-.calloutlist img {
-    width: 1.5em;
-}
-
 /***************************************************************************
                                Notes, warnings etc:
  ***************************************************************************/

--- a/doc/style.css
+++ b/doc/style.css
@@ -29,8 +29,8 @@ h2 /* chapters, appendices, subtitle */
 }
 
 /* Extra space between chapters, appendices. */
-div.chapter > div.titlepage h2, div.appendix > div.titlepage h2 
-{ 
+div.chapter > div.titlepage h2, div.appendix > div.titlepage h2
+{
     margin-top: 1.5em;
 }
 
@@ -118,6 +118,14 @@ div.example pre.programlisting
     margin: 0 0 0 0;
 }
 
+.programlisting img {
+    width: 1em;
+}
+
+
+.calloutlist img {
+    width: 1.5em;
+}
 
 /***************************************************************************
                                Notes, warnings etc:
@@ -172,7 +180,7 @@ div.navfooter *
 
 
 /***************************************************************************
-                        Links colors and highlighting: 
+                        Links colors and highlighting:
  ***************************************************************************/
 
 a { text-decoration: none; }
@@ -209,7 +217,7 @@ tt, code
 .term
 {
     font-weight: bold;
-    
+
 }
 
 div.variablelist dd p, div.glosslist dd p


### PR DESCRIPTION
Replace the `gif` callout images with SVGs for higher quality rendering. Also works in the epub.

Note the now/before also shows some style / color changes to the text. These are _NOT_ being changed, the docs build with one style and are changed when they deploy to nixos.org.

I'll backport this too.

Now:

![](https://screenshotscdn.firefoxusercontent.com/images/dec76eb2-1eb4-409f-94b3-69204f59dc80.png)

Before:

![](https://screenshotscdn.firefoxusercontent.com/images/4f218493-cd7c-4063-afb8-020ad6056cc7.png)
