### PR TITLE
nixpkgs docs: syntax highlight

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -3,3 +3,4 @@
 .version
 out
 manual-full.xml
+highlightjs

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,16 +6,17 @@ all: validate out/html/index.html out/epub/manual.epub
 .PHONY: debug
 debug:
 	nix-shell --run "xmloscopy --docbook5 ./manual.xml ./manual-full.xml"
+
 .PHONY: clean
 clean:
 	rm -f ${MD_TARGETS} .version manual-full.xml
-	rm -rf ./out/
+	rm -rf ./out/ ./highlightjs
 
 .PHONY: validate
 validate: manual-full.xml
 	jing "$$RNG" manual-full.xml
 
-out/html/index.html: manual-full.xml style.css
+out/html/index.html: manual-full.xml style.css highlightjs
 	mkdir -p out/html
 	xsltproc ${xsltFlags} \
 		--nonet --xinclude \
@@ -23,12 +24,22 @@ out/html/index.html: manual-full.xml style.css
 		"$$XSL/docbook/xhtml/docbook.xsl" \
 		./manual-full.xml
 
+	mkdir -p out/html/highlightjs/
+	echo "document.onreadystatechange = function () { \
+	  var listings = document.querySelectorAll('.programlisting, .screen'); \
+	  for (i = 0; i < listings.length; ++i) { \
+	     hljs.highlightBlock(listings[i]); \
+	  } \
+	} " > out/html/highlightjs/loader.js
+
+	cp -r highlightjs out/html/
+
 	cp ./overrides.css out/html/
 	cp ./style.css out/html/style.css
 
 	mkdir -p out/html/images/callouts
 	cp "$$XSL/docbook/images/callouts/"*.svg out/html/images/callouts/
-	chmod u+w -R out/html/images/
+	chmod u+w -R out/html/
 
 out/epub/manual.epub: manual-full.xml
 	mkdir -p out/epub/scratch
@@ -46,6 +57,13 @@ out/epub/manual.epub: manual-full.xml
 	rm mimetype
 	cd "out/epub/scratch/" && zip -Xr9D "../manual.epub" *
 	rm -rf "out/epub/scratch/"
+
+highlightjs:
+	mkdir -p highlightjs
+	cp -r "$$HIGHLIGHTJS/highlight.pack.js" highlightjs/
+	cp -r "$$HIGHLIGHTJS/LICENSE" highlightjs/
+	cp -r "$$HIGHLIGHTJS/mono-blue.css" highlightjs/
+
 
 manual-full.xml: ${MD_TARGETS} .version *.xml
 	xmllint --nonet --xinclude --noxincludenode manual.xml --output manual-full.xml

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -11,12 +11,18 @@ pkgs.stdenv.mkDerivation {
 
   src = ./.;
 
+  # Hacking on these variables? Make sure to close and open
+  # nix-shell between each test, maybe even:
+  # $ nix-shell --run "make clean all"
+  # otherwise they won't reapply :)
+  HIGHLIGHTJS = pkgs.documentation-highlighter;
   XSL = "${pkgs.docbook5_xsl}/xml/xsl";
   RNG = "${pkgs.docbook5}/xml/rng/docbook/docbook.rng";
   xsltFlags = lib.concatStringsSep " " [
     "--param section.autolabel 1"
     "--param section.label.includes.component.label 1"
-    "--stringparam html.stylesheet 'style.css overrides.css'"
+    "--stringparam html.stylesheet 'style.css overrides.css highlightjs/mono-blue.css'"
+    "--stringparam html.script './highlightjs/highlight.pack.js ./highlightjs/loader.js'"
     "--param xref.with.number.and.title 1"
     "--param toc.section.depth 3"
     "--stringparam admon.style ''"

--- a/doc/style.css
+++ b/doc/style.css
@@ -104,7 +104,7 @@ pre.screen, pre.programlisting
     padding: 3px 3px;
     margin-left: 1.5em;
     margin-right: 1.5em;
-    color: #600000;
+
     background: #f4f4f8;
     font-family: monospace;
     border-radius: 0.4em;


### PR DESCRIPTION
###### Motivation for this change

 - Closes https://github.com/NixOS/nixpkgs/issues/4901
 - Supersedes https://github.com/NixOS/nixpkgs/pull/7034

![image](https://user-images.githubusercontent.com/76716/37942213-10a1e288-3140-11e8-8b45-36c686cd333d.png)


Should backport to 18.03.

I plan on merging this in 12-24hrs.