### PR TITLE
txt2man: 1.5.6 -> 1.6.0

### DIFF
--- a/pkgs/tools/misc/txt2man/default.nix
+++ b/pkgs/tools/misc/txt2man/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, coreutils, gawk }:
 
 stdenv.mkDerivation rec {
-  name = "txt2man-1.5.6";
+  name = "txt2man-${version}";
+  version = "1.6.0";
 
   src = fetchurl {
-    url = "http://mvertes.free.fr/download/${name}.tar.gz";
-    sha256 = "0ammlb4pwc4ya1kc9791vjl830074zrpfcmzc18lkcqczp2jaj4q";
+    url = "https://github.com/mvertes/txt2man/archive/${name}.tar.gz";
+    sha256 = "168cj96974n2z0igin6j1ic1m45zyic7nm5ark7frq8j78rrx4zn";
   };
 
   preConfigure = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/txt2man/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/vydx2fidxsxrqm9kanw76gbb8fp4imaz-txt2man-1.6.0/bin/src2man -h` got 0 exit code
- ran `/nix/store/vydx2fidxsxrqm9kanw76gbb8fp4imaz-txt2man-1.6.0/bin/src2man --help` got 0 exit code
- ran `/nix/store/vydx2fidxsxrqm9kanw76gbb8fp4imaz-txt2man-1.6.0/bin/bookman -h` got 0 exit code
- ran `/nix/store/vydx2fidxsxrqm9kanw76gbb8fp4imaz-txt2man-1.6.0/bin/bookman --help` got 0 exit code
- ran `/nix/store/vydx2fidxsxrqm9kanw76gbb8fp4imaz-txt2man-1.6.0/bin/txt2man -h` got 0 exit code
- ran `/nix/store/vydx2fidxsxrqm9kanw76gbb8fp4imaz-txt2man-1.6.0/bin/txt2man --help` got 0 exit code
- ran `/nix/store/vydx2fidxsxrqm9kanw76gbb8fp4imaz-txt2man-1.6.0/bin/txt2man help` got 0 exit code
- directory tree listing: https://gist.github.com/ae0f9873f1dd72fc8e50875212ed15b3

cc @bjornfor for review