### PR TITLE
slurm: 17.11.3 -> 17.11.5

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-${version}";
-  version = "17.11.3";
+  version = "17.11.5";
 
   src = fetchurl {
     url = "https://download.schedmd.com/slurm/${name}.tar.bz2";
-    sha256 = "1x3i6z03d9m46fvj1cslrapm1drvgyqch9pn4xf23kvbz4gkhaps";
+    sha256 = "07ghyyz12k4rksm06xf7dshwp1ndm13zphdbqja99401q4xwbx9r";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/slurm/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/kpn869z54bm58ib47qmv74lv01dfyp4f-slurm-17.11.5/bin/sattach -h` got 0 exit code
- ran `/nix/store/kpn869z54bm58ib47qmv74lv01dfyp4f-slurm-17.11.5/bin/sattach --help` got 0 exit code
- ran `/nix/store/kpn869z54bm58ib47qmv74lv01dfyp4f-slurm-17.11.5/bin/sattach -V` and found version 17.11.5
- ran `/nix/store/kpn869z54bm58ib47qmv74lv01dfyp4f-slurm-17.11.5/bin/sattach --version` and found version 17.11.5
- ran `/nix/store/kpn869z54bm58ib47qmv74lv01dfyp4f-slurm-17.11.5/bin/slurmd -h` got 0 exit code
- ran `/nix/store/kpn869z54bm58ib47qmv74lv01dfyp4f-slurm-17.11.5/bin/slurmd -V` and found version 17.11.5
- found 17.11.5 with grep in /nix/store/kpn869z54bm58ib47qmv74lv01dfyp4f-slurm-17.11.5
- directory tree listing: https://gist.github.com/a4fb120a8f87f92e70daccf30910015b

cc @jagajaga for review