### PR TITLE
chirp: 20170714 -> 20180325

### DIFF
--- a/pkgs/applications/misc/chirp/default.nix
+++ b/pkgs/applications/misc/chirp/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "chirp-daily-${version}";
-  version = "20170714";
+  version = "20180325";
 
   src = fetchurl {
     url = "http://trac.chirp.danplanet.com/chirp_daily/daily-${version}/${name}.tar.gz";
-    sha256 = "1pglsmc0pf50w7df4vv30z5hmdxy4aqjl3qrv8kfiax7rld21gcy";
+    sha256 = "0z2m74hhkxvxchxv819wy947v3wl13kxrdq4kjjazzrlyaky921y";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/chirp-daily/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 20180325 with grep in /nix/store/xlgh06iiayz3f6svbqhdvnmhklvi4w3i-chirp-daily-20180325
- directory tree listing: https://gist.github.com/fe1b7b075a9c5f16ef47891d6730b7bb

cc @the-kenny for review