### PR TITLE
gitAndTools.stgit: 0.17.1 -> 0.18

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/stgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/stgit/default.nix
@@ -1,14 +1,15 @@
 { stdenv, fetchurl, python2, git }:
 
 let
-  name = "stgit-0.17.1";
+  name = "stgit-${version}";
+  version = "0.18";
 in
 stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
-    url = "http://download.gna.org/stgit/${name}.tar.gz";
-    sha256 = "1pka0ns9x0kabn036zsf0mwmwiynckhnva51kgxsch9fqah6acyl";
+    url = "https://github.com/ctmarinas/stgit/archive/v${version}.tar.gz";
+    sha256 = "19fk6vw3pgp2a98wpd4j3kyiyll5dy9bi4921wq1mrky0l53mj00";
   };
 
   buildInputs = [ python2 git ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/stgit/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/fwhfsvfs23x3jwc2wgx805x229vxwd24-stgit-0.18/bin/stg -h` got 0 exit code
- ran `/nix/store/fwhfsvfs23x3jwc2wgx805x229vxwd24-stgit-0.18/bin/stg --help` got 0 exit code
- ran `/nix/store/fwhfsvfs23x3jwc2wgx805x229vxwd24-stgit-0.18/bin/stg help` got 0 exit code
- found 0.18 with grep in /nix/store/fwhfsvfs23x3jwc2wgx805x229vxwd24-stgit-0.18
- directory tree listing: https://gist.github.com/b3a9f7bf9ff22a7858ac4f6e4d7d7be0

cc @the-kenny for review