### PR TITLE
gmtp: pass --datapath in the wrapper

### DIFF
--- a/pkgs/applications/misc/gmtp/default.nix
+++ b/pkgs/applications/misc/gmtp/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  preFixup = ''
+    gappsWrapperArgs+=(--add-flags "--datapath \"$out/share\"");
+  '';
+
   meta = {
     description = "A simple MP3 and Media player client for UNIX and UNIX like systems.";
     homepage = https://gmtp.sourceforge.io;


### PR DESCRIPTION
###### Motivation for this change

Some icons (locales maybe too...?) are missing. Seems like a minor change that could perhaps be included in 18.03 as well?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

