### PR TITLE
pipes: 1.2.0 -> 1.16.1

### DIFF
--- a/pkgs/misc/screensavers/pipes/default.nix
+++ b/pkgs/misc/screensavers/pipes/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pipes-${version}";
-  version = "1.2.0";
+  version = "1.16.1";
 
   src = fetchurl {
-    url = "https://github.com/pipeseroni/pipes.sh/archive/v${version}.tar.gz";
-    sha256 = "1v0xhgq30zkfjk9l5g8swpivh7rxfjbzhbjpr2c5c836wgn026fb";
+    url = "http://bisqwit.iki.fi/src/arch/${name}.tar.bz2";
+    sha256 = "0b56mls2ygg66p1b66ldws5x0a0k3vk4rmyhlis13s8fw7vh5fyp";
   };
 
   buildInputs = with pkgs; [ bash ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/pipes/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/03b50dc1980c3536f4862a67ac805d5f

cc @matthiasbeyer for review