### PR TITLE
ptex: 2.1.28 -> 2.1.33

### DIFF
--- a/pkgs/development/libraries/ptex/default.nix
+++ b/pkgs/development/libraries/ptex/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec
 {
   name = "ptex-${version}";
-  version = "2.1.28";
+  version = "2.1.33";
 
   src = fetchFromGitHub {
     owner = "wdas";
     repo = "ptex";
     rev = "v${version}";
-    sha256 = "1h6gb3mpis4m6ph7h9q764w50f9jrar3jz2ja76rn5czy6wn318x";
+    sha256 = "15ijjq3w7hwgm4mqah0x4jzjy3v2nnmmv28lbqzmxzcxjgh4sjkn";
   };
 
   outputs = [ "bin" "dev" "out" "lib" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/ptex/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/88ea582c17048ee1efddf1b2e87ef3bc

cc @guibou for review