### PR TITLE
php: 7.2.3 -> 7.2.4

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -353,7 +353,7 @@ in {
   };
 
   php72 = generic {
-    version = "7.2.3";
-    sha256 = "14mzsp6ysjgc7f6vl0z0j996qf8n75yh0aga121dsr571fn5lwsa";
+    version = "7.2.4";
+    sha256 = "1wvy8jdd1l5hmdqgw7lq2ynkim3mxfsx8q7vp4il1jadfq6qlr8i";
   };
 }


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/php/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/phar.phar help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/phar.phar version` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/phar.phar help` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php -h` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php --help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php -v` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php --version` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/phpdbg -V` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/phpdbg --version` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-cgi -h` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-cgi --help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-cgi -v` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-cgi --version` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pear -h` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pear --help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pear help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pear -V` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pear version` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/peardev -h` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/peardev --help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/peardev help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/peardev -V` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/peardev version` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pecl -h` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pecl --help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pecl help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pecl -V` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/pecl version` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-fpm -h` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-fpm --help` got 0 exit code
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-fpm -v` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-fpm --version` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-fpm -h` and found version 7.2.4
- ran `/nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4/bin/php-fpm --help` and found version 7.2.4
- found 7.2.4 with grep in /nix/store/jkzy4favahn0mxn1i9ags1zazg4z7y8l-php-7.2.4
- directory tree listing: https://gist.github.com/3c197892ad9174dae3d07c1dd61b418c

cc @globin @etu for review