### PR TITLE
Backport: godot: 2.1.4 -> 3.0 + godot_headers

### DIFF
--- a/pkgs/development/libraries/godot_headers/default.nix
+++ b/pkgs/development/libraries/godot_headers/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "godot_headers";
+  version = "2018-02-09";
+  src = fetchFromGitHub {
+    owner = "GodotNativeTools";
+    repo = "godot_headers";
+    rev = "51bca3bf5d917341f3e15076c5a9191f8a5118ae";
+    sha256 = "0z562pqm8y8wldmfiya72cvwwpvcfznpl0wypagw50v0f41ilywh";
+  };
+  buildPhase = "true";
+  installPhase = ''
+    mkdir $out
+    cp -r . $out/include
+  '';
+  meta = {
+    homepage = "https://github.com/GodotNativeTools/godot_headers/";
+    description = "Headers for the Godot API supplied by the GDNative module";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.twey ];
+  };
+}

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -1,41 +1,54 @@
-{ stdenv, fetchFromGitHub, gcc5, scons, pkgconfig, libX11, libXcursor
-, libXinerama, libXrandr, libXrender, freetype, openssl, alsaLib
-, libpulseaudio, libGLU, zlib }:
+{ stdenv, lib, fetchFromGitHub, scons, pkgconfig, libX11, libXcursor
+, libXinerama, libXrandr, libXrender, libpulseaudio ? null
+, libXi ? null, libXext, libXfixes, freetype, openssl
+, alsaLib, libGLU, zlib, yasm ? null }:
 
-stdenv.mkDerivation rec {
+let
+  options = {
+    touch = libXi != null;
+    pulseaudio = false;
+  };
+in stdenv.mkDerivation rec {
   name    = "godot-${version}";
-  version = "2.1.4";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner  = "godotengine";
     repo   = "godot";
     rev    = "${version}-stable";
-    sha256 = "0d2zczn5k7296sky5gllq55cxd586nx134y2iwjpkqqjr62g0h48";
+    sha256 = "1ca1zznb7qqn4vf2nfwb8nww5x0k8fc4lwjvgydr6nr2mn70xka4";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    gcc5 scons libX11 libXcursor libXinerama libXrandr libXrender
-    freetype openssl alsaLib libpulseaudio libGLU zlib
+    scons libX11 libXcursor libXinerama libXrandr libXrender
+    libXi libXext libXfixes freetype openssl alsaLib libpulseaudio
+    libGLU zlib yasm
   ];
 
-  patches = [ ./pkg_config_additions.patch ];
+  patches = [
+    ./pkg_config_additions.patch
+    ./dont_clobber_environment.patch
+  ];
 
   enableParallelBuilding = true;
 
   buildPhase = ''
-    scons platform=x11 prefix=$out -j $NIX_BUILD_CORES
+    scons platform=x11 prefix=$out -j $NIX_BUILD_CORES \
+      ${lib.concatStringsSep " "
+          (lib.mapAttrsToList (k: v: "${k}=${builtins.toJSON v}") options)}
   '';
 
   installPhase = ''
-    mkdir $out/bin -p
-    cp bin/godot.* $out/bin/
+    mkdir -p $out/bin
+    cp bin/godot.x11.tools.* $out/bin/godot
   '';
 
   meta = {
     homepage    = "https://godotengine.org";
     description = "Free and Open Source 2D and 3D game engine";
     license     = stdenv.lib.licenses.mit;
-    platforms   = stdenv.lib.platforms.linux;
+    platforms   = [ "i686-linux" "x86_64-linux" ];
+    maintainers = [ stdenv.lib.maintainers.twey ];
   };
 }

--- a/pkgs/development/tools/godot/dont_clobber_environment.patch
+++ b/pkgs/development/tools/godot/dont_clobber_environment.patch
@@ -1,0 +1,16 @@
++++ build/SConstruct
+@@ -69,10 +69,10 @@
+         custom_tools = ['mingw']
+ 
+ env_base = Environment(tools=custom_tools)
+-if 'TERM' in os.environ:
+-    env_base['ENV']['TERM'] = os.environ['TERM']
+-env_base.AppendENVPath('PATH', os.getenv('PATH'))
+-env_base.AppendENVPath('PKG_CONFIG_PATH', os.getenv('PKG_CONFIG_PATH'))
++for k in ("TERM", "PATH", "PKG_CONFIG_PATH"):
++    if (k in os.environ):
++        env_base["ENV"][k] = os.environ[k]
++
+ env_base.global_defaults = global_defaults
+ env_base.android_maven_repos = []
+ env_base.android_flat_dirs = []

--- a/pkgs/development/tools/godot/pkg_config_additions.patch
+++ b/pkgs/development/tools/godot/pkg_config_additions.patch
@@ -1,12 +1,13 @@
-+++ build/platform/x11/detect.py
-@@ -139,6 +139,10 @@
-     env.ParseConfig('pkg-config xinerama --cflags --libs')
++++ b/platform/x11/detect.py
+@@ -142,6 +142,11 @@
      env.ParseConfig('pkg-config xcursor --cflags --libs')
+     env.ParseConfig('pkg-config xinerama --cflags --libs')
      env.ParseConfig('pkg-config xrandr --cflags --libs')
 +    env.ParseConfig('pkg-config xrender --cflags --libs')
-+    env.ParseConfig('pkg-config oslibGLU_combined --cflags')
++    env.ParseConfig('pkg-config xext --cflags --libs')
++    env.ParseConfig('pkg-config xfixes --cflags --libs')
 +    env.ParseConfig('pkg-config glu --cflags --libs')
 +    env.ParseConfig('pkg-config zlib --cflags --libs')
-
-     if (env['builtin_openssl'] == 'no'):
-         # Currently not compatible with OpenSSL 1.1.0+
+ 
+     if (env['touch']):
+         x11_error = os.system("pkg-config xi --modversion > /dev/null ")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2551,6 +2551,7 @@ with pkgs;
   gocryptfs = callPackage ../tools/filesystems/gocrypfs { };
 
   godot = callPackage ../development/tools/godot {};
+  godot_headers = callPackage ../development/libraries/godot_headers {};
 
   goklp = callPackage ../tools/networking/goklp {};
 


### PR DESCRIPTION
godot: 2.1.4 -> 3.0 + godot_headers
(cherry picked from commit 048724c4affebacbc4bd40d1a667ba6a7551fdd0)

###### Motivation for this change
I missed that this was flagged for inclusion in 18.03 in #36453 

###### Things done
Cherried the merge