### PR TITLE
buku: 3.6 -> 3.7

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -1,14 +1,14 @@
 { stdenv, python3, fetchFromGitHub }:
 
 with python3.pkgs; buildPythonApplication rec {
-  version = "3.6";
+  version = "3.7";
   name = "buku-${version}";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "buku";
     rev = "v${version}";
-    sha256 = "1639sf200n9rxgkvvhlhnrjsb7vn42p1fl1rx562axh3vpr6j4c4";
+    sha256 = "0qc6xkrhf2phaj9fhym19blr4rr2vllvnyljjz909xr4vsynvb41";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/buku/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7/bin/.buku-wrapped -h` got 0 exit code
- ran `/nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7/bin/.buku-wrapped --help` got 0 exit code
- ran `/nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7/bin/.buku-wrapped -h` and found version 3.7
- ran `/nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7/bin/.buku-wrapped --help` and found version 3.7
- ran `/nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7/bin/buku -h` got 0 exit code
- ran `/nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7/bin/buku --help` got 0 exit code
- ran `/nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7/bin/buku -h` and found version 3.7
- ran `/nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7/bin/buku --help` and found version 3.7
- found 3.7 with grep in /nix/store/xhqxppgivy66mf4v46acf4p9qzqrnfhs-buku-3.7
- directory tree listing: https://gist.github.com/231e0667743da0993083d1dd37c787b7

cc @matthiasbeyer @infinisil for review