### PR TITLE
imapnotify: init at 0.4.1

### DIFF
--- a/pkgs/development/node-packages/node-packages-v6.json
+++ b/pkgs/development/node-packages/node-packages-v6.json
@@ -36,6 +36,7 @@
 , "ionic"
 , "ios-deploy"
 , "istanbul"
+, "imapnotify"
 , "javascript-typescript-langserver"
 , "jayschema"
 , "jsdoc"

--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -4,22 +4,40 @@
 
 let
   sources = {
-    "@ionic/cli-framework-0.1.2" = {
-      name = "_at_ionic_slash_cli-framework";
-      packageName = "@ionic/cli-framework";
-      version = "0.1.2";
+    "@cliqz-oss/firefox-client-0.3.1" = {
+      name = "_at_cliqz-oss_slash_firefox-client";
+      packageName = "@cliqz-oss/firefox-client";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-0.1.2.tgz";
-        sha512 = "265kszf17mdz60zpfrj5i47lqwwgp6h1b7i8vymig1pnlqd3lnljibxvd2d1rfa3827ks435k9wws458z3dk7fyq8wfmzmv8fk9qjhh";
+        url = "https://registry.npmjs.org/@cliqz-oss/firefox-client/-/firefox-client-0.3.1.tgz";
+        sha512 = "0mzrszrx3b26v168dxy14mafp9dnczzl10yrdg203q46xcasi6a668yg2zf3nlzmf4klylfkbca3b3amd0646barp0nkh1zkfi97vs4";
       };
     };
-    "@ionic/cli-utils-1.19.1" = {
+    "@cliqz-oss/node-firefox-connect-1.2.1" = {
+      name = "_at_cliqz-oss_slash_node-firefox-connect";
+      packageName = "@cliqz-oss/node-firefox-connect";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@cliqz-oss/node-firefox-connect/-/node-firefox-connect-1.2.1.tgz";
+        sha512 = "2f8l9alm034f4mrp2shf3pgcvm1m9lvbw2n5jpjnnmk6mn36qmwz4hjnrky279z4wnphgr2wv1vksn57w6ncl3cfr13nzv93s435wiv";
+      };
+    };
+    "@ionic/cli-framework-0.1.3" = {
+      name = "_at_ionic_slash_cli-framework";
+      packageName = "@ionic/cli-framework";
+      version = "0.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-0.1.3.tgz";
+        sha512 = "0l4lpl9477wf6i2xzqqqv5lmrmnyf82n0rbww6ynaszyb6cl38m2dpbz4xv0ksy5mayjyfkq6nj7mjzh4cvak12zfwp4cgrrai6ybkg";
+      };
+    };
+    "@ionic/cli-utils-1.19.2" = {
       name = "_at_ionic_slash_cli-utils";
       packageName = "@ionic/cli-utils";
-      version = "1.19.1";
+      version = "1.19.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/cli-utils/-/cli-utils-1.19.1.tgz";
-        sha512 = "3anhsxw0zyzi9j4kfnqxg2h4fxqjyw6pabb75z5b17hmksmjcyy6psic9fziyrgllp5rqksadqdzbkbb6lrviclhiz26sj8f7gjfi8r";
+        url = "https://registry.npmjs.org/@ionic/cli-utils/-/cli-utils-1.19.2.tgz";
+        sha512 = "10fl86bf0p911b7w0dnz2q3b8092c50h6x8kf79lwg8bg3jnmnmvz0i868xhf7qnawyaikhqdf5nifpb42f9jr3x0mxgmp4ppdwadlx";
       };
     };
     "@ionic/discover-0.4.0" = {
@@ -76,22 +94,22 @@ let
         sha512 = "2fv2qaz90rp6ib2s45ix0p3a4bd6yl6k94k1kkhw7w4s2aa5mqc6chppkf6pfvsz1l6phh7y0xswyfyzjgny7qzascch8c7ws20a0r4";
       };
     };
-    "@types/node-8.9.5" = {
+    "@types/node-8.10.1" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "8.9.5";
+      version = "8.10.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz";
-        sha512 = "06wcjpwrp2zkccv51w2j75yq11jcdb69r7y04l1qihncwhd56dagwcvvn7lm48bjp7rkfcxbsfn18658wjy9wqrdvfxacpjrdddy4cd";
+        url = "https://registry.npmjs.org/@types/node/-/node-8.10.1.tgz";
+        sha512 = "0idg6lra5659kj2sbfhfp209bsxbg7s2gxkg6pa566grjw498iida3f0w1dd2cbzh1zw7q6zdww3q19ikq789mbqkqpx990wx84iyjz";
       };
     };
-    "@types/node-9.4.7" = {
+    "@types/node-9.6.1" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "9.4.7";
+      version = "9.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz";
-        sha512 = "1rk1inz71x7pkcc7j3w776wf7wi8byz3h2203wzl3vpmxrhmy4vfkmhy25sdhi05pc6f0dy1254qilfn1hwivm7dmfwgiwdcp9bs5p0";
+        url = "https://registry.npmjs.org/@types/node/-/node-9.6.1.tgz";
+        sha512 = "2sxvv78fkmdrpqq04pkyq69fkny1xj1abcp8ajkmmmfn1cs3jdiir545s9h1gsnxzls1iiigbzj8dlkimlqdfpbgdlm8h6pj2mlf2f7";
       };
     };
     "@types/request-2.47.0" = {
@@ -301,15 +319,6 @@ let
         sha512 = "0wmwifv9mm9gqcir9zbz5y1gl1rgwwprqh1f3csjydj8kf3byca7img3rh5b54kbnw3ik34bc6ynbnzsd01zmxrsfdvjv95hn84rpld";
       };
     };
-    "acorn-dynamic-import-2.0.2" = {
-      name = "acorn-dynamic-import";
-      packageName = "acorn-dynamic-import";
-      version = "2.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz";
-        sha1 = "c752bd210bef679501b6c6cb7fc84f8f47158cc4";
-      };
-    };
     "acorn-dynamic-import-3.0.0" = {
       name = "acorn-dynamic-import";
       packageName = "acorn-dynamic-import";
@@ -418,13 +427,13 @@ let
         sha1 = "6a7990437ca736d5e1288db92bd3266d5f5cb2aa";
       };
     };
-    "addons-linter-0.35.0" = {
+    "addons-linter-0.41.0" = {
       name = "addons-linter";
       packageName = "addons-linter";
-      version = "0.35.0";
+      version = "0.41.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-0.35.0.tgz";
-        sha1 = "85872cce58983ff339ced297dbff486c02ecd336";
+        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-0.41.0.tgz";
+        sha512 = "1cdq1s3zaz5547yn12h23434f3g6jjchrjdwv7x0qbg38zilaix5x04ajy87pw94rs1mk6kkawa517whzjn0jd7kpx6nac75qw7rcwf";
       };
     };
     "addr-to-ip-port-1.4.3" = {
@@ -562,13 +571,22 @@ let
         sha1 = "73b5eeca3fab653e3d3f9422b341ad42205dc965";
       };
     };
-    "ajv-6.2.1" = {
+    "ajv-6.3.0" = {
       name = "ajv";
       packageName = "ajv";
-      version = "6.2.1";
+      version = "6.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz";
-        sha1 = "28a6abc493a2abe0fb4c8507acaedb43fa550671";
+        url = "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz";
+        sha1 = "1650a41114ef00574cac10b8032d8f4c14812da7";
+      };
+    };
+    "ajv-6.4.0" = {
+      name = "ajv";
+      packageName = "ajv";
+      version = "6.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz";
+        sha1 = "d3aff78e9277549771daf0164cff48482b754fc6";
       };
     };
     "ajv-keywords-1.5.1" = {
@@ -679,13 +697,13 @@ let
         sha1 = "3e75c037475217544ed763a8db5709fa9ae5bf9a";
       };
     };
-    "ansi-diff-stream-1.2.0" = {
+    "ansi-diff-stream-1.2.1" = {
       name = "ansi-diff-stream";
       packageName = "ansi-diff-stream";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-diff-stream/-/ansi-diff-stream-1.2.0.tgz";
-        sha1 = "eb325c20ac3623ecd592011a9295d76d97de460e";
+        url = "https://registry.npmjs.org/ansi-diff-stream/-/ansi-diff-stream-1.2.1.tgz";
+        sha512 = "3lf59lflmnm783cbczclcms4qp42l79s7jbzx7xgz89rzk325nfj26bzd61g83lp250a3pjwh8q5w1khvfjkwn8rm9sm80dhbgsr8ix";
       };
     };
     "ansi-escapes-1.4.0" = {
@@ -697,13 +715,13 @@ let
         sha1 = "d3a8a83b319aa67793662b13e761c7911422306e";
       };
     };
-    "ansi-escapes-3.0.0" = {
+    "ansi-escapes-3.1.0" = {
       name = "ansi-escapes";
       packageName = "ansi-escapes";
-      version = "3.0.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz";
-        sha512 = "06szfav8g7xywvqsis16nnkjqs2snhv37r4m53l1ax8k2sahvqv9id2klam32jajqd08ylw8g9wbcjr971igx6vh8idan76drrjby9v";
+        url = "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz";
+        sha512 = "1bm72rs09dwjhfif8kqjxnpb5fgmcdgkn5483f11j6791s5161f2kvxy69pkgcq0jdws6kqfmr1bx5189lnvkzgkq851qs3gzq1n02j";
       };
     };
     "ansi-gray-0.1.1" = {
@@ -1543,13 +1561,13 @@ let
         sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
       };
     };
-    "atob-2.0.3" = {
+    "atob-2.1.0" = {
       name = "atob";
       packageName = "atob";
-      version = "2.0.3";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz";
-        sha1 = "19c7a760473774468f20b2d2d03372ad7d4cbf5d";
+        url = "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz";
+        sha512 = "0dyf7054n94f1pwp9chcy6vawgwd2wqp8jqrnvxl489jyxxbg46n2vkb5vfs5jqnkmh6kbyv4lpysrn13hzzh5q021frc6vrcgqms2a";
       };
     };
     "atomic-batcher-1.0.2" = {
@@ -1579,13 +1597,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.208.0" = {
+    "aws-sdk-2.216.1" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.208.0";
+      version = "2.216.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.208.0.tgz";
-        sha1 = "f95e44524cb62c9a6e0ef95270236fc6a62178d6";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.216.1.tgz";
+        sha1 = "9dbf964206d722240507cc60d46e8d3bae9c34f0";
       };
     };
     "aws-sign-0.2.0" = {
@@ -1759,13 +1777,13 @@ let
         sha1 = "f63a6dad0355633d9347fb403f417fb195fe3b91";
       };
     };
-    "azure-arm-network-4.0.1" = {
+    "azure-arm-network-5.1.0" = {
       name = "azure-arm-network";
       packageName = "azure-arm-network";
-      version = "4.0.1";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-network/-/azure-arm-network-4.0.1.tgz";
-        sha1 = "577d8a2be2eb9e5298b561837405b2eaef283a19";
+        url = "https://registry.npmjs.org/azure-arm-network/-/azure-arm-network-5.1.0.tgz";
+        sha1 = "b2be4bfc27173b1cb7fc54425cbee27824f65b52";
       };
     };
     "azure-arm-powerbiembedded-0.1.0" = {
@@ -2281,15 +2299,6 @@ let
         sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
       };
     };
-    "base64-js-1.2.0" = {
-      name = "base64-js";
-      packageName = "base64-js";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz";
-        sha1 = "a39992d723584811982be5e290bb6a53d86700f1";
-      };
-    };
     "base64-js-1.2.3" = {
       name = "base64-js";
       packageName = "base64-js";
@@ -2497,13 +2506,13 @@ let
         sha1 = "159a49b9a9714c1fb102f2e0ed1906fab6a450f4";
       };
     };
-    "big-integer-1.6.26" = {
+    "big-integer-1.6.27" = {
       name = "big-integer";
       packageName = "big-integer";
-      version = "1.6.26";
+      version = "1.6.27";
       src = fetchurl {
-        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.26.tgz";
-        sha1 = "3af1672fa62daf2d5ecafacf6e5aa0d25e02c1c8";
+        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.27.tgz";
+        sha512 = "2v5f59yjsa3hzwhk333s84nfl1x24w52h9hqpwbav0p5v5d5prkna0flw25ywccrrjziq3lylbl874qqikzljkyz2g6jjdqhlqhld9p";
       };
     };
     "big.js-3.2.0" = {
@@ -2668,13 +2677,13 @@ let
         sha1 = "fdca871a99713aa00d19e3bbba41c44787a65398";
       };
     };
-    "bl-1.2.1" = {
+    "bl-1.2.2" = {
       name = "bl";
       packageName = "bl";
-      version = "1.2.1";
+      version = "1.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz";
-        sha1 = "cac328f7bee45730d404b692203fcb590e172d5e";
+        url = "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz";
+        sha512 = "0810nalazir8szyxvbg53d7416j4a7xy94sdri37mwmnax9s9hx88mzky882sr9dv0is7w9fqlp7ys6ijr1z1imc2dnfxk8fri51jvv";
       };
     };
     "blake2b-2.1.2" = {
@@ -2911,13 +2920,13 @@ let
         sha1 = "4d67dc2602c0cc16dd9bce7ebf87e948290f5812";
       };
     };
-    "bower-1.8.2" = {
+    "bower-1.8.4" = {
       name = "bower";
       packageName = "bower";
-      version = "1.8.2";
+      version = "1.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz";
-        sha1 = "adf53529c8d4af02ef24fb8d5341c1419d33e2f7";
+        url = "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz";
+        sha1 = "e7876a076deb8137f7d06525dc5e8c66db82f28a";
       };
     };
     "bower-endpoint-parser-0.2.1" = {
@@ -3235,6 +3244,24 @@ let
         sha512 = "1ipkzdnq03rnxyl50wmzigdbd96lh0mgzffcab80yxl38x7k316kzs3h0w0bxdjj7vqh6dw3wgb7y3rsqab0ar4ky9rbh0r1f1i2hk2";
       };
     };
+    "buffer-alloc-1.1.0" = {
+      name = "buffer-alloc";
+      packageName = "buffer-alloc";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz";
+        sha1 = "05514d33bf1656d3540c684f65b1202e90eca303";
+      };
+    };
+    "buffer-alloc-unsafe-0.1.1" = {
+      name = "buffer-alloc-unsafe";
+      packageName = "buffer-alloc-unsafe";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz";
+        sha1 = "ffe1f67551dd055737de253337bfe853dfab1a6a";
+      };
+    };
     "buffer-alloc-unsafe-1.0.0" = {
       name = "buffer-alloc-unsafe";
       packageName = "buffer-alloc-unsafe";
@@ -3296,6 +3323,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz";
         sha1 = "0353b54fd07fd9564170671ae6f66b9cf10d27f5";
+      };
+    };
+    "buffer-fill-0.1.1" = {
+      name = "buffer-fill";
+      packageName = "buffer-fill";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz";
+        sha512 = "3nny0zbpnaxp1544gp7lc53jvs1jgzpmp92cy939dik36bi8lvhrsh4g082lxdplwsma22cgg9q93dw5dnbn1ljqkh4fb2i6w3lq032";
+      };
+    };
+    "buffer-from-1.0.0" = {
+      name = "buffer-from";
+      packageName = "buffer-from";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz";
+        sha512 = "3252laq8prm41lgzlhmc7rdj99gwcvpf7cn6j686g4qmspnl3haid5khv9pc9cfjja9wb64nwfvgdwi2kpdf125xfg48aqapwssjxpk";
       };
     };
     "buffer-indexof-1.1.1" = {
@@ -3415,13 +3460,13 @@ let
         sha1 = "cb94faeb61c8696451db36534e1422f94f0aee88";
       };
     };
-    "bulk-write-stream-1.1.3" = {
+    "bulk-write-stream-1.1.4" = {
       name = "bulk-write-stream";
       packageName = "bulk-write-stream";
-      version = "1.1.3";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-1.1.3.tgz";
-        sha1 = "d29ca385fbd53f357aee5bd3d3028732b62ae275";
+        url = "https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-1.1.4.tgz";
+        sha512 = "2g3ccqw8k5vhdhnks27i954xglllw5gay8nvy3zgm2c7jpwnjc2imarwshx53pz54br6q4i4x2va4s80ixavafphhsykdhyzrvv1lhs";
       };
     };
     "bunyan-1.5.1" = {
@@ -3973,6 +4018,15 @@ let
         sha1 = "b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2";
       };
     };
+    "charenc-0.0.2" = {
+      name = "charenc";
+      packageName = "charenc";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz";
+        sha1 = "c0a1d2f3a7092e03774bfa83f14c0fc5790a8667";
+      };
+    };
     "check-error-1.0.2" = {
       name = "check-error";
       packageName = "check-error";
@@ -4036,13 +4090,13 @@ let
         sha1 = "798e689778151c8076b4b360e5edd28cda2bb468";
       };
     };
-    "chokidar-2.0.2" = {
+    "chokidar-2.0.3" = {
       name = "chokidar";
       packageName = "chokidar";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz";
-        sha512 = "1kncf65ax274b43r63m0bfbap3j5ah7dn86niqwpzzw6ilvpc7yy0fan14k584lw8ycf4nl78n5gv3bpyr4jrk5j3v441ragk1qfzcp";
+        url = "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz";
+        sha512 = "0r9sfr7gz91aphg4vk476c4z07gqq6wdyhlhk3brazjwfvqz9jqccl19qyrwiwijx0aw85jw0zhnfayapk9wzzcj9wcqp3dhrfj4vyd";
       };
     };
     "chownr-0.0.2" = {
@@ -4124,6 +4178,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz";
         sha512 = "3cm9kdc1sv7pakzlhrc1pazdvg9lk4hv31lximwbcrgmwfzg6imxrndszgx9yzlizknfh2b73cr7b5mfcv50bldpyq6jr5s4zknsj1a";
+      };
+    };
+    "circular-append-file-1.0.1" = {
+      name = "circular-append-file";
+      packageName = "circular-append-file";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/circular-append-file/-/circular-append-file-1.0.1.tgz";
+        sha512 = "294ys13wj7mq7c2sb6h20a25z98wv9mar62nliikcsnb55xyqqwy3hj2ghcmc71yrx61i9s15x0qy71sy9x6i0ghsaxf2akn2zcah05";
       };
     };
     "circular-json-0.3.3" = {
@@ -4423,13 +4486,13 @@ let
         sha1 = "c6126a90ad4f72dbf5acdb243cc37724fe93fc1f";
       };
     };
-    "clone-1.0.3" = {
+    "clone-1.0.4" = {
       name = "clone";
       packageName = "clone";
-      version = "1.0.3";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz";
-        sha1 = "298d7e2231660f40c003c2ed3140decf3f53085f";
+        url = "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz";
+        sha1 = "da309cc263df15994c688ca902179ca3c7cd7c7e";
       };
     };
     "clone-2.1.1" = {
@@ -4439,6 +4502,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz";
         sha1 = "d217d1e961118e3ac9a4b8bba3285553bf647cdb";
+      };
+    };
+    "clone-2.1.2" = {
+      name = "clone";
+      packageName = "clone";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz";
+        sha1 = "1b7f4b9f591f1e8f83670401600345a02887435f";
       };
     };
     "clone-buffer-1.0.0" = {
@@ -4459,13 +4531,13 @@ let
         sha1 = "348c61ae9cdbe0edfe053d91ff4cc521d790ede8";
       };
     };
-    "clone-regexp-1.0.0" = {
+    "clone-regexp-1.0.1" = {
       name = "clone-regexp";
       packageName = "clone-regexp";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz";
-        sha1 = "eae0a2413f55c0942f818c229fefce845d7f3b1c";
+        url = "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz";
+        sha512 = "2dkam277bx7ajypbx3z8jrpigy0lqfflbj3ic5crhprjilxlfm8nh6xzpjm1p3n4ndx6pjw2pnm5shjirs2cj6lg7bnwnqiiksa7j0m";
       };
     };
     "clone-response-1.0.2" = {
@@ -4495,13 +4567,13 @@ let
         sha1 = "b3782dff8bb5474e18b9b6bf0fdfe782f8777680";
       };
     };
-    "cloneable-readable-1.1.1" = {
+    "cloneable-readable-1.1.2" = {
       name = "cloneable-readable";
       packageName = "cloneable-readable";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.1.tgz";
-        sha512 = "3bfsmhwhasp3dqnj54lss7pcmyliy2i15x9sqm11yrlah27i6xyiiagh4f252ss7kr7b7spgqpcslv45am4vg9drm7i3a2xlaml9lqc";
+        url = "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz";
+        sha512 = "2kg2ysl15s9cxgj62p43gzagfqf3kk2zqj4i6g3ckxs2b0fvx71blw7qy7v7gmy2pi9z9jsrc81v43kz7khagrvhlpwyv55vzibxbh6";
       };
     };
     "cmd-shim-2.0.2" = {
@@ -4621,13 +4693,13 @@ let
         sha1 = "4bc0373c164bc3291b4d368c829cf1a80a59dca0";
       };
     };
-    "color-2.0.1" = {
+    "color-3.0.0" = {
       name = "color";
       packageName = "color";
-      version = "2.0.1";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/color/-/color-2.0.1.tgz";
-        sha512 = "1gir7mfj6033amg78p7jvpj0nk2hw61hqd81r6x3a2qmgizbw3d89k0qk62680zhm9ypcx6c9p2cgwjvb8smxv0qgvblkwza9ah5ddr";
+        url = "https://registry.npmjs.org/color/-/color-3.0.0.tgz";
+        sha512 = "3xh3l9zhh6dav7pp5hy88kbb6c52j0pf331ywpp6w2jaf94w25fjn4am930775mskxy75cxl90fji17cym40ivslxxlpcrlxgkmsalc";
       };
     };
     "color-convert-1.9.1" = {
@@ -4736,15 +4808,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz";
         sha1 = "458c07e09e0d900fc28b70a3fec2dacd1d2cb7f6";
-      };
-    };
-    "combine-source-map-0.7.2" = {
-      name = "combine-source-map";
-      packageName = "combine-source-map";
-      version = "0.7.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz";
-        sha1 = "0870312856b307a87cc4ac486f3a9a62aeccc09e";
       };
     };
     "combine-source-map-0.8.0" = {
@@ -4873,13 +4936,13 @@ let
         sha512 = "11j7mwxfdnhi3yfkhxjvfkg1mzdsi3wq7iygma6ksmj1f7hfs0z8rpfcysqmy85f67mqvzhda3w1lyy1jqxxm31k799sazbipm7b17r";
       };
     };
-    "commander-2.15.0" = {
+    "commander-2.15.1" = {
       name = "commander";
       packageName = "commander";
-      version = "2.15.0";
+      version = "2.15.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz";
-        sha512 = "090my2m6q69l4kgn1slqs845mf9s5zx7l1p345z2qij174pyk4jr2xkalnq8k0dfhghvdmcjxba03qn959n64r8nkg2cq9d3ja647gc";
+        url = "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz";
+        sha512 = "1mb8z6hhy74rfdgj3spmk52sdqa5bb2w5wp28z3md1daqcca4vbbsg66wz8hdhrv0fnnmf8yzdkmnw3c373vcccmyizzlnmbpsd6msn";
       };
     };
     "commander-2.6.0" = {
@@ -5022,7 +5085,7 @@ let
       packageName = "compression";
       version = "1.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz";
+        url = "http://registry.npmjs.org/compression/-/compression-1.5.2.tgz";
         sha1 = "b03b8d86e6f8ad29683cba8df91ddc6ffc77b395";
       };
     };
@@ -5031,7 +5094,7 @@ let
       packageName = "compression";
       version = "1.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz";
+        url = "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz";
         sha1 = "aaffbcd6aaf854b44ebb280353d5ad1651f59a69";
       };
     };
@@ -5071,13 +5134,13 @@ let
         sha1 = "0aac662fd52be78964d5532f694784e70110acf7";
       };
     };
-    "concat-stream-1.6.1" = {
+    "concat-stream-1.6.2" = {
       name = "concat-stream";
       packageName = "concat-stream";
-      version = "1.6.1";
+      version = "1.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz";
-        sha512 = "1gyp2id8ifqdpzk81qz5q7200wf8m66ammg6cz8cxv4blmqh7rf761fxd1536ib4kcdp8jccvyx1l9vi6kjl26pwyd05pblki455jc2";
+        url = "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz";
+        sha512 = "05nnf80j9ls12y3cw2dfnc6rmand3ya5sx9cqn9dgg19ljzdnyfjjv8ig79xi73gr2y4rkfzn9wjip2zzwp5n2d49njd3ki2a1c3cfv";
       };
     };
     "conf-1.4.0" = {
@@ -5125,13 +5188,13 @@ let
         sha1 = "737a3a7036e9886102aa6099e47bb33ab1aba1a1";
       };
     };
-    "configstore-3.1.1" = {
+    "configstore-3.1.2" = {
       name = "configstore";
       packageName = "configstore";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz";
-        sha512 = "2zmidvkp20q25yv6a5d7k1daawdg0w6ppgayxzpwfhyvmgwybkkv7ni0j4b2j9c8wjn8z33zf5d4bjr8jywb5qixc75vypyy87n90z6";
+        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz";
+        sha512 = "2difdg3f56d584kfxl1zvm4ik5m3ln949m0q9sxq6ranzx2iwqa9zxqxy2l5i2lsm8jwmaiqkf7rc73gfnfip5m2qh8awd3s4ggknxy";
       };
     };
     "connect-1.9.2" = {
@@ -5387,13 +5450,13 @@ let
         sha1 = "bd727a7faed77e71ff3985ac93351a912733ad0f";
       };
     };
-    "conventional-changelog-1.1.18" = {
+    "conventional-changelog-1.1.23" = {
       name = "conventional-changelog";
       packageName = "conventional-changelog";
-      version = "1.1.18";
+      version = "1.1.23";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.18.tgz";
-        sha512 = "02967qizq9ymmgf5yahk2rca3dkrjsslqwrdsdsw4a8qjfhkliijsngzvi8p95mkr84mh4651kapbybiwdwyfncv4cgpv36m1pgj1xk";
+        url = "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.23.tgz";
+        sha512 = "2775l94nr8rbnvhihkrwyszncc2g7z1kvbsqpbvni86h8072xvxngbba6yxzzw4dfs57ghklkh9l0ibjy17rl7ldrh6q9lpyd9xf8y8";
       };
     };
     "conventional-changelog-angular-1.6.6" = {
@@ -5405,67 +5468,67 @@ let
         sha512 = "0v02kj8l2ji18jmcgjqa0nqsfn4h9jklgy4g9brf1ppm0n8344in3xpmyc5y06i5k3jjxl8sv90cndh2fbg4fhn0wr1ric258ajgr5j";
       };
     };
-    "conventional-changelog-atom-0.2.4" = {
+    "conventional-changelog-atom-0.2.8" = {
       name = "conventional-changelog-atom";
       packageName = "conventional-changelog-atom";
-      version = "0.2.4";
+      version = "0.2.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.4.tgz";
-        sha512 = "2b43fd5cpi069hsmfswl320lnpnvahmqmnrc9csk6qv0dq72nfj0jzafmbv5gsb3ds2ssr29lswwky61shy3n9hbxshq0qw3in6ds73";
+        url = "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz";
+        sha512 = "3m1yhgjwbz0x993dfdw3g2n4svz4ym4k1snhg57iraw1418glgdwpz52j01300v8d1p6ldjjbrv7x3gqa08xcqq6inpkbhv2fmdk4zj";
       };
     };
-    "conventional-changelog-cli-1.3.16" = {
+    "conventional-changelog-cli-1.3.21" = {
       name = "conventional-changelog-cli";
       packageName = "conventional-changelog-cli";
-      version = "1.3.16";
+      version = "1.3.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.16.tgz";
-        sha512 = "1h3h3vq237a95wqm6ml85794lhr268mq6v3j7574hmb04ssw7mrls5b6mn5q9azs5i594xxi9klaxzbrnqwxcyyz5cnz1svngzcdl6c";
+        url = "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.21.tgz";
+        sha512 = "1n93839r75vwj9fl4i3x3l06zc84kin92cp8nrlxksga9lqdpxc8b8i72wvi9jvwk0z6i29wisxdpiw6y7rrmdl13ch9f3k7jb43m9b";
       };
     };
-    "conventional-changelog-codemirror-0.3.4" = {
+    "conventional-changelog-codemirror-0.3.8" = {
       name = "conventional-changelog-codemirror";
       packageName = "conventional-changelog-codemirror";
-      version = "0.3.4";
+      version = "0.3.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.4.tgz";
-        sha512 = "33091h0zm06gdwhcqi5c3xvcjl6fw8cj3wvis9hyl5gix1vl2wd2pifymgp7rag6dbyzilb0g5q3ak29dcsrdzizqzibk8m0hdfkkph";
+        url = "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz";
+        sha512 = "24l71rg9rqfl9aa8fi3c1dc2iqxmdsh6ba8b9rwrrj7dg1gzfc5afw03rns5b1h6zld15942aqsjvwklwp6myzw3q1aakaps0m5jwfw";
       };
     };
-    "conventional-changelog-core-2.0.5" = {
+    "conventional-changelog-core-2.0.10" = {
       name = "conventional-changelog-core";
       packageName = "conventional-changelog-core";
-      version = "2.0.5";
+      version = "2.0.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.5.tgz";
-        sha512 = "1agyx5rj0lbrky9ndhha25la98lh2h1lyli2r4r27r1p0pr48niwg04al4whnvcldh0592fmyrdgf8vqqp5n6xz3df43j6dkpnnrzcl";
+        url = "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.10.tgz";
+        sha512 = "19pvarpv78qfmlnsz11c8anrwfg1v04qmwrsrcnai8p3xmbzdyvp1znz9j23l0i6l26yabkd4b631wybnkgxr4qgwzgb9hvf8fhvz8l";
       };
     };
-    "conventional-changelog-ember-0.3.6" = {
+    "conventional-changelog-ember-0.3.11" = {
       name = "conventional-changelog-ember";
       packageName = "conventional-changelog-ember";
-      version = "0.3.6";
+      version = "0.3.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.6.tgz";
-        sha512 = "24dx0snmkfhr4qi7vdq0aywjw9k23x68kaqh0gn92lca7j1268zbzr6vf00izx5g86kkjihlzgsgx8piyy1mnimn9nk7bj8pv2ka4w4";
+        url = "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.11.tgz";
+        sha512 = "1pm9wncjsfizvxzf84fp9ywdfm0znj0af0h2012ylazva8iis7zp4vph9ymrnd87kfmdv5gk2s0nsq8gqm6vxh87vbdykg640zczf0j";
       };
     };
-    "conventional-changelog-eslint-1.0.5" = {
+    "conventional-changelog-eslint-1.0.9" = {
       name = "conventional-changelog-eslint";
       packageName = "conventional-changelog-eslint";
-      version = "1.0.5";
+      version = "1.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.5.tgz";
-        sha512 = "272hf880yc54va1r1h5zg9fk2vhfcacw7jixn3ksgaxk4nld0kdlfrpnv7b2nf682dssagbk6mdkqljgc0ldig3yqwccjqf0gx2zmgc";
+        url = "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz";
+        sha512 = "3nl1q7m2f7yf8fr40dpns2x6n9z3n8m4kd74fxn2z4d0v0dp2si3h2xbg339984wyfa1ina5w61n6q8n1pcybwjghyxjzbnb1yygkl7";
       };
     };
-    "conventional-changelog-express-0.3.4" = {
+    "conventional-changelog-express-0.3.6" = {
       name = "conventional-changelog-express";
       packageName = "conventional-changelog-express";
-      version = "0.3.4";
+      version = "0.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.4.tgz";
-        sha512 = "3w3pm3dqwn8bj29809j0ivybw8vn2grnz486h9bm4kk9bn4849k9pxiqmx2ifpqf09hdl17fjk1xw320zz33wnvjzx78kbrpmpi9r9k";
+        url = "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz";
+        sha512 = "3qvnznizyjsb4nxznraiw24wydli7ky95905792az7mgm4dpc0hhxg6l9n5jlx5saglig9sm2gi3i0grqy39plvkp8ikxar2as9a9fy";
       };
     };
     "conventional-changelog-jquery-0.1.0" = {
@@ -5486,49 +5549,49 @@ let
         sha1 = "0479eb443cc7d72c58bf0bcf0ef1d444a92f0e5c";
       };
     };
-    "conventional-changelog-jshint-0.3.4" = {
+    "conventional-changelog-jshint-0.3.8" = {
       name = "conventional-changelog-jshint";
       packageName = "conventional-changelog-jshint";
-      version = "0.3.4";
+      version = "0.3.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.4.tgz";
-        sha512 = "0lzbgx3x2bfchxp8p4ppjavnp4yywjks3486yrxanq3skq0x5g4wnbhcf2viwm167mhn3aiawxygsxql5ww8md1xzssdrqb730fmnh9";
+        url = "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz";
+        sha512 = "25274wd4xzrjinpfglybkna5wm74wnfqhyll32ixz8fnq43gg50b99ip2sj17nqd5x9a5l111d0922gqv9j93q2sdwrbzs8hr9m0zw6";
       };
     };
-    "conventional-changelog-preset-loader-1.1.6" = {
+    "conventional-changelog-preset-loader-1.1.8" = {
       name = "conventional-changelog-preset-loader";
       packageName = "conventional-changelog-preset-loader";
-      version = "1.1.6";
+      version = "1.1.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.6.tgz";
-        sha512 = "12qk33piqbilkyrvin1vsjzp5pcvs7sschn5jry272r1hnv3x0jrwb1dlnik8vpp3zqai6n70h4ls55q2ch5n13a6g25c1hvhzwhqy9";
+        url = "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz";
+        sha512 = "1rl5rdcffc9nr30wxf718hl5qkcnb5hi5d85rchw48v2gyjbw371910qcd9v7pwfc9isrg1xxg8npnq2lxnv31xjp6dlqdqh4rjqj9j";
       };
     };
-    "conventional-changelog-writer-3.0.4" = {
+    "conventional-changelog-writer-3.0.9" = {
       name = "conventional-changelog-writer";
       packageName = "conventional-changelog-writer";
-      version = "3.0.4";
+      version = "3.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.4.tgz";
-        sha512 = "1ryw2mmza9y6bk5hs2ivhvp9p5hq7hhydhis2880w41dajr193zvccwhglp7js7j435d3i2d38i5aikydqg2r4jdc7753w4d22zyiqi";
+        url = "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz";
+        sha512 = "3ypk00r7ddkzx8ayyzdss65167c8h4qgn7f0m2p7zif0sw55ljpbx07zr0hmw8rkyzq0dv7ydr5l14wa60c1fkja8n19ia936rrpllz";
       };
     };
-    "conventional-commits-filter-1.1.5" = {
+    "conventional-commits-filter-1.1.6" = {
       name = "conventional-commits-filter";
       packageName = "conventional-commits-filter";
-      version = "1.1.5";
+      version = "1.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.5.tgz";
-        sha512 = "0dw3vksvzwig2hiiw1kky2p424136r2faa941bkcdy3ljhp7mgd9i8pz3vdccw23v51z7vhh1dkw7wg363qxg9kvcxr2lgwp1cgwgcs";
+        url = "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz";
+        sha512 = "38pzjvxmmjg6y92qyskzpxngphp9s5lxy89ldq9mwx4dcy4n8am2d57j1w4gb7h2fkggbfy5744xrj7ycz2v5afr8hj892a4jsf1h19";
       };
     };
-    "conventional-commits-parser-2.1.5" = {
+    "conventional-commits-parser-2.1.7" = {
       name = "conventional-commits-parser";
       packageName = "conventional-commits-parser";
-      version = "2.1.5";
+      version = "2.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.5.tgz";
-        sha512 = "2nb2s8hrbv3sl19xzz9x5pqgmm4kimrsaqlzs8xa2wzr0zg68090xnlq5ifcbmcm47fg5l9m63kkri248idzrvz2y689y3jbbmhz84d";
+        url = "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz";
+        sha512 = "0ahfqxbkswm1pnbj477wz7kl2588dbg8skjz7xzyykv4w2bw9aal3idvs8kjchlv140s64jcfa2clli93phw4jk85wa09q4s9sim0q6";
       };
     };
     "conventional-recommended-bump-1.2.1" = {
@@ -5801,13 +5864,13 @@ let
         sha1 = "652294c14651db28fa93bd2d5ff2983a4f08c636";
       };
     };
-    "core-js-2.5.3" = {
+    "core-js-2.5.4" = {
       name = "core-js";
       packageName = "core-js";
-      version = "2.5.3";
+      version = "2.5.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz";
-        sha1 = "8acc38345824f16d8365b7c9b4259168e8ed603e";
+        url = "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz";
+        sha1 = "f2c8bf181f2a80b92f360121429ce63a2f0aeae0";
       };
     };
     "core-util-is-1.0.2" = {
@@ -5988,6 +6051,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/crx-parser/-/crx-parser-0.1.2.tgz";
         sha1 = "7eeeed9eddc95e22c189382e34624044a89a5a6d";
+      };
+    };
+    "crypt-0.0.2" = {
+      name = "crypt";
+      packageName = "crypt";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz";
+        sha1 = "88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b";
       };
     };
     "crypt3-0.2.0" = {
@@ -6395,22 +6467,22 @@ let
         sha512 = "2lc9p062gaa2xrf07z14xqgid3rw5fg05ak3s13g3mrr5hf8zxmdvp3lq4wggj7k5pc2c43r3d4yyy7rfrqafsdm7hfisdda4zgsi1w";
       };
     };
-    "dat-ignore-2.0.0" = {
+    "dat-ignore-2.1.1" = {
       name = "dat-ignore";
       packageName = "dat-ignore";
-      version = "2.0.0";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dat-ignore/-/dat-ignore-2.0.0.tgz";
-        sha512 = "1s78mv3ngs1v1cgpcp97y1xmns97m2r6gjkkrksl63j5d870vpsmmrhsfm1vw4q0dz4c1yfnfcpijlgbqai9c5d2zj1lz56rih0kxk8";
+        url = "https://registry.npmjs.org/dat-ignore/-/dat-ignore-2.1.1.tgz";
+        sha512 = "3ars15n4l3fgvnzah15zpfzirg66clg2a72d2qawg340ad1f0xbahxgzfj52q3ib48s6k7m4a8zcpv5n3pq2blkm1dhpyz1s9d9y44d";
       };
     };
