### PR TITLE
QGIS: 2.18.17 -> 3.0.1 plus required libs

### DIFF
--- a/pkgs/applications/gis/qgis/3.0.nix
+++ b/pkgs/applications/gis/qgis/3.0.nix
@@ -1,0 +1,51 @@
+{ stdenv, lib, fetchurl, cmake, ninja, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
+, qwt, fcgi, python3Packages, libspatialindex, libspatialite, postgresql
+, txt2tags, openssl, libzip
+, qtbase, qtwebkit, qtsensors, qca-qt5, qtkeychain, qscintilla
+, withGrass ? true, grass
+}:
+with lib;
+let
+  pythonBuildInputs = with python3Packages;
+    [ python3Packages.qscintilla gdal jinja2 numpy psycopg2
+      chardet dateutil pyyaml pytz requests urllib3 pygments pyqt5 sip OWSLib six ];
+in stdenv.mkDerivation rec {
+  version = "3.0.1";
+  name = "qgis-unwrapped-${version}";
+
+  src = fetchurl {
+    url = "http://qgis.org/downloads/qgis-${version}.tar.bz2";
+    sha256 = "1m24kjl784csbv0dgx1wbdwg8r92cpc1j718aaw85p7vgicm8acy";
+  };
+
+  inherit pythonBuildInputs;
+
+  buildInputs = [ flex openssl bison proj geos xlibsWrapper sqlite gsl qwt
+    fcgi libspatialindex libspatialite postgresql txt2tags libzip
+    qtbase qtwebkit qtsensors qca-qt5 qtkeychain qscintilla ] ++
+    (stdenv.lib.optional withGrass grass) ++ pythonBuildInputs;
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  # Force this pyqt_sip_dir variable to point to the sip dir in PyQt5
+  #
+  # TODO: Correct PyQt5 to provide the expected directory and fix
+  # build to use PYQT5_SIP_DIR consistently.
+  postPatch = ''
+    substituteInPlace cmake/FindPyQt5.py \
+      --replace 'pyqtcfg.pyqt_sip_dir' '"${python3Packages.pyqt5}/share/sip/PyQt5"'
+  '';
+
+  cmakeFlags = [ "-DPYQT5_SIP_DIR=${python3Packages.pyqt5}/share/sip/PyQt5"
+                 "-DQSCI_SIP_DIR=${python3Packages.qscintilla}/share/sip/PyQt5"
+                 "-DCMAKE_SKIP_BUILD_RPATH=OFF" ] ++
+            stdenv.lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}";
+
+  meta = {
+    description = "User friendly Open Source Geographic Information System";
+    homepage = http://www.qgis.org;
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with stdenv.lib.maintainers; [viric];
+  };
+}

--- a/pkgs/applications/gis/qgis/wrapped.nix
+++ b/pkgs/applications/gis/qgis/wrapped.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, fetchurl, openssl, python3Packages, makeWrapper, symlinkJoin
+, qgis3-unwrapped
+}:
+with lib;
+symlinkJoin rec {
+  inherit (qgis3-unwrapped) version;
+  name = "qgis-${version}";
+
+  paths = [ qgis3-unwrapped ];
+
+  nativeBuildInputs = [ makeWrapper python3Packages.wrapPython ];
+
+  # extend to add to the python environment of QGIS without rebuilding QGIS application.
+  pythonInputs = qgis3-unwrapped.pythonBuildInputs;
+
+  # use the source archive directly to avoid rebuilding when changing qgis distro
+  inherit (qgis3-unwrapped) src;
+
+  postBuild = ''
+    unpackPhase
+
+    buildPythonPath "$pythonInputs"
+
+    wrapProgram $out/bin/qgis \
+      --prefix PATH : $program_PATH \
+      --set PYTHONPATH $program_PYTHONPATH
+
+    # desktop link
+    mkdir -p $out/share/applications
+
+    sed "/^Exec=/c\Exec=$out/bin/qgis" \
+      < $sourceRoot/debian/qgis.desktop \
+      > $out/share/applications/qgis.desktop
+
+    # mime types
+    mkdir -p $out/share/mime/packages
+    cp $sourceRoot/debian/qgis.xml $out/share/mime/packages
+
+    # vector icon
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp $sourceRoot/images/icons/qgis_icon.svg $out/share/icons/hicolor/scalable/apps/qgis.svg
+  '';
+}

