### PR TITLE
haskell.lib: Add {en,dis}ableExecutableProfiling transformer

### DIFF
--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -162,6 +162,9 @@ rec {
   enableLibraryProfiling = drv: overrideCabal drv (drv: { enableLibraryProfiling = true; });
   disableLibraryProfiling = drv: overrideCabal drv (drv: { enableLibraryProfiling = false; });
 
+  enableExecutableProfiling = drv: overrideCabal drv (drv: { enableExecutableProfiling = true; });
+  disableExecutableProfiling = drv: overrideCabal drv (drv: { enableExecutableProfiling = false; });
+
   enableSharedExecutables = drv: overrideCabal drv (drv: { enableSharedExecutables = true; });
   disableSharedExecutables = drv: overrideCabal drv (drv: { enableSharedExecutables = false; });
 


### PR DESCRIPTION
###### Motivation for this change

We already have {en,dis}ableLibraryProfiling and the builder already
accepts the executable profiling attribute; let's make it easy to use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

