### PR TITLE
svn-all-fast-export: update patch

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -117,11 +117,14 @@ rec {
     git = gitSVN;
   };
 
-  svn_all_fast_export = libsForQt5.callPackage ./svn-all-fast-export { };
+  svn-all-fast-export = libsForQt5.callPackage ./svn-all-fast-export { };
 
   tig = callPackage ./tig { };
 
   topGit = callPackage ./topgit { };
 
   transcrypt = callPackage ./transcrypt { };
+
+  # aliases
+  svn_all_fast_export = svn-all-fast-export;
 }

--- a/pkgs/applications/version-management/git-and-tools/svn-all-fast-export/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/svn-all-fast-export/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
   patches = [
     (fetchpatch {
       name = "pr40.patch";
-      sha256 = "1qndhk5csf7kddk3giailx7r0cdipq46lj73nkcws43n4n93synk";
-      url = https://github.com/svn-all-fast-export/svn2git/pull/40.diff;
+      sha256 = "0mwncklzncsifql9zlxlbj3clsif5p2v1xs8nmxrw44mqvaysjw3";
+      url = https://github.com/svn-all-fast-export/svn2git/compare/f00d5a5...flokli:nixos-20180326.patch;
     })
   ];
 
@@ -30,8 +30,6 @@ stdenv.mkDerivation {
     "APR_INCLUDE=${apr.dev}/include/apr-1"
     "SVN_INCLUDE=${subversion.dev}/include/subversion-1"
   ];
-
-  installPhase = "make install INSTALL_ROOT=$out";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/svn-all-fast-export/svn2git;


### PR DESCRIPTION
also, rename to svn-all-fast-export, but keep an alias to the old name

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

