### PR TITLE
mate.libmatekbd: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/libmatekbd/default.nix
+++ b/pkgs/desktops/mate/libmatekbd/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libmatekbd-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1n2zphb3g6ai54nfr0r9s06vn3bmm361xpjga88hmq947fvbpx19";
+    sha256 = "1d80xnbb8w51cv9cziybdxca037lksqkc5bd8wqlyb2p79z77426";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/libmatekbd/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.20.1 with grep in /nix/store/03zsljdh5dy4xidfi0hr9irs23z5lvj4-libmatekbd-1.20.1
- directory tree listing: https://gist.github.com/16b4b6e371f933ba6a7c385070a069c0

cc @romildo for review