### PR TITLE
checkbashism: 2.0.0.2 -> 2.18.1

### DIFF
--- a/pkgs/development/tools/misc/checkbashisms/default.nix
+++ b/pkgs/development/tools/misc/checkbashisms/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perl }:
 stdenv.mkDerivation rec {
-  version = "2.0.0.2";
+  version = "2.18.1";
   name = "checkbashisms-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/checkbaskisms/${version}/checkbashisms";
-    sha256 = "1vm0yykkg58ja9ianfpm3mgrpah109gj33b41kl0jmmm11zip9jd";
+    url = "mirror://debian/pool/main/d/devscripts/devscripts_${version}.tar.xz";
+    sha256 = "1yaygfzv5jzvcbahz6sdfnzhch9mxgsrlsym2ad62nk0svsnp24n";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/checkbashisms/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- directory tree listing: https://gist.github.com/6e3ce06d60c67525f1f11df0822e6b36