### PR TITLE
nilfs-utils: apply upstream patches to fix w/musl

### DIFF
--- a/pkgs/tools/filesystems/nilfs-utils/default.nix
+++ b/pkgs/tools/filesystems/nilfs-utils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libuuid, libselinux }:
+{ stdenv, fetchurl, fetchpatch, libuuid, libselinux }:
 let 
   sourceInfo = rec {
     version = "2.2.7";
@@ -22,6 +22,18 @@ stdenv.mkDerivation rec {
     sed -e "s@sbindir=/sbin@sbindir=$out/sbin@" -i configure
     sed -e 's@/sbin/@'"$out"'/sbin/@' -i ./lib/cleaner*.c
   '';
+
+  patches = [
+    # Fix w/musl
+    (fetchpatch {
+      url = "https://github.com/nilfs-dev/nilfs-utils/commit/115fe4b976858c487cf83065f513d8626089579a.patch";
+      sha256 = "0h89jz9l5d4rqj647ljbnv451l4ncqpsvzj0v70mn5391hfwsjlv";
+    })
+    (fetchpatch {
+      url =  "https://github.com/nilfs-dev/nilfs-utils/commit/51b32c614be9e98c32de7f531ee600ca0740946f.patch";
+      sha256 = "1ycq83c6jjy74aif47v075k5y2szzwhq6mbcrpd1z4b4i1x6yhpn";
+    })
+  ];
 
   # FIXME: https://github.com/NixOS/patchelf/pull/98 is in, but stdenv
   # still doesn't use it


### PR DESCRIPTION
Should be included in next version.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---