### PR TITLE
nixos/monit: restart if config changes

### DIFF
--- a/nixos/modules/services/monitoring/monit.nix
+++ b/nixos/modules/services/monitoring/monit.nix
@@ -26,16 +26,10 @@ in
 
     environment.systemPackages = [ pkgs.monit ];
 
-    environment.etc = [
-      {
-        source = pkgs.writeTextFile {
-          name = "monitrc";
-          text = config.services.monit.config;
-        };
-        target = "monitrc";
-        mode = "0400";
-      }
-    ];
+    environment.etc."monitrc" = {
+      text = config.services.monit.config;
+      mode = "0400";
+    };
 
     systemd.services.monit = {
       description = "Pro-active monitoring utility for unix systems";
@@ -48,6 +42,8 @@ in
         KillMode = "process";
         Restart = "always";
       };
+      restartTriggers = [ config.environment.etc."monitrc".source ];
     };
+
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Monit did not restart if the config changed before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

