### PR TITLE
radamsa: 0.4 -> 0.5

### DIFF
--- a/pkgs/tools/security/radamsa/default.nix
+++ b/pkgs/tools/security/radamsa/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "radamsa-${version}";
-  version = "0.4";
+  version = "0.5";
 
   src = fetchurl {
-    url = "http://haltp.org/download/${name}.tar.gz";
-    sha256 = "1xs9dsrq6qrf104yi9x21scpr73crfikbi8q9njimiw5c1y6alrv";
+    url = "https://github.com/aoh/radamsa/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "1d2chp45fbdb2v5zpsx6gh3bv8fhcjv0zijz10clcznadnm8c6p2";
   };
 
   patchPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/radamsa/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/vjls4rpfr18a844phj56y6zkgjhkk44n-radamsa-0.5/bin/radamsa -h` got 0 exit code
- ran `/nix/store/vjls4rpfr18a844phj56y6zkgjhkk44n-radamsa-0.5/bin/radamsa --help` got 0 exit code
- ran `/nix/store/vjls4rpfr18a844phj56y6zkgjhkk44n-radamsa-0.5/bin/radamsa -V` and found version 0.5
- ran `/nix/store/vjls4rpfr18a844phj56y6zkgjhkk44n-radamsa-0.5/bin/radamsa --version` and found version 0.5
- found 0.5 with grep in /nix/store/vjls4rpfr18a844phj56y6zkgjhkk44n-radamsa-0.5
- directory tree listing: https://gist.github.com/fc1b475926e3a86b55b9d18567458bd4