### PR TITLE
beancount: 2.0rc1 -> 2.0.0

### DIFF
--- a/pkgs/applications/office/beancount/default.nix
+++ b/pkgs/applications/office/beancount/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchhg, pkgs, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
-  version = "2.0rc1";
+  version = "2.0.0";
   name = "beancount-${version}";
   namePrefix = "";
 
   src = pkgs.fetchurl {
     url = "mirror://pypi/b/beancount/${name}.tar.gz";
-    sha256 = "12vlkck4q3dax9866krp6963c6d845b7inkkwrlkk4njh84n71wf";
+    sha256 = "0wxwf02d3raglwqsxdsgf89fniakv1m19q825w76k5z004g18y42";
   };
 
   buildInputs = with pythonPackages; [ nose ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/beancount/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-bake-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-bake-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-bake -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-bake --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-check-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-check-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-check -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-check --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-doctor-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-doctor-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-doctor -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-doctor --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-example-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-example-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-example -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-example --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-extract-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-extract-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-extract -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-extract --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-file-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-file-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-file -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-file --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-format-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-format-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-format -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-format --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-identify-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-identify-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-identify -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-identify --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-price-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-price-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-price -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-price --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-query-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-query-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-query -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-query --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-report-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-report-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-report-wrapped help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-report -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-report --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-report help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-sql-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-sql-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-sql -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-sql --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-web-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.bean-web-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-web -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/bean-web --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.treeify-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.treeify-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/treeify -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/treeify --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.upload-to-sheets-wrapped -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/.upload-to-sheets-wrapped --help` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/upload-to-sheets -h` got 0 exit code
- ran `/nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0/bin/upload-to-sheets --help` got 0 exit code
- found 2.0.0 with grep in /nix/store/5r7zwzwph71lx046skfi6jc6akxwr5kl-beancount-2.0.0
- directory tree listing: https://gist.github.com/3d2aa084b7967bb83107f51498228abe

cc @matthiasbeyer for review