### PR TITLE
jbake: 2.5.1 -> 2.6.0

### DIFF
--- a/pkgs/development/tools/jbake/default.nix
+++ b/pkgs/development/tools/jbake/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchzip, jre }:
 
 stdenv.mkDerivation rec {
-  version = "2.5.1";
+  version = "2.6.0";
   name = "jbake-${version}";
 
   src = fetchzip {
     url = "https://dl.bintray.com/jbake/binary/${name}-bin.zip";
-    sha256 = "1ib5gvz6sl7k0ywx22anhz69i40wc6jj5lxjxj2aa14qf4lrw912";
+    sha256 = "1k71rz82fwyi51xhyghg8laz794xyz06d5apmxa9psy7yz184ylk";
   };
 
   buildInputs = [ jre ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/jbake/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0/bin/jbake -h` got 0 exit code
- ran `/nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0/bin/jbake --help` got 0 exit code
- ran `/nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0/bin/jbake help` got 0 exit code
- ran `/nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0/bin/jbake version` and found version 2.6.0
- ran `/nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0/bin/jbake -h` and found version 2.6.0
- ran `/nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0/bin/jbake --help` and found version 2.6.0
- ran `/nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0/bin/jbake help` and found version 2.6.0
- found 2.6.0 with grep in /nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0
- found 2.6.0 in filename of file in /nix/store/mn3b11ybbp508yngrds39czbycjhacf6-jbake-2.6.0
- directory tree listing: https://gist.github.com/1cd96e2ec3fd1a83c4b62c8a7213936c

cc @moaxcp for review