### PR TITLE
[17.09] firefox{,-bin,-esr} updates for MFSA2018-10

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,975 +1,975 @@
 {
-  version = "59.0.1";
+  version = "59.0.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ach/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ach/firefox-59.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "b982f2bd54312d66b7a1d6d6e775bad21eb1bce3bbe161cf980d03e55d4bfb5eaa217b05c16c72cd55165cdf7ee409c2e0a56143a82374f66c67609fed1464ae";
+      sha512 = "6242d81b96456c52a25af82049ffae548f7b5e14e47e2e643cea94f338e10027270d67b13c27a4a77fddc378b1e0869b5a0f897b9b269fecbe1d55336dfa4718";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/af/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/af/firefox-59.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "fbafd3dcfc473b7ebc0d6230cff487819c37b6f41135060cceca72e8704afa147edf71405c1367137bab6c8013fdd98ad487bd7039a291f64b0b37eb468d5b18";
+      sha512 = "e2aa156326a38c4ac55b4ebcbcd460ce64d5e9abc210bd53d484cb97bded59bd73045fb7b3099ff3301f0262938ce8b4b90f5b0f807f73d9b7637a826a5055d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/an/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/an/firefox-59.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "b7cf1261c2e776874ecb7c709d82f288e74d16770acd3215fbdcf44f6167544e626c1f809e4d68dac7a040e0dacba0095d24c1994fe329e5613c7a561ad652f2";
+      sha512 = "2946fdb675ac86e32e91b3a6cf4c26d14a5c977f22a587315a1c5a03db69f84efcd5057d7bd7f8b37e7433f53d915e9e9e5ab0c9d35739ce82e1c3183b1c4d5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ar/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ar/firefox-59.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "16e308336b1ea37bc7aa18184e30eee4f1a073bc1dfe009c515a338f6412de6ad19ce96653cd58aa99d4ca34476e16693c03b01b7d5b1df3154ecab58fca157b";
+      sha512 = "2d497f930358fdd36ae5e708bd73e151461497f8715b11efd5a2b6c23b71fbf985faeeb2bfa5cc2816982e81f27091705f849923cb724078764b50fa684374f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/as/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/as/firefox-59.0.2.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "a6de3e421126adf95a02911db3140791c5a5dc9030e63327fbafd5fa3f5d6d81f4d62fa705c84a573788840e921ea1ab71e52d08df443405a6c8b2e69773e76b";
+      sha512 = "a1d51a99f8a5b47668c74414372d11120160f264762a3bfb988be2aaeb958ad5d3897472618a86a4a8422850c46f2895cf426fe9d064938c263bca96a9592eb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ast/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ast/firefox-59.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "2bd15deae2a01d09a622df87ce5329adb5d5da2e76dce678aaee202eec2a7ddd0ae79de205d3dabbcd189fbd3aa5293ee551c31bb3850b3cd7e5c02d73862548";
+      sha512 = "dcd450fb49cce376f27e8135f8c27400af1c2cf139120602c000091231703db2cac791c82de157c9335fb09050cd4e4ee6013da3068b1527dcd9e0aedda16c5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/az/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/az/firefox-59.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "ba021c1531fbcc1c7f4b44f798d0046c39b2578fb4fa8f81927f7a4bb3a3e8b3d7de545bb2d818cfe1c095cb4387477d05541b5e5021c56086a700e8cf928b64";
+      sha512 = "fb004315a6ad15cc9ccb6d3b36901c4c495ea21fe146df3869711fc7ae8fb625a109fc416079e85163e79524bb987b366b2d057cd0808d0dfc61f78910fbef96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/be/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/be/firefox-59.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "ba5ac2b182f9534825468829b62359f5c24a2cfcfc0e27ff47469b814f746240155ceb228bb7fdf1855e378048806b70106bc0a3999b0cc2d4f69b28f7565784";
+      sha512 = "ba51003823e74734726f655cfd20fe968ebe5feacd0c985f7c8b2cf9766d7b68fe74dafc8baa0605b8fb46b22312a593218c5a57fdfabddea6a51491de74cc13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/bg/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/bg/firefox-59.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "a1aff58b327ffa5dc62975e31e59306350bc8b4a2b38e5993aea4ca70fd4c0e295b7e25a8deafc9d354fc674d8c55ae917a110bfa832f54fd0067f4e2f35dd71";
+      sha512 = "f9df1a70c569f853b94c912d8cdbc7cf98a57eda9d461777f9f94c776f4db0a70b6093478ae1e7c87e80f37cfc5a39af3d2b37897ca60496f0d00ac9b45c1713";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/bn-BD/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/bn-BD/firefox-59.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "fe96f073482488f66f0b7a46852d763212e444c80cba0f495e275b4c73711374949d742bd8ca0c69cb9e662e71b13b28084c004b3530f702445796d7c1716f0d";
+      sha512 = "85758a1ac327b067a59358d3faa0663244a24a4769ac0dfe03bf9dddd5a680503ea4bc9313294d9771bc7e4f3341904c68e0059d912b563aba8061dd0b6cc793";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/bn-IN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/bn-IN/firefox-59.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "31d8f589ec72a8ff3315fec3bcf9894ff6590768f2c380313c38efa2106bbc71bd11d54b553eca568cee0a7768f0e57b3ef8038d14ae2615fa1160145b123cb0";
+      sha512 = "895d63b62be42947e955ce426e03f7f8cbf8333d77fd3ff4ca6623db18cc740fb1ea6c41aefbc75aa79d60fca2f00b75f1b2e6b5b0bb1ddcec61f9c0772dedfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/br/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/br/firefox-59.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "7ed8310521f981a4ff75037198a9bcde4fa07077c298c43f5baf532e84be017d604d27d59ae38c10d0c422a1cc793652c148e7c3944171044f4e9f267b64993b";
+      sha512 = "e62f445437a07f9fa070335328064355715d2e5ef81e5572f04a8644f47dd1c8cf8a3a7ac6fa88038c4e996229ab695e692aa1c0b0b3becf214579aaa76a5569";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/bs/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/bs/firefox-59.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "7ce16040b19d61d39936fd220351d6dce0210aa0edc0494d1956d1f19d7e027cb2d8d100940bbc34a77f05d305a5af3708d16bc78bd9b2364407bdb71ff05052";
+      sha512 = "d3adea6061daa0fd54d5cd7d9d8a00f8b88db8ed36545f9fcaee7520c1cfe58534d1fb57e8297fdc8b4f348bd6c728891f6a88f1d4d36f59a7f2ffbe0e4eb229";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ca/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ca/firefox-59.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "8f8ec749c55c4dd930d3e359b9a3003edddfb6ca36f6f65f0119d0049b09a4c3cbaf558178a327583769fafa2d64272099882833e2ef7d6956b606c05f8a6b76";
+      sha512 = "5bab1fe909680ff6eacf8fadc9aba7786d801379a2e79e5da04e973a3a218de8807c3d08f7641be554fd49c592028949e30b262fcda52413303d9044e161a60e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/cak/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/cak/firefox-59.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "41f6ae5d0aa44b90724e578d51ad7a3d6903dd74d30957a8786cddbd3ae427da0a453c1504a11ff13ab9dbb350829c1928d27ca0ec67e94995346e1414109e26";
+      sha512 = "f54a09501c7311890542d91b0ec96dfa5cb634685af4ef0fcc69e633157183f0c5ef906a205fadba6e132c9ee657f7161879a83ea382bbe400694e92c065de64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/cs/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/cs/firefox-59.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "e219ec91c7346a72b64503f89088554f8d322968fbed0ff764d90df53fac06d4febf407773192530ad98d6c51dea23fb7c5f07e2b9099c736759a3b60b8b0a48";
+      sha512 = "28f17b2ef72356a058976da30960af1c8d4f2a02a946aec57b3671d71887573a98375eecca4a2f0f21b37bcbe0dd189ce4ee17ccb9af8fc60d63e9bd20ca44b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/cy/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/cy/firefox-59.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "c6650b47193449b28e1d9f6420b59c1235986ececcf724234e26fd8168f52120274d3d8acd8aba036c494393eb635c0ccd68833a1961a36a10b04b1a1050bd7a";
+      sha512 = "36c8a1ac125a55db15d0bf7c8d8fed1ca3b0031a9421437b683adf7691fca281a499af6812cccd608e65bbcda3e1e94469b16ead2a9093708c8c2daf4ea7d588";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/da/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/da/firefox-59.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "b66299d7f65fdde01b644a21524635806c703df27cb4eff928189d65285f12140926e8d20d1f83b54263b8b17b7621034ac1da5867fd28d36b2733212c9b65ab";
+      sha512 = "fd8c669362fcf945b6280d103d1b9524741993db8d38b78e494ae14106309999d09f4b13d55b8521612cac9e5dad622ef361fa16f197389405ff620b3eeac467";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/de/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/de/firefox-59.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "463ebdafacbe1eb4d0df9d4843ceb41849fc2680404e1e5f4af563bcd4fc4410f8cb212a396ccfca874c37a4cb245bfef8de4aa9620d3e30908f1c94d262cf71";
+      sha512 = "32cbc3d054628a11959ccc7b553fdcf98f863a86373307bf8f558a78482de0161e533b71cbfc03142b0ac7aded506e53e821213e42c574d28132fd2f98a753e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/dsb/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/dsb/firefox-59.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "947dbe47ad286c57a62557532232a5e833cc6f7b6295699415c727bc30cd1cd67074a568c1f842e3e7b95460595b16b0a9c87e94f38a37f22b5e8db82a3a4932";
+      sha512 = "4e7c2f6b980dd4872850f7dfcc068c7e40a8bc896e27ede759029bf0324e1189e605ffdd2291d2e6a4a0c61e56bff6cd760b77e232209127e9a90a38b012e4fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/el/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/el/firefox-59.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "b0d5015676280816cde17b217e078c8b912aaa87167317393c0c20b8ebb27460ead4a4656587bda19b93fcf4362e07ce11a0f5410cee733ab44bc2b1f0a1f093";
+      sha512 = "ecf743c23ef70e92e1f7ddfd2f1862b5b60b446f0e1020778a79ec11af94ce5f03ffea9b0b7048a7ee0861602d5c32f4f4bc8cd4b7171ae306987e1ca9993ddf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/en-GB/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/en-GB/firefox-59.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "94864d56052d619d495c527af0941979470a3c7410e51c01e5a04be565a62a29a6055eaaa9f5b4bd6b443fb87702f52c935b3071b4ddccaf97a494fc2256728f";
+      sha512 = "ddec1dfcf976f93d1eb310ccacd9e04dac8e0b075d37b54be1402531d12c11ee9dce2be7d0bfa92c9b654192c71781fd2631cad24c8153275e786552b9ab11e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/en-US/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "ef8c7518bc9abd2f730efa428ccc418410c7c571b32c06633ecf82c949aeb3e4006d888362ab511d55db98ee2d6e152f9ed7cecdd976272c89f8cc5957c9132e";
+      sha512 = "3257084102282621f15207af04e6dcbb98887b13a8be911069572c151d8ad96f90e7c083e571b4ecd4d4d4ff3bfeee1dc539042d8e5bc6a0fbd7f36c427da402";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/en-ZA/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/en-ZA/firefox-59.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "7e172fd957b000d77e4ff832ebbbf6b46a192668289394370ec95f12e5f319cee59da140bb3a809bcb7e161349c32f682083e7639bfb3f6fa5cab53ac4f33716";
+      sha512 = "35d2f29daddfb6ba439b160644869bf806ce7a2e36c26d4dc9ef2ff2eb5079e0bda9095edd727fca9c64c3be5a5646e56892bd7ff76b2c67300c1ec7f074d98f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/eo/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/eo/firefox-59.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "369e76a861625bc9e757980c896fbd1563e5127ce770557aa7e81cd80040146af62c526ab148168b2a078a9c16432e97e96ca4fffa5db5945c3475353cfc894f";
+      sha512 = "867ac54d47f2266ad357d1666c9206c00e45d7184f6b3a0199c2474b63829ad1d41e95491d2c977885e878d36e2d7e93d215c53e629886e7cb04abc198a06e42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/es-AR/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/es-AR/firefox-59.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "a053bba1fb77617ccd9b2bb1595ebaf040760307dedc9984d3ccf5212f572835f9463611f38bce684e71728b04c4d3e484cbe6c20875b0703d39c3fdcddc6cec";
+      sha512 = "3d577099cb28dd4c4d1349141a715783215510d015f7b2b02739d530222ece5229ab3e6cfe481be4e9d1d17c40aaacac10af9d9c2be37f7956620924e56c87e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/es-CL/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/es-CL/firefox-59.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "618eb3fef5f3669bc104ba60b76cf280503bbb4f2700341e95a6024fb3113c56388fcfeca294e3fffa3af5db15d639c0e7613397505c63509d7f248e7a1825e2";
+      sha512 = "821738beffdb260b6b3d8b5c3a1395b6b7d58db6b05a744899c0eb83a291855152f5055c3ca6d9a460bd032d5e72829198cb72dedfcf6614aafe1d7b8189dc26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/es-ES/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/es-ES/firefox-59.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "f8fa78438bf7561d422d9187b16c1284df2a79c6f8cfdbdcd838501b5f2fca1d2e05bfad6d59b9484f46e4dabd2630706a8c47f3323534e24ef4c8fbc4937a56";
+      sha512 = "10ae818fd27acc38a5386d06cd7d890d4eaa44407fe6334b81cdbe3f43ded90be72e749f075e165105e9a6f02e08014aabd7cd783860d6790b67eb2889718e5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/es-MX/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/es-MX/firefox-59.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "4dfc8c70cfd5eca191ed4feaaf8c4dcf2dadfd7226f1ebd939997e8bdcd7d867afe0c27a51cf5d578c380665023770b2e54110dc2af78ca63a2a38165d879665";
+      sha512 = "239d3c287eeface29994c8c2bb9bacd739d638cb277e18e57dc729e35cc0c11f6c7168673c110206f3e931c850bfebaf1a26d4f690d8f3ff6f85a61147522941";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/et/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/et/firefox-59.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "9710192f0c87ebbbd68bf336f1560007a86f9c9d55ee3df7311725f7c81e1415f5d5346378fc86424cf1d94e51efcaf791318f040c3652132dacce59a8c2668b";
+      sha512 = "824b63c3c596191f1f1c60734bbed70058cb9bf71959dbba759a2b2e75a76d0b0c50ead203c093d568a18bb622372ae112ac22da0a33e4cfe89e5a42d7329b04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/eu/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/eu/firefox-59.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "47a76627b97b2190f532ac82a6684787a6cd45f4f831b2af6315e6242367af68f84be7965cb6d91df89d8e43d04655c0e41231eff0b86cf329ffff5b26a56dc4";
+      sha512 = "01e0991d3a1926f41708353bd98e3aa00d3cc71dc7635b9cce52c3699aa5ee670818db76e9d82de4afce338165fa01bb0e88c3e8b86ab2d92d1b8d3845183510";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/fa/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/fa/firefox-59.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "3a888e43b737998938a624003c6eca6362aad95d0e13203d655d67c4b76c69484240da43d00e24a809e1fa40b18249c9549d52794f9cd92469a028ddb4b585ec";
+      sha512 = "726100abc12832418c5cdc15b9e9083d88d72a70a0f6a1a567ce781173a554cc4495da0e53539185e6ec27143bae98e952a5002dea91fceaa5f8d8e51b6d6a2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ff/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ff/firefox-59.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "365b907bb5d720874d206cc2fd3e6f21095ea1681a0bff5ffe51b49135bb3b3984e5cbb0a50951afc5bab3ef2bd2ea55af29912d25dba8f4680bf6bc25f24b05";
+      sha512 = "1a0d97e27008ff5f3bf3fe85cb14c303320a3015cf928b2ea4c2e115a5a1cfd809743d801157f53d6ffdfcc359c3738f2e2a0e12e5ca7ac8e3f2b93253654e8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/fi/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/fi/firefox-59.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "9361b0554f221e13c4146f9eb0df4af64625062a368ff828d80350e932ef0bf6f9cd87e3399bdb42ca5e7ca0dfaec9357d57a345a978ff936958ddd074ac6c67";
+      sha512 = "ba0278c06463d0ef44308f46326a3fb9dfc0cc4243086dd9acb856e54465ad672bcfac68afd9ff81d08a1d0c924a044e0ac5afb299be9d06b657c159f6c8ceec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/fr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/fr/firefox-59.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "61123f188e491c32e9b912026554afee17d83ed8bb3480bc6ed8f10f46049e81f2444f6850c5a9f7841f9e897311ac0955105401fd2661ee703243c6e204fd60";
+      sha512 = "bd8ca7884937574f0d6b4dc5399771135778aef06bd09aac275ca11c2a8dff580be45ffbea5ceb58f8baa7d7007587aa07c3ddedd407f0852c1a3940e7ccfc8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/fy-NL/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/fy-NL/firefox-59.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "4575949552f1e0951d75b2f3eae5a6ea5fbbc6b69f0ba5d82b69922209a46b8f9701112cd1dd61b6c892eb1f4e6463e28874f3f84891e3eca3de0b52036ad429";
+      sha512 = "9e5fa467a99cd7a9ab102eb2a50ef14a4402d03ad3dec5b6d511c7da3843e779b1492b1ba22cc72f83070ff88353ffdbf1a9d26636462c0e3bdaa6dccd6a6200";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ga-IE/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ga-IE/firefox-59.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "4a05d48803502ee435ea3b50f38ed262aa57048b0f013c7165af37ad44494a1aae7f643e14d5aaaf7a2d5a1085a67a078e70ade9e614bfe33295351686661ccd";
+      sha512 = "1226faa2c14196824f31da863aca7d076972a47d71a971847c09c66d268d07a9aa2677fa0a7e8f11f149b77261636d62c39e7a382db3abb2917bbbac74330d45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/gd/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/gd/firefox-59.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "df9dcc72aacd44ecf73f0ddc34a6d97dafc9deddb35075273c2b958b2c23ce3a346433b050766f8b83040c495c2a84b454cd7742cdf6b59b69894a94553c21c0";
+      sha512 = "eb0dd803b7ba91574a044503d2edbf633e08c834f8eaa5e546975d91ac7254b3fd4357710fe4627d742a2ea3e64f568a5ef1a893363c516f958e4a153f528f12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/gl/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/gl/firefox-59.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "3f55336a02249aa06674adbe8f378ad2b1a7b99164608f04cefe8c642ecffd336f9f370fcc190debeb89f97f630032d41aacb46e03cfd09a9a20bdf5f207312d";
+      sha512 = "e789fdf2452043165df90c83ce4bc0ca641366ffe5f89026bb763480973073d79c097313b744c3b2017be3d80f690d18459d1b8969538ce310b802163a2eec45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/gn/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/gn/firefox-59.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "9bdb650bb25ad573a5722595d7b062b370d79ef6a9079354ee467ae8fdb8e319d3b666bef0569286a868e7d64453b2c69098945539a259184334910f70914211";
+      sha512 = "c368f07013b7b4fcc74e88d68a07d5d0a1fb5133991fb343d5b1a86145108e14a762962f3a3d5c7188d8cd75188cba7f26bee5555d3a5e7cfb9741e2e11ed42a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/gu-IN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/gu-IN/firefox-59.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "5f2621253981d58aa643da76dadae44da76bad3f50d08c35c43d52da5b0a8521ee4c5df5262558edb4b2bd817985aa02d6ff908f326d99ea58dd4d96b9f04819";
+      sha512 = "34795309248224a31ef64cef9ff335f357505684f38edc06b9365dc0da98c5b96aa38f21e317e5f0cff0d3d3fa94ef7f8aea6c27f67501aeac68c3112b63cc43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/he/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/he/firefox-59.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "ba7b0bedc2f8146dddb7f0a8a2c357dea4d23481e85f23e5d1f820da6b9c6ea84298ef609967e62741a2f9b57a6c4e94b0a90896daccb80b888313c75359879a";
+      sha512 = "05e21abbec43babe818f28f2f12e55159e413b0e6e0871fee76f50c380085ea129620864642d3d26e80e039a50a8434015ed348c51341b6d87190c627b90bb82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/hi-IN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/hi-IN/firefox-59.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "7804c9b6bab169fda70db8ff3f638add9fc22a6b8f9adde30482558e97d32946085258bfdf93b0e67a35709c474fb3aa028816e7f501dd554ef05a282f656815";
+      sha512 = "f6964340a688305ac3855efa57280e3b5eb64f22e11445d76fe28edbe04216318a16c1fd02009b8a66ccc2ec689d8e0bc374e485bc03e964dd5b65ad27e535e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/hr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/hr/firefox-59.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "e97cd1b68d5a1d471edfddedbc05321444880dc9ad2910010c447515ace632c25b0516ca1dbd529d44777c8f9046b5a660a768bdb35ac5e199d1685724c6a7ef";
+      sha512 = "e0966ea4bfa256eb3a255eab7c89fc9073789512941311863199d96db4014f657acbd1e403a6a4dfc8165dc39d54fb1f9ef48790e942eadaf90f0cb7ffe15ef4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/hsb/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/hsb/firefox-59.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "098842a0e8226eee716859b7e1bd1919a2bd251bc368ff6df58c95b556dc503f15186bb483503087a7e02d785453edc77d081e267b08487c0ff874361a82ee1d";
+      sha512 = "e8ac60e1b925e7530884777a4ae05037e5c577fe6dc834ff8a007f473846b052290787d3d2f0c19b56e573385b6471336208d360c4c13a3ea3dd686429c28fe2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/hu/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/hu/firefox-59.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "cd6846f6268d96f84d405aac06c11322e188da3124ad848faaaaac7cd562c004655a8f7732294b0ce2ca42597c82d82fe8b1eb65dc5b0b659f7be342aec648ca";
+      sha512 = "737634b022794a37223779592ec948015a90c6c96c952acff5821c3af9c060e7fc60c988f17d87d5faa822fb860e6697e233601c7fb910ab5596935fce12ba49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/hy-AM/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/hy-AM/firefox-59.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "3e4f4f536c4dbd4337e301272fd433e4e0ea26976f2a5add8a0d90f310e2c3fb14a4b558c556214409788bc2be09d36bdbf95bc5385260b70408f00ec71c30da";
+      sha512 = "53d3a10011e8cbd22bbe86c6ed256775de580f7b8094ce30d8337268362cffa2df85267fe11432f659a012047a164a63d1c143014c0dd26ff865760119223f5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ia/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ia/firefox-59.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "35adfd5eaaeb3d40e32d501ff49979e4db878b6fab5598d64c3943cf57f846e439ef88693b39a03df65367436ce3efada9c367ee5de20a1d769620b00299bbaf";
+      sha512 = "5d1ba2fa31d3c5ee692d3bf8ae0995ab166ea0c31044e056b4806bca141d34f93ed5117630c311c072d22cf65d12efefa812203a8237464cc9a285c236439810";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/id/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/id/firefox-59.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "3203f599f6ed436280143aaa563780c64864488f125462a56241785f9e7d6d48b2d3fadd0366fee131d575d8dadc8ca4820716a03de4c3b23eb0f0b033cc73f3";
+      sha512 = "b94a086208cff6fa7b4b3f7eb4d681e77d2042ef1c6b21af322ef7316b8551344aa72c3d7a39b86826b8c6d69f847b9d20f60143a048ee28db88847dedfd1d37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/is/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/is/firefox-59.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "2100f728268efc1d2c0f96e745e2574847aa844ef4366dab44f9f0d89e79372a2180d530c7fdfe627e17644871b3a71387037057058a0ebd117e187343b5d1fc";
+      sha512 = "9767dcbe58dd91364b313f4b7b8f85e1768148080ff97220fa1dfb3dc8d5a69e6fb8fbd607a92411d5f4adbfb856c101bc80f922b0b1ce8b63a79039e84c329b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/it/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/it/firefox-59.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "abef6687c0e0b90f9857e29d5b82ded6dbc0b304dcabf2586e1328bbfb9948b37f582a5ac1c58cb46026ed674863c437a15872c46741fc4e8d0a4a4be80cc05e";
+      sha512 = "f8ffccb521f97f0f18f70a0cd2cecc1c31162072bbbd929a1952823275d7b7d07f36e64bf6811e1aaba64b880c432b1dd342483b9ad5a594971a0bd068c45197";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ja/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ja/firefox-59.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "d953aabe2368ebe9f944d91769b6e0fe18b1b5ad819040705283af6739b03fdf6fe9f3cfdbadf5231c9789ce62dbbe831035f8776f570e0be1e483b6eea578a3";
+      sha512 = "bd97cbffe8c4c1ca0fd8e44615a6e04dc5929c8ab896952911a04da3796a9132f797a4e32ee262af7a2d8bad294a30e11349731306d86ad18200715408337437";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ka/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ka/firefox-59.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "52c4b6338dbc79a670b33e97d7996daf1ef72c22982f16840ea0cde0e6ec16eda6eee1688e6eafa2ce6eaa9cacb33ceb7196f2923c81d4e1fdb3af9c200b9c7f";
+      sha512 = "1b5a69053263a0571227e614e0ed05ca1cf8bfd7a6294fb82778c2bc99b209fc68b7d644cafa223686ae2a54ee125036a91a3a847a753c194982c0f2327b3b49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/kab/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/kab/firefox-59.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "4832c730d37b5890a85091109ca150b882202be9028b448aa57fa8e74a2f91673d2c6be4e963235c0453cbf070a996423e64f7cd93caed973d5c5018d26d7a4d";
+      sha512 = "33805bf3976c9ff6699767ef69336f06eb86f08b540b54b33c8997b6af42eaac6be7b9dc8f29d3099ca9530209516ef84e819fcf98f3a7bef3e8d47be8d372b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/kk/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/kk/firefox-59.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "efb2fac05f337f22c326822efa17f7063dc71180d54621b95c000d6c86bf5180d5ecb012ab72cef23177cf07d7f46f507bda862f87dea507a4c1be026829ca1d";
+      sha512 = "c2bc89ceadb7ea2c81ee2b4d72bfbeac8a34cd1838f0c2201d7ef0c819e597b87a935a0e6be0831b997ecd290e286de7a1c9b903a10daaa5dfc0fdec2309b260";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/km/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/km/firefox-59.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "c7817dc8cd3e78b15708a863727627ebcdc6ad054da252f273a6e68cc914f5999fd6d7495d64586e1d218c068c9f38250db0ae54944a67f1116e5a12132c9dcd";
+      sha512 = "cb1919f31651b38a77683850077cccd73c27496e1f9b4354accfc35f294d479b92549ebbfa173fdfadf95b03bbb45cf1baa0c8a4e51f132448ffb9fb2293a67b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/kn/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/kn/firefox-59.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "9ed4c6d0a6a5579d1cb32e35a97df2b05d836e5eab5df59406da4d86ebae6374c38649232c2dff849865f538ce4264d8f08c7fa6c778f9ac65362cd47297ce51";
+      sha512 = "4293747292be73ccf60a19744120f9cc13b45a7be0c5de4243dacb5a2258eb88391d6dc6b240420ca5097ff5f5e2d5d36240289f6a5c51ba7d0fd31729d342fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ko/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ko/firefox-59.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "f133fda3bfbc59f895ead4257a097102af10954f0fb7ddd6bc9337a520641d8f1a26bd86011c0922c2770e8191e68d96e46d56a76d498c7a44c713207a9f8585";
+      sha512 = "1a4723d890649ae29e9030ed2fe3208e44ed10adbe35c25877003a6adc21e033278874241bf5fc971b93f94d33fb4b503dda438153a8bc80b187b584841423ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/lij/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/lij/firefox-59.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "e4d55a021271186cf3553781aab1953c9bc53b86c5d8550c6d45bfcf2363dcf32def20d411c4df10aca3e7c2a79ee527b23e248910ec1bbef8d1e15793e1b831";
+      sha512 = "564260546bc6436dc47ebe6b413abad6d2d25dd7a64d9b5ddbd52fdec49af951b9ce26f3aeccc330aa9601605bec7b3b1f8701668d2b01ee06a228f723600fc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/lt/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/lt/firefox-59.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "a08315a4134181e2f8c559e0c70ff05b1455f85a85d5b5b06c5b8cc70bb17f3761468af42c27be476ea3e342365262f18b98c523e35576425ee8e5ef8df9c362";
+      sha512 = "0aa6b9bb99ae8284f7287def5048af21372d03211a279f2226de7a739523fe189b3e06e207660be7ab35751b5ccc6aaa1b53dc293417971300a4a8e7cc162b6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/lv/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/lv/firefox-59.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "e6e62886b8bf972668e3da6452bbaa970cd16aa5593c8a3d765e0d784ba755e17641a1d7e5410ea6474484eb14b3b6b18b69e3be38f2e2ff30890afa18c9a405";
+      sha512 = "f63955b57e40d2d49d5d1b276ad5b2bdd5122daf476c560dc64e82afa36e4a649e384957c69609e74ff96935004ddbd45c8043a27991d082e59e0f42e7221aac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/mai/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/mai/firefox-59.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "a28537a457989974e11161ae84dee2de28d783447c0a0a6b5b03a36fcd1650d609ddbb40ed063f0c68149d314b1eb17dfe92d5396c855794d45a0bf8e3491c7a";
+      sha512 = "7e857033b14656e972ecbb6f60454cc63f79a9c775bb1fdc669f44af3bde4e1d04ceac3f7028eaab17fccd8136c417d937009b6fc0e80c45200b279660924bd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/mk/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/mk/firefox-59.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "da601ab25113316cb9ad44d2a8bd0eba23800fc97ab18ade8324048b1d7c757c51db9fe039992d18fa7b78846b5be496d9f3439500448f21d66a9d3a335479ae";
+      sha512 = "8f7bf3418145af3ab47372af8e131b4a8b350dcfa8a7f74720a96812563327a4e4816976c2fd655fbaced91fadeb98489bf0fd043e103e5e0923b9c2ee408188";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ml/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ml/firefox-59.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "eacba5bf549f1398f561ad574775af8c749251f9d4a57a2c91400236cb2b72b00e429d4dcd4597b6dc6fe95a629d4b56c2c1776e03cf5d158cbc85743bbdd443";
+      sha512 = "b9e65dd54f8b4c1da28f6079938320f9943ff94ea0a0a7857192805ff84b53e7de6b762d05f8a66b6dee9f8586623932c5cac7163db2829fe41a13b3c73c27a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/mr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/mr/firefox-59.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "e9e9b13cc3c4f48871d5b73ea88aba384d0ae792f7c2bb49f41d5b7da36243c108dd96925c122abb0b202ba8ee7591d8edd783546402c2066f5459883a255897";
+      sha512 = "80e20cc4d30dd2ce2a7d5c40b4c98271a0c0834cff7bf201c3db8df4bece056becbe71dce7056d24b837d16889cb15ec73be7e853384d88447d9d00eada4fcd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ms/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ms/firefox-59.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "edf6153c9e18e620558e283086a96d49e484a74983b7d5823b1c17f9276f3c41d4282a46dc120a181a7e53595e1434f56658d34b2cad4c97e30753c07c899fbf";
+      sha512 = "ab4e6a3c244a7e1c4683f58252d02865cc9e8be51a2fe189d8bf555c968260dde63af130a491a8c3b093776a1d1d6b883e32b4054c19a20a9d1856685b4cbe35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/my/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/my/firefox-59.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "c153e6cc2bb3ea49de8dea3661b4c5ec23193cd40e68da8160108b40fcda6717e35e7ef3bd2708ac2e47014b224e53f74b9183cb2c50f36d517f1a5ade425d40";
+      sha512 = "aef82a1dff4adc9d93c967ca4fa3e4601772e8b748c3d41a08d2893667bc661a0c640b02450bfa647d35b9c097919ce90a4a4034f83cf4ec51d2341651205aab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/nb-NO/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/nb-NO/firefox-59.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "1b94a618ec8f132bbf5b246354da4b424a682fcca74259b94f1ff5cb12cb0602d327dc7b9af2814fde45e5da829159df316442db6388fc45bee8c8255418a1ee";
+      sha512 = "edd9601c678f8f551fa379d7f3c31d2e4c68434d9d3401b40f2945622e6c844993fcf3aaf010ec5b3bc13eb8c8cbe951d76b66a908b4824526b8da368361a347";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ne-NP/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ne-NP/firefox-59.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "552aa2504e1d5c15a413a0e7e47b509d37a8b424be9ec4371f0920a9ac8b6ada2cafb9adf054b695499d41fc9b606f6f0c95d99104318cee1d69998ed7bd1812";
+      sha512 = "6d7a5d81e0551e675d8dee4be7fc0b8a39afb37b74949d408f197562bb8d7866706dd1b9fad60de4410cac9bc91a4ecdb92aa75a60b2fc2e2b7cc51fc9e46c60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/nl/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/nl/firefox-59.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "2449c6f7cb6106e7f49b5160ecf973a73882d653c68a8e5648a31595367ba41dd93e334f3a67e69958f4bf429a17069bdf5d66163f2be14e86068a30acc29045";
+      sha512 = "3d4c3714c7d1c7d4865bace3827df94068bf0cfa4037af130cb7ce0a5f6cf7eaa0e37d091fb36758b13f52a5307288e5480ddcae50bd8645cec527481c03d7f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/nn-NO/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/nn-NO/firefox-59.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "c80169f8f2cab78efa8ad06a6e3dcea41359bfa2b4af7baa034b88c934d27243eb5b20b4ca4f956707472daaf1e315ee4d34e5abdc25edbdd0b8aa3915c14d5a";
+      sha512 = "753e792e3402a5b75043899a5f50f5926ce31d2439ee1eed16193932e962338cddd974194ac94f7aa1ef0df548d95f901a50988abbf9f3e9820f89ac372e39d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/or/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/or/firefox-59.0.2.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "48ebeb9e4233b303bf5300c9d7413c82f9340a7f1fdb4ce23cd9868ae6c8c7b61532535dde653fec0f9a56a3b8d4595d451c3abddee75f6aeaa5b2450f26b0d7";
+      sha512 = "ac0068afcdd2b6bf5416298e1be065387606bb0b79cffa364aeef9011535ca5c155d1d28fec0715a648f065628efd2c847f47785ac7f27415ceda1902da1add8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/pa-IN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/pa-IN/firefox-59.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "4d2caea086ddd56544b59793d3e2422940d64b16a623e9b9717329a639ce8a89f9e69d7c8ed9121bd08d692462c99316e1364d89eb8d1cbe978c67f99bff2469";
+      sha512 = "fe77072b374c34f5026de80ffae16fd4b30705969a795079ef9e81dcf66dddddfe01287dd44bb4f0001427935671d2753d22a8b80469f9c4e896e215400dd9f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/pl/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/pl/firefox-59.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "6d10818fe57a2b10bd5cccf068f42ef8e2d949a79c4ce6e4b2ae088944f17dee8ce14396b2e3f86d492e3ce31780bbd96ecd4bfe39cb8e15dbc70cbdad6a3927";
+      sha512 = "e4b05ab04418e65880f989d642478023bde4ba5ce17627f806b223d19005b4e6825d8a9d5c532c878a397b3cbd8220c4aa4c2627b17b83fd6f4acc395c0a1923";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/pt-BR/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/pt-BR/firefox-59.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "b2a8732a03983b00e7e606099a215a8b6545e093e243662988400e059757f6699571a29e6c24433b345de5e47484d19c08685fe1b5410d71bfafe023d3bbc669";
+      sha512 = "9d67c1264b90dc58ac62fa094792955b75724791b7941354d5836cecf2c5c13ec279cad12f93287e524f0f0dfc2302f68f7585dd783998630007dac806f7e2d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/pt-PT/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/pt-PT/firefox-59.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "ffc7c4a8cb7a092ffb86ff32ff8d6e54b4c49600ea9c8ac77e337f4c71b283adced784d23cfe8e69d034b9cc22f118756af44fc5a22003c77c33135a24197b2c";
+      sha512 = "a241e003b6d1a3537b5232fc793aa6dce194433028987753bbeaa5c21cdec58b326e12bd4136656cb35bae3cdece5dac100f912151aeee7548420de2d3875e93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/rm/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/rm/firefox-59.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "ca174bb51554e73d647207c62f4f17de52b47ca6960dc13f45becf0a0e43b73edcc7925a913fd42e3b151acaeded5bb68d6cdc6ac17f3add2bcdecb8a4b20c3e";
+      sha512 = "87ada5bbfeb43e3a42f1eaa44c58e025f66ddce965e1c97de8ca0df190ca18106eacd2d1f28c959a104e79df583672206c047eb79c51a32f431f8cb6fd68bccb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ro/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ro/firefox-59.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "4046be435da5d23a46ea007ed04c35cc9431d22858211fb2647df1ad4e00e84476544448ca86ce353b889a8db92fa1723c0598e7d560fc9980b1c7b82fae1552";
+      sha512 = "97c5d69e1e40bcb779ce058820b0a4afa4000b3c12170c63ecff1ad4b5994f71ddf36c49536280edefb971fafa6be52a3b436a405ca9a1762aa08d2cd61022c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ru/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ru/firefox-59.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "a7b4becbe30e27c8bec3c71af691a03b916774a77e4626a89743a7a7deeb07e9489ba6e276e80b53becb78e5c2575465b6f141f694b71bf9cd68dd761c0442bb";
+      sha512 = "74fb10b42eef3a2391aeab0e3dd1ce463b58cadba5c42e2fc8a5e0bdb1f9df122aec65a662c9ecb8a14b1ee76bb060c64de93f116a37d207b4cc0887ecc0e2bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/si/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/si/firefox-59.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "a9d8162bd8784be11924e9cc0567ea720b87232d175dee18212dbecd8280fecc610a964df77a3499c5f25cbbd466344221f5b071c8d83c3268d936e108adae48";
+      sha512 = "d63503345ef7896e9d9a3ecfc80395b6ced67c38b02c19f7afcf94a9efde01f3ac53f1d581b8151d78eed6c7f8eb69f9edccaa3be49133aa3abf2a1eb759a02e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/sk/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/sk/firefox-59.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "999229f133193f19b49b9e4107515963fa28b524323cbf88a2d13542568997a91af911c42a3b353ab3d9dc4d05e45b8e2c9e08b4e6436da6292073365cb5db0d";
+      sha512 = "1020baafadd4a1de8118bbdf4e281c704595730937d3aca9c8185a6ada54f4a72b8efcc7c493200c32a6a11e7121ef52d7aace68c47784eb5d17ed7fdda32d60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/sl/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/sl/firefox-59.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "10ecfc7d338462aa350aa957b3ca6c0de5eba93fdd680aa2dc406bbc0cbad821854c9a45dd12c72403393d7f9447d5dcc86981921f0eab4ce3c06549c642e08f";
+      sha512 = "a93e20498b5b3a2b5d19197bbeb48c4502217e44a25c48372f8855a49f762e89438262ccf5dde1fea24af1199bc8cc5c935b1bc886e0bb581d698d10a59d60e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/son/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/son/firefox-59.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "c0cea7d6ca475896c0b2b281a4a0df33311eda128d573b38b89b8f1653596d8d16bba713b8cc8bba267afc2a5cf734aa578532afaa3197cc92c5cd03db030dd1";
+      sha512 = "24411644b553e6f3c305b8a893a7bcd4ed59568a6fb7001b999be114a3e88f30d40ac6f3351c28b3287bd2a9e6aec461c54433caa45fdd349aea07e83401fc2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/sq/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/sq/firefox-59.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "45191b5974de941748d38ae74e87b135ffc813d5f207219b21469ca7804cb4b6ce9e7fdc1892bc6a6f4fc15d0935a7e770e82baf94f1c31dc77d1108d5f25cba";
+      sha512 = "40ec8fdcc4fcec937a710e5d19077243d0ff5cd832bd20365817e4f4ff1cae5eeb2a664906ce7f60a5184fb053735df5825ffddce41276797fcce3a11548f4db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/sr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/sr/firefox-59.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "e931f1d47644d6a770f193cea61148445d8f43eaf5670d7cc76b3b115db15ccd4fc0938a59e7bce237d2d05a924660a791f4b19d44ccf06572d814a692cb9173";
+      sha512 = "e538596cf0de4a9d8af4e801d7c17d00c1e63c56775cef0d087a77e320cda2269cca74f0c73f679208a184c6cbf4b20c56d1d222e8846f15fc4a91c16ae3ea5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/sv-SE/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/sv-SE/firefox-59.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "95a8391082341543c2044a72d7f52de39767079957c99ec75c6daf95607877fce0ff1d3c42175964516cf93ff632789647f420687d51e717d3d51a280f5c9272";
+      sha512 = "3466f482ec04f5e8827f437c9456908f04e78c67ffd299b841f2f82cdc2c38a61a566c8d85405312c144aa5c45698b5f6e81190aaee739adf4384f95c81f9e76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ta/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ta/firefox-59.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "428e2269126ce169f0e83ba1274d4a11cbad2964dd6bb31e8f3c3afdfd3968fc9a06d0f92a77a0bd745f36810a526a75f8c670489cb8a28bfe086cd04819fb0e";
+      sha512 = "7598994ca03afb1c2933b640298453a618d140791fe20255789081babb0d9788c4f3ab34d5ede82e1d688f5dc0486fa0f842f1d125dc5a955580d14b1efb6489";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/te/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/te/firefox-59.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "34c0b91b14d70670ed0d1624a5d6b93ead775151b432add41bc13544ac2fc5acdf3ad9f8f26059655effc8f5507081461f737289011b41bb3972edf7dcf933ec";
+      sha512 = "759be69dcd9b795f7b1b8192928e27799061d83d86e0234cd2a1fdda0d922a7a9d958b19655bbe976d409297f2e2fb2d2a6a525f90f77fa53071d510ffdc6438";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/th/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/th/firefox-59.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "bd7bce3cf04674cd6423fcf7276bbcd3585c061b77c692cf33680f122b09d2c5c29ba0a2d8ec857425d9741ffce1ee23383d35c9b7a620aef5579d59dcbe0049";
+      sha512 = "a46d7eae4a2670615e100707ec3e340d48502b63d6f6f98d4a3140c1bc9d0826b44001bd8ef940c4e786ba5d3f8a00e350faa18d30fcc7663f9c29f20e7a20fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/tr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/tr/firefox-59.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "580604b9e4336aa6eac536d4514a41603890ceb6e9630609b4a36cfb0b34952f3d273ba1d100ea1b5509a6dc8dce9f10a335bf5aee7a0c6b133abaae3c4c7352";
+      sha512 = "ec5ecf9c76315d1fdc508c94023cdd60edaeba44ef6ee49859ba0689413819f11f54c9ba787000a166b0fd7f628e3c2b42f42c9014f9e7823da257d0abe88cba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/uk/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/uk/firefox-59.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "f6c7a9fe068ce1f760a7ca45a82dc5dd28c7e054823e3b9dacb6d00d628ba56c8b2d831a36237290d8803b3284b90cbd29c3ef685cd0d4973ee338b91ab541d8";
+      sha512 = "430cbe8281803ca0a4e124fb62a8d2dcafb751ae20441e22dbfd45e544cf906371eef4889f16df5c1be91a4eafa193303e053f75ff15fbe82a836df3ef19a5ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/ur/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/ur/firefox-59.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "41c6ae7d2f80704754865982d4b64252a9a04a222c5cde279708960c8a2c167f68805ca2302a86f03ab55ba93afd069d4c289434dff8ec61b245123347e53e78";
+      sha512 = "b293eaea548f8d1e96087e111e96fa35940254477599a3c2aec9bbe005347cdcfdcd79f9e3e6d22829fe52b091d6d18dc04ce768724f9709a6e397838974c45a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/uz/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/uz/firefox-59.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "5974e06472aa75eb2b9cdf1494d8bdf0f394d5a7493e9f77d631f47dbf0a0047dffda5fdbe23f32dbe65612b9b77caeb7c3f15887cc51fa7c2609d3960b9d32a";
+      sha512 = "dc0a6b771469b89cca470a50afe47c642fe6bae284599c876c51c2c5834147cec435508c101f33d76d1e4ce5760f52f3a59592495c82db314de426a9602097ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/vi/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/vi/firefox-59.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "5b35c3ab9593074c8f88f2ad34db0e161c075d8b04785ea658a8ba49172707e9776a5882b291645d0aea5e333870723b5fbbe6c7957f7ee02c9674eb237a63ee";
+      sha512 = "6f7b9acc584e41be34b884da9b9f2d7aae602958cbac9843d73dada11d1a584101e603f9111c24983dc3ca0b70462091cbcf755c93b7811469b179aa2b3ecc60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/xh/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/xh/firefox-59.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "8ae8b2f36cac9e1aac1f44a786d6992ea6b31dd83cfc22d1cfd75d057ae429a35e1d61272aac7ecd24d4dbfd8448f54682388e4e708222d1c2f6c6e54c0b0da8";
+      sha512 = "7623715582708bf3e18ce924aa6e1d0fc6c8bf38503691d3ede092070860db3a116b2f39ee1e467d286e0566bad594679b489b39d2c5b5885321982689b8a56a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/zh-CN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/zh-CN/firefox-59.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "76e09c7f0835270ed7788330486e1d00d10e8237e5e6b5af9bc2de227fdabb958c697c11f74d7df5b6876339adac09b6bd5e87c9d31b3c7945ffd00ef0d7527b";
+      sha512 = "9d0e41df6cf6a7244c4aa29913ac664c67463ad50b91ffa1e7e345601eaeba76d8553523b322ae477ef0f0c5fce55ad2e1cf5bfc5fd777d9433ebedcd2474d98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-x86_64/zh-TW/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-x86_64/zh-TW/firefox-59.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "87f298e06f0b58500231367da1e9fcf19f39c25cbf2b4d20980f45947539398f6f394833a6baa676c6ea27f87da26e5f211333c76ce91b40e7a3e2a6c6a33fea";
+      sha512 = "c65832ecb353527c6b9e11dacccc9e3d1cbfbb16db1872c8afb4472f632a0e2b4f994af43144e430aa8c8ba6aa6a579d3c024c9111fcbfa6531a4b2b7377414c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ach/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ach/firefox-59.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "3d922035f62c78c21e997f0b9e1265c8f9f8bbcd53d67d7042d8d30d418d54b3bc4f5b8fa056149d8c8dcd54afcae1ba3e418fc0b89ec19b7c3af27239a0d4d9";
+      sha512 = "468b25a5e90b385514b0f486bc3fd09a1e7c8c7230b8e31b04dc4bd18027396078b525fc5b51c9747e642d1bc60be49a7e2cfafafd528d95f08033abd12b0757";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/af/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/af/firefox-59.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "d85f3a911741b6dceb35ea6f2daab06a6258e66b07b79fa7fba4b1c277ae8debe5fb1c45c3d9eb07b910a172ff94baf6e4520a6fe755cdeaf19204b4dadb1f42";
+      sha512 = "a3b92e792d1ef58e029fc097eb354940094c8a94da97dd39b1f69610ffdb9a1a6527b01da2b6716c6c199d85886b6e05aa084bab30f8a2d0ba33ad4c2f6c36ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/an/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/an/firefox-59.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "f1be5c00436a1b613fe46f5adfc19eafbb0639687346a3939437e10e64a7ba0c94b9656bff988a07210be68c7e57e982e9280aa03a0e69c2cce9f3501846ff20";
+      sha512 = "9fcb76d123b657b9eb7c62c53c703ea27afa2f41b5107cd67dc01923ffb9dc6d3f334f5d801058f05925b18afea289eac03dfc3c2b188bd2059f4dd0c40710fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ar/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ar/firefox-59.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "aa2ce3ec19633a86d998132fe54eba30e52fc29d5b1dcde1c3197aab0bcf0a9f73caac3662d58e5465923edabcfb0559e8f23bff7f13b5cf89a11bde7d4b2eb2";
+      sha512 = "eee65b88c2269081dd04fbb37d360b0738e6527581e60dfef60093719a3a15b44d0d594321b4865a35784d2f378e8d86f308736d8be76c1cb7d39152b916bbc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/as/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/as/firefox-59.0.2.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "993be32e81700a094358999edc280a0e0999efd1478eb03f0924c0fa6b8c6347e69e0408725b916a80f350d3fe93484bfe83137fc0ba007e7f7a0f41d1c12e60";
+      sha512 = "f2e54d00258b6f1c55bd8a1deed5e9c9b1e6f1579447ad832f348b50bec8fce66e50c78b2ee6e05c885359a6b2b1f9d298e907fe99478536967103708143f24a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ast/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ast/firefox-59.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "ed49c1ea33b0057a8b6cd406820c788248016bede3983121503a8c5332fb305837add00f7a5c75ea0aeacbda16873cb519980f440d9c11b0b54b01c674832132";
+      sha512 = "4f23798708447a4a3801b392a2ac27207df7d2b722291d3836163b3900c7745404399cb700873cf6afa70121c429ba31bbd8b0b1f597e8c91b2f970d0d6421e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/az/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/az/firefox-59.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "f02af6b9865d4f6469f62c1168bc33ac1f2abbd0a238d38524643dc5fd84de4a48b146928ca7c6d82f9db3e55ebbe861c29850a0a3aca3b3c1cea632a6938f0d";
+      sha512 = "2f12c45870d5ac1a6baea455bda954cf3b112b0a3b46249a23b7cfc064c6eb00cf0ed2952deb220777cc084fa2345368b95388e143dad6e45042e7863c6c3038";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/be/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/be/firefox-59.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "5b82b010b2ad960b8281e0cc016f7125bdae1b1f3b93a581998c4ef891ecf49b6b075949420d595ad644aa5c75ac6c552e7d26086b5ee6e807df5179ee6ad36d";
+      sha512 = "f70af6a6f464b6098802e65226b198f670e5d9ecb2fd56f9c375cabec1e602211c4cf7d80e430f961bb56694cb1d546aa116c7a5aaeb06d13319ed41e3e69ddb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/bg/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/bg/firefox-59.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "b404b3f97a9dc8675e701ea2ef8bc0a57b40a2390d98573434fdc82097b12abf28e9179de3cdecd0e3c03f0cf78f47cade1e41795eaafc113ea2c954a197a1e1";
+      sha512 = "87377e96a52ed8866be4a3e6ee9c20c6d8acfaaccb53de0d2a4fd553060166c20b3677a2cd3322523f3b3f7d03618e6a6c27e485113184698207cd4b88b7e699";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/bn-BD/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/bn-BD/firefox-59.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "a992b1cd5ae8c2237acc97bd1f7e61dfe2abb3b93c270e64d2ca190d8ebb84c84f8a45de5cfe7eb853f4e3e99d79eb19838c4d0a02c73f13795fbc42e79ec04a";
+      sha512 = "0d275fdd76d8ee85615f67a11ef46bbf8b718c54a09cf6f3c7f2336098e0bc282caf429a4b228e31e7c3622be41f41384af174da9fa856fe36dc46271f55ed1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/bn-IN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/bn-IN/firefox-59.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "4188f40867dc0f23b2c52d59e569b7f030d4392bf7715d35678c69a29b85b0573bc3de6701bc550735881b1055bc66258f4c7090e5f4277ea494a60549ad98d0";
+      sha512 = "b77374481f21f37e246eb325ee41202fed9916ce36065a88f51e28fe5a015e2df341417b3420d2bff0df93437a56adb4e1fae0422bb094918a19157c655fa34d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/br/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/br/firefox-59.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "c69b56c43aea2821d9b085c7be10d3cd8c7f609b8c053d8fe8bbce5f719001e620bc56d1e70fd85c77e01501a0df466cbca62e2e6ecff78196ad91b6c30cd8cb";
+      sha512 = "ba071fe6a668ebc7c00baec930a568a90d03c866a0b5f0011b25e8427f40fd32d54fd770e94610da43775a882eb27eff6359c67d65670fa0fc6179e788cd1394";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/bs/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/bs/firefox-59.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "77dab75b3c10d6ec24ddfa436dc9a6e037da3d692912d0417a6781890eef992cef250e8a38d5c1d03045dec7a073d2658a3d17a1f3e9c6d85a58c93ee7b4e19b";
+      sha512 = "de70dff3aa71422c96e17e637bd56c18d4b74c8cf1ef5834f1f077249f6d7d1e95703f55063737b464916b2aa87eb4469d197e3fe772d168d184e72979712e65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ca/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ca/firefox-59.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "7fdf1fa6eb06cc338d06d30e8f1ca432cf1d7930a534c6c613e0f1278ccc70f1e81f74e43cce1e1b865bdcf2b9bf10607d73fb18d51e796c731a735f1e729dcc";
+      sha512 = "e197d847b044a9ff4e09b67c64a2e4bca5eb2a1770ed4cd9ba965342106b7ec809950d611367308fe2c556c4b413640f050cbbaa00532402d71b59d51c4b60c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/cak/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/cak/firefox-59.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "e4e35ea7e81190343337439a3fc95786f318c1f0dc338f2d816a9845b596473067095d0f3b446087ca8dea98dd2aff4db1c8e9a8c1f8fc5d304644b06e0042ee";
+      sha512 = "a716ff884d1d5260b9ed830877223eff731ad301c1349c9f1dcfea5b9dbed0770269c27aa8a336516270386c4b896a87721e3a5e433e92bd579e0d88311271e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/cs/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/cs/firefox-59.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "48288a7ceb3fbd579511950b9c6d5fc133c1fcea8435994e804ea423e0cbfaf4780fdd6317bfea37a958f800a79b62792e01c7aa25a908fe62b21684d6fda060";
+      sha512 = "d66e5f440b2bcece18013499129462ed20d85d9b27ec803ed27bb7d4302d2369331b2320970d256b6e61ba77d93e362171ed012843ec926047c281223218a25a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/cy/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/cy/firefox-59.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "ae9fc1b0c8d9b46b86b6ec9bcfd97798fbab2410c6ddfab531e364871be70a3a74c48936bfec085220bc5f37397cd83fd31da4a709f337c57a8bd944e635e7c7";
+      sha512 = "87c2c1056bb56b5fc3d1fa9aaf8a1d99a5ad5558016b3953d0dd1f7c70b989863fd1d66f6a8d7a0d14fff351dee8f436b89d5dc593e610721068fe187055aca4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/da/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/da/firefox-59.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "9ea4433a5c295abba639faed9681d68fb8976b1935a131ab763f6ac12f32afab2c1ead3709ad741e04c005b19fe230e13a93334434c76a033df69d6891f960a4";
+      sha512 = "6243867a2a5a7a30176c4698888e7998c35ad84790a75a86808e6490f013990890a8137579928573564ac7dadaee6efe921579423773a0c25aa57db17a216eeb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/de/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/de/firefox-59.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "6d864350a270efabd5258157c78ac6b70bb81677939bfd381b6996fb672da240b5c7ef5780819729d3ade763b9eb5a4222c361394e48d9c1c9eafc54795be93f";
+      sha512 = "d21c6a44def103db09a072ad72fc42d3876fee9095c5b660fd491084301e2d3bbe383b4c7f9419d666dbf280bec59743a034b4f576cd618142dc7f498fc69e5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/dsb/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/dsb/firefox-59.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "71e5608acee3d2cac48160e71739540c6d94fe5523415d9b639a3b493910347d38f6230afc0febb444e35838e3d402fb5b3018cf437eb48632ca1d8b873ce0e9";
+      sha512 = "34446bdb17e81da9ec3689eac248b2ca0fb11ceff7a153bb502a5e0d62a16d2d4a090f9a29e4ff61ae1f87ec68f2fef94be53895a409678d14ad99331058495c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/el/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/el/firefox-59.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "37ec4073075a29403e4637b48a74bed5c470ad9722c28cfc3e1d7aa5bb63034a0660fcdd2f78d8681ad21b569bc9060be05f4e1cd3eaa3d347ba0d2304075eba";
+      sha512 = "f5d73ccbe24e30eed81546b6132dc70f08feaac68dffb749ecd7af14052b343aaa4de7bf0ff73924b28b4c5b86c29ca1f6a69caf85ee77d4c4088b925547825b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/en-GB/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/en-GB/firefox-59.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "d2731ba3dad5298e07edb49b608f04784312e6d7e0d1219eb45dfd38a65ef62c1f9b94eff5f97bf35d75ba36cce8a831db6964251873572edc60656a87ea5ff8";
+      sha512 = "4dbf56a7aa86341c2d08b799d76c7e0dde04d418539657f74e18a088df29d390ee10b60c1b9625bdf46ffc4f458b6ca3e86aa93b1a2d948f10b7d7bb6ac250d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/en-US/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/en-US/firefox-59.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "d56c62b111bb629a30e9de4098a9bfb11b9b437bab572f3e588f4d565d86979c64ec0bd4be4a54b6c1d2718e5cd91094ea046424c9e85952a4ddac2c5de8fc24";
+      sha512 = "15e93c9d069d0e4761520cefa508fdd7e06cca979ddb9cfa1762d70d104f5758fdccfecb531c6099f9372f112abc88dd273a29a67f720cbfa1be5c440378363e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/en-ZA/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/en-ZA/firefox-59.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "5fd28d0239dd61c54a062a0f6efd5d0f406bcb483cbcc111a631199d430839129dcdba84b4da66d35f1c5052d530da07e3bc8fdd7f177a366974bfa54cb3303b";
+      sha512 = "772ca9b0318e1175e455d2243ea537a5bfab8d84541a7ee306b3670084240b9eb165935f41ef874650c3b1f5e4632ad2d5c0bce3f29a05a0676ed3ddf133cbd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/eo/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/eo/firefox-59.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "327b89fbc100d238f2c1211752ea1a95d2a5c33cdbf8fba35b44ff52f2b63f2d05d84c4c714090693df28c0057e29d047278fef6d4f7e5989ec207495bac3134";
+      sha512 = "cc3c98e80c343b065ac8f6af6875d1b2146113303ebaac42c5866d03ff254aebab2cafe398aa1fe38ef8c9d4fb8ece87345e09114145e06a2a7d6c783f1ef601";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/es-AR/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/es-AR/firefox-59.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "676b58cde2394983a7be06039fcd1150f6e73c95518f5889702cf71ce780c4994629c5452924354ce9826aa5e0726a5de75321295f55004afd10f727d456659d";
+      sha512 = "fea909cd16c4558ed05602cab2c3a22186d727da969143b77deb9515ef4d87dd41e59e7fc6a322e924f0b809b6205f37297576106a50b5896b4920cdab2e4749";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/es-CL/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/es-CL/firefox-59.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "274acb52107294b4a65f22114da6e79d4bcb6b06a126002a371c983a926a2ab9882896439f94ee2d2ded5e5955d42cc4a87fc0f16c8960e42d406b773e2a5fd5";
+      sha512 = "5015cdb3a1d803abed9a143fca7a118a239e37a38a65898de7ae60981066113f270260fe8e9b83822385115c2b5e378cc58ed68949ef6297e0f7fc1e28c9c8e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/es-ES/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/es-ES/firefox-59.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "d23192f6cbbad388d8f3183876a176197bd82ea0bd596ef03935eb020d5d6dbb94692335dbfc1b98e63097b7c66521154b0b3d013cc769c83bd48883646e44d8";
+      sha512 = "81fe49a2f31913c030cb801180daf730855dedc5f6adbd39d7d1d8a4b359a3aeee063d7fef0ce35641f163f5f8c965603bc549a1ae3b2458682c390d16a0faf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/es-MX/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/es-MX/firefox-59.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "48da06b532fa91a6b482b57a8cbbdfe3ee938b353433d22af479786129bed784380134ddebbfdc58bf06f5fb81629ec982ec5e1d9b51e92d75bde44014770fa3";
+      sha512 = "24bff972bb2f27530b18cb7a640f2f85190977725cd82b1e86c1b47578f1d3058fcb7387d19cb2e1dece49b72c17048829bf6a66aabee2592a4b9503e3c4e546";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/et/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/et/firefox-59.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "71ec513f6b3dba3145c7b424c8f331c2108d0420a75a91045b4dfa4529448923e3ccc8fcb6b90cc01d8acd18e2164755ace78aae2d8da5eec056222b4dcb1b00";
+      sha512 = "d60b637f9d78a2b9e53dbab8e6db27aafa701af3cde841e056158d3de53d1c0c1032c5381f7c388edf59b1476078e0dc8166e82f39f7c006fc28c5d897f0e1b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/eu/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/eu/firefox-59.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "b978c35a4ccf0efb9023f22cb05ae9696c94c8a642e3deded9c44900c84d3c0a58cfbce95aaafe7e99ee108db07a6b07a76813f7c2c3d971757eca817dc10ba6";
+      sha512 = "47ed51fa6f27e8b7bd9dd0c3556af3d85e6b004d5c6a5868db8c844ba97a06eba4d3998295058ef92c4a49dad31fca0a3c24b19603e1fafccbf6b7d461596080";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/fa/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/fa/firefox-59.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "a67f89767cbeb3b37012c4a1ee64c53e74b30de6c5a14bce2fca15a16ce11a048ccba4e55f88ce7f2a888b7248df51fcfd03e0b0715e826f6b936db953313994";
+      sha512 = "8919e1daf708630e397200f09b3e9810b3aa40feb87769af5e1f0ae44ab49c63fcda1982cae5ac4753c600164b34f533054e055293a87e5a8fcf55809cda61c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ff/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ff/firefox-59.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "d7b7d9b86b90d5ca609870313b2533b6feb048060902727ccf34dbbb4f180f7fdd69683e34a7483804a1ba2dae8b264ed3fbff81b065083631b234a2893d4716";
+      sha512 = "b0a6f5a974750f3ee5b485872d1e7c51a3d894c4118de139b718e85eab94624be302ce2603233fdc3a75df3f12242d4d57c9a96ca1f429bf9e0613d2b299ee86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/fi/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/fi/firefox-59.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "7c555f5ebe3fd74eb782cf9f3508c9714844cbaaa3520bc1c3b60bc8d2840874850e5f92bbd1db4f2dcc4cfba211f4aba485307f898f0b47d4b9ec93b4346ec8";
+      sha512 = "7dc300de36cd860d566a9b84de0ce2c4fdd5eeda4bf641a45e40779e98087c7dc881d2c623c99f8551c08bc84b98b1ab4547ab8144b1a22795710f57112285c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/fr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/fr/firefox-59.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "edf4f0669c732312c27aa40f4aca66aa2a676f9b019cf1d35d0deef2ab4d27f5441ca9aafb3ed896e20538f765de4715b67a546e4364f384e05748cd495b3f0c";
+      sha512 = "ff793e4873e8895259b2657d613513404953d27d81bcb0c26ac97c3c2ef2c1ed8db3ec909ecb744dcaa7d194b4fa0660885daf96932270f1382742dd55e0f5b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/fy-NL/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/fy-NL/firefox-59.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "58238d57335a18e63230fcbc67f83059e2439528f3d0ac508750dcfad4a2c48296e43c53ecc203258f917f87be78fe50dcafaabf88b6183d5d790761bd21a7ff";
+      sha512 = "cbb9bf54a401aad2bc8bb869f8680ee4c00e5ae206ca9b7db732c955ee256e4ad226ccb8ffa320cb3e08aaaa787032b3dbed06aad548e733ba43ec87ddb52bb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ga-IE/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ga-IE/firefox-59.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "fe4865df72926342c139309d34c8d42187b39e098848ff32b7a0bfa21798f2d1e6dc0879dcb17ae150d977942f355c532de7d402fca3226010de8812da0ffbe0";
+      sha512 = "bdfc3de17be432cb55219bf3f2a3d1371f3fe4776f452a0fb37ce4f5259fadb46487778ec63f6065dfec2cce43758be2e5ed8c5f75394f1604f3318e96f56363";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/gd/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/gd/firefox-59.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "68f94b2511f72a2049c07a20d120fe282a6b85a3f4284e9695ab5cbd6eadd4ee1926bcb133fc7f7394d90d2e3b47e2ee75b9860a49229012c208a144fde5e85a";
+      sha512 = "008548e75853625b690bd92e60cea25c1d9b302f7f78f42fdb4536413c10b8203f337c8384b45c3c9b729e6541f57a22e12ba264594ccfa82742373df571ebff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/gl/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/gl/firefox-59.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "24bb4da7b5bd5a8bbb3d5bc8ccdc96ed29d9435ef00c35c70b67e0aec5baacbb910d77daec54fddaae7d68541bf1e9d051f3b1bc80e8467cc78f3c503acc0682";
+      sha512 = "212ce344a4592ff36006e4671c29b7a4734e513d5267c4ed0e7c50c6d0b794547cb042d543feeb55a48ced69bf001670683df159354f152f9d45786cc7184c03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/gn/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/gn/firefox-59.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "24a6a40ecf5f8ca418c83c828cdc6905ed43afe137a0d59b036e68c093df3d8be679c64d06a71973a891d5765f9c366252959d6c95cfc8a5e9b5b145999526df";
+      sha512 = "6f60fe0c208b6447b4ee9f8c550805f070f4b3209632de91fd0a60853cdba70aa9e6653a29429ea4686dff3ccfe5dcc5a1fedd6495c7d7c38b623f31c2cfe19d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/gu-IN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/gu-IN/firefox-59.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "b36047e9e9957002d33be2c540104dc530d010a646ab8d8516ecffde0b89b9a6f82bf8b94bb3f55fafb002b5c39437b7941d5fb2a0cfdccc5159c2013db1b058";
+      sha512 = "0ec6bdefeffbbd52655d332b9c21be2b372f6ee260684cd28216679aa1af267d0408d5ba641a5dcee145b80c357936a090700427520f9ee7d712e20eec13c57f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/he/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/he/firefox-59.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "c4d0195f72ee0afd3aa746d0a1ae5f0f7ef58646f6b4e7bffff8b1c4ac863275881c29fb7cca09ff12765e9902a6bf9404f11b45399919c9873758bbae8d017f";
+      sha512 = "2a4a76c674fd53eed5a73f3ef5d143138752e9d52db5c69d56fd5d0dff1c19349afba6987c4736d53391bc602245c1d4ac9f5c9b60a0c1d561f4162c859ae3b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/hi-IN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/hi-IN/firefox-59.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "7bab64a89c03e37add1c6d45756acc3ba19751313f212f3069b9c1938f7533ad1d0cb99b7bca392bb5598e2c10b461f79a47b45dbb77285f7afe12f5de781e94";
+      sha512 = "34d932f073e803678990098623149dc0ea427a70ed3e604651fb622a87404ddaf25c3a79503f4e343315101704f5cd1db058a262ed47ae02eba85f102a64f780";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/hr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/hr/firefox-59.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "aa68496e4e82fa5f491b0df056460ab3169be81869248fff0d3ce2a180c9b9963edfbfbe5b051846302ab713f436836dc63d40f65ac10ab185bc12e5942fc71b";
+      sha512 = "474f5d71087f8eb2646750bb6a14c993b2d3708234a09b4ecee7b43e2ed75a8b9d249749f16408751a019b9a32ed8be57c5d61f9fdc36ad0f1e7aa7b5863ab9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/hsb/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/hsb/firefox-59.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "89640b9df29c1fa946351fb74ca61e6f318ac190976f75b73aa56c66f2a67ef88b64c663cbdeea86c30c6644cf7870b59c2f9fa479ac6557e368dd486fbc4a34";
+      sha512 = "9b9127af72f9f4d780714c41a54d26ac3e8065c8ec42e0ed1318013896a3e8d920786713c79ba626f4930c92d44f2acad72ac600b5735122470fa3e3ea317965";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/hu/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/hu/firefox-59.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "46a6cdddc77b1d29bf85b40e6e33ab0d6b11a72d425ff59e9156cae7548288f02e3e1a54d296e4e1df1efc1e8e3c252a955c2a5be8bcb9e22d9d0e6e6b12d08e";
+      sha512 = "cec7b19e6e3fc11708c4b67105b191433880b53da8316fc8fa4d6af9eea23cf17423bbfa2f6283490815ee5c7ab33ba8e66ee7bdc201e3eef39808db34d572e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/hy-AM/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/hy-AM/firefox-59.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "0697f146aa1e7d0d4aa8be28b72a642c66a15d7e6a2208a4d704ee8559f4f814a8a6cf601c58a7516816c86a374bca5f755d30e11ca668d9f77c8ea4e388f204";
+      sha512 = "4c25802601dadbac82dc260e329db69dff3b69d1eb9237fff76ae6de98a00a79dde0702d4cecfe67016a26e2a7ea4b1f15ce70eb82f422ea3bb8afb9810313bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ia/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ia/firefox-59.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "107bdfde5633415250fa0cd34ecf29dc39bceb8a5762445b9b5429f4c83690193fe433128799446029f458492d4bb2fea27d7654dcba5a7ce3007bcf40052ff2";
+      sha512 = "99b3d9c4533d376ee7a9f8fd364b9b44a8f0b9f235346a60755f144fae4550a6d51993952736b58e28ed3d07a549cd1d2da5223d7af28f187c78b41959e5d733";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/id/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/id/firefox-59.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "6935a4805b0498d5246f73720e02a022665fa40750937d31ba35d887ab289bcfc65fd122e6c18297443a6488a92a983e00844d384611e04e2e947d20a1aa82a5";
+      sha512 = "27275c8e2deb6716c8492fbc4ff56b8a2061be51101a2a7085c0a4bdf35c0bfec77af1f650236d13096ad204b93df695d5ab238ff6c312f9092f4d8adbc8d431";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/is/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/is/firefox-59.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "f04f5a86e348802e38593a0c6868a1f0c534113d4511a35ad4e831a2b3d00d8d9f7522e9813230e2abe710708d61c502337de031f934813275e0d81eea8b0379";
+      sha512 = "54b6be973aab07231843455b3e0adf8f7dbc19ecd1e484795af7d6a3e346ae717621d0950297379c88a955bd75af0a19497f55015cc624609510fc3ff7b8355e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/it/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/it/firefox-59.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "c0db0620e0df091f31ff576d5c87004f4c283a7455afb0098a5de50cfc8bb7879ece4d8525ec1c7f4d0af9d7934d254f114cbded07c8a93126cc6b35d6058f61";
+      sha512 = "bea36ccf3c3202bb41d09ef07cf4a30d8f3b7d64a96e4955f1e62c6ce1c252726991bb3dbd1d41b840ad7d626ca2abc83eca59a1997325d0f54231daea95ff06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ja/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ja/firefox-59.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "8a705718db55246b74ec0d1baa30e82c18b5898151d4b0ffa7f888cd53cf704444627c47a00af70eb381f9d5e4d163119ac57b23eb316524a4f949a722809d6a";
+      sha512 = "bfc409fd6487ff113045732d1826589f8020597958cad12d2b821f496eeb53e65cd4e1b1d002527f6255350254b60a96d9d04c47bcde8bac89483b04270f5b86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ka/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ka/firefox-59.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "6c0c0f2b67f327e03d874ea02fd084caac2756c21838c9787a03213961bc585db5bb0f2eb068a714dcc028a7d503836f1e7f652f60e08c0e9ab45f496e53b780";
+      sha512 = "f62ff3d950324b140238dc9e521e6a038a64dcc22c2679b36b59900b0f58b15d774084fdea7a1f82125a7d09d1b5c831808424e63612aac9e0a61320f6a3e4f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/kab/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/kab/firefox-59.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "381d4835f2dfc3a3a553d228e821daaa6966efcb47ca5d7a625813d59db8081a81a46dfd2f246842c937f75121585124c0e7607a9bd0cafb59ab42d88a2c908c";
+      sha512 = "573b7cbca69294ac56fd714308caed1549dbaff2c3716887765cf968c20d0ed37b1e0f2849af2481ef237d7c617c6641c42ecf0337fb0fc18afba82c89def034";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/kk/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/kk/firefox-59.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "82f0e6cbbc9a686be9bf76a0c582800f75edd3f608671faceb813addc0e2fb66a631082e083016118dd3aff8775432ef566319cf9834a8aaa09ed6f774ddc34d";
+      sha512 = "0503e33fc8716dd94c455a0a6201334ad2bbe1f3ad9cbce057d69ec77d65bdda48a126464335cee62117b3638be636e8f2908a003951dd2866908c964a9f889d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/km/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/km/firefox-59.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "7b1e81cf13051609897ad632afa18709dc6d9bbc66a6b7289188abe2f04a9bd1be159aa08342ce746930fc0cb50b19f0ff8abbea695787433acd25ad1cb48c58";
+      sha512 = "15797d366faf6f4daa60191e4c91cd9feab242e0879204ae8114ca5824a78fc42941c79d190526e1387ec28d2c150d008d4f69c78c450fa6c6aa9d3cbbd151c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/kn/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/kn/firefox-59.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "c17d8eba5bd0c1923f958dbde4a2fca62c423213b249fa1e2829361ade947aad32cdbe257cccf5d5160dd36033e827a78c6934db6bf96f166152b967a2c5d07d";
+      sha512 = "53908d7a78feb6b4ac8365aeacfa7cc845af5f324b57e0fed6bce78eb4298b316ccad268d022e9adc409eb9be49b9777c7f01197dad4ab79746b8805877c1706";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ko/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ko/firefox-59.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "c34c899ed8628829dcfb48b80a8b4022db9fadafc4edac4e227849ee58e06b0a9cd4fe089e080ff65e70177f7068686dab678f2e7b04dafbf1338caaea779b62";
+      sha512 = "ee4bc8ffdbd1a329df5dac2580122d883895418b93c69146206ae4e516ba1e5e993b23870ff487fb26df198b3ad73b708f9cd1f8c3f6a9f60dab73dea6ecd373";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/lij/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/lij/firefox-59.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "be96ae1d90a0e5f2308af47cae8bef7e028f01ef156bbd0497e578a0440a7362b18c63b36806ab4f1f2f1c4f8d6c9e5d9d03593ce38d1271809745cd2b266584";
+      sha512 = "a3e92d13e071ec8e76c9a4b946fadc146664263b5176ecd56dc6d412d4a0b8165b67c6be568805455e2179dacb2dc9d5d917981e3b6d52b8ce994d4062d7aae5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/lt/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/lt/firefox-59.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "b141b12385d040596085c328ce95b4ac741ccaebe1e950f00ebe09e96a2ea5b5ade4c5438f9b622423ef658f84659bab414eb467227cd9a664542fe76471d1f1";
+      sha512 = "47c6066bea50fa958812ac3389efa3408b2c35ace30c99d9ffb91ae037f1a2444933eb081992b97e3419554ef6ede9aff7c445b5262a59a324e7c1301059f149";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/lv/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/lv/firefox-59.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "ca296c7d74bfb0b4aa59da3f82dfe32b7c6564953c9850513bcb429ad68b6c867112eef7b7a2f9e1eb0bb8b7baa5f0f4caf4c9da311729e21976d70f8847bf44";
+      sha512 = "090db495b0e0883e0e378d992a855aee03e2f2fa02ea257522485742e5a879ca42231029c2e36b8a8c31425e343ea0fcc2568a9a961752ca709737c3b3bc32ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/mai/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/mai/firefox-59.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "378b32c8ca6cf0319c54dc239bfcd9edc8b834a5ecbe8c990ff8d7f7f28a89a30c53384c413352219309bf537dc4b0961ec0ea7eb2c1a4977b062c280ec130df";
+      sha512 = "b073c397f8d5196e14d0bbd45485532ac11cd01c42fba883c6d2f3b8f831b6cd6ce095f44e279b17ec60a12e48b776004edbc22ab76fde69af875842a48fb2c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/mk/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/mk/firefox-59.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "7925c3a6beca9e35cf301dc7b4ebb059fc87cd710e0243c71b65c55918d10ada853b4a4b8a1c7aa0e0c89bd8e9cd4414d5a162a430cf2222e3d5c0e824b96c73";
+      sha512 = "eb20befd569cf18a9bd8455d56d152e48b194e6703cc21457af6407348f5db0405d9fa6a7b503b8c72c96b9cda953c3e0167e5803f6f62947751e042562ad427";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ml/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ml/firefox-59.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "aa291245bcd21bd1e1a08f1b84346ec61311df8a9fa6f9b4af5b9cc6fcac6f332472cfe009f02faa9d842383c5e0588dd7705eaffb37c030f5e20951a4c0b2f9";
+      sha512 = "d91c916c45e9ac2abeb655bb318030553139294859701ad99cbaed1c946a24b71ebe63b7efc2d66f995cefe09b7d04bc5bda17784713d8e4a5f27702c4ac7797";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/mr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/mr/firefox-59.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "3bf781cc015ff35393f2d30244bc7a8c32a0ac789b0eb9da9616b1d58bb211982db2b03873a91d500f3972d0ddc32383a8e77af4b2f453d2fb8dccb71c7532c4";
+      sha512 = "9d925c4828a427bc77631b28ffd6857f5adc38266731be58e283aa99b2fb4ed304ab464b32f33bce4ce1506c13c76947264891eabd7e63dfdbd020605bb1e8c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ms/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ms/firefox-59.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "705665d30a04883d1fe5791348edc2fe0aa1554cbf2932901b99ef1f4334a1ea9658574fc02c05ee64f6b2e3e8d487b8520b1f1963f285f6475af1334160e5b9";
+      sha512 = "2e0f463f9db9f6c0e44e354ea495cc06f5dda8c92af586745744434c112073f4f46eab7576d1e26c93a7a8b739deb09930b10cca01eea70f6bc245a44d58fa74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/my/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/my/firefox-59.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "b1272fc81d358c3386cbdebad0595c7595b1d16dcee3fdef5f49776d6607f8737bdd4807140989e16873455df4a8746e00b8d3548f60cc9b22c282a5cea5a136";
+      sha512 = "3e279289928231a02436cb344f1629b990b220c22df04e4cd3583a4995e59901a0062763e246e8cbc44ec696c7a94eb8e25ab7534a9f32b957f1332228af9b7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/nb-NO/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/nb-NO/firefox-59.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "b44fc5f73c1dc3625ce50c9f6058f56f874a91e04178bb179667c6fde462a2436c6b35d58155ccabf340742f03d0ac1470b56fba405a13caaec4075567b3b8c7";
+      sha512 = "abf3048155dff62d4225471531568292410bae499f10a7f51caa493bf3c66d45a30fd3fe62db2bc21447259aa75e024681abd8b1f8567fd7647202b7399b256e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ne-NP/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ne-NP/firefox-59.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "bb063e310856adfbf3fe433d60d4fa19e8d5ace617064d334faa595cffc77d39d4e4e303b82858af8a956d43956928c7fcf70f319ce4059dae9b750d46ee3cf7";
+      sha512 = "a0a9a872bb6f92cc1f5fbf17e8ffa06fe841d5c0f50bfc543779caf10726e1a0a18bd003aef9619b25110b5a37510375de077461c3fab276cd58b319f4107a1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/nl/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/nl/firefox-59.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "64f3cfc10133c3fb0e566422282764679f9d1587b1aa742f24e9ba77f1f45e2c1dde4cb9b97d0eb3895b745cf2037a6dda9bcec469fce3b1ee125967f2869380";
+      sha512 = "0b0a0b5df01a72c4a433938dd8f750c60594e393108564ba20745205fa87e30231e8518e28bedb770d5b988c3684ea80f27f7de28d864a26da69fda3a5c39617";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/nn-NO/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/nn-NO/firefox-59.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "621c8767c5874fe530a0b4775df12be89c778915ba1f0d46271390c2208672d4211a9de501449458e88429483bf1ce453db652256c59308b3d42aa294d36649b";
+      sha512 = "0a8c474d2e0103dad61e7efbfe8bdabcf246395e7abc213a6b195aff79ae28d843c4dbcfcdbb1740c6d49e2329a1afbbde8e798dc50044be4924450c7f024396";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/or/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/or/firefox-59.0.2.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "3c271c3e01611d8e046d44fc90ea3a13cc974ad3fe08aeb1c3fa5f18f104dd1481a5a5c9273bf21a29b7aa15f49791584b32bacd26063ffde1ea4846166d4225";
+      sha512 = "3b97c26b98859f1fa6e8cd682908c46fcfac7bc4aa6d6e8b0495bcdd4e1ddb53f924d4436499dcf0f059ab24d516439c2c8b4881c938d74ebb7c0e2b30911a14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/pa-IN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/pa-IN/firefox-59.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "b0f6248a44d247c7affc35c2c4e664620e6ad5b83c4135d66f803245180052e77fa84db9d05b96475a221d5c2c288b73ad23cd7c717cabf2557282d72731cf4e";
+      sha512 = "978e0143198910d4c8c47764f7fce401cace00018318e5deb71a22666d7f94df735304354dd07ec2ca4386898ed4c15c8cd3efb1104dd054a4c1c11661b7619a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/pl/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/pl/firefox-59.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "75726fff593b0143a192cf3947f6c83a30c77552b227ccf2e5d0869b7a48dde22b1d555fee3baae8398b5cab58e1523ba7e15db6e237ece085b920f5fbbf4094";
+      sha512 = "618f2dd7460090dd0b1c0edff4b33d5ae51f1298f20ec5ccf845e5e6e5e4128c55b937496257ef49064806a720b5c8326cedca9764702824391447a83ed2118c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/pt-BR/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/pt-BR/firefox-59.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "701ffb3a4dd31cb6cf50a5523a384f222b6578c2d2a2870dc1e1cd985137dc9b78e81de092b1ebaee0108164bebc94aa1a8ea12981c02d49f885d8d6c9c8281c";
+      sha512 = "7e12f0f18562fb628b994df2e2c2a9bac4fe85ad593a0de37f3e1c3b1dce60406d2f28606aec5cf84ecec05570b38e7dd95d6f348dbadee09bf27ac34d52b47e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/pt-PT/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/pt-PT/firefox-59.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "a978e219a044b3e507ff5d907626939f8f9d0c3c988662ccdf394e613ca1127b2714c9973d90bd7d835e2af574d115b495c277f2d668142155b54e9098a285ae";
+      sha512 = "80d9c00f741ab177a5d0ffd94a8462077240c07a56dfb49213e222264224d5df5f4f964dac55d097b0ba9d658dd42ed50761ca86fc087c29cc4ef9d2972956ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/rm/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/rm/firefox-59.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "f0f3d5e022793bc92cc84fa5f8b413fc1ae1ec9da126386283297b41e47d722b4399722f69a05aac216d46d1a1ee90a1b6fb57194284c157e68c84121d4d989c";
+      sha512 = "9ef01b038cb0971b41fbb19d250db4ca96adc31f0a9cf8b7197ebe700acfab69b2dae35f2c3487ae1983df0793cacd5a7aca7d9fdec8b7fa94cb245ff1308338";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ro/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ro/firefox-59.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "4995938aeb22e69a6cd8a6b37b479e9d23a140b73ce2e5c4e29e6ff4f34d702db426346a596e207c2dd2e4d1bc6f1dfea00bc7ab7a2eae763ffe9fcfbf3e00b5";
+      sha512 = "d60ec8a9bddaabdae7b210c7b8f4229b10ae1080a89a3a661b6ffbffae479c81ec8f620b82655d92a792e31d4f1fad9477d195005dfdc803a7f3998d4a091413";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ru/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ru/firefox-59.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "32ab4f1bca6a51d204c54f4485d9642e8ccbebc008cd56e0cba55ea3a5ae5aebca050fe1e8e2b2a7fdf04480ecbab04515c0944c0d5aae0b81e350370cc2cabd";
+      sha512 = "8a42c89e4a0ac8f26421450637c2781c2dac2fd4469080f5d17a86cbbaa2c1cae56cc641797e6c1efb1576467c2d9e960b8a486f4b79556eba1d8a099d82e567";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/si/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/si/firefox-59.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "c2407c652b1907b3508f655c1bc831ecda75b8135dbfcaa1aed1a509a65fe2f21f22720bc80fdceede1e77c86fe39d0badf8d23f37ae48310df132c115bca448";
+      sha512 = "230b155c90db9c05a8f896357c1cb2baca0f96cada2a62fced73caa94a49116459b4ae42a4f61ce03dd08d9ce03541067a5cc64a53ad17cd63debbfe645a2614";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/sk/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/sk/firefox-59.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "f2a99e4f688a3384d23d36a87017ba0b5f28bfef2152867f8e8c8ca134a26e26052339c6edca1c24dfe5db5ce09d194675cac364a4918e46ae765d30ae3ab8d0";
+      sha512 = "1072c117830b85c54e7c1ead8ca552e92ce0c1971f26a28d27490802ceeb15fc105323599fd768a8ecd94597b3f51f8efdfb3e91743395c19b52a152ffb383d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/sl/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/sl/firefox-59.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "f454a9cf5a2e1528a546a82d6c2a1f4f2a668bd2b56633216d3955ec5c1c89d8734d8cdb0ee9306698aaa5060bc5f4797a9e0fa1c8967a00fd204eb035a8ba29";
+      sha512 = "5580f6777ce0acd2d47af993a8bec2e23ef16d77e6fb653147637e1efa08e82006a41108b94b213e7bb6d57b9dc27e8cc2bc1f0a26e9c2cf766e9c82dcc673d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/son/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/son/firefox-59.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "4b020b9c0f6e9bd594afc47900025dbd2223e50668f9f43f139b00f5534487806810bc933ab0258f5fcc8c277f7c5d2411d8605dd0fbae893f5809f9cc400c22";
+      sha512 = "0f930af28da8a3643d424dc957643682909d86f83d2cde87656abb33fd5d9c5277a46cf46d4ed28a790eaa0b5681f48cc43a2184c8273cb85c821359d07ad46e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/sq/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/sq/firefox-59.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "959f10db2a46cd8616686618d55119b01f0ac8e00e79093a949788ac903b6d3845a919a420d7517813e28b1227bd6f70fe8be9df39de8406743ddd7c65865e28";
+      sha512 = "08589b3b4bfb670a912045614bb408a856b48aee4184b98e475101b1ff0ce3f6659c13ae4ffeb981e28f0b7243ba6b340065224dae0cef85e6f5877b0b150db0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/sr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/sr/firefox-59.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "407e9337429d644ed75d3b2ae4953c5da3c6994e2f2ef2320becbde68662f16c711c987d4dfe2f0a784833b3c721c62cdd0080cdc1ed45a099b0c7b256411b85";
+      sha512 = "2abe8a5c502564823ffeaf59925d6749463e4aa0fcb0732f0c68acd8243b5a1bf5a71834fd9e519df8aa4b7b32fe69336ed9976b1ffb2ca67068cbe47f9b6987";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/sv-SE/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/sv-SE/firefox-59.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "f59c60fbeb82cb56ddd447d4c3d4125ea3a98e95a74e7802d73eac25489f2acd4566e01397b9ee6c70260779bb895fb104ace61f2ce9268b4f3f3758d686de1b";
+      sha512 = "ff79a7639d654cc2714f75e619c0c6c5862c1e4216fe7e2eeaf3876c47e16a6555dfa28e9be6b8215fe9e308e4c8753c5d70bcc6f3979c8a70fd7330652126ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ta/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ta/firefox-59.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "3ddc5a37d37a7db421f46d1d66d52197473f0e73c5c633ae52f12caa473ad5a4e73612a57bfc8d5d212c2b573b8308fb1b7697f78e153094230f8da64f074b64";
+      sha512 = "fb4d4c6def12ffe32eb9517858488921f1c77380f3d1d35a8652ebe7b9e14429709debffa6dd6a1008fee71c664fd8f582db1052a203dc1d7c10ba418222f7fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/te/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/te/firefox-59.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "c60cd73ec1eb27f9ab5e4ea63d3b4dc691c5c85d57a486ea408cda99f0c44c6c17e7d8e2a1de585dab1d4717bcdd7417b38b785c6f37722a3056a701163917b8";
+      sha512 = "ae97d60ac98c6cd9bad620a7c5dba8d51bdb2b035132daa0d915d1fc1e04802a25137bbbac82009ec51c0d858346e2f5c43f9981c48e991cc094cf11711fdeef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/th/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/th/firefox-59.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "0ec9c7b5143268d1266e939e5ed2617edf41c99e5bddf2d4240f49b1ee2822c4c6b269a24aa607623bc82a54b501cebc1f924a9c87fac21f95108089495414f6";
+      sha512 = "695fae213cc6705ec130c4dc08dd1c28f6ad605e0a2d0e92deef13737cc2780cd420dd883dc5153bf9cd174e1740effbc817054b16417fed90d04be04f21ab24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/tr/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/tr/firefox-59.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "ecf26013bc9cc189c89780c4b8b01c4f25dbc8f3f6c7bf924f528fe06ebf8c4952133e8446b3e0c8a09e3fa9d84b09883b3d4665d27ca7c028d90d3fe3d7fc1b";
+      sha512 = "f79e1f5027a84b772358d25f0441744036f60da7de5c0b26428ebd81900977e70d2c36b454e73f7026b7e20c058830502c92bdb8cc7d55c3ab40df43b7380d31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/uk/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/uk/firefox-59.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "c8595f21e86c4d1124b882ae4f1be026756b7cecb3ed5a02b4c723c37a999e2829881fab5d6349485078965881a91cfaf28bc926b5e96245e1771a9160adec76";
+      sha512 = "30b7661e84a875ff356284a87d1dc00a9e8fc1c03c953c471d785445e78cf4568450fec97bb16a1c63b092931719119510f33f55f02ff56e38adf4fb3be3f2c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/ur/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/ur/firefox-59.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "8d7be769c17135ad58a120cba472565597ddf05893f061e1efe2d2cf57c79bd8ec6f6a55e3271773fbc6a452e1794979cc619cc1a41d1bb13670b4f1badf4bb6";
+      sha512 = "9ef6fed1bea2857fc60e22eb9a87db8261316ba0852a3c5d35d65c3ead474ae34ee532588e25942f76be2f13a341c9bd9b672e5b192db1d3ccfee3f6a6787b83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/uz/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/uz/firefox-59.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "cd75b674a8ff62be2abc78cfa25873950914a7ef0fb6b652c483486c8dec888bed9276c2c7b323e5787ce802583e1d140d9414e7af9ce3ffc736e38fb1521177";
+      sha512 = "ab75b5c8e81b6bfc12b07b4fb2872cf2297c7249c352f5b66d95d867698f3e9a601f273e708bcb8855505eaba87b384e2b62f9d0b85e5976acf1c948e5e5a3e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/vi/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/vi/firefox-59.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "c5f9cb57563ff819236358c0ad18992f2c3f8b80decf690ec3945b029e2dbd6bc6f564af2a5bb6394eddb8a52ed0a0cab446cbd9c49284de821a814b766b60b0";
+      sha512 = "d08e244d22c92c0e64c1104d5bbaaa19fa3b0d8f7a3616ae0df71d8f141039f1e7e87480f52d319f57d545f58c7095da643d4bac150e47c3e595b27cb793076f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/xh/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/xh/firefox-59.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "9f96977530f745eeb1cdb14b40bf657e9a3d9e322b250fab799b37d801665fa47a47aa88c1f28998a29ed69523e42f300b69e008f5d2ff7f166e12b3c1fb4497";
+      sha512 = "b956f01619afc421ed23ac644af51f62fa9f5cffcd7f5b6bf640014d1326583f8ba871e4e4f5cf8e81ab0a2b46335b5e921243e71ed16d51b2c89f0a7d1a1280";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/zh-CN/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/zh-CN/firefox-59.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "5f3cbcfad55017b30e72ec4fb266d5b9f822804cee329c67c5998ad44a9fb6852b32764179586862cff1dc311c9a9a84259894282d57b5d2146c1d4de86442e4";
+      sha512 = "80f3c557a7fa2d51f5ba2d07adef2bd6980a4cd256b95702ee4fac2967d039476ea3b828ce951b354be9fea9508ecae2ea12a8b29f8feb0101b2101d741bf633";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.1/linux-i686/zh-TW/firefox-59.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/59.0.2/linux-i686/zh-TW/firefox-59.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "3f48bc028239f8cc8bf2f818129b1509f0e8d895087e8e7b16375df447e0d0ba7b543679a808aa579fc92bf2fc4af6c3797eacf03c905ce3714eed897a8b8f86";
+      sha512 = "50668a428310083cd175ce0dd9d09742866143d56efb0b13d11de1905d5b1d9f61e441bf1364e518aa87ebc790a335cc3b69d2438d3a4f92b4802345b8a443fa";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,10 +6,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "59.0.1";
+    version = "59.0.2";
     src = fetchurl {
-      url = "https://hg.mozilla.org/releases/mozilla-release/archive/3db9e3d52b17563efca181ccbb50deb8660c59ae.tar.bz2";
-      sha512 = "3da3gmfv2aalsbsx15csas4mwnvlliy1q081sd2riz3nvxr7qyrdx1qvxj4gdr97wlmvz7mig9djhh5gwx7ddah5hfhj23cvccmw6jw";
+      url = "https://hg.mozilla.org/releases/mozilla-release/archive/239e434d6d2b8e1e2b697c3416d1e96d48fe98e5.tar.bz2";
+      sha512 = "3kfh224sfc9ig4733frnskcs49xzjkrs00lxllsvx1imm6f4sf117mqlvc7bhgrn8ldiqn6vaa5g6gd9b7awkk1g975bbzk9namb3yv";
     };
 
     patches =

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -28,10 +28,10 @@ rec {
 
   firefox-esr = common rec {
     pname = "firefox-esr";
-    version = "52.7.2esr";
+    version = "52.7.3esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "e275fd10fd32a0dc237135af3395e3a1ae501844632c973ff3b9bca1456702ee36dbee99fc57300598403c924c0db63bd62a199845c8f4a2e29db5d1e5973395";
+      sha512 = "31y3qrslg61724vmly6gr1lqcrqgpkh3zsl8riax45gizfcp3qbgkvmd5wwfn9fiwjqi6ww3i08j51wxrfxcxznv7c6qzsvzzc30mgw";
     };
 
     meta = firefox.meta // {


### PR DESCRIPTION
###### Motivation for this change

Backports updates from #37960 & 73a7d67795654d35647d217d6d1d3cb0f9cf0899

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

