### PR TITLE
gatling: 0.13 -> 0.15

### DIFF
--- a/pkgs/servers/http/gatling/default.nix
+++ b/pkgs/servers/http/gatling/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, libowfat, zlib, openssl }:
 
 let
-  version = "0.13";
+  version = "0.15";
 in
 stdenv.mkDerivation rec {
   name = "gatling-${version}";
 
   src = fetchurl {
-    url = "http://dl.fefe.de/${name}.tar.bz2";
-    sha256 = "0icjx20ws8gqxgpm77dx7p9zcwi1fv162in6igx04rmnyzyla8dl";
+    url = "https://www.fefe.de/gatling/${name}.tar.xz";
+    sha256 = "194srqyja3pczpbl6l169zlvx179v7ln0m6yipmhvj6hrv82k8vg";
   };
 
   buildInputs = [  libowfat zlib openssl.dev ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/gatling/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/gatling -h` got 0 exit code
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/gatling --help` got 0 exit code
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/gatling --version` and found version 0.15
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/gatling --help` and found version 0.15
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/dl -h` got 0 exit code
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/dl --help` got 0 exit code
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/dl help` got 0 exit code
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/dl -V` and found version 0.15
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/dl --version` and found version 0.15
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/dl -h` and found version 0.15
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/dl --help` and found version 0.15
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/getlinks -h` got 0 exit code
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/getlinks --help` got 0 exit code
- ran `/nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15/bin/getlinks help` got 0 exit code
- found 0.15 with grep in /nix/store/l781ikxl4sjd90dkwylgyvyz53lyn5vm-gatling-0.15
- directory tree listing: https://gist.github.com/d54dd9d5cdf367db1648e6719090a75d

cc @the-kenny for review