--- a/pkgs/development/python-modules/OWSLib/default.nix
+++ b/pkgs/development/python-modules/OWSLib/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, dateutil
+, pep8
+, pillow
+, pyproj
+, pytz
+, pytest
+, pytestcov
+, requests
+, tox
+}:
+
+buildPythonPackage rec {
+  pname = "OWSLib";
+  version = "0.16.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0m05225g1sqd2i8r2riaan33953hfni9wjq7n225snhl7klsb5gc";
+  };
+
+  buildInputs = [ dateutil pep8 pillow pyproj pytz requests tox ];
+  checkInputs = [ pytest pytestcov ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Client programming with Open Geospatial Consortium (OGC) web service.";
+    license = licenses.bsd3;
+    homepage = http://geopython.github.io/OWSLib;
+  };
+}

--- a/pkgs/development/python-modules/OWSLib/default.nix
+++ b/pkgs/development/python-modules/OWSLib/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
   buildInputs = [ dateutil pep8 pillow pyproj pytz requests tox ];
   checkInputs = [ pytest pytestcov ];
 
+  # test runner finds no tests and fails build with no displayed error.
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -6,7 +6,7 @@
 
 let
   pname = "PyQt";
-  version = "5.10";
+  version = "5.10.1";
 
   inherit (pythonPackages) buildPythonPackage python dbus-python sip;
 
@@ -25,7 +25,7 @@ in buildPythonPackage {
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/PyQt5/PyQt-${version}/PyQt5_gpl-${version}.tar.gz";
-    sha256 = "0l2zy6b7bfjxmg4bb8yikg6i8iy2xdwmvk7knfmrzfpqbmkycbrl";
+    sha256 = "1vz9c4v0k8azk2b08swwybrshzw32x8djjpq13mf9v15x1qyjclr";
   };
 
   outputs = [ "out" "dev" ];
@@ -51,7 +51,7 @@ in buildPythonPackage {
       --replace 'install_dir=pydbusmoddir' "install_dir='$out/${python.sitePackages}/dbus/mainloop'" \
       --replace "ModuleMetadata(qmake_QT=['webkitwidgets'])" "ModuleMetadata(qmake_QT=['webkitwidgets', 'printsupport'])"
 
-    ${python.executable} configure.py  -w \
+    ${python.executable} configure.py -w \
       --confirm-license \
       --dbus=${dbus_libs.dev}/include/dbus-1.0 \
       --no-qml-plugin \

--- a/pkgs/development/python-modules/qscintilla/base.nix
+++ b/pkgs/development/python-modules/qscintilla/base.nix
@@ -1,0 +1,15 @@
+{ lib
+, qscintillaCpp
+}: rec {
+  name = "qscintilla-${version}";
+  version = qscintillaCpp.version;
+  format = "other";
+  src = qscintillaCpp.src;
+
+  meta = with lib; {
+    description = "A Python binding to QScintilla, Qt based text editing control";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ danbst ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/qscintilla/default.nix
+++ b/pkgs/development/python-modules/qscintilla/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, qscintillaCpp
+, lndir
+, pyqt4
+}:
+
+let base = import ./base.nix { inherit lib qscintillaCpp; };
+in buildPythonPackage (base // rec {
+  buildInputs = [ lndir pyqt4.qt qscintillaCpp ];
+  propagatedBuildInputs = [ pyqt4 ];
+
+  # TODO: with qscintilla 2.10 this will have to use configure.py
+  preConfigure = ''
+    mkdir -p $out
+    lndir ${pyqt4} $out
+    rm -rf "$out/nix-support"
+    cd Python
+    ${python.executable} ./configure-old.py \
+        --destdir $out/lib/${python.libPrefix}/site-packages/PyQt4 \
+        --apidir $out/api/${python.libPrefix} \
+        -n ${qscintillaCpp}/include \
+        -o ${qscintillaCpp}/lib \
+        --sipdir $out/share/sip
+  '';
+})

--- a/pkgs/development/python-modules/qscintilla/py3k.nix
+++ b/pkgs/development/python-modules/qscintilla/py3k.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, libsForQt5
+, lndir
+, pyqt5
+, qt5
+}:
+
+let
+  qscintillaCpp = libsForQt5.qscintilla;
+  base = import ./base.nix { inherit lib qscintillaCpp; };
+in buildPythonPackage (base // {
+  buildInputs = [ lndir qt5.qtbase qscintillaCpp ];
+  propagatedBuildInputs = [ pyqt5 ];
+
+  # a dependency on QT's widget module is missing.
+  patches = [ ./qscintilla-pyqt5-widgets.patch ];
+
+  preConfigure = ''
+    mkdir -p $out
+    lndir ${pyqt5} $out
+    rm -rf "$out/nix-support"
+    cd Python
+    ${python.executable} ./configure.py \
+        --pyqt=PyQt5 \
+        --destdir=$out/lib/${python.libPrefix}/site-packages/PyQt5 \
+        --stubsdir=$out/lib/${python.libPrefix}/site-packages/PyQt5 \
+        --apidir=$out/api/${python.libPrefix} \
+        --qsci-incdir=${qscintillaCpp}/include \
+        --qsci-libdir=${qscintillaCpp}/lib \
+        --pyqt-sipdir=${pyqt5}/share/sip/PyQt5 \
+        --qsci-sipdir=$out/share/sip/PyQt5
+  '';
+})

