### PR TITLE
ppp: fix build with newer kernel headers

### DIFF
--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -23,15 +23,30 @@ stdenv.mkDerivation rec {
         url = "https://anonscm.debian.org/git/collab-maint/pkg-ppp.git/plain/debian/patches/rc_mksid-no-buffer-overflow?h=debian/2.4.7-1%2b4";
         sha256 = "1dk00j7bg9nfgskw39fagnwv1xgsmyv0xnkd6n1v5gy0psw0lvqh";
       })
+      (fetchurl {
+        url = "https://anonscm.debian.org/git/collab-maint/pkg-ppp.git/plain/debian/patches/0016-pppoe-include-netinet-in.h-before-linux-in.h.patch";
+        sha256 = "1xnmqn02kc6g5y84xynjwnpv9cvrfn3nyv7h7r8j8xi7qf2aj4q8";
+      })
       ./musl-fix-headers.patch
     ];
 
   buildInputs = [ libpcap ];
 
+  postPatch = ''
+    # strip is not found when cross compiling with seemingly no way to point
+    # make to the right place, fixup phase will correctly strip
+    # everything anyway so we remove it from the Makefiles
+    for file in $(find -name Makefile.linux); do
+      substituteInPlace "$file" --replace '$(INSTALL) -s' '$(INSTALL)'
+    done
+  '';
+
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     make install
     install -D -m 755 scripts/{pon,poff,plog} $out/bin
+    runHook postInstall
   '';
 
   postFixup = ''

--- a/pkgs/tools/networking/ppp/musl-fix-headers.patch
+++ b/pkgs/tools/networking/ppp/musl-fix-headers.patch
@@ -89,12 +89,12 @@ index 3d3bf4e..b5f82d3 100644
     use different frame types... sigh... */
  
 diff --git a/pppd/plugins/rp-pppoe/pppoe.h b/pppd/plugins/rp-pppoe/pppoe.h
-index 9ab2eee..4d68147 100644
+index c4aaa6e..70aef85 100644
 --- a/pppd/plugins/rp-pppoe/pppoe.h
 +++ b/pppd/plugins/rp-pppoe/pppoe.h
-@@ -86,18 +86,6 @@ typedef unsigned long UINT32_t;
- 
- #include <netinet/in.h>
+@@ -88,18 +88,6 @@ typedef unsigned long UINT32_t;
+ #include <linux/if_ether.h>
+ #endif
  
 -#ifdef HAVE_NETINET_IF_ETHER_H
 -#include <sys/types.h>
@@ -108,9 +108,9 @@ index 9ab2eee..4d68147 100644
 -#endif
 -
 -
- 
  /* Ethernet frame types according to RFC 2516 */
  #define ETH_PPPOE_DISCOVERY 0x8863
+ #define ETH_PPPOE_SESSION   0x8864
 diff --git a/pppd/sys-linux.c b/pppd/sys-linux.c
 index 6d71530..86d224e 100644
 --- a/pppd/sys-linux.c


### PR DESCRIPTION
###### Motivation for this change

The package would build but with some components missing, see https://github.com/NixOS/nixpkgs/issues/37926 and https://hydra.nixos.org/build/70939248/nixlog/1 -> CTRL-F error:

Not sure how to test this beyond checking the missing `.so` now exists.

Hopefully fixes #37926 /cc @TvoroG.

/cc @dtzWill as I had to regenerate the musl patch + there was some `strip` weirdness in the install phase when I tried to build for musl.

Should probably be backported to 18.03 as well as it seems to have the same issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

