### PR TITLE
slim: musl patch

### DIFF
--- a/pkgs/applications/display-managers/slim/default.nix
+++ b/pkgs/applications/display-managers/slim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, xorg, libjpeg, libpng
+{ stdenv, fetchurl, fetchpatch, cmake, pkgconfig, xorg, libjpeg, libpng
 , fontconfig, freetype, pam, dbus_libs, makeWrapper }:
 
 stdenv.mkDerivation rec {
@@ -26,7 +26,10 @@ stdenv.mkDerivation rec {
       # Allow to set logfile to a special "/dev/stderr" in order to continue
       # logging to stderr and thus to the journal.
       ./no-logfile.patch
-    ];
+    ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/musl/8eddda8072add075ebf56cf6d288bc1450d6b5f8/x11-misc/slim/files/slim-1.3.6-add-missing-libgen_h.patch";
+      sha256 = "0f82672s2r2cmdqfn2mbg3di76mbla9n0ik20p2gv4igi6p866xm";
+    });
 
   preConfigure = "substituteInPlace CMakeLists.txt --replace /lib $out/lib";
 


### PR DESCRIPTION
Add missing include on `libgen.h`, fix w/musl.

I don't think slim is still maintained,
so unlikely to see this upstreamed.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---