--- a/pkgs/development/python-modules/qscintilla/qscintilla-pyqt5-widgets.patch
+++ b/pkgs/development/python-modules/qscintilla/qscintilla-pyqt5-widgets.patch
@@ -1,0 +1,12 @@
+diff -u -r orig/Python/configure.py QScintilla_gpl-2.10.3/Python/configure.py
+--- orig/Python/configure.py    2018-03-26 17:29:11.070069140 -0700
++++ QScintilla_gpl-2.10.3/Python/configure.py   2018-03-26 17:29:30.304262024 -0700
+@@ -314,6 +314,8 @@
+         if target_configuration.qsci_features_dir is not None:
+                      os.environ['QMAKEFEATURES'] = target_configuration.qsci_features_dir
+
++        qmake['QT'] = 'widgets printsupport'
++
+         return qmake
+
+     @staticmethod

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17342,7 +17342,15 @@ with pkgs;
 
   qemu-riscv = callPackage ../applications/virtualization/qemu/riscv.nix {};
 
-  qgis = callPackage ../applications/gis/qgis {};
+  qgis3-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/3.0.nix {
+    postgresql = postgresql100;
+  };
+
+  qgis3 = callPackage ../applications/gis/qgis/wrapped.nix {};
+
+  qgis2 = callPackage ../applications/gis/qgis {};
+
+  qgis = qgis2;
 
   qgroundcontrol = libsForQt5.callPackage ../applications/science/robotics/qgroundcontrol { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10065,6 +10065,8 @@ in {
     };
   };
 
+  OWSLib = callPackage ../development/python-modules/OWSLib { };
+
   pint = buildPythonPackage rec {
     name = "pint-${version}";
     version = "0.7.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8815,7 +8815,7 @@ in {
   keyutils = callPackage ../development/python-modules/keyutils { };
 
   klein = callPackage ../development/python-modules/klein { };
- 
+
   koji = callPackage ../development/python-modules/koji { };
 
   kombu = buildPythonPackage rec {
@@ -14045,38 +14045,17 @@ in {
   # alias for an older package which did not support Python 3
   Quandl = callPackage ../development/python-modules/quandl { };
 
-  qscintilla = disabledIf (isPy3k || isPyPy)
-    (buildPythonPackage rec {
-      # TODO: Qt5 support
-      name = "qscintilla-${version}";
-      version = pkgs.qscintilla.version;
-      format = "other";
-
-      src = pkgs.qscintilla.src;
-
-      buildInputs = with self; [ pkgs.xorg.lndir pyqt4.qt pyqt4 ];
-
-      preConfigure = ''
-        mkdir -p $out
-        lndir ${self.pyqt4} $out
-        rm -rf "$out/nix-support"
-        cd Python
-        ${python.executable} ./configure-old.py \
-            --destdir $out/lib/${python.libPrefix}/site-packages/PyQt4 \
-            --apidir $out/api/${python.libPrefix} \
-            -n ${pkgs.qscintilla}/include \
-            -o ${pkgs.qscintilla}/lib \
-            --sipdir $out/share/sip
-      '';
-
-      meta = with stdenv.lib; {
-        description = "A Python binding to QScintilla, Qt based text editing control";
-        license = licenses.lgpl21Plus;
-        maintainers = with maintainers; [ danbst ];
-        platforms = platforms.linux;
-      };
-    });
-
+  qscintilla =
+    if isPy3k then
+      callPackage ../development/python-modules/qscintilla/py3k.nix {
+        lndir = pkgs.xorg.lndir;
+      }
+    else disabledIf isPyPy (
+      callPackage ../development/python-modules/qscintilla {
+        qscintillaCpp = pkgs.qscintilla;
+        lndir = pkgs.xorg.lndir;
+      }
+    );
 
   qserve = buildPythonPackage rec {
     name = "qserve-0.2.8";


### PR DESCRIPTION
I think the wrapper could use some improvements, but it's functional.

###### Motivation for this change

1. update QGIS to 3.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

