### PR TITLE
tachyon: 0.98.9 -> 0.99b2

### DIFF
--- a/pkgs/development/libraries/tachyon/default.nix
+++ b/pkgs/development/libraries/tachyon/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl}:
 stdenv.mkDerivation rec {
   name = "tachyon-${version}";
-  version = "0.98.9";
+  version = "0.99b2";
   src = fetchurl {
     url = "http://jedi.ks.uiuc.edu/~johns/tachyon/files/${version}/${name}.tar.gz";
-    sha256 = "1ms0xr4ibrzz291ibm265lyjrdjrmhfrx0a70hwykhsdxn6jk8y6";
+    sha256 = "04m0bniszyg7ryknj8laj3rl5sspacw5nr45x59j2swcsxmdvn1v";
   };
   buildInputs = [];
   preBuild = "cd unix";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/tachyon/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/xpwz7yb6jqisimg2rw0xn5zh8n8i89fb-tachyon-0.99b2/bin/tachyon help` got 0 exit code
- directory tree listing: https://gist.github.com/755515ff78d7dad0ef3e73cb3333c2d4

cc @7c6f434c for review