### PR TITLE
polyml: 5.7 -> 5.7.1

### DIFF
--- a/pkgs/development/compilers/polyml/default.nix
+++ b/pkgs/development/compilers/polyml/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "polyml-${version}";
-  version = "5.7";
+  version = "5.7.1";
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure.ac --replace stdc++ c++
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "polyml";
     repo = "polyml";
     rev = "v${version}";
-    sha256 = "10nsljmcl0zjbcc7ifc991ypwfwq5gh4rcp5rg4nnb706c6bs16y";
+    sha256 = "0j0wv3ijfrjkfngy7dswm4k1dchk3jak9chl5735dl8yrl8mq755";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/polyml/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/ac6iwd3ixncb9cqjg59fbj2nzcfmsqgn-polyml-5.7.1/bin/poly --help` got 0 exit code
- ran `/nix/store/ac6iwd3ixncb9cqjg59fbj2nzcfmsqgn-polyml-5.7.1/bin/poly -v` and found version 5.7.1
- ran `/nix/store/ac6iwd3ixncb9cqjg59fbj2nzcfmsqgn-polyml-5.7.1/bin/poly --help` and found version 5.7.1
- ran `/nix/store/ac6iwd3ixncb9cqjg59fbj2nzcfmsqgn-polyml-5.7.1/bin/polyc --help` got 0 exit code
- ran `/nix/store/ac6iwd3ixncb9cqjg59fbj2nzcfmsqgn-polyml-5.7.1/bin/polyc --help` and found version 5.7.1
- found 5.7.1 with grep in /nix/store/ac6iwd3ixncb9cqjg59fbj2nzcfmsqgn-polyml-5.7.1
- directory tree listing: https://gist.github.com/e23988ea219cf9deddb7b7c0578cfd89

cc @maggesi @yurrriq for review