### PR TITLE
usbredir: -Wno-error

### DIFF
--- a/pkgs/development/libraries/usbredir/default.nix
+++ b/pkgs/development/libraries/usbredir/default.nix
@@ -9,9 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wsnmk4wjpdhbn1zaxg6bmyxspcki2zgy0am9lk037rnl4krwzj0";
   };
 
-  # Works around bunch of "format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'uint64_t {aka long long unsigned int}'" warnings
-  NIX_CFLAGS_COMPILE = stdenv.lib.optional (!stdenv.is64bit) "-Wno-error=format"
-    ++ [ "-Wno-error=format-truncation" ]; # newly detected with gcc-7
+  NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libusb ];


### PR DESCRIPTION
Already adding two `-Wno-error` workarounds,
instead of adding another to accomodate use of `sys/cdefs.h` w/musl
simplify and don't disable warnings-are-errors altogether.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---