### PR TITLE
wirelesstools: 30.pre2 -> 30

### DIFF
--- a/pkgs/os-specific/linux/wireless-tools/default.nix
+++ b/pkgs/os-specific/linux/wireless-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "wireless-tools-${version}";
-  version = "30.pre2";
+  version = "30";
 
   src = fetchurl {
-    url = "http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/wireless_tools.${version}.tar.gz";
-    sha256 = "01lgf592nk8fnk7l5afqvar4szkngwpgcv4xh58qsg9wkkjlhnls";
+    url = "http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/wireless_tools.${version}.pre9.tar.gz";
+    sha256 = "0qscyd44jmhs4k32ggp107hlym1pcyjzihiai48xs7xzib4wbndb";
   };
 
   preBuild = "


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/wireless-tools/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/ifrename -v` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/ifrename --version` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwconfig -h` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwconfig --help` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwconfig -v` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwconfig --version` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwevent -h` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwevent --help` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwevent -v` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwevent --version` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwgetid -h` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwgetid --help` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwlist -h` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwlist --help` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwlist -v` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwlist --version` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwpriv -h` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwpriv --help` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwpriv help` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwpriv -v` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwpriv --version` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwspy -h` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwspy --help` got 0 exit code
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwspy -v` and found version 30
- ran `/nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30/bin/iwspy --version` and found version 30
- found 30 with grep in /nix/store/dkmg0bv0fi6hqsna2qply6r44hgkgw21-wireless-tools-30
- directory tree listing: https://gist.github.com/a986cf91a58c3814a2ce5cf1ce53ceaf