### PR TITLE
pythonPackage.nipype: fix build

### DIFF
--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -36,6 +36,9 @@ buildPythonPackage rec {
     sha256 = "47f62fda3d6b9a37aa407a6b78c80e91240aa71e61191ed00da68b02839fe258";
   };
 
+  # see https://github.com/nipy/nipype/issues/2240
+  patches = [ ./prov-version.patch ];
+
   doCheck = false;  # fails with TypeError: None is not callable
   checkInputs = [ which ];
   buildInputs = [ pytest mock ];  # required in installPhase

--- a/pkgs/development/python-modules/nipype/prov-version.patch
+++ b/pkgs/development/python-modules/nipype/prov-version.patch
@@ -1,0 +1,21 @@
+diff --git a/nipype/info.py b/nipype/info.py
+index 1daa382e2..da338d0ea 100644
+--- a/nipype/info.py
++++ b/nipype/info.py
+@@ -108,7 +108,6 @@ DATEUTIL_MIN_VERSION = '2.2'
+ PYTEST_MIN_VERSION = '3.0'
+ FUTURE_MIN_VERSION = '0.16.0'
+ SIMPLEJSON_MIN_VERSION = '3.8.0'
+-PROV_VERSION = '1.5.0'
+ CLICK_MIN_VERSION = '6.6.0'
+ PYDOT_MIN_VERSION = '1.2.3'
+ 
+@@ -140,7 +139,7 @@ REQUIRES = [
+     'traits>=%s' % TRAITS_MIN_VERSION,
+     'future>=%s' % FUTURE_MIN_VERSION,
+     'simplejson>=%s' % SIMPLEJSON_MIN_VERSION,
+-    'prov==%s' % PROV_VERSION,
++    'prov<2',
+     'click>=%s' % CLICK_MIN_VERSION,
+     'funcsigs',
+     'pytest>=%s' % PYTEST_MIN_VERSION,


### PR DESCRIPTION
###### Motivation for this change

`pythonPackages.prov` has been bumped to `1.5.2`, however `nipype`
pinned `prov` to `1.5.0`. Patching `nipype/info.py` fixes this issue by
bumping to the current `prov` version in nixpkgs.

See https://hydra.nixos.org/build/71817962/log
See ticket #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

