### PR TITLE
bspwm: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/applications/window-managers/bspwm/default.nix
+++ b/pkgs/applications/window-managers/bspwm/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "bspwm-${version}";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner  = "baskerville";
     repo   = "bspwm";
     rev    = version;
-    sha256 = "144g0vg0jsy0lja2jv1qbdps8k05nk70pc7vslj3im61a21vnbis";
+    sha256 = "1srgsszp184zg123wdij0zp57c16m7lmal51rhflyx2c9fiiqm9l";
   };
 
   buildInputs = [ libxcb libXinerama xcbutil xcbutilkeysyms xcbutilwm ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nix-update tools.

This update was made based on information from https://repology.org/metapackage/bspwm/versions.

These checks were done:

- built on NixOS
- ran `/nix/store/w78rv4f7aq8nww3k2nmmkwfgl0mcqf60-bspwm-0.9.4/bin/bspwm -h` got 0 exit code
- ran `/nix/store/w78rv4f7aq8nww3k2nmmkwfgl0mcqf60-bspwm-0.9.4/bin/bspwm --help` got 0 exit code
- ran `/nix/store/w78rv4f7aq8nww3k2nmmkwfgl0mcqf60-bspwm-0.9.4/bin/bspwm --version` and found version 0.9.4
- ran `/nix/store/w78rv4f7aq8nww3k2nmmkwfgl0mcqf60-bspwm-0.9.4/bin/bspwm --help` and found version 0.9.4
- found 0.9.4 with grep in /nix/store/w78rv4f7aq8nww3k2nmmkwfgl0mcqf60-bspwm-0.9.4
- directory tree listing: https://gist.github.com/7ea8e79c97fb5b6594093a8d96aeb4e0

cc @meisternu for review