### PR TITLE
lxcfs: 2.0.8 -> 3.0.0

### DIFF
--- a/pkgs/os-specific/linux/lxcfs/default.nix
+++ b/pkgs/os-specific/linux/lxcfs/default.nix
@@ -3,13 +3,13 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "lxcfs-2.0.8";
+  name = "lxcfs-3.0.0";
 
   src = fetchFromGitHub {
     owner = "lxc";
     repo = "lxcfs";
     rev = name;
-    sha256 = "04dzn6snqgw0znf7a7qdm64400jirip6q8amcx5fmz4705qdqahc";
+    sha256 = "0fsy2h7b5dkzvfm6m8vqzhnji42cszdn0b3ndnaxiwv3402ccmvk";
   };
 
   nativeBuildInputs = [ pkgconfig help2man autoreconfHook ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/lxcfs/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/8zp1vyhabqmk756rycka64phbc77q0pf-lxcfs-3.0.0/bin/lxcfs --version` and found version 3.0.0
- found 3.0.0 with grep in /nix/store/8zp1vyhabqmk756rycka64phbc77q0pf-lxcfs-3.0.0
- directory tree listing: https://gist.github.com/a1cba7cee628c2f7061269bc3f706957

cc @mic92 @fpletz for review