### PR TITLE
libmowgli: 0.9.50 -> 2.1.3

### DIFF
--- a/pkgs/development/libraries/libmowgli/default.nix
+++ b/pkgs/development/libraries/libmowgli/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libmowgli-0.9.50";
+  name = "libmowgli-${version}";
+  version = "2.1.3";
   
   src = fetchurl {
-    url = "http://distfiles.atheme.org/${name}.tar.bz2";
-    sha256 = "0wbnpd2rzk5jg6pghgxyx7brjrdmsyg4p0mm9blwmrdrj5ybxx9z";
+    url = "https://github.com/atheme/libmowgli-2/archive/v${version}.tar.gz";
+    sha256 = "0xx4vndmwz40pxa5gikl8z8cskpdl9a30i2i5fjncqzlp4pspymp";
   };
   
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/libmowgli/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 2.1.3 with grep in /nix/store/2dwfl61xs1bwl8xkml0asgxpwcg33n2k-libmowgli-2.1.3
- directory tree listing: https://gist.github.com/bac007dbe50cb7dc4d1a836655fd1179