### PR TITLE
ocamlPackages.ocp-ocamlres: 0.3 -> 0.4

### DIFF
--- a/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
+++ b/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
@@ -1,16 +1,20 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, pprint }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, astring, pprint }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "ocp-ocamlres is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation rec {
 	name = "ocaml${ocaml.version}-ocp-ocamlres-${version}";
-	version = "0.3";
+	version = "0.4";
 	src = fetchFromGitHub {
 		owner = "OCamlPro";
 		repo = "ocp-ocamlres";
 		rev = "v${version}";
-		sha256 = "0pm1g38f6pmch1x4pcc09ky587x5g7p7n9dfbbif8zkjqr603ixg";
+		sha256 = "0smfwrj8qhzknhzawygxi0vgl2af4vyi652fkma59rzjpvscqrnn";
 	};
 
-	buildInputs = [ ocaml findlib pprint ];
+	buildInputs = [ ocaml findlib astring pprint ];
 	createFindlibDestdir = true;
 
 	installFlags = [ "BINDIR=$(out)/bin" ];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

