### PR TITLE
{erlang,elixir}/generic-builder: /bin/sh fixes

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -35,6 +35,10 @@ in
       then "ERL_COMPILER_OPTIONS=debug_info"
       else "";
 
+    preConfigure = ''
+      patchShebangs bin/elixir
+    '';
+
     preBuild = ''
       # The build process uses ./rebar. Link it to the nixpkgs rebar
       rm -v rebar

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -66,6 +66,8 @@ in stdenv.mkDerivation ({
 
   postPatch = ''
     patchShebangs make
+    substituteInPlace erts/etc/unix/Install.src  \
+      --replace "#!/bin/sh" "#!${stdenv.shell}"
 
     ${postPatch}
   '';


### PR DESCRIPTION
###### Motivation for this change

See commit messages.

- #36853
- #36823
- #37638

I would propose backporting to 18.03.

---
- [x] ran nox-review with `nixStable2` obtained from nixpkgs @ 
c5f141ff7a6403ca8abc3fcff90f13a8fe164fe4 (from before backports of `/bin/sh` fixes).
---

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