-    "dat-json-1.0.1" = {
+    "dat-json-1.0.2" = {
       name = "dat-json";
       packageName = "dat-json";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dat-json/-/dat-json-1.0.1.tgz";
-        sha512 = "13nn20vg6jx1h8ypazv9zn236hvv29wwq52mdbbfl77zrg8d7syni933v2mm3y1jsk25c7dc2gs1876fz0yblniryncnbjxrf0aq0nq";
+        url = "https://registry.npmjs.org/dat-json/-/dat-json-1.0.2.tgz";
+        sha512 = "0i32dn4p0dmjbljm9csnrfibnrgljbqcqkiy5n2wn0mdqpklnv6k9imrv93c0j6p5hsrpnnpjdibhw6fyf5a3183g2wxd1zw5avx6hi";
       };
     };
     "dat-link-resolve-2.1.0" = {
@@ -6791,15 +6863,6 @@ let
         sha1 = "634780f2f8656ab771af8fa8431ed1ccee55c7b0";
       };
     };
-    "deepmerge-1.5.2" = {
-      name = "deepmerge";
-      packageName = "deepmerge";
-      version = "1.5.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz";
-        sha512 = "2sylzgq5rwi12ac5y4fbvyyhs128zlcrp1q1i0bkp27fvlg60hr1slxzckk22x2rzgmwsqqlvzyylm9v0gwzbsbprd3c1mg78c396gp";
-      };
-    };
     "deepmerge-2.1.0" = {
       name = "deepmerge";
       packageName = "deepmerge";
@@ -7124,15 +7187,6 @@ let
         sha1 = "343276308ec991b7bc82267ed55bc1411f971666";
       };
     };
-    "diff-1.4.0" = {
-      name = "diff";
-      packageName = "diff";
-      version = "1.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz";
-        sha1 = "7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf";
-      };
-    };
     "diff-3.2.0" = {
       name = "diff";
       packageName = "diff";
@@ -7196,13 +7250,13 @@ let
         sha1 = "4d5afc5187edba67ec6ab0e55f6422a0e2cb7338";
       };
     };
-    "discovery-channel-5.4.7" = {
+    "discovery-channel-5.5.1" = {
       name = "discovery-channel";
       packageName = "discovery-channel";
-      version = "5.4.7";
+      version = "5.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/discovery-channel/-/discovery-channel-5.4.7.tgz";
-        sha512 = "3c8npbdr7r6725kkj76h5zy72l3gd8ndb3dy4dwbapxapfzccl9f6iy0zdy3wxywcfb6cc64w4mf089v00rcr1aqcjdlvn483pnzs78";
+        url = "https://registry.npmjs.org/discovery-channel/-/discovery-channel-5.5.1.tgz";
+        sha512 = "2zzy8n58w43cvmnascylmw3nppynm334nsjd85w329k8461lwif8xz8b5xqhx8grhpiawhhrri9nlf08ajxriiy4sn26gila509jj8h";
       };
     };
     "discovery-swarm-4.4.2" = {
@@ -7214,13 +7268,13 @@ let
         sha1 = "5d3160a46019e50e874195765df7d601ee55a813";
       };
     };
-    "dispensary-0.12.0" = {
+    "dispensary-0.16.0" = {
       name = "dispensary";
       packageName = "dispensary";
-      version = "0.12.0";
+      version = "0.16.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.12.0.tgz";
-        sha1 = "cc491bbbfa66a57414c958c68582a4c8703ff159";
+        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.16.0.tgz";
+        sha1 = "7173f2828380135e3c8eb9f61719fa038c0cd133";
       };
     };
     "diveSync-0.3.0" = {
@@ -7239,6 +7293,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/dns-discovery/-/dns-discovery-5.6.1.tgz";
         sha512 = "2hda8mbvxc2r10g5p9dsrjk3qdrp7gpk66ps0dikwzcdgn9bvsf8ih9k19kxw7wr299cm7hav2q6rjp5m76zyb6mb19bfa3g6zxyvmg";
+      };
+    };
+    "dns-discovery-6.1.0" = {
+      name = "dns-discovery";
+      packageName = "dns-discovery";
+      version = "6.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dns-discovery/-/dns-discovery-6.1.0.tgz";
+        sha512 = "2qyx3fzq9h9x0m2l5b9226hx2vxpl7w3sgh352qfpa683zmjbzsm8x984jvfmrl3yzzipwg07p6dqdcm8ba3v19x5q1sdgfdhpssp9a";
       };
     };
     "dns-equal-1.0.0" = {
@@ -7268,6 +7331,15 @@ let
         sha512 = "19g682cvkba33mwrism28hibd2nv9xd16k5bj807jx3ih1cc7ff9dn8chmfjnqgglzl6lq3m3jarxng9vbarccgchd0aq118d15yk6i";
       };
     };
+    "dns-packet-4.1.1" = {
+      name = "dns-packet";
+      packageName = "dns-packet";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dns-packet/-/dns-packet-4.1.1.tgz";
+        sha512 = "09adhjnzfiilwrksrckjrxcfi54gy5xgcsvkq24r98j0xh1asvl5iywj4p37s4l7drgysmdlkv95iki5c554gviaj4738fnlhgn42v3";
+      };
+    };
     "dns-socket-1.6.3" = {
       name = "dns-socket";
       packageName = "dns-socket";
@@ -7275,6 +7347,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/dns-socket/-/dns-socket-1.6.3.tgz";
         sha512 = "2g9g9jqx44qpiawlxfn1g647dqwwz2djjpy350c83d1z79d5wa21cknh1jz4wrwsjkvgn14vhmjjxqxf5n8fqq6fjyzw85aa7fk4rgy";
+      };
+    };
+    "dns-socket-3.0.0" = {
+      name = "dns-socket";
+      packageName = "dns-socket";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dns-socket/-/dns-socket-3.0.0.tgz";
+        sha512 = "3yrr8f842jzbhkhbi8a5pgqasyqn03n74gq9l43qmr33ih6ms57kdl5ffkb6zpaaicgj2w8w7kdx4s4xh10aw3vz3k69zh9583s8i9k";
       };
     };
     "dns-txt-2.0.2" = {
@@ -7304,13 +7385,13 @@ let
         sha1 = "33dc69291eac3414f84871f2d59d77b6f6948be4";
       };
     };
-    "doctoc-1.3.0" = {
+    "doctoc-1.3.1" = {
       name = "doctoc";
       packageName = "doctoc";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/doctoc/-/doctoc-1.3.0.tgz";
-        sha1 = "7f0839851dd58c808a2cae55d9504e012d08ee30";
+        url = "https://registry.npmjs.org/doctoc/-/doctoc-1.3.1.tgz";
+        sha1 = "f012e3603e3156254c2ef22ac88c7190f55426ba";
       };
     };
     "doctrine-2.1.0" = {
@@ -7358,13 +7439,13 @@ let
         sha1 = "073c697546ce0780ce23be4a28e293e40bc30c82";
       };
     };
-    "dom-storage-2.0.2" = {
+    "dom-storage-2.1.0" = {
       name = "dom-storage";
       packageName = "dom-storage";
-      version = "2.0.2";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dom-storage/-/dom-storage-2.0.2.tgz";
-        sha1 = "ed17cbf68abd10e0aef8182713e297c5e4b500b0";
+        url = "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz";
+        sha512 = "3ckwbdpfa94f4kv5vav65l1qm56bg54bs2wgz9x5nx64avazbg3p07w05mjbfw066clq69vmyfg1fcph5r99i74x18l95zkcp4nk943";
       };
     };
     "dom-walk-0.1.1" = {
@@ -7439,13 +7520,13 @@ let
         sha1 = "892e47000a99be55bbf3774ffea0561d8879c259";
       };
     };
-    "domino-1.0.30" = {
+    "domino-2.0.2" = {
       name = "domino";
       packageName = "domino";
-      version = "1.0.30";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/domino/-/domino-1.0.30.tgz";
-        sha512 = "1g3pbkg3gg3kjffah03vil47662ra58gckz5z8qymfgb9xq97k7vsd83410fmncbbll1p40rs0s4r0pgdypfvj9j2fq146j41dbqjla";
+        url = "https://registry.npmjs.org/domino/-/domino-2.0.2.tgz";
+        sha512 = "1a0ns7fggllfrkgr3xv2wjpxrai04ikz2bi61n9mnkz6pblw8q2b4i1ivxx9k5kryziqbg9imia3i6sr3xkfss4lwsrphqlm58s8g5z";
       };
     };
     "domutils-1.4.3" = {
@@ -7926,15 +8007,6 @@ let
         sha1 = "a115c32504b6302e85a76269d7a57ccdd962e359";
       };
     };
-    "enhanced-resolve-3.4.1" = {
-      name = "enhanced-resolve";
-      packageName = "enhanced-resolve";
-      version = "3.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz";
-        sha1 = "0421e339fd71419b3da13d129b3979040230476e";
-      };
-    };
     "enhanced-resolve-4.0.0" = {
       name = "enhanced-resolve";
       packageName = "enhanced-resolve";
@@ -8043,13 +8115,13 @@ let
         sha1 = "eaba64ca5d542a311ac945f582defc336165d9f4";
       };
     };
-    "es-abstract-1.10.0" = {
+    "es-abstract-1.11.0" = {
       name = "es-abstract";
       packageName = "es-abstract";
-      version = "1.10.0";
+      version = "1.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz";
-        sha512 = "04nd5ylkfffc08vn5kjhz0saqh44nj19f5j3ahrrhf3zvc9da5rf6snnh63xv4gfhacjbax1jajzgqv4zpm77v806jf883a2w77zs7y";
+        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz";
+        sha512 = "2aaq6ivy5raj1a99db6gvw7qn2vs27h0pqvgpf2fqfm9avwqsirr8gs86yx7n36qysjw1vabz6mlc8dfpi6fmz9yqvk8kapz49jnx36";
       };
     };
     "es-to-primitive-1.1.1" = {
@@ -8061,13 +8133,13 @@ let
         sha1 = "45355248a88979034b6792e19bb81f2b7975dd0d";
       };
     };
-    "es5-ext-0.10.40" = {
+    "es5-ext-0.10.42" = {
       name = "es5-ext";
       packageName = "es5-ext";
-      version = "0.10.40";
+      version = "0.10.42";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.40.tgz";
-        sha512 = "2ylf5xas3zi45vg84c8r81d1lw1d1wmckzf8pvnkwgmq6js0n5mms6lrpnmac7sbi4fv9aqlnrspz7s97vbqii3c6py7r4sikg63lab";
+        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz";
+        sha512 = "1412ssfrx1kvraz8kp4x9lc1jzcdh2952vbmlimrfalmbjv44rh504ihb4fg5mjwx8ix1f1wii0a0qngwrfk4gl271mcywgp7b4x700";
       };
     };
     "es5-ext-0.8.2" = {
@@ -8277,22 +8349,22 @@ let
         sha1 = "c8fc6201c7f40dd08941b87c085767386a679acc";
       };
     };
-    "eslint-4.15.0" = {
+    "eslint-4.19.0" = {
       name = "eslint";
       packageName = "eslint";
-      version = "4.15.0";
+      version = "4.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz";
-        sha512 = "3l1j4qy0gqa8rkwpdsmkkbqcmbx23ym8h64d1bbj5i5ds5ks0g91myldzp0y25r6b3ba9646hy4i2jiad2jmm8h68z89i2larkvyhyc";
+        url = "https://registry.npmjs.org/eslint/-/eslint-4.19.0.tgz";
+        sha512 = "29dc1z24n3c60hfac5afy7rk3mqdch8hnn07fnb9314dbyk5ih2l1284vl3nsgsm5ja5w144nsgmipbycva47gwpl1qfsma5gjcpkdg";
       };
     };
-    "eslint-4.18.2" = {
+    "eslint-4.19.1" = {
       name = "eslint";
       packageName = "eslint";
-      version = "4.18.2";
+      version = "4.19.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz";
-        sha512 = "0mqvxkfl52068bfkpxjn14dgwfv4vv8w0a8pq2rw54bkbshfa2y6rpx122ssk3si3dy9298g68079ns1n7m0jrzgwca7a430ggj4bmb";
+        url = "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz";
+        sha512 = "0hw70vjlg6z0y9kf6vjr7g0w9hbm426fwvyzr88l62c5hd9mxrbw5v34b6zb31vbbyda3mkvcwgfnxgqaxvpn0wlrxr0va43pbzygbd";
       };
     };
     "eslint-plugin-no-unsafe-innerhtml-1.0.16" = {
@@ -8471,7 +8543,7 @@ let
       packageName = "event-stream";
       version = "0.5.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz";
+        url = "http://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz";
         sha1 = "b77b9309f7107addfeab63f0c0eafd8db0bd8c1c";
       };
     };
@@ -8480,7 +8552,7 @@ let
       packageName = "event-stream";
       version = "3.1.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/event-stream/-/event-stream-3.1.5.tgz";
+        url = "http://registry.npmjs.org/event-stream/-/event-stream-3.1.5.tgz";
         sha1 = "6cba5a3ae02a7e4967d65ad04ef12502a2fff66c";
       };
     };
@@ -8489,7 +8561,7 @@ let
       packageName = "event-stream";
       version = "3.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/event-stream/-/event-stream-3.2.2.tgz";
+        url = "http://registry.npmjs.org/event-stream/-/event-stream-3.2.2.tgz";
         sha1 = "f79f9984c07ee3fd9b44ffb3cd0422b13e24084d";
       };
     };
@@ -8498,7 +8570,7 @@ let
       packageName = "event-stream";
       version = "3.3.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz";
+        url = "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz";
         sha1 = "4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571";
       };
     };
@@ -8959,15 +9031,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz";
         sha1 = "5abbedc98c0d5202e3278727f9192d7e086c6be1";
-      };
-    };
-    "extract-text-webpack-plugin-3.0.2" = {
-      name = "extract-text-webpack-plugin";
-      packageName = "extract-text-webpack-plugin";
-      version = "3.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz";
-        sha512 = "10rc4hfyzf8n5b30q0fpawnbnr1cs33mmrz9466hhcxjzlz7ys44zbsr5kbvr1jn5nivcr91nmfhpq2mqi1wxmr19zsnimri5kwppvf";
       };
     };
     "extract-zip-1.5.0" = {
@@ -9465,15 +9528,6 @@ let
         sha1 = "b37dc844b76a2f5e7081e884f7c0ae344f153476";
       };
     };
-    "firefox-client-0.3.0" = {
-      name = "firefox-client";
-      packageName = "firefox-client";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/firefox-client/-/firefox-client-0.3.0.tgz";
-        sha1 = "3794460f6eb6afcf41376addcbc7462e24a4cd8b";
-      };
-    };
     "firefox-profile-1.1.0" = {
       name = "firefox-profile";
       packageName = "firefox-profile";
@@ -9573,15 +9627,6 @@ let
         sha1 = "554440766da0a0d603999f433453f6c2fc6a75c1";
       };
     };
-    "fluent-0.4.1" = {
-      name = "fluent";
-      packageName = "fluent";
-      version = "0.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fluent/-/fluent-0.4.1.tgz";
-        sha512 = "2hrbkg2399py60vsz1k5xydrm5kwfh1f6fpgpbkrs9nni1xpq4isy8aif5jq5dakyksbf0yjx3sh7jl9f54c3r6jkf3amm3grxlbaxx";
-      };
-    };
     "fluent-ffmpeg-2.1.2" = {
       name = "fluent-ffmpeg";
       packageName = "fluent-ffmpeg";
@@ -9591,13 +9636,22 @@ let
         sha1 = "c952de2240f812ebda0aa8006d7776ee2acf7d74";
       };
     };
-    "flush-write-stream-1.0.2" = {
+    "fluent-syntax-0.6.6" = {
+      name = "fluent-syntax";
+      packageName = "fluent-syntax";
+      version = "0.6.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.6.6.tgz";
+        sha512 = "18dv619kjzc3fdahfc242r7lb27a3pjxx5xd8shascb9xb8c1zncsrbnj0an8qjsg1pwf0az7h7gv5v0g50b3pixznr7wk7d8yqfazj";
+      };
+    };
+    "flush-write-stream-1.0.3" = {
       name = "flush-write-stream";
       packageName = "flush-write-stream";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz";
-        sha1 = "c81b90d8746766f1a609a46809946c45dd8ae417";
+        url = "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz";
+        sha512 = "0dycj5bh8djmx4lj5llrbg3cg0ynq32qn8pzk8zl9j8pm6nv5n1qzk4m7dq81q96ygzh8jl9chqh8826rrbl8maa9643fvl5lq5kabi";
       };
     };
     "follow-redirects-0.0.3" = {
@@ -9807,13 +9861,13 @@ let
         sha1 = "ef5491490f9433b705faa77249c99029ae348559";
       };
     };
-    "formidable-1.2.0" = {
+    "formidable-1.2.1" = {
       name = "formidable";
       packageName = "formidable";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/formidable/-/formidable-1.2.0.tgz";
-        sha512 = "00p3bjjkrbwf4xcizvkz2bdc1h0cs8gnshfwn35ncx0zs5qy8pzgc65xg6ndma0mlfy69v5r0cg3zj8x6j6jdn4gzj2w0ibgm7mmgw6";
+        url = "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz";
+        sha512 = "1x0n2rfaiasdjbw1mm7s29z84f68c7iji7lb1gkxvpknvv6q7bwns7z55ijcf4vkh4kvis12rbgaaih49jf9lj53s30mllb1d35bkqn";
       };
     };
     "forwarded-0.1.2" = {
@@ -10311,13 +10365,13 @@ let
         sha1 = "dc15ca1c672387ca76bd37ac0a395ba2042a2c28";
       };
     };
-    "getmac-1.2.1" = {
+    "getmac-1.4.1" = {
       name = "getmac";
       packageName = "getmac";
-      version = "1.2.1";
+      version = "1.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/getmac/-/getmac-1.2.1.tgz";
-        sha1 = "0d095fd0627850043eac1dcfa0b120bbdc1426d1";
+        url = "https://registry.npmjs.org/getmac/-/getmac-1.4.1.tgz";
+        sha512 = "0r7zqgvfiv3r6zy8fms9gdcf3a1r46kpf8pm5x7vwrc27vgv69ra244s89k73hb9rna6r3s9v20yzbwjmz2c13gh3s0bbd07zq7w2lr";
       };
     };
     "getpass-0.1.7" = {
@@ -10338,13 +10392,13 @@ let
         sha1 = "2c5a6638d893934b9b55037d0ad82cb7004b2679";
       };
     };
-    "git-raw-commits-1.3.4" = {
+    "git-raw-commits-1.3.6" = {
       name = "git-raw-commits";
       packageName = "git-raw-commits";
-      version = "1.3.4";
+      version = "1.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.4.tgz";
-        sha512 = "0yfkxk071bahnzw2h5ip6qb7mq76psfwiqs232gkzr91hc55kqw57pjn33j04h3xiwvgrikl20mbccisi006rxyh0lwfvj7bkivwwqv";
+        url = "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz";
+        sha512 = "111718czypc8jr47xq3n5xvfwx6nib7y36bpb882id57sdhv49bfpdmkgxbrb524942rw3k6wq15128mlv4q8fbkh5g3wjhmgdhmyxj";
       };
     };
     "git-remote-origin-url-2.0.0" = {
@@ -10365,13 +10419,13 @@ let
         sha1 = "a0c2e3dd392abcf6b76962e27fc75fb3223449ce";
       };
     };
-    "git-semver-tags-1.3.4" = {
+    "git-semver-tags-1.3.6" = {
       name = "git-semver-tags";
       packageName = "git-semver-tags";
-      version = "1.3.4";
+      version = "1.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.4.tgz";
-        sha512 = "0hhdj4992a96ys5i9k6pjbn99wwsabb92drxr0s7vzxyxlpydrvjzbb4rwdnsd0rm7h92420yr2f3khpakkp6ivgg09fp9hhgprkvax";
+        url = "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz";
+        sha512 = "25114wyd4p8qn681l730d9s1wgh4kmvizin5361hx5qvpd82adi2fkjkvv289nk1vb6hx8q13ikhyc705hw8iag1b23zq37g4kfacfs";
       };
     };
     "gitconfiglocal-1.0.0" = {
@@ -10636,13 +10690,13 @@ let
         sha1 = "dbf743c6c14992593c655568cb66ed32c0122ebe";
       };
     };
-    "globals-11.3.0" = {
+    "globals-11.4.0" = {
       name = "globals";
       packageName = "globals";
-      version = "11.3.0";
+      version = "11.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz";
-        sha512 = "1vlgbj6gcsd9dshs7xldhg92zd62r3w51jf9x80qnn0y4llbl2ji5sl7ibmv7ysr0iv8hzid151n8zxhyi84rlnczysjhb6v4l5qjlj";
+        url = "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz";
+        sha512 = "0fgjya5jfxjd8gzgpnpig973bbplfq2i5fkfpi5lxyjsi3988wq3by19ka2ql2j4a80l9bk5g5brq4vvd2hr61ak79pzwm5z24ycb0g";
       };
     };
     "globals-9.18.0" = {
@@ -11671,31 +11725,31 @@ let
         sha1 = "a65b34459ad6367adbb3707a82a3c9f916167030";
       };
     };
-    "humanize-string-1.0.1" = {
+    "humanize-string-1.0.2" = {
       name = "humanize-string";
       packageName = "humanize-string";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/humanize-string/-/humanize-string-1.0.1.tgz";
-        sha1 = "fce2d6c545efc25dea1f23235182c98da0180b42";
+        url = "https://registry.npmjs.org/humanize-string/-/humanize-string-1.0.2.tgz";
+        sha512 = "3bml62y8rmpga8wbcxfqm6izvc9xxlblx0vc08r778qa42jgw6fjif4i7f9bj2y98bz4xyimg5vfgch92j6i2l7zcwiq5za8l34cziw";
       };
     };
-    "hypercore-6.12.3" = {
+    "hypercore-6.12.7" = {
       name = "hypercore";
       packageName = "hypercore";
-      version = "6.12.3";
+      version = "6.12.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hypercore/-/hypercore-6.12.3.tgz";
-        sha512 = "0gxq17xmp2926g01dram5fdny52r40lvvanf83d35vvrhsck95zx2ymrhn6hv81hp8wvlwlqs84zbz35xp6d0nf3396pa0kra44ma4k";
+        url = "https://registry.npmjs.org/hypercore/-/hypercore-6.12.7.tgz";
+        sha512 = "28wgk53py46wrcp8h8xkirakbc3v64r1aaqnl0g0ivp9x7791wkga63mbjl0cdsa3yif0cvbp8djwcpzx0smfyyqkdz7skjdgsbg57j";
       };
     };
-    "hypercore-protocol-6.6.0" = {
+    "hypercore-protocol-6.6.4" = {
       name = "hypercore-protocol";
       packageName = "hypercore-protocol";
-      version = "6.6.0";
+      version = "6.6.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.6.0.tgz";
-        sha512 = "3kwmsg8vfza3i9nbx84v43sh4gi5bjpmj7mn15xyvxg30k0074yvgpng16g8310r88dsk055awlj9zf5zpsk1r0zy61890k9y7bpppg";
+        url = "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.6.4.tgz";
+        sha512 = "0rxj8d4lp45q7v3wwwv23m7qi84vw3wvyafqiy9x5f9lqkynq8v8yajpq9bcnc935927qjnxajn8n0cyhg0fqjnpywlfyxgxczkndgm";
       };
     };
     "hyperdrive-9.12.3" = {
@@ -11795,6 +11849,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz";
         sha1 = "c6019a7595f2cefca702eab694a010bcd9298d20";
+      };
+    };
+    "ieee754-1.1.11" = {
+      name = "ieee754";
+      packageName = "ieee754";
+      version = "1.1.11";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz";
+        sha512 = "0g5x1ijy37vzfz46pnh03mxkmdb9d2qd9f8ncy49xj4j9xkks9p0x8s5hnyc7grwh6sryk118rd7w7wz6w0hzyw9agwnavvlc4g642n";
       };
     };
     "ieee754-1.1.8" = {
@@ -12103,13 +12166,13 @@ let
         sha512 = "1wsmzzva3rfjb4bfks7ba2nvha9ziwgq2kag6xxibc5cc6mz19xbgj4fm3a7ghvfbfx4am0x13ibc8j2s5m3sv12nph44rq56gnvv47";
       };
     };
-    "insert-module-globals-7.0.2" = {
+    "insert-module-globals-7.0.5" = {
       name = "insert-module-globals";
       packageName = "insert-module-globals";
-      version = "7.0.2";
+      version = "7.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.2.tgz";
-        sha512 = "19lb0lqjmyxr13va9m2mdyjmpfb2c4lgnnnwysri85znpa37gcgi6b57zj0h5ymk6fbl3snjfw07gb9azb8yvkldj6av6wdvs1knyx7";
+        url = "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.5.tgz";
+        sha512 = "3fk0jxs2s9i64hqs1y6ncl81nddpb2kr58myi8805mg9j3xgmn5svxmk8xwvm2358snahh9r0k1zmpv6512sq383zp4m6sc5an6s162";
       };
     };
     "insight-0.8.4" = {
@@ -12166,13 +12229,13 @@ let
         sha1 = "96fb0a936c12babd6ff1752a17d05616abd094c6";
       };
     };
-    "invariant-2.2.3" = {
+    "invariant-2.2.4" = {
       name = "invariant";
       packageName = "invariant";
-      version = "2.2.3";
+      version = "2.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz";
-        sha512 = "2s1gvqa56gnq2pkh0yy5ch3pb69dkwxr6myw9r3cc1c55xnrpiwzgc90ns4n9lij9slw0aayzm95k3x3rfrv0m7dnikq39hx0ylz7pd";
+        url = "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz";
+        sha512 = "0sa0bflh46zr7zqdifqk3a48bmqlmpikrnmwvgz8nx6979piw2m92qrn1g5xnpjzxn864y2jq3gl84jkws2dad3mlwr6s3fa10my4m6";
       };
     };
     "invert-kv-1.0.0" = {
@@ -12598,6 +12661,15 @@ let
         sha1 = "0dfd98f5a9111716dd535dda6492f67bf3d25a80";
       };
     };
+    "is-mergeable-object-1.1.0" = {
+      name = "is-mergeable-object";
+      packageName = "is-mergeable-object";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.0.tgz";
+        sha512 = "03srgd19nl1p2b2ny8gamq5qvv4k124inq5fzkb1kqxdw9y45fr46g8awmpnx0hgwpfg0blysfms7r8n89sf5183hr2xd8x0l7q7z15";
+      };
+    };
     "is-my-ip-valid-1.0.0" = {
       name = "is-my-ip-valid";
       packageName = "is-my-ip-valid";
@@ -12706,13 +12778,13 @@ let
         sha1 = "d225ec23132e89edd38fda767472e62e65f1106d";
       };
     };
-    "is-path-in-cwd-1.0.0" = {
+    "is-path-in-cwd-1.0.1" = {
       name = "is-path-in-cwd";
       packageName = "is-path-in-cwd";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz";
-        sha1 = "6477582b8214d602346094567003be8a9eac04dc";
+        url = "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz";
+        sha512 = "1lrmbdvciajn2smq4j80qvp3gpkkzqddiyay3xgbzni3gi4vljkawyyw68i6h8m1jfdg4jy8l8c16rlfvr17pnfb314xw5q6m2pad8n";
       };
     };
     "is-path-inside-1.0.1" = {
@@ -12904,13 +12976,13 @@ let
         sha1 = "8a59117d932de1de00f245fcdd39ce43f1e939a6";
       };
     };
-    "is-supported-regexp-flag-1.0.0" = {
+    "is-supported-regexp-flag-1.0.1" = {
       name = "is-supported-regexp-flag";
       packageName = "is-supported-regexp-flag";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz";
-        sha1 = "8b520c85fae7a253382d4b02652e045576e13bb8";
+        url = "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz";
+        sha512 = "0lrp2yp3bjcq9v1sxn5451bmmnj129aws8g0ym3a2s4wkc2y6ym591pym51dgs2xg7cpid087hvmnvqjr36pp6gm419ibhlqmwhkxyy";
       };
     };
     "is-symbol-1.0.1" = {
@@ -12958,13 +13030,13 @@ let
         sha512 = "2asak63h3kc1vackrpai7qfiv15ndr231w1yc753m1dy7fd6ywxsr0rvh88b9ppyxhmc373fqk89a0pw3dllv7m5nbbbcqzvmaskccs";
       };
     };
-    "is-url-1.2.2" = {
+    "is-url-1.2.4" = {
       name = "is-url";
       packageName = "is-url";
-      version = "1.2.2";
+      version = "1.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz";
-        sha1 = "498905a593bf47cc2d9e7f738372bbf7696c7f26";
+        url = "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz";
+        sha512 = "31qfylxnpb1y8vczgi2nh57ayl7s5ppn8iskp21607l6ka7jxq409pf2mvspwnx6pj29b63ldayjgljsbhyc442gfc1i185dy5ccfr1";
       };
     };
     "is-utf8-0.2.1" = {
@@ -13037,6 +13109,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz";
         sha1 = "a37d94ed9cda2d59865c9f76fe596ee1f338741e";
+      };
+    };
+    "isarray-2.0.4" = {
+      name = "isarray";
+      packageName = "isarray";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz";
+        sha512 = "1l996rw6ql1ypf4jvy0yhl3d08zislzsxc0lgbc4hh3kb4qzlxqv29d9nblq9ai6lkiwvxfgynknk8j6j9qm49jqlsnib924lx5gk0q";
       };
     };
     "isbinaryfile-3.0.2" = {
@@ -13343,15 +13424,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz";
         sha1 = "1e60b0fef1bc0af67bc0d146dfdde5486cd615b4";
-      };
-    };
-    "json-loader-0.5.7" = {
-      name = "json-loader";
-      packageName = "json-loader";
-      version = "0.5.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz";
-        sha512 = "3iwy9jwca9hg6h1k7cmcdlsygn2qzjv7w72fsrfjfpdrcyd4xc5fb11sf664rvnzrfmz24f19kvi3qawif4n63lggvpg5pv73qfrcs0";
       };
     };
     "json-merge-patch-0.2.3" = {
@@ -13976,22 +14048,22 @@ let
         sha512 = "2qh1bqb9lj7l92pwcrwmpcanbyn65rmni3swyv6hrphn7xbaw8mkir3w67sf4ardk1iqvz9waalq2wf2rgpvvblhva2n2hssq6as6yr";
       };
     };
-    "kuduscript-1.0.15" = {
+    "kuduscript-1.0.16" = {
       name = "kuduscript";
       packageName = "kuduscript";
-      version = "1.0.15";
+      version = "1.0.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/kuduscript/-/kuduscript-1.0.15.tgz";
-        sha1 = "2721f05aa6876534cd30d6ded9418651cadfaa21";
+        url = "https://registry.npmjs.org/kuduscript/-/kuduscript-1.0.16.tgz";
+        sha512 = "2pws4jvqqdysxbqb5bw1m67wklk7lrxl293q5w9cd58drz6jzs4qzgiy6gg7dzx9m2pgn9kqxns8pw445d68ncqk2nxpdcimnnsbszv";
       };
     };
-    "labeled-stream-splicer-2.0.0" = {
+    "labeled-stream-splicer-2.0.1" = {
       name = "labeled-stream-splicer";
       packageName = "labeled-stream-splicer";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz";
-        sha1 = "a52e1d138024c00b86b1c0c91f677918b8ae0a59";
+        url = "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz";
+        sha512 = "0z3ssjaq1bx4j1dcysbbmsnq24zglv2gdsm3by6dr34w10jrlg06rrh3l7qa8a3ch7ag9gmkjfrw6m448sra299gz5rvg2ifsc7hbrh";
       };
     };
     "last-one-wins-1.0.4" = {
@@ -14678,15 +14750,6 @@ let
         sha1 = "bec1024f85b1bd96cbea405b23c14ad6443a6f81";
       };
     };
-    "lodash.endswith-4.2.1" = {
-      name = "lodash.endswith";
-      packageName = "lodash.endswith";
-      version = "4.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz";
-        sha1 = "fed59ac1738ed3e236edd7064ec456448b37bc09";
-      };
-    };
     "lodash.escape-3.2.0" = {
       name = "lodash.escape";
       packageName = "lodash.escape";
@@ -14793,15 +14856,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz";
         sha1 = "415c4478f2bcc30120c22ce10ed3226f7d3e18e0";
-      };
-    };
-    "lodash.isfunction-3.0.9" = {
-      name = "lodash.isfunction";
-      packageName = "lodash.isfunction";
-      version = "3.0.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz";
-        sha512 = "0ki8njk33gc8ayf2vmnx2jrfdapwckm7dx2z4zn1ik07hwgwx5zb3fsi9mlamhg6rnj1qlvfwsbg2074x19x8gq60615fbr7lvdfah2";
       };
     };
     "lodash.isplainobject-4.0.6" = {
@@ -14955,15 +15009,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz";
         sha1 = "edd14c824e2cc9c1e0b0a1b42bb5210516a42438";
-      };
-    };
-    "lodash.startswith-4.2.1" = {
-      name = "lodash.startswith";
-      packageName = "lodash.startswith";
-      version = "4.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz";
-        sha1 = "c598c4adce188a27e53145731cdc6c0e7177600c";
       };
     };
     "lodash.template-3.6.2" = {
@@ -15182,6 +15227,15 @@ let
         sha1 = "4e3366b39e7f5457e35f1324bdf6f88d0bfc7306";
       };
     };
+    "lowercase-keys-1.0.1" = {
+      name = "lowercase-keys";
+      packageName = "lowercase-keys";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz";
+        sha512 = "1a7qa1zn5zl1nf7i6w3299lc3biabfb0w2c30cl770l2dbldvi72nwvjdlinhx7j0ldip82sj710aprdjbmbg782i2pa3jpbgmy6qhv";
+      };
+    };
     "lru-2.0.1" = {
       name = "lru";
       packageName = "lru";
@@ -15252,15 +15306,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz";
         sha512 = "1whynbvy3pbwcpkxk6rqhsymj2h3bh7p13nfhs9ch6hfx96vrh86j7vd4lqcaqjy5dhsfjps6sh2wqndh269wjz42khbh6339g9a1y2";
-      };
-    };
-    "lsmod-1.0.0" = {
-      name = "lsmod";
-      packageName = "lsmod";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz";
-        sha1 = "9a00f76dca36eb23fa05350afe1b585d4299e64b";
       };
     };
     "ltgt-1.0.2" = {
@@ -15524,13 +15569,13 @@ let
         sha1 = "0e2cba81390b0549a9153ec3b0d915b61c164be7";
       };
     };
-    "marked-0.3.17" = {
+    "marked-0.3.19" = {
       name = "marked";
       packageName = "marked";
-      version = "0.3.17";
+      version = "0.3.19";
       src = fetchurl {
-        url = "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz";
-        sha512 = "2cw4hwy4hyxspppby5ww0sljhyg0nhlgy0aamqvf7nrhg4vyrgyp8ah52pz99rr8pvsjk3h9z9q8fhrlqaixw5kgk2si5yrr0v9n0pq";
+        url = "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz";
+        sha512 = "2940np3jq9midbdw8mhfry1msy3572i2gj0y3z9c8z1dyrdhxg1rivcxhgihpqs6gihqnzgdhbgmgsabm2ch7gzbvf16dxacccrxbbr";
       };
     };
     "matcher-collection-1.0.5" = {
@@ -15540,6 +15585,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz";
         sha512 = "1hfvbsx85xqrw6g0k7rkqwngl8b2nwj92ax10ilx3b4lma2mcp8q6zpvam1sffgqsssa9d13cj7prrzg5c00mf0c8q92w59m36ach4x";
+      };
+    };
+    "md5-2.2.1" = {
+      name = "md5";
+      packageName = "md5";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz";
+        sha1 = "53ab38d5fe3c8891ba465329ea23fac0540126f9";
       };
     };
     "md5.js-1.3.4" = {
@@ -15821,13 +15875,13 @@ let
         sha1 = "86677c97d1720b363431d04d0d15293bd38c1565";
       };
     };
-    "micromatch-3.1.9" = {
+    "micromatch-3.1.10" = {
       name = "micromatch";
       packageName = "micromatch";
-      version = "3.1.9";
+      version = "3.1.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz";
-        sha512 = "3vfciram7xbwcwvhii8960vnvf3jczn092sfbfgx1vivk3scvkm9znjnbq2ppywg9h8i86d8vq3ha4c9a3jllaian0gcl7rrgm36lja";
+        url = "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz";
+        sha512 = "1r9rsac8gdslsplya0cnzyk6q0bh7m0wnxccdisacr5327k5k0v6f48dzp0022z8qqpzpvxw7sv1gzhvrqn6v5sz7qcvx37by1a8s1i";
       };
     };
     "miller-rabin-4.0.1" = {
@@ -16091,13 +16145,13 @@ let
         sha512 = "1slngp5z9rczjirv9lpdwiv1ap4xmp28jxl4r0i5hpds1khlm89qp70ziz8k5h2vwjph6srjqi3gb2yrwwsnnwli6p8yxvlyx7nn80p";
       };
     };
-    "minipass-2.2.1" = {
+    "minipass-2.2.4" = {
       name = "minipass";
       packageName = "minipass";
-      version = "2.2.1";
+      version = "2.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz";
-        sha512 = "3yy9s65iwrx5hndcqbxrks88xi9cf8hra6zalgf8xfr4ahpp31s0i8lv6jpyb42p0y7z55ac3390sbqxcgcvan3xls449agbjb98mmv";
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz";
+        sha512 = "3r74gps1yd2fabj46qd42hknvpkg4aqwg3cdz8xjn8aqww0rsk3nmbgh8p2h0rkjlpxihg1wnpfa4bmpgmnydlbhpb1rz5dcxcwhdc7";
       };
     };
     "minizlib-1.1.0" = {
@@ -16217,13 +16271,13 @@ let
         sha1 = "f1fa58899f3f452d788f1573401212a4ef898de5";
       };
     };
-    "modify-values-1.0.0" = {
+    "modify-values-1.0.1" = {
       name = "modify-values";
       packageName = "modify-values";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz";
-        sha1 = "e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2";
+        url = "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz";
+        sha512 = "15hcc3355684n37j7979fs72xj57d71cpl1vbqf3n0nkj3mdairyl91q80xhrhrzlpbxc1yccvqqbh31zv7p4wmilcbl5vswg2rnpf5";
       };
     };
     "module-deps-4.1.1" = {
@@ -16235,13 +16289,13 @@ let
         sha1 = "23215833f1da13fd606ccb8087b44852dcb821fd";
       };
     };
-    "module-deps-6.0.0" = {
+    "module-deps-6.0.2" = {
       name = "module-deps";
       packageName = "module-deps";
-      version = "6.0.0";
+      version = "6.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/module-deps/-/module-deps-6.0.0.tgz";
-        sha512 = "0ri32x2v7ywi8n4h92scc5pq6zlh7mmzbmk0gh2gsh3490w4d9islz1rs0in98cl2h5fl0dfx2dfcad0disnaiqflw46d24ja20raq4";
+        url = "https://registry.npmjs.org/module-deps/-/module-deps-6.0.2.tgz";
+        sha512 = "2zf8ycbhqnh9hc6zd3h5s1ii6bjg41z721ffg760j8i045vjjzpzzg542c02ylkic68p0skw1ss97lwphblcw8rip3ik29x9pglhq19";
       };
     };
     "moment-2.1.0" = {
@@ -16505,13 +16559,13 @@ let
         sha1 = "8bce09f053b1565dbaa8bd022ca40155c35b0fde";
       };
     };
