### PR TITLE
uhd: 3.10.3.0 -> 3.11.0.0

### DIFF
--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -8,18 +8,18 @@
 #   SUBSYSTEMS=="usb", ATTRS{idVendor}=="2500", ATTRS{idProduct}=="0002", MODE:="0666"
 
 let
-  uhdVer = "003_010_003_000";
-  ImgVer = stdenv.lib.replaceStrings ["_"] ["."] uhdVer;
+  uhdVer = "v" + version;
+  ImgVer = "uhd-images_3.11.0.git-227-g9277fc58.tar.xz";
 
   # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
-  # and xxx.yyy.zzz. Hrmpf...
-  version = "3.10.3.0";
+  # and xxx.yyy.zzz. Hrmpf... style keeps changing
+  version = "3.11.0.0";
 
   # Firmware images are downloaded (pre-built) from:
   # http://files.ettus.com/binaries/images/
   uhdImagesSrc = fetchurl {
-    url = "http://files.ettus.com/binaries/images/uhd-images_${ImgVer}-release.tar.gz";
-    sha256 = "198awvw6zsh19ydgx5qry5yc6yahdval9wjrsqbyj51pnr6s5qvy";
+    url = "http://files.ettus.com/binaries/images/${ImgVer}";
+    sha256 = "1z8isnlxc5h0168jjpdvdv7rkd55x4dkfh14m8pc501zsf8azd6z";
   };
 
 in stdenv.mkDerivation {
@@ -28,19 +28,24 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "EttusResearch";
     repo = "uhd";
-    rev = "release_${uhdVer}";
-    sha256 = "1aj8qizbyz4shwawj3qlhl6pyyda59hhgm9cwrj7s5kfdi4vdlc3";
+    rev = "${uhdVer}";
+    sha256 = "1ilx1a8k5zygfq7acm9yk2fi368b1a1l7ll21kmmxjv6ifz8ds5q";
   };
 
   enableParallelBuilding = true;
 
-  cmakeFlags = "-DLIBUSB_INCLUDE_DIRS=${libusb1.dev}/include/libusb-1.0";
+  # ABI differences GCC 7.1
+  # /nix/store/wd6r25miqbk9ia53pp669gn4wrg9n9cj-gcc-7.3.0/include/c++/7.3.0/bits/vector.tcc:394:7: note: parameter passing for argument of type 'std::vector<uhd::range_t>::iterator {aka __gnu_cxx::__normal_iterator<uhd::range_t*, std::vector<uhd::range_t> >}' changed in GCC 7.1
+
+  cmakeFlags = [ "-DLIBUSB_INCLUDE_DIRS=${libusb1.dev}/include/libusb-1.0"] ++
+               [ (stdenv.lib.optionalString stdenv.isArm "-DCMAKE_CXX_FLAGS=-Wno-psabi") ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ python pythonPackages.pyramid_mako orc libusb1 boost ];
 
   # Build only the host software
   preConfigure = "cd host";
+  patches = if stdenv.isArm then ./neon.patch else null;
 
   postPhases = [ "installFirmware" ];
 
@@ -60,6 +65,6 @@ in stdenv.mkDerivation {
     homepage = https://uhd.ettus.com/;
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ bjornfor fpletz ];
+    maintainers = with maintainers; [ bjornfor fpletz tomberek ];
   };
 }

--- a/pkgs/development/tools/misc/uhd/neon.patch
+++ b/pkgs/development/tools/misc/uhd/neon.patch
@@ -1,0 +1,19 @@
+Description: When building for armhf, enable NEON
+ NEON is part of the armhf baseline, so this will always be enabled on
+ armhf.
+Author: Paul Tagliamonte <paultag@debian.org>
+Bug-Debian: https://bugs.debian.org/873608
+Origin: vendor
+Last-Update: 2017-08-29
+
+--- uhd-3.10.2.0.orig/host/lib/convert/CMakeLists.txt
++++ uhd-3.10.2.0/host/lib/convert/CMakeLists.txt
+@@ -67,6 +67,8 @@ IF(HAVE_ARM_NEON_H AND (${CMAKE_SIZEOF_V
+         ${CMAKE_CURRENT_SOURCE_DIR}/convert_with_neon.cpp
+         ${CMAKE_CURRENT_SOURCE_DIR}/convert_neon.S
+     )
++
++    SET ( CMAKE_CXX_FLAGS "-mfpu=neon" )
+ ENDIF()
+ 
+ ########################################################################


### PR DESCRIPTION
Bump version and add patch/conditionals to allow compilation on ARM with neon
support. Neon patch from:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=873608
thanks @paultag

###### Motivation for this change
Update UHD and allow use on ARM.

###### Things done
Tested on ARM NixOS on Tinker Board, and x86 Ubuntu, and x86 NixOS.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change: not aware of any
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (only on Ubuntu)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

