### PR TITLE
sylpheed: 3.6.0 -> 3.7.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/sylpheed/default.nix
+++ b/pkgs/applications/networking/mailreaders/sylpheed/default.nix
@@ -8,11 +8,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "sylpheed-${version}";
-  version = "3.6.0";
+  version = "3.7.0";
 
   src = fetchurl {
-    url = "http://sylpheed.sraoss.jp/sylpheed/v3.6/${name}.tar.bz2";
-    sha256 = "0idk9nz3d200l2bxc38vnxlx0wcslrvncy9lk50vz7dl8c5sg97b";
+    url = "http://sylpheed.sraoss.jp/sylpheed/v3.7/${name}.tar.xz";
+    sha256 = "0j9y5vdzch251s264diw9clrn88dn20bqqkwfmis9l7m8vmwasqd";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/sylpheed/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/h2523jz7ladr0j6m3v6a0x45ak0z9iq8-sylpheed-3.7.0/bin/sylpheed --version` and found version 3.7.0
- found 3.7.0 with grep in /nix/store/h2523jz7ladr0j6m3v6a0x45ak0z9iq8-sylpheed-3.7.0
- directory tree listing: https://gist.github.com/8f404aeeccf14771245b2a25b3a1231e

cc @edolstra for review