### PR TITLE
diskrsync: add ssh to PATH

### DIFF
--- a/pkgs/tools/backup/diskrsync/default.nix
+++ b/pkgs/tools/backup/diskrsync/default.nix
@@ -1,4 +1,4 @@
-{ buildGoPackage, fetchFromGitHub, stdenv }:
+{ buildGoPackage, fetchFromGitHub, stdenv, openssh, makeWrapper }:
 
 buildGoPackage rec {
 
@@ -15,6 +15,12 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/dop251/diskrsync";
   goDeps = ./deps.nix;
+
+  buildInputs = [ makeWrapper ];
+
+  preFixup = ''
+    wrapProgram "$bin/bin/diskrsync" --prefix PATH : ${openssh}/bin
+  '';
 
   meta = with stdenv.lib; {
     description = "Rsync for block devices and disk images";


### PR DESCRIPTION
###### Motivation for this change

SSH is a required runtime-only dependency of Diskrsync. This adds SSH to PATH by
using a wrapper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

