### PR TITLE
gflags: fix build on case-insensitive filesystems

### DIFF
--- a/pkgs/development/libraries/gflags/default.nix
+++ b/pkgs/development/libraries/gflags/default.nix
@@ -7,4 +7,13 @@ stdenv.mkDerivation
         sha256 = "03lxc2ah8i392kh1naq99iip34k4fpv22kwflyx3byd2ssycs9xf";
       };
     nativeBuildInputs = [ cmake ];
+    # for case-insensitive filesystems
+    prePatch = "mv BUILD BUILD.bazel";
+
+    meta = with stdenv.lib; {
+      description = "C++ library that implements commandline flags processing";
+      homepage = "https://github.com/gflags/gflags";
+      license = licenses.bsd3;
+      platforms = platforms.unix;
+    };
   }


### PR DESCRIPTION
###### Motivation for this change

Darwin machines come with a case-insensitive filesystem by default. The
gflags package's source contains a file 'BUILD' and the build process
attempts to create a directory called 'build', which fails on
case-insensitive filesystems.

###### Things done

Add a prePatch hook to rename the BUILD file (which is for use with an unrelated build tool).

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions

- [ ] I did not test compilation of all pkgs that depend on this change because this should not produce a change to any machine code
- [x] Tested execution of the bash completion script in bin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

