### PR TITLE
chromaprint: 1.3.2 -> 1.4.3

### DIFF
--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "chromaprint-${version}";
-  version = "1.3.2";
+  version = "1.4.3";
 
   src = fetchurl {
-    url = "http://bitbucket.org/acoustid/chromaprint/downloads/${name}.tar.gz";
-    sha256 = "0lln8dh33gslb9cbmd1hcv33pr6jxdwipd8m8gbsyhksiq6r1by3";
+    url = "https://github.com/acoustid/chromaprint/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "10kz8lncal4s2rp2rqpgc6xyjp0jzcrihgkx7chf127vfs5n067a";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/chromaprint/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 1.4.3 with grep in /nix/store/6x9xsd68jksc7c2y710z4wsrjwgd8wsp-chromaprint-1.4.3
- found 1.4.3 in filename of file in /nix/store/6x9xsd68jksc7c2y710z4wsrjwgd8wsp-chromaprint-1.4.3
- directory tree listing: https://gist.github.com/92fabeb9999c33c02a2f56a437b69c64