### PR TITLE
libqalculate: 2.2.1 -> 2.3.0

### DIFF
--- a/pkgs/development/libraries/libqalculate/default.nix
+++ b/pkgs/development/libraries/libqalculate/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "libqalculate-${version}";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchurl {
     url = "https://github.com/Qalculate/libqalculate/archive/v${version}.tar.gz";
-    sha256 = "0bam1xvw4n5sm3g4kmggz2aha34xaw64kw15wl2lbkd2yzdjdm4l";
+    sha256 = "1wrd9ajf00h1ja56r25vljjsgklg0qlzmziax7x26wjqkigc28iq";
   };
 
   outputs = [ "out" "dev" "doc" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/libqalculate/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/llqc0hh85xfdxqzkwzxqxhjjjck4vbh7-libqalculate-2.3.0/bin/qalc -h` got 0 exit code
- ran `/nix/store/llqc0hh85xfdxqzkwzxqxhjjjck4vbh7-libqalculate-2.3.0/bin/qalc --help` got 0 exit code
- ran `/nix/store/llqc0hh85xfdxqzkwzxqxhjjjck4vbh7-libqalculate-2.3.0/bin/qalc help` got 0 exit code
- ran `/nix/store/llqc0hh85xfdxqzkwzxqxhjjjck4vbh7-libqalculate-2.3.0/bin/qalc -v` and found version 2.3.0
- ran `/nix/store/llqc0hh85xfdxqzkwzxqxhjjjck4vbh7-libqalculate-2.3.0/bin/qalc --version` and found version 2.3.0
- found 2.3.0 with grep in /nix/store/llqc0hh85xfdxqzkwzxqxhjjjck4vbh7-libqalculate-2.3.0
- directory tree listing: https://gist.github.com/6f930e6da5dc3ef9c09229cc76f36a31

cc @gebner for review