### PR TITLE
todiff: init at 0.4.0

### DIFF
--- a/pkgs/applications/misc/todiff/default.nix
+++ b/pkgs/applications/misc/todiff/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  name = "todiff-${version}";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Ekleog";
+    repo = "todiff";
+    rev = version;
+    sha256 = "0n3sifinwhny651q1v1a6y9ybim1b0nd5s1z26sigjdhdvxckn65";
+  };
+
+  cargoSha256 = "0mxdpn98fvmxrp656vwxvzl9vprz5mvqj7d1hvvs4gsjrsiyp0fy";
+
+  meta = with stdenv.lib; {
+    description = "Human-readable diff for todo.txt files";
+    homepage = "https://github.com/Ekleog/todiff";
+    maintainers = with maintainers; [ ekleog ];
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17958,6 +17958,8 @@ with pkgs;
 
   tnef = callPackage ../applications/misc/tnef { };
 
+  todiff = callPackage ../applications/misc/todiff { };
+
   todo-txt-cli = callPackage ../applications/office/todo.txt-cli { };
 
   tomahawk = callPackage ../applications/audio/tomahawk {


### PR DESCRIPTION
###### Motivation for this change

OK, so this is me packaging a program I wrote myself. I wouldn't do it were I the sole user on NixOS I knew of, but at least two friends of mine also started using it, so I guess it does interest at least a few people.

I still hesitated, and people on #nixos-dev told me to just package it because it would be better if I maintained it myself (at least it'd be up-to-date), so here it is, but feel free to reject if you don't think it brings substantial improvements to nixpkgs :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

