### PR TITLE
confuse: 2.7 -> 3.2.1

### DIFF
--- a/pkgs/development/libraries/confuse/default.nix
+++ b/pkgs/development/libraries/confuse/default.nix
@@ -1,10 +1,11 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "confuse-2.7";
+  name = "confuse-${version}";
+  version = "3.2.1";
   src = fetchurl {
-    url = "mirror://savannah/confuse/${name}.tar.gz";
-    sha256 = "0y47r2ashz44wvnxdb18ivpmj8nxhw3y9bf7v9w0g5byhgyp89g3";
+    url = "https://github.com/martinh/libconfuse/releases/download/v${version}/${name}.tar.xz";
+    sha256 = "0pnjmlj9i0alp407qd7c0vq83sz7gpsjrbdgpcn4xvzjp9r35ii3";
   };
 
   meta = {


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/confuse/versions.

These checks were done:

- built on NixOS
- Warning: no binary found that responded to help or version flags. (This warning appears even if the package isn't expected to have binaries.)
- found 3.2.1 with grep in /nix/store/nbr6d47mgzxmmxymjh3rw0yc7il66wks-confuse-3.2.1
- directory tree listing: https://gist.github.com/cc2599089248ae14f15a25547413838b