-    "ms-rest-azure-2.5.4" = {
+    "ms-rest-azure-2.5.5" = {
       name = "ms-rest-azure";
       packageName = "ms-rest-azure";
-      version = "2.5.4";
+      version = "2.5.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.4.tgz";
-        sha512 = "049vfg1l6jfzdn82m5shchi6zzlfk81csihlalwj1mm96j0dykbx885sbjyv3wr0iqwjwzp4i1x2kv750xvzvyljfqrlnh1kfhrq32b";
+        url = "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.5.tgz";
+        sha512 = "37sgjm2jqs7fnlzbxihq6sdxxd4w7m5nnkmvp5rrnq9ghsfbbk9pr1z4lm6my3yg06hhqgdyg7rnnzvds26yxjwic7d1g1ab1igjwrf";
       };
     };
     "msgpack-1.0.2" = {
@@ -16568,6 +16622,15 @@ let
         sha512 = "3m42kr8y2s1krl4gzb5xsa9v3h01xalvrgdkj99gyfaq7761asmj5m6kzm70mxb22125gia12g7rmarnzmh09403j8j2cyvx7jqjblf";
       };
     };
+    "multicast-dns-7.0.0" = {
+      name = "multicast-dns";
+      packageName = "multicast-dns";
+      version = "7.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.0.tgz";
+        sha512 = "3z5r41v1y4fk8751g0s7ssgzpiaw7g3bwbnjk9gvdh5x3rijzpnlk03s0vlng9yx3f5j9h0zfy6rjfmh183gxyxh2y8y7hps977k806";
+      };
+    };
     "multicast-dns-service-types-1.1.0" = {
       name = "multicast-dns-service-types";
       packageName = "multicast-dns-service-types";
@@ -16620,6 +16683,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz";
         sha1 = "2a8f2ddf70eed564dff2d57f1e1a137d9f05078b";
+      };
+    };
+    "multistream-2.1.0" = {
+      name = "multistream";
+      packageName = "multistream";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multistream/-/multistream-2.1.0.tgz";
+        sha1 = "625c267d5c44424ad6294788b5bb4da3dcb32f1d";
       };
     };
     "muri-0.3.1" = {
@@ -16766,6 +16838,15 @@ let
         sha1 = "020a7ccedc63fdee85f85967d5607849e74abbe8";
       };
     };
+    "nan-2.10.0" = {
+      name = "nan";
+      packageName = "nan";
+      version = "2.10.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz";
+        sha512 = "349rr7x0djrlkav4gbhkg355852ingn965r0kkch8rr4cwp7qki9676zpq8cq988yszzd2hld6szsbbnd1v6rghzf11abn1nyzlj1vc";
+      };
+    };
     "nan-2.3.5" = {
       name = "nan";
       packageName = "nan";
@@ -16791,15 +16872,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz";
         sha1 = "e4ff34e6c95fdfb5aecc08de6596f43605a7db45";
-      };
-    };
-    "nan-2.9.2" = {
-      name = "nan";
-      packageName = "nan";
-      version = "2.9.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz";
-        sha512 = "1iwlv98jbkr46c7hy28crk2m89jiskrp4qfa5ysyacyq8dkbk4hii3cc61irf39b7n6wd9cjlaasmakv9dsknqhb3876zrvrbjvmmcn";
       };
     };
     "nanoassert-1.1.0" = {
@@ -16905,13 +16977,13 @@ let
         sha1 = "20a318c30cb45f71fe7adfbf7b21c99c1472ef11";
       };
     };
-    "natives-1.1.1" = {
+    "natives-1.1.2" = {
       name = "natives";
       packageName = "natives";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz";
-        sha512 = "08a9lf00d2pkqmdi6ipp00pjin0gwl6fh283cjdjbayaz834lppwrw19kn4s642kwa46bfcway3033j6rbqd96iy86qrzrfgz35mr7i";
+        url = "https://registry.npmjs.org/natives/-/natives-1.1.2.tgz";
+        sha512 = "246d44jpalvlcvk1ig1b2qc05fsgq8gy926xcl86bdnx663k8bh7pi4ny1pa7xr0bxydm33rhkvwzz3fjrrr7pkrjx0pmj44x5l1d75";
       };
     };
     "natural-compare-1.4.0" = {
@@ -17237,15 +17309,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz";
         sha512 = "0lz5m15w7qaks0a0s3dm0crsjrsd123dy00pn6qwcp50zfjykxkp22i5ymh6smlc0ags38nmdxlxw9yyq509azlv8kcdvdiq857h5in";
-      };
-    };
-    "node-firefox-connect-1.2.0" = {
-      name = "node-firefox-connect";
-      packageName = "node-firefox-connect";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-firefox-connect/-/node-firefox-connect-1.2.0.tgz";
-        sha1 = "42403848313240c98514ef14b3302816fe3b84e1";
       };
     };
     "node-forge-0.6.23" = {
@@ -17671,13 +17734,13 @@ let
         sha1 = "5b1d577e4c8869d6c8603bc89e9cd1637303e46e";
       };
     };
-    "npm-5.6.0" = {
+    "npm-5.7.1" = {
       name = "npm";
       packageName = "npm";
-      version = "5.6.0";
+      version = "5.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm/-/npm-5.6.0.tgz";
-        sha512 = "0nnr796ik5h8bsd3k9ygivivr3na2ksnf5iipf8dsnn20j10i9sgmhmsnzbimd2pqgjbrpp8gbpl2q7j5c7yjqjfirrh8xcc3v3gpws";
+        url = "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz";
+        sha512 = "147xlh1d389j8yilssidlk7w8qgp1354y5p2bhv30a0m74vmfbl48859yfidij4ixbf0dhdmzkg6zz6viik2cskkrz4nw56zsz2nn5g";
       };
     };
     "npm-bundled-1.0.3" = {
@@ -17960,13 +18023,13 @@ let
         sha1 = "7e7d858b781bd7c991a41ba975ed3812754e998c";
       };
     };
-    "object-hash-1.2.0" = {
+    "object-hash-1.3.0" = {
       name = "object-hash";
       packageName = "object-hash";
-      version = "1.2.0";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/object-hash/-/object-hash-1.2.0.tgz";
-        sha512 = "19310wpjhfybr8gslg93qybbsrf3fjlmdgsgvn7d9yim1nmpcgjn5az280w4p8spvhq1djly7naa9434166gcmbavv0xirg75gmcr5j";
+        url = "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz";
+        sha512 = "2qnadlb3xqg732666500m9gssayfvlzrhipcl3hyw3qm1yhmvnz72slbmzlbfi8kgzl95a32a896f1lf175ql4jmn9f2j95pm1v74nk";
       };
     };
     "object-keys-1.0.11" = {
@@ -18154,7 +18217,7 @@ let
       packageName = "onetime";
       version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz";
+        url = "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz";
         sha1 = "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789";
       };
     };
@@ -18255,6 +18318,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz";
         sha512 = "12iyalgghs3dj0pfb7rxa013x946169yfsjfd15fsfrx5kv80z2qh082x7v7d91hh7bf9vxcm4wqmyyj9ckk3gnvc7mw77j6fkwdpr5";
+      };
+    };
+    "opn-5.3.0" = {
+      name = "opn";
+      packageName = "opn";
+      version = "5.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz";
+        sha512 = "3d5s5y22sx4wfswzs8fmhr7sarmjigs8qhmmyrkiplfda6kkfk3kv67fs8npdklf8zbc9hmx76zsxqfv4bn5qlpzbfq96nfyailg0kd";
       };
     };
     "optimist-0.2.8" = {
@@ -19238,22 +19310,22 @@ let
         sha512 = "30bb7vx0m1k1m3d1i1khgvmgddx3ahqgprs421ssrh5plpx50k5bazsj67gdi7qiknircqy59yxbclq95s2rnmk8ysgkqdpsddijfw2";
       };
     };
-    "peer-wire-protocol-0.7.0" = {
+    "peer-wire-protocol-0.7.1" = {
       name = "peer-wire-protocol";
       packageName = "peer-wire-protocol";
-      version = "0.7.0";
+      version = "0.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/peer-wire-protocol/-/peer-wire-protocol-0.7.0.tgz";
-        sha1 = "6c015abf24b4877ed9eca3822b22d996078011da";
+        url = "https://registry.npmjs.org/peer-wire-protocol/-/peer-wire-protocol-0.7.1.tgz";
+        sha512 = "2dzhv7b379pzls7q7kd168h4ckh3gnfxcizknb8bvqrpxrm847vjc8c0vpn1b490k94sgl5yxndfiw30rply4phymrx6z2wyrmi7njp";
       };
     };
-    "peer-wire-swarm-0.12.1" = {
+    "peer-wire-swarm-0.12.2" = {
       name = "peer-wire-swarm";
       packageName = "peer-wire-swarm";
-      version = "0.12.1";
+      version = "0.12.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/peer-wire-swarm/-/peer-wire-swarm-0.12.1.tgz";
-        sha1 = "51b75da99c335c64c9ba9ef99fe27a4a5951ff42";
+        url = "https://registry.npmjs.org/peer-wire-swarm/-/peer-wire-swarm-0.12.2.tgz";
+        sha512 = "3bchr23xpdvjf588f8qx52ylri5kcqnqi4lf4mgh3i0j8sk1cljvsikd47l09jk4v3drg500q3p5q01nm2z4xfj4fk5xxnbfkb9k1dh";
       };
     };
     "peerflix-0.34.0" = {
@@ -19365,13 +19437,22 @@ let
         sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
       };
     };
-    "pino-4.10.3" = {
+    "pino-4.14.0" = {
       name = "pino";
       packageName = "pino";
-      version = "4.10.3";
+      version = "4.14.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pino/-/pino-4.10.3.tgz";
-        sha512 = "2kg8qqb15pav0a2f16xmj5iqzkx28d0c6i1ydy3vzn71hfv7b7kvsbv917bwj68bh8m2mgy9j0kj8j4npy14hg2h09q4h85sz8wm990";
+        url = "https://registry.npmjs.org/pino/-/pino-4.14.0.tgz";
+        sha512 = "1x3dsg8pg321khfaf3dd91ykkwhdn60wk169l3b2kp8wkbw242ld99qiv7cmbn76ccba75wdydv8mb2v4fg58lrfnn7jf5pvk2x7qwy";
+      };
+    };
+    "pino-std-serializers-1.2.0" = {
+      name = "pino-std-serializers";
+      packageName = "pino-std-serializers";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-1.2.0.tgz";
+        sha512 = "0h8xndhy3qwgkycbmypfp7a2dvk875prgnfg46zj9vz14i24xqqdw1xp748hkv2xl2phwhyaa82yr1ym6jn6r61527kz5f7f8qird78";
       };
     };
     "pkg-dir-2.0.0" = {
@@ -19455,13 +19536,13 @@ let
         sha1 = "0a32ca9481b1c364e92e18dc55c876de9d01da8b";
       };
     };
-    "plist-2.1.0" = {
+    "plist-3.0.1" = {
       name = "plist";
       packageName = "plist";
-      version = "2.1.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz";
-        sha1 = "57ccdb7a0821df21831217a3cad54e3e146a1025";
+        url = "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz";
+        sha512 = "12n868myk28as4ivyihfw9ai50y0vc1jrr77r55drlidyi7qpwlm23aj9n05qqlzhs544yah6p535b5hiayh6xykf81q68wg8f2z60s";
       };
     };
     "pluralize-1.2.1" = {
@@ -19480,6 +19561,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz";
         sha512 = "2ihaln20qjx82jx73wgzirbyp8mfmhxr75am1h0w8n5hy2gsbgvw9dricv7h57ycxzax84bma96wjscmdszs5mr2lsyxpfjvhwl2601";
+      };
+    };
+    "pn-1.1.0" = {
+      name = "pn";
+      packageName = "pn";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz";
+        sha512 = "2fgy9i99qaapk6lrqsf0i396i0hw5prvpn2wwsccs7j9jz8960r59vjz98kjhfiif2pyf4fiizrwpminc29rdhpld2v8m7n18hxm8fs";
       };
     };
     "po2json-0.4.5" = {
@@ -19572,15 +19662,6 @@ let
         sha1 = "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab";
       };
     };
-    "postcss-6.0.14" = {
-      name = "postcss";
-      packageName = "postcss";
-      version = "6.0.14";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz";
-        sha512 = "2id33g6232s35n25daqrkz0bvzm2zmhlkfzmigkgia5q4jy9xg38spppmsdg0qswjankyi28wrbjsdwhczqfkx7h71gg8dmzz8p779l";
-      };
-    };
     "postcss-6.0.19" = {
       name = "postcss";
       packageName = "postcss";
@@ -19588,6 +19669,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz";
         sha512 = "174sg3cs8v8bqg8rnk673qp365n46kls3f3a41pp0jx48qivkg06rck0j2bfyzm5hr1i6kjbcn82h1rkjgfi5jbd0amrd877m3wfpbz";
+      };
+    };
+    "postcss-6.0.21" = {
+      name = "postcss";
+      packageName = "postcss";
+      version = "6.0.21";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz";
+        sha512 = "1vvp2mzw4gq6zm875fi7hgyypy0a44mbdpv0i4aqxsq8xajdxfyaz4ap4idh29v74ag4z26wla48k315yyg3d0h83zxkn1kniywmxnb";
       };
     };
     "prebuild-install-2.1.2" = {
@@ -19689,6 +19779,15 @@ let
         sha512 = "2x2535hml3hmhh6qbsl9r97mpa264mbpvmv0lbsqsfkv3sfd8wv7zw1b68555qsj5c6ma4b66qkgdsrr6355lhbmz052hqzq2qx082h";
       };
     };
+    "printf-0.2.5" = {
+      name = "printf";
+      packageName = "printf";
+      version = "0.2.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/printf/-/printf-0.2.5.tgz";
+        sha1 = "c438ca2ca33e3927671db4ab69c0e52f936a4f0f";
+      };
+    };
     "private-0.1.8" = {
       name = "private";
       packageName = "private";
@@ -19698,13 +19797,13 @@ let
         sha512 = "2dgznnpxsgy9bgp4kfby1is72blvca4lhmqb3nlja8yiig1v52c12p5yw0aag8jqazhkqvihpxmqf9gsjlg5dr1jb56jxzgnqrazy2n";
       };
     };
-    "probe-image-size-3.2.0" = {
+    "probe-image-size-4.0.0" = {
       name = "probe-image-size";
       packageName = "probe-image-size";
-      version = "3.2.0";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/probe-image-size/-/probe-image-size-3.2.0.tgz";
-        sha512 = "2ss74kxzba7k01p9fz756q4q9g6m29h49s5pp9wg1larrjmlcm1avhy7rwmqqkpd8azblwa3wk736xz1nrlvzc1h274g863ywifckic";
+        url = "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.0.0.tgz";
+        sha512 = "1qwy2hmhw201igjdk90dpky6b1qpc9b2jm7nxrsshcagf0ln73s62mwfd2j0mkfx29bhsndjmm8v2fk3nwk8jinzavcz9iicnyx2vly";
       };
     };
     "process-0.11.10" = {
@@ -20049,13 +20148,13 @@ let
         sha1 = "39f699f3a46560dd5ebacbca693caf7c65c18cc6";
       };
     };
-    "pug-2.0.1" = {
+    "pug-2.0.3" = {
       name = "pug";
       packageName = "pug";
-      version = "2.0.1";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pug/-/pug-2.0.1.tgz";
-        sha1 = "27c151612b53d729abe8e8285aac6bc89345b5d0";
+        url = "https://registry.npmjs.org/pug/-/pug-2.0.3.tgz";
+        sha1 = "71cba82537c95a5eab7ed04696e4221f53aa878e";
       };
     };
     "pug-attrs-2.0.3" = {
@@ -20085,13 +20184,13 @@ let
         sha1 = "53ae7d9d29bb03cf564493a026109f54c47f5f26";
       };
     };
-    "pug-filters-3.0.1" = {
+    "pug-filters-3.1.0" = {
       name = "pug-filters";
       packageName = "pug-filters";
-      version = "3.0.1";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pug-filters/-/pug-filters-3.0.1.tgz";
-        sha1 = "163ef73bfbb1f1544d032b2b40f45130eb52dccb";
+        url = "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.0.tgz";
+        sha1 = "27165555bc04c236e4aa2b0366246dfa021b626e";
       };
     };
     "pug-lexer-4.0.0" = {
@@ -20193,13 +20292,13 @@ let
         sha1 = "5f2f3aed47ad86919f01b12a2e99d6f1bd776581";
       };
     };
-    "pull-stream-3.6.2" = {
+    "pull-stream-3.6.7" = {
       name = "pull-stream";
       packageName = "pull-stream";
-      version = "3.6.2";
+      version = "3.6.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.2.tgz";
-        sha1 = "1ea14c6f13174e6ac4def0c2a4e76567b7cb0c5c";
+        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.7.tgz";
+        sha512 = "0cq5h32fsfnhxa9wbgk55jhr0z4mx6zmm42nx9r6n3j4bpl6sw2a6vh41raicq2q11bxh1vg7jxv2cdqw7nq6zb0fxm5nj8ipz3dlax";
       };
     };
     "pull-window-2.1.4" = {
@@ -20236,6 +20335,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz";
         sha512 = "288hcmlwdnqda84ylx9cv413ic0r59k0dp71hy7a200jsb7h1y63277jwdp1jdp13c1b3pl6g2gzr5gjv9p72f5sp7w3p0d34swrqxf";
+      };
+    };
+    "pump-3.0.0" = {
+      name = "pump";
+      packageName = "pump";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz";
+        sha512 = "31n24fqakqmhzk2ch644gziskmysmrgiwclsdsr0rwk9spgikqpwickbnayap0rynfjlq72s7iny2p35n3qszypr97ws5njkpx741ig";
       };
     };
     "pumpify-1.4.0" = {
@@ -20481,13 +20589,13 @@ let
         sha1 = "63ac953352499ad670a9681a75680f6bf3dd1faf";
       };
     };
-    "query-string-5.1.0" = {
+    "query-string-5.1.1" = {
       name = "query-string";
       packageName = "query-string";
-      version = "5.1.0";
+      version = "5.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz";
-        sha512 = "04m33y2wlmhz19y109cv7l537bdagzl15jv3y0jc3mb7wrw3jpz15pws8m7pbfbqv9nwad46cg3c4cd620f27mwzs1hml2q373y8w0p";
+        url = "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz";
+        sha512 = "0kkwn38nmjd6n6byiz52gngvyiw46fbibx9c9p1vzn9g7l11f2jpbs39d4aqajk7kk2a6k69wx5bjgavbg1lh275ih6k84jdnr8wdc2";
       };
     };
     "querystring-0.2.0" = {
@@ -20643,13 +20751,13 @@ let
         sha1 = "f49be6b487894ddc40dcc94a322f611092e00d5e";
       };
     };
-    "raven-2.3.0" = {
+    "raven-2.4.2" = {
       name = "raven";
       packageName = "raven";
-      version = "2.3.0";
+      version = "2.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/raven/-/raven-2.3.0.tgz";
-        sha1 = "96f15346bdaa433b3b6d47130804506155833d69";
+        url = "https://registry.npmjs.org/raven/-/raven-2.4.2.tgz";
+        sha1 = "0129e2adc30788646fd530b67d08a8ce25d4f6dc";
       };
     };
     "raw-body-0.0.3" = {
@@ -20715,13 +20823,13 @@ let
         sha1 = "ce24a2029ad94c3a40d09604a87227027d7210d3";
       };
     };
-    "rc-1.2.5" = {
+    "rc-1.2.6" = {
       name = "rc";
       packageName = "rc";
-      version = "1.2.5";
+      version = "1.2.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz";
-        sha1 = "275cd687f6e3b36cc756baa26dfee80a790301fd";
+        url = "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz";
+        sha1 = "eb18989c6d4f4f162c399f79ddd29f3835568092";
       };
     };
     "rc-config-loader-2.0.1" = {
@@ -20949,13 +21057,13 @@ let
         sha512 = "0bb5d70l5lg02x515r2klvjhhz6xcxdb4ykbx16wq45l822bbsdd8sbki7vb28j17xr7181fmwlzhx3bizvr5xdq6cxpv53sidrq44x";
       };
     };
-    "recursive-watch-1.1.3" = {
+    "recursive-watch-1.1.4" = {
       name = "recursive-watch";
       packageName = "recursive-watch";
-      version = "1.1.3";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.3.tgz";
-        sha512 = "3m0s8140jpamg1xxdlsslshx10qznb889s6yc8av6vvqbs56banhmjqy9lgl7g4ppsrsja0d2lhb5lacl3nxm8ggsrpdd7xqf53hvzx";
+        url = "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.4.tgz";
+        sha512 = "0yks7j98w5d3y375fb99kfbb8rz5qz72v6ld5i15h7fds1i02fq027w82ipanv3dkgvvrxyybw1v8lyrcs54h9airzv12sbcw1a6rvx";
       };
     };
     "redent-1.0.0" = {
@@ -21082,6 +21190,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz";
         sha512 = "3cggngaj8m70zdn8kghha4mhvavm7jfy5xm2iqi94w4gi5m5irs3nlrgg975w2231y49jnnw7zhsg648pbkl9zb6vwhii83926q7917";
+      };
+    };
+    "regexpp-1.0.1" = {
+      name = "regexpp";
+      packageName = "regexpp";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/regexpp/-/regexpp-1.0.1.tgz";
+        sha512 = "0pz7sa22w939la9qh15gk7gh2gzkkasp4gbk67yh0nmsqxrqapv82ixikbi8snfqy7mws0dvg0zjfcqjmi0qnmv92c26plsb7dppy7h";
       };
     };
     "registry-auth-token-3.3.2" = {
@@ -21300,15 +21417,6 @@ let
         sha1 = "c6928946a0e06c5f8d6f8a9333469ffda46298a0";
       };
     };
-    "request-2.83.0" = {
-      name = "request";
-      packageName = "request";
-      version = "2.83.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.83.0.tgz";
-        sha512 = "0by1djkn836sqd9pk2c777wcjvp34qbk1plx7s4lmykljrblpjc64dvn6ni2vyxsbyk33wnl6avym8vgw0ggr4226xakck8mw7y07cm";
-      };
-    };
     "request-2.85.0" = {
       name = "request";
       packageName = "request";
@@ -21417,13 +21525,13 @@ let
         sha1 = "203114d82ad2c5ed9e8e0411b3932875e889e97b";
       };
     };
-    "resolve-1.5.0" = {
+    "resolve-1.6.0" = {
       name = "resolve";
       packageName = "resolve";
-      version = "1.5.0";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz";
-        sha512 = "25scf9zkhf5yc9x3d7mfq2im5vyxmq3ih939na6jzblal7mgfcijmadl2maz501mkccykj714gvdhhmlzi86hbk7k03r9ipnwd142l6";
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz";
+        sha512 = "1vidqan0cvx5paxxhp9ir7kfd1j7k2ll0z9d0arj8wrqrfw20mdj3ckwy8gwl7n2xagc3z3jm6zy1d3fhl3w2qffcj144xrvd0cj3lv";
       };
     };
     "resolve-dir-1.0.1" = {
@@ -21705,13 +21813,13 @@ let
         sha1 = "0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0";
       };
     };
-    "run-parallel-1.1.7" = {
+    "run-parallel-1.1.8" = {
       name = "run-parallel";
       packageName = "run-parallel";
-      version = "1.1.7";
+      version = "1.1.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.7.tgz";
-        sha512 = "322cb6n7h8761gprij4m1z52rizyzvxwviima893gphrbrxkhjv6q4ifwspd0w9jhlk7jj0x64449aagms18v7ps6hr774ymvavh7lw";
+        url = "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.8.tgz";
+        sha512 = "1jzs29b3g9xx5408i8gzyflx0wajfa1ai9sgm63pbvkaas0351j9y92kxq06x8dhg7w829skizs88cdlf156zfm1yk5brbbb0spb6vv";
       };
     };
     "run-queue-1.0.3" = {
@@ -21723,13 +21831,13 @@ let
         sha1 = "e848396f057d223f24386924618e25694161ec47";
       };
     };
-    "run-series-1.1.4" = {
+    "run-series-1.1.6" = {
       name = "run-series";
       packageName = "run-series";
-      version = "1.1.4";
+      version = "1.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz";
-        sha1 = "89a73ddc5e75c9ef8ab6320c0a1600d6a41179b9";
+        url = "https://registry.npmjs.org/run-series/-/run-series-1.1.6.tgz";
+        sha512 = "2rpksrvsfrz5kv3cwr448d60521dlky61p5hp3ci7g8140yfm58g7xak4gkqysfc9cm6hknxyizfs832939fxg01qslxrzlx7l805a1";
       };
     };
     "rusha-0.8.13" = {
@@ -21786,13 +21894,13 @@ let
         sha1 = "753b87a89a11c95467c4ac1626c4efc4e05c67be";
       };
     };
-    "rxjs-5.5.6" = {
+    "rxjs-5.5.8" = {
       name = "rxjs";
       packageName = "rxjs";
-      version = "5.5.6";
+      version = "5.5.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz";
-        sha512 = "293yj2n5f5bj8b8y9czwgm5l3bqa0g3bbghnxsxwdpiz6s2mxiw6a79w3sqq3c1by3avmb5bgk8xgi0yss5y09pxw87055l60f3k15z";
+        url = "https://registry.npmjs.org/rxjs/-/rxjs-5.5.8.tgz";
+        sha512 = "32whnkvnay58zbcwimj3lpagg52k7swjdcys6i14a0im2hj1svh602bpvpb3zrqv36k96a1gsjjzbjxvfy6aj89i838l06mxsiflgh7";
       };
     };
     "safe-buffer-5.0.1" = {
@@ -21901,15 +22009,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz";
         sha512 = "1dn291mjsda42w8kldlbmngk6dhjxfbvvd5lckyqmwbjaj6069iq3wx0nvcfglwnpddz2qa93lzf4hv77iz43bd2qixa079sjzl799n";
-      };
-    };
-    "schema-utils-0.3.0" = {
-      name = "schema-utils";
-      packageName = "schema-utils";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz";
-        sha1 = "f5877222ce3e931edae039f17eb3716e7137f8cf";
       };
     };
     "schema-utils-0.4.5" = {
@@ -22047,13 +22146,13 @@ let
         sha1 = "57f41de69707a62709a7e0104ba2117109ea47e8";
       };
     };
-    "semver-utils-1.1.1" = {
+    "semver-utils-1.1.2" = {
       name = "semver-utils";
       packageName = "semver-utils";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz";
-        sha1 = "27d92fec34d27cfa42707d3b40d025ae9855f2df";
+        url = "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.2.tgz";
+        sha512 = "09ryf3nvrfjqr93b8fj691lh48pvqhrpah5a5fm87szs42xcnl33sss49piv1grb9h2i7icdvz0i0m5yak5ccxa6xbv4x294rsfs6zr";
       };
     };
     "send-0.0.3" = {
@@ -22335,13 +22434,13 @@ let
         sha512 = "2jlhhawfqdiga1m6if01ks1q3yx56k5vj6wf372589vkswvdflw7224viivxali56b0jjsckpmjy10rj6fcakhw2dbq2psr197kzw86";
       };
     };
-    "sha.js-2.4.10" = {
+    "sha.js-2.4.11" = {
       name = "sha.js";
       packageName = "sha.js";
-      version = "2.4.10";
+      version = "2.4.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz";
-        sha512 = "2lfna0mg4mzdki4p3q29rsgywbghvy6f6jy6b61zj68d2d936wfqjgqpsdjchfcqkiim53qknpcnq9iiafyidfrw154qf75a2n2cz5y";
+        url = "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz";
+        sha512 = "2lihh3p2mrwymrly93ni37b1dvzwbm1jc47iqp66ax4bj41js4mr94wghv3c2agq98bb44nxxddn2n67ab978zk00xx2znw3vj2kha0";
       };
     };
     "shallow-clone-0.1.2" = {
@@ -22461,13 +22560,13 @@ let
         sha1 = "3ff21f198cad2175f9f3b781853fd94d0d19b590";
       };
     };
-    "sign-addon-0.2.2" = {
+    "sign-addon-0.3.0" = {
       name = "sign-addon";
       packageName = "sign-addon";
-      version = "0.2.2";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sign-addon/-/sign-addon-0.2.2.tgz";
-        sha512 = "3v5myvfbil1c5fsvqx32vqdv7mk62059isry4811avmkgzfv95scw8pnkwa77m6zg9g8vgsp3glqjm65k3rj8xfxnqv24mcmhjk78bz";
+        url = "https://registry.npmjs.org/sign-addon/-/sign-addon-0.3.0.tgz";
+        sha512 = "2czjlarf0pa0svlhbdb9i6hrk429za0gsialmxbmgwgbhyjx7mxkgf5mww4rkmsbncdi2va8p64rxjxf7gv8b0jd2a87cvm7rw5pky5";
       };
     };
     "signal-exit-3.0.2" = {
@@ -22839,13 +22938,13 @@ let
         sha512 = "0k2smmr24w5hb1cpql6vcgh58vzp4pmh9anf0bgz3arlsgq1mapnlq9fjqr6xs10aq1cmxaw987fwknqi62frax0fvs9bj3q3kmpg8l";
       };
     };
-    "snyk-1.70.0" = {
+    "snyk-1.70.3" = {
       name = "snyk";
       packageName = "snyk";
-      version = "1.70.0";
+      version = "1.70.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk/-/snyk-1.70.0.tgz";
-        sha1 = "141a5ab88c262ef1bd6cb2b590bc50d4f46f4dc8";
+        url = "https://registry.npmjs.org/snyk/-/snyk-1.70.3.tgz";
+        sha1 = "53c98949d27bf57905eeb7beed94d360a24fff55";
       };
     };
     "snyk-config-1.0.1" = {
@@ -22920,13 +23019,13 @@ let
         sha1 = "2a7bf0f07c7b811b9dda93cf9bbb10dc992dd7bc";
       };
     };
-    "snyk-python-plugin-1.5.6" = {
+    "snyk-python-plugin-1.5.7" = {
       name = "snyk-python-plugin";
       packageName = "snyk-python-plugin";
-      version = "1.5.6";
+      version = "1.5.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.5.6.tgz";
-        sha512 = "1iv7h9k0vj7g2zzx8nzighx84q70kwvl4hhzd4fzxmc8vv06ymwwn4v7cirgbksqrjf9z1bfxq8id308ifb1flyas7blz8zs7xf4w30";
+        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.5.7.tgz";
+        sha512 = "3fqq6dbx31yysvd835ng60linxmbkzixiqqf28yxq9pdx3x8dq55syhv1g6as3s85wd04q5vc5qlfgdl91jlhwcgjvdwjjr2wwp84pq";
       };
     };
     "snyk-resolve-1.0.0" = {
@@ -23136,13 +23235,13 @@ let
         sha512 = "33yfj0m61wn7g9s59m7mxhm6w91nkdrd7hcnnbacrj58zqgykpyr7f6lsggvc9xzysrf951ncxh4malqi11yf8z6909fasllxi6cnxh";
       };
     };
-    "sodium-javascript-0.5.4" = {
+    "sodium-javascript-0.5.5" = {
       name = "sodium-javascript";
       packageName = "sodium-javascript";
-      version = "0.5.4";
+      version = "0.5.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.4.tgz";
-        sha512 = "1dqdzm0qjk1rwq62b010b649wdpvlzdxpmwc972p0dcwsc86wqfcm8lbdcxlrwypkn2jq5df1xpbxhxfphnpr993ac543p9s212si30";
+        url = "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.5.tgz";
+        sha512 = "3451wvpagbw2ib50galmlfrb5za3zh0ml1irbm2ijd0lbjblg9va4fnag6sfs7msb1m0i5zicz93jwp90c22v0n40qzpczhicg85jah";
       };
     };
     "sodium-native-2.1.4" = {
@@ -23334,24 +23433,6 @@ let
         sha1 = "32552aa64b458392a85eab3b0b5ee61527167aeb";
       };
     };
-    "source-map-support-0.5.0" = {
-      name = "source-map-support";
-      packageName = "source-map-support";
-      version = "0.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz";
-        sha512 = "3nwgpximc17yn0lfg8658fxkm2hwbpvnbx5x1g0qgqvjm3vzld96rh1gf6iw1srbkicp0m825sq92r9bnj2r2gl8ys0f7fzivf0sjmx";
-      };
-    };
-    "source-map-support-0.5.1" = {
-      name = "source-map-support";
-      packageName = "source-map-support";
-      version = "0.5.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.1.tgz";
-        sha512 = "276x5a16yv0nlzjdvspsnbkxqhv8lvfj7a0sfzkaasfcwa2rm1ni3h3c0fva63bfqnazbywvs4pzrnbwg43j7gpymjd9cbbndq5x4qi";
-      };
-    };
     "source-map-support-0.5.3" = {
       name = "source-map-support";
       packageName = "source-map-support";
@@ -23359,6 +23440,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz";
         sha512 = "3xy2ylp2qm8jwglcsf2fjwvn5w56im64w7yjghyv9ilw2fc5qj65w8h38lpls27m3b5prv8x9cnfmrhkfk7rlb52hmf810ycs0i7abq";
+      };
+    };
+    "source-map-support-0.5.4" = {
+      name = "source-map-support";
+      packageName = "source-map-support";
+      version = "0.5.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz";
+        sha512 = "1vfdnbvldylljhm89hfxwsr3pd108my5z1l9gx8ld1j2v2bfpranqc7kc8i9mj24lbq6c4xxs181anrsa5ypbfd3r08v3c1dqyd4i1w";
       };
     };
     "source-map-url-0.4.0" = {
@@ -23577,13 +23667,13 @@ let
         sha1 = "512675a28f08f1e581779e1989ab1e13effb49e4";
       };
     };
-    "sshpk-1.13.1" = {
+    "sshpk-1.14.1" = {
       name = "sshpk";
       packageName = "sshpk";
-      version = "1.13.1";
+      version = "1.14.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz";
-        sha1 = "512df6da6287144316dc4c18fe1cf1d940739be3";
+        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz";
+        sha1 = "130f5975eddad963f1d56f92b9ac6c51fa9f83eb";
       };
     };
     "sshpk-1.7.1" = {
@@ -23604,13 +23694,13 @@ let
         sha1 = "62e143c18530fda103320b3403e8ad42786d9718";
       };
     };
-    "ssri-5.2.4" = {
+    "ssri-5.3.0" = {
       name = "ssri";
       packageName = "ssri";
-      version = "5.2.4";
+      version = "5.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz";
-        sha512 = "2si1dr4dwg0bkvsn38d6rk5raw5lbn2m9giwf8pnhy55wqgxsvv7b1pn252wj166cd8j302a2gwjy00ni473yr1vrxrzmssqs000waj";
+        url = "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz";
+        sha512 = "00qc3iqsi21cc2az3nz36q88psab4ickpzranndk6vmrb6yhn5xsq3kgp21x3lp0406bdaalpb59xy7zzqnl40ans69v3z2l8z8h52x";
       };
     };
     "stable-0.1.6" = {
@@ -23694,6 +23784,15 @@ let
         sha512 = "1xxwqpj713rq1idbmp7mj7cj9dl52lazgpd5x8a9g88jawbkn9xpwbgljl7cvnd0jqkll2zpdj5xy63dlis9l2k8vmx1n1gvyv8456f";
       };
     };
+    "statuses-1.5.0" = {
+      name = "statuses";
+      packageName = "statuses";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz";
+        sha1 = "161c7dac177659fd9811f43771fa99381478628c";
+      };
+    };
     "steno-0.4.4" = {
       name = "steno";
       packageName = "steno";
@@ -23775,13 +23874,13 @@ let
         sha512 = "2h4ymczmf5aqldga4sj8acqlzc3almazi2vwiv7kx63k28sz1wwkqgzzv1hn47jf49k1x94w25fmmi001h5mj3n6g9in1s6b1n5vkcr";
       };
     };
-    "stream-http-2.8.0" = {
+    "stream-http-2.8.1" = {
       name = "stream-http";
       packageName = "stream-http";
-      version = "2.8.0";
+      version = "2.8.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz";
-        sha512 = "2ghzil78wsr29z8p1883i0vwx9gpsspha4wvdbpvqzbknrfiavwis010i5a7vy0xx8n486f6kwmjxsk3mg1w4bjy4whvizriz28b4xi";
+        url = "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz";
+        sha512 = "3fbvnv92iyjjnbpggg15blfwzyk4q0f5rsdz2wyyd20j05vw8qgmr185r1r36i3m6qqb82il99qn0b09bb4b7s1myvccbf1bsij63bi";
       };
     };
     "stream-parser-0.3.1" = {
@@ -24000,13 +24099,13 @@ let
         sha512 = "29s1fqgr4mnhfxwczgdghfmmc1f792m9hysvcjxw2h5lfj8ndf2b6gm02m96qk5m75g4aisijvng4pk618anwbr8i9ay2jyszkqgslw";
       };
     };
-    "string.prototype.codepointat-0.2.0" = {
+    "string.prototype.codepointat-0.2.1" = {
       name = "string.prototype.codepointat";
       packageName = "string.prototype.codepointat";
-      version = "0.2.0";
+      version = "0.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz";
-        sha1 = "6b26e9bd3afcaa7be3b4269b526de1b82000ac78";
+        url = "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz";
+        sha512 = "1r18lbap331hx5hfic2irpd3rai1ymp5s93p5xfzfr0khw9krkx51glwhmdjxbrk07kryqqdc2fly59avw3pq3q2apq7q487q55bh6r";
       };
     };
     "string2compact-1.2.2" = {
@@ -24405,15 +24504,6 @@ let
         sha512 = "2q47avrxblc0an2g5ij8sd7ss2bqhdxy2949dk774gyg9vmsivg7fwyn885v2va72sxiv5k59ifvi3hg4ra6z95lr8in6sjyw008jai";
       };
     };
-    "table-4.0.3" = {
-      name = "table";
-      packageName = "table";
-      version = "4.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/table/-/table-4.0.3.tgz";
-        sha512 = "0m684sf5sicq9hlavaw7wrm8d10p2vm1cvvrxgl7f2rpqbn5cm6hhsbzb0is6r1bm19p7960dwxif6lc48bz712kx27s176hhafgfjb";
-      };
-    };
     "tabtab-1.3.2" = {
       name = "tabtab";
       packageName = "tabtab";
@@ -24505,13 +24595,13 @@ let
         sha512 = "1ryql8hyrrhd0gdd71ishbj3cnr8ay0i0wpvy9mj3hjiy35cc1wa0h07wz8jwils98j00gr03ix3cf2j1xm43xjn9bsavwn1yr4a0x5";
       };
     };
