### PR TITLE
shaarli: 0.9.5 -> 0.9.6

### DIFF
--- a/pkgs/servers/web-apps/shaarli/default.nix
+++ b/pkgs/servers/web-apps/shaarli/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "shaarli-${version}";
-  version = "0.9.5";
+  version = "0.9.6";
 
   src = fetchurl {
     url = "https://github.com/shaarli/Shaarli/releases/download/v${version}/shaarli-v${version}-full.tar.gz";
-    sha256 = "133ffxyw9bf61rky01d3rkkm34np5z4kwmgwx6ygshl83y0ylnwf";
+    sha256 = "0vi59988bjxb1cyifh0fynpxa7l6cl0v57hrxima5c9iid10pw54";
   };
 
   outputs = [ "out" "doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/shaarli/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 0.9.6 with grep in /nix/store/4asag0l86pv5s0klsgh61zga9ih1sllq-shaarli-0.9.6
- directory tree listing: https://gist.github.com/00a45b2940bf8949773bbdbe4e80767d

cc @schneefux for review