### PR TITLE
petsc: 3.8.3 -> 3.8.4

### DIFF
--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   name = "petsc-${version}";
-  version = "3.8.3";
+  version = "3.8.4";
 
   src = fetchurl {
     url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${version}.tar.gz";
-    sha256 = "1b1yr93g6df8kx10ri2y26bp3l3w3jv10r80krnarbvyjgnw7y81";
+    sha256 = "1iy49gagxncx09d88kxnwkj876p35683mpfk33x37165si6xqy4z";
   };
 
   nativeBuildInputs = [ blas gfortran.cc.lib liblapack python ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/petsc/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/saws/getSAWs.bash -h` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/saws/getSAWs.bash --help` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/saws/getSAWs.bash help` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/petscdiff -h` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/petscdiff --help` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/petscdiff -h` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/petscdiff --help` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py -h` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py --help` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py help` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py -V` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py -v` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py --version` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py version` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py -h` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py --help` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/update.py help` and found version 3.8.4
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/sendToJenkins -h` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/sendToJenkins --help` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/petscnagupgrade.py -h` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/petscnagupgrade.py --help` got 0 exit code
- ran `/nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4/bin/petscnagupgrade.py help` got 0 exit code
- found 3.8.4 with grep in /nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4
- found 3.8.4 in filename of file in /nix/store/czmq31v2xa85ql17whbn05774cncbr4a-petsc-3.8.4
- directory tree listing: https://gist.github.com/da90b8c44c7ed274deb2e1a2c7de8dad