### PR TITLE
fatsort: 1.3.365 -> 1.4.2.439

### DIFF
--- a/pkgs/tools/filesystems/fatsort/default.nix
+++ b/pkgs/tools/filesystems/fatsort/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, help2man}:
 
 stdenv.mkDerivation rec {
-  version = "1.3.365";
+  version = "1.4.2.439";
   name = "fatsort-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/fatsort/${name}.tar.gz";
-    sha256 = "0g9zn2ns86g7zmy0y8hw1w1zhnd51hy8yl6kflyhxs49n5sc7b3p";
+    url = "mirror://sourceforge/fatsort/${name}.tar.xz";
+    sha256 = "1q51qq69854kr12knhyqjv7skj95qld6j04pv5v3xvxs0y9zkg5x";
   };
 
   patches = [ ./fatsort-Makefiles.patch ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/fatsort/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/b33c7wq3ps8qwpx6yy05ml23k764i6cm-fatsort-1.4.2.439/bin/fatsort -h` got 0 exit code
- ran `/nix/store/b33c7wq3ps8qwpx6yy05ml23k764i6cm-fatsort-1.4.2.439/bin/fatsort --help` got 0 exit code
- directory tree listing: https://gist.github.com/9465f304d46013ae6d70d46558fd0c45

cc @kovirobi for review