-    "tar-4.4.0" = {
+    "tar-4.4.1" = {
       name = "tar";
       packageName = "tar";
-      version = "4.4.0";
+      version = "4.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-4.4.0.tgz";
-        sha512 = "2jqkq86l5d9kaqvxd7m5r48smv4f8y10vx7r0rpwafwz5sskrmlpdswp8g351jfk5if2jv0a3wbjpss31x1cf6x5dx8zhib465576c0";
+        url = "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz";
+        sha512 = "33gymcvk33znj1lscj0kds60g5jzagw2dcx1fcbpxz85pi21kqlazvwz579p301x0vqvir1nslh901zq28sfx2zpsnd7qldvjpzbsrv";
       };
     };
     "tar-fs-1.16.0" = {
@@ -24874,13 +24964,13 @@ let
         sha1 = "320b5a52d83abb5978d81a3e887d4aefb15a6164";
       };
     };
-    "titleize-1.0.0" = {
+    "titleize-1.0.1" = {
       name = "titleize";
       packageName = "titleize";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/titleize/-/titleize-1.0.0.tgz";
-        sha1 = "7d350722061830ba6617631e0cfd3ea08398d95a";
+        url = "https://registry.npmjs.org/titleize/-/titleize-1.0.1.tgz";
+        sha512 = "1xp43r14ynva5c21rihxm625x47109zj7k3j0cpdmm74lc4fwml3vags077221gz2gf7vafwnskncmag4wnsisiz0bmiawapc70ck5d";
       };
     };
     "tmp-0.0.28" = {
@@ -25072,13 +25162,13 @@ let
         sha1 = "50346e42a43b35daf2a86f414afb153629a854be";
       };
     };
-    "torrent-stream-1.0.3" = {
+    "torrent-stream-1.0.4" = {
       name = "torrent-stream";
       packageName = "torrent-stream";
-      version = "1.0.3";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/torrent-stream/-/torrent-stream-1.0.3.tgz";
-        sha1 = "d8c043b44c3c448c9397a3aec42d2df55887037b";
+        url = "https://registry.npmjs.org/torrent-stream/-/torrent-stream-1.0.4.tgz";
+        sha512 = "3ka40l845bfjydjk9jbiz27x4cqd8birv5zfzvdm7ciij7r53ydz6y7pwmk0628qwdnkchgh10z4kdc3408zi8a8pimq7506qrji010";
       };
     };
     "tosource-1.0.0" = {
@@ -25450,6 +25540,15 @@ let
         sha512 = "2gjv6xyp9rqfdfqadayc4b36b79sjdiwsxa38z43v01cdn3xbc06ax90mjv36hxj9j96nfbwr6w1wn7n0zq8f3y3fw4jfy0j1hw5557";
       };
     };
+    "typescript-2.8.1" = {
+      name = "typescript";
+      packageName = "typescript";
+      version = "2.8.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz";
+        sha512 = "1v0ac83sjf21wg11fpllicxz8irx9yg341zmng7vz15524gbfphc9ch70n4x9r70gm0r4ak79xyaxw9zh6b2cwcs7mg447qvzlxz3q2";
+      };
+    };
     "typewise-1.0.3" = {
       name = "typewise";
       packageName = "typewise";
@@ -25558,13 +25657,13 @@ let
         sha1 = "29c5733148057bb4e1f75df35b7a9cb72e6a59dd";
       };
     };
-    "uglify-js-3.3.14" = {
+    "uglify-js-3.3.16" = {
       name = "uglify-js";
       packageName = "uglify-js";
-      version = "3.3.14";
+      version = "3.3.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.14.tgz";
-        sha512 = "0b7d9nvyrhc5ij0xaxvgha7h97d5h36zhnwmbbbj5abk64bvn38sf4d5jwy64n8algm2q36a08n0z4k4khhnnq4h4ysvrin0lyib3rr";
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz";
+        sha512 = "2zdbgaqy5a8mrv3gkljjw8iishfj4iwncazi3g0zcymqppc19474s24irqvmnhs1iy38g18086l72ilqkvlvnhnyipnhi49394pkj0l";
       };
     };
     "uglify-js-3.3.6" = {
@@ -25585,22 +25684,13 @@ let
         sha1 = "6e0924d6bda6b5afe349e39a6d632850a0f882b7";
       };
     };
-    "uglifyjs-webpack-plugin-0.4.6" = {
+    "uglifyjs-webpack-plugin-1.2.4" = {
       name = "uglifyjs-webpack-plugin";
       packageName = "uglifyjs-webpack-plugin";
-      version = "0.4.6";
+      version = "1.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz";
-        sha1 = "b951f4abb6bd617e66f63eb891498e391763e309";
-      };
-    };
-    "uglifyjs-webpack-plugin-1.2.3" = {
-      name = "uglifyjs-webpack-plugin";
-      packageName = "uglifyjs-webpack-plugin";
-      version = "1.2.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.3.tgz";
-        sha512 = "3dhgxlb6k66s9ah10iapb3lsyygxg6hxrdrs734pgppyrqf8h9ib6mv1vhja19j1chnhffqryl84i6p77qmdq86i53f5fkmgv9zkkva";
+        url = "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz";
+        sha512 = "14jcr2nd1d4l940llkm93b2rm9886qi9vz16ab85nji84bmsr99rvzvv4vwzj3j0m2lpkkm2gskd4p29lv4vzjr76zp6vxwjn71nhng";
       };
     };
     "uid-0.0.2" = {
@@ -25666,13 +25756,13 @@ let
         sha1 = "483126e11774df2f71b8b639dcd799c376162b82";
       };
     };
-    "uint64be-2.0.1" = {
+    "uint64be-2.0.2" = {
       name = "uint64be";
       packageName = "uint64be";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uint64be/-/uint64be-2.0.1.tgz";
-        sha1 = "a310d94e4e5e0b02a95d678e33323f802bdc8428";
+        url = "https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz";
+        sha512 = "34jzmdzz81fdi4s48rxr9dzs63iln7w6y9d44ckq6nvxd6v7y0wpc6x90zc2md21ddc1abfwk5h20py3s79bzhknqqphkchj6z9s2pm";
       };
     };
     "ultron-1.0.2" = {
@@ -25693,13 +25783,13 @@ let
         sha512 = "0x78hsv3jykmjl6qdqlqiz7v5nf06li8b5yvzpj6grnzwbcjch8ngyg55lm8g8mg4znvk7qbryvrr2dxacz3cvyb1nsm64qsw21g0ah";
       };
     };
-    "umd-3.0.2" = {
+    "umd-3.0.3" = {
       name = "umd";
       packageName = "umd";
-      version = "3.0.2";
+      version = "3.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/umd/-/umd-3.0.2.tgz";
-        sha512 = "0wgy2hbi34ncj74m0vw30yjcrw0wg3m465r28y458kvvkp7lsmm3klki0f79slyspfnr4c3l0qzcmpggcybk4d6lcb05kh0aj5c2rx6";
+        url = "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz";
+        sha512 = "2iz3bypw716y5lgdg89d7jwnkqnla4sid3l5hr2259ypf8h6sbkw3n0xa51ckzkkayf0c39ksaiax2j6ighj36p5ipwh5p1wx50d1z0";
       };
     };
     "unc-path-regex-0.1.2" = {
@@ -26053,15 +26143,6 @@ let
         sha1 = "d2f0f737d16b0615e72a6935ed04214572d56f97";
       };
     };
-    "upath-1.0.2" = {
-      name = "upath";
-      packageName = "upath";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/upath/-/upath-1.0.2.tgz";
-        sha512 = "19nv38v416yy515gbq0lvg549w1m48mg17ibl9jp6g0pzlzg6j3lzygbw3c4ia2i9vk0ij0g4fcwfvsa9snxpgdk4a7qbprnj7s4abw";
-      };
-    };
     "upath-1.0.4" = {
       name = "upath";
       packageName = "upath";
@@ -26096,6 +26177,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz";
         sha1 = "4e8827a6bb915140ab093559d7014e3ebb837451";
+      };
+    };
+    "update-notifier-2.4.0" = {
+      name = "update-notifier";
+      packageName = "update-notifier";
+      version = "2.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz";
+        sha1 = "f9b4c700fbfd4ec12c811587258777d563d8c866";
       };
     };
     "update-section-0.3.3" = {
@@ -26323,22 +26413,22 @@ let
         sha1 = "ae43eb7745f5fe63dcc2f277cb4164ad27087f30";
       };
     };
-    "utp-native-1.6.2" = {
+    "utp-native-1.7.0" = {
       name = "utp-native";
       packageName = "utp-native";
-      version = "1.6.2";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/utp-native/-/utp-native-1.6.2.tgz";
-        sha512 = "2mcnn6w5as2dvz6rj4fb33174z3a1rl9bm2cfazrr4084gq7aal0bkmkwr1cjpkvy1zgni3zdk0570fx7cmnd0k0hg18wfb2hvbigfg";
+        url = "https://registry.npmjs.org/utp-native/-/utp-native-1.7.0.tgz";
+        sha512 = "1d0ccaz56506y44838shld6zkqx9rcx3cpw5qddbfbyjyjr73704gysrl3qwii6i80kx1i2ysnn8bdx6q0i4biwzjj36ksx2865i0yz";
       };
     };
-    "uue-3.1.1" = {
+    "uue-3.1.2" = {
       name = "uue";
       packageName = "uue";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uue/-/uue-3.1.1.tgz";
-        sha512 = "29ykgvcsrhwbifm7aa4mf8876c6z2ksc26cnpxf3ljwhg7vfrjz2asvl7ylkjj91alnp2d7n1xvi5qphmn0a1ci091a20mdmnbzg91i";
+        url = "https://registry.npmjs.org/uue/-/uue-3.1.2.tgz";
+        sha512 = "0pcj6km8jmr85nr0xvnq9nmicnz9a2ysy8bj7s9qxin8c0hzd992bwx8bsnxlmbw02iynqyp0l7a9c7zi2ipqrsfczx5ddhb9fqn4kb";
       };
     };
     "uuid-2.0.3" = {
@@ -26800,13 +26890,13 @@ let
         sha1 = "631bdbf716dccab0e65291a8dc25c23232085a52";
       };
     };
-    "walk-2.3.9" = {
+    "walk-2.3.13" = {
       name = "walk";
       packageName = "walk";
-      version = "2.3.9";
+      version = "2.3.13";
       src = fetchurl {
-        url = "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz";
-        sha1 = "31b4db6678f2ae01c39ea9fb8725a9031e558a7b";
+        url = "https://registry.npmjs.org/walk/-/walk-2.3.13.tgz";
+        sha512 = "2g4ayyccqgq4fx68dhds9pwhvj2344n9p0lhb4z1hnsi882apm64s434lqz57rx4b0r1x9w1njfqrywd1la0ljqm7j4xxg8nixqri7g";
       };
     };
     "walk-sync-0.3.2" = {
@@ -26825,15 +26915,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz";
         sha1 = "d1b14f39d2e2cb4ab8c4098f756fe4b164e473d4";
-      };
-    };
-    "watchpack-1.4.0" = {
-      name = "watchpack";
-      packageName = "watchpack";
-      version = "1.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz";
-        sha1 = "4a1472bcbb952bd0a9bb4036801f954dfb39faac";
       };
     };
     "watchpack-1.5.0" = {
@@ -26870,15 +26951,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz";
         sha512 = "15gwgjh9anvzcissfhxy3gki7jxn1dy9vq5rma1sgwkbbra8wbxnvimwalgmy8anm33x56mfp492akzhs0gidwmbnadx0ck3fdq23v1";
-      };
-    };
-    "webpack-3.10.0" = {
-      name = "webpack";
-      packageName = "webpack";
-      version = "3.10.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz";
-        sha512 = "0n3rl5qq259csi0x5qh12wzyaypfds5wy0zrzky19wqsa0mjibrn19fdfgbabply2l576vlj8j69nzkb23jqfy6a36xb3cwi1g4l73z";
       };
     };
     "webpack-sources-1.1.0" = {
@@ -27403,6 +27475,15 @@ let
         sha1 = "496b2cc109eca8dbacfe2dc72b603c17c5870ad4";
       };
     };
+    "xenvar-0.5.1" = {
+      name = "xenvar";
+      packageName = "xenvar";
+      version = "0.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xenvar/-/xenvar-0.5.1.tgz";
+        sha1 = "f82d2fedee63af76687b70115ce6274dc71310e9";
+      };
+    };
     "xhr-2.4.1" = {
       name = "xhr";
       packageName = "xhr";
@@ -27746,15 +27827,6 @@ let
         sha1 = "054de8b61f22eefdb7207059eaef9d6b83fb931a";
       };
     };
-    "yargs-10.0.3" = {
-      name = "yargs";
-      packageName = "yargs";
-      version = "10.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz";
-        sha512 = "1vn6jsqrhybxddyhmvkh0d43n2lk1z8081glfq80zpjfs4xgwpk0mmgdiry9zgsihmv9a2qidmp5hhyqqq8mzzkr037wla0qd1nk80f";
-      };
-    };
     "yargs-10.1.2" = {
       name = "yargs";
       packageName = "yargs";
@@ -27762,6 +27834,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz";
         sha512 = "25gvc8vjalpbv69v0frmh10x203dsnl0jrnx8c2mww3qrxl69kms5ppzry3lp51lgaby524hc6qa80kgrz0zcdvas8flq26l33aix4a";
+      };
+    };
+    "yargs-11.0.0" = {
+      name = "yargs";
+      packageName = "yargs";
+      version = "11.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz";
+        sha512 = "03n9lfnyx1dfj5sm811f3d96djsr6fixd5qi6cl6wj8xf0y01sgn7w3ynv5gn2vl30dwq5mz2hw5f522v8xbwc8m9h6nf8hqsa7wfj6";
+      };
+    };
+    "yargs-11.1.0" = {
+      name = "yargs";
+      packageName = "yargs";
+      version = "11.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz";
+        sha512 = "3j5awbfcbh8ik0kz01mycydpi1bz9fg70xc66lk1r1qvrs5x41i2w8nvgj0aip7z9vypcsxks76z75sz4lr6z3ida9c04inkvsbl19p";
       };
     };
     "yargs-3.10.0" = {
@@ -27881,6 +27971,15 @@ let
         sha512 = "0jyff04yy5xlrgvccky4f7phgp99lk2r1n7dk67hkb0picdjpa2ap27g4jrm94cw1d31vw8sh2b5cvnvga2w838bgh6l1kwld1bmzy8";
       };
     };
+    "yargs-parser-9.0.2" = {
+      name = "yargs-parser";
+      packageName = "yargs-parser";
+      version = "9.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz";
+        sha1 = "9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077";
+      };
+    };
     "yauzl-2.4.1" = {
       name = "yauzl";
       packageName = "yauzl";
@@ -27935,13 +28034,13 @@ let
         sha512 = "3kfwj39dplgp9w79zmk9p5hm4dfw21304srx68f0hzxhak45iql4j8gzxj4l3q9p4jcmwf25ar0ak4sm57rzx46bv4z2f3q3vybpxgb";
       };
     };
