### PR TITLE
libatomic_ops: 7.6.2 -> 7.6.4

### DIFF
--- a/pkgs/development/libraries/libatomic_ops/default.nix
+++ b/pkgs/development/libraries/libatomic_ops/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "libatomic_ops-${version}";
-  version = "7.6.2";
+  version = "7.6.4";
 
   src = fetchurl {
     urls = [
       "http://www.ivmaisoft.com/_bin/atomic_ops/libatomic_ops-${version}.tar.gz"
       "https://github.com/ivmai/libatomic_ops/releases/download/v${version}/libatomic_ops-${version}.tar.gz"
     ];
-    sha256 ="1rif2hjscq5mh639nsnjhb90c01gnmy1sbmj6x6hsn1xmpnj95r1";
+    sha256 ="0knxncsjhbknlyy6lx7ycxhpzfk3sykhvicgxyp0rmsxd1d3v0jv";
   };
 
   outputs = [ "out" "dev" "doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/libatomic_ops/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 7.6.4 with grep in /nix/store/n84mhrmyf5gi8ypx3rk8vnj3jzpcr4ss-libatomic_ops-7.6.4
- directory tree listing: https://gist.github.com/3efac1c700e321bd79a10ade1fb376ee

cc @7c6f434c for review