### PR TITLE
mate.mate-desktop: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-desktop-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0y5172sbj6f4dvimf4pmz74b9cfidbpmnwwb9f6vlc6fa0kp5l1n";
+    sha256 = "0jxhhf9w6mz8ha6ymgj2alzmiydylg4ngqslkjxx37vvpvms2dyx";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mate-desktop/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/1pkc0ykfrmr39ah5av4bb1nzyb5vx0vg-mate-desktop-1.20.1/bin/mate-about -h` got 0 exit code
- ran `/nix/store/1pkc0ykfrmr39ah5av4bb1nzyb5vx0vg-mate-desktop-1.20.1/bin/mate-about --help` got 0 exit code
- ran `/nix/store/1pkc0ykfrmr39ah5av4bb1nzyb5vx0vg-mate-desktop-1.20.1/bin/.mate-about-wrapped -h` got 0 exit code
- ran `/nix/store/1pkc0ykfrmr39ah5av4bb1nzyb5vx0vg-mate-desktop-1.20.1/bin/.mate-about-wrapped --help` got 0 exit code
- found 1.20.1 with grep in /nix/store/1pkc0ykfrmr39ah5av4bb1nzyb5vx0vg-mate-desktop-1.20.1
- directory tree listing: https://gist.github.com/d509aa61ab7b795e96d46f3e0e3d3e38

cc @romildo for review