### PR TITLE
mate.mate-panel: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-panel-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0cz1pfwvsmrjcd0wa83cid9yjcygla6rhigyr7f75d75kiknlcm7";
+    sha256 = "1vmvn93apvq6r9m823zyrncbxgsjr4nmigw9k4s4n05z8zd8wy8k";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mate-panel/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1/bin/mate-desktop-item-edit -h` got 0 exit code
- ran `/nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1/bin/mate-desktop-item-edit --help` got 0 exit code
- ran `/nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1/bin/mate-panel-test-applets -h` got 0 exit code
- ran `/nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1/bin/mate-panel-test-applets --help` got 0 exit code
- ran `/nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1/bin/.mate-desktop-item-edit-wrapped -h` got 0 exit code
- ran `/nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1/bin/.mate-desktop-item-edit-wrapped --help` got 0 exit code
- ran `/nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1/bin/.mate-panel-test-applets-wrapped -h` got 0 exit code
- ran `/nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1/bin/.mate-panel-test-applets-wrapped --help` got 0 exit code
- found 1.20.1 with grep in /nix/store/k3l12ksm4cczvxiaj9g5j76ri43vi8xi-mate-panel-1.20.1
- directory tree listing: https://gist.github.com/5498a5168ebb3f4e2c6cd2cf3279ba16

cc @romildo for review