### PR TITLE
pantheon-terminal: fixes "Using the 'memory' GSettings backend" issue

### DIFF
--- a/pkgs/desktops/pantheon/apps/pantheon-terminal/default.nix
+++ b/pkgs/desktops/pantheon/apps/pantheon-terminal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, cmake, vala_0_38, pkgconfig, glib, gtk3, granite, gnome3, libnotify, gettext, makeWrapper, gobjectIntrospection }:
+{ stdenv, fetchurl, perl, cmake, vala_0_38, pkgconfig, glib, gtk3, granite, gnome3, libnotify, gettext, wrapGAppsHook, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   majorVersion = "0.4";
@@ -9,19 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0bfrqxig26i9qhm15kk7h9lgmzgnqada5snbbwqkp0n0pnyyh4ss";
   };
 
-  preConfigure = ''
-    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${granite}/lib64/pkgconfig"
-  '';
-
-  preFixup = ''
-    for f in $out/bin/*; do
-      wrapProgram $f \
-        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$XDG_ICON_DIRS:$out/share"
-    done
-  '';
-
   nativeBuildInputs = [
-    perl cmake vala_0_38 pkgconfig makeWrapper
+    perl cmake vala_0_38 pkgconfig wrapGAppsHook
     # For setup hook
     gobjectIntrospection
   ];


### PR DESCRIPTION
###### Motivation for this change

fix annoying issue

/cc @jtojnar

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

