### PR TITLE
varnish: 5.2.1 -> 6.0.0

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -43,8 +43,8 @@ in
     sha256 = "11zwyasz2fn9qxc87r175wb5ba7388sd79mlygjmqn3yv2m89n12";
   };
   varnish5 = common {
-    version = "5.2.1";
-    sha256 = "1cqlj12m426c1lak1hr1fx5zcfsjjvka3hfirz47hvy1g2fjqidq";
+    version = "6.0.0";
+    sha256 = "1vhbdch33m6ig4ijy57zvrramhs9n7cba85wd8rizgxjjnf87cn7";
   };
   varnish6 = common {
     version = "6.0.0";


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/varnish/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/.varnishd-wrapped -V` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishadm -h` got 0 exit code
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishd -V` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishhist -h` got 0 exit code
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishhist -V` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishhist -h` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishlog -h` got 0 exit code
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishlog -V` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishlog -h` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishncsa -h` got 0 exit code
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishncsa -V` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishncsa -h` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishstat -h` got 0 exit code
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishstat --help` got 0 exit code
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishstat -V` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishstat -h` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishstat --help` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishtop -h` got 0 exit code
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishtop -V` and found version 6.0.0
- ran `/nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0/bin/varnishtop -h` and found version 6.0.0
- found 6.0.0 with grep in /nix/store/lby1kpm8y740il2n9dqlklqd8dblk6z7-varnish-6.0.0
- directory tree listing: https://gist.github.com/9eadf379ed25ea49c0157493dfd4e6e8

cc @garbas @fpletz for review