### PR TITLE
libuuid: use OSSP uuid

### DIFF
--- a/pkgs/applications/audio/lash/default.nix
+++ b/pkgs/applications/audio/lash/default.nix
@@ -1,8 +1,6 @@
 { stdenv, fetchurl, alsaLib, gtk2, libjack2, libuuid, libxml2
 , makeWrapper, pkgconfig, readline }:
 
-assert libuuid != null;
-
 stdenv.mkDerivation  rec {
   name = "lash-${version}";
   version = "0.5.4";

--- a/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
@@ -10,7 +10,7 @@ let
     [gtk2 glib stdenv.cc.cc];
 
   rpathPlugin = makeLibraryPath
-    ([ stdenv.cc.cc gtk2 glib xorg.libX11 gdk_pixbuf libXext libXfixes libXrender libXrandr libXcomposite libpulseaudio ] ++ optional (libuuid != null) libuuid);
+    ([ stdenv.cc.cc gtk2 glib xorg.libX11 gdk_pixbuf libXext libXfixes libXrender libXrandr libXcomposite libpulseaudio libuuid ];
 
 in
 

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -21,7 +21,7 @@
 , libiconv, postgresql, v8_3_16_14, clang, sqlite, zlib, imagemagick
 , pkgconfig , ncurses, xapian_1_2_22, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
 , cmake, libssh2, openssl, mysql, darwin, git, perl, pcre, gecode_3, curl
-, libmsgpack, qt48, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
+, libmsgpack, qt48, libsodium, snappy, libuuid, lxc, libpcap, xorg, gtk2, buildRubyGem
 , cairo, re2, rake, gobjectIntrospection, gdk_pixbuf
 }@args:
 
@@ -332,7 +332,7 @@ in
   };
 
   uuid4r = attrs: {
-    buildInputs = [ which libossp_uuid ];
+    buildInputs = [ which libuuid ];
   };
 
   xapian-ruby = attrs: {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, glibc, fetchurl, zlib, readline, libossp_uuid, openssl, libxml2, makeWrapper }:
+{ lib, stdenv, glibc, fetchurl, zlib, readline, libuuid, openssl, libxml2, makeWrapper }:
 
 let
 
@@ -15,8 +15,7 @@ let
     setOutputFlags = false; # $out retains configureFlags :-/
 
     buildInputs =
-      [ zlib readline openssl libxml2 makeWrapper ]
-      ++ lib.optionals (!stdenv.isDarwin) [ libossp_uuid ];
+      [ zlib readline openssl libxml2 makeWrapper libuuid ];
 
     enableParallelBuilding = true;
 
@@ -27,9 +26,8 @@ let
       "--with-libxml"
       "--sysconfdir=/etc"
       "--libdir=$(lib)/lib"
-    ]
-      ++ lib.optional (stdenv.isDarwin)  "--with-uuid=e2fs"
-      ++ lib.optional (!stdenv.isDarwin) "--with-ossp-uuid";
+      "--with-ossp-uuid"
+    ];
 
     patches =
       [ (if atLeast "9.4" then ./disable-resolve_symlinks-94.patch else ./disable-resolve_symlinks.patch)

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -122,6 +122,7 @@ mapAliases (rec {
   libgumbo = gumbo; # added 2018-01-21
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
+  libossp_uuid = libuuid; # added 2018-03-27
   libtidy = html-tidy;  # added 2014-12-21
   links = links2; # added 2016-01-31
   lttngTools = lttng-tools;  # added 2014-07-31

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13080,26 +13080,7 @@ with pkgs;
 
   fwts = callPackage ../os-specific/linux/fwts { };
 
-  libossp_uuid = callPackage ../development/libraries/libossp-uuid { };
-
-  libuuid =
-    if targetPlatform != buildPlatform && targetPlatform.config == "i586-pc-gnu"
-    then (utillinuxMinimal // {
-      crossDrv = lib.overrideDerivation utillinuxMinimal.crossDrv (args: {
-        # `libblkid' fails to build on GNU/Hurd.
-        configureFlags = args.configureFlags
-          + " --disable-libblkid --disable-mount --disable-libmount"
-          + " --disable-fsck --enable-static --disable-partx";
-        doCheck = false;
-        CPPFLAGS =                    # ugly hack for ugly software!
-          lib.concatStringsSep " "
-            (map (v: "-D${v}=4096")
-                 [ "PATH_MAX" "MAXPATHLEN" "MAXHOSTNAMELEN" ]);
-      });
-    })
-    else if stdenv.isLinux
-    then utillinuxMinimal
-    else null;
+  libuuid = callPackage ../development/libraries/libossp-uuid { };
 
   light = callPackage ../os-specific/linux/light { };
 


### PR DESCRIPTION
Old libuuid came from util-linux. I'm trying to remove it so we can
get better cross platform support. Currently waiting on build status.

This should help us support macOS better.