### PR TITLE
qpdfview: port to qt5

### DIFF
--- a/pkgs/applications/misc/qpdfview/default.nix
+++ b/pkgs/applications/misc/qpdfview/default.nix
@@ -21,16 +21,11 @@ stdenv.mkDerivation {
   src = fetchurl {
     inherit (s) url sha256;
   };
-  qmakeFlags = [
-    "*.pro"
-    "TARGET_INSTALL_PATH=${placeholder "out"}/bin"
-    "PLUGIN_INSTALL_PATH=${placeholder "out"}/lib/qpdfview"
-    "DATA_INSTALL_PATH=${placeholder "out"}/share/qpdfview"
-    "MANUAL_INSTALL_PATH=${placeholder "out"}/share/man/man1"
-    "ICON_INSTALL_PATH=${placeholder "out"}/share/icons/hicolor/scalable/apps"
-    "LAUNCHER_INSTALL_PATH=${placeholder "out"}/share/applications"
-    "APPDATA_INSTALL_PATH=${placeholder "out"}/share/appdata"
-  ];
+
+  # TODO: revert this once placeholder is supported
+  preConfigure = ''
+    qmakeFlags="$qmakeFlags *.pro TARGET_INSTALL_PATH=$out/bin PLUGIN_INSTALL_PATH=$out/lib/qpdfview DATA_INSTALL_PATH=$out/share/qpdfview MANUAL_INSTALL_PATH=$out/share/man/man1 ICON_INSTALL_PATH=$out/share/icons/hicolor/scalable/apps LAUNCHER_INSTALL_PATH=$out/share/applications APPDATA_INSTALL_PATH=$out/share/appdata"
+  '';
 
   meta = {
     inherit (s) version;

--- a/pkgs/applications/misc/qpdfview/default.nix
+++ b/pkgs/applications/misc/qpdfview/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, qt4, pkgconfig, poppler_qt4, djvulibre, libspectre, cups
+{stdenv, fetchurl, qmake, qtbase, qtsvg, pkgconfig, poppler_qt5, djvulibre, libspectre, cups
 , file, ghostscript
 }:
 let
@@ -10,9 +10,9 @@ let
     url="https://launchpad.net/qpdfview/trunk/${version}/+download/qpdfview-${version}.tar.gz";
     sha256 = "0zysjhr58nnmx7ba01q3zvgidkgcqxjdj4ld3gx5fc7wzvl1dm7s";
   };
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ qmake pkgconfig ];
   buildInputs = [
-    qt4 poppler_qt4 djvulibre libspectre cups file ghostscript
+    qtbase qtsvg poppler_qt5 djvulibre libspectre cups file ghostscript
   ];
 in
 stdenv.mkDerivation {
@@ -21,13 +21,17 @@ stdenv.mkDerivation {
   src = fetchurl {
     inherit (s) url sha256;
   };
-  configurePhase = ''
-    qmake *.pro
-    for i in *.pro; do 
-      qmake "$i" -o "Makefile.$(basename "$i" .pro)"
-    done
-    sed -e "s@/usr/@$out/@g" -i Makefile*
-  '';
+  qmakeFlags = [
+    "*.pro"
+    "TARGET_INSTALL_PATH=${placeholder "out"}/bin"
+    "PLUGIN_INSTALL_PATH=${placeholder "out"}/lib/qpdfview"
+    "DATA_INSTALL_PATH=${placeholder "out"}/share/qpdfview"
+    "MANUAL_INSTALL_PATH=${placeholder "out"}/share/man/man1"
+    "ICON_INSTALL_PATH=${placeholder "out"}/share/icons/hicolor/scalable/apps"
+    "LAUNCHER_INSTALL_PATH=${placeholder "out"}/share/applications"
+    "APPDATA_INSTALL_PATH=${placeholder "out"}/share/appdata"
+  ];
+
   meta = {
     inherit (s) version;
     description = "A tabbed document viewer";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18213,7 +18213,7 @@ with pkgs;
 
   vimNox = lowPrio (vim_configurable.override { source = "vim-nox"; });
 
-  qpdfview = callPackage ../applications/misc/qpdfview {};
+  qpdfview = libsForQt5.callPackage ../applications/misc/qpdfview {};
 
   qtile = callPackage ../applications/window-managers/qtile {
     inherit (xorg) libxcb;


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/32883

Depends on: #37693 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

