### PR TITLE
tvheadend: 4.2.5 -> 4.2.6

### DIFF
--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -3,7 +3,7 @@
 , which, zlib }:
 
 let
-  version = "4.2.5";
+  version = "4.2.6";
 
 in stdenv.mkDerivation rec {
   name = "tvheadend-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
     owner  = "tvheadend";
     repo   = "tvheadend";
     rev    = "v${version}";
-    sha256 = "199b0xm4lfdspmrirvzzg511yh358awciz23zmccvlvq86b548pz";
+    sha256 = "0rnhk0r34mfmz3cnf735nzkkyal7pnv16hfyrs0g4v5rk99rlab3";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/tvheadend/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend -h` got 0 exit code
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend --help` got 0 exit code
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend help` got 0 exit code
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend -V` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend -v` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend --version` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend version` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend -h` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend --help` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/tvheadend help` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped -h` got 0 exit code
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped --help` got 0 exit code
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped help` got 0 exit code
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped -V` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped -v` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped --version` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped version` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped -h` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped --help` and found version 4.2.6
- ran `/nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6/bin/.tvheadend-wrapped help` and found version 4.2.6
- found 4.2.6 with grep in /nix/store/b6w4xxckl2r7raw0zcyiq27f79cv16ng-tvheadend-4.2.6
- directory tree listing: https://gist.github.com/9bfa9dd5fc53c3f7b58b2db82fee94ef

cc @simonvandel for review