### PR TITLE
peek: 1.2.2 -> 1.3.0

### DIFF
--- a/pkgs/applications/video/peek/default.nix
+++ b/pkgs/applications/video/peek/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "peek-${version}";
-  version = "1.2.2";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "phw";
     repo = "peek";
     rev = version;
-    sha256 = "1ihmq914g2h5iw86bigkkblzqimr50yq6z883lzq656xkcayd8gh";
+    sha256 = "0yizf55rzkm88bfjzwr8yyhm33yqp1mbih2ifwhvnjd1911db0x9";
   };
 
   nativeBuildInputs = [ cmake gettext pkgconfig libxml2.bin txt2man vala wrapGAppsHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/peek/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0/bin/peek -h` got 0 exit code
- ran `/nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0/bin/peek --help` got 0 exit code
- ran `/nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0/bin/peek -v` and found version 1.3.0
- ran `/nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0/bin/peek --version` and found version 1.3.0
- ran `/nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0/bin/.peek-wrapped -h` got 0 exit code
- ran `/nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0/bin/.peek-wrapped --help` got 0 exit code
- ran `/nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0/bin/.peek-wrapped -v` and found version 1.3.0
- ran `/nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0/bin/.peek-wrapped --version` and found version 1.3.0
- found 1.3.0 with grep in /nix/store/m8j6kly45y6clj5pjfza04jfmaklxwwy-peek-1.3.0
- directory tree listing: https://gist.github.com/551f0552b9f1c003d36fd0e56c41a3cc

cc @puffnfresh for review