### PR TITLE
mate.mate-calc: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/mate-calc/default.nix
+++ b/pkgs/desktops/mate/mate-calc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-calc-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "03cma6b00chd4026pbnh5i0ckpl8b1l7i1ppvcmbfbx0s3vpbc73";
+    sha256 = "00k063ia4dclvcpg1q733lbi56533s6mj8bgb1nrgna6y7zw4q87";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mate-calc/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.20.1 with grep in /nix/store/n3d10s2lcxwlq38y4ffdgbnnx9kid3a1-mate-calc-1.20.1
- directory tree listing: https://gist.github.com/dd5057aba9569a13321ad8a61f05bea6

cc @romildo for review