### PR TITLE
toxiproxy: Init at 2.1.3

### DIFF
--- a/pkgs/development/tools/toxiproxy/default.nix
+++ b/pkgs/development/tools/toxiproxy/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "toxiproxy-${version}";
+  version = "2.1.3";
+  src = fetchFromGitHub {
+    owner = "Shopify";
+    repo = "toxiproxy";
+    rev = "v${version}";
+    sha256 = "1a7yry846iwi9cs9xam2vjbw73fjy45agjrwk214k0n1ziaawz2f";
+  };
+
+  goPackagePath = "github.com/Shopify/toxiproxy";
+  subPackages = ["cmd" "cli"];
+  buildFlagsArray = "-ldflags=-X github.com/Shopify/toxiproxy.Version=v${version}";
+
+  postInstall = ''
+    mv $bin/bin/cli $bin/bin/toxiproxy-cli
+    mv $bin/bin/cmd $bin/bin/toxiproxy-cmd
+  '';
+
+  meta = {
+    description = "Proxy for for simulating network conditions.";
+    maintainers = with lib.maintainers; [ avnik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17912,6 +17912,8 @@ with pkgs;
 
   toxic = callPackage ../applications/networking/instant-messengers/toxic { };
 
+  toxiproxy = callPackage ../development/tools/toxiproxy { };
+
   tqsl = callPackage ../applications/misc/tqsl { };
 
   transcode = callPackage ../applications/audio/transcode { };


### PR DESCRIPTION
###### Motivation for this change

Testing tool, for simulate network conditions (slowdown, breakups, etc)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

