### PR TITLE
nx-libs updates

### DIFF
--- a/pkgs/development/libraries/libxcomp/default.nix
+++ b/pkgs/development/libraries/libxcomp/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, autoreconfHook, libjpeg, libpng, libX11, zlib }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libjpeg, libpng, libX11, zlib }:
 
 stdenv.mkDerivation rec {
   name = "libxcomp-${version}";
-  version = "3.5.0.33";
+  version = "3.5.99.16";
 
   src = fetchurl {
-    sha256 = "17qjsd6v2ldpfmyjrkdnlq4qk05hz5l6qs54g8h0glzq43w28f74";
+    sha256 = "1m3z9w3h6qpgk265xf030w7lcs181jgw2cdyzshb7l97mn1f7hh2";
     url = "http://code.x2go.org/releases/source/nx-libs/nx-libs-${version}-lite.tar.gz";
   };
 
   buildInputs = [ libjpeg libpng libX11 zlib ];
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   preAutoreconf = ''
     cd nxcomp/
+    sed -i 's|/src/.libs/libXcomp.a|/src/.libs/libXcomp.la|' test/Makefile.am
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/tools/admin/nxproxy/default.nix
+++ b/pkgs/tools/admin/nxproxy/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, autoreconfHook, libxcomp }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libxcomp }:
 
 stdenv.mkDerivation rec {
   name = "nxproxy-${version}";
-  version = "3.5.0.33";
+  version = "3.5.99.16";
 
   src = fetchurl {
-    sha256 = "17qjsd6v2ldpfmyjrkdnlq4qk05hz5l6qs54g8h0glzq43w28f74";
+    sha256 = "1m3z9w3h6qpgk265xf030w7lcs181jgw2cdyzshb7l97mn1f7hh2";
     url = "http://code.x2go.org/releases/source/nx-libs/nx-libs-${version}-lite.tar.gz";
   };
 
   buildInputs = [ libxcomp ];
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   preAutoreconf = ''
     cd nxproxy/
+    sed -i 's|-L\$(top_srcdir)/../nxcomp/src/.libs ||' src/Makefile.am
   '';
 
   makeFlags = [ "exec_prefix=$(out)" ];


### PR DESCRIPTION
###### Motivation for this change

Update to current nx-libs release. Note that there are no direct binaries, these libs are currently only used for x2goclient, which seems to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

