### PR TITLE
tachyon: Add support for jpeg, png, more platforms

### DIFF
--- a/pkgs/development/libraries/tachyon/default.nix
+++ b/pkgs/development/libraries/tachyon/default.nix
@@ -1,4 +1,17 @@
-{stdenv, fetchurl}:
+{ stdenv
+, fetchurl
+, fetchpatch
+, Carbon ? null
+, libjpeg ? null
+, libpng ? null
+, withJpegSupport ? true # support jpeg output
+, withPngSupport ? true # support png output
+}:
+
+assert withJpegSupport -> libjpeg != null;
+assert withPngSupport -> libpng != null;
+assert stdenv.isDarwin -> Carbon != null;
+
 stdenv.mkDerivation rec {
   name = "tachyon-${version}";
   version = "0.99b2";
@@ -6,12 +19,39 @@ stdenv.mkDerivation rec {
     url = "http://jedi.ks.uiuc.edu/~johns/tachyon/files/${version}/${name}.tar.gz";
     sha256 = "04m0bniszyg7ryknj8laj3rl5sspacw5nr45x59j2swcsxmdvn1v";
   };
-  buildInputs = [];
-  preBuild = "cd unix";
-  arch = if stdenv.system == "x86_64-linux" then "linux-64-thr" else
-         if stdenv.system == "i686-linux"   then "linux-thr"    else
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [
+    Carbon
+  ] ++ stdenv.lib.optionals withJpegSupport [
+    libjpeg
+  ] ++ stdenv.lib.optionals withPngSupport [
+    libpng
+  ];
+  preBuild = ''
+    cd unix
+  '' + stdenv.lib.optionalString withJpegSupport ''
+    export USEJPEG=" -DUSEJPEG"
+    export JPEGLIB=" -ljpeg"
+  '' + stdenv.lib.optionalString withPngSupport ''
+    export USEPNG=" -DUSEPNG"
+    export PNGLIB=" -lpng -lz"
+  '';
+  arch = if stdenv.system == "x86_64-linux"   then "linux-64-thr"  else
+         if stdenv.system == "i686-linux"     then "linux-thr"     else
+         if stdenv.system == "aarch64-linux"  then "linux-arm-thr" else
+         if stdenv.system == "x86_64-darwin"  then "macosx-thr"    else
+         if stdenv.system == "i686-darwin"    then "macosx-64-thr" else
+         if stdenv.system == "i686-cygwin"    then "win32"         else
+         if stdenv.system == "x86_64-freebsd" then "bsd"           else
+         if stdenv.system == "x686-freebsd"   then "bsd"           else
          throw "Don't know what arch to select for tachyon build";
   makeFlags = "${arch}";
+  patches = [
+    # Remove absolute paths in Make-config (and unset variables so they can be set in preBuild)
+    ./no-absolute-paths.patch
+    # Include new targets (like arm)
+    ./make-archs.patch
+  ];
+
   installPhase = ''
     cd ../compile/${arch}
     mkdir -p "$out"/{bin,lib,include,share/doc/tachyon,share/tachyon}
@@ -26,7 +66,8 @@ stdenv.mkDerivation rec {
     description = ''A Parallel / Multiprocessor Ray Tracing System'';
     license = stdenv.lib.licenses.bsd3;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    # darwin fails due to missing Carbon.h, even though Carbon is a build input
+    platforms = with stdenv.lib.platforms; linux ++ cygwin;
     homepage = http://jedi.ks.uiuc.edu/~johns/tachyon/;
   };
 }

--- a/pkgs/development/libraries/tachyon/make-archs.patch
+++ b/pkgs/development/libraries/tachyon/make-archs.patch
@@ -1,0 +1,37 @@
+diff --git a/unix/Make-arch b/unix/Make-arch
+index 08afb85..dbeb691 100644
+--- a/unix/Make-arch
++++ b/unix/Make-arch
+@@ -920,6 +920,15 @@ macosx:
+ 	"RANLIB = ranlib" \
+ 	"LIBS = -L. -ltachyon $(MISCLIB)"
+ 
++macosx-64:
++	$(MAKE) all \
++	"ARCH = macosx" \
++	"CFLAGS = -Os -m64 -ffast-math -DBsd $(MISCFLAGS)" \
++	"ARFLAGS = r" \
++	"STRIP = strip" \
++	"RANLIB = ranlib" \
++	"LIBS = -L. -ltachyon $(MISCLIB)"
++
+ macosx-thr:
+ 	$(MAKE) all \
+ 	"ARCH = macosx-thr" \
+@@ -1209,6 +1218,16 @@ linux-thr:
+ 	"RANLIB = ranlib" \
+ 	"LIBS = -L. -ltachyon $(MISCLIB) -lm -lpthread"
+ 
++# Linux Arm using gcc, with threads
++linux-arm-thr:
++	$(MAKE) all \
++	"ARCH = linux-arm-thr" \
++	"CFLAGS = -Wall -O3 -fomit-frame-pointer -ffast-math -DLinux -DTHR -D_REENTRANT $(MISCFLAGS)" \
++	"ARFLAGS = r" \
++	"STRIP = strip" \
++	"RANLIB = ranlib" \
++	"LIBS = -L. -ltachyon $(MISCLIB) -lm -lpthread"
++
+ # Linux x86 using gcc, threads, and OpenGL
+ linux-thr-ogl:
+ 	$(MAKE) all \

--- a/pkgs/development/libraries/tachyon/no-absolute-paths.patch
+++ b/pkgs/development/libraries/tachyon/no-absolute-paths.patch
@@ -1,0 +1,57 @@
+diff --git a/unix/Make-config b/unix/Make-config
+index ee4f388..c1d51d4 100644
+--- a/unix/Make-config
++++ b/unix/Make-config
+@@ -18,7 +18,7 @@
+ # Bourne Shell Configuration:
+ #   set SHELL=/bin/sh or wherever your bourne shell is
+ ##########################################################################
+-SHELL=/bin/sh
++# SHELL=/bin/sh
+ 
+ 
+ 
+@@ -30,7 +30,7 @@ SHELL=/bin/sh
+ 
+ # The following line should be set to -Ixxx where xxx is your X11 include path
+ # Sun puts X11 in /usr/openwin/xxx
+-X11INC= -I/usr/openwin/include
++# X11INC= -I/usr/openwin/include
+ 
+ # Others typically use /usr/X11 or /usr/X11R6
+ #X11INC= -I/usr/X11
+@@ -57,7 +57,7 @@ X11LIB= -lX11
+ ##########################################################################
+ 
+ # Standard MPICH installation location
+-MPIDIR=/usr/local/mpi
++# MPIDIR=/usr/local/mpi
+ 
+ # UMR CS Dept
+ #MPIDIR=/software/all/mpi
+@@ -108,9 +108,9 @@ MBOX=
+ #   http://www.ijg.org/files/
+ ##########################################################################
+ # Uncomment the following lines to disable JPEG support
+-USEJPEG=
+-JPEGINC=
+-JPEGLIB=
++# USEJPEG=
++# JPEGINC=
++# JPEGLIB=
+ 
+ # Uncomment the following lines to enable JPEG support
+ #USEJPEG= -DUSEJPEG
+@@ -128,9 +128,9 @@ JPEGLIB=
+ #   http://www.libpng.org/
+ ##########################################################################
+ # Uncomment the following lines to disable PNG support
+-USEPNG=
+-PNGINC=
+-PNGLIB=
++# USEPNG=
++# PNGINC=
++# PNGLIB=
+ 
+ # Uncomment the following lines to enable PNG support
+ #USEPNG= -DUSEPNG

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11569,7 +11569,9 @@ with pkgs;
 
   t1lib = callPackage ../development/libraries/t1lib { };
 
-  tachyon = callPackage ../development/libraries/tachyon {};
+  tachyon = callPackage ../development/libraries/tachyon {
+    inherit (darwin.apple_sdk.frameworks) Carbon;
+  };
 
   taglib = callPackage ../development/libraries/taglib { };
   taglib_1_9 = callPackage ../development/libraries/taglib/1.9.nix { };


### PR DESCRIPTION
###### Motivation for this change

Tachyon supports jpeg and png, but those need to be enabled at build time.

I also added some new platforms, I *did not* test on any platform besides 64 bit linux though. However, since it is supported upstream and I lifted the platform definitions from the (presumably well-tested) sage spkg, there is good reason to believe that they will work.

Pinging maintainer @7c6f434c.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

