### PR TITLE
nixos/gogs: allow git operations over ssh

### DIFF
--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -35,6 +35,9 @@ let
     SECRET_KEY = #secretkey#
     INSTALL_LOCK = true
 
+    [log]
+    ROOT_PATH = ${cfg.stateDir}/log
+
     ${cfg.extraConfig}
   '';
 in


### PR DESCRIPTION
Without `ROOT_PATH` set, `gogs serv` tries to open logs in writing in its store directory. This blocks cloning or pushing over ssh, and results in a gogs internal error.

I've tested the workaround on 18.03 with 
```nix
{
  service.gogs.extraConfig = ''
    [log]
    ROOT_PATH = /var/lib/gogs/log
  '';
}
```