### PR TITLE
papirus-icon-theme: 20180214 -> 20180311

### DIFF
--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "papirus-icon-theme-${version}";
-  version = "20180214";
+  version = "20180311";
 
   src = fetchFromGitHub {
     owner = "PapirusDevelopmentTeam";
     repo = "papirus-icon-theme";
     rev = version;
-    sha256 = "0lsp5cmq5wdqw6vyh6hqqrshgpzxfj8dx87l7qdlgrk73dajjmki";
+    sha256 = "11a6z07awq6cxv5wrwh87sj3czdc4r0w9r8883dgg8cmxpzsg3cd";
   };
 
   nativeBuildInputs = [ gtk3 ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/papirus-icon-theme/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/59544662542e96023a79920e1f2b7ae9