### PR TITLE
squeezelite: 2016-05-27 -> 2018-08-14

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -272,7 +272,7 @@
       nzbget = 245;
       mosquitto = 246;
       toxvpn = 247;
-      squeezelite = 248;
+      # squeezelite = 248; # DynamicUser = true
       turnserver = 249;
       smokeping = 250;
       gocd-agent = 251;

--- a/nixos/modules/services/audio/squeezelite.nix
+++ b/nixos/modules/services/audio/squeezelite.nix
@@ -3,9 +3,7 @@
 with lib;
 
 let
-
-  uid = config.ids.uids.squeezelite;
-  cfg = config.services.squeezelite;
+  dataDir = "/var/lib/squeezelite";
 
 in {
 
@@ -16,14 +14,6 @@ in {
     services.squeezelite= {
 
       enable = mkEnableOption "Squeezelite, a software Squeezebox emulator";
-
-      dataDir = mkOption {
-        default = "/var/lib/squeezelite";
-        type = types.str;
-        description = ''
-          The directory where Squeezelite stores its name file.
-        '';
-      };
 
       extraArguments = mkOption {
         default = "";
@@ -46,20 +36,12 @@ in {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" "sound.target" ];
       description = "Software Squeezebox emulator";
-      preStart = "mkdir -p ${cfg.dataDir} && chown -R squeezelite ${cfg.dataDir}";
       serviceConfig = {
-        ExecStart = "${pkgs.squeezelite}/bin/squeezelite -N ${cfg.dataDir}/player-name ${cfg.extraArguments}";
-        User = "squeezelite";
-        PermissionsStartOnly = true;
+        DynamicUser = true;
+        ExecStart = "${pkgs.squeezelite}/bin/squeezelite -N ${dataDir}/player-name ${cfg.extraArguments}";
+        StateDirectory = builtins.baseNameOf dataDir;
+        SupplementaryGroups = "audio";
       };
-    };
-
-    users.users.squeezelite= {
-      inherit uid;
-      group = "nogroup";
-      extraGroups = [ "audio" ];
-      description = "Squeezelite user";
-      home = "${cfg.dataDir}";
     };
 
   };

--- a/pkgs/applications/audio/squeezelite/default.nix
+++ b/pkgs/applications/audio/squeezelite/default.nix
@@ -1,20 +1,26 @@
 { stdenv, fetchFromGitHub, alsaLib, faad2, flac, libmad, libvorbis, mpg123 }:
 
 stdenv.mkDerivation {
-  name = "squeezelite-git-2016-05-27";
+  name = "squeezelite-git-2018-08-14";
 
   src = fetchFromGitHub {
-    owner = "ralph-irving";
-    repo = "squeezelite";
-    rev = "e37ed17fed9e11a7346cbe9f1e1deeccc051f42e";
-    sha256 = "15ihx2dbp4kr6k6r50g9q5npqad5zyv8nqf5cr37bhg964syvbdm";
+    owner  = "ralph-irving";
+    repo   = "squeezelite";
+    rev    = "ecb6e3696a42113994640e5345d0b5ca2e77d28b";
+    sha256 = "0di3d5qy8fhawijq6bxy524fgffvzl08dprrws0fs2j1a70fs0fh";
   };
 
   buildInputs = [ alsaLib faad2 flac libmad libvorbis mpg123 ];
 
+  enableParallelBuilding = true;
+
   installPhase = ''
-    mkdir -p $out/bin
-    cp squeezelite $out/bin
+    runHook preInstall
+
+    install -Dm755 -t $out/bin                   squeezelite
+    install -Dm644 -t $out/share/doc/squeezelite *.txt *.md
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Regular update + get rid of the dedicated user by using ```DynamicUser = true```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

