### PR TITLE
facter: 3.10.0 -> 3.11.0

### DIFF
--- a/pkgs/tools/system/facter/default.nix
+++ b/pkgs/tools/system/facter/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "facter-${version}";
-  version = "3.10.0";
+  version = "3.11.0";
 
   src = fetchFromGitHub {
-    sha256 = "0qj23n5h98iirwhnjpcqzmirqf92sjd8mws5dky0pap359j6w792";
+    sha256 = "15cqn09ng23k6a70xvxbpjjqlxw46838k7qr9216lcvxwl2banih";
     rev = version;
     repo = "facter";
     owner = "puppetlabs";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/facter/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/azfbahp02g1xs110kvk4j281biimil8d-facter-3.11.0/bin/facter -h` got 0 exit code
- ran `/nix/store/azfbahp02g1xs110kvk4j281biimil8d-facter-3.11.0/bin/facter --help` got 0 exit code
- ran `/nix/store/azfbahp02g1xs110kvk4j281biimil8d-facter-3.11.0/bin/facter help` got 0 exit code
- ran `/nix/store/azfbahp02g1xs110kvk4j281biimil8d-facter-3.11.0/bin/facter -v` and found version 3.11.0
- ran `/nix/store/azfbahp02g1xs110kvk4j281biimil8d-facter-3.11.0/bin/facter --version` and found version 3.11.0
- found 3.11.0 with grep in /nix/store/azfbahp02g1xs110kvk4j281biimil8d-facter-3.11.0
- found 3.11.0 in filename of file in /nix/store/azfbahp02g1xs110kvk4j281biimil8d-facter-3.11.0
- directory tree listing: https://gist.github.com/f7f2e9775c3cd7188e8466f33d703e81

cc @womfoo for review