### PR TITLE
linuxPackages.phc-intel: 0.4.0-rev24 -> 0.4.0-rev25

### DIFF
--- a/pkgs/os-specific/linux/phc-intel/default.nix
+++ b/pkgs/os-specific/linux/phc-intel/default.nix
@@ -6,14 +6,14 @@ assert stdenv.lib.versionAtLeast kernel.version "4.10";
 
 let
   release = "0.4.0";
-  revbump = "rev24"; # don't forget to change forum download id...
+  revbump = "rev25"; # don't forget to change forum download id...
 in stdenv.mkDerivation rec {
   name = "linux-phc-intel-${version}-${kernel.version}";
   version = "${release}-${revbump}";
 
   src = fetchurl {
-    sha256 = "02b4j8ap1fy09z36pmpplbw4vpwqdi16jyzw5kl0a60ydgxkmrpz";
-    url = "http://www.linux-phc.org/forum/download/file.php?id=178";
+    sha256 = "1w91hpphd8i0br7g5qra26jdydqar45zqwq6jq8yyz6l0vb10zlz";
+    url = "http://www.linux-phc.org/forum/download/file.php?id=194";
     name = "phc-intel-pack-${revbump}.tar.bz2";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Upstream update, fixes compatibility with 4.15 kernel. Please backport to 18.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

