### PR TITLE
pythonPackages.mrbob: fix build

### DIFF
--- a/pkgs/development/python-modules/mrbob/default.nix
+++ b/pkgs/development/python-modules/mrbob/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage, stdenv, glibcLocales, mock, nose, isPy3k, argparse, jinja2, six
+, fetchPypi, lib
+}:
+
+buildPythonPackage rec {
+  pname = "mrbob";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6737eaf98aaeae85e07ebef844ee5156df2f06a8b28d7c3dcb056f811c588121";
+  };
+
+  disabled = isPy3k;
+
+  checkInputs = [ nose glibcLocales mock ];
+  checkPhase = ''
+    LC_ALL="en_US.UTF-8" nosetests
+  '';
+
+  propagatedBuildInputs = [ argparse jinja2 six ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/domenkozar/mr.bob;
+    description = "A tool to generate code skeletons from templates";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9837,30 +9837,7 @@ in {
 
   };
 
-
-  mrbob = buildPythonPackage rec {
-    name = "mrbob-${version}";
-    version = "0.1.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/m/mr.bob/mr.bob-${version}.tar.gz";
-      sha256 = "6737eaf98aaeae85e07ebef844ee5156df2f06a8b28d7c3dcb056f811c588121";
-    };
-
-    buildInputs = [ pkgs.glibcLocales self.mock ];
-
-    disabled = isPy3k;
-
-    LC_ALL="en_US.UTF-8";
-
-    propagatedBuildInputs = with self; [ argparse jinja2 six ] ++
-                            (optionals isPy26 [ importlib ordereddict ]);
-
-    meta = {
-      homepage = https://github.com/domenkozar/mr.bob.git;
-      description = "A tool to generate code skeletons from templates";
-    };
-  };
+  mrbob = callPackage ../development/python-modules/mrbob {};
 
   msgpack = callPackage ../development/python-modules/msgpack {};
 


### PR DESCRIPTION
###### Motivation for this change

Tests broke on Hydra as the `checkPhase` wasn't configured properly. By
explicitly relying on `nosetests` and injecting `LC_ALL` into the
`checkPhase` the tests work again.

The license (bsd3) according to `LICENSE` distributed with the upstream
package wasn't specified in the meta section which could've caused legal
issues.

The expression has been moved into its own file to reduce the length and
complexity of `pkgs/top-level/python-packages.nix`.

See https://hydra.nixos.org/build/70689499/log
See #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

