### PR TITLE
sddm: add missing include for gettimeofday, fix w/musl

### DIFF
--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -22,6 +22,10 @@ in mkDerivation rec {
     # Module Qt5::Test must be included in `find_package` before it is used.
     ''
       sed -i CMakeLists.txt -e '/find_package(Qt5/ s|)| Test)|'
+    ''
+    # Fix missing include for gettimeofday()
+    + ''
+      sed -e '1i#include <sys/time.h>' -i src/helper/HelperApp.cpp
     '';
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig qttools ];


### PR DESCRIPTION
Fix build w/musl by providing include that is needed when using `gettimeofday`.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---