### PR TITLE
knot-resolver: 2.1.1 -> 2.2.0

### DIFF
--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -12,11 +12,11 @@ inherit (stdenv.lib) optional optionals optionalString concatStringsSep;
 
 unwrapped = stdenv.mkDerivation rec {
   name = "knot-resolver-${version}";
-  version = "2.1.1";
+  version = "2.2.0";
 
   src = fetchurl {
     url = "http://secure.nic.cz/files/knot-resolver/${name}.tar.xz";
-    sha256 = "0b9caee03d7cd30e1dc8fa0ce5fafade31fc1785314986bbf77cad446522a1b3";
+    sha256 = "1yhlwvpl81klyfb8hhvrhii99q7wvydi3vandmq9j7dvig6z1dvv";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/knot-resolver/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/2fpr2hzspmrnnvmawxd3mv28774rysma-knot-resolver-2.2.0/bin/kresd -h` got 0 exit code
- ran `/nix/store/2fpr2hzspmrnnvmawxd3mv28774rysma-knot-resolver-2.2.0/bin/kresd --help` got 0 exit code
- ran `/nix/store/2fpr2hzspmrnnvmawxd3mv28774rysma-knot-resolver-2.2.0/bin/kresd -V` and found version 2.2.0
- ran `/nix/store/2fpr2hzspmrnnvmawxd3mv28774rysma-knot-resolver-2.2.0/bin/kresd --version` and found version 2.2.0
- ran `/nix/store/2fpr2hzspmrnnvmawxd3mv28774rysma-knot-resolver-2.2.0/bin/kresd -h` and found version 2.2.0
- ran `/nix/store/2fpr2hzspmrnnvmawxd3mv28774rysma-knot-resolver-2.2.0/bin/kresd --help` and found version 2.2.0
- found 2.2.0 with grep in /nix/store/2fpr2hzspmrnnvmawxd3mv28774rysma-knot-resolver-2.2.0
- directory tree listing: https://gist.github.com/3b59aaaf9f7d90b8de351b6eb712e2a5

cc @vcunat for review