### PR TITLE
pythonPackages.vxi11: init at 0.9

### DIFF
--- a/pkgs/development/python-modules/vxi11/default.nix
+++ b/pkgs/development/python-modules/vxi11/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "python-vxi11";
+  version = "0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zvd0wxp6mccaxy9fzlzk3i4pr2ggnj79r3awimjqd89pvaxiyq1";
+  };
+
+  checkInputs = [ nose ];
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "VXI-11 driver for controlling instruments over Ethernet";
+    homepage = https://github.com/python-ivi/python-vxi11;
+    license = licenses.mit;
+    maintainers = with maintainers; [ bgamari ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19253,6 +19253,8 @@ EOF
     };
   };
 
+  vxi11 = callPackage ../development/python-modules/vxi11 { };
+
   svg2tikz = self.buildPythonPackage {
     name = "svg2tikz-1.0.0";
     disabled = ! isPy27;


### PR DESCRIPTION
###### Motivation for this change

This is a useful package for interfacing with test and measurement equipment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

