### PR TITLE
oidentd: 2.0.8 -> 2.2.2

### DIFF
--- a/pkgs/servers/identd/oidentd/default.nix
+++ b/pkgs/servers/identd/oidentd/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "oidentd-2.0.8";
+  name = "oidentd-${version}";
+  version = "2.2.2";
 
   CFLAGS = [ "--std=gnu89" ];
 
   src = fetchurl {
-    url = "mirror://sourceforge/ojnk/${name}.tar.gz";
-    sha256 = "0vzv2086rrxcaavrm3js7aqvyc0grgaqy78x61d8s7r8hz8vwk55";
+    url = "https://ftp.janikrabe.com/pub/oidentd/releases/${version}/${name}.tar.gz";
+    sha256 = "1svj7ymljp4s17d7jlx6602n9081714qsj5yymmv1s9wagzjqyn9";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/oidentd/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/19rf4km35iddw3nbslr0nak3va625620-oidentd-2.2.2/bin/oidentd -h` got 0 exit code
- ran `/nix/store/19rf4km35iddw3nbslr0nak3va625620-oidentd-2.2.2/bin/oidentd --help` got 0 exit code
- ran `/nix/store/19rf4km35iddw3nbslr0nak3va625620-oidentd-2.2.2/bin/oidentd -v` and found version 2.2.2
- ran `/nix/store/19rf4km35iddw3nbslr0nak3va625620-oidentd-2.2.2/bin/oidentd --version` and found version 2.2.2
- ran `/nix/store/19rf4km35iddw3nbslr0nak3va625620-oidentd-2.2.2/bin/oidentd -h` and found version 2.2.2
- ran `/nix/store/19rf4km35iddw3nbslr0nak3va625620-oidentd-2.2.2/bin/oidentd --help` and found version 2.2.2
- found 2.2.2 with grep in /nix/store/19rf4km35iddw3nbslr0nak3va625620-oidentd-2.2.2
- directory tree listing: https://gist.github.com/7435022bd0d74e9187ebde35c4fd39f9