### PR TITLE
nixos/monit: reload monit if config changes

### DIFF
--- a/nixos/modules/services/monitoring/monit.nix
+++ b/nixos/modules/services/monitoring/monit.nix
@@ -49,5 +49,21 @@ in
         Restart = "always";
       };
     };
+
+    systemd.services.monit-reload = {
+      description = "Reload monit";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.systemd}/bin/systemctl reload monit";
+      };
+    };
+
+    systemd.paths.monit-reload = {
+      pathConfig = {
+        PathChanged = "/etc/monitrc";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+
   };
 }


### PR DESCRIPTION
Previously, if `monit.config` changes, the monit service would not reload it. This commit adds a systemd path and unit to check for changes and reload if the config file changes.

I'm not sure if this is the right way to do this. It seems kind of hacky that it isn't an activation script. I think most services accomplish this kind of reloading/restarting by having the configuration file passed as a parameter to the service in `ExecStart`, but we cannot do this because Monit expects the configuration file to have mode `400`, which is not possible for a file directly in the nix store.