### PR TITLE
nixos/version: fix nixops pre 1.6 compatibility

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -16,6 +16,21 @@ in
 
   options.system = {
 
+    # XXX: Reintroduce old options to make nixops before 1.6 able to evaluate configurations
+    # XXX: Remove after nixops has been bumped to a compatible version
+    nixosVersion = mkOption {
+      readOnly = true;
+      internal = true;
+      type = types.str;
+      default = config.system.nixos.version;
+    };
+    nixosVersionSuffix = mkOption {
+      readOnly = true;
+      internal = true;
+      type = types.str;
+      default = config.system.nixos.versionSuffix;
+    };
+
     nixos.version = mkOption {
       internal = true;
       type = types.str;

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -196,9 +196,9 @@ with lib;
     (mkRenamedOptionModule [ "virtualization" "growPartition" ] [ "boot" "growPartition" ])
 
     # misc/version.nix
-    (mkRenamedOptionModule [ "config" "system" "nixosVersion" ] [ "config" "system" "nixos" "version" ])
+    #(mkRenamedOptionModule [ "config" "system" "nixosVersion" ] [ "config" "system" "nixos" "version" ])
     (mkRenamedOptionModule [ "config" "system" "nixosRelease" ] [ "config" "system" "nixos" "release" ])
-    (mkRenamedOptionModule [ "config" "system" "nixosVersionSuffix" ] [ "config" "system" "nixos" "versionSuffix" ])
+    #(mkRenamedOptionModule [ "config" "system" "nixosVersionSuffix" ] [ "config" "system" "nixos" "versionSuffix" ])
     (mkRenamedOptionModule [ "config" "system" "nixosRevision" ] [ "config" "system" "nixos" "revision" ])
     (mkRenamedOptionModule [ "config" "system" "nixosCodeName" ] [ "config" "system" "nixos" "codeName" ])
     (mkRenamedOptionModule [ "config" "system" "nixosLabel" ] [ "config" "system" "nixos" "label" ])


### PR DESCRIPTION
We should be able to deploy a NixOS 18.03 system with the current nixops stable release. Some options were renamed, so instead of `mkRenamedOptionModule` we introduce them as read-only interal options that won't be rendered in the manual.

Only the options that are needed to make nixops evaluations succeed were added.

This commit should probably be reverted after or before the 18.09 release, depending on the nixops 1.6 release.

The user will not get the warning that these have been renamed but this change is mentioned in the release notes.

Fixes #34253.

cc @vcunat 