### PR TITLE
ocamlPackages.js_of_ocaml-ppx_deriving_json: init at 3.1.0

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
@@ -1,0 +1,15 @@
+{ stdenv, ocaml, findlib, jbuilder, js_of_ocaml-compiler
+, js_of_ocaml, ppx_deriving
+}:
+
+stdenv.mkDerivation rec {
+	name = "js_of_ocaml-ppx_deriving_json-${version}";
+
+	inherit (js_of_ocaml-compiler) version src installPhase meta;
+
+	buildInputs = [ ocaml findlib jbuilder ];
+
+	propagatedBuildInputs = [ js_of_ocaml ppx_deriving ];
+
+	buildPhase = "jbuilder build -p js_of_ocaml-ppx_deriving_json";
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -330,6 +330,8 @@ let
 
     js_of_ocaml-ppx = callPackage ../development/tools/ocaml/js_of_ocaml/ppx.nix {};
 
+    js_of_ocaml-ppx_deriving_json = callPackage ../development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix {};
+
     jsonm = callPackage ../development/ocaml-modules/jsonm { };
 
     lablgl = callPackage ../development/ocaml-modules/lablgl { };


### PR DESCRIPTION
###### Motivation for this change

Required to update `eliom`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

