### PR TITLE
mate.caja: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "caja-${version}";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "05shyqqapqbz4w0gbhx0i3kj6xg7rcj80hkaq7wf5pyj91wmkxqg";
+    sha256 = "1qqqq3fi1aqjqg36y3v73z4d0bqkx7d5f79i6h9lxyh3s0876v9c";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/caja/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1/bin/caja -h` got 0 exit code
- ran `/nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1/bin/caja --help` got 0 exit code
- ran `/nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1/bin/caja-connect-server -h` got 0 exit code
- ran `/nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1/bin/caja-connect-server --help` got 0 exit code
- ran `/nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1/bin/.caja-wrapped -h` got 0 exit code
- ran `/nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1/bin/.caja-wrapped --help` got 0 exit code
- ran `/nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1/bin/.caja-connect-server-wrapped -h` got 0 exit code
- ran `/nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1/bin/.caja-connect-server-wrapped --help` got 0 exit code
- found 1.20.1 with grep in /nix/store/ldcsqk6apjpigv38q8h6ns6ibyi8ch3j-caja-1.20.1
- directory tree listing: https://gist.github.com/fca0531e6f5ba7a3ba6f73c2e58c2eed

cc @romildo for review