### PR TITLE
mate.mate-control-center: 1.20.0 -> 1.20.2

### DIFF
--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-control-center-${version}";
-  version = "1.20.0";
+  version = "1.20.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0qq3ln40w7lxa7qvbvbsgdq1c5ybzqw3bw2x4z6y6brl4c77sbh7";
+    sha256 = "1x40gxrz1hrzbdfl8vbag231g08h45vaky5z827k44qwl6pjd6nl";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mate-control-center/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-appearance-properties -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-appearance-properties --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-default-applications-properties -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-default-applications-properties --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-keyboard-properties -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-keyboard-properties --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-mouse-properties -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-mouse-properties --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-thumbnail-font -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-thumbnail-font --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-font-viewer -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-font-viewer --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-control-center -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/mate-control-center --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-appearance-properties-wrapped -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-appearance-properties-wrapped --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-default-applications-properties-wrapped -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-default-applications-properties-wrapped --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-keyboard-properties-wrapped -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-keyboard-properties-wrapped --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-mouse-properties-wrapped -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-mouse-properties-wrapped --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-thumbnail-font-wrapped -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-thumbnail-font-wrapped --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-font-viewer-wrapped -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-font-viewer-wrapped --help` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-control-center-wrapped -h` got 0 exit code
- ran `/nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2/bin/.mate-control-center-wrapped --help` got 0 exit code
- found 1.20.2 with grep in /nix/store/0m22i16f18nmpqwna76x1bazaqsbn7sb-mate-control-center-1.20.2
- directory tree listing: https://gist.github.com/6185ae89e86df301c5213f917605137b

cc @romildo for review