### PR TITLE
convmv: 2.04 -> 2.05

### DIFF
--- a/pkgs/tools/misc/convmv/default.nix
+++ b/pkgs/tools/misc/convmv/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
-  name = "convmv-2.04";
+  name = "convmv-2.05";
 
   src = fetchurl {
     url = "http://www.j3e.de/linux/convmv/${name}.tar.gz";
-    sha256 = "075xn1ill26hbhg4nl54sp75b55db3ikl7lvhqb9ijvkpi67j6yy";
+    sha256 = "19hwv197p7c23f43vvav5bs19z9b72jzca2npkjsxgprwj5ardjk";
   };
 
   preBuild=''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/convmv/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.05 with grep in /nix/store/m6nrjfc07fmfrb5bgqa47r4rqg3m33bm-convmv-2.05
- directory tree listing: https://gist.github.com/f979cfc98f20cef8a081e913a83cca1f