### PR TITLE
isocodes: 3.74 -> 3.79

### DIFF
--- a/pkgs/development/libraries/iso-codes/default.nix
+++ b/pkgs/development/libraries/iso-codes/default.nix
@@ -1,11 +1,12 @@
 {stdenv, fetchurl, gettext, python3, xz}:
 
 stdenv.mkDerivation rec {
-  name = "iso-codes-3.74";
+  name = "iso-codes-${version}";
+  version = "3.79";
 
   src = fetchurl {
-    url = "http://pkg-isocodes.alioth.debian.org/downloads/${name}.tar.xz";
-    sha256 = "1vkaxkcx8h8lbg3z3jjfjs1x1rz1l01j6ll46ysza2gym37g7x11";
+    url = "https://salsa.debian.org/iso-codes-team/iso-codes/uploads/ef8de8bc12e0512d26ed73436a477871/${name}.tar.xz";
+    sha256 = "08i8hjy0qjlw9kd9i87jx967ihwh45l2xi55q1aa5265sind7byb";
   };
   patchPhase = ''
     for i in `find . -name \*.py`


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/iso-codes/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.79 with grep in /nix/store/v3cwlccrh7g5m03wj8j7fhwc9xyrdj1q-iso-codes-3.79
- directory tree listing: https://gist.github.com/0636a62cebb498fde2d51579ff9c3e99