### PR TITLE
cquery: init at 2018-03-25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3581,6 +3581,11 @@
     github = "tnias";
     name = "Philipp Bartsch";
   };
+  tobim = {
+    email = "nix@tobim.fastmail.fm";
+    github = "tobimpub";
+    name = "Tobias Mayer";
+  };
   tohl = {
     email = "tom@logand.com";
     github = "tohl";

--- a/pkgs/development/tools/misc/cquery/default.nix
+++ b/pkgs/development/tools/misc/cquery/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub, makeWrapper
+, cmake, llvmPackages, ncurses }:
+
+let
+  src = fetchFromGitHub {
+    owner = "cquery-project";
+    repo = "cquery";
+    rev = "e45a9ebbb6d8bfaf8bf1a3135b6faa910afea37e";
+    sha256 = "049gkqbamq4r2nz9yjcwq369zrmwrikzbhfza2x2vndqzaavq5yg";
+    fetchSubmodules = true;
+  };
+
+  stdenv = llvmPackages.stdenv;
+
+in
+stdenv.mkDerivation rec {
+  name    = "cquery-${version}";
+  version = "2018-03-25";
+
+  inherit src;
+
+  nativeBuildInputs = [ cmake makeWrapper ];
+  buildInputs = with llvmPackages; [ clang clang-unwrapped llvm ncurses ];
+
+  cmakeFlags = [
+    "-DSYSTEM_CLANG=ON"
+    "-DCLANG_CXX=ON"
+  ];
+
+  postFixup = ''
+    # We need to tell cquery where to find the standard library headers.
+
+    args="\"-isystem\", \"${if (stdenv.hostPlatform.libc == "glibc") then stdenv.cc.libc.dev else stdenv.cc.libc}/include\""
+    args+=", \"-isystem\", \"${llvmPackages.libcxx}/include/c++/v1\""
+
+    wrapProgram $out/bin/cquery \
+      --add-flags "'"'--init={"extraClangArguments": ['"''${args}"']}'"'"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    pushd ${src}
+    $out/bin/cquery --ci --clang-sanity-check && \
+    $out/bin/cquery --ci --test-unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A c/c++ language server powered by libclang";
+    homepage    = https://github.com/cquery-project/cquery;
+    license     = licenses.mit;
+    platforms   = platforms.linux ++ platforms.darwin;
+    maintainers = [ maintainers.tobim ];
+  };
+}

--- a/pkgs/development/tools/misc/cquery/wrapper
+++ b/pkgs/development/tools/misc/cquery/wrapper
@@ -1,0 +1,12 @@
+#! @shell@ -e
+
+initString="--init={\"extraClangArguments\": [@standard_library_includes@"
+
+if [ "${NIX_CFLAGS_COMPILE}" != "" ]; then
+  read -a cflags_array <<< ${NIX_CFLAGS_COMPILE}
+  initString+=$(printf ', \"%s\"' "${cflags_array[@]}")
+fi
+
+initString+="]}"
+
+exec -a "$0" "@out@/bin/@wrapped@" "${initString}" "${extraFlagsArray[@]}" "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7655,6 +7655,10 @@ with pkgs;
 
   cppcheck = callPackage ../development/tools/analysis/cppcheck { };
 
+  cquery = callPackage ../development/tools/misc/cquery {
+    llvmPackages = llvmPackages_6;
+  };
+
   creduce = callPackage ../development/tools/misc/creduce {
     inherit (perlPackages) perl
       ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey;


### PR DESCRIPTION
###### Motivation for this change
Add the cquery language server

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

