### PR TITLE
iana-etc: 20180108 -> 20180221

### DIFF
--- a/pkgs/data/misc/iana-etc/default.nix
+++ b/pkgs/data/misc/iana-etc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "iana-etc-${version}";
-  version = "20180108";
+  version = "20180221";
 
   src = fetchurl {
     url = "https://github.com/Mic92/iana-etc/releases/download/${version}/iana-etc-${version}.tar.gz";
-    sha256 = "1x4jacrvjwcsan88rg2wf2a8bajsglg6w4396vbr18zh0sya84a2";
+    sha256 = "0rb74kqvbw5gdddp3h7c1sc735wzllgvmnp331446p5jvh2sirjh";
   };
 
   installPhase = ''


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/iana-etc/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/289f6783d68f048ce72d01862ad97fa0