### PR TITLE
commandergenius: 1822release -> 2.2.0

### DIFF
--- a/pkgs/games/commandergenius/default.nix
+++ b/pkgs/games/commandergenius/default.nix
@@ -1,19 +1,24 @@
 { lib, stdenv, fetchFromGitHub, SDL2, SDL2_image, pkgconfig
-, libvorbis, libGL, boost, cmake }:
-
+, libvorbis, libGL, boost, cmake, zlib, curl, SDL2_mixer, python3
+}:
 
 stdenv.mkDerivation rec {
   name = "commandergenius-${version}";
-  version = "1822release";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "gerstrong";
     repo = "Commander-Genius";
     rev = "v${version}";
-    sha256 = "07vxg8p1dnnkajzs5nifxpwn4mdd1hxsw05jl25gvaimpl9p2qc8";
+    sha256 = "1hjx4j325vj1ayxi3j2dpplpd3x0iqx98gyb093ld7dfnsyilbph";
   };
 
-  buildInputs = [ SDL2 SDL2_image libGL boost libvorbis ];
+  buildInputs = [ SDL2 SDL2_image SDL2_mixer libGL boost libvorbis zlib curl python3 ];
+
+  preConfigure = ''
+    export cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_PREFIX=$out -DSHAREDIR=$out/share"
+    export makeFlags="$makeFlags DESTDIR=$(out)"
+  '';
 
   nativeBuildInputs = [ cmake pkgconfig ];
 


### PR DESCRIPTION
###### Motivation for this change

The `1822-release` build breaks on Hydra, some days ago the stable
`2.2.0` release has been tagged on upstream.

It required some new build inputs (zlib, curl, SDL2_mixer, python3) and
some minor changes in the cmakeFlags and makeFlags for the build.

See https://hydra.nixos.org/build/71818713/log
See ticket #36453 and #31747

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

