### PR TITLE
yakuake: 3.0.4 -> 3.0.5

### DIFF
--- a/pkgs/applications/misc/yakuake/default.nix
+++ b/pkgs/applications/misc/yakuake/default.nix
@@ -20,12 +20,12 @@
 
 mkDerivation rec {
   pname = "yakuake";
-  version = "3.0.4";
+  version = "3.0.5";
   name = "${pname}-${version}";
 
     src = fetchurl {
       url = "http://download.kde.org/stable/${pname}/${version}/src/${name}.tar.xz";
-      sha256 = "1q31p1cqhz8b2bikqjrr7fww86kaq723ib4ys2zwablfa1ybbqhh";
+      sha256 = "021a9mnghffv2mrdl987mn7wbg8bk6bnf6xz8kn2nwsqxp9kpqh8";
     };
 
     buildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/yakuake/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.0.5 with grep in /nix/store/8ynmx32jvp39xw8x1n6spjxn7acamcys-yakuake-3.0.5
- directory tree listing: https://gist.github.com/b997d1ba53b4383b309cdbe6423958b6

cc @fridh for review