### PR TITLE
mate.pluma: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pluma-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0w2x270n11rfa321cdlycfhcgncwxqpikjyl3lwmn4vkx8nhgq5f";
+    sha256 = "09arzypdz6q1zpxd1qqnsn1ykvhmzlf7nylkz2vpwlvnnd3x8ip3";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/pluma/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1/bin/pluma -h` got 0 exit code
- ran `/nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1/bin/pluma --help` got 0 exit code
- ran `/nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1/bin/pluma -V` and found version 1.20.1
- ran `/nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1/bin/pluma --version` and found version 1.20.1
- ran `/nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1/bin/.pluma-wrapped -h` got 0 exit code
- ran `/nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1/bin/.pluma-wrapped --help` got 0 exit code
- ran `/nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1/bin/.pluma-wrapped -V` and found version 1.20.1
- ran `/nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1/bin/.pluma-wrapped --version` and found version 1.20.1
- found 1.20.1 with grep in /nix/store/9037vgfwy4wdwna1s424vxy5j8mg2jhv-pluma-1.20.1
- directory tree listing: https://gist.github.com/acdcb2b6c22dc6400f8945338623543f

cc @romildo for review