### PR TITLE
libgringotts: 1.1.2 -> 1.2.1

### DIFF
--- a/pkgs/development/libraries/libgringotts/default.nix
+++ b/pkgs/development/libraries/libgringotts/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libgringotts-${version}";
-  version = "1.1.2";
+  version = "1.2.1";
 
   src = fetchurl {
-    url = "http://libgringotts.sourceforge.net/current/${name}.tar.bz2";
-    sha256 = "1bzfnpf2gwc2bisbrw06s63g9z9v4mh1n9ksqr6pbgj2prz7bvlk";
+    url = "https://sourceforge.net/projects/gringotts.berlios/files/${name}.tar.bz2";
+    sha256 = "1ldz1lyl1aml5ci1mpnys8dg6n7khpcs4zpycak3spcpgdsnypm7";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/libgringotts/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.2.1 with grep in /nix/store/9z57bh8m3wr1fjaksavpyjr8y9xanf0l-libgringotts-1.2.1
- directory tree listing: https://gist.github.com/6efcd3f0105df20d27e52a1f3e69b142

cc @pSub for review