### PR TITLE
Backport: opal: build with gcc6

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10764,6 +10764,7 @@ with pkgs;
 
   opal = callPackage ../development/libraries/opal {
     ffmpeg = ffmpeg_2;
+    stdenv = overrideCC stdenv gcc6;
   };
 
   openh264 = callPackage ../development/libraries/openh264 { };


### PR DESCRIPTION
(cherry picked from commit 6a589dea596a55802e14a71eed17e1d457923e6f)

###### Motivation for this change
ZHF #36453

