### PR TITLE
flow: 0.66.0 -> 0.68.0

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -1,0 +1,19 @@
+{ stdenv, jbuilder, ocaml, findlib, lwt, ppx_tools_versioned }:
+
+stdenv.mkDerivation {
+  name = "ocaml${ocaml.version}-lwt_ppx-${lwt.version}";
+
+  inherit (lwt) src;
+
+  buildInputs = [ jbuilder ocaml findlib ppx_tools_versioned ];
+
+  propagatedBuildInputs = [ lwt ];
+
+  buildPhase = "jbuilder build -p lwt_ppx";
+  installPhase = "${jbuilder.installPhase} lwt_ppx.install";
+
+  meta = {
+    description = "Ppx syntax extension for Lwt";
+    inherit (lwt.meta) license platforms homepage maintainers;
+  };
+}

--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchFromGitHub, lib, ocaml, libelf, cf-private, CoreServices,
-  findlib, camlp4, sedlex, ocamlbuild, ocaml_lwt, wtf8, dtoa }:
+  findlib, camlp4, sedlex, ocamlbuild, lwt_ppx, wtf8, dtoa }:
 
 with lib;
 
 stdenv.mkDerivation rec {
-  version = "0.66.0";
+  version = "0.68.0";
   name = "flow-${version}";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "flow";
     rev = "v${version}";
-    sha256 = "0l1sdd1n0llmz8m81vym3zhcn824sr9w46h9jpb7i7wrcm4y410d";
+    sha256 = "0wags0msk7s1z3gi6ns6d7zdpqk8wh5ryafvdyk6zwqwhaqgr5jw";
   };
 
   installPhase = ''
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    ocaml libelf findlib camlp4 sedlex ocamlbuild ocaml_lwt wtf8 dtoa
+    ocaml libelf findlib camlp4 sedlex ocamlbuild lwt_ppx wtf8 dtoa
   ] ++ optionals stdenv.isDarwin [ cf-private CoreServices ];
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7780,7 +7780,7 @@ with pkgs;
   flow = callPackage ../development/tools/analysis/flow {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     inherit (darwin) cf-private;
-    inherit (ocamlPackages) ocaml findlib camlp4 sedlex ocamlbuild ocaml_lwt
+    inherit (ocamlPackages) ocaml findlib camlp4 sedlex ocamlbuild lwt_ppx
       wtf8 dtoa;
   };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -374,6 +374,10 @@ let
 
     ocaml_lwt = if lib.versionOlder "4.02" ocaml.version then lwt3 else lwt2;
 
+    lwt_ppx = callPackage ../development/ocaml-modules/lwt/ppx.nix {
+      lwt = lwt3;
+    };
+
     lwt_react = callPackage ../development/ocaml-modules/lwt_react {
       lwt = lwt3;
     };


### PR DESCRIPTION
###### Motivation for this change

See #37729: updating `flow` needs new package `lwt_ppx`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

