### PR TITLE
i2c-tools: 3.1.2 -> 4.0

### DIFF
--- a/pkgs/os-specific/linux/i2c-tools/default.nix
+++ b/pkgs/os-specific/linux/i2c-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "i2c-tools-${version}";
-  version = "3.1.2";
+  version = "4.0";
 
   src = fetchurl {
-    url = "http://http.debian.net/debian/pool/main/i/i2c-tools/i2c-tools_${version}.orig.tar.bz2";
-    sha256 = "0hd4c1w8lnwc3j95h3vpd125170l1d4myspyrlpamqx6wbr6jpnv";
+    url = "https://www.kernel.org/pub/software/utils/i2c-tools/${name}.tar.xz";
+    sha256 = "1mi8mykvl89y6liinc9jv1x8m2q093wrdc2hm86a47n524fcl06r";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/i2c-tools/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-dimms -h` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-dimms --help` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-dimms help` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-dimms -h` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-dimms --help` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-vaio -h` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-vaio --help` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-vaio help` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid -h` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid --help` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid help` got 0 exit code
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid -V` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid -v` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid --version` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid version` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid -h` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid --help` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/decode-edid help` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/i2cdetect -V` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/i2cdump -V` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/i2cget -V` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/i2cset -V` and found version 4.0
- ran `/nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0/bin/i2ctransfer -V` and found version 4.0
- found 4.0 with grep in /nix/store/01psgfkqwlff69addbhp08xi5z2p3y7w-i2c-tools-4.0
- directory tree listing: https://gist.github.com/7e7d303f66bb0a865a35ab286258a07e

cc @dezgeg for review