### PR TITLE
diction: 1.11 -> 1.13

### DIFF
--- a/pkgs/tools/text/diction/default.nix
+++ b/pkgs/tools/text/diction/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "diction-1.11";
+  name = "diction-${version}";
+  version = "1.13";
 
   src = fetchurl {
-    url = "mirror://gnu/diction/${name}.tar.gz";
-    sha256 = "1xi4l1x1vvzmzmbhpx0ghmfnwwrhabjwizrpyylmy3fzinzz3him";
+    url = "http://www.moria.de/~michael/diction/${name}.tar.gz";
+    sha256 = "08fi971b8qa4xycxbgb42i6b5ms3qx9zpp5hwpbxy2vypfs0wph9";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/diction/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13/bin/diction -h` got 0 exit code
- ran `/nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13/bin/diction --help` got 0 exit code
- ran `/nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13/bin/diction help` got 0 exit code
- ran `/nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13/bin/diction --version` and found version 1.13
- ran `/nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13/bin/style -h` got 0 exit code
- ran `/nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13/bin/style --help` got 0 exit code
- ran `/nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13/bin/style help` got 0 exit code
- ran `/nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13/bin/style --version` and found version 1.13
- found 1.13 with grep in /nix/store/7583849c1dwqg9ryxy8ws0y8sagnxm1s-diction-1.13
- directory tree listing: https://gist.github.com/e06700dfb7b8b7cf0f1f8e7e6f84aba6