### PR TITLE
parted: add missing fnctl include, fix w/musl

### DIFF
--- a/pkgs/tools/misc/parted/default.nix
+++ b/pkgs/tools/misc/parted/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, devicemapper, libuuid, gettext, readline, perl, python2
+{ stdenv, fetchurl, fetchpatch, devicemapper, libuuid, gettext, readline, perl, python2
 , utillinux, check, enableStatic ? false, hurd ? null }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "1r3qpg3bhz37mgvp9chsaa3k0csby3vayfvz8ggsqz194af5i2w5";
   };
 
-  patches = stdenv.lib.optional doCheck ./gpt-unicode-test-fix.patch;
+  patches = stdenv.lib.optional doCheck ./gpt-unicode-test-fix.patch
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl
+    (fetchpatch {
+      url = "https://git.alpinelinux.org/cgit/aports/plain/main/parted/fix-includes.patch?id=9c5cd3c329a40ba4559cc1d8c7d17a9bf95c237b";
+      sha256 = "117ypyiwvzym6pi8xmy16wa5z3sbpx7gh6haabs6kfb1x2894z7q";
+    });
 
   postPatch = stdenv.lib.optionalString doCheck ''
     patchShebangs tests
@@ -31,7 +36,7 @@ stdenv.mkDerivation rec {
 
   # Tests were previously failing due to Hydra running builds as uid 0.
   # That should hopefully be fixed now.
-  doCheck = true;
+  doCheck = !stdenv.hostPlatform.isMusl; /* translation test */
 
   preCheck =
     stdenv.lib.optionalString doCheck


### PR DESCRIPTION
Disable tests on musl, maybe fix or refine this in the future.


Depends on being able to build sytemd w/musl in order to build/test,
but fixing this is part of upstreaming fixes that make it possible
to test systemd-musl via NixOS tests.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---