### PR TITLE
krakenx: init at 0.0.1

### DIFF
--- a/pkgs/tools/system/krakenx/default.nix
+++ b/pkgs/tools/system/krakenx/default.nix
@@ -1,0 +1,23 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "krakenx";
+  version = "0.0.1";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1vxyindph81srya0pfmb3n64n8h7ghp38ak86vc2zc5nyirf5zq8";
+  };
+
+  propagatedBuildInputs = lib.singleton python3Packages.pyusb;
+
+  doCheck = false; # there are no tests
+
+  meta = with lib; {
+    description = "Python script to control NZXT cooler Kraken X52/X62";
+    homepage = https://github.com/KsenijaS/krakenx;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.willibutz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3160,6 +3160,8 @@ with pkgs;
 
   kore = callPackage ../development/web/kore { };
 
+  krakenx = callPackage ../tools/system/krakenx { };
+
   partition-manager = libsForQt5.callPackage ../tools/misc/partition-manager { };
 
   kpcli = callPackage ../tools/security/kpcli { };


### PR DESCRIPTION
This adds the python script `colctl` to control the colors as well as fan- and pump-speed of the `NZXT Kraken X62/X52` cpu coolers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested color, fan- and pump-speed control functionality
---

