### PR TITLE
untex: 1.2 -> 1.3

### DIFF
--- a/pkgs/tools/text/untex/default.nix
+++ b/pkgs/tools/text/untex/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "untex-${version}";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchurl {
-    url = "https://www.ctan.org/tex-archive/support/untex/${name}.tar.gz";
-    sha256 = "07p836jydd5yjy905m5ylnnac1h4cc4jsr41panqb808mlsiwmmy";
+    url = "ftp://ftp.thp.uni-duisburg.de/pub/source/${name}.tar.gz";
+    sha256 = "1jww43pl9qvg6kwh4h8imp966fzd62dk99pb4s93786lmp3kgdjv";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/untex/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.3 with grep in /nix/store/vj06kpkl7dm511fy5vnx60dx48n2fhl5-untex-1.3
- directory tree listing: https://gist.github.com/7507195ef91ce9d4ae79a3f80dc453ac

cc @joachifm for review