### PR TITLE
lyx: 2.2.3 -> 2.3.0

### DIFF
--- a/pkgs/applications/misc/lyx/default.nix
+++ b/pkgs/applications/misc/lyx/default.nix
@@ -3,12 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.2.3";
+  version = "2.3.0";
   name = "lyx-${version}";
 
   src = fetchurl {
-    url = "ftp://ftp.lyx.org/pub/lyx/stable/2.2.x/${name}.tar.xz";
-    sha256 = "0mrbr24xbdg25gd7w8g76gpmy0a10nrnz0mz47mdjwi441yfpjjg";
+    url = "ftp://ftp.lyx.org/pub/lyx/stable/2.3.x/${name}.tar.xz";
+    sha256 = "0axri2h8xkna4mkfchfyyysbjl7s486vx80p5hzj9zgsvdm5a3ri";
   };
 
   # LaTeX is used from $PATH, as people often want to have it with extra pkgs


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/lyx/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/lyxclient -h` got 0 exit code
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/tex2lyx -h` got 0 exit code
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/tex2lyx --help` got 0 exit code
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/tex2lyx -v` and found version 2.3.0
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/tex2lyx --version` and found version 2.3.0
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/tex2lyx -h` and found version 2.3.0
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/tex2lyx --help` and found version 2.3.0
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/.lyx-wrapped --help` got 0 exit code
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/.lyx-wrapped --version` and found version 2.3.0
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/lyx --help` got 0 exit code
- ran `/nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0/bin/lyx --version` and found version 2.3.0
- found 2.3.0 with grep in /nix/store/p9561m3hhl936qh6wc3zhaypz9axywar-lyx-2.3.0
- directory tree listing: https://gist.github.com/446d7f60ddce2b781c23ff41a2d673d1

cc @vcunat for review