### PR TITLE
Make dbus look for .conf files in share/dbus-1/system.d/ too

### DIFF
--- a/pkgs/development/libraries/dbus/make-system-conf.xsl
+++ b/pkgs/development/libraries/dbus/make-system-conf.xsl
@@ -27,6 +27,7 @@
       <xsl:for-each select="str:tokenize($serviceDirectories)">
         <servicedir><xsl:value-of select="." />/share/dbus-1/system-services</servicedir>
         <includedir><xsl:value-of select="." />/etc/dbus-1/system.d</includedir>
+        <includedir><xsl:value-of select="." />/share/dbus-1/system.d</includedir>
       </xsl:for-each>
     </busconfig>
   </xsl:template>


### PR DESCRIPTION
###### Motivation for this change

Some packages install their dbus config files to `share/dbus-1/system.d` instead
of `etc/dbus-1/system.d`, so look in both places.

Specifically this happens with `colord`, which [breaks the Night Light feature on Gnome Shell](https://github.com/NixOS/nixpkgs/pull/37613). A `nix-locate` search makes it clear that this location is uncommon, with `usbguard` being the only other package that uses it.

However it seems like this is a standard location according to the [dbus manual](https://dbus.freedesktop.org/doc/dbus-daemon.1.html) (my emphasis):
> This is intended to allow extension of the system bus by particular packages. For example, if CUPS wants to be able to send out notification of printer queue changes, it could install a file to **/usr/share/dbus-1/system.d** or **/etc/dbus-1/system.d** that allowed all apps to receive this message and allowed the printer daemon user to send it.

So instead of patching specific packages, looking for `.conf` files in `share/dbus-1/system.d` by default seems sane.

###### Things done

Running my system with the commit makes Night Light work

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

