### PR TITLE
mate.mate-settings-daemon: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-settings-daemon-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0p4fr2sgkjcjsrmkdy579xmk20dl0sa6az40rzvm6fb2w6693sf5";
+    sha256 = "1hmc5qfr9yrvrlc1d2mmsqbhv0lhikbadaac18bxjynw9ff857iq";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mate-settings-daemon/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.20.1 with grep in /nix/store/n8ns53r2lfxa944hp7a8k9ylrwl18mp0-mate-settings-daemon-1.20.1
- directory tree listing: https://gist.github.com/de97ad2597f0b680b23b448f8353527b

cc @romildo for review