### PR TITLE
mate.mate-applets: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/mate-applets/default.nix
+++ b/pkgs/desktops/mate/mate-applets/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-applets-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1jmhswfcbawp9ax5p5h2dj8pyajadjdyxa0ac7ldvh7viv8qy52s";
+    sha256 = "1a119g49sr7jrd8i32bw7sn2qlsg3sdiwqdb2v36bm2999j261wc";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mate-applets/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.20.1 with grep in /nix/store/yivfww8swkvh2y5sf83brw5wbvklz26r-mate-applets-1.20.1
- directory tree listing: https://gist.github.com/ff5a1f8bc5fd9849a34c7e1d1bbc0c87

cc @romildo for review