### PR TITLE
dovecot: 2.3.0.1 -> 2.3.1

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -30,6 +30,7 @@ let
 
     ''
       default_internal_user = ${cfg.user}
+      default_internal_group = ${cfg.group}
       ${optionalString (cfg.mailUser != null) "mail_uid = ${cfg.mailUser}"}
       ${optionalString (cfg.mailGroup != null) "mail_gid = ${cfg.mailGroup}"}
 

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -8,7 +8,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.3.0.1";
+  name = "dovecot-2.3.1";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs =
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://dovecot.org/releases/2.3/${name}.tar.gz";
-    sha256 = "0lzisrdgrj5qqwjb7bv99mf2aljm568r6g108yisp0s644z2nxxb";
+    sha256 = "14zva4f8k64x86sm9n21cp2yvrpph6k6k52bm22a00pxjwdq50q8";
   };
 
   preConfigure = ''

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
-  version = "0.5.0.1";
+  version = "0.5.1";
 
   src = fetchurl {
     url = "http://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-${version}.tar.gz";
-    sha256 = "1lpsdqh9pwqx917z5v23bahhhbrcb3y5ps3l413sli8cn4a6sdan";
+    sha256 = "0ivmaxic6cygfphvlrvy0xgggydm7j7kjv1ssfqbr08q4rcsmc73";
   };
 
   buildInputs = [ dovecot openssl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/dovecot/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/c20ip7wyymd39l7zisx38ky3bxp1sybv-dovecot-2.3.1/bin/dovecot --help` got 0 exit code
- ran `/nix/store/c20ip7wyymd39l7zisx38ky3bxp1sybv-dovecot-2.3.1/bin/dovecot --version` and found version 2.3.1
- found 2.3.1 with grep in /nix/store/c20ip7wyymd39l7zisx38ky3bxp1sybv-dovecot-2.3.1
- directory tree listing: https://gist.github.com/6d90467ee7649d7efc0a48eeacfc42c8

cc @viric @peti @rickynils @fpletz for review