### PR TITLE
pythonPackages.root_numpy: fix build

### DIFF
--- a/pkgs/development/python-modules/root_numpy/default.nix
+++ b/pkgs/development/python-modules/root_numpy/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, isPy3k, buildPythonPackage, numpy, root }:
+{ lib, fetchPypi, isPy3k, buildPythonPackage, numpy, root, nose }:
 
 buildPythonPackage rec {
   pname = "root_numpy";
@@ -11,6 +11,11 @@ buildPythonPackage rec {
   };
 
   disabled = isPy3k; # blocked by #27649
+  checkInputs = [ nose ];
+  checkPhase = ''
+    python setup.py install_lib -d .
+    nosetests -s -v root_numpy
+  '';
 
   propagatedBuildInputs = [ numpy root ];
 


### PR DESCRIPTION
###### Motivation for this change

Build has failed ever since checks were enabled by default. checkPhase needs to run nosetest.

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

