### PR TITLE
[18.03] openssl{,1_1_0} update (1.0.2o, 1.1.0h)

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -113,8 +113,8 @@ let
 in {
 
   openssl_1_0_2 = common {
-    version = "1.0.2n";
-    sha256 = "1zm82pyq5a9jm10q6iv7d3dih3xwjds4x30fqph3k317byvsn2rp";
+    version = "1.0.2o";
+    sha256 = "0kcy13l701054nhpbd901mz32v1kn4g311z0nifd83xs2jbmqgzc";
   };
 
   openssl_1_1_0 = common {

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -118,15 +118,8 @@ in {
   };
 
   openssl_1_1_0 = common {
-    version = "1.1.0g";
-    sha256 = "1bvka2wf33w2vxv7yw578nnjqyhz2b3chvfb0l4k2ffscw950kfy";
-    patches = [
-      (fetchpatch {
-        name = "CVE-2017-3738.patch";
-        url = "https://github.com/openssl/openssl/commit/563066.patch";
-        sha256 = "0ni9fwpxf8raw8b58pfa15akbqmxx4q64v0ldsm4b9dqhbxf8mkz";
-      })
-    ];
+    version = "1.1.0h";
+    sha256 = "05x509lccqjscgyi935z809pwfm708islypwhmjnb6cyvrn64daq";
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Updating openssl to the latest (known secure) version.

See https://www.openssl.org/news/secadv/20180327.txt.

This is a backport of #37931.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

