### PR TITLE
newsboat: 2.10.2 -> 2.11

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "newsboat-${version}";
-  version = "2.10.2";
+  version = "2.11";
 
   src = fetchurl {
     url = "https://newsboat.org/releases/${version}/${name}.tar.xz";
-    sha256 = "1x4nxx1kvmrcm8jy73dvg56h4z15y3sach2vr13cw8rsbi7v99px";
+    sha256 = "0yh1qdk15s9k4pffiw1155whfckpffq72dpyp9rck7yxgy5ya1hx";
   };
 
   prePatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/newsboat/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/newsboat -h` got 0 exit code
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/newsboat --help` got 0 exit code
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/newsboat -V` and found version 2.11
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/newsboat -v` and found version 2.11
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/newsboat --version` and found version 2.11
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/newsboat -h` and found version 2.11
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/newsboat --help` and found version 2.11
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/podboat -h` got 0 exit code
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/podboat --help` got 0 exit code
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/podboat -h` and found version 2.11
- ran `/nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11/bin/podboat --help` and found version 2.11
- found 2.11 with grep in /nix/store/nh2qv0hhzggrpyh1jpyc86aqfwm2v469-newsboat-2.11
- directory tree listing: https://gist.github.com/0f097babc1eb329357e02d979e211d62

cc @dotlambda @nicknovitski for review