### PR TITLE
babeltrace: 1.5.4 -> 1.5.5

### DIFF
--- a/pkgs/development/tools/misc/babeltrace/default.nix
+++ b/pkgs/development/tools/misc/babeltrace/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, libuuid, popt, elfutils }:
 
 stdenv.mkDerivation rec {
-  name = "babeltrace-1.5.4";
+  name = "babeltrace-1.5.5";
 
   src = fetchurl {
     url = "http://www.efficios.com/files/babeltrace/${name}.tar.bz2";
-    sha256 = "1h8zi7afilbfx4jvdlhhgysj6x01w3799mdk4mdcgax04fch6hwn";
+    sha256 = "1b78fam1gbsalga5pppn8ka461q35a9svz3mlbv82ssakdw4d4a0";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/babeltrace/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/yhd43sy0rj5fr0gwh298l959b7bmcsh8-babeltrace-1.5.5/bin/babeltrace -h` got 0 exit code
- ran `/nix/store/yhd43sy0rj5fr0gwh298l959b7bmcsh8-babeltrace-1.5.5/bin/babeltrace --help` got 0 exit code
- ran `/nix/store/yhd43sy0rj5fr0gwh298l959b7bmcsh8-babeltrace-1.5.5/bin/babeltrace -h` and found version 1.5.5
- ran `/nix/store/yhd43sy0rj5fr0gwh298l959b7bmcsh8-babeltrace-1.5.5/bin/babeltrace --help` and found version 1.5.5
- ran `/nix/store/yhd43sy0rj5fr0gwh298l959b7bmcsh8-babeltrace-1.5.5/bin/babeltrace-log -h` got 0 exit code
- ran `/nix/store/yhd43sy0rj5fr0gwh298l959b7bmcsh8-babeltrace-1.5.5/bin/babeltrace-log -h` and found version 1.5.5
- found 1.5.5 with grep in /nix/store/yhd43sy0rj5fr0gwh298l959b7bmcsh8-babeltrace-1.5.5
- directory tree listing: https://gist.github.com/d849a2026946a7542bc3e2e6a586d713

cc @bjornfor for review