### PR TITLE
mandoc: 1.13.4 -> 1.14.3

### DIFF
--- a/pkgs/tools/misc/mandoc/default.nix
+++ b/pkgs/tools/misc/mandoc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mandoc-${version}";
-  version = "1.13.4";
+  version = "1.14.3";
 
   src = fetchurl {
-    url = "http://mdocml.bsd.lv/snapshots/mdocml-${version}.tar.gz";
-    sha256 = "1vz0g5nvjbz1ckrg9cn6ivlnb13bcl1r6nc4yzb7300qvfnw2m8a";
+    url = "http://mdocml.bsd.lv/snapshots/${name}.tar.gz";
+    sha256 = "0a4mv4pk6939v544dbfjvxwvi13r6c66i45nskm6j5ccjmkqy30b";
   };
 
   buildInputs = [ zlib ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/mandoc/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/9az9m22hp4dqbnb2fl0rrs92bh2wr47l-mandoc-1.14.3/bin/demandoc help` got 0 exit code
- directory tree listing: https://gist.github.com/9c37570ea9583a96c58a0d50dd6b500a

cc @ramkromberg for review