### PR TITLE
pythonPackages.pytest-flake8: 0.9.1 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/pytest-flake8/default.nix
+++ b/pkgs/development/python-modules/pytest-flake8/default.nix
@@ -1,9 +1,8 @@
 {lib, buildPythonPackage, fetchPypi, fetchpatch, pytest, flake8}:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "pytest-flake8";
-  version = "0.9.1";
+  version = "1.0.0";
 
   # although pytest is a runtime dependency, do not add it as
   # propagatedBuildInputs in order to allow packages depend on another version
@@ -13,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0032l4x2i5qn7ikaaw0kjs9f4ccpas21j564spyxwmx50wnhf5p7";
+    sha256 = "01driw4sc6nfi3m3ii7d074pxi3h1h4mbiyad9crg5i1l5jxx5ir";
   };
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Upgrade pytest-flake8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

