### PR TITLE
checkSSLCert: 1.51.0 -> 1.64.0

### DIFF
--- a/pkgs/servers/monitoring/nagios/plugins/check_ssl_cert.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/check_ssl_cert.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "check_ssl_cert-${version}";
-  version = "1.51.0";
+  version = "1.64.0";
 
   src = fetchFromGitHub {
     owner = "matteocorti";
     repo = "check_ssl_cert";
     rev = "v${version}";
-    sha256 = "07g4dhwp1plzmlqazapn0s0hysmf3kk0pa2x0wns482xm1v1mr05";
+    sha256 = "0pq297sbz9hzcaccnnsfmra0bac81cki9xfrnb22a1hgfhqjxy5r";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/check_ssl_cert/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.64.0 with grep in /nix/store/yiphzx29lcf6zx02g4bh1p80pappzw6f-check_ssl_cert-1.64.0
- directory tree listing: https://gist.github.com/37591ae2c040336904beb8059082afdc