### PR TITLE
firmwareLinuxNonfree: 2018-01-04 -> 2018-03-20

### DIFF
--- a/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
@@ -2,51 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "firmware-linux-nonfree-${version}";
-  version = "2018-03-20-${src.iwlRev}";
+  version = "2018-03-20";
 
-  # The src runCommand automates the process of building a merged repository of both
-  #
-  # https://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git/
-  # https://git.kernel.org/cgit/linux/kernel/git/iwlwifi/linux-firmware.git/
-  #
-  # This gives us up to date iwlwifi firmware as well as
-  # the usual set of firmware. firmware/linux-firmware usually lags kernel releases
-  # so iwlwifi cards will fail to load on newly released kernels.
-  #
-  # To update, go to the above repositories and look for latest tags / commits, then
-  # update version to the more recent commit date
-
-  src = runCommand "firmware-linux-nonfree-src-merged-${version}" {
-    shallowSince = "2017-10-01";
-    baseRev = "44476f2465dac9c22bce90da66e86b2b56ba34f0";
-    iwlRev = "iwlwifi-fw-2018-03-02";
-
-    # When updating this, you need to let it run with a wrong hash, in order to find out the desired hash
-    # randomly mutate the hash to break out of fixed hash, when updating
-    outputHash = "1gh5a2km33jj151j3q7mgkjzzhaaxlqxbb53n4ff46q658gv0wma";
-
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-
-    # Doing the download on a remote machine just duplicates network
-    # traffic, so don't do that.
-    preferLocalBuild = true;
-
-    nativeBuildInputs = [ cacert git gnupg ];
-  } ''
-    git init src && (
-      cd src
-      git config user.email "build-daemon@nixos.org"
-      git config user.name "Nixos Build Daemon $name"
-      git remote add base https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-      git remote add iwl https://git.kernel.org/pub/scm/linux/kernel/git/iwlwifi/linux-firmware.git
-      git fetch --shallow-since=$shallowSince base
-      git fetch --shallow-since=$shallowSince iwl
-      git checkout -b work $baseRev
-      git merge $iwlRev)
-    rm -rf src/.git
-    cp -a src $out
-  '';
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git";
+    sha256 = "1gh5a2km33jj151j3q7mgkjzzhaaxlqxbb53n4ff46q658gv0wma";
+  };
 
   preInstall = ''
     mkdir -p $out

--- a/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "firmware-linux-nonfree-${version}";
-  version = "2018-01-04-${src.iwlRev}";
+  version = "2018-03-20-${src.iwlRev}";
 
   # The src runCommand automates the process of building a merged repository of both
   #
@@ -18,12 +18,12 @@ stdenv.mkDerivation rec {
 
   src = runCommand "firmware-linux-nonfree-src-merged-${version}" {
     shallowSince = "2017-10-01";
-    baseRev = "65b1c68c63f974d72610db38dfae49861117cae2";
-    iwlRev = "iwlwifi-fw-2017-11-15";
+    baseRev = "44476f2465dac9c22bce90da66e86b2b56ba34f0";
+    iwlRev = "iwlwifi-fw-2018-03-02";
 
     # When updating this, you need to let it run with a wrong hash, in order to find out the desired hash
     # randomly mutate the hash to break out of fixed hash, when updating
-    outputHash = "1anr7fblxfcrfrrgq98kzy64yrwygc2wdgi47skdmjxhi3wbrvxz";
+    outputHash = "1gh5a2km33jj151j3q7mgkjzzhaaxlqxbb53n4ff46q658gv0wma";
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";


### PR DESCRIPTION
Looking to use newer ath10k_pci firmware for my XPS 9560 laptop,
the newer firmware seems to resolve long-standing problems with
disconnects / firmeware crashing, although may require significant
testing (days, weeks) before and after to confirm.

Commit log for linux-firmware from updated revision: https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/?id=44476f2465dac9c22bce90da66e86b2b56ba34f0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Not sure what our usual policy is re:testing these firmware updates,
suggestions welcome on that front.

Probably should get at least one iwlwifi user to check things out?