### PR TITLE
sysvinit: 2.88dsf -> 2.89

### DIFF
--- a/pkgs/os-specific/linux/sysvinit/default.nix
+++ b/pkgs/os-specific/linux/sysvinit/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, withoutInitTools ? false }:
 
-let version = "2.88dsf"; in
+let version = "2.89"; in
 
 stdenv.mkDerivation {
   name = (if withoutInitTools then "sysvtools" else "sysvinit") + "-" + version;
 
   src = fetchurl {
     url = "mirror://savannah/sysvinit/sysvinit-${version}.tar.bz2";
-    sha256 = "068mvzaz808a673zigyaqb63xc8bndh2klk16zi5c83rw70wifv0";
+    sha256 = "0rdw5lgg2rpcfdmq90br388qr01w89vsqmpvrqcqjqsmxk9zw3c2";
   };
 
   prePatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/sysvinit/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/n54idc6ddkgkwnbbg8y6avb5wvzb5s34-sysvinit-2.89/bin/last help` got 0 exit code
- ran `/nix/store/n54idc6ddkgkwnbbg8y6avb5wvzb5s34-sysvinit-2.89/bin/utmpdump -h` got 0 exit code
- ran `/nix/store/n54idc6ddkgkwnbbg8y6avb5wvzb5s34-sysvinit-2.89/bin/wall help` got 0 exit code
- found 2.89 with grep in /nix/store/n54idc6ddkgkwnbbg8y6avb5wvzb5s34-sysvinit-2.89
- directory tree listing: https://gist.github.com/6fdc40b90f12b6caa767385d367da4d9