### PR TITLE
fatrace: 0.12 -> 0.13

### DIFF
--- a/pkgs/os-specific/linux/fatrace/default.nix
+++ b/pkgs/os-specific/linux/fatrace/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "fatrace-${version}";
-  version = "0.12";
+  version = "0.13";
 
   src = fetchurl {
     url = "http://launchpad.net/fatrace/trunk/${version}/+download/${name}.tar.bz2";
-    sha256 = "0szn86rbbvmjcw192vjhhgc3v99s5lm2kg93gk1yzm6ay831grsh";
+    sha256 = "0hrh45bpzncw0jkxw3x2smh748r65k2yxvfai466043bi5q0d2vx";
   };
 
   buildInputs = [ python3 which ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/fatrace/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/6qkvyq8dkw4g27id4gz509wixsvz5786-fatrace-0.13/bin/fatrace -h` got 0 exit code
- ran `/nix/store/6qkvyq8dkw4g27id4gz509wixsvz5786-fatrace-0.13/bin/fatrace --help` got 0 exit code
- directory tree listing: https://gist.github.com/621ef8c6e91074c88839f359832f776e