### PR TITLE
gecode: 5.0.0 -> 6.0.0

### DIFF
--- a/pkgs/development/libraries/gecode/default.nix
+++ b/pkgs/development/libraries/gecode/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gecode-${version}";
-  version = "5.0.0";
+  version = "6.0.0";
 
   src = fetchurl {
     url = "http://www.gecode.org/download/${name}.tar.gz";
-    sha256 = "0yz7m4msp7g2jzsn216q74d9n7rv6qh8abcv0jdc1n7y2nhjzzzl";
+    sha256 = "0dp7bm6k790jx669y4jr0ffi5cdfpwsqm1ykj2c0zh56jsgs6hfs";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/gecode/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/fzn-gecode --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/fzn-gecode --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/alpha -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/alpha --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/alpha help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/alpha --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bacp -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bacp --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bacp help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bacp --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bibd -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bibd --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bibd help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bibd --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/donald -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/donald --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/donald help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/donald --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/efpa -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/efpa --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/efpa help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/efpa --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/eq20 -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/eq20 --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/eq20 help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/eq20 --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/golomb-ruler -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/golomb-ruler --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/golomb-ruler help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/golomb-ruler --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/graph-color -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/graph-color --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/graph-color help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/graph-color --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/grocery -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/grocery --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/grocery help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/grocery --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/ind-set -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/ind-set --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/ind-set help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/ind-set --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/magic-sequence --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/magic-sequence --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/magic-square --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/magic-square --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/money -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/money --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/money help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/money --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/ortho-latin --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/ortho-latin --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/partition --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/partition --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/photo -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/photo --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/photo help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/photo --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/queens --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/queens --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/sudoku -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/sudoku --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/sudoku help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/sudoku --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/kakuro -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/kakuro --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/kakuro help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/kakuro --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/nonogram -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/nonogram --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/nonogram help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/nonogram --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/pentominoes -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/pentominoes --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/pentominoes help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/pentominoes --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crowded-chess --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crowded-chess --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/black-hole -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/black-hole --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/black-hole help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/black-hole --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/minesweeper -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/minesweeper --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/minesweeper help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/minesweeper --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/domino -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/domino --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/domino help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/domino --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/steel-mill --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/steel-mill --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/sports-league --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/sports-league --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/all-interval --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/all-interval --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/langford-number -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/langford-number --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/langford-number help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/langford-number --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/warehouses -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/warehouses --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/warehouses help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/warehouses --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/radiotherapy -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/radiotherapy --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/radiotherapy help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/radiotherapy --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/word-square --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/word-square --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crossword -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crossword --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crossword help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crossword --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/open-shop -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/open-shop --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/open-shop help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/open-shop --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/car-sequencing -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/car-sequencing --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/car-sequencing help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/car-sequencing --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/sat --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/sat --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bin-packing --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/bin-packing --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/knights --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/knights --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/tsp -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/tsp --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/tsp help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/tsp --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/perfect-square -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/perfect-square --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/perfect-square help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/perfect-square --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/schurs-lemma -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/schurs-lemma --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/schurs-lemma help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/schurs-lemma --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/dominating-queens --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/dominating-queens --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/colored-matrix --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/colored-matrix --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/multi-bin-packing --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/multi-bin-packing --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/qcp --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/qcp --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crew -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crew --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crew help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/crew --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/golf -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/golf --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/golf help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/golf --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/hamming -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/hamming --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/hamming help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/hamming --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/steiner --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/steiner --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/queen-armies -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/queen-armies --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/queen-armies help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/queen-armies --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/cartesian-heart --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/cartesian-heart --help` and found version 6.0.0
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/descartes-folium -h` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/descartes-folium --help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/descartes-folium help` got 0 exit code
- ran `/nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0/bin/descartes-folium --help` and found version 6.0.0
- found 6.0.0 with grep in /nix/store/39yw7af1kjv8nxb43jfmz5l3vm8czl26-gecode-6.0.0
- directory tree listing: https://gist.github.com/e064209ab25e76839d89e65c77630cf7

cc @manveru for review