### PR TITLE
mate.mate-power-manager: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/mate-power-manager/default.nix
+++ b/pkgs/desktops/mate/mate-power-manager/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-power-manager-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "038c2q5kqvqmkp1i93p4pp9x8p6a9i7lyn3nv522mq06qsbynbww";
+    sha256 = "1s46jvjcrai6xb2k0dy7i121b9ihfl5h3y5809fg9fzrbvw6bafn";
   };
 
   buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mate-power-manager/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-manager -h` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-manager --help` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-manager --version` and found version 1.20.1
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-preferences -h` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-preferences --help` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-statistics -h` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-statistics --help` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/.mate-power-manager-wrapped -h` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/.mate-power-manager-wrapped --help` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/.mate-power-manager-wrapped --version` and found version 1.20.1
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/.mate-power-preferences-wrapped -h` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/.mate-power-preferences-wrapped --help` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/.mate-power-statistics-wrapped -h` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/.mate-power-statistics-wrapped --help` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-backlight-helper -h` got 0 exit code
- ran `/nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1/bin/mate-power-backlight-helper --help` got 0 exit code
- found 1.20.1 with grep in /nix/store/0qj1rkdjfc3yazdk2xa46147sg5rhzd4-mate-power-manager-1.20.1
- directory tree listing: https://gist.github.com/a6a1ffa6917fe4c0aa8b463061551af2

cc @romildo @chpatrick for review