### PR TITLE
calibre: remove unnecessary patch

### DIFF
--- a/pkgs/applications/misc/calibre/no_updates_dialog.patch
+++ b/pkgs/applications/misc/calibre/no_updates_dialog.patch
@@ -13,15 +13,3 @@ diff -burN calibre-2.9.0.orig/src/calibre/gui2/main.py calibre-2.9.0/src/calibre
      parser.add_option('--ignore-plugins', default=False, action='store_true',
              help=_('Ignore custom plugins, useful if you installed a plugin'
                  ' that is preventing calibre from starting'))
-diff -burN calibre-2.9.0.orig/src/calibre/gui2/update.py calibre-2.9.0/src/calibre/gui2/update.py
---- calibre-2.9.0.orig/src/calibre/gui2/update.py	2014-11-09 20:09:54.082231864 +0800
-+++ calibre-2.9.0/src/calibre/gui2/update.py	2014-11-09 20:17:49.954767115 +0800
-@@ -154,6 +154,8 @@
-             self.update_checker.signal.update_found.connect(self.update_found,
-                     type=Qt.QueuedConnection)
-             self.update_checker.start()
-+        else:
-+            self.update_checker = None
- 
-     def recalc_update_label(self, number_of_plugin_updates):
-         self.update_found(self.last_newest_calibre_version, number_of_plugin_updates)


### PR DESCRIPTION

###### Motivation for this change

In addition to bumping the version, remove a patch which made self.update_checker None. This caused errors that showed on the terminal after closing Calibre (if it was launched from a terminal).

@AndersonTorres Perhaps you know if it is safe to remove this patch as you added it? Why was it added? It causes an error on exit (only visible from the terminal). Probably not serious, and I believe next Calibre version will not have this issue, but still, I don't see any reason for the patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

