### PR TITLE
sxhkd: 0.5.8 -> 0.5.9

### DIFF
--- a/pkgs/applications/window-managers/sxhkd/default.nix
+++ b/pkgs/applications/window-managers/sxhkd/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "sxhkd-${version}";
-  version = "0.5.8";
+  version = "0.5.9";
 
   src = fetchFromGitHub {
     owner = "baskerville";
     repo = "sxhkd";
     rev = version;
-    sha256 = "0vnm0d2ckijsp8kc2v8jz4raamb487vg62v58v01a3rb9gzzgl06";
+    sha256 = "0cw547x7vky55k3ksrmzmrra4zhslqcwq9xw0y4cmbvy4s1qf64v";
   };
 
   buildInputs = [ asciidoc libxcb xcbutil xcbutilkeysyms xcbutilwm ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/sxhkd/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/psgpqlc79whix5834kvvs9klgiyinl72-sxhkd-0.5.9/bin/sxhkd -h` got 0 exit code
- ran `/nix/store/psgpqlc79whix5834kvvs9klgiyinl72-sxhkd-0.5.9/bin/sxhkd --help` got 0 exit code
- ran `/nix/store/psgpqlc79whix5834kvvs9klgiyinl72-sxhkd-0.5.9/bin/sxhkd -v` and found version 0.5.9
- ran `/nix/store/psgpqlc79whix5834kvvs9klgiyinl72-sxhkd-0.5.9/bin/sxhkd --version` and found version 0.5.9
- ran `/nix/store/psgpqlc79whix5834kvvs9klgiyinl72-sxhkd-0.5.9/bin/sxhkd --help` and found version 0.5.9
- found 0.5.9 with grep in /nix/store/psgpqlc79whix5834kvvs9klgiyinl72-sxhkd-0.5.9
- directory tree listing: https://gist.github.com/7b7f60bf79af2063b4100fb74b4c468c

cc @vyp for review