### PR TITLE
busybox: 1.28.1 -> 1.28.2

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -33,14 +33,14 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "busybox-1.28.1";
+  name = "busybox-1.28.2";
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
   # still builds after the update.
   src = fetchurl {
     url = "http://busybox.net/downloads/${name}.tar.bz2";
-    sha256 = "0bk52cxxlya5hg9va87snr9caz9ppdrpdyjwrnbwamhi64y1vzlq";
+    sha256 = "03abp2n08xk32x8lhdinpxb8gk3faxjmgrv0xqw6ijbp12k98jmn";
   };
 
   hardeningDisable = [ "format" ] ++ lib.optionals enableStatic [ "fortify" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/busybox/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/6hb5pdrhbqaadszay9afnvh87r7zkyfy-busybox-1.28.2/bin/busybox --help` got 0 exit code
- ran `/nix/store/6hb5pdrhbqaadszay9afnvh87r7zkyfy-busybox-1.28.2/bin/busybox --help` and found version 1.28.2
- found 1.28.2 with grep in /nix/store/6hb5pdrhbqaadszay9afnvh87r7zkyfy-busybox-1.28.2
- directory tree listing: https://gist.github.com/fa3a6f072c619484d1bcce6c8b4f306a

cc @viric for review