### PR TITLE
telepathy-gabble: 0.18.3 -> 0.18.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
@@ -2,11 +2,11 @@
 , sqlite, libsoup, libnice, gnutls}:
 
 stdenv.mkDerivation rec {
-  name = "telepathy-gabble-0.18.3";
+  name = "telepathy-gabble-0.18.4";
 
   src = fetchurl {
     url = "http://telepathy.freedesktop.org/releases/telepathy-gabble/${name}.tar.gz";
-    sha256 = "1hl9k6jwn2afwwv7br16wfw5szdhwxqziba47xd8vjwvgrh19iwf";
+    sha256 = "174nlkqm055vrhv11gy73m20jbsggcb0ddi51c7s9m3j5ibr2p0i";
   };
 
   nativeBuildInputs = [ pkgconfig libxslt ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/telepathy-gabble/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.18.4 with grep in /nix/store/pg936ixgiw96xqsrdzbwc1civylmy1q5-telepathy-gabble-0.18.4
- found 0.18.4 in filename of file in /nix/store/pg936ixgiw96xqsrdzbwc1civylmy1q5-telepathy-gabble-0.18.4
- directory tree listing: https://gist.github.com/92190024cdfe17a3e79730f988d904f6