### PR TITLE
panopticon: init -> 0.16.0

### DIFF
--- a/pkgs/development/tools/analysis/panopticon/default.nix
+++ b/pkgs/development/tools/analysis/panopticon/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, rustPlatform, qt5, git, cmake
+, pkgconfig, makeWrapper }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "panopticon";
+  version = "unstable-20171202";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "das-labor";
+    repo = pname;
+    rev = "33ffec0d6d379d51b38d6ea00d040f54b1356ae4";
+    sha256 = "1zv87nqhrzsxx0m891df4vagzssj3kblfv9yp7j96dw0vn9950qa";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ makeWrapper ];
+  propagatedBuildInputs = with qt5; [
+     qt5.qtbase
+     qtdeclarative
+     qtsvg
+     qtquickcontrols2
+     qtgraphicaleffects
+     pkgconfig
+     git
+  ];
+
+  cargoSha256 = "02k21mh0jyc6vz52jx1qijsfk07pkdv1g2hqx7gyvmm4v10vbfna";
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/${pname} $out/bin
+    cp -R qml $out/share/${pname}
+    mv $out/bin/${pname} $out/share/${pname}
+    chmod +x $out/share/${pname}
+    makeWrapper $out/share/${pname}/${pname} $out/bin/${pname}
+     '';
+
+  meta = with stdenv.lib; {
+    description = "A libre cross-platform disassembler";
+    longDescription = ''
+      Panopticon is a cross platform disassembler for reverse
+      engineering written in Rust. It can disassemble AMD64,
+      x86, AVR and MOS 6502 instruction sets and open ELF files.
+      Panopticon comes with Qt GUI for browsing and annotating
+      control flow graphs.
+    '';
+    license = with licenses; [ gpl3 ];
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8039,6 +8039,8 @@ with pkgs;
 
   pahole = callPackage ../development/tools/misc/pahole {};
 
+  panopticon = callPackage ../development/tools/analysis/panopticon {};
+
   pants = callPackage ../development/tools/build-managers/pants {};
 
   parse-cli-bin = callPackage ../development/tools/parse-cli-bin { };


### PR DESCRIPTION
###### Motivation for this change

New, useful cross platform disassembler for reverse engineering that can disassemble AMD64, x86, AVR and MOS 6502 instruction sets and open ELF files. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

