### PR TITLE
ansible_2_5: init at 2.5.0

### DIFF
--- a/pkgs/tools/admin/ansible/2.5.nix
+++ b/pkgs/tools/admin/ansible/2.5.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchurl
+, pythonPackages
+, windowsSupport ? false
+}:
+
+pythonPackages.buildPythonPackage rec {
+  pname = "ansible";
+  version = "2.5.0";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://releases.ansible.com/ansible/${name}.tar.gz";
+    sha256 = "1p76d1pv89yhi8q05jas5gskkd1anjmqqvaks8nynmal1x5xwkki";
+  };
+
+  prePatch = ''
+    sed -i "s,/usr/,$out," lib/ansible/constants.py
+  '';
+
+  doCheck = false;
+  dontStrip = true;
+  dontPatchELF = true;
+  dontPatchShebangs = false;
+
+  propagatedBuildInputs = with pythonPackages; [
+    pycrypto paramiko jinja2 pyyaml httplib2 boto six netaddr dnspython
+  ] ++ stdenv.lib.optional windowsSupport pywinrm;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.ansible.com;
+    description = "A simple automation tool";
+    license = with licenses; [ gpl3 ];
+    maintainers = with maintainers; [
+      jgeerds
+      joamaki
+    ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7425,6 +7425,7 @@ with pkgs;
   ansible_2_2 = callPackage ../tools/admin/ansible/2.2.nix {};
   ansible_2_3 = callPackage ../tools/admin/ansible/2.3.nix {};
   ansible_2_4 = callPackage ../tools/admin/ansible/2.4.nix {};
+  ansible_2_5 = callPackage ../tools/admin/ansible/2.5.nix {};
   ansible  = ansible_2_4;
   ansible2 = ansible_2_4;
 


### PR DESCRIPTION
###### Motivation for this change

New ansible version 2.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Should the reference for `ansible` and `ansible2` changed to the new version as well?