### PR TITLE
idnkit: 1.0 -> 2.3

### DIFF
--- a/pkgs/development/libraries/idnkit/default.nix
+++ b/pkgs/development/libraries/idnkit/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "idnkit-1.0";
+  name = "idnkit-${version}";
+  version = "2.3";
 
   src = fetchurl {
-    url = "http://www.nic.ad.jp/ja/idn/idnkit/download/sources/${name}-src.tar.gz";
-    sha256 = "1z4i6fmyv67sflmjg763ymcxrcv84rbj1kv15im0s655h775zk8n";
+    url = "https://jprs.co.jp/idn/${name}.tar.bz2";
+    sha256 = "0zp9yc84ff5s0g2i6v9yfyza2n2x4xh0kq7hjd3anhh0clbp3l16";
   };
 
   buildInputs = [ libiconv ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/idnkit/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3/bin/idncheck -h` got 0 exit code
- ran `/nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3/bin/idncheck help` got 0 exit code
- ran `/nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3/bin/idncheck -v` and found version 2.3
- ran `/nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3/bin/idncmp -h` got 0 exit code
- ran `/nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3/bin/idncmp -v` and found version 2.3
- ran `/nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3/bin/idnconv2 -h` got 0 exit code
- ran `/nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3/bin/idnconv2 -v` and found version 2.3
- found 2.3 with grep in /nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3
- found 2.3 in filename of file in /nix/store/i6jnwdj4yjd07jpr0v9alrvprv06qm39-idnkit-2.3
- directory tree listing: https://gist.github.com/79f15455351ddaf8b8f16b15897f346f

cc @wkennington for review