### PR TITLE
saga: 6.2.0 -> 6.3.0

### DIFF
--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -2,15 +2,15 @@
   libharu, opencv, vigra, postgresql }:
 
 stdenv.mkDerivation rec {
-  name = "saga-6.2.0";
+  name = "saga-6.3.0";
 
   buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma jasper ];
 
   enableParallelBuilding = true;
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/saga-gis/SAGA%20-%206/SAGA%20-%206.2.0/saga-6.2.0.tar.gz";
-    sha256 = "91b030892c894ba02eb4292ebfc9ccbf4acf3062118f2a89a9a11208773fa280";
+    url = "mirror://sourceforge/project/saga-gis/SAGA%20-%206/SAGA%20-%206.3.0/saga-6.3.0.tar.gz";
+    sha256 = "0hyjim8fcp3mna1hig22nnn4ki3j6b7096am2amcs99sdr09jjxv";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/saga/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/2wk34cz1vvl58pzw8szv4fdy5qwcc1g9-saga-6.3.0/bin/saga_cmd -h` got 0 exit code
- ran `/nix/store/2wk34cz1vvl58pzw8szv4fdy5qwcc1g9-saga-6.3.0/bin/saga_cmd --help` got 0 exit code
- ran `/nix/store/2wk34cz1vvl58pzw8szv4fdy5qwcc1g9-saga-6.3.0/bin/saga_cmd -v` and found version 6.3.0
- ran `/nix/store/2wk34cz1vvl58pzw8szv4fdy5qwcc1g9-saga-6.3.0/bin/saga_cmd --version` and found version 6.3.0
- ran `/nix/store/2wk34cz1vvl58pzw8szv4fdy5qwcc1g9-saga-6.3.0/bin/saga_cmd -h` and found version 6.3.0
- ran `/nix/store/2wk34cz1vvl58pzw8szv4fdy5qwcc1g9-saga-6.3.0/bin/saga_cmd --help` and found version 6.3.0
- found 6.3.0 with grep in /nix/store/2wk34cz1vvl58pzw8szv4fdy5qwcc1g9-saga-6.3.0
- found 6.3.0 in filename of file in /nix/store/2wk34cz1vvl58pzw8szv4fdy5qwcc1g9-saga-6.3.0
- directory tree listing: https://gist.github.com/338621d772f5e116a34641ab1a84ee1e

cc @michelk for review