-    "yosay-2.0.1" = {
+    "yosay-2.0.2" = {
       name = "yosay";
       packageName = "yosay";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yosay/-/yosay-2.0.1.tgz";
-        sha512 = "1n6z65vkm1r31a1ms8wn32m9q61vrlz9isn43lm00qka1zvnich78zbnp29xwy72z361is2yimrpglmc55w97hbi9pas5pqlnvqbpw4";
+        url = "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz";
+        sha512 = "1n24pfz9fc1pd1p1cc2bl3jy6nb9xxbqadmzx3grims5xmk9r64xy98ybnim6wwz4kj3z91qc391v785s4876ki6749xcly7ngzmxba";
       };
     };
     "zen-observable-0.5.2" = {
@@ -28040,10 +28139,10 @@ in
       sources."chalk-1.1.3"
       sources."chmodr-1.0.2"
       sources."colors-1.2.1"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."concat-map-0.0.1"
       sources."convert-source-map-1.5.1"
-      sources."core-js-2.5.3"
+      sources."core-js-2.5.4"
       sources."deasync-0.1.12"
       sources."debug-2.6.9"
       sources."detect-indent-4.0.0"
@@ -28066,7 +28165,7 @@ in
       sources."home-or-tmp-2.0.0"
       sources."homedir-polyfill-1.0.1"
       sources."ini-1.3.5"
-      sources."invariant-2.2.3"
+      sources."invariant-2.2.4"
       sources."is-3.2.1"
       sources."is-finite-1.0.2"
       sources."is-windows-1.0.2"
@@ -28090,7 +28189,7 @@ in
       sources."mkdirp-0.5.1"
       sources."moment-2.20.1"
       sources."ms-2.0.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."node.extend-2.0.0"
       sources."nomnom-1.8.1"
       sources."number-is-nan-1.0.1"
@@ -28103,7 +28202,7 @@ in
       sources."private-0.1.8"
       sources."regenerator-runtime-0.11.1"
       sources."repeating-2.0.1"
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."sax-0.5.8"
       sources."slash-1.0.0"
       sources."source-map-0.6.1"
@@ -28156,7 +28255,7 @@ in
       sources."chromium-pickle-js-0.2.0"
       sources."co-4.6.0"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."concat-map-0.0.1"
       sources."core-util-is-1.0.2"
       (sources."cryptiles-3.1.2" // {
@@ -28222,7 +28321,7 @@ in
       sources."rimraf-2.6.2"
       sources."safe-buffer-5.1.1"
       sources."sntp-2.1.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."string_decoder-0.10.31"
       sources."stringstream-0.0.5"
       sources."tmp-0.0.28"
@@ -28251,15 +28350,15 @@ in
   azure-cli = nodeEnv.buildNodePackage {
     name = "azure-cli";
     packageName = "azure-cli";
-    version = "0.10.17";
+    version = "0.10.18";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.17.tgz";
-      sha1 = "e991dfa17dc5d7d91731180851fd9cbfbadf73c3";
+      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.18.tgz";
+      sha512 = "05k876g0s9ac53vrqqcn5h2l6s9ccawihr29gxvj8fib49qg2mhf1v52277r2wgcjxibj7vq2b3zp2jkp0vwd6d1pkv8alwf84ri6wc";
     };
     dependencies = [
       sources."@types/caseless-0.12.1"
       sources."@types/form-data-2.2.1"
-      sources."@types/node-8.9.5"
+      sources."@types/node-8.10.1"
       sources."@types/request-2.47.0"
       sources."@types/tough-cookie-2.3.2"
       sources."@types/uuid-3.4.3"
@@ -28326,7 +28425,7 @@ in
       sources."azure-arm-hdinsight-jobs-0.1.0"
       sources."azure-arm-insights-0.11.3"
       sources."azure-arm-iothub-1.0.1-preview"
-      sources."azure-arm-network-4.0.1"
+      sources."azure-arm-network-5.1.0"
       (sources."azure-arm-powerbiembedded-0.1.0" // {
         dependencies = [
           sources."async-0.2.7"
@@ -28433,16 +28532,17 @@ in
       sources."brace-expansion-1.1.11"
       sources."browserify-mime-1.2.9"
       sources."buffer-equal-constant-time-1.0.1"
+      sources."buffer-from-1.0.0"
       sources."caller-id-0.1.0"
       sources."caseless-0.12.0"
       sources."chalk-0.4.0"
-      sources."clone-1.0.3"
+      sources."clone-1.0.4"
       sources."co-4.6.0"
       sources."colors-1.1.2"
       sources."combined-stream-1.0.6"
       sources."commander-1.0.4"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."core-util-is-1.0.2"
       (sources."cryptiles-3.1.2" // {
         dependencies = [
@@ -28523,7 +28623,7 @@ in
       sources."jws-3.1.4"
       sources."jwt-decode-2.2.0"
       sources."keypress-0.1.0"
-      (sources."kuduscript-1.0.15" // {
+      (sources."kuduscript-1.0.16" // {
         dependencies = [
           sources."commander-1.1.1"
           sources."streamline-0.4.11"
@@ -28546,12 +28646,12 @@ in
           sources."tunnel-0.0.5"
         ];
       })
-      (sources."ms-rest-azure-2.5.4" // {
+      (sources."ms-rest-azure-2.5.5" // {
         dependencies = [
-          sources."@types/node-9.4.7"
+          sources."@types/node-9.6.1"
           (sources."adal-node-0.1.28" // {
             dependencies = [
-              sources."@types/node-8.9.5"
+              sources."@types/node-8.10.1"
             ];
           })
           sources."async-2.6.0"
@@ -28606,7 +28706,7 @@ in
           sources."boom-2.10.1"
           sources."caseless-0.11.0"
           sources."chalk-1.1.3"
-          sources."commander-2.15.0"
+          sources."commander-2.15.1"
           sources."cryptiles-2.0.5"
           sources."extend-3.0.1"
           sources."form-data-1.0.1"
@@ -28633,7 +28733,7 @@ in
           sources."asn1-0.1.11"
         ];
       })
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."stack-trace-0.0.10"
       sources."stream-combiner-0.0.4"
       sources."streamline-0.10.17"
@@ -28692,10 +28792,10 @@ in
   bower = nodeEnv.buildNodePackage {
     name = "bower";
     packageName = "bower";
-    version = "1.8.2";
+    version = "1.8.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz";
-      sha1 = "adf53529c8d4af02ef24fb8d5341c1419d33e2f7";
+      url = "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz";
+      sha1 = "e7876a076deb8137f7d06525dc5e8c66db82f28a";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -28718,7 +28818,7 @@ in
       sources."argparse-1.0.4"
       sources."array-find-index-1.0.2"
       sources."balanced-match-1.0.0"
-      sources."bower-1.8.2"
+      sources."bower-1.8.4"
       sources."bower-endpoint-parser-0.2.1"
       sources."bower-json-0.6.0"
       sources."bower-logger-0.2.1"
@@ -28772,7 +28872,7 @@ in
       sources."minimist-1.2.0"
       sources."mkdirp-0.5.1"
       sources."ms-2.0.0"
-      sources."natives-1.1.1"
+      sources."natives-1.1.2"
       sources."normalize-package-data-2.4.0"
       sources."number-is-nan-1.0.1"
       sources."object-assign-4.1.1"
@@ -28861,13 +28961,14 @@ in
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
       sources."buffer-5.1.0"
+      sources."buffer-from-1.0.0"
       sources."buffer-xor-1.0.3"
       sources."builtin-status-codes-3.0.0"
       sources."cached-path-relative-1.0.1"
       sources."cipher-base-1.0.4"
       sources."combine-source-map-0.8.0"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."console-browserify-1.1.0"
       sources."constants-browserify-1.0.0"
       sources."convert-source-map-1.1.3"
@@ -28900,29 +29001,18 @@ in
       sources."hmac-drbg-1.0.1"
       sources."htmlescape-1.1.1"
       sources."https-browserify-1.0.0"
-      sources."ieee754-1.1.8"
+      sources."ieee754-1.1.11"
       sources."indexof-0.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."inline-source-map-0.6.2"
-      (sources."insert-module-globals-7.0.2" // {
-        dependencies = [
-          sources."combine-source-map-0.7.2"
-          sources."concat-stream-1.5.2"
-          sources."readable-stream-2.0.6"
-          sources."string_decoder-0.10.31"
-        ];
-      })
+      sources."insert-module-globals-7.0.5"
       sources."is-buffer-1.1.6"
-      sources."isarray-1.0.0"
+      sources."isarray-2.0.4"
       sources."json-stable-stringify-0.0.1"
       sources."jsonify-0.0.0"
       sources."jsonparse-1.3.1"
-      (sources."labeled-stream-splicer-2.0.0" // {
-        dependencies = [
-          sources."isarray-0.0.1"
-        ];
-      })
+      sources."labeled-stream-splicer-2.0.1"
       sources."lexical-scope-1.2.0"
       sources."lodash.memoize-3.0.4"
       sources."md5.js-1.3.4"
@@ -28932,7 +29022,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      (sources."module-deps-6.0.0" // {
+      (sources."module-deps-6.0.2" // {
         dependencies = [
           sources."acorn-5.5.3"
           sources."minimist-1.2.0"
@@ -28949,7 +29039,7 @@ in
       sources."path-platform-0.11.15"
       sources."pbkdf2-3.0.14"
       sources."process-0.11.10"
-      sources."process-nextick-args-1.0.7"
+      sources."process-nextick-args-2.0.0"
       sources."public-encrypt-4.0.0"
       sources."punycode-1.4.1"
       sources."querystring-0.2.0"
@@ -28959,19 +29049,19 @@ in
       sources."read-only-stream-2.0.0"
       (sources."readable-stream-2.3.5" // {
         dependencies = [
-          sources."process-nextick-args-2.0.0"
+          sources."isarray-1.0.0"
         ];
       })
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."ripemd160-2.0.1"
       sources."safe-buffer-5.1.1"
-      sources."sha.js-2.4.10"
+      sources."sha.js-2.4.11"
       sources."shasum-1.0.2"
       sources."shell-quote-1.6.1"
       sources."source-map-0.5.7"
       sources."stream-browserify-2.0.1"
       sources."stream-combiner2-1.1.1"
-      sources."stream-http-2.8.0"
+      sources."stream-http-2.8.1"
       sources."stream-splicer-2.0.0"
       sources."string_decoder-1.0.3"
       (sources."subarg-1.0.0" // {
@@ -28986,7 +29076,7 @@ in
       sources."to-arraybuffer-1.0.1"
       sources."tty-browserify-0.0.1"
       sources."typedarray-0.0.6"
-      sources."umd-3.0.2"
+      sources."umd-3.0.3"
       (sources."url-0.11.0" // {
         dependencies = [
           sources."punycode-1.3.2"
@@ -29033,7 +29123,7 @@ in
       sources."async-0.2.10"
       sources."aws-sign-0.2.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.2.0"
+      sources."base64-js-1.2.3"
       sources."bencode-2.0.0"
       sources."bitfield-0.1.0"
       sources."bittorrent-dht-6.4.2"
@@ -29043,9 +29133,12 @@ in
       sources."bncode-0.5.3"
       sources."boom-0.3.8"
       sources."brace-expansion-1.1.11"
+      sources."buffer-alloc-1.1.0"
       sources."buffer-alloc-unsafe-1.0.0"
       sources."buffer-equal-0.0.1"
       sources."buffer-equals-1.0.4"
+      sources."buffer-fill-0.1.1"
+      sources."buffer-from-1.0.0"
       sources."bufferview-1.0.1"
       sources."builtin-modules-1.1.1"
       sources."bytebuffer-3.5.5"
@@ -29062,10 +29155,10 @@ in
       sources."codepage-1.4.0"
       sources."colour-0.7.1"
       sources."combined-stream-0.0.7"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."compact2string-1.4.0"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."cookie-jar-0.2.0"
       sources."core-util-is-1.0.2"
       sources."cryptiles-0.1.3"
@@ -29179,8 +29272,8 @@ in
       sources."path-exists-2.1.0"
       sources."path-is-absolute-1.0.1"
       sources."path-type-1.1.0"
-      sources."peer-wire-protocol-0.7.0"
-      (sources."peer-wire-swarm-0.12.1" // {
+      sources."peer-wire-protocol-0.7.1"
+      (sources."peer-wire-swarm-0.12.2" // {
         dependencies = [
           sources."bncode-0.2.3"
         ];
@@ -29188,6 +29281,7 @@ in
       (sources."peerflix-0.34.0" // {
         dependencies = [
           sources."bencode-0.7.0"
+          sources."buffer-alloc-unsafe-0.1.1"
           sources."debug-3.1.0"
           sources."end-of-stream-0.1.5"
           sources."get-stdin-5.0.1"
@@ -29218,7 +29312,7 @@ in
           sources."supports-color-0.2.0"
         ];
       })
-      sources."plist-2.1.0"
+      sources."plist-3.0.1"
       sources."process-nextick-args-2.0.0"
       sources."promiscuous-0.6.0"
       sources."protobufjs-3.8.2"
@@ -29255,8 +29349,8 @@ in
       sources."request-2.16.6"
       sources."rimraf-2.6.2"
       sources."router-0.6.2"
-      sources."run-parallel-1.1.7"
-      sources."run-series-1.1.4"
+      sources."run-parallel-1.1.8"
+      sources."run-series-1.1.6"
       sources."rusha-0.8.13"
       sources."rx-2.5.3"
       sources."safe-buffer-5.1.1"
@@ -29304,7 +29398,7 @@ in
         ];
       })
       sources."torrent-piece-1.1.1"
-      (sources."torrent-stream-1.0.3" // {
+      (sources."torrent-stream-1.0.4" // {
         dependencies = [
           sources."bencode-0.8.0"
           sources."debug-2.6.9"
@@ -29330,12 +29424,8 @@ in
       sources."wrap-fn-0.1.5"
       sources."wrappy-1.0.2"
       sources."ws-1.1.5"
-      (sources."xml2js-0.4.19" // {
-        dependencies = [
-          sources."xmlbuilder-9.0.7"
-        ];
-      })
-      sources."xmlbuilder-8.2.2"
+      sources."xml2js-0.4.19"
+      sources."xmlbuilder-9.0.7"
       sources."xmldom-0.1.27"
       sources."xspfr-0.3.1"
       sources."xtend-4.0.1"
@@ -29406,7 +29496,7 @@ in
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."colors-1.2.1"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."debug-3.1.0"
       sources."escape-string-regexp-1.0.5"
       sources."follow-redirects-1.4.1"
@@ -29505,7 +29595,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-0.0.8"
       sources."bcrypt-pbkdf-1.0.1"
-      sources."big-integer-1.6.26"
+      sources."big-integer-1.6.27"
       sources."block-stream-0.0.9"
       sources."bn.js-4.11.8"
       (sources."body-parser-1.18.2" // {
@@ -29537,6 +29627,7 @@ in
       sources."browserify-transform-tools-1.7.0"
       sources."browserify-zlib-0.1.4"
       sources."buffer-5.1.0"
+      sources."buffer-from-1.0.0"
       sources."buffer-xor-1.0.3"
       sources."builtin-modules-1.1.1"
       sources."builtin-status-codes-3.0.0"
@@ -29551,7 +29642,7 @@ in
       sources."code-point-at-1.1.0"
       sources."combine-source-map-0.8.0"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."compressible-2.0.13"
       sources."compression-1.7.2"
       sources."concat-map-0.0.1"
@@ -29581,14 +29672,13 @@ in
       (sources."cordova-js-4.2.2" // {
         dependencies = [
           sources."acorn-5.5.3"
-          sources."isarray-0.0.1"
+          sources."isarray-2.0.4"
         ];
       })
       (sources."cordova-lib-8.0.0" // {
         dependencies = [
           sources."acorn-4.0.13"
           sources."base64-js-1.2.3"
-          sources."combine-source-map-0.7.2"
           sources."glob-7.1.1"
           sources."hash-base-2.0.2"
           sources."isarray-1.0.0"
@@ -29697,7 +29787,7 @@ in
       sources."http-signature-1.1.1"
       sources."https-browserify-1.0.0"
       sources."iconv-lite-0.4.19"
-      sources."ieee754-1.1.8"
+      sources."ieee754-1.1.11"
       sources."imurmurhash-0.1.4"
       sources."indexof-0.0.1"
       sources."infinity-agent-2.0.3"
@@ -29707,7 +29797,11 @@ in
       sources."init-package-json-1.10.3"
       sources."inline-source-map-0.6.2"
       sources."inquirer-0.10.1"
-      sources."insert-module-globals-7.0.2"
+      (sources."insert-module-globals-7.0.5" // {
+        dependencies = [
+          sources."concat-stream-1.6.2"
+        ];
+      })
       (sources."insight-0.8.4" // {
         dependencies = [
           (sources."configstore-1.4.0" // {
@@ -29734,7 +29828,7 @@ in
       sources."is-redirect-1.0.0"
       sources."is-stream-1.1.0"
       sources."is-typedarray-1.0.0"
-      sources."is-url-1.2.2"
+      sources."is-url-1.2.4"
       sources."isarray-0.0.1"
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
@@ -29750,14 +29844,14 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      sources."labeled-stream-splicer-2.0.0"
+      sources."labeled-stream-splicer-2.0.1"
       sources."latest-version-1.0.1"
       sources."lexical-scope-1.2.0"
       sources."lodash-3.10.1"
       sources."lodash._getnative-3.9.1"
       sources."lodash.debounce-3.1.1"
       sources."lodash.memoize-3.0.4"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."md5.js-1.3.4"
       sources."media-typer-0.3.0"
       sources."merge-descriptors-1.0.1"
@@ -29826,7 +29920,7 @@ in
       sources."randomfill-1.0.4"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.2"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."read-1.0.7"
       sources."read-all-stream-3.1.0"
       sources."read-only-stream-2.0.0"
@@ -29837,7 +29931,7 @@ in
       sources."registry-url-3.1.0"
       sources."repeating-1.1.3"
       sources."request-2.79.0"
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."restore-cursor-1.0.1"
       sources."rimraf-2.6.2"
       sources."ripemd160-2.0.1"
@@ -29850,7 +29944,7 @@ in
       sources."send-0.16.2"
       sources."serve-static-1.13.2"
       sources."setprototypeof-1.1.0"
-      sources."sha.js-2.4.10"
+      sources."sha.js-2.4.11"
       sources."shasum-1.0.2"
       sources."shell-quote-1.6.1"
       sources."shelljs-0.5.3"
@@ -29863,7 +29957,7 @@ in
       sources."spdx-exceptions-2.1.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.0"
-      (sources."sshpk-1.13.1" // {
+      (sources."sshpk-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -29872,11 +29966,11 @@ in
       sources."stream-browserify-2.0.1"
       sources."stream-buffers-2.2.0"
       sources."stream-combiner2-1.1.1"
-      sources."stream-http-2.8.0"
+      sources."stream-http-2.8.1"
       sources."stream-shift-1.0.0"
       sources."stream-splicer-2.0.0"
       sources."string-length-1.0.1"
-      sources."string.prototype.codepointat-0.2.0"
+      sources."string.prototype.codepointat-0.2.1"
       sources."string_decoder-1.0.3"
       sources."stringstream-0.0.5"
       sources."strip-ansi-3.0.1"
@@ -29896,7 +29990,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.16"
       sources."typedarray-0.0.6"
-      sources."umd-3.0.2"
+      sources."umd-3.0.3"
       sources."underscore-1.8.3"
       sources."unorm-1.4.1"
       sources."unpipe-1.0.0"
@@ -29957,7 +30051,7 @@ in
       sha1 = "19cc3eda322160fd3f7232af1cb2a360e898a2e9";
     };
     dependencies = [
-      sources."clone-2.1.1"
+      sources."clone-2.1.2"
       sources."parserlib-1.1.1"
     ];
     buildInputs = globalBuildInputs;
@@ -29980,7 +30074,7 @@ in
     dependencies = [
       sources."abstract-random-access-1.1.2"
       sources."ajv-5.5.2"
-      sources."ansi-diff-stream-1.2.0"
+      sources."ansi-diff-stream-1.2.1"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
       sources."anymatch-1.3.2"
@@ -30016,13 +30110,18 @@ in
           sources."kind-of-4.0.0"
         ];
       })
+      sources."buffer-alloc-1.1.0"
+      sources."buffer-alloc-unsafe-1.0.0"
       sources."buffer-equals-1.0.4"
+      sources."buffer-fill-0.1.1"
+      sources."buffer-from-1.0.0"
       sources."buffer-indexof-1.1.1"
-      sources."bulk-write-stream-1.1.3"
+      sources."bulk-write-stream-1.1.4"
       sources."bytes-3.0.0"
       sources."call-me-maybe-1.0.1"
       sources."caseless-0.12.0"
       sources."chalk-2.3.2"
+      sources."circular-append-file-1.0.1"
       sources."cli-truncate-1.1.0"
       sources."cliclopts-1.1.1"
       sources."co-4.6.0"
@@ -30032,7 +30131,7 @@ in
       sources."colors-1.2.1"
       sources."combined-stream-1.0.6"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."connections-1.4.2"
       sources."content-types-0.1.0"
       sources."core-util-is-1.0.2"
@@ -30048,13 +30147,16 @@ in
       (sources."dat-doctor-1.3.1" // {
         dependencies = [
           sources."debug-2.6.9"
+          sources."dns-packet-1.3.1"
+          sources."dns-socket-1.6.3"
           sources."lru-2.0.1"
+          sources."multicast-dns-6.2.3"
           sources."pump-1.0.3"
         ];
       })
       sources."dat-encoding-5.0.1"
-      sources."dat-ignore-2.0.0"
-      (sources."dat-json-1.0.1" // {
+      sources."dat-ignore-2.1.1"
+      (sources."dat-json-1.0.2" // {
         dependencies = [
           sources."dat-encoding-4.0.2"
           sources."debug-2.6.9"
@@ -30072,6 +30174,7 @@ in
       })
       (sources."dat-node-3.5.8" // {
         dependencies = [
+          sources."buffer-alloc-unsafe-0.1.1"
           sources."minimist-0.0.8"
           sources."process-nextick-args-1.0.7"
           sources."pump-1.0.3"
@@ -30088,15 +30191,24 @@ in
       sources."deep-equal-0.2.2"
       sources."delayed-stream-1.0.0"
       sources."directory-index-html-2.1.0"
-      sources."discovery-channel-5.4.7"
+      (sources."discovery-channel-5.5.1" // {
+        dependencies = [
+          sources."pump-3.0.0"
+        ];
+      })
       (sources."discovery-swarm-4.4.2" // {
         dependencies = [
+          (sources."dns-discovery-6.1.0" // {
+            dependencies = [
+              sources."thunky-1.0.2"
+            ];
+          })
           sources."thunky-0.1.0"
         ];
       })
       sources."dns-discovery-5.6.1"
-      sources."dns-packet-1.3.1"
-      sources."dns-socket-1.6.3"
+      sources."dns-packet-4.1.1"
+      sources."dns-socket-3.0.0"
       sources."dns-txt-2.0.2"
       sources."dom-walk-0.1.1"
       sources."duplexify-3.5.4"
@@ -30134,12 +30246,12 @@ in
       sources."hoek-4.2.1"
       sources."http-methods-0.1.0"
       sources."http-signature-1.2.0"
-      (sources."hypercore-6.12.3" // {
+      (sources."hypercore-6.12.7" // {
         dependencies = [
           sources."varint-5.0.0"
         ];
       })
-      sources."hypercore-protocol-6.6.0"
+      sources."hypercore-protocol-6.6.4"
       (sources."hyperdrive-9.12.3" // {
         dependencies = [
           sources."varint-4.0.1"
@@ -30201,11 +30313,12 @@ in
       sources."mkdirp-0.5.1"
       sources."ms-2.0.0"
       sources."multi-random-access-2.1.1"
-      sources."multicast-dns-6.2.3"
+      sources."multicast-dns-7.0.0"
       sources."multicb-1.2.2"
+      sources."multistream-2.1.0"
       sources."mute-stream-0.0.7"
       sources."mutexify-1.2.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."nanoassert-1.1.0"
       sources."nanobus-3.3.0"
       sources."nanotiming-1.0.1"
@@ -30259,7 +30372,7 @@ in
       sources."range-parser-1.2.0"
       sources."read-1.0.7"
       sources."readable-stream-2.3.5"
-      sources."recursive-watch-1.1.3"
+      sources."recursive-watch-1.1.4"
       sources."regex-cache-0.4.4"
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.2"
@@ -30274,14 +30387,14 @@ in
       sources."siphash24-1.1.0"
       sources."slice-ansi-1.0.0"
       sources."sntp-2.1.0"
-      sources."sodium-javascript-0.5.4"
+      sources."sodium-javascript-0.5.5"
       sources."sodium-native-2.1.4"
       sources."sodium-universal-2.0.0"
       sources."sorted-array-functions-1.1.0"
       sources."sorted-indexof-1.0.0"
       sources."sparse-bitfield-3.0.3"
       sources."speedometer-1.0.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."stack-trace-0.0.10"
       sources."status-logger-3.1.1"
       sources."stream-collector-1.0.1"
@@ -30314,14 +30427,14 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."typedarray-0.0.6"
-      sources."uint64be-2.0.1"
+      sources."uint64be-2.0.2"
       sources."unixify-1.0.0"
       sources."unordered-array-remove-1.0.2"
       sources."unordered-set-1.1.0"
       sources."untildify-3.0.2"
       sources."util-deprecate-1.0.2"
       sources."utile-0.3.0"
-      sources."utp-native-1.6.2"
+      sources."utp-native-1.7.0"
       sources."uuid-3.2.1"
       sources."varint-3.0.1"
       sources."verror-1.10.0"
@@ -30445,7 +30558,7 @@ in
       sources."mime-types-2.1.18"
       sources."minimist-0.0.10"
       sources."ms-0.7.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       (sources."native-dns-git+https://github.com/okTurtles/node-dns.git#08433ec98f517eed3c6d5e47bdf62603539cd402" // {
         dependencies = [
           sources."native-dns-packet-git+https://github.com/okTurtles/native-dns-packet.git#8bf2714c318cfe7d31bca2006385882ccbf503e4"
@@ -30607,7 +30720,7 @@ in
       sources."pull-level-2.0.4"
       sources."pull-live-1.0.1"
       sources."pull-pushable-2.2.0"
-      sources."pull-stream-3.6.2"
+      sources."pull-stream-3.6.7"
       sources."pull-window-2.1.4"
       sources."pump-1.0.3"
       (sources."pumpify-1.4.0" // {
@@ -30628,7 +30741,7 @@ in
       sources."string_decoder-0.10.31"
       (sources."tar-stream-1.5.5" // {
         dependencies = [
-          sources."bl-1.2.1"
+          sources."bl-1.2.2"
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.5"
           sources."string_decoder-1.0.3"
@@ -30673,7 +30786,7 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.0"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.208.0"
+      sources."aws-sdk-2.216.1"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.6.0"
       sources."base64-js-1.2.3"
@@ -30735,7 +30848,7 @@ in
       sources."safe-buffer-5.1.1"
       sources."sax-1.2.1"
       sources."sntp-2.1.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."stringstream-0.0.5"
       sources."through-2.3.8"
       sources."tough-cookie-2.3.4"
@@ -30806,7 +30919,7 @@ in
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."concat-map-0.0.1"
       sources."core-util-is-1.0.2"
       sources."cross-spawn-4.0.0"
@@ -30887,7 +31000,7 @@ in
       sources."minimist-1.2.0"
       sources."mkdirp-0.5.1"
       sources."murmur-hash-js-1.0.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       (sources."node-elm-compiler-4.3.3" // {
         dependencies = [
           sources."firstline-1.2.0"
@@ -30930,7 +31043,7 @@ in
       sources."set-immediate-shim-1.0.1"
       sources."sntp-1.0.9"
       sources."split-1.0.1"
-      (sources."sshpk-1.13.1" // {
+      (sources."sshpk-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -30972,7 +31085,7 @@ in
       sha512 = "06w3hpcnxg63wg262ldhw4s2shyr1f1bvilqshy88i4svamgxk0qzdhhma2rwcwq7qpjwjlr8m1z2qbmqw9faff5f8hl45yj3jxrs3z";
     };
     dependencies = [
-      sources."ansi-escapes-3.0.0"
+      sources."ansi-escapes-3.1.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-2.2.1"
       sources."arch-2.1.0"
@@ -31013,7 +31126,7 @@ in
       sources."concat-map-0.0.1"
       sources."conf-1.4.0"
       sources."convert-source-map-1.5.1"
-      sources."core-js-2.5.3"
+      sources."core-js-2.5.4"
       sources."cross-spawn-5.1.0"
       sources."currently-unhandled-0.4.1"
       sources."debug-2.6.9"
@@ -31060,7 +31173,7 @@ in
         ];
       })
       sources."ink-text-input-1.1.1"
-      sources."invariant-2.2.3"
+      sources."invariant-2.2.4"
       sources."is-arrayish-0.2.1"
       sources."is-builtin-module-1.0.0"
       sources."is-finite-1.0.2"
@@ -31086,7 +31199,7 @@ in
       sources."log-update-2.3.0"
       sources."loose-envify-1.3.1"
       sources."loud-rejection-1.6.0"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
       sources."map-obj-1.0.1"
@@ -31189,10 +31302,10 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "4.18.2";
+    version = "4.19.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz";
-      sha512 = "0mqvxkfl52068bfkpxjn14dgwfv4vv8w0a8pq2rw54bkbshfa2y6rpx122ssk3si3dy9298g68079ns1n7m0jrzgwca7a430ggj4bmb";
+      url = "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz";
+      sha512 = "0hw70vjlg6z0y9kf6vjr7g0w9hbm426fwvyzr88l62c5hd9mxrbw5v34b6zb31vbbyda3mkvcwgfnxgqaxvpn0wlrxr0va43pbzygbd";
     };
     dependencies = [
       sources."acorn-5.5.3"
@@ -31203,7 +31316,7 @@ in
       })
       sources."ajv-5.5.2"
       sources."ajv-keywords-2.1.1"
-      sources."ansi-escapes-3.0.0"
+      sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
       sources."argparse-1.0.10"
@@ -31218,6 +31331,7 @@ in
       })
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
+      sources."buffer-from-1.0.0"
       sources."caller-path-0.1.0"
       sources."callsites-0.2.0"
       (sources."chalk-2.3.2" // {
@@ -31234,7 +31348,7 @@ in
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."core-util-is-1.0.2"
       sources."cross-spawn-5.1.0"
       sources."debug-3.1.0"
@@ -31260,7 +31374,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
       sources."glob-7.1.2"
-      sources."globals-11.3.0"
+      sources."globals-11.4.0"
       sources."globby-5.0.0"
       sources."graceful-fs-4.1.11"
       sources."has-ansi-2.0.0"
@@ -31273,7 +31387,7 @@ in
       sources."inquirer-3.3.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-path-cwd-1.0.0"
-      sources."is-path-in-cwd-1.0.0"
+      sources."is-path-in-cwd-1.0.1"
       sources."is-path-inside-1.0.1"
       sources."is-promise-2.1.0"
       sources."is-resolvable-1.1.0"
@@ -31309,6 +31423,7 @@ in
       sources."progress-2.0.0"
       sources."pseudomap-1.0.2"
       sources."readable-stream-2.3.5"
+      sources."regexpp-1.0.1"
       sources."require-uncached-1.0.3"
       sources."resolve-from-1.0.1"
       sources."restore-cursor-2.0.0"
@@ -31371,7 +31486,7 @@ in
       })
       sources."ajv-5.5.2"
       sources."ajv-keywords-2.1.1"
-      sources."ansi-escapes-3.0.0"
+      sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
       sources."argparse-1.0.10"
@@ -31386,6 +31501,7 @@ in
       })
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
+      sources."buffer-from-1.0.0"
       sources."caller-path-0.1.0"
       sources."callsites-0.2.0"
       (sources."chalk-1.1.3" // {
@@ -31401,7 +31517,7 @@ in
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."core-util-is-1.0.2"
       sources."cross-spawn-5.1.0"
       sources."debug-3.1.0"
@@ -31409,7 +31525,7 @@ in
       sources."del-2.2.2"
       sources."doctrine-2.1.0"
       sources."escape-string-regexp-1.0.5"
-      (sources."eslint-4.18.2" // {
+      (sources."eslint-4.19.1" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
           sources."ansi-styles-3.2.1"
@@ -31440,7 +31556,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
       sources."glob-7.1.2"
-      sources."globals-11.3.0"
+      sources."globals-11.4.0"
       sources."globby-5.0.0"
       sources."graceful-fs-4.1.11"
       sources."has-ansi-2.0.0"
@@ -31453,7 +31569,7 @@ in
       sources."inquirer-3.3.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-path-cwd-1.0.0"
-      sources."is-path-in-cwd-1.0.0"
+      sources."is-path-in-cwd-1.0.1"
       sources."is-path-inside-1.0.1"
       sources."is-promise-2.1.0"
       sources."is-resolvable-1.1.0"
@@ -31490,8 +31606,9 @@ in
       sources."progress-2.0.0"
       sources."pseudomap-1.0.2"
       sources."readable-stream-2.3.5"
+      sources."regexpp-1.0.1"
       sources."require-uncached-1.0.3"
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."resolve-from-1.0.1"
       sources."restore-cursor-2.0.0"
       sources."rimraf-2.6.2"
@@ -31706,7 +31823,7 @@ in
       sources."spdx-exceptions-2.1.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."string_decoder-1.0.3"
       sources."stringstream-0.0.5"
       sources."strip-ansi-3.0.1"
@@ -31746,7 +31863,7 @@ in
       sha1 = "c027feb75a512001d1287bbfb3ffaafba67eb92f";
     };
     dependencies = [
-      sources."bower-1.8.2"
+      sources."bower-1.8.4"
       sources."bower-endpoint-parser-0.2.1"
       sources."bower-logger-0.2.1"
       sources."glob-3.2.11"
@@ -31794,7 +31911,7 @@ in
           sources."colors-1.0.3"
         ];
       })
-      sources."clone-1.0.3"
+      sources."clone-1.0.4"
       sources."colors-0.6.2"
       sources."concat-map-0.0.1"
       sources."core-util-is-1.0.2"
@@ -31855,7 +31972,7 @@ in
       sources."minimist-0.0.10"
       sources."mkdirp-0.5.1"
       sources."mute-stream-0.0.7"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       (sources."nconf-0.6.9" // {
         dependencies = [
           sources."async-0.2.9"
@@ -32062,7 +32179,7 @@ in
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."msgpack-1.0.2"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."optimist-0.3.7"
       sources."pop-iterate-1.0.1"
       sources."promise-6.1.0"
@@ -32126,7 +32243,7 @@ in
       sources."array-uniq-1.0.3"
       sources."array-unique-0.3.2"
       sources."assign-symbols-1.0.0"
-      sources."atob-2.0.3"
+      sources."atob-2.1.0"
       sources."balanced-match-1.0.0"
       (sources."base-0.11.2" // {
         dependencies = [
@@ -32153,7 +32270,7 @@ in
           sources."define-property-0.2.5"
         ];
       })
-      sources."clone-1.0.3"
+      sources."clone-1.0.4"
       sources."clone-stats-0.0.1"
       sources."collection-visit-1.0.0"
       sources."color-support-1.1.3"
@@ -32304,7 +32421,7 @@ in
       sources."make-iterator-1.0.0"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
-      (sources."micromatch-3.1.9" // {
+      (sources."micromatch-3.1.10" // {
         dependencies = [
           (sources."is-accessor-descriptor-0.1.6" // {
             dependencies = [
@@ -32327,7 +32444,7 @@ in
       sources."ms-2.0.0"
       sources."multipipe-0.1.2"
       sources."nanomatch-1.2.9"
-      sources."natives-1.1.1"
+      sources."natives-1.1.2"
       sources."object-assign-3.0.0"
       sources."object-copy-0.1.0"
       sources."object-visit-1.0.1"
@@ -32353,7 +32470,7 @@ in
       sources."repeat-element-1.1.2"
       sources."repeat-string-1.6.1"
       sources."replace-ext-0.0.1"
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
@@ -32562,15 +32679,15 @@ in
   html-minifier = nodeEnv.buildNodePackage {
     name = "html-minifier";
     packageName = "html-minifier";
-    version = "3.5.10";
+    version = "3.5.12";
     src = fetchurl {
-      url = "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.10.tgz";
-      sha512 = "1kbzriri14n8z4mjn3a8azsvspj4lzdhzp3nsagkja15py5q35k4cf2py19x37bg0irifbi1k4jyn6nn952fqqm2sp0h6484w1j5kz5";
+      url = "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz";
+      sha512 = "0d7a4fxplkf6m4b5b9m269xzn1xs8qgs5z9795l46yljdh4sywhxlfkz1gn68clsazvxcvl6qs8dmv1m3qlrx60n60iblfzlbrgpppq";
     };
     dependencies = [
       sources."camel-case-3.0.0"
       sources."clean-css-4.1.11"
-      sources."commander-2.14.1"
+      sources."commander-2.15.1"
       sources."he-1.1.1"
       sources."lower-case-1.1.4"
       sources."ncname-1.0.0"
@@ -32578,7 +32695,7 @@ in
       sources."param-case-2.1.1"
       sources."relateurl-0.2.7"
       sources."source-map-0.5.7"
-      (sources."uglify-js-3.3.14" // {
+      (sources."uglify-js-3.3.16" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -32598,14 +32715,14 @@ in
   ionic = nodeEnv.buildNodePackage {
     name = "ionic";
     packageName = "ionic";
-    version = "3.19.1";
+    version = "3.20.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ionic/-/ionic-3.19.1.tgz";
-      sha512 = "11hpd51qzi8fms87q1xqwc347dp9mxhvzci2jlw94ayvs1v2n3iaqwdic1g1213k91xwzp52z6y17a08via45l936bgda3pi6zfbmsk";
+      url = "https://registry.npmjs.org/ionic/-/ionic-3.20.0.tgz";
+      sha512 = "2a051r5s0p9ihcahqysmbjklhivms8rlv5zxxi7bqrxa3x8sqqpyhbjpl7z5k4263vmfkqj3qmzciz6kbyivgk3arz22jqfqsxczqn9";
     };
     dependencies = [
-      sources."@ionic/cli-framework-0.1.2"
-      (sources."@ionic/cli-utils-1.19.1" // {
+      sources."@ionic/cli-framework-0.1.3"
+      (sources."@ionic/cli-utils-1.19.2" // {
         dependencies = [
           sources."bytes-1.0.0"
           sources."debug-2.6.9"
@@ -32614,13 +32731,14 @@ in
           sources."mime-1.4.1"
           sources."raw-body-1.1.7"
           sources."setprototypeof-1.1.0"
+          sources."statuses-1.4.0"
           sources."string_decoder-0.10.31"
           sources."yallist-3.0.2"
         ];
       })
       sources."@ionic/discover-0.4.0"
       sources."accepts-1.3.5"
-      sources."ansi-escapes-3.0.0"
+      sources."ansi-escapes-3.1.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
       sources."anymatch-1.3.2"
@@ -32637,7 +32755,7 @@ in
       sources."balanced-match-1.0.0"
       sources."basic-auth-1.1.0"
       sources."binary-extensions-1.11.0"
-      sources."bl-1.2.1"
+      sources."bl-1.2.2"
       sources."body-5.1.0"
       sources."body-parser-1.18.2"
       sources."brace-expansion-1.1.11"
@@ -32700,7 +32818,7 @@ in
       sources."for-in-1.0.2"
       sources."for-own-0.1.5"
       sources."form-data-2.3.2"
-      sources."formidable-1.2.0"
+      sources."formidable-1.2.1"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."fs-minipass-1.2.5"
@@ -32768,12 +32886,12 @@ in
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      sources."minipass-2.2.1"
+      sources."minipass-2.2.4"
       sources."minizlib-1.1.0"
       sources."mkdirp-0.5.1"
       sources."ms-2.0.0"
       sources."mute-stream-0.0.7"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."ncp-2.0.0"
       sources."negotiator-0.6.1"
       sources."netmask-1.0.6"
@@ -32783,7 +32901,7 @@ in
       sources."on-finished-2.3.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
-      sources."opn-5.2.0"
+      sources."opn-5.3.0"
       sources."os-name-2.0.1"
       sources."os-tmpdir-1.0.2"
       sources."parse-glob-3.0.4"
@@ -32832,14 +32950,14 @@ in
       sources."signal-exit-3.0.2"
       sources."slice-ansi-1.0.0"
       sources."ssh-config-1.1.3"
-      sources."statuses-1.4.0"
+      sources."statuses-1.5.0"
       sources."string-template-0.2.1"
       sources."string-width-2.1.1"
       sources."string_decoder-1.0.3"
       sources."strip-ansi-4.0.0"
       sources."superagent-3.8.2"
       sources."supports-color-5.3.0"
-      (sources."tar-4.4.0" // {
+      (sources."tar-4.4.1" // {
         dependencies = [
           sources."minimist-0.0.8"
         ];
@@ -32988,6 +33106,68 @@ in
     production = true;
     bypassCache = false;
   };
+  imapnotify = nodeEnv.buildNodePackage {
+    name = "imapnotify";
+    packageName = "imapnotify";
+    version = "0.4.1";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/imapnotify/-/imapnotify-0.4.1.tgz";
+      sha512 = "0fn58ydrck0mwpq48pj2in6aql522avzyabrddq4ixykr1h29ha3cvh1v0mga8ghg1v9zpkii81qqac74qwm9ikr1kll616fcz0cc0s";
+    };
+    dependencies = [
+      sources."async-0.2.10"
+      sources."balanced-match-1.0.0"
+      sources."brace-expansion-1.1.11"
+      sources."bunyan-1.8.12"
+      sources."colors-0.6.2"
+      sources."concat-map-0.0.1"
+      sources."core-util-is-1.0.2"
+      sources."cycle-1.0.3"
+      sources."dtrace-provider-0.8.6"
+      sources."eyes-0.1.8"
+      sources."glob-6.0.4"
+      sources."imap-0.8.19"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.3"
+      sources."isarray-0.0.1"
+      sources."isstream-0.1.2"
+      sources."minimatch-3.0.4"
+      sources."minimist-0.0.10"
+      (sources."mkdirp-0.5.1" // {
+        dependencies = [
+          sources."minimist-0.0.8"
+        ];
+      })
+      sources."moment-2.21.0"
+      sources."mv-2.1.1"
+      sources."nan-2.10.0"
+      sources."ncp-2.0.0"
+      sources."once-1.4.0"
+      sources."optimist-0.6.1"
+      sources."path-is-absolute-1.0.1"
+      sources."pkginfo-0.3.1"
+      sources."printf-0.2.5"
+      sources."readable-stream-1.1.14"
+      sources."rimraf-2.4.5"
+      sources."safe-json-stringify-1.1.0"
+      sources."semver-5.3.0"
+      sources."stack-trace-0.0.10"
+      sources."string_decoder-0.10.31"
+      sources."utf7-1.0.2"
+      sources."winston-0.8.3"
+      sources."wordwrap-0.0.3"
+      sources."wrappy-1.0.2"
+      sources."xenvar-0.5.1"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Execute scripts on new messages using IDLE imap command";
+      homepage = "https://github.com/a-sk/node-imapnotify#readme";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = false;
+  };
   javascript-typescript-langserver = nodeEnv.buildNodePackage {
     name = "javascript-typescript-langserver";
     packageName = "javascript-typescript-langserver";
@@ -33010,7 +33190,7 @@ in
       sources."check-error-1.0.2"
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."concat-map-0.0.1"
       sources."deep-eql-3.0.1"
       sources."deep-equal-1.0.1"
@@ -33035,12 +33215,12 @@ in
       sources."mz-2.7.0"
       sources."node-int64-0.4.0"
       sources."object-assign-4.1.1"
-      sources."object-hash-1.2.0"
+      sources."object-hash-1.3.0"
       sources."once-1.4.0"
       sources."opentracing-0.14.1"
       sources."path-is-absolute-1.0.1"
       sources."pathval-1.1.0"
-      sources."rxjs-5.5.6"
+      sources."rxjs-5.5.8"
       sources."semaphore-async-await-1.5.1"
       sources."string-similarity-1.2.0"
       sources."string-template-0.2.1"
@@ -33114,7 +33294,7 @@ in
       sources."graceful-fs-4.1.11"
       sources."js2xmlparser-3.0.0"
       sources."klaw-2.0.0"
-      sources."marked-0.3.17"
+      sources."marked-0.3.19"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       (sources."requizzle-0.2.1" // {
@@ -33219,7 +33399,7 @@ in
     dependencies = [
       sources."abbrev-1.1.1"
       sources."bluebird-3.5.1"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."config-chain-1.1.11"
       sources."editorconfig-0.13.3"
       sources."ini-1.3.5"
@@ -33327,7 +33507,7 @@ in
       sources."esprima-4.0.0"
       sources."extend-3.0.1"
       sources."form-data-2.3.2"
-      sources."formidable-1.2.0"
+      sources."formidable-1.2.1"
       sources."graphlib-2.1.5"
       sources."inherits-2.0.3"
       sources."isarray-1.0.0"
@@ -33391,6 +33571,7 @@ in
       sources."capture-stack-trace-1.0.0"
       sources."caseless-0.12.0"
       sources."chalk-2.3.2"
+      sources."ci-info-1.1.3"
       sources."cli-boxes-1.0.0"
       sources."cliui-4.0.0"
       sources."co-4.6.0"
@@ -33400,7 +33581,7 @@ in
       sources."combined-stream-1.0.6"
       sources."compressible-2.0.13"
       sources."compression-1.7.2"
-      sources."configstore-3.1.1"
+      sources."configstore-3.1.2"
       sources."connect-pause-0.1.1"
       sources."content-disposition-0.5.2"
       sources."content-type-1.0.4"
@@ -33436,6 +33617,7 @@ in
       (sources."express-4.16.3" // {
         dependencies = [
           sources."setprototypeof-1.1.0"
+          sources."statuses-1.4.0"
         ];
       })
       (sources."express-urlrewrite-1.2.0" // {
@@ -33477,6 +33659,7 @@ in
       sources."ini-1.3.5"
       sources."invert-kv-1.0.0"
       sources."ipaddr.js-1.6.0"
+      sources."is-ci-1.1.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-installed-globally-0.1.0"
       sources."is-npm-1.0.0"
@@ -33503,7 +33686,7 @@ in
       sources."lodash-4.17.5"
       sources."lodash-id-0.14.0"
       sources."lowdb-0.15.5"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
       sources."media-typer-0.3.0"
@@ -33548,7 +33731,7 @@ in
       sources."qs-6.5.1"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.2"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."registry-auth-token-3.3.2"
       sources."registry-url-3.1.0"
       sources."request-2.85.0"
@@ -33566,8 +33749,8 @@ in
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
       sources."sntp-2.1.0"
-      sources."sshpk-1.13.1"
-      sources."statuses-1.4.0"
+      sources."sshpk-1.14.1"
+      sources."statuses-1.5.0"
       sources."steno-0.4.4"
       sources."string-width-2.1.1"
       sources."stringstream-0.0.5"
@@ -33584,7 +33767,7 @@ in
       sources."unique-string-1.0.0"
       sources."unpipe-1.0.0"
       sources."unzip-response-2.0.1"
-      sources."update-notifier-2.3.0"
+      sources."update-notifier-2.4.0"
       sources."url-parse-lax-1.0.0"
       sources."utils-merge-1.0.1"
       sources."uuid-3.2.1"
@@ -33724,9 +33907,8 @@ in
       (sources."browserify-14.5.0" // {
         dependencies = [
           sources."acorn-5.5.3"
-          sources."combine-source-map-0.7.2"
           sources."hash-base-2.0.2"
-          sources."isarray-0.0.1"
+          sources."isarray-2.0.4"
           sources."process-nextick-args-2.0.0"
           sources."source-map-0.5.7"
         ];
@@ -33738,6 +33920,7 @@ in
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
       sources."buffer-5.1.0"
+      sources."buffer-from-1.0.0"
       sources."buffer-more-ints-0.0.2"
       sources."buffer-xor-1.0.3"
       sources."buildmail-4.0.1"
@@ -33755,7 +33938,7 @@ in
       sources."combine-lists-1.0.1"
       sources."combine-source-map-0.8.0"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
       sources."component-inherit-0.0.3"
@@ -33776,7 +33959,7 @@ in
       sources."content-type-1.0.4"
       sources."convert-source-map-1.1.3"
       sources."cookie-0.3.1"
-      sources."core-js-2.5.3"
+      sources."core-js-2.5.4"
       sources."core-util-is-1.0.2"
       sources."create-ecdh-4.0.0"
       sources."create-hash-1.1.3"
@@ -33899,13 +34082,17 @@ in
       sources."https-browserify-1.0.0"
       sources."https-proxy-agent-1.0.0"
       sources."iconv-lite-0.4.19"
-      sources."ieee754-1.1.8"
+      sources."ieee754-1.1.11"
       sources."indexof-0.0.1"
       sources."inflection-1.10.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."inline-source-map-0.6.2"
-      sources."insert-module-globals-7.0.2"
+      (sources."insert-module-globals-7.0.5" // {
+        dependencies = [
+          sources."concat-stream-1.6.2"
+        ];
+      })
       sources."ip-1.0.1"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
@@ -33936,7 +34123,7 @@ in
       sources."jsonpointer-4.0.1"
       sources."jsprim-1.4.1"
       sources."kind-of-3.2.2"
-      sources."labeled-stream-splicer-2.0.0"
+      sources."labeled-stream-splicer-2.0.1"
       sources."levn-0.3.0"
       sources."lexical-scope-1.2.0"
       sources."libbase64-0.1.0"
@@ -33996,7 +34183,7 @@ in
       sources."mkdirp-0.5.1"
       sources."module-deps-4.1.1"
       sources."ms-2.0.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."negotiator-0.6.1"
       sources."netmask-1.0.6"
       sources."node-uuid-1.4.8"
@@ -34087,14 +34274,14 @@ in
       sources."request-2.85.0"
       sources."requestretry-1.13.0"
       sources."requires-port-1.0.0"
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."rimraf-2.6.2"
       sources."ripemd160-2.0.1"
       sources."safe-buffer-5.1.1"
       sources."semver-5.5.0"
       sources."set-immediate-shim-1.0.1"
       sources."setprototypeof-1.0.3"
-      sources."sha.js-2.4.10"
+      sources."sha.js-2.4.11"
       sources."shasum-1.0.2"
       sources."shell-quote-1.6.1"
       sources."slack-node-0.2.0"
@@ -34116,11 +34303,11 @@ in
       sources."socks-1.1.10"
       sources."socks-proxy-agent-2.1.1"
       sources."source-map-0.6.1"
-      sources."sshpk-1.13.1"
-      sources."statuses-1.4.0"
+      sources."sshpk-1.14.1"
+      sources."statuses-1.5.0"
       sources."stream-browserify-2.0.1"
       sources."stream-combiner2-1.1.1"
-      sources."stream-http-2.8.0"
+      sources."stream-http-2.8.1"
       sources."stream-splicer-2.0.0"
       sources."streamroller-0.7.0"
       sources."string_decoder-1.0.3"
@@ -34146,7 +34333,7 @@ in
       sources."type-is-1.6.16"
       sources."typedarray-0.0.6"
       sources."ultron-1.1.1"
-      sources."umd-3.0.2"
+      sources."umd-3.0.3"
       sources."underscore-1.7.0"
       sources."unpipe-1.0.0"
       (sources."url-0.11.0" // {
@@ -34329,7 +34516,7 @@ in
           sources."ms-0.7.1"
         ];
       })
-      sources."statuses-1.4.0"
+      sources."statuses-1.5.0"
       sources."stream-counter-0.2.0"
       sources."string_decoder-0.10.31"
       sources."tsscmp-1.0.5"
@@ -34364,7 +34551,7 @@ in
       sources."add-stream-1.0.0"
       sources."align-text-0.1.4"
       sources."amdefine-1.0.1"
-      sources."ansi-escapes-3.0.0"
+      sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-3.2.1"
       sources."aproba-1.2.0"
@@ -34377,6 +34564,7 @@ in
       sources."async-1.5.2"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
+      sources."buffer-from-1.0.0"
       sources."builtin-modules-1.1.1"
       sources."byline-5.0.0"
       sources."camelcase-1.2.1"
@@ -34389,7 +34577,7 @@ in
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
       sources."cliui-2.1.0"
-      sources."clone-1.0.3"
+      sources."clone-1.0.4"
       sources."cmd-shim-2.0.2"
       sources."code-point-at-1.1.0"
       sources."color-convert-1.9.1"
@@ -34398,9 +34586,9 @@ in
       sources."command-join-2.0.0"
       sources."compare-func-1.3.2"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."console-control-strings-1.1.0"
-      (sources."conventional-changelog-1.1.18" // {
+      (sources."conventional-changelog-1.1.23" // {
         dependencies = [
           sources."camelcase-4.1.0"
           sources."map-obj-1.0.1"
@@ -34408,8 +34596,8 @@ in
         ];
       })
       sources."conventional-changelog-angular-1.6.6"
-      sources."conventional-changelog-atom-0.2.4"
-      (sources."conventional-changelog-cli-1.3.16" // {
+      sources."conventional-changelog-atom-0.2.8"
+      (sources."conventional-changelog-cli-1.3.21" // {
         dependencies = [
           sources."camelcase-2.1.1"
           sources."camelcase-keys-4.2.0"
@@ -34432,22 +34620,22 @@ in
           sources."yargs-3.10.0"
         ];
       })
-      sources."conventional-changelog-codemirror-0.3.4"
-      (sources."conventional-changelog-core-2.0.5" // {
+      sources."conventional-changelog-codemirror-0.3.8"
+      (sources."conventional-changelog-core-2.0.10" // {
         dependencies = [
           sources."meow-4.0.0"
         ];
       })
-      sources."conventional-changelog-ember-0.3.6"
-      sources."conventional-changelog-eslint-1.0.5"
-      sources."conventional-changelog-express-0.3.4"
+      sources."conventional-changelog-ember-0.3.11"
+      sources."conventional-changelog-eslint-1.0.9"
+      sources."conventional-changelog-express-0.3.6"
       sources."conventional-changelog-jquery-0.1.0"
       sources."conventional-changelog-jscs-0.1.0"
-      sources."conventional-changelog-jshint-0.3.4"
-      sources."conventional-changelog-preset-loader-1.1.6"
-      sources."conventional-changelog-writer-3.0.4"
-      sources."conventional-commits-filter-1.1.5"
-      sources."conventional-commits-parser-2.1.5"
+      sources."conventional-changelog-jshint-0.3.8"
+      sources."conventional-changelog-preset-loader-1.1.8"
+      sources."conventional-changelog-writer-3.0.9"
+      sources."conventional-commits-filter-1.1.6"
+      sources."conventional-commits-parser-2.1.7"
       (sources."conventional-recommended-bump-1.2.1" // {
         dependencies = [
           sources."meow-3.7.0"
@@ -34484,14 +34672,14 @@ in
       sources."get-port-3.2.0"
       sources."get-stdin-4.0.1"
       sources."get-stream-3.0.0"
-      (sources."git-raw-commits-1.3.4" // {
+      (sources."git-raw-commits-1.3.6" // {
         dependencies = [
           sources."read-pkg-3.0.0"
           sources."read-pkg-up-3.0.0"
         ];
       })
       sources."git-remote-origin-url-2.0.0"
-      sources."git-semver-tags-1.3.4"
+      sources."git-semver-tags-1.3.6"
       sources."gitconfiglocal-1.0.0"
       sources."glob-7.1.2"
       sources."glob-parent-3.1.0"
@@ -34558,7 +34746,7 @@ in
       sources."lodash.templatesettings-4.1.0"
       sources."longest-1.0.1"
       sources."loud-rejection-1.6.0"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
       sources."map-obj-1.0.1"
@@ -34578,7 +34766,7 @@ in
       sources."minimist-0.0.8"
       sources."minimist-options-3.0.2"
       sources."mkdirp-0.5.1"
-      sources."modify-values-1.0.0"
+      sources."modify-values-1.0.1"
       sources."moment-2.21.0"
       sources."mute-stream-0.0.7"
       sources."normalize-package-data-2.4.0"
@@ -34620,7 +34808,7 @@ in
       sources."pseudomap-1.0.2"
       sources."q-1.5.1"
       sources."quick-lru-1.1.0"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."read-cmd-shim-1.0.1"
       sources."read-pkg-3.0.0"
       sources."read-pkg-up-1.0.1"
@@ -34802,7 +34990,7 @@ in
       sources."safe-buffer-5.1.1"
       sources."sntp-1.0.9"
       sources."source-map-0.5.7"
-      (sources."sshpk-1.13.1" // {
+      (sources."sshpk-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -34865,10 +35053,10 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."clone-2.1.1"
+      sources."clone-2.1.2"
       sources."clone-buffer-1.0.0"
       sources."clone-stats-1.0.0"
-      sources."cloneable-readable-1.1.1"
+      sources."cloneable-readable-1.1.2"
       sources."concat-map-0.0.1"
       sources."convert-source-map-1.5.1"
       sources."core-util-is-1.0.2"
@@ -34964,7 +35152,7 @@ in
       sources."vinyl-2.1.0"
       (sources."vinyl-fs-2.4.4" // {
         dependencies = [
-          sources."clone-1.0.3"
+          sources."clone-1.0.4"
           sources."clone-stats-0.0.1"
           sources."is-extglob-1.0.0"
           sources."is-glob-2.0.1"
@@ -35076,6 +35264,7 @@ in
       (sources."express-4.16.3" // {
         dependencies = [
           sources."setprototypeof-1.1.0"
+          sources."statuses-1.4.0"
         ];
       })
       sources."extend-3.0.1"
@@ -35153,14 +35342,14 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       sources."ms-2.0.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."negotiator-0.6.1"
       sources."normalize-path-2.1.1"
       sources."oauth-sign-0.8.2"
       sources."object-component-0.0.3"
       sources."object.omit-2.0.1"
       sources."on-finished-2.3.0"
-      sources."opn-5.2.0"
+      sources."opn-5.3.0"
       sources."parse-glob-3.0.4"
       sources."parseqs-0.0.5"
       sources."parseuri-0.0.5"
@@ -35210,8 +35399,8 @@ in
         ];
       })
       sources."sprintf-js-1.0.3"
-      sources."sshpk-1.13.1"
-      sources."statuses-1.4.0"
+      sources."sshpk-1.14.1"
+      sources."statuses-1.5.0"
       sources."string_decoder-1.0.3"
       sources."stringstream-0.0.5"
       sources."to-array-0.1.4"
@@ -35334,14 +35523,14 @@ in
         ];
       })
       sources."ms-0.7.1"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."negotiator-0.6.1"
       sources."normalize-path-2.1.1"
       sources."object-assign-4.1.1"
       sources."object.omit-2.0.1"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.1"
-      sources."opn-5.2.0"
+      sources."opn-5.3.0"
       sources."parse-glob-3.0.4"
       sources."parseurl-1.3.2"
       sources."path-is-absolute-1.0.1"
@@ -35443,10 +35632,10 @@ in
   mocha = nodeEnv.buildNodePackage {
     name = "mocha";
     packageName = "mocha";
-    version = "5.0.4";
+    version = "5.0.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz";
-      sha512 = "1agv3n6vr1rhjv18n6nfra7wlz7jmf38aym85299fdidy0qq6wsl9zcnvsn4867dcwjgrmrfgnymvg5f7c8sxccw10lvcb8y40akhww";
+      url = "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz";
+      sha512 = "20cyp9x4b3gfrd50w8dcfkm0dv2mc6z0ikvfpkc8dzca6hppslgn0yiw2qdzc4ggf234kzcdvs0hw7lnv7ywilaml4w39vr6r93ghyw";
     };
     dependencies = [
       sources."balanced-match-1.0.0"
@@ -35494,7 +35683,7 @@ in
       sources."argparse-1.0.10"
       sources."asynckit-0.4.0"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."component-emitter-1.2.1"
       sources."cookiejar-2.1.1"
       sources."core-util-is-1.0.2"
@@ -35503,7 +35692,7 @@ in
       sources."esprima-4.0.0"
       sources."extend-3.0.1"
       sources."form-data-2.3.2"
-      sources."formidable-1.2.0"
+      sources."formidable-1.2.1"
       sources."graphlib-2.1.5"
       sources."inherits-2.0.3"
       sources."isarray-1.0.0"
@@ -35580,13 +35769,14 @@ in
       sources."base64-js-1.2.3"
       sources."bcrypt-pbkdf-1.0.1"
       sources."boom-4.3.1"
+      sources."buffer-from-1.0.0"
       sources."builtin-modules-1.1.1"
       sources."builtins-1.0.3"
       sources."caseless-0.12.0"
       sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.6"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."config-chain-1.1.11"
       sources."console-control-strings-1.1.0"
       sources."core-util-is-1.0.2"
@@ -35639,7 +35829,7 @@ in
       sources."mime-db-1.33.0"
       sources."mime-types-2.1.18"
       sources."minimist-0.0.8"
-      sources."minipass-2.2.1"
+      sources."minipass-2.2.4"
       sources."minizlib-1.1.0"
       sources."mkdirp-0.5.1"
       sources."ncp-0.4.2"
@@ -35683,8 +35873,8 @@ in
       sources."spdx-exceptions-2.1.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.0"
-      sources."sshpk-1.13.1"
-      sources."ssri-5.2.4"
+      sources."sshpk-1.14.1"
+      sources."ssri-5.3.0"
       sources."string-width-1.0.2"
       sources."string_decoder-1.0.3"
       sources."stringstream-0.0.5"
@@ -35701,7 +35891,7 @@ in
       sources."validate-npm-package-license-3.0.3"
       sources."validate-npm-package-name-3.0.0"
       sources."verror-1.10.0"
-      sources."walk-2.3.9"
+      sources."walk-2.3.13"
       sources."wide-align-1.1.2"
       sources."wrappy-1.0.2"
       sources."yallist-3.0.2"
@@ -35812,7 +36002,7 @@ in
       sources."set-blocking-2.0.0"
       sources."signal-exit-3.0.2"
       sources."sntp-2.1.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."string-width-1.0.2"
       sources."string_decoder-1.0.3"
       sources."stringstream-0.0.5"
@@ -35886,7 +36076,7 @@ in
           sources."yargs-1.3.3"
         ];
       })
-      sources."big-integer-1.6.26"
+      sources."big-integer-1.6.27"
       sources."block-stream-0.0.9"
       (sources."body-parser-1.18.2" // {
         dependencies = [
@@ -36007,7 +36197,7 @@ in
       sources."minimist-1.2.0"
       sources."mkdirp-0.5.1"
       sources."ms-2.0.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."negotiator-0.6.1"
       sources."node-pre-gyp-0.6.39"
       sources."nopt-4.0.1"
@@ -36044,7 +36234,7 @@ in
       sources."qs-6.5.1"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.2"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."read-pkg-1.1.0"
       sources."read-pkg-up-1.0.1"
       sources."readable-stream-2.3.5"
@@ -36065,7 +36255,7 @@ in
       sources."spdx-exceptions-2.1.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.0"
-      (sources."sshpk-1.13.1" // {
+      (sources."sshpk-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -36132,124 +36322,76 @@ in
   node-pre-gyp = nodeEnv.buildNodePackage {
     name = "node-pre-gyp";
     packageName = "node-pre-gyp";
-    version = "0.8.0";
+    version = "0.9.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.8.0.tgz";
-      sha512 = "3z3mz92ya4hx3mg902sb6kwlkfz8dkc12hxcnp4sygbiahbiknzh585jrf9zf3bqd9xgsh9109dz5mqwjh268zl0nmn2n30fl7cqa49";
+      url = "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.0.tgz";
+      sha1 = "bdd4c3afac9b1b1ebff0a9ff3362859eb6781bb8";
     };
     dependencies = [
       sources."abbrev-1.1.1"
-      sources."ajv-5.5.2"
       sources."ansi-regex-2.1.1"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.4"
-      sources."asn1-0.2.3"
-      sources."assert-plus-1.0.0"
-      sources."asynckit-0.4.0"
-      sources."aws-sign2-0.7.0"
-      sources."aws4-1.6.0"
       sources."balanced-match-1.0.0"
-      sources."bcrypt-pbkdf-1.0.1"
-      sources."boom-4.3.1"
       sources."brace-expansion-1.1.11"
-      sources."caseless-0.12.0"
       sources."chownr-1.0.1"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
-      sources."combined-stream-1.0.6"
       sources."concat-map-0.0.1"
       sources."console-control-strings-1.1.0"
       sources."core-util-is-1.0.2"
-      (sources."cryptiles-3.1.2" // {
-        dependencies = [
-          sources."boom-5.2.0"
-        ];
-      })
-      sources."dashdash-1.14.1"
+      sources."debug-2.6.9"
       sources."deep-extend-0.4.2"
-      sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
       sources."detect-libc-1.0.3"
-      sources."ecc-jsbn-0.1.1"
-      sources."extend-3.0.1"
-      sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
-      sources."fast-json-stable-stringify-2.0.0"
-      sources."forever-agent-0.6.1"
-      sources."form-data-2.3.2"
       sources."fs-minipass-1.2.5"
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
-      sources."getpass-0.1.7"
       sources."glob-7.1.2"
-      sources."har-schema-2.0.0"
-      sources."har-validator-5.0.3"
       sources."has-unicode-2.0.1"
-      sources."hawk-6.0.2"
-      sources."hoek-4.2.1"
-      sources."http-signature-1.2.0"
+      sources."iconv-lite-0.4.19"
       sources."ignore-walk-3.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."ini-1.3.5"
       sources."is-fullwidth-code-point-1.0.0"
-      sources."is-typedarray-1.0.0"
       sources."isarray-1.0.0"
-      sources."isstream-0.1.2"
-      sources."jsbn-0.1.1"
-      sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
-      sources."json-stringify-safe-5.0.1"
-      sources."jsprim-1.4.1"
-      sources."mime-db-1.33.0"
-      sources."mime-types-2.1.18"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.2.1"
+      sources."minipass-2.2.4"
       sources."minizlib-1.1.0"
       sources."mkdirp-0.5.1"
+      sources."ms-2.0.0"
+      sources."needle-2.2.0"
       sources."nopt-4.0.1"
       sources."npm-bundled-1.0.3"
       sources."npm-packlist-1.1.10"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
-      sources."oauth-sign-0.8.2"
       sources."object-assign-4.1.1"
       sources."once-1.4.0"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
       sources."path-is-absolute-1.0.1"
-      sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.0"
-      sources."punycode-1.4.1"
-      sources."qs-6.5.1"
-      (sources."rc-1.2.5" // {
+      (sources."rc-1.2.6" // {
         dependencies = [
           sources."minimist-1.2.0"
         ];
       })
       sources."readable-stream-2.3.5"
-      sources."request-2.83.0"
       sources."rimraf-2.6.2"
       sources."safe-buffer-5.1.1"
+      sources."sax-1.2.4"
       sources."semver-5.5.0"
       sources."set-blocking-2.0.0"
       sources."signal-exit-3.0.2"
-      sources."sntp-2.1.0"
-      sources."sshpk-1.13.1"
       sources."string-width-1.0.2"
       sources."string_decoder-1.0.3"
-      sources."stringstream-0.0.5"
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
-      sources."tar-4.4.0"
-      sources."tough-cookie-2.3.4"
-      sources."tunnel-agent-0.6.0"
-      sources."tweetnacl-0.14.5"
+      sources."tar-4.4.1"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.2.1"
-      sources."verror-1.10.0"
       sources."wide-align-1.1.2"
       sources."wrappy-1.0.2"
       sources."yallist-3.0.2"
@@ -36266,10 +36408,10 @@ in
   nodemon = nodeEnv.buildNodePackage {
     name = "nodemon";
     packageName = "nodemon";
-    version = "1.17.1";
+    version = "1.17.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/nodemon/-/nodemon-1.17.1.tgz";
-      sha512 = "2dnscknr22xf5r06zcrjz0ljaa2agbrnczh4faf42qsmqfpcng6znv6138nwyyr16fpqk28wgfab1bw3snrsyfz8pirmjl9ywdqibx7";
+      url = "https://registry.npmjs.org/nodemon/-/nodemon-1.17.2.tgz";
+      sha512 = "21s43bf7rf7cgnff0spwl9hnzvnqf5gwd11k4dg70pp5vh1kkkf03zzcbali25iazcifw8xbqh8mqnsggap6kpn7x3p0slr0rzdamxz";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -36290,7 +36432,7 @@ in
       sources."array-unique-0.3.2"
       sources."assign-symbols-1.0.0"
       sources."async-each-1.0.1"
-      sources."atob-2.0.3"
+      sources."atob-2.1.0"
       sources."balanced-match-1.0.0"
       (sources."base-0.11.2" // {
         dependencies = [
@@ -36316,7 +36458,7 @@ in
       sources."camelcase-4.1.0"
       sources."capture-stack-trace-1.0.0"
       sources."chalk-2.3.2"
-      (sources."chokidar-2.0.2" // {
+      (sources."chokidar-2.0.3" // {
         dependencies = [
           sources."debug-2.6.9"
           sources."define-property-1.0.0"
@@ -36341,6 +36483,7 @@ in
           })
         ];
       })
+      sources."ci-info-1.1.3"
       (sources."class-utils-0.3.6" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -36352,7 +36495,7 @@ in
       sources."color-name-1.1.3"
       sources."component-emitter-1.2.1"
       sources."concat-map-0.0.1"
-      sources."configstore-3.1.1"
+      sources."configstore-3.1.2"
       sources."copy-descriptor-0.1.1"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
@@ -36407,6 +36550,7 @@ in
       sources."is-accessor-descriptor-1.0.0"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
+      sources."is-ci-1.1.0"
       sources."is-data-descriptor-1.0.0"
       sources."is-descriptor-1.0.2"
       sources."is-extendable-1.0.1"
@@ -36429,13 +36573,13 @@ in
       sources."isobject-3.0.1"
       sources."kind-of-6.0.2"
       sources."latest-version-3.1.0"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
       sources."map-cache-0.2.2"
       sources."map-stream-0.1.0"
       sources."map-visit-1.0.0"
-      (sources."micromatch-3.1.9" // {
+      (sources."micromatch-3.1.10" // {
         dependencies = [
           (sources."is-accessor-descriptor-0.1.6" // {
             dependencies = [
@@ -36455,7 +36599,7 @@ in
       sources."minimist-1.2.0"
       sources."mixin-deep-1.3.1"
       sources."ms-2.0.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."nanomatch-1.2.9"
       sources."nopt-1.0.10"
       sources."normalize-path-2.1.1"
@@ -36478,7 +36622,7 @@ in
       sources."ps-tree-1.1.0"
       sources."pseudomap-1.0.2"
       sources."pstree.remy-1.1.0"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."readable-stream-2.3.5"
       sources."readdirp-2.1.0"
       sources."regex-not-1.0.2"
@@ -36562,7 +36706,7 @@ in
       })
       sources."unzip-response-2.0.1"
       sources."upath-1.0.4"
-      sources."update-notifier-2.3.0"
+      sources."update-notifier-2.4.0"
       sources."urix-0.1.0"
       sources."url-parse-lax-1.0.0"
       (sources."use-3.1.0" // {
@@ -36618,12 +36762,13 @@ in
       sources."bcrypt-1.0.3"
       sources."bcrypt-pbkdf-1.0.1"
       sources."bcryptjs-2.4.3"
-      sources."bl-1.2.1"
+      sources."bl-1.2.2"
       sources."block-stream-0.0.9"
       sources."body-parser-1.18.2"
       sources."boolbase-1.0.0"
       sources."boom-4.3.1"
       sources."brace-expansion-1.1.11"
+      sources."buffer-from-1.0.0"
       sources."buildmail-2.0.0"
       sources."busboy-0.2.14"
       sources."bytes-3.0.0"
@@ -36641,7 +36786,7 @@ in
       sources."commander-2.13.0"
       sources."commist-1.0.0"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."console-control-strings-1.1.0"
       sources."content-disposition-0.5.2"
       sources."content-type-1.0.4"
@@ -36835,7 +36980,7 @@ in
       (sources."node-red-node-email-0.1.24" // {
         dependencies = [
           sources."addressparser-1.0.1"
-          sources."clone-1.0.3"
+          sources."clone-1.0.4"
           sources."isarray-0.0.1"
           sources."minimist-0.0.10"
           sources."readable-stream-1.1.14"
@@ -36892,7 +37037,7 @@ in
       sources."random-bytes-1.0.0"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.2"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."readable-stream-2.3.5"
       sources."reinterval-1.1.0"
       sources."remove-trailing-separator-1.1.0"
@@ -36913,8 +37058,8 @@ in
       sources."source-map-0.6.1"
       sources."split2-2.2.0"
       sources."sprintf-js-1.0.3"
-      sources."sshpk-1.13.1"
-      sources."statuses-1.4.0"
+      sources."sshpk-1.14.1"
+      sources."statuses-1.5.0"
       sources."stream-shift-1.0.0"
       sources."streamsearch-0.1.2"
       sources."string-width-1.0.2"
@@ -36945,7 +37090,7 @@ in
       sources."utf7-1.0.2"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uue-3.1.1"
+      sources."uue-3.1.2"
       sources."uuid-3.2.1"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
@@ -37049,7 +37194,7 @@ in
       sources."ms-0.1.0"
       sources."muri-0.3.1"
       sources."nan-1.0.0"
-      sources."natives-1.1.1"
+      sources."natives-1.1.2"
       (sources."net-ping-1.1.7" // {
         dependencies = [
           sources."nan-2.3.5"
@@ -37103,10 +37248,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "5.7.1";
+    version = "5.8.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz";
-      sha512 = "147xlh1d389j8yilssidlk7w8qgp1354y5p2bhv30a0m74vmfbl48859yfidij4ixbf0dhdmzkg6zz6viik2cskkrz4nw56zsz2nn5g";
+      url = "https://registry.npmjs.org/npm/-/npm-5.8.0.tgz";
+      sha512 = "32zs775qksijpj23rwly4h8gs435lbsgaxzw6dmyjjg3i8qd40bmmadv3ac9mdxd0cd2x0m3ncsqa0j5vkmkvh8dknn0j9d1k6ig30f";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -37219,7 +37364,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.3.5"
-      sources."natives-1.1.1"
+      sources."natives-1.1.2"
       sources."ncp-0.4.2"
       sources."nopt-2.2.1"
       (sources."npm-registry-client-0.2.27" // {
@@ -37256,7 +37401,7 @@ in
       sources."signal-exit-3.0.2"
       sources."slide-1.1.6"
       sources."sntp-2.1.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."string-width-1.0.2"
       sources."string_decoder-1.0.3"
       sources."stringstream-0.0.5"
@@ -37282,7 +37427,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."uuid-3.2.1"
       sources."verror-1.10.0"
-      sources."walk-2.3.9"
+      sources."walk-2.3.13"
       sources."wide-align-1.1.2"
       sources."wrappy-1.0.2"
     ];
@@ -37325,6 +37470,7 @@ in
       sources."capture-stack-trace-1.0.0"
       sources."center-align-0.1.3"
       sources."chalk-1.1.3"
+      sources."ci-info-1.1.3"
       sources."cint-8.2.1"
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-1.0.2"
@@ -37337,7 +37483,7 @@ in
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."colors-1.0.3"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."concat-map-0.0.1"
       (sources."configstore-1.4.0" // {
         dependencies = [
@@ -37391,6 +37537,7 @@ in
       sources."is-arrayish-0.2.1"
       sources."is-buffer-1.1.6"
       sources."is-builtin-module-1.0.0"
+      sources."is-ci-1.1.0"
       sources."is-extendable-0.1.1"
       sources."is-finite-1.0.2"
       sources."is-fullwidth-code-point-1.0.0"
@@ -37423,7 +37570,7 @@ in
       sources."lodash.defaultsdeep-4.6.0"
       sources."lodash.mergewith-4.6.1"
       sources."longest-1.0.1"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
       sources."minimatch-3.0.4"
@@ -37479,7 +37626,7 @@ in
       sources."pseudomap-1.0.2"
       sources."punycode-1.3.2"
       sources."querystring-0.2.0"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."rc-config-loader-2.0.1"
       sources."read-all-stream-3.1.0"
       sources."read-pkg-1.1.0"
@@ -37501,7 +37648,7 @@ in
       sources."sax-1.2.4"
       sources."semver-5.5.0"
       sources."semver-diff-2.1.0"
-      sources."semver-utils-1.1.1"
+      sources."semver-utils-1.1.2"
       sources."set-blocking-2.0.0"
       (sources."shallow-clone-0.1.2" // {
         dependencies = [
@@ -37512,7 +37659,7 @@ in
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
       sources."slide-1.1.6"
-      (sources."snyk-1.70.0" // {
+      (sources."snyk-1.70.3" // {
         dependencies = [
           sources."async-0.9.2"
           sources."camelcase-3.0.0"
@@ -37556,7 +37703,7 @@ in
           sources."debug-2.6.9"
         ];
       })
-      sources."snyk-python-plugin-1.5.6"
+      sources."snyk-python-plugin-1.5.7"
       (sources."snyk-resolve-1.0.0" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -37610,14 +37757,14 @@ in
       sources."undefsafe-0.0.3"
       sources."unique-string-1.0.0"
       sources."unzip-response-1.0.2"
-      (sources."update-notifier-2.3.0" // {
+      (sources."update-notifier-2.4.0" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
           sources."ansi-styles-3.2.1"
           sources."boxen-1.3.0"
           sources."camelcase-4.1.0"
           sources."chalk-2.3.2"
-          sources."configstore-3.1.1"
+          sources."configstore-3.1.2"
           sources."dot-prop-4.2.0"
           sources."got-6.7.1"
           sources."is-fullwidth-code-point-2.0.0"
@@ -37676,7 +37823,7 @@ in
     };
     dependencies = [
       sources."agent-base-4.2.0"
-      sources."ansi-escapes-3.0.0"
+      sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-3.2.1"
       sources."boom-5.2.0"
@@ -37811,10 +37958,10 @@ in
   ocaml-language-server = nodeEnv.buildNodePackage {
     name = "ocaml-language-server";
     packageName = "ocaml-language-server";
-    version = "1.0.28";
+    version = "1.0.32";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ocaml-language-server/-/ocaml-language-server-1.0.28.tgz";
-      sha512 = "2brmnb1vvd9aw553ngmvfsf5m9wl3i4ykjlms5khiplp02hvsj7g8ag9vn6dznp1r1jg6v5w8sg77z5d23n354jfnfwpxpwl571d307";
+      url = "https://registry.npmjs.org/ocaml-language-server/-/ocaml-language-server-1.0.32.tgz";
+      sha512 = "2hdrvr25l7lv0plz31dqgnrr0qli6332z69ywwns4mxmmyk3mc1s7rjdsgf201rw11nqhwbhj2w7n0zijqldbwi5chdnma667lihcyc";
     };
     dependencies = [
       sources."async-2.6.0"
@@ -37852,10 +37999,10 @@ in
   parsoid = nodeEnv.buildNodePackage {
     name = "parsoid";
     packageName = "parsoid";
-    version = "0.8.0";
+    version = "0.9.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/parsoid/-/parsoid-0.8.0.tgz";
-      sha1 = "fbedac4c5c0b721f4c241287b81bdc3e4c7987c9";
+      url = "https://registry.npmjs.org/parsoid/-/parsoid-0.9.0.tgz";
+      sha512 = "3lvlzvg1anfd8awwwwygwb3s9k6la04asyf6i20wcjmhv328ccx9sicq52w2lqdbyk0x323vk761z1izyd3qbl32rvh7z2657ls9j6x";
     };
     dependencies = [
       sources."accepts-1.3.5"
@@ -37868,18 +38015,18 @@ in
       sources."asap-2.0.6"
       sources."asn1-0.2.3"
       sources."assert-plus-1.0.0"
-      sources."async-0.9.2"
+      sources."async-1.5.2"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.6.0"
       sources."babybird-0.0.1"
       sources."balanced-match-1.0.0"
       sources."bcrypt-pbkdf-1.0.1"
-      sources."bl-1.2.1"
+      sources."bl-1.2.2"
       sources."bluebird-3.5.1"
       (sources."body-parser-1.18.2" // {
         dependencies = [
-          sources."content-type-1.0.4"
+          sources."setprototypeof-1.0.3"
         ];
       })
       sources."boom-4.3.1"
@@ -37906,7 +38053,7 @@ in
       sources."content-type-git+https://github.com/wikimedia/content-type.git#master"
       sources."cookie-0.3.1"
       sources."cookie-signature-1.0.6"
-      sources."core-js-2.5.3"
+      sources."core-js-2.5.4"
       sources."core-util-is-1.0.2"
       (sources."cryptiles-3.1.2" // {
         dependencies = [
@@ -37921,15 +38068,15 @@ in
       sources."depd-1.1.2"
       sources."destroy-1.0.4"
       sources."dicer-0.2.5"
-      sources."diff-1.4.0"
       sources."dnscache-1.0.1"
-      sources."dom-storage-2.0.2"
-      sources."domino-1.0.30"
+      sources."dom-storage-2.1.0"
+      sources."domino-2.0.2"
       sources."dtrace-provider-0.8.6"
       sources."ecc-jsbn-0.1.1"
       sources."ee-first-1.1.1"
       sources."encodeurl-1.0.2"
       sources."entities-1.1.1"
+      sources."errno-0.1.7"
       sources."error-ex-1.3.1"
       sources."escape-html-1.0.3"
       sources."esprima-4.0.0"
@@ -37937,12 +38084,10 @@ in
       (sources."express-4.16.3" // {
         dependencies = [
           sources."content-type-1.0.4"
-          sources."setprototypeof-1.1.0"
         ];
       })
       (sources."express-handlebars-3.0.0" // {
         dependencies = [
-          sources."async-1.5.2"
           sources."wordwrap-0.0.2"
           sources."yargs-3.10.0"
         ];
@@ -38028,7 +38173,7 @@ in
       sources."ms-2.0.0"
       sources."msgpack5-3.6.0"
       sources."mv-2.1.1"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."ncp-2.0.0"
       sources."negotiator-git+https://github.com/arlolra/negotiator.git#full-parse-access"
       sources."normalize-package-data-2.4.0"
@@ -38052,10 +38197,12 @@ in
       sources."pify-2.3.0"
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
+      sources."pn-1.1.0"
       sources."prfun-2.1.5"
       sources."process-nextick-args-2.0.0"
       sources."promise-7.3.1"
       sources."proxy-addr-2.0.3"
+      sources."prr-1.0.1"
       sources."punycode-1.4.1"
       sources."qs-6.5.1"
       sources."range-parser-1.2.0"
@@ -38077,6 +38224,7 @@ in
       sources."serve-static-1.13.2"
       (sources."service-runner-2.5.2" // {
         dependencies = [
+          sources."async-0.9.2"
           sources."isarray-1.0.0"
           sources."minimist-0.0.8"
           sources."ms-0.7.3"
@@ -38085,7 +38233,7 @@ in
         ];
       })
       sources."set-blocking-2.0.0"
-      sources."setprototypeof-1.0.3"
+      sources."setprototypeof-1.1.0"
       sources."simplediff-0.1.1"
       sources."sntp-2.1.0"
       sources."source-map-0.4.4"
@@ -38094,7 +38242,7 @@ in
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.0"
       sources."sprintf-js-1.0.3"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."statuses-1.4.0"
       sources."streamsearch-0.1.2"
       sources."string-width-1.0.2"
@@ -38122,6 +38270,7 @@ in
       sources."which-module-1.0.0"
       sources."window-size-0.1.0"
       sources."wordwrap-0.0.3"
+      sources."worker-farm-1.6.0"
       sources."wrap-ansi-2.1.0"
       sources."wrappy-1.0.2"
       sources."y18n-3.2.1"
@@ -38163,7 +38312,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-0.0.8"
       sources."bencode-2.0.0"
-      sources."big-integer-1.6.26"
+      sources."big-integer-1.6.27"
       sources."bitfield-0.1.0"
       sources."bittorrent-dht-6.4.2"
       sources."bittorrent-tracker-7.7.0"
@@ -38174,9 +38323,12 @@ in
       sources."bplist-creator-0.0.6"
       sources."bplist-parser-0.1.1"
       sources."brace-expansion-1.1.11"
+      sources."buffer-alloc-1.1.0"
       sources."buffer-alloc-unsafe-1.0.0"
       sources."buffer-equal-0.0.1"
       sources."buffer-equals-1.0.4"
+      sources."buffer-fill-0.1.1"
+      sources."buffer-from-1.0.0"
       sources."buffer-indexof-1.1.1"
       sources."builtin-modules-1.1.1"
       sources."camelcase-2.1.1"
@@ -38188,7 +38340,7 @@ in
       sources."code-point-at-1.1.0"
       sources."compact2string-1.4.0"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."consume-http-header-1.0.0"
       sources."consume-until-1.0.0"
       sources."core-util-is-1.0.2"
@@ -38299,8 +38451,8 @@ in
       sources."path-exists-2.1.0"
       sources."path-is-absolute-1.0.1"
       sources."path-type-1.1.0"
-      sources."peer-wire-protocol-0.7.0"
-      (sources."peer-wire-swarm-0.12.1" // {
+      sources."peer-wire-protocol-0.7.1"
+      (sources."peer-wire-swarm-0.12.2" // {
         dependencies = [
           sources."bncode-0.2.3"
         ];
@@ -38315,7 +38467,7 @@ in
       sources."random-iterate-1.0.1"
       sources."randombytes-2.0.6"
       sources."range-parser-1.2.0"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."re-emitter-1.1.3"
       sources."read-pkg-1.1.0"
       sources."read-pkg-up-1.0.1"
@@ -38326,8 +38478,8 @@ in
       sources."reverse-http-1.3.0"
       sources."rimraf-2.6.2"
       sources."run-async-2.3.0"
-      sources."run-parallel-1.1.7"
-      sources."run-series-1.1.4"
+      sources."run-parallel-1.1.8"
+      sources."run-series-1.1.6"
       sources."rusha-0.8.13"
       sources."rx-4.1.0"
       sources."safe-buffer-5.1.1"
@@ -38373,9 +38525,10 @@ in
         ];
       })
       sources."torrent-piece-1.1.1"
-      (sources."torrent-stream-1.0.3" // {
+      (sources."torrent-stream-1.0.4" // {
         dependencies = [
           sources."bencode-0.7.0"
+          sources."buffer-alloc-unsafe-0.1.1"
           sources."end-of-stream-0.1.5"
           sources."isarray-0.0.1"
           sources."magnet-uri-4.2.3"
@@ -38448,9 +38601,12 @@ in
       sources."body-parser-1.13.3"
       sources."boom-0.3.8"
       sources."brace-expansion-1.1.11"
+      sources."buffer-alloc-1.1.0"
       sources."buffer-alloc-unsafe-1.0.0"
       sources."buffer-equal-0.0.1"
       sources."buffer-equals-1.0.4"
+      sources."buffer-fill-0.1.1"
+      sources."buffer-from-1.0.0"
       sources."bytes-2.1.0"
       sources."callsite-1.0.0"
       sources."combined-stream-0.0.7"
@@ -38606,8 +38762,8 @@ in
       sources."parseurl-1.3.2"
       sources."path-is-absolute-1.0.1"
       sources."pause-0.1.0"
-      sources."peer-wire-protocol-0.7.0"
-      (sources."peer-wire-swarm-0.12.1" // {
+      sources."peer-wire-protocol-0.7.1"
+      (sources."peer-wire-swarm-0.12.2" // {
         dependencies = [
           sources."bncode-0.2.3"
         ];
@@ -38644,8 +38800,8 @@ in
       })
       sources."rimraf-2.6.2"
       sources."rndm-1.2.0"
-      sources."run-parallel-1.1.7"
-      sources."run-series-1.1.4"
+      sources."run-parallel-1.1.8"
+      sources."run-series-1.1.6"
       sources."rusha-0.8.13"
       sources."safe-buffer-5.1.1"
       (sources."send-0.13.0" // {
@@ -38690,7 +38846,7 @@ in
         ];
       })
       sources."speedometer-0.1.4"
-      sources."statuses-1.4.0"
+      sources."statuses-1.5.0"
       sources."stream-counter-0.2.0"
       sources."string2compact-1.2.2"
       sources."string_decoder-0.10.31"
@@ -38699,9 +38855,10 @@ in
       sources."to-array-0.1.4"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.1"
-      (sources."torrent-stream-1.0.3" // {
+      (sources."torrent-stream-1.0.4" // {
         dependencies = [
           sources."bencode-0.8.0"
+          sources."buffer-alloc-unsafe-0.1.1"
           sources."debug-2.6.9"
           sources."end-of-stream-0.1.5"
           sources."isarray-1.0.0"
@@ -38767,7 +38924,7 @@ in
       sources."caseless-0.11.0"
       sources."chalk-1.1.3"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.5.0"
       sources."core-util-is-1.0.2"
@@ -38839,7 +38996,7 @@ in
       sources."request-progress-2.0.1"
       sources."rimraf-2.6.2"
       sources."sntp-1.0.9"
-      (sources."sshpk-1.13.1" // {
+      (sources."sshpk-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -38927,7 +39084,7 @@ in
       sources."astw-2.2.0"
       sources."async-1.5.2"
       sources."async-each-1.0.1"
-      sources."atob-2.0.3"
+      sources."atob-2.1.0"
       sources."balanced-match-1.0.0"
       (sources."base-0.11.2" // {
         dependencies = [
@@ -38958,14 +39115,13 @@ in
       (sources."browserify-13.3.0" // {
         dependencies = [
           sources."acorn-5.5.3"
-          sources."combine-source-map-0.7.2"
           (sources."concat-stream-1.5.2" // {
             dependencies = [
               sources."readable-stream-2.0.6"
             ];
           })
           sources."hash-base-2.0.2"
-          sources."isarray-0.0.1"
+          sources."isarray-2.0.4"
           sources."process-nextick-args-2.0.0"
         ];
       })
@@ -38983,11 +39139,12 @@ in
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.1.4"
       sources."buffer-4.9.1"
+      sources."buffer-from-1.0.0"
       sources."buffer-xor-1.0.3"
       sources."builtin-status-codes-3.0.0"
       sources."cache-base-1.0.1"
       sources."cached-path-relative-1.0.1"
-      (sources."chokidar-2.0.2" // {
+      (sources."chokidar-2.0.3" // {
         dependencies = [
           sources."is-accessor-descriptor-1.0.0"
           sources."is-data-descriptor-1.0.0"
@@ -39006,7 +39163,7 @@ in
       sources."combine-source-map-0.8.0"
       sources."component-emitter-1.2.1"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."console-browserify-1.1.0"
       sources."constants-browserify-1.0.0"
       sources."convert-source-map-1.1.3"
@@ -39065,12 +39222,16 @@ in
       sources."hmac-drbg-1.0.1"
       sources."htmlescape-1.1.1"
       sources."https-browserify-0.0.1"
-      sources."ieee754-1.1.8"
+      sources."ieee754-1.1.11"
       sources."indexof-0.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."inline-source-map-0.6.2"
-      sources."insert-module-globals-7.0.2"
+      (sources."insert-module-globals-7.0.5" // {
+        dependencies = [
+          sources."concat-stream-1.6.2"
+        ];
+      })
       sources."is-accessor-descriptor-1.0.0"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
@@ -39090,13 +39251,13 @@ in
       sources."jsonify-0.0.0"
       sources."jsonparse-1.3.1"
       sources."kind-of-6.0.2"
-      sources."labeled-stream-splicer-2.0.0"
+      sources."labeled-stream-splicer-2.0.1"
       sources."lexical-scope-1.2.0"
       sources."lodash.memoize-3.0.4"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
       sources."md5.js-1.3.4"
-      sources."micromatch-3.1.9"
+      sources."micromatch-3.1.10"
       sources."miller-rabin-4.0.1"
       sources."mime-1.6.0"
       sources."minimalistic-assert-1.0.0"
@@ -39107,7 +39268,7 @@ in
       sources."module-deps-4.1.1"
       sources."ms-2.0.0"
       sources."mute-stream-0.0.7"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."nanomatch-1.2.9"
       sources."neo-async-2.5.0"
       (sources."node-static-0.7.10" // {
@@ -39156,7 +39317,7 @@ in
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.2"
       sources."repeat-string-1.6.1"
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
       sources."rimraf-2.2.8"
@@ -39165,7 +39326,7 @@ in
       sources."safe-regex-1.1.0"
       sources."set-immediate-shim-1.0.1"
       sources."set-value-2.0.0"
-      sources."sha.js-2.4.10"
+      sources."sha.js-2.4.11"
       sources."shasum-1.0.2"
       sources."shell-quote-1.6.1"
       (sources."snapdragon-0.8.2" // {
@@ -39197,7 +39358,7 @@ in
       sources."static-extend-0.1.2"
       sources."stream-browserify-2.0.1"
       sources."stream-combiner2-1.1.1"
-      sources."stream-http-2.8.0"
+      sources."stream-http-2.8.1"
       sources."stream-splicer-2.0.0"
       sources."string-stream-0.0.7"
       sources."string_decoder-0.10.31"
@@ -39214,7 +39375,7 @@ in
       sources."tree-kill-1.2.0"
       sources."tty-browserify-0.0.1"
       sources."typedarray-0.0.6"
-      sources."umd-3.0.2"
+      sources."umd-3.0.3"
       (sources."union-value-1.0.0" // {
         dependencies = [
           sources."set-value-0.4.3"
@@ -39306,7 +39467,6 @@ in
       })
       sources."ajv-4.11.8"
       sources."align-text-0.1.4"
-      sources."amdefine-1.0.1"
       sources."ansi-regex-2.1.1"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.4"
@@ -39323,7 +39483,7 @@ in
       sources."basic-auth-2.0.0"
       sources."bcrypt-pbkdf-1.0.1"
       sources."bindings-1.2.1"
-      sources."bl-1.2.1"
+      sources."bl-1.2.2"
       sources."body-parser-1.18.2"
       sources."boom-2.10.1"
       sources."bufferutil-2.0.1"
@@ -39333,12 +39493,12 @@ in
       sources."center-align-0.1.3"
       sources."character-parser-2.2.0"
       sources."chownr-1.0.1"
-      sources."clean-css-3.4.28"
+      sources."clean-css-4.1.11"
       sources."cliui-2.1.0"
       sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."console-control-strings-1.1.0"
       sources."constantinople-3.1.2"
       sources."content-disposition-0.5.2"
@@ -39346,7 +39506,7 @@ in
       sources."cookie-0.3.1"
       sources."cookie-parser-1.4.3"
       sources."cookie-signature-1.0.6"
-      sources."core-js-2.5.3"
+      sources."core-js-2.5.4"
       sources."core-util-is-1.0.2"
       sources."cryptiles-2.0.5"
       sources."dashdash-1.14.1"
@@ -39371,6 +39531,7 @@ in
       (sources."express-4.16.3" // {
         dependencies = [
           sources."setprototypeof-1.1.0"
+          sources."statuses-1.4.0"
         ];
       })
       sources."extend-3.0.1"
@@ -39385,7 +39546,6 @@ in
       sources."getpass-0.1.7"
       sources."github-from-package-0.0.0"
       sources."graceful-fs-4.1.11"
-      sources."graceful-readlink-1.0.1"
       sources."har-schema-1.0.5"
       sources."har-validator-4.2.1"
       sources."has-1.0.1"
@@ -39476,21 +39636,15 @@ in
       sources."promise-7.3.1"
       sources."proxy-addr-2.0.3"
       sources."prr-1.0.1"
-      (sources."pug-2.0.1" // {
+      (sources."pug-2.0.3" // {
         dependencies = [
           sources."acorn-4.0.13"
-          sources."commander-2.8.1"
-          sources."source-map-0.4.4"
         ];
       })
       sources."pug-attrs-2.0.3"
       sources."pug-code-gen-2.0.1"
       sources."pug-error-1.3.2"
-      (sources."pug-filters-3.0.1" // {
-        dependencies = [
-          sources."source-map-0.5.7"
-        ];
-      })
+      sources."pug-filters-3.1.0"
       sources."pug-lexer-4.0.0"
       sources."pug-linker-3.0.5"
       sources."pug-load-2.0.11"
@@ -39504,12 +39658,12 @@ in
       sources."qtdatastream-0.7.1"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.2"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."readable-stream-2.3.5"
       sources."regenerator-runtime-0.11.1"
       sources."repeat-string-1.6.1"
       sources."request-2.81.0"
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."right-align-0.1.3"
       sources."safe-buffer-5.1.1"
       sources."semver-5.5.0"
@@ -39528,12 +39682,12 @@ in
       sources."simple-get-1.4.3"
       sources."sntp-1.0.9"
       sources."source-map-0.5.7"
-      (sources."sshpk-1.13.1" // {
+      (sources."sshpk-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
       })
-      sources."statuses-1.4.0"
+      sources."statuses-1.5.0"
       sources."string-width-1.0.2"
       sources."string_decoder-1.0.3"
       sources."stringstream-0.0.5"
@@ -39591,7 +39745,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base62-0.1.1"
       sources."brace-expansion-1.1.11"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."commoner-0.10.8"
       sources."concat-map-0.0.1"
       sources."defined-1.0.0"
@@ -39811,7 +39965,7 @@ in
       sources."sax-1.2.4"
       sources."send-0.1.4"
       sources."sntp-2.1.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."stream-counter-0.2.0"
       sources."string-1.6.1"
       sources."string_decoder-0.10.31"
@@ -39901,7 +40055,7 @@ in
       sources."color-name-1.1.3"
       sources."compressible-2.0.13"
       sources."compression-1.7.2"
-      sources."configstore-3.1.1"
+      sources."configstore-3.1.2"
       sources."content-type-1.0.4"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-5.1.0"
@@ -39964,7 +40118,7 @@ in
       sources."lazy-cache-1.0.4"
       sources."lodash-4.17.5"
       sources."longest-1.0.1"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
       sources."micro-9.1.0"
@@ -39994,7 +40148,7 @@ in
       sources."pseudomap-1.0.2"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.2"
-      sources."rc-1.2.5"
+      sources."rc-1.2.6"
       sources."registry-auth-token-3.3.2"
       sources."registry-url-3.1.0"
       sources."repeat-string-1.6.1"
@@ -40006,6 +40160,7 @@ in
         dependencies = [
           sources."depd-1.1.2"
           sources."ms-2.0.0"
+          sources."statuses-1.4.0"
         ];
       })
       sources."setprototypeof-1.0.3"
@@ -40013,7 +40168,7 @@ in
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
       sources."source-map-0.4.4"
-      sources."statuses-1.4.0"
+      sources."statuses-1.5.0"
       sources."string-similarity-1.2.0"
       sources."string-width-2.1.1"
       sources."strip-ansi-4.0.0"
@@ -40097,7 +40252,7 @@ in
       })
       sources."co-4.6.0"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.1.2"
       sources."component-inherit-0.0.3"
@@ -40241,7 +40396,7 @@ in
       sources."socket.io-client-1.0.6"
       sources."socket.io-parser-2.2.0"
       sources."split-0.3.3"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."statuses-1.4.0"
       sources."stream-combiner-0.0.4"
       sources."string_decoder-0.10.31"
@@ -40318,7 +40473,7 @@ in
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."compressible-2.0.13"
       (sources."compression-1.7.2" // {
         dependencies = [
@@ -40431,7 +40586,7 @@ in
       sources."moment-2.21.0"
       sources."ms-2.0.0"
       sources."mv-2.1.1"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."ncp-2.0.0"
       sources."negotiator-0.6.1"
       sources."number-is-nan-1.0.1"
@@ -40444,7 +40599,7 @@ in
       sources."path-is-absolute-1.0.1"
       sources."path-to-regexp-0.1.7"
       sources."performance-now-2.1.0"
-      sources."postcss-6.0.19"
+      sources."postcss-6.0.21"
       sources."process-nextick-args-2.0.0"
       sources."proxy-addr-1.1.5"
       sources."punycode-1.4.1"
@@ -40488,7 +40643,7 @@ in
       sources."source-map-0.1.43"
       sources."sprintf-js-1.0.3"
       sources."srcset-1.0.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."statuses-1.3.1"
       sources."string_decoder-1.0.3"
       sources."stringstream-0.0.5"
@@ -40592,7 +40747,7 @@ in
       sources."ecc-jsbn-0.1.1"
       sources."escape-regexp-component-1.0.2"
       sources."extsprintf-1.2.0"
-      sources."formidable-1.2.0"
+      sources."formidable-1.2.1"
       sources."glob-6.0.4"
       sources."http-signature-0.11.0"
       sources."inflight-1.0.6"
@@ -40609,7 +40764,7 @@ in
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."mv-2.1.1"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."ncp-2.0.0"
       sources."negotiator-0.5.3"
       sources."node-uuid-1.4.8"
@@ -40800,7 +40955,7 @@ in
       sources."hashring-3.2.0"
       sources."keypress-0.1.0"
       sources."modern-syslog-1.1.2"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."sequence-2.2.1"
       sources."simple-lru-cache-0.0.2"
       sources."winser-0.1.6"
@@ -40921,7 +41076,7 @@ in
       sources."domelementtype-1.3.0"
       sources."domutils-1.5.1"
       sources."entities-1.1.1"
-      sources."es-abstract-1.10.0"
+      sources."es-abstract-1.11.0"
       sources."es-to-primitive-1.1.1"
       sources."esprima-4.0.0"
       sources."foreach-2.0.5"
@@ -41033,7 +41188,7 @@ in
       sources."co-4.6.0"
       sources."colors-1.1.2"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."core-util-is-1.0.2"
       sources."cryptiles-2.0.5"
       sources."cycle-1.0.3"
@@ -41128,7 +41283,7 @@ in
       sources."source-map-0.1.32"
       sources."source-map-support-0.3.2"
       sources."sprintf-0.1.5"
-      (sources."sshpk-1.13.1" // {
+      (sources."sshpk-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -41169,10 +41324,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "2.7.2";
+    version = "2.8.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz";
-      sha512 = "2gjv6xyp9rqfdfqadayc4b36b79sjdiwsxa38z43v01cdn3xbc06ax90mjv36hxj9j96nfbwr6w1wn7n0zq8f3y3fw4jfy0j1hw5557";
+      url = "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz";
+      sha512 = "1v0ac83sjf21wg11fpllicxz8irx9yg341zmng7vz15524gbfphc9ch70n4x9r70gm0r4ak79xyaxw9zh6b2cwcs7mg447qvzlxz3q2";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -41206,9 +41361,11 @@ in
       sources."bluebird-3.5.1"
       sources."boxen-1.3.0"
       sources."brace-expansion-1.1.11"
+      sources."buffer-from-1.0.0"
       sources."camelcase-4.1.0"
       sources."capture-stack-trace-1.0.0"
       sources."chalk-1.1.3"
+      sources."ci-info-1.1.3"
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-1.0.2"
       (sources."cli-truncate-1.1.0" // {
@@ -41217,14 +41374,14 @@ in
           sources."strip-ansi-4.0.0"
         ];
       })
-      sources."clone-1.0.3"
+      sources."clone-1.0.4"
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."columnify-1.5.4"
       sources."combined-stream-1.0.6"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
-      sources."configstore-3.1.1"
+      sources."concat-stream-1.6.2"
+      sources."configstore-3.1.2"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-5.1.0"
@@ -41261,9 +41418,10 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."ini-1.3.5"
-      sources."invariant-2.2.3"
+      sources."invariant-2.2.4"
       sources."is-absolute-0.2.6"
       sources."is-arrayish-0.2.1"
+      sources."is-ci-1.1.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-installed-globally-0.1.0"
       sources."is-npm-1.0.0"
@@ -41286,7 +41444,7 @@ in
       sources."lockfile-1.0.3"
       sources."log-update-1.0.2"
       sources."loose-envify-1.3.1"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
       sources."make-error-1.3.4"
@@ -41319,7 +41477,7 @@ in
       sources."promise-finally-3.0.0"
       sources."pseudomap-1.0.2"
       sources."punycode-1.4.1"
-      (sources."rc-1.2.5" // {
+      (sources."rc-1.2.6" // {
         dependencies = [
           sources."minimist-1.2.0"
         ];
@@ -41352,7 +41510,7 @@ in
       sources."touch-1.0.0"
       sources."tough-cookie-2.3.4"
       sources."typedarray-0.0.6"
-      sources."typescript-2.7.2"
+      sources."typescript-2.8.1"
       (sources."typings-core-2.3.3" // {
         dependencies = [
           sources."minimist-0.0.8"
@@ -41361,7 +41519,7 @@ in
       sources."unc-path-regex-0.1.2"
       sources."unique-string-1.0.0"
       sources."unzip-response-2.0.1"
-      (sources."update-notifier-2.3.0" // {
+      (sources."update-notifier-2.4.0" // {
         dependencies = [
           sources."ansi-styles-3.2.1"
           sources."chalk-2.3.2"
@@ -41394,19 +41552,19 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "3.3.14";
+    version = "3.3.16";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.14.tgz";
-      sha512 = "0b7d9nvyrhc5ij0xaxvgha7h97d5h36zhnwmbbbj5abk64bvn38sf4d5jwy64n8algm2q36a08n0z4k4khhnnq4h4ysvrin0lyib3rr";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz";
+      sha512 = "2zdbgaqy5a8mrv3gkljjw8iishfj4iwncazi3g0zcymqppc19474s24irqvmnhs1iy38g18086l72ilqkvlvnhnyipnhi49394pkj0l";
     };
     dependencies = [
-      sources."commander-2.14.1"
+      sources."commander-2.15.1"
       sources."source-map-0.6.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "JavaScript parser, mangler/compressor and beautifier toolkit";
-      homepage = http://lisperator.net/uglifyjs;
+      homepage = "https://github.com/mishoo/UglifyJS2#readme";
       license = "BSD-2-Clause";
     };
     production = true;
@@ -41415,10 +41573,10 @@ in
   ungit = nodeEnv.buildNodePackage {
     name = "ungit";
     packageName = "ungit";
-    version = "1.4.12";
+    version = "1.4.17";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ungit/-/ungit-1.4.12.tgz";
-      sha512 = "2g1lac2bgp7zgrl4jvmapyqy51rvzmphx3nlvy1hmy6ld2k5dycmhbv6qqq740ypdi57wd7vch5nlrf2w833mbk54rglhq80ly7vwk6";
+      url = "https://registry.npmjs.org/ungit/-/ungit-1.4.17.tgz";
+      sha512 = "1qy7j5zv8kvk5c9y4pjh0x8m243yhc1prv9s3kqbbpsxkgapdk8ap6dwa3nhh93cj5v1mb29jnfqqy20lypwvy8j8z3436vdckhc480";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -41449,21 +41607,23 @@ in
       sources."body-parser-1.18.2"
       sources."boom-4.3.1"
       sources."brace-expansion-1.1.11"
+      sources."buffer-from-1.0.0"
       sources."builtin-modules-1.1.1"
       sources."builtins-1.0.3"
       sources."bytes-3.0.0"
       sources."callsite-1.0.0"
       sources."camelcase-4.1.0"
       sources."caseless-0.12.0"
+      sources."charenc-0.0.2"
       (sources."cliui-4.0.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
         ];
       })
-      sources."clone-2.1.1"
+      sources."clone-2.1.2"
       sources."co-4.6.0"
       sources."code-point-at-1.1.0"
-      sources."color-2.0.1"
+      sources."color-3.0.0"
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."color-string-1.5.2"
@@ -41473,7 +41633,7 @@ in
       sources."component-emitter-1.1.2"
       sources."component-inherit-0.0.3"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."console-control-strings-1.1.0"
       sources."content-disposition-0.5.2"
       sources."content-type-1.0.4"
@@ -41485,6 +41645,7 @@ in
       sources."crc-3.4.4"
       sources."cross-spawn-5.1.0"
       sources."crossroads-0.12.2"
+      sources."crypt-0.0.2"
       (sources."cryptiles-3.1.2" // {
         dependencies = [
           sources."boom-5.2.0"
@@ -41528,6 +41689,7 @@ in
       (sources."express-4.16.3" // {
         dependencies = [
           sources."setprototypeof-1.1.0"
+          sources."statuses-1.4.0"
         ];
       })
       sources."express-session-1.15.6"
@@ -41548,7 +41710,7 @@ in
       sources."gauge-2.7.4"
       sources."get-caller-file-1.0.2"
       sources."get-stream-3.0.0"
-      sources."getmac-1.2.1"
+      sources."getmac-1.4.1"
       sources."getpass-0.1.7"
       sources."glob-7.1.2"
       sources."graceful-fs-4.1.11"
@@ -41577,6 +41739,7 @@ in
       sources."invert-kv-1.0.0"
       sources."ipaddr.js-1.6.0"
       sources."is-arrayish-0.3.1"
+      sources."is-buffer-1.1.6"
       sources."is-builtin-module-1.0.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."is-stream-1.1.0"
@@ -41604,7 +41767,7 @@ in
       sources."locate-path-2.0.0"
       sources."lodash-4.17.5"
       sources."lru-cache-4.1.2"
-      sources."lsmod-1.0.0"
+      sources."md5-2.2.1"
       sources."media-typer-0.3.0"
       sources."mem-1.1.0"
       (sources."memorystore-1.6.0" // {
@@ -41621,13 +41784,13 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."moment-2.20.1"
+      sources."moment-2.21.0"
       sources."ms-2.0.0"
       sources."negotiator-0.6.1"
       sources."node-cache-4.1.1"
       sources."nopt-1.0.10"
       sources."normalize-package-data-2.4.0"
-      sources."npm-5.6.0"
+      sources."npm-5.7.1"
       sources."npm-package-arg-6.0.0"
       (sources."npm-registry-client-8.5.1" // {
         dependencies = [
@@ -41679,13 +41842,13 @@ in
       sources."qs-6.5.1"
       sources."random-bytes-1.0.0"
       sources."range-parser-1.2.0"
-      (sources."raven-2.3.0" // {
+      (sources."raven-2.4.2" // {
         dependencies = [
           sources."uuid-3.0.0"
         ];
       })
       sources."raw-body-2.3.2"
-      (sources."rc-1.2.5" // {
+      (sources."rc-1.2.6" // {
         dependencies = [
           sources."minimist-1.2.0"
         ];
@@ -41698,7 +41861,7 @@ in
       sources."retry-0.10.1"
       sources."rimraf-2.6.2"
       sources."safe-buffer-5.1.1"
-      sources."semver-5.4.1"
+      sources."semver-5.5.0"
       sources."send-0.16.2"
       sources."serve-static-1.13.2"
       sources."set-blocking-2.0.0"
@@ -41728,10 +41891,10 @@ in
       sources."spdx-exceptions-2.1.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.0"
-      sources."sshpk-1.13.1"
-      sources."ssri-5.2.4"
+      sources."sshpk-1.14.1"
+      sources."ssri-5.3.0"
       sources."stack-trace-0.0.9"
-      sources."statuses-1.4.0"
+      sources."statuses-1.5.0"
       sources."string-width-1.0.2"
       sources."string_decoder-0.10.31"
       sources."stringstream-0.0.5"
@@ -41747,7 +41910,7 @@ in
           sources."delayed-stream-1.0.0"
           sources."extend-3.0.1"
           sources."form-data-2.3.2"
-          sources."formidable-1.2.0"
+          sources."formidable-1.2.1"
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.5"
           sources."string_decoder-1.0.3"
@@ -41798,7 +41961,7 @@ in
       sources."xmlhttprequest-ssl-1.5.5"
       sources."y18n-3.2.1"
       sources."yallist-2.1.2"
-      (sources."yargs-10.1.2" // {
+      (sources."yargs-11.1.0" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
           sources."is-fullwidth-code-point-2.0.0"
@@ -41806,7 +41969,7 @@ in
           sources."strip-ansi-4.0.0"
         ];
       })
-      sources."yargs-parser-8.1.0"
+      sources."yargs-parser-9.0.2"
       sources."yeast-0.1.2"
     ];
     buildInputs = globalBuildInputs;
@@ -41843,7 +42006,7 @@ in
       sources."caseless-0.11.0"
       sources."chalk-1.1.3"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.5.0"
       (sources."config-chain-1.1.11" // {
@@ -41934,7 +42097,7 @@ in
       sources."rimraf-2.6.2"
       sources."semver-2.3.2"
       sources."sntp-1.0.9"
-      (sources."sshpk-1.13.1" // {
+      (sources."sshpk-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -41969,15 +42132,15 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "4.1.1";
+    version = "4.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-4.1.1.tgz";
-      sha512 = "2gs8dnr0n1p7npwjb37f3mh08gfrab0xcfp6cwm4zyxvx5lkx2hvqr81sd8mcyys9062f2pvx7njbr6zzwbr68lr37kcbkjrlgll31z";
+      url = "https://registry.npmjs.org/webpack/-/webpack-4.3.0.tgz";
+      sha512 = "2400lwkwf9k7jyyw0a7ldddcnbn8s50zprrqy32fxph9rv82qa8y7lk4kvili1g8xxzkivwsb1isfxzc7jxls4yw5w8bw3kkhpdhmm0";
     };
     dependencies = [
       sources."acorn-5.5.3"
       sources."acorn-dynamic-import-3.0.0"
-      sources."ajv-6.2.1"
+      sources."ajv-6.4.0"
       sources."ajv-keywords-3.1.0"
       sources."anymatch-2.0.0"
       sources."aproba-1.2.0"
@@ -41989,7 +42152,7 @@ in
       sources."assert-1.4.1"
       sources."assign-symbols-1.0.0"
       sources."async-each-1.0.1"
-      sources."atob-2.0.3"
+      sources."atob-2.1.0"
       sources."balanced-match-1.0.0"
       (sources."base-0.11.2" // {
         dependencies = [
@@ -42022,11 +42185,12 @@ in
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
       sources."buffer-4.9.1"
+      sources."buffer-from-1.0.0"
       sources."buffer-xor-1.0.3"
       sources."builtin-status-codes-3.0.0"
       sources."cacache-10.0.4"
       sources."cache-base-1.0.1"
-      sources."chokidar-2.0.2"
+      sources."chokidar-2.0.3"
       sources."chownr-1.0.1"
       sources."chrome-trace-event-0.1.2"
       sources."cipher-base-1.0.4"
@@ -42040,7 +42204,7 @@ in
       sources."commondir-1.0.1"
       sources."component-emitter-1.2.1"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
+      sources."concat-stream-1.6.2"
       sources."console-browserify-1.1.0"
       sources."constants-browserify-1.0.0"
       sources."copy-concurrently-1.0.5"
@@ -42092,7 +42256,7 @@ in
       })
       sources."find-cache-dir-1.0.0"
       sources."find-up-2.1.0"
-      sources."flush-write-stream-1.0.2"
+      sources."flush-write-stream-1.0.3"
       sources."for-in-1.0.2"
       sources."fragment-cache-0.2.1"
       sources."from2-2.3.0"
@@ -42113,7 +42277,7 @@ in
       sources."hash.js-1.1.3"
       sources."hmac-drbg-1.0.1"
       sources."https-browserify-1.0.0"
-      sources."ieee754-1.1.8"
+      sources."ieee754-1.1.11"
       sources."iferr-0.1.5"
       sources."imurmurhash-0.1.4"
       sources."indexof-0.0.1"
@@ -42145,7 +42309,7 @@ in
       sources."map-visit-1.0.0"
       sources."md5.js-1.3.4"
       sources."memory-fs-0.4.1"
-      (sources."micromatch-3.1.9" // {
+      (sources."micromatch-3.1.10" // {
         dependencies = [
           sources."has-values-0.1.4"
           (sources."is-accessor-descriptor-0.1.6" // {
@@ -42173,13 +42337,14 @@ in
       sources."mkdirp-0.5.1"
       sources."move-concurrently-1.0.1"
       sources."ms-2.0.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
       sources."nanomatch-1.2.9"
       sources."neo-async-2.5.0"
       (sources."node-libs-browser-2.1.0" // {
         dependencies = [
           sources."hash-base-2.0.2"
           sources."inherits-2.0.1"
+          sources."punycode-1.4.1"
         ];
       })
       sources."normalize-path-2.1.1"
@@ -42211,7 +42376,7 @@ in
       sources."public-encrypt-4.0.0"
       sources."pump-2.0.1"
       sources."pumpify-1.4.0"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.0"
       sources."querystring-0.2.0"
       sources."querystring-es3-0.2.1"
       sources."randombytes-2.0.6"
@@ -42234,7 +42399,7 @@ in
       sources."set-immediate-shim-1.0.1"
       sources."set-value-2.0.0"
       sources."setimmediate-1.0.5"
-      sources."sha.js-2.4.10"
+      sources."sha.js-2.4.11"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
           (sources."define-property-0.2.5" // {
@@ -42281,11 +42446,11 @@ in
           sources."extend-shallow-3.0.2"
         ];
       })
-      sources."ssri-5.2.4"
+      sources."ssri-5.3.0"
       sources."static-extend-0.1.2"
       sources."stream-browserify-2.0.1"
       sources."stream-each-1.2.2"
-      sources."stream-http-2.8.0"
+      sources."stream-http-2.8.1"
       sources."stream-shift-1.0.0"
       sources."string_decoder-1.0.3"
       sources."tapable-1.0.0"
@@ -42298,7 +42463,7 @@ in
       sources."tty-browserify-0.0.0"
       sources."typedarray-0.0.6"
       sources."uglify-es-3.3.10"
-      (sources."uglifyjs-webpack-plugin-1.2.3" // {
+      (sources."uglifyjs-webpack-plugin-1.2.4" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -42320,6 +42485,7 @@ in
         ];
       })
       sources."upath-1.0.4"
+      sources."uri-js-3.0.2"
       sources."urix-0.1.0"
       (sources."url-0.11.0" // {
         dependencies = [
@@ -42358,20 +42524,18 @@ in
   web-ext = nodeEnv.buildNodePackage {
     name = "web-ext";
     packageName = "web-ext";
-    version = "2.4.0";
+    version = "2.6.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/web-ext/-/web-ext-2.4.0.tgz";
-      sha1 = "4103e737196eb2a9fe83087752357d1dfe618294";
+      url = "https://registry.npmjs.org/web-ext/-/web-ext-2.6.0.tgz";
+      sha1 = "52c074123e6376a4fb673e565c33dd027714e9b0";
     };
     dependencies = [
-      sources."@types/node-9.4.7"
+      sources."@cliqz-oss/firefox-client-0.3.1"
+      sources."@cliqz-oss/node-firefox-connect-1.2.1"
+      sources."@types/node-9.6.1"
       sources."JSONSelect-0.2.1"
+      sources."abbrev-1.1.1"
       sources."acorn-5.5.3"
-      (sources."acorn-dynamic-import-2.0.2" // {
-        dependencies = [
-          sources."acorn-4.0.13"
-        ];
-      })
       (sources."acorn-jsx-3.0.1" // {
         dependencies = [
           sources."acorn-3.3.0"
@@ -42380,7 +42544,7 @@ in
       sources."adbkit-2.11.0"
       sources."adbkit-logcat-1.1.0"
       sources."adbkit-monkey-1.0.1"
-      (sources."addons-linter-0.35.0" // {
+      (sources."addons-linter-0.41.0" // {
         dependencies = [
           sources."ajv-keywords-1.5.1"
           sources."ansi-escapes-1.4.0"
@@ -42389,80 +42553,110 @@ in
           sources."async-2.6.0"
           sources."camelcase-1.2.1"
           sources."cli-cursor-1.0.2"
-          (sources."cliui-3.2.0" // {
-            dependencies = [
-              sources."string-width-1.0.2"
-            ];
-          })
+          sources."cliui-3.2.0"
           sources."debug-3.1.0"
           sources."decamelize-1.2.0"
           sources."domelementtype-1.1.3"
+          sources."es6-promise-3.3.1"
           sources."figures-1.7.0"
-          sources."globals-11.3.0"
-          sources."hash-base-2.0.2"
-          sources."inherits-2.0.1"
+          sources."find-up-2.1.0"
+          sources."for-in-0.1.8"
+          sources."globals-11.4.0"
+          sources."got-3.3.1"
           sources."inquirer-0.12.0"
           sources."is-fullwidth-code-point-1.0.0"
+          sources."latest-version-1.0.1"
+          sources."lazy-cache-0.2.7"
           sources."mute-stream-0.0.5"
+          sources."object-assign-3.0.0"
           sources."onetime-1.1.0"
+          sources."package-json-1.2.0"
           sources."parse-json-2.2.0"
+          sources."path-exists-3.0.0"
           sources."pluralize-1.2.1"
           sources."progress-1.1.8"
-          sources."punycode-2.1.0"
+          sources."punycode-1.3.2"
+          sources."repeating-1.1.3"
           sources."restore-cursor-1.0.1"
           sources."run-async-0.1.0"
           sources."rx-lite-3.1.2"
           sources."slice-ansi-0.0.4"
           sources."source-map-0.6.1"
-          sources."source-map-support-0.5.1"
+          sources."source-map-support-0.5.4"
           sources."string-width-1.0.2"
           sources."strip-ansi-4.0.0"
-          sources."supports-color-4.5.0"
+          sources."strip-bom-2.0.0"
+          sources."supports-color-5.3.0"
           sources."table-3.8.3"
+          sources."timed-out-2.0.0"
+          sources."traverse-0.6.6"
           sources."underscore-1.6.0"
+          sources."update-notifier-0.5.0"
+          sources."which-module-2.0.0"
+          sources."window-size-0.2.0"
           sources."wordwrap-0.0.2"
-          (sources."yargs-10.0.3" // {
+          (sources."yargs-11.0.0" // {
             dependencies = [
               sources."camelcase-4.1.0"
+              sources."cliui-4.0.0"
               sources."is-fullwidth-code-point-2.0.0"
               sources."string-width-2.1.1"
             ];
           })
-          sources."yargs-parser-8.1.0"
+          sources."yargs-parser-9.0.2"
         ];
       })
       sources."adm-zip-0.4.7"
-      sources."ajv-5.5.2"
-      sources."ajv-keywords-3.1.0"
+      sources."ajv-6.3.0"
+      sources."ajv-keywords-2.1.1"
       sources."ajv-merge-patch-3.0.0"
       sources."align-text-0.1.4"
       sources."anchor-markdown-header-0.5.7"
       sources."ansi-align-2.0.0"
-      sources."ansi-escapes-3.0.0"
+      sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
+      sources."ansicolors-0.3.2"
       sources."any-promise-1.3.0"
-      sources."anymatch-1.3.2"
+      (sources."anymatch-2.0.0" // {
+        dependencies = [
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."is-extendable-1.0.1"
+        ];
+      })
       sources."archiver-2.1.1"
       sources."archiver-utils-1.3.0"
+      sources."archy-1.0.0"
       sources."argparse-1.0.10"
-      sources."arr-diff-2.0.0"
+      sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
+      sources."arr-union-3.1.0"
       sources."array-filter-0.0.1"
       sources."array-from-2.1.1"
       sources."array-map-0.0.0"
       sources."array-reduce-0.0.0"
       sources."array-union-1.0.2"
       sources."array-uniq-1.0.3"
-      sources."array-unique-0.2.1"
+      sources."array-unique-0.3.2"
       sources."arrify-1.0.1"
+      sources."asap-2.0.6"
       sources."asn1-0.2.3"
-      sources."asn1.js-4.10.1"
-      sources."assert-1.4.1"
       sources."assert-plus-1.0.0"
+      sources."assign-symbols-1.0.0"
       sources."async-0.2.10"
       sources."async-each-1.0.1"
       sources."asynckit-0.4.0"
+      sources."atob-2.1.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.6.0"
       sources."babel-code-frame-6.26.0"
@@ -42488,43 +42682,40 @@ in
       sources."babylon-6.18.0"
       sources."bail-1.0.2"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.2.3"
-      sources."base64url-2.0.0"
-      sources."bcrypt-pbkdf-1.0.1"
-      sources."big.js-3.2.0"
-      sources."binary-extensions-1.11.0"
-      sources."bl-1.2.1"
-      sources."bluebird-2.9.34"
-      sources."bn.js-4.11.8"
-      sources."boolbase-1.0.0"
-      sources."boom-4.3.1"
-      sources."boundary-1.0.1"
-      sources."boxen-1.3.0"
-      sources."brace-expansion-1.1.11"
-      (sources."braces-1.8.5" // {
+      (sources."base-0.11.2" // {
         dependencies = [
-          sources."kind-of-4.0.0"
+          (sources."define-property-1.0.0" // {
+            dependencies = [
+              sources."kind-of-6.0.2"
+            ];
+          })
+          sources."kind-of-3.2.2"
         ];
       })
-      sources."brorand-1.1.0"
-      sources."browserify-aes-1.1.1"
-      sources."browserify-cipher-1.0.0"
-      sources."browserify-des-1.0.0"
-      sources."browserify-rsa-4.0.1"
-      sources."browserify-sign-4.0.4"
-      sources."browserify-zlib-0.2.0"
-      sources."buffer-4.9.1"
+      sources."base64-js-0.0.2"
+      sources."base64url-2.0.0"
+      sources."bcrypt-pbkdf-1.0.1"
+      sources."binary-extensions-1.11.0"
+      sources."bl-1.2.2"
+      sources."bluebird-2.9.34"
+      sources."boolbase-1.0.0"
+      sources."boom-4.3.1"
+      sources."bops-0.1.1"
+      sources."boundary-1.0.1"
+      sources."boxen-0.3.1"
+      sources."brace-expansion-1.1.11"
+      sources."braces-2.3.1"
       sources."buffer-crc32-0.2.13"
       sources."buffer-equal-constant-time-1.0.1"
-      sources."buffer-xor-1.0.3"
+      sources."buffer-from-1.0.0"
       sources."builtin-modules-1.1.1"
-      sources."builtin-status-codes-3.0.0"
       (sources."bunyan-1.8.12" // {
         dependencies = [
           sources."glob-6.0.4"
           sources."rimraf-2.4.5"
         ];
       })
+      sources."cache-base-1.0.1"
       sources."caller-path-0.1.0"
       sources."callsites-0.2.0"
       sources."camelcase-4.1.0"
@@ -42532,7 +42723,7 @@ in
       sources."caseless-0.12.0"
       sources."ccount-1.0.2"
       sources."center-align-0.1.3"
-      sources."chalk-2.3.0"
+      sources."chalk-2.3.2"
       sources."character-entities-1.2.1"
       sources."character-entities-html4-1.1.1"
       sources."character-entities-legacy-1.1.1"
@@ -42543,39 +42734,54 @@ in
           sources."domelementtype-1.3.0"
         ];
       })
-      sources."chokidar-1.7.0"
-      sources."cipher-base-1.0.4"
+      (sources."chokidar-2.0.3" // {
+        dependencies = [
+          sources."is-accessor-descriptor-1.0.0"
+          sources."is-data-descriptor-1.0.0"
+          sources."is-descriptor-1.0.2"
+          sources."is-extendable-0.1.1"
+        ];
+      })
       sources."circular-json-0.3.3"
+      (sources."class-utils-0.3.6" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+        ];
+      })
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
+      sources."clite-0.3.0"
       sources."cliui-2.1.0"
-      sources."clone-1.0.3"
+      sources."clone-1.0.4"
+      sources."clone-deep-0.3.0"
       sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."collapse-white-space-1.0.3"
+      sources."collection-visit-1.0.0"
       sources."color-convert-1.9.1"
       sources."color-name-1.1.3"
       sources."colors-0.5.1"
       sources."columnify-1.5.4"
       sources."combined-stream-1.0.6"
-      sources."commander-2.15.0"
+      sources."commander-2.15.1"
       sources."common-tags-1.7.2"
+      sources."component-emitter-1.2.1"
       sources."compress-commons-1.2.2"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
-      sources."configstore-3.1.1"
-      sources."console-browserify-1.1.0"
-      sources."constants-browserify-1.0.0"
+      sources."concat-stream-1.6.2"
+      (sources."configstore-1.4.0" // {
+        dependencies = [
+          sources."uuid-2.0.3"
+        ];
+      })
       sources."convert-source-map-1.5.1"
-      sources."core-js-2.5.3"
+      sources."copy-descriptor-0.1.1"
+      sources."core-js-2.5.4"
       sources."core-util-is-1.0.2"
       sources."crc-3.5.0"
       sources."crc32-stream-2.0.0"
-      sources."create-ecdh-4.0.0"
       sources."create-error-class-3.0.2"
-      sources."create-hash-1.1.3"
-      sources."create-hmac-1.1.6"
       sources."cross-spawn-5.1.0"
       sources."crx-parser-0.1.2"
       (sources."cryptiles-3.1.2" // {
@@ -42583,67 +42789,67 @@ in
           sources."boom-5.2.0"
         ];
       })
-      sources."crypto-browserify-3.12.0"
       sources."crypto-random-string-1.0.0"
       sources."css-select-1.2.0"
       sources."css-what-2.1.0"
       sources."d-1.0.0"
       sources."dashdash-1.14.1"
-      sources."date-now-0.1.4"
       sources."debounce-1.1.0"
       sources."debug-2.6.9"
       sources."decamelize-2.0.0"
+      sources."decode-uri-component-0.2.0"
       sources."deep-equal-1.0.1"
       sources."deep-extend-0.4.2"
       sources."deep-is-0.1.3"
       sources."deepcopy-0.6.3"
-      sources."deepmerge-1.5.2"
+      sources."deepmerge-2.1.0"
       sources."defaults-1.0.3"
+      sources."define-property-2.0.2"
       sources."del-2.2.2"
       sources."delayed-stream-1.0.0"
-      sources."des.js-1.0.0"
       sources."detect-indent-4.0.0"
-      sources."diffie-hellman-5.0.2"
-      (sources."dispensary-0.12.0" // {
+      (sources."dispensary-0.16.0" // {
         dependencies = [
-          sources."semver-5.4.1"
-          sources."source-map-support-0.5.0"
+          sources."ajv-5.5.2"
         ];
       })
-      sources."doctoc-1.3.0"
+      sources."doctoc-1.3.1"
       sources."doctrine-2.1.0"
       sources."dom-serializer-0.1.0"
-      sources."domain-browser-1.2.0"
       sources."domelementtype-1.3.0"
       sources."domhandler-2.4.1"
       sources."domutils-1.5.1"
-      sources."dot-prop-4.2.0"
+      sources."dot-prop-3.0.0"
       sources."dtrace-provider-0.8.6"
+      sources."duplexer2-0.1.4"
       sources."duplexer3-0.1.4"
+      sources."duplexify-3.5.4"
       sources."ecc-jsbn-0.1.1"
       sources."ecdsa-sig-formatter-1.0.9"
-      sources."elliptic-6.4.0"
+      sources."email-validator-1.1.1"
       sources."emoji-regex-6.1.3"
-      sources."emojis-list-2.1.0"
       sources."encoding-0.1.12"
       sources."end-of-stream-1.4.1"
-      sources."enhanced-resolve-3.4.1"
       sources."entities-1.1.1"
-      sources."errno-0.1.7"
       sources."error-ex-1.3.1"
-      sources."es5-ext-0.10.40"
+      sources."es5-ext-0.10.42"
       sources."es6-error-4.1.1"
       sources."es6-iterator-2.0.3"
       sources."es6-map-0.1.5"
-      sources."es6-promise-4.2.4"
-      sources."es6-promisify-5.0.0"
+      sources."es6-promise-2.3.0"
+      (sources."es6-promisify-5.0.0" // {
+        dependencies = [
+          sources."es6-promise-4.2.4"
+        ];
+      })
       sources."es6-set-0.1.5"
       sources."es6-symbol-3.1.1"
       sources."es6-weak-map-2.0.2"
       sources."escape-string-regexp-1.0.5"
       sources."escope-3.6.0"
-      (sources."eslint-4.15.0" // {
+      (sources."eslint-4.19.0" // {
         dependencies = [
+          sources."ajv-5.5.2"
           sources."esprima-4.0.0"
         ];
       })
@@ -42678,16 +42884,23 @@ in
       sources."esutils-2.0.2"
       sources."event-emitter-0.3.5"
       sources."event-to-promise-0.8.0"
-      sources."events-1.1.1"
-      sources."evp_bytestokey-1.0.3"
       sources."execa-0.7.0"
       sources."exit-hook-1.1.1"
-      sources."expand-brackets-0.1.5"
-      sources."expand-range-1.8.2"
+      (sources."expand-brackets-2.1.4" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+        ];
+      })
       sources."extend-3.0.1"
+      sources."extend-shallow-3.0.2"
       sources."external-editor-2.1.0"
-      sources."extglob-0.3.2"
-      sources."extract-text-webpack-plugin-3.0.2"
+      (sources."extglob-2.0.4" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."extend-shallow-2.0.1"
+          sources."kind-of-5.1.0"
+        ];
+      })
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-parse-1.0.3"
@@ -42698,10 +42911,9 @@ in
       sources."fd-slicer-1.0.1"
       sources."figures-2.0.0"
       sources."file-entry-cache-2.0.0"
-      sources."filename-regex-2.0.1"
-      sources."fill-range-2.2.3"
-      sources."find-up-2.1.0"
-      sources."firefox-client-0.3.0"
+      sources."fill-range-4.0.0"
+      sources."filled-array-1.1.0"
+      sources."find-up-1.1.2"
       (sources."firefox-profile-1.1.0" // {
         dependencies = [
           sources."async-2.5.0"
@@ -42710,11 +42922,12 @@ in
       sources."first-chunk-stream-2.0.0"
       sources."flat-cache-1.3.0"
       sources."flatstr-1.0.5"
-      sources."fluent-0.4.1"
+      sources."fluent-syntax-0.6.6"
       sources."for-in-1.0.2"
-      sources."for-own-0.1.5"
+      sources."for-own-1.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.2"
+      sources."fragment-cache-0.2.1"
       sources."fs-extra-4.0.3"
       sources."fs.realpath-1.0.0"
       sources."fsevents-1.1.3"
@@ -42732,6 +42945,7 @@ in
       sources."generate-object-property-1.2.0"
       sources."get-caller-file-1.0.2"
       sources."get-stream-3.0.0"
+      sources."get-value-2.0.6"
       sources."getpass-0.1.7"
       sources."gettext-parser-1.1.0"
       (sources."git-rev-sync-1.9.1" // {
@@ -42740,71 +42954,75 @@ in
         ];
       })
       sources."glob-7.1.2"
-      sources."glob-base-0.3.0"
-      sources."glob-parent-2.0.0"
+      (sources."glob-parent-3.1.0" // {
+        dependencies = [
+          sources."is-glob-3.1.0"
+        ];
+      })
       sources."global-dirs-0.1.1"
       sources."globals-9.18.0"
       sources."globby-5.0.0"
-      sources."got-6.7.1"
+      sources."got-5.7.1"
       sources."graceful-fs-4.1.11"
       sources."graceful-readlink-1.0.1"
+      sources."graphlib-2.1.5"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.0.3"
       sources."has-1.0.1"
       sources."has-ansi-2.0.0"
       sources."has-color-0.1.7"
-      sources."has-flag-2.0.0"
-      sources."hash-base-3.0.4"
-      sources."hash.js-1.1.3"
+      sources."has-flag-3.0.0"
+      sources."has-value-1.0.0"
+      sources."has-values-1.0.0"
+      sources."hasbin-1.2.3"
       sources."hawk-6.0.2"
-      sources."hmac-drbg-1.0.1"
       sources."hoek-4.2.1"
       sources."home-or-tmp-2.0.0"
       sources."hosted-git-info-2.6.0"
       sources."htmlparser2-3.9.2"
       sources."http-signature-1.2.0"
-      sources."https-browserify-1.0.0"
       sources."iconv-lite-0.4.19"
-      sources."ieee754-1.1.8"
       sources."ignore-3.3.7"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
-      sources."indexof-0.0.1"
+      sources."infinity-agent-2.0.3"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."ini-1.3.5"
       sources."inquirer-3.3.0"
       sources."interpret-1.1.0"
-      sources."invariant-2.2.3"
+      sources."invariant-2.2.4"
       sources."invert-kv-1.0.0"
       sources."is-absolute-0.1.7"
+      sources."is-accessor-descriptor-1.0.0"
       sources."is-alphabetical-1.0.1"
       sources."is-alphanumerical-1.0.1"
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
       sources."is-builtin-module-1.0.0"
+      sources."is-data-descriptor-1.0.0"
       sources."is-decimal-1.0.1"
-      sources."is-dotfile-1.0.3"
-      sources."is-equal-shallow-0.1.3"
+      sources."is-descriptor-1.0.2"
       sources."is-extendable-0.1.1"
-      sources."is-extglob-1.0.0"
+      sources."is-extglob-2.1.1"
       sources."is-finite-1.0.2"
       sources."is-fullwidth-code-point-2.0.0"
-      sources."is-glob-2.0.1"
+      sources."is-glob-4.0.0"
       sources."is-hexadecimal-1.0.1"
       sources."is-installed-globally-0.1.0"
+      sources."is-mergeable-object-1.1.0"
       sources."is-my-ip-valid-1.0.0"
       sources."is-my-json-valid-2.17.2"
       sources."is-npm-1.0.0"
-      sources."is-number-2.1.0"
+      sources."is-number-4.0.0"
       sources."is-obj-1.0.1"
+      sources."is-odd-2.0.0"
       sources."is-path-cwd-1.0.0"
-      sources."is-path-in-cwd-1.0.0"
+      sources."is-path-in-cwd-1.0.1"
       sources."is-path-inside-1.0.1"
-      sources."is-posix-bracket-0.1.1"
-      sources."is-primitive-2.0.0"
+      sources."is-plain-object-2.0.4"
       sources."is-promise-2.1.0"
       sources."is-property-1.0.2"
       sources."is-redirect-1.0.0"
@@ -42814,10 +43032,11 @@ in
       sources."is-stream-1.1.0"
       sources."is-typedarray-1.0.0"
       sources."is-utf8-0.2.1"
+      sources."is-windows-1.0.2"
       sources."isarray-1.0.0"
       sources."isemail-1.2.0"
       sources."isexe-2.0.0"
-      sources."isobject-2.1.0"
+      sources."isobject-3.0.1"
       sources."isstream-0.1.2"
       sources."jed-1.1.1"
       sources."jetpack-id-1.0.0"
@@ -42827,7 +43046,6 @@ in
       sources."js-yaml-3.11.0"
       sources."jsbn-0.1.1"
       sources."jsesc-1.3.0"
-      sources."json-loader-0.5.7"
       sources."json-merge-patch-0.2.3"
       sources."json-parse-better-errors-1.0.1"
       sources."json-schema-0.2.3"
@@ -42845,42 +43063,44 @@ in
       sources."jwa-1.1.5"
       sources."jws-3.1.4"
       sources."kind-of-3.2.2"
-      sources."latest-version-3.1.0"
+      sources."latest-version-2.0.0"
       sources."lazy-cache-1.0.4"
       sources."lazystream-1.0.0"
       sources."lcid-1.0.0"
       sources."levn-0.3.0"
-      sources."load-json-file-2.0.0"
-      sources."loader-runner-2.3.0"
-      sources."loader-utils-1.1.0"
+      sources."load-json-file-1.1.0"
       sources."locate-path-2.0.0"
       sources."lodash-4.17.5"
-      sources."lodash.endswith-4.2.1"
-      sources."lodash.isfunction-3.0.9"
-      sources."lodash.isstring-4.0.1"
+      sources."lodash.assign-4.2.0"
+      sources."lodash.clonedeep-4.5.0"
+      sources."lodash.defaults-4.2.0"
+      sources."lodash.defaultsdeep-4.6.0"
+      sources."lodash.mergewith-4.6.1"
       sources."lodash.once-4.1.1"
       sources."lodash.sortby-4.7.0"
-      sources."lodash.startswith-4.2.1"
       sources."longest-1.0.1"
       sources."longest-streak-1.0.0"
       sources."loose-envify-1.3.1"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
+      sources."map-cache-0.2.2"
+      sources."map-visit-1.0.0"
       sources."markdown-table-0.4.0"
       sources."markdown-to-ast-3.4.0"
-      sources."md5.js-1.3.4"
       sources."mem-1.1.0"
-      sources."memory-fs-0.4.1"
-      sources."micromatch-2.3.11"
-      sources."miller-rabin-4.0.1"
+      (sources."micromatch-3.1.10" // {
+        dependencies = [
+          sources."is-extendable-0.1.1"
+        ];
+      })
       sources."mime-db-1.33.0"
       sources."mime-types-2.1.18"
       sources."mimic-fn-1.2.0"
-      sources."minimalistic-assert-1.0.0"
-      sources."minimalistic-crypto-utils-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
+      sources."mixin-deep-1.3.1"
+      sources."mixin-object-2.0.1"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
@@ -42891,20 +43111,23 @@ in
       sources."mute-stream-0.0.7"
       sources."mv-2.1.1"
       sources."mz-2.7.0"
-      sources."nan-2.9.2"
+      sources."nan-2.10.0"
+      sources."nanomatch-1.2.9"
       sources."natural-compare-1.4.0"
       sources."natural-compare-lite-1.4.0"
+      sources."nconf-0.7.2"
       sources."ncp-2.0.0"
-      sources."next-tick-1.0.0"
-      (sources."node-firefox-connect-1.2.0" // {
+      (sources."needle-2.2.0" // {
         dependencies = [
-          sources."es6-promise-2.3.0"
-          sources."traverse-0.4.6"
+          sources."debug-2.6.9"
         ];
       })
+      sources."neo-async-2.5.0"
+      sources."nested-error-stacks-1.0.2"
+      sources."next-tick-1.0.0"
       sources."node-forge-0.7.4"
-      sources."node-libs-browser-2.1.0"
       sources."node-notifier-5.2.1"
+      sources."node-status-codes-1.0.0"
       sources."nomnom-1.8.1"
       sources."normalize-package-data-2.4.0"
       sources."normalize-path-2.1.1"
@@ -42913,41 +43136,44 @@ in
       sources."number-is-nan-1.0.1"
       sources."oauth-sign-0.8.2"
       sources."object-assign-4.1.1"
-      sources."object.omit-2.0.1"
+      sources."object-copy-0.1.0"
+      sources."object-visit-1.0.1"
+      sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."open-0.0.5"
       sources."optionator-0.8.2"
-      sources."os-browserify-0.3.0"
       sources."os-homedir-1.0.2"
       sources."os-locale-2.1.0"
+      sources."os-name-1.0.3"
       sources."os-shim-0.1.3"
       sources."os-tmpdir-1.0.2"
+      sources."osenv-0.1.5"
+      sources."osx-release-1.1.0"
       sources."p-finally-1.0.0"
       sources."p-limit-1.2.0"
       sources."p-locate-2.0.0"
       sources."p-try-1.0.0"
-      sources."package-json-4.0.1"
+      sources."package-json-2.4.0"
       sources."pako-1.0.6"
-      sources."parse-asn1-5.1.0"
       sources."parse-entities-1.1.1"
-      sources."parse-glob-3.0.4"
       sources."parse-json-4.0.0"
       sources."parse5-3.0.3"
-      sources."path-browserify-0.0.0"
-      sources."path-exists-3.0.0"
+      sources."pascalcase-0.1.1"
+      sources."path-dirname-1.0.2"
+      sources."path-exists-2.1.0"
       sources."path-is-absolute-1.0.1"
       sources."path-is-inside-1.0.2"
       sources."path-key-2.0.1"
       sources."path-parse-1.0.5"
-      sources."path-type-2.0.0"
-      sources."pbkdf2-3.0.14"
+      sources."path-type-1.1.0"
       sources."pend-1.2.0"
       sources."performance-now-2.1.0"
       sources."pify-2.3.0"
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
-      sources."pino-4.10.3"
+      sources."pino-4.14.0"
+      sources."pino-std-serializers-1.2.0"
       sources."pluralize-7.0.0"
       (sources."po2json-0.4.5" // {
         dependencies = [
@@ -42956,48 +43182,38 @@ in
           sources."strip-ansi-0.1.1"
         ];
       })
-      sources."postcss-6.0.14"
+      sources."posix-character-classes-0.1.1"
+      sources."postcss-6.0.19"
       sources."prelude-ls-1.1.2"
       sources."prepend-http-1.0.4"
-      sources."preserve-0.2.0"
       sources."private-0.1.8"
-      (sources."probe-image-size-3.2.0" // {
+      (sources."probe-image-size-4.0.0" // {
         dependencies = [
           sources."debug-2.6.9"
         ];
       })
-      sources."process-0.11.10"
       sources."process-nextick-args-2.0.0"
       sources."progress-2.0.0"
-      sources."prr-1.0.1"
+      sources."promise-7.3.1"
+      sources."proxy-from-env-1.0.0"
       sources."pseudomap-1.0.2"
-      sources."public-encrypt-4.0.0"
-      sources."pump-2.0.1"
+      sources."pump-3.0.0"
       sources."punycode-1.4.1"
       sources."qs-6.5.1"
       sources."querystring-0.2.0"
-      sources."querystring-es3-0.2.1"
       sources."quick-format-unescaped-1.1.2"
-      (sources."randomatic-1.1.7" // {
-        dependencies = [
-          (sources."is-number-3.0.0" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-        ];
-      })
-      sources."randombytes-2.0.6"
-      sources."randomfill-1.0.4"
-      sources."rc-1.2.5"
-      sources."read-pkg-2.0.0"
-      sources."read-pkg-up-2.0.0"
+      sources."rc-1.2.6"
+      sources."read-all-stream-3.1.0"
+      sources."read-pkg-1.1.0"
+      sources."read-pkg-up-1.0.1"
       sources."readable-stream-2.3.5"
       sources."readdirp-2.1.0"
       sources."readline2-1.0.1"
       sources."rechoir-0.6.2"
+      sources."recursive-readdir-2.2.2"
       sources."regenerator-runtime-0.11.1"
-      sources."regex-cache-0.4.4"
+      sources."regex-not-1.0.2"
+      sources."regexpp-1.0.1"
       sources."registry-auth-token-3.3.2"
       sources."registry-url-3.1.0"
       (sources."relaxed-json-1.0.1" // {
@@ -43020,31 +43236,38 @@ in
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
       sources."require-uncached-1.0.3"
-      sources."resolve-1.5.0"
+      sources."resolve-1.6.0"
       sources."resolve-from-1.0.1"
+      sources."resolve-url-0.2.1"
       sources."restore-cursor-2.0.0"
+      sources."ret-0.1.15"
       sources."right-align-0.1.3"
       sources."rimraf-2.6.2"
-      sources."ripemd160-2.0.1"
       sources."run-async-2.3.0"
+      sources."rx-4.1.0"
       sources."rx-lite-4.0.8"
       sources."rx-lite-aggregates-4.0.8"
       sources."safe-buffer-5.1.1"
       sources."safe-json-stringify-1.1.0"
+      sources."safe-regex-1.1.0"
       sources."sax-1.2.4"
-      sources."schema-utils-0.3.0"
       sources."semver-5.5.0"
       sources."semver-diff-2.1.0"
       sources."set-blocking-2.0.0"
       sources."set-immediate-shim-1.0.1"
-      sources."setimmediate-1.0.5"
-      sources."sha.js-2.4.10"
+      sources."set-value-2.0.0"
+      sources."sha.js-2.4.11"
+      (sources."shallow-clone-0.1.2" // {
+        dependencies = [
+          sources."kind-of-2.0.1"
+        ];
+      })
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shell-quote-1.6.1"
       sources."shelljs-0.8.1"
       sources."shellwords-0.1.1"
-      (sources."sign-addon-0.2.2" // {
+      (sources."sign-addon-0.3.0" // {
         dependencies = [
           sources."assert-plus-0.2.0"
           sources."aws-sign2-0.6.0"
@@ -43072,26 +43295,118 @@ in
       sources."signal-exit-3.0.2"
       sources."slash-1.0.0"
       sources."slice-ansi-1.0.0"
+      sources."slide-1.1.6"
+      (sources."snapdragon-0.8.2" // {
+        dependencies = [
+          (sources."define-property-0.2.5" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+          sources."extend-shallow-2.0.1"
+          sources."kind-of-4.0.0"
+        ];
+      })
+      (sources."snapdragon-node-2.1.1" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."snapdragon-util-3.0.1"
       sources."sntp-2.1.0"
-      sources."source-list-map-2.0.0"
+      (sources."snyk-1.70.3" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."ansi-styles-2.2.1"
+          sources."async-1.5.2"
+          sources."camelcase-3.0.0"
+          sources."chalk-1.1.3"
+          sources."inquirer-1.0.3"
+          sources."mute-stream-0.0.6"
+          sources."os-locale-1.4.0"
+          sources."run-async-2.3.0"
+          sources."strip-ansi-3.0.1"
+          sources."supports-color-2.0.0"
+          sources."yargs-3.15.0"
+        ];
+      })
+      (sources."snyk-config-1.0.1" // {
+        dependencies = [
+          sources."async-0.9.2"
+          sources."debug-2.6.9"
+        ];
+      })
+      sources."snyk-go-plugin-1.4.5"
+      sources."snyk-gradle-plugin-1.2.0"
+      (sources."snyk-module-1.8.1" // {
+        dependencies = [
+          sources."debug-2.6.9"
+        ];
+      })
+      sources."snyk-mvn-plugin-1.1.1"
+      (sources."snyk-nuget-plugin-1.3.9" // {
+        dependencies = [
+          sources."es6-promise-4.2.4"
+        ];
+      })
+      sources."snyk-php-plugin-1.3.2"
+      (sources."snyk-policy-1.10.2" // {
+        dependencies = [
+          sources."debug-2.6.9"
+        ];
+      })
+      sources."snyk-python-plugin-1.5.7"
+      (sources."snyk-resolve-1.0.0" // {
+        dependencies = [
+          sources."debug-2.6.9"
+        ];
+      })
+      (sources."snyk-resolve-deps-1.7.0" // {
+        dependencies = [
+          sources."configstore-2.1.0"
+          sources."debug-2.6.9"
+          sources."update-notifier-0.6.3"
+          sources."uuid-2.0.3"
+          sources."yargs-4.8.1"
+        ];
+      })
+      (sources."snyk-sbt-plugin-1.2.5" // {
+        dependencies = [
+          sources."debug-2.6.9"
+        ];
+      })
+      sources."snyk-tree-1.0.0"
+      (sources."snyk-try-require-1.2.0" // {
+        dependencies = [
+          sources."debug-2.6.9"
+        ];
+      })
       sources."source-map-0.5.7"
+      sources."source-map-resolve-0.5.1"
       (sources."source-map-support-0.5.3" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
       })
+      sources."source-map-url-0.4.0"
       sources."spawn-sync-1.0.15"
       sources."spdx-correct-3.0.0"
       sources."spdx-exceptions-2.1.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.0"
       sources."split-0.3.3"
+      (sources."split-string-3.1.0" // {
+        dependencies = [
+          sources."extend-shallow-3.0.2"
+          sources."is-extendable-1.0.1"
+        ];
+      })
       sources."split2-2.2.0"
       sources."sprintf-js-1.0.3"
-      sources."sshpk-1.13.1"
-      sources."stream-browserify-2.0.1"
-      sources."stream-http-2.8.0"
+      sources."sshpk-1.14.1"
+      sources."static-extend-0.1.2"
       sources."stream-parser-0.3.1"
+      sources."stream-shift-1.0.0"
       sources."stream-to-array-2.3.0"
       (sources."stream-to-promise-2.2.0" // {
         dependencies = [
@@ -43099,6 +43414,7 @@ in
           sources."once-1.3.3"
         ];
       })
+      sources."string-length-1.0.1"
       sources."string-width-2.1.1"
       sources."string_decoder-1.0.3"
       sources."stringify-entities-1.3.1"
@@ -43111,114 +43427,143 @@ in
       sources."strip-json-comments-2.0.1"
       sources."structured-source-3.0.2"
       sources."supports-color-2.0.0"
-      (sources."table-4.0.3" // {
+      sources."table-4.0.2"
+      sources."tar-stream-1.5.5"
+      (sources."tempfile-1.1.1" // {
         dependencies = [
-          sources."ajv-6.2.1"
+          sources."uuid-2.0.3"
         ];
       })
-      sources."tapable-0.2.8"
-      sources."tar-stream-1.5.5"
       sources."term-size-1.2.0"
       sources."text-table-0.2.0"
+      sources."then-fs-2.0.0"
       sources."thenify-3.3.0"
       sources."thenify-all-1.6.0"
       sources."through-2.3.8"
       sources."through2-2.0.3"
-      sources."timed-out-4.0.1"
-      sources."timers-browserify-2.0.6"
+      sources."timed-out-3.1.3"
       sources."tmp-0.0.33"
-      sources."to-arraybuffer-1.0.1"
       sources."to-fast-properties-1.0.3"
+      sources."to-object-path-0.3.0"
+      sources."to-regex-3.0.2"
+      sources."to-regex-range-2.1.1"
+      sources."to-utf8-0.0.1"
+      sources."toml-2.3.3"
       sources."topo-1.1.0"
       sources."tosource-1.0.0"
       sources."tough-cookie-2.3.4"
       sources."tr46-1.0.1"
-      sources."traverse-0.6.6"
+      sources."traverse-0.4.6"
       sources."trim-0.0.1"
       sources."trim-right-1.0.1"
       sources."trim-trailing-lines-1.1.0"
       sources."trough-1.0.1"
-      sources."tty-browserify-0.0.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-check-0.3.2"
       sources."typedarray-0.0.6"
-      sources."uglify-js-2.8.29"
-      sources."uglify-to-browserify-1.0.2"
-      (sources."uglifyjs-webpack-plugin-0.4.6" // {
-        dependencies = [
-          sources."yargs-3.10.0"
-        ];
-      })
+      sources."undefsafe-0.0.3"
       sources."underscore-1.8.3"
       sources."unherit-1.1.0"
       sources."unified-4.2.1"
+      (sources."union-value-1.0.0" // {
+        dependencies = [
+          sources."set-value-0.4.3"
+        ];
+      })
       sources."unique-string-1.0.0"
       sources."unist-util-is-2.1.1"
       sources."unist-util-remove-position-1.1.1"
       sources."unist-util-visit-1.3.0"
       sources."universalify-0.1.1"
-      sources."unzip-response-2.0.1"
-      sources."upath-1.0.2"
+      (sources."unset-value-1.0.0" // {
+        dependencies = [
+          (sources."has-value-0.3.1" // {
+            dependencies = [
+              sources."isobject-2.1.0"
+            ];
+          })
+        ];
+      })
+      sources."unzip-response-1.0.2"
+      sources."upath-1.0.4"
       (sources."update-notifier-2.3.0" // {
         dependencies = [
+          sources."boxen-1.3.0"
+          sources."configstore-3.1.2"
+          sources."dot-prop-4.2.0"
+          sources."got-6.7.1"
+          sources."latest-version-3.1.0"
+          sources."package-json-4.0.1"
           sources."pify-3.0.0"
+          sources."timed-out-4.0.1"
+          sources."unzip-response-2.0.1"
+          sources."widest-line-2.0.0"
+          sources."write-file-atomic-2.3.0"
+          sources."xdg-basedir-3.0.0"
         ];
       })
       sources."update-section-0.3.3"
-      (sources."url-0.11.0" // {
+      sources."urix-0.1.0"
+      sources."url-0.11.0"
+      sources."url-parse-lax-1.0.0"
+      (sources."use-3.1.0" // {
         dependencies = [
-          sources."punycode-1.3.2"
+          sources."kind-of-6.0.2"
         ];
       })
-      sources."url-parse-lax-1.0.0"
       sources."user-home-2.0.0"
-      sources."util-0.10.3"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.2.1"
       sources."validate-npm-package-license-3.0.3"
       sources."verror-1.10.0"
       sources."vfile-1.4.0"
       sources."vfile-location-2.0.2"
-      sources."vm-browserify-0.0.4"
-      (sources."watchpack-1.4.0" // {
+      (sources."watchpack-1.5.0" // {
         dependencies = [
-          sources."async-2.6.0"
+          sources."define-property-1.0.0"
+          sources."extend-shallow-2.0.1"
+          sources."has-values-0.1.4"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."is-extendable-1.0.1"
+          (sources."is-number-3.0.0" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."kind-of-6.0.2"
         ];
       })
       sources."wcwidth-1.0.1"
       sources."webidl-conversions-4.0.2"
-      (sources."webpack-3.10.0" // {
+      (sources."whatwg-url-6.3.0" // {
         dependencies = [
-          sources."ajv-keywords-2.1.1"
-          sources."ansi-regex-2.1.1"
-          sources."camelcase-4.1.0"
-          sources."is-fullwidth-code-point-2.0.0"
-          sources."source-map-0.5.7"
-          sources."string-width-2.1.1"
-          sources."strip-ansi-3.0.1"
-          (sources."yargs-8.0.2" // {
-            dependencies = [
-              sources."ansi-regex-3.0.0"
-              sources."strip-ansi-4.0.0"
-            ];
-          })
+          sources."punycode-2.1.0"
         ];
       })
-      sources."webpack-sources-1.1.0"
-      sources."whatwg-url-6.3.0"
       sources."when-3.7.7"
       sources."which-1.3.0"
-      sources."which-module-2.0.0"
-      sources."widest-line-2.0.0"
-      sources."window-size-0.1.0"
+      sources."which-module-1.0.0"
+      sources."widest-line-1.0.0"
+      sources."win-release-1.1.1"
+      sources."window-size-0.1.4"
       sources."winreg-0.0.12"
       sources."wordwrap-1.0.0"
       sources."wrap-ansi-2.1.0"
       sources."wrappy-1.0.2"
       sources."write-0.2.1"
-      sources."write-file-atomic-2.3.0"
-      sources."xdg-basedir-3.0.0"
+      sources."write-file-atomic-1.3.4"
+      sources."xdg-basedir-2.0.0"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
       sources."xmldom-0.1.27"
@@ -43231,23 +43576,15 @@ in
           sources."camelcase-3.0.0"
           sources."cliui-3.2.0"
           sources."decamelize-1.2.0"
-          sources."find-up-1.1.2"
           sources."is-fullwidth-code-point-1.0.0"
-          sources."load-json-file-1.1.0"
           sources."os-locale-1.4.0"
-          sources."parse-json-2.2.0"
-          sources."path-exists-2.1.0"
-          sources."path-type-1.1.0"
-          sources."read-pkg-1.1.0"
-          sources."read-pkg-up-1.0.1"
           sources."string-width-1.0.2"
-          sources."strip-bom-2.0.0"
-          sources."which-module-1.0.0"
           sources."yargs-parser-4.2.1"
         ];
       })
-      sources."yargs-parser-7.0.0"
+      sources."yargs-parser-2.4.1"
       sources."yauzl-2.9.1"
+      sources."zip-1.2.0"
       (sources."zip-dir-1.0.2" // {
         dependencies = [
           sources."async-1.5.2"
@@ -43312,7 +43649,7 @@ in
       sources."ajv-5.5.2"
       sources."ansi-0.3.1"
       sources."ansi-align-2.0.0"
-      sources."ansi-escapes-3.0.0"
+      sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
       sources."are-we-there-yet-1.1.4"
@@ -43337,21 +43674,27 @@ in
       sources."boom-4.3.1"
       sources."boxen-1.3.0"
       sources."brace-expansion-1.1.11"
+      sources."buffer-from-1.0.0"
       sources."builtin-modules-1.1.1"
-      sources."cacheable-request-2.1.4"
+      (sources."cacheable-request-2.1.4" // {
+        dependencies = [
+          sources."lowercase-keys-1.0.0"
+        ];
+      })
       sources."camelcase-2.1.1"
       sources."camelcase-keys-2.1.0"
       sources."capture-stack-trace-1.0.0"
       sources."caseless-0.12.0"
       sources."chalk-1.1.3"
       sources."chardet-0.4.2"
+      sources."ci-info-1.1.3"
       sources."clean-stack-1.3.0"
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
       sources."cli-list-0.2.0"
       sources."cli-width-2.2.0"
-      sources."clone-1.0.3"
-      sources."clone-regexp-1.0.0"
+      sources."clone-1.0.4"
+      sources."clone-regexp-1.0.1"
       sources."clone-response-1.0.2"
       sources."clone-stats-0.0.1"
       sources."co-4.6.0"
@@ -43360,8 +43703,8 @@ in
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.6"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.1"
-      sources."configstore-3.1.1"
+      sources."concat-stream-1.6.2"
+      sources."configstore-3.1.2"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-5.1.0"
@@ -43437,7 +43780,7 @@ in
       sources."hosted-git-info-2.6.0"
       sources."http-cache-semantics-3.8.1"
       sources."http-signature-1.2.0"
-      sources."humanize-string-1.0.1"
+      sources."humanize-string-1.0.2"
       sources."iconv-lite-0.4.19"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
@@ -43482,6 +43825,7 @@ in
       sources."into-stream-3.1.0"
       sources."is-arrayish-0.2.1"
       sources."is-builtin-module-1.0.0"
+      sources."is-ci-1.1.0"
       sources."is-docker-1.1.0"
       sources."is-finite-1.0.2"
       sources."is-fullwidth-code-point-2.0.0"
@@ -43498,7 +43842,7 @@ in
       sources."is-root-1.0.0"
       sources."is-scoped-1.0.0"
       sources."is-stream-1.1.0"
-      sources."is-supported-regexp-flag-1.0.0"
+      sources."is-supported-regexp-flag-1.0.1"
       sources."is-typedarray-1.0.0"
       sources."is-utf8-0.2.1"
       sources."isarray-1.0.0"
@@ -43523,7 +43867,7 @@ in
       sources."lodash.padstart-4.6.1"
       sources."log-symbols-1.0.2"
       sources."loud-rejection-1.6.0"
-      sources."lowercase-keys-1.0.0"
+      sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.2"
       sources."make-dir-1.2.0"
       sources."map-obj-1.0.1"
@@ -43613,8 +43957,8 @@ in
       sources."pseudomap-1.0.2"
       sources."punycode-1.4.1"
       sources."qs-6.5.1"
-      sources."query-string-5.1.0"
-      sources."rc-1.2.5"
+      sources."query-string-5.1.1"
+      sources."rc-1.2.6"
       sources."read-pkg-1.1.0"
       (sources."read-pkg-up-2.0.0" // {
         dependencies = [
@@ -43665,7 +44009,7 @@ in
       sources."spdx-exceptions-2.1.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.0"
-      sources."sshpk-1.13.1"
+      sources."sshpk-1.14.1"
       sources."strict-uri-encode-1.1.0"
       sources."string-length-1.0.1"
       sources."string-width-2.1.1"
@@ -43700,7 +44044,7 @@ in
       sources."through-2.3.8"
       sources."through2-2.0.3"
       sources."timed-out-4.0.1"
-      sources."titleize-1.0.0"
+      sources."titleize-1.0.1"
       sources."tmp-0.0.33"
       sources."tough-cookie-2.3.4"
       sources."trim-newlines-1.0.0"
@@ -43711,7 +44055,7 @@ in
       sources."unique-string-1.0.0"
       sources."untildify-3.0.2"
       sources."unzip-response-2.0.1"
-      (sources."update-notifier-2.3.0" // {
+      (sources."update-notifier-2.4.0" // {
         dependencies = [
           sources."ansi-styles-3.2.1"
           sources."camelcase-4.1.0"
@@ -43729,7 +44073,7 @@ in
       sources."verror-1.10.0"
       sources."vinyl-1.2.0"
       sources."vinyl-file-2.0.0"
-      sources."walk-2.3.9"
+      sources."walk-2.3.13"
       sources."which-1.3.0"
       sources."widest-line-2.0.0"
       sources."win-release-1.1.1"
@@ -43764,7 +44108,7 @@ in
           sources."supports-color-5.3.0"
         ];
       })
-      (sources."yosay-2.0.1" // {
+      (sources."yosay-2.0.2" // {
         dependencies = [
           sources."ansi-styles-3.2.1"
           sources."is-fullwidth-code-point-1.0.0"

--- a/pkgs/development/node-packages/node-packages-v8.nix
+++ b/pkgs/development/node-packages/node-packages-v8.nix
@@ -337,13 +337,13 @@ let
         sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
       };
     };
-    "atob-2.0.3" = {
+    "atob-2.1.0" = {
       name = "atob";
       packageName = "atob";
-      version = "2.0.3";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz";
-        sha1 = "19c7a760473774468f20b2d2d03372ad7d4cbf5d";
+        url = "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz";
+        sha512 = "0dyf7054n94f1pwp9chcy6vawgwd2wqp8jqrnvxl489jyxxbg46n2vkb5vfs5jqnkmh6kbyv4lpysrn13hzzh5q021frc6vrcgqms2a";
       };
     };
     "atomic-batcher-1.0.2" = {
@@ -589,13 +589,13 @@ let
         sha1 = "0353b54fd07fd9564170671ae6f66b9cf10d27f5";
       };
     };
-    "buffer-fill-0.1.0" = {
+    "buffer-fill-0.1.1" = {
       name = "buffer-fill";
       packageName = "buffer-fill";
-      version = "0.1.0";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.0.tgz";
-        sha1 = "ca9470e8d4d1b977fd7543f4e2ab6a7dc95101a8";
+        url = "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz";
+        sha512 = "3nny0zbpnaxp1544gp7lc53jvs1jgzpmp92cy939dik36bi8lvhrsh4g082lxdplwsma22cgg9q93dw5dnbn1ljqkh4fb2i6w3lq032";
       };
     };
     "buffer-from-1.0.0" = {
@@ -767,6 +767,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz";
         sha1 = "e2a75042a9551908bebd25b8523d5f9769d79181";
+      };
+    };
+    "ci-info-1.1.3" = {
+      name = "ci-info";
+      packageName = "ci-info";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz";
+        sha512 = "0p634fyx3kkll2blj5f5bjmz273d7ba201yi3jlrvy7p7lnmmi479d6s3khwmp9lnfrb314l4kw5dq40q60hzfnmfycqibzm3izrbs8";
       };
     };
     "circular-append-file-1.0.1" = {
@@ -1012,13 +1021,13 @@ let
         sha512 = "05nnf80j9ls12y3cw2dfnc6rmand3ya5sx9cqn9dgg19ljzdnyfjjv8ig79xi73gr2y4rkfzn9wjip2zzwp5n2d49njd3ki2a1c3cfv";
       };
     };
-    "configstore-3.1.1" = {
+    "configstore-3.1.2" = {
       name = "configstore";
       packageName = "configstore";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz";
-        sha512 = "2zmidvkp20q25yv6a5d7k1daawdg0w6ppgayxzpwfhyvmgwybkkv7ni0j4b2j9c8wjn8z33zf5d4bjr8jywb5qixc75vypyy87n90z6";
+        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz";
+        sha512 = "2difdg3f56d584kfxl1zvm4ik5m3ln949m0q9sxq6ranzx2iwqa9zxqxy2l5i2lsm8jwmaiqkf7rc73gfnfip5m2qh8awd3s4ggknxy";
       };
     };
     "connect-3.6.6" = {
@@ -1219,13 +1228,13 @@ let
         sha512 = "2lc9p062gaa2xrf07z14xqgid3rw5fg05ak3s13g3mrr5hf8zxmdvp3lq4wggj7k5pc2c43r3d4yyy7rfrqafsdm7hfisdda4zgsi1w";
       };
     };
-    "dat-ignore-2.1.0" = {
+    "dat-ignore-2.1.1" = {
       name = "dat-ignore";
       packageName = "dat-ignore";
-      version = "2.1.0";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dat-ignore/-/dat-ignore-2.1.0.tgz";
-        sha512 = "2lngf74v9m0xibm5g6lj1aj988bpmx69bd7m8b1kpzlbz7kh0binbyadaj993isk679pljasygycilmwb976bhywq8b46fgl0lmagqs";
+        url = "https://registry.npmjs.org/dat-ignore/-/dat-ignore-2.1.1.tgz";
+        sha512 = "3ars15n4l3fgvnzah15zpfzirg66clg2a72d2qawg340ad1f0xbahxgzfj52q3ib48s6k7m4a8zcpv5n3pq2blkm1dhpyz1s9d9y44d";
       };
     };
     "dat-json-1.0.2" = {
@@ -1543,13 +1552,13 @@ let
         sha512 = "19g682cvkba33mwrism28hibd2nv9xd16k5bj807jx3ih1cc7ff9dn8chmfjnqgglzl6lq3m3jarxng9vbarccgchd0aq118d15yk6i";
       };
     };
-    "dns-packet-4.1.0" = {
+    "dns-packet-4.1.1" = {
       name = "dns-packet";
       packageName = "dns-packet";
-      version = "4.1.0";
+      version = "4.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dns-packet/-/dns-packet-4.1.0.tgz";
-        sha512 = "1jkqjdbc3dchmbkg3nn7ymayqix9gh3ll3rgbqps2qc484zgkj6a2v1wgy4agybkh8719i36b6fi8mx1m4h00gvpdmhdnxx5x1r1m3h";
+        url = "https://registry.npmjs.org/dns-packet/-/dns-packet-4.1.1.tgz";
+        sha512 = "09adhjnzfiilwrksrckjrxcfi54gy5xgcsvkq24r98j0xh1asvl5iywj4p37s4l7drgysmdlkv95iki5c554gviaj4738fnlhgn42v3";
       };
     };
     "dns-socket-1.6.3" = {
@@ -2407,22 +2416,22 @@ let
         sha1 = "9aecd925114772f3d95b65a60abb8f7c18fbace1";
       };
     };
-    "hypercore-6.12.5" = {
+    "hypercore-6.12.7" = {
       name = "hypercore";
       packageName = "hypercore";
-      version = "6.12.5";
+      version = "6.12.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hypercore/-/hypercore-6.12.5.tgz";
-        sha512 = "247lnm7sq3fx7ihflpp3pmrdd47hpl68y0ifmg2jmaw4kn745s3i9m9r6c1kmzq4i14zb3k251xhq1s0vldc1yxa9wkvial78cn27hz";
+        url = "https://registry.npmjs.org/hypercore/-/hypercore-6.12.7.tgz";
+        sha512 = "28wgk53py46wrcp8h8xkirakbc3v64r1aaqnl0g0ivp9x7791wkga63mbjl0cdsa3yif0cvbp8djwcpzx0smfyyqkdz7skjdgsbg57j";
       };
     };
-    "hypercore-protocol-6.6.2" = {
+    "hypercore-protocol-6.6.4" = {
       name = "hypercore-protocol";
       packageName = "hypercore-protocol";
-      version = "6.6.2";
+      version = "6.6.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.6.2.tgz";
-        sha512 = "3d62qzd0spz8j902qgvjg4wqr2bcjhvrxhg12a44x3rv0dwn9n0l78bgz8cghbsiwk36bivz7wsyf0fdpgif9a41yyi81mslf8wkdmf";
+        url = "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.6.4.tgz";
+        sha512 = "0rxj8d4lp45q7v3wwwv23m7qi84vw3wvyafqiy9x5f9lqkynq8v8yajpq9bcnc935927qjnxajn8n0cyhg0fqjnpywlfyxgxczkndgm";
       };
     };
     "hyperdrive-9.12.3" = {
@@ -2594,6 +2603,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz";
         sha512 = "3kr8dm9qyklmm2xyiz75s8db90bfilfals4x0g276kncihrrrz0ar4y6dqpvc7pwy7h43jay1bayi1r62x97nzvcswkk4ap18pl1irm";
+      };
+    };
+    "is-ci-1.1.0" = {
+      name = "is-ci";
+      packageName = "is-ci";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz";
+        sha512 = "0m66alrh568wj40xwshf8q99gsjfk1jr0czp4jc2sm519wfzzzprkl5zjvw2r5h49p72d50ywj9qg67dnyazq0ijy4flgny2b1ygd3k";
       };
     };
     "is-data-descriptor-0.1.4" = {
@@ -4729,13 +4747,13 @@ let
         sha1 = "41059608ffc154757b715d9989d199ffbf372e35";
       };
     };
-    "recursive-watch-1.1.3" = {
+    "recursive-watch-1.1.4" = {
       name = "recursive-watch";
       packageName = "recursive-watch";
-      version = "1.1.3";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.3.tgz";
-        sha512 = "3m0s8140jpamg1xxdlsslshx10qznb889s6yc8av6vvqbs56banhmjqy9lgl7g4ppsrsja0d2lhb5lacl3nxm8ggsrpdd7xqf53hvzx";
+        url = "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.4.tgz";
+        sha512 = "0yks7j98w5d3y375fb99kfbb8rz5qz72v6ld5i15h7fds1i02fq027w82ipanv3dkgvvrxyybw1v8lyrcs54h9airzv12sbcw1a6rvx";
       };
     };
     "reduce-component-1.0.1" = {
@@ -5971,13 +5989,13 @@ let
         sha512 = "0xw24ba88hfvwwgniyn17n26av45g1pxqf095231065l4n9dp5w3hyc7azjd8sqyix7pnfx1pmr44fzmwwazkz0ly83cp214g4qk13p";
       };
     };
-    "update-notifier-2.3.0" = {
+    "update-notifier-2.4.0" = {
       name = "update-notifier";
       packageName = "update-notifier";
-      version = "2.3.0";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz";
-        sha1 = "4e8827a6bb915140ab093559d7014e3ebb837451";
+        url = "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz";
+        sha1 = "f9b4c700fbfd4ec12c811587258777d563d8c866";
       };
     };
     "uri-js-3.0.2" = {
@@ -6292,10 +6310,10 @@ in
   bower = nodeEnv.buildNodePackage {
     name = "bower";
     packageName = "bower";
-    version = "1.8.2";
+    version = "1.8.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz";
-      sha1 = "adf53529c8d4af02ef24fb8d5341c1419d33e2f7";
+      url = "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz";
+      sha1 = "e7876a076deb8137f7d06525dc5e8c66db82f28a";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -6373,7 +6391,7 @@ in
       sources."buffer-alloc-1.1.0"
       sources."buffer-alloc-unsafe-1.0.0"
       sources."buffer-equals-1.0.4"
-      sources."buffer-fill-0.1.0"
+      sources."buffer-fill-0.1.1"
       sources."buffer-from-1.0.0"
       sources."buffer-indexof-1.1.1"
       sources."bulk-write-stream-1.1.4"
@@ -6415,7 +6433,7 @@ in
         ];
       })
       sources."dat-encoding-5.0.1"
-      sources."dat-ignore-2.1.0"
+      sources."dat-ignore-2.1.1"
       (sources."dat-json-1.0.2" // {
         dependencies = [
           sources."dat-encoding-4.0.2"
@@ -6467,7 +6485,7 @@ in
         ];
       })
       sources."dns-discovery-5.6.1"
-      sources."dns-packet-4.1.0"
+      sources."dns-packet-4.1.1"
       sources."dns-socket-3.0.0"
       sources."dns-txt-2.0.2"
       sources."dom-walk-0.1.1"
@@ -6506,12 +6524,12 @@ in
       sources."hoek-4.2.1"
       sources."http-methods-0.1.0"
       sources."http-signature-1.2.0"
-      (sources."hypercore-6.12.5" // {
+      (sources."hypercore-6.12.7" // {
         dependencies = [
           sources."varint-5.0.0"
         ];
       })
-      sources."hypercore-protocol-6.6.2"
+      sources."hypercore-protocol-6.6.4"
       (sources."hyperdrive-9.12.3" // {
         dependencies = [
           sources."varint-4.0.1"
@@ -6632,7 +6650,7 @@ in
       sources."range-parser-1.2.0"
       sources."read-1.0.7"
       sources."readable-stream-2.3.5"
-      sources."recursive-watch-1.1.3"
+      sources."recursive-watch-1.1.4"
       sources."regex-cache-0.4.4"
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.2"
@@ -7044,10 +7062,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "1.36.1";
+    version = "1.37.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-1.36.1.tgz";
-      sha1 = "43537276c39cc2d9e749d1fd7a3c159b2db39877";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-1.37.3.tgz";
+      sha1 = "592f62fb50633506494bd683a0533a95520ef968";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -7158,7 +7176,7 @@ in
       sources."async-1.5.2"
       sources."async-each-1.0.1"
       sources."asynckit-0.4.0"
-      sources."atob-2.0.3"
+      sources."atob-2.1.0"
       sources."balanced-match-1.0.0"
       (sources."base-0.11.2" // {
         dependencies = [
@@ -7202,6 +7220,7 @@ in
           sources."is-extendable-1.0.1"
         ];
       })
+      sources."ci-info-1.1.3"
       (sources."class-utils-0.3.6" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -7221,7 +7240,7 @@ in
       sources."component-emitter-1.2.1"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
-      sources."configstore-3.1.1"
+      sources."configstore-3.1.2"
       sources."connect-3.6.6"
       sources."content-type-1.0.4"
       sources."cookiejar-2.1.1"
@@ -7314,6 +7333,7 @@ in
       sources."is-accessor-descriptor-1.0.0"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
+      sources."is-ci-1.1.0"
       sources."is-data-descriptor-1.0.0"
       sources."is-descriptor-1.0.2"
       sources."is-extendable-1.0.1"
@@ -7662,7 +7682,7 @@ in
       })
       sources."unzip-response-2.0.1"
       sources."upath-1.0.4"
-      sources."update-notifier-2.3.0"
+      sources."update-notifier-2.4.0"
       sources."uri-js-3.0.2"
       sources."urix-0.1.0"
       sources."url-parse-lax-1.0.0"


### PR DESCRIPTION
###### Motivation for this change

Goal: add the [imapnotify](https://www.npmjs.com/package/imapnotify) program, based on nodejs.

This is my first commit to nixpkgs, so I hope I did not make anything wrong. Basically, I just ran on my debian based system `nix-channel --update && nix-env -u node2nix`, I edited the `json` file in order to add imapnotify, and then I ran the script `./generate.sh`. Hope it's fine!

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS) ===> Not possible because no namespace on debian + not a multi-user install ?
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` ==> not enough memory, crash my system 
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

