### PR TITLE
init libaom 0.10

### DIFF
--- a/pkgs/development/libraries/libaom/default.nix
+++ b/pkgs/development/libraries/libaom/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit, yasm, perl, cmake,  pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "libaom-0.1.0";
+
+  src = fetchgit {
+    url = "https://aomedia.googlesource.com/aom";
+    rev	= "105e9b195bb90c9b06edcbcb13b6232dab6db0b7";
+    sha256 = "1fl2sca4df01gyn00s0xcwwirxccfnjppvjdrxdnb8f2naj721by";
+  };
+
+  buildInputs = [ perl yasm  ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  cmakeFlags = [
+    "-DCONFIG_UNIT_TESTS=0"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "AV1 Bitstream and Decoding Library";
+    homepage    = https://aomedia.org/av1-features/get-started/;
+    maintainers = with maintainers; [ kiloreux ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9569,6 +9569,8 @@ with pkgs;
 
   libantlr3c = callPackage ../development/libraries/libantlr3c {};
 
+  libaom = callPackage ../development/libraries/libaom { };
+  
   libappindicator-gtk2 = callPackage ../development/libraries/libappindicator { gtkVersion = "2"; };
   libappindicator-gtk3 = callPackage ../development/libraries/libappindicator { gtkVersion = "3"; };
 


### PR DESCRIPTION
###### Motivation for this change
Initialize libaom at 0.1.0 ffmpeg coming version will depend on it. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

