### PR TITLE
gpu-switch: init at 2017-04-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2465,6 +2465,11 @@
     github = "mschristiansen";
     name = "Mikkel Christiansen";
   };
+  msiedlarek = {
+    email = "mikolaj@siedlarek.pl";
+    github = "msiedlarek";
+    name = "Mikołaj Siedlarek";
+  };
   mstarzyk = {
     email = "mstarzyk@gmail.com";
     github = "mstarzyk";

--- a/pkgs/os-specific/linux/gpu-switch/default.nix
+++ b/pkgs/os-specific/linux/gpu-switch/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gpu-switch-unstable-${version}";
+  version = "2017-04-28";
+  src = fetchFromGitHub {
+    owner = "0xbb";
+    repo = "gpu-switch";
+    rev = "a365f56d435c8ef84c4dd2ab935ede4992359e31";
+    sha256 = "1jnh43nijkqd83h7piq7225ixziggyzaalabgissyxdyz6szcn0r";
+  };
+  installPhase = ''
+    mkdir -p $out/bin
+    cp gpu-switch $out/bin/
+  '';
+  meta = with lib; {
+    description = "Application that allows to switch between the graphic cards of dual-GPU MacBook Pro models";
+    homepage = https://github.com/0xbb/gpu-switch;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msiedlarek ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13173,6 +13173,8 @@ with pkgs;
 
   gpm-ncurses = gpm.override { inherit ncurses; };
 
+  gpu-switch = callPackage ../os-specific/linux/gpu-switch { };
+
   gradm = callPackage ../os-specific/linux/gradm {
     flex = flex_2_5_35;
   };


### PR DESCRIPTION
###### Motivation for this change

Simple script that allows to switch between the graphic cards of dual-GPU MacBook Pro models.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

