### PR TITLE
mate.marco: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/marco/default.nix
+++ b/pkgs/desktops/mate/marco/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "marco-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "07asf8i15ih6ajkp5yapk720qyssi2cinxwg2z5q5j9m6mxax6lr";
+    sha256 = "1qnx47aibvl00qaf1jik457cwncxb71pf5pd1m3gdg7ky61ljkm4";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/marco/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/ayqx1pzkcj6igi9xs9k370wwrwnyqgfy-marco-1.20.1/bin/marco -h` got 0 exit code
- ran `/nix/store/ayqx1pzkcj6igi9xs9k370wwrwnyqgfy-marco-1.20.1/bin/marco --help` got 0 exit code
- ran `/nix/store/ayqx1pzkcj6igi9xs9k370wwrwnyqgfy-marco-1.20.1/bin/marco --version` and found version 1.20.1
- ran `/nix/store/ayqx1pzkcj6igi9xs9k370wwrwnyqgfy-marco-1.20.1/bin/.marco-wrapped -h` got 0 exit code
- ran `/nix/store/ayqx1pzkcj6igi9xs9k370wwrwnyqgfy-marco-1.20.1/bin/.marco-wrapped --help` got 0 exit code
- ran `/nix/store/ayqx1pzkcj6igi9xs9k370wwrwnyqgfy-marco-1.20.1/bin/.marco-wrapped --version` and found version 1.20.1
- found 1.20.1 with grep in /nix/store/ayqx1pzkcj6igi9xs9k370wwrwnyqgfy-marco-1.20.1
- directory tree listing: https://gist.github.com/10191e76177426ba4d6e8b8f8e9bfdb9

cc @romildo for review