### PR TITLE
flint: Always create proper so file, support blas

### DIFF
--- a/pkgs/development/libraries/flint/default.nix
+++ b/pkgs/development/libraries/flint/default.nix
@@ -1,14 +1,48 @@
-{stdenv, fetchurl, gmp, mpir, mpfr, openblas, ntl}:
+{ stdenv
+, fetchurl
+, fetchpatch
+, gmp
+, mpir
+, mpfr
+, ntl
+, openblas ? null
+, withBlas ? true
+}:
+
+assert withBlas -> openblas != null;
+
 stdenv.mkDerivation rec {
   name = "flint-${version}";
-  version = "2.5.2";
-  # or fetchFromGitHub(owner,repo,rev) or fetchgit(rev)
+  version = "2.5.2"; # remove libflint.so.MAJOR patch when updating
   src = fetchurl {
     url = "http://www.flintlib.org/flint-${version}.tar.gz";
     sha256 = "11syazv1a8rrnac3wj3hnyhhflpqcmq02q8pqk2m6g2k6h0gxwfb";
   };
-  buildInputs = [gmp mpir mpfr openblas ntl];
-  configureFlags = "--with-gmp=${gmp} --with-mpir=${mpir} --with-mpfr=${mpfr} --with-blas=${openblas} --with-ntl=${ntl}";
+  buildInputs = [
+    gmp
+    mpir
+    mpfr
+    ntl
+  ] ++ stdenv.lib.optionals withBlas [
+    openblas
+  ];
+  configureFlags = [
+    "--with-gmp=${gmp}"
+    "--with-mpir=${mpir}"
+    "--with-mpfr=${mpfr}"
+    "--with-ntl=${ntl}"
+  ] ++ stdenv.lib.optionals withBlas [
+    "--with-blas=${openblas}"
+  ];
+  patches = [
+    (fetchpatch {
+      # Always produce libflint.so.MAJOR; will be included in the next flint version
+      # See https://github.com/wbhart/flint2/pull/347
+      url = "https://github.com/wbhart/flint2/commit/49fbcd8f736f847d3f9667f9f7d5567ef4550ecb.patch";
+      sha256 = "09w09bpq85kjf752bd3y3i5lvy59b8xjiy7qmrcxzibx2a21pj73";
+    })
+  ];
+  doCheck = true;
   meta = {
     inherit version;
     description = ''Fast Library for Number Theory'';


### PR DESCRIPTION
###### Motivation for this change

Flint non-deterministically sometimes does not produces the proper .so.major file. This adds a patch (from usptream) to prevent this).

While doing that I also made blas support optional and enabled tests.

Pinging maintainer @7c6f434c.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

