### PR TITLE
buildRustCrate: fix equality testing

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate.nix
@@ -19,7 +19,7 @@ let makeDeps = dependencies:
       echo_build_heading() {
        start=""
        end=""
-       if [[ x"${colors}" = x"always" ]]; then
+       if [[ "${colors}" == "always" ]]; then
          start="$(printf '\033[0;1;32m')" #set bold, and set green.
          end="$(printf '\033[0m')" #returns to "normal"
        fi
@@ -34,7 +34,7 @@ let makeDeps = dependencies:
       noisily() {
         start=""
         end=""
-        if [[ x"${colors}" = x"always" ]]; then
+        if [[ "${colors}" == "always" ]]; then
           start="$(printf '\033[0;1;32m')" #set bold, and set green.
           end="$(printf '\033[0m')" #returns to "normal"
         fi
@@ -194,7 +194,7 @@ let makeDeps = dependencies:
       bold=""
       green=""
       boldgreen=""
-      if [[ "${colors}" = "always" ]]; then
+      if [[ "${colors}" == "always" ]]; then
         norm="$(printf '\033[0m')" #returns to "normal"
         bold="$(printf '\033[0;1m')" #set bold
         green="$(printf '\033[0;32m')" #set green

--- a/pkgs/build-support/rust/build-rust-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate.nix
@@ -19,7 +19,7 @@ let makeDeps = dependencies:
       echo_build_heading() {
        start=""
        end=""
-       if [[ x"${colors}" -eq x"always" ]]; then
+       if [[ x"${colors}" = x"always" ]]; then
          start="$(printf '\033[0;1;32m')" #set bold, and set green.
          end="$(printf '\033[0m')" #returns to "normal"
        fi
@@ -34,7 +34,7 @@ let makeDeps = dependencies:
       noisily() {
         start=""
         end=""
-        if [[ x"${colors}" -eq x"always" ]]; then
+        if [[ x"${colors}" = x"always" ]]; then
           start="$(printf '\033[0;1;32m')" #set bold, and set green.
           end="$(printf '\033[0m')" #returns to "normal"
         fi
@@ -194,7 +194,7 @@ let makeDeps = dependencies:
       bold=""
       green=""
       boldgreen=""
-      if [[ "${colors}" -eq "always" ]]; then
+      if [[ "${colors}" = "always" ]]; then
         norm="$(printf '\033[0m')" #returns to "normal"
         bold="$(printf '\033[0;1m')" #set bold
         green="$(printf '\033[0;32m')" #set green
@@ -230,7 +230,7 @@ let makeDeps = dependencies:
           ${crateFeatures} --out-dir target/bin --emit=dep-info,link -L dependency=target/deps \
           $LINK ${deps}$EXTRA_LIB --cap-lints allow \
           $BUILD_OUT_DIR $EXTRA_BUILD $EXTRA_FEATURES --color ${colors}
-        if [ "$crate_name_" -ne "$crate_name" ]; then
+        if [ "$crate_name_" != "$crate_name" ]; then
           mv target/bin/$crate_name_ target/bin/$crate_name
         fi
       }


### PR DESCRIPTION
Use string equality instead of integer equality.

###### Motivation for this change

Compiling a crate named cargo-watch results in a binary named cargo_watch due to a script error - the logic already existed to name the binary correctly, but used the wrong comparison operator and so failed.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

