### PR TITLE
urlwatch: 2.8 -> 2.9

### DIFF
--- a/pkgs/tools/networking/urlwatch/default.nix
+++ b/pkgs/tools/networking/urlwatch/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "urlwatch-${version}";
-  version = "2.8";
+  version = "2.9";
 
   src = fetchFromGitHub {
     owner  = "thp";
     repo   = "urlwatch";
     rev    = version;
-    sha256 = "1nja7n6pc45azd3l1xyvav89855lvcgwabrvf34rps81dbl8cnl4";
+    sha256 = "0biy02vyhdwghy9qjmjwlfd8hzaz9gfsssd53ng6zpww4wkkiydz";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/urlwatch/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/2rxia8pnparqbq5fim3w2wkzd80dpnd6-urlwatch-2.9/bin/.urlwatch-wrapped -h` got 0 exit code
- ran `/nix/store/2rxia8pnparqbq5fim3w2wkzd80dpnd6-urlwatch-2.9/bin/.urlwatch-wrapped --help` got 0 exit code
- ran `/nix/store/2rxia8pnparqbq5fim3w2wkzd80dpnd6-urlwatch-2.9/bin/.urlwatch-wrapped --version` and found version 2.9
- ran `/nix/store/2rxia8pnparqbq5fim3w2wkzd80dpnd6-urlwatch-2.9/bin/urlwatch -h` got 0 exit code
- ran `/nix/store/2rxia8pnparqbq5fim3w2wkzd80dpnd6-urlwatch-2.9/bin/urlwatch --help` got 0 exit code
- ran `/nix/store/2rxia8pnparqbq5fim3w2wkzd80dpnd6-urlwatch-2.9/bin/urlwatch --version` and found version 2.9
- found 2.9 with grep in /nix/store/2rxia8pnparqbq5fim3w2wkzd80dpnd6-urlwatch-2.9
- directory tree listing: https://gist.github.com/0eda6a1b4d363b26b50e23e30e7a5397

cc @4z3 for review