### PR TITLE
efl: patch binary to handle manual dependency on libcurl.so

### DIFF
--- a/pkgs/desktops/enlightenment/econnman.nix
+++ b/pkgs/desktops/enlightenment/econnman.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, python2Packages, dbus, curl, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, efl, python2Packages, dbus, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "econnman-${version}";
@@ -11,13 +11,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper pkgconfig python2Packages.wrapPython ];
 
-  buildInputs = [ efl python2Packages.python dbus curl ];
+  buildInputs = [ efl python2Packages.python dbus ];
 
   pythonPath = [ python2Packages.pythonefl python2Packages.dbus-python ];
 
   postInstall = ''
     wrapPythonPrograms
-    wrapProgram $out/bin/econnman-bin --prefix LD_LIBRARY_PATH : ${curl.out}/lib
   '';
 
   meta = {

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -70,6 +70,12 @@ stdenv.mkDerivation rec {
       'Cflags: -I''${includedir}/eina-1/eina'"$modules"
   '';
 
+  # EFL applications depend on libcurl, although it is linked at
+  # runtime by hand in code (it is dlopened).
+  postFixup = ''
+    patchelf --add-needed ${curl.out}/lib/libcurl.so $out/lib/libecore_con.so
+  '';
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/desktops/enlightenment/ephoto.nix
+++ b/pkgs/desktops/enlightenment/ephoto.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, pcre, curl, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, efl, pcre, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "ephoto-${version}";
@@ -11,11 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ (pkgconfig.override { vanilla = true; }) makeWrapper ];
 
-  buildInputs = [ efl pcre curl ];
-
-  postInstall = ''
-    wrapProgram $out/bin/ephoto --prefix LD_LIBRARY_PATH : ${curl.out}/lib
-  '';
+  buildInputs = [ efl pcre ];
 
   meta = {
     description = "Image viewer and editor written using the Enlightenment Foundation Libraries";

--- a/pkgs/desktops/enlightenment/rage.nix
+++ b/pkgs/desktops/enlightenment/rage.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, efl, gst_all_1, pcre, curl, wrapGAppsHook }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, efl, gst_all_1, pcre, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "rage-${version}";
@@ -24,12 +24,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-libav
     pcre
-    curl
- ];
-
-  postInstall = ''
-    wrapProgram $out/bin/rage --prefix LD_LIBRARY_PATH : ${curl.out}/lib
-  '';
+  ];
 
   meta = {
     description = "Video + Audio player along the lines of mplayer";

--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, pcre, curl, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, efl, pcre, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "terminology-${version}";
@@ -17,14 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     efl
     pcre
-    curl
   ];
-
-  postInstall = ''
-    for f in $out/bin/*; do
-      wrapProgram $f --prefix LD_LIBRARY_PATH : ${curl.out}/lib
-    done
-  '';
 
   meta = {
     description = "The best terminal emulator written with the EFL";


### PR DESCRIPTION
###### Motivation for this change

EFL has a runtime dependency on `libcurl.so` that is manually linked with dlopen, as expalined in https://github.com/NixOS/nixpkgs/pull/25412#issuecomment-316076953.

Instead of wrapping all binaries that depends on EFL so that `libcurl.so` can be found, this PR patches the EFL library itself to add `libcurl.so` as a needed library. This way all binaries with such dependency on `libcurl.so` are automatically fixed. Therefore this also fixes the issue with some binaries that has not been wrapped, like `emixer` (from enlightenment).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).