### PR TITLE
haproxy: 1.8.4 -> 1.8.5

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -9,12 +9,12 @@ assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
-  version = "1.8.4";
+  version = "1.8.5";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${name}.tar.gz";
-    sha256 = "19l4i0p92ahm3vaw42gz3rmmidfivk36mvqyhir81h6ywyjb01g3";
+    sha256 = "1j90p8wdj8criy05h9c0knnqg3d28znaga4s3jmxacjkm0zhh8hw";
   };
 
   buildInputs = [ openssl zlib ]


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/haproxy/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/skhmvmz0vcqa7gbpsppd0fwrh6a8n761-haproxy-1.8.5/bin/haproxy -v` and found version 1.8.5
- found 1.8.5 with grep in /nix/store/skhmvmz0vcqa7gbpsppd0fwrh6a8n761-haproxy-1.8.5
- directory tree listing: https://gist.github.com/1549b5d3c19c1a8193ffc81587748646

cc @garbas for review