### PR TITLE
spectre-meltdown-checker: 0.35 -> 0.36

### DIFF
--- a/pkgs/tools/security/spectre-meltdown-checker/default.nix
+++ b/pkgs/tools/security/spectre-meltdown-checker/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "spectre-meltdown-checker-${version}";
-  version = "0.35";
+  version = "0.36";
 
   src = fetchFromGitHub {
     owner = "speed47";
     repo = "spectre-meltdown-checker";
     rev = "v${version}";
-    sha256 = "0pzs6iznrar5zkg92gsh6d0zhdi715zwqcb8hh1aaykx9igjb1xw";
+    sha256 = "0pcw300hizzm130d0ip7j0ivf53sjlv6qzsdk9l68bj2lpx9n3kd";
   };
 
   prePatch = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/spectre-meltdown-checker/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/7lrw74lhzrxf9qlykxbq0z4zqick818s-spectre-meltdown-checker-0.36/bin/spectre-meltdown-checker -h` got 0 exit code
- ran `/nix/store/7lrw74lhzrxf9qlykxbq0z4zqick818s-spectre-meltdown-checker-0.36/bin/spectre-meltdown-checker --help` got 0 exit code
- ran `/nix/store/7lrw74lhzrxf9qlykxbq0z4zqick818s-spectre-meltdown-checker-0.36/bin/spectre-meltdown-checker --version` and found version 0.36
- ran `/nix/store/7lrw74lhzrxf9qlykxbq0z4zqick818s-spectre-meltdown-checker-0.36/bin/spectre-meltdown-checker -h` and found version 0.36
- ran `/nix/store/7lrw74lhzrxf9qlykxbq0z4zqick818s-spectre-meltdown-checker-0.36/bin/spectre-meltdown-checker --help` and found version 0.36
- found 0.36 with grep in /nix/store/7lrw74lhzrxf9qlykxbq0z4zqick818s-spectre-meltdown-checker-0.36
- directory tree listing: https://gist.github.com/ecf768a2a6ae0c7389c9248d2e0b98dc

cc @dotlambda for review