### PR TITLE
Move some python modules from python-packages.nix

### DIFF
--- a/pkgs/development/python-modules/amqp/default.nix
+++ b/pkgs/development/python-modules/amqp/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, case, vine }:
+
+buildPythonPackage rec {
+  pname = "amqp";
+  version = "2.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ybywzkd840v1qvb1p2bs08js260vq1jscjg8182hv7bmwacqy0k";
+  };
+
+  buildInputs = [ pytest case ];
+  propagatedBuildInputs = [ vine ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/celery/py-amqp;
+    description = "Python client for the Advanced Message Queuing Procotol (AMQP). This is a fork of amqplib which is maintained by the Celery project";
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/python-modules/application/default.nix
+++ b/pkgs/development/python-modules/application/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, buildPythonPackage, fetchdarcs, zope_interface, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "python-application";
+  version = "2.0.2";
+  disabled = isPy3k;
+
+  src = fetchdarcs {
+    url = "http://devel.ag-projects.com/repositories/${pname}";
+    rev = "release-${version}";
+    sha256 = "19dszv44py8qrq0jcjdycxpa7z2p8hi3ijq9gnqdsazbbjzf9svn";
+  };
+
+  buildInputs = [ zope_interface ];
+}

--- a/pkgs/development/python-modules/asyncio/default.nix
+++ b/pkgs/development/python-modules/asyncio/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy33, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "asyncio";
+  version = "3.4.3";
+  disabled = pythonOlder "3.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hfbqwk9y0bbfgxzg93s2wyk6gcjsdxlr5jwy97hx64ppkw0ydl3";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Reference implementation of PEP 3156";
+    homepage = http://www.python.org/dev/peps/pep-3156;
+    license = licenses.free;
+  };
+}

--- a/pkgs/development/python-modules/atomiclong/default.nix
+++ b/pkgs/development/python-modules/atomiclong/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, cffi }:
+
+buildPythonPackage rec {
+  pname = "atomiclong";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gjbc9lvpkgg8vj7dspif1gz9aq4flkhxia16qj6yvb7rp27h4yb";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ cffi ];
+
+  meta = with stdenv.lib; {
+    description = "Long data type with atomic operations using CFFI";
+    homepage = https://github.com/dreid/atomiclong;
+    license = licenses.mit;
+    maintainers = with maintainers; [ robbinch ];
+  };
+}

--- a/pkgs/development/python-modules/atomicwrites/default.nix
+++ b/pkgs/development/python-modules/atomicwrites/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "atomicwrites";
+  version = "0.1.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08s05h211r07vs66r4din3swrbzb344vli041fihpg34q3lcxpvw";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Atomic file writes on POSIX";
+    homepage = https://pypi.python.org/pypi/atomicwrites;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}

--- a/pkgs/development/python-modules/attrdict/default.nix
+++ b/pkgs/development/python-modules/attrdict/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, coverage, nose, six }:
+
+buildPythonPackage rec {
+  pname = "attrdict";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1lrailzxy40dx6sn1hbpnpqfbg7ar75dfj41kx0480wyh39vdbl6";
+  };
+
+  propagatedBuildInputs = [ coverage nose six ];
+
+  meta = with stdenv.lib; {
+    description = "A dict with attribute-style access";
+    homepage = https://github.com/bcj/AttrDict;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/avro/default.nix
+++ b/pkgs/development/python-modules/avro/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "avro";
+  version = "1.7.6";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mbsf1y7gnzmnfmqh8aw62yrwnpwm5bhmmkkbbq92a5vr91l3wgd";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A serialization and RPC framework";
+    homepage = https://pypi.python.org/pypi/avro/;
+  };
+}

--- a/pkgs/development/python-modules/avro3k/default.nix
+++ b/pkgs/development/python-modules/avro3k/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "avro3k";
+  version = "1.7.7-SNAPSHOT";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15ahl0irwwj558s964abdxg4vp6iwlabri7klsm2am6q5r0ngsky";
+  };
+
+  doCheck = false;        # No such file or directory: './run_tests.py
+
+  meta = with stdenv.lib; {
+    description = "A serialization and RPC framework";
+    homepage = https://pypi.python.org/pypi/avro3k/;
+  };
+}

--- a/pkgs/development/python-modules/babelfish/default.nix
+++ b/pkgs/development/python-modules/babelfish/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "babelfish";
+  version = "0.5.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8380879fa51164ac54a3e393f83c4551a275f03617f54a99d70151358e444104";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://pypi.python.org/pypi/babelfish;
+    description = "A module to work with countries and languages";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/batinfo/default.nix
+++ b/pkgs/development/python-modules/batinfo/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "batinfo";
+  version = "0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gyzkxzvj5l6qrw706bnm3cckqzzzbrjr7jkxc087d7775a73499";
+  };
+
+  # No tests included
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/nicolargo/batinfo;
+    description = "A simple Python lib to retrieve battery information";
+    license = licenses.lgpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ koral ];
+  };
+}

--- a/pkgs/development/python-modules/bcdoc/default.nix
+++ b/pkgs/development/python-modules/bcdoc/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, docutils, six }:
+
+buildPythonPackage rec {
+  pname = "bcdoc";
+  version = "0.14.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1s2kdqs1n2mj7wq3w0pq30zs7vxq0l3abik2clqnc4hm2j7crbk8";
+  };
+
+  buildInputs = [ docutils six ];
+
+  # Tests fail due to nix file timestamp normalization.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/botocore/bcdoc;
+    license = licenses.asl20;
+    description = "ReST document generation tools for botocore";
+  };
+}

--- a/pkgs/development/python-modules/betamax/default.nix
+++ b/pkgs/development/python-modules/betamax/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  pname = "betamax";
+  version = "0.8.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hki1c2vs7adq7zr56wi6i5bhrkia4s2ywpv2c98ibnczz709w2v";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://betamax.readthedocs.org/en/latest/;
+    description = "A VCR imitation for requests";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pSub ];
+  };
+}

--- a/pkgs/development/python-modules/billiard/default.nix
+++ b/pkgs/development/python-modules/billiard/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy, pytest, case }:
+
+buildPythonPackage rec {
+  pname = "billiard";
+  version = "3.5.0.2";
+  disabled = isPyPy;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1anw68rkja1dbgvndxz5mq6f89hmxwaha0fjcdnsl5j1wj7imc1y";
+  };
+
+  buildInputs = [ pytest case ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/celery/billiard;
+    description = "Python multiprocessing fork with improvements and bugfixes";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/bitbucket-api/default.nix
+++ b/pkgs/development/python-modules/bitbucket-api/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, requests_oauthlib, nose, sh }:
+
+buildPythonPackage rec {
+  pname = "bitbucket-api";
+  version = "0.4.4";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1cl5xa55ijjd23xs8znsd4w4vb3q1vkbmchy7hh6z6nmjcwbr478";
+  };
+
+  propagatedBuildInputs = [ requests_oauthlib nose sh ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Sheeprider/BitBucket-api;
+    description = "Python library to interact with BitBucket REST API";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/bitbucket-cli/default.nix
+++ b/pkgs/development/python-modules/bitbucket-cli/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, requests }:
+
+buildPythonPackage rec {
+  pname = "bitbucket-cli";
+  version = "0.5.1";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1xmn73x6jirnwfwcdy380ncmkai9f9dhmld6zin01ypbqwgf50fq";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Bitbucket command line interface";
+    homepage = https://bitbucket.org/zhemao/bitbucket-cli;
+    maintainers = with maintainers; [ refnil ];
+  };
+}

--- a/pkgs/development/python-modules/blinker/default.nix
+++ b/pkgs/development/python-modules/blinker/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "blinker";
+  version = "1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dpq0vb01p36jjwbhhd08ylvrnyvcc82yxx3mwjx6awrycjyw6j7";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://pythonhosted.org/blinker/;
+    description = "Fast, simple object-to-object and broadcast signaling";
+    license = licenses.mit;
+    maintainers = with maintainers; [ garbas ];
+  };
+}

--- a/pkgs/development/python-modules/bottle/default.nix
+++ b/pkgs/development/python-modules/bottle/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, setuptools }:
+
+buildPythonPackage rec {
+  pname = "bottle";
+  version = "0.12.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0cd787lzggs933qfav6xicx5c78dz6npwgg3xc4rhah44nbqz5d1";
+  };
+
+  propagatedBuildInputs = [ setuptools ];
+
+  meta = with stdenv.lib; {
+    homepage = http://bottlepy.org;
+    description = "A fast and simple micro-framework for small web-applications";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ koral ];
+  };
+}

--- a/pkgs/development/python-modules/bugwarrior/default.nix
+++ b/pkgs/development/python-modules/bugwarrior/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, mock, unittest2, nose
+, twiggy, requests, offtrac, bugzilla, taskw, dateutil, pytz, keyring, six
+, jinja2, pycurl, dogpile_cache, lockfile, click, pyxdg, future15 }:
+
+buildPythonPackage rec {
+  pname = "bugwarrior";
+  version = "1.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kxknjbw5kchd88i577vlzibg8j60r7zzdhbnragj9wg5s3w60xb";
+  };
+
+  buildInputs = [ mock unittest2 nose /* jira megaplan */ ];
+  propagatedBuildInputs = [
+    twiggy requests offtrac bugzilla taskw dateutil pytz keyring six
+    jinja2 pycurl dogpile_cache lockfile click pyxdg future15
+  ];
+
+  # for the moment jira>=0.22 and megaplan>=1.4 are missing for running the test suite.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage =  https://github.com/ralphbean/bugwarrior;
+    description = "Sync github, bitbucket, bugzilla, and trac issues with taskwarrior";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pierron ];
+  };
+}

--- a/pkgs/development/python-modules/bugzilla/default.nix
+++ b/pkgs/development/python-modules/bugzilla/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pep8, coverage, logilab_common, requests }:
+
+buildPythonPackage rec {
+  pname = "bugzilla";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ikx21nm7cch4lz9agv5h1hx6zvg2alkpfdrl01khqgilhsicdhi";
+  };
+
+  patches = [ ./checkPhase-fix-cookie-compare.patch ];
+
+  buildInputs = [ pep8 coverage logilab_common ];
+  propagatedBuildInputs = [ requests ];
+
+  preCheck = ''
+    mkdir -p check-phase
+    export HOME=$(pwd)/check-phase
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://fedorahosted.org/python-bugzilla/;
+    description = "Bugzilla XMLRPC access module";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pierron ];
+  };
+}

--- a/pkgs/development/python-modules/buildout/default.nix
+++ b/pkgs/development/python-modules/buildout/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "zc.buildout";
+  version = "2.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1xafi6ndlm964qj7pnmzmvhp719c8pgs7r7wkr508v3cq2jjw4m6";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://www.buildout.org;
+    description = "A software build and configuration system";
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ garbas ];
+  };
+}

--- a/pkgs/development/python-modules/bunch/default.nix
+++ b/pkgs/development/python-modules/bunch/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "bunch";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1akalx2pd1fjlvrq69plvcx783ppslvikqdm93z2sdybq07pmish";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/buttersink/default.nix
+++ b/pkgs/development/python-modules/buttersink/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, boto, crcmod, psutil }:
+
+buildPythonPackage rec {
+  pname = "buttersink";
+  version = "0.6.8";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04gc63kfcqkw4qba5rijqk01xiphf04yk7hky9180ii64v2ip0j3";
+  };
+
+  propagatedBuildInputs = [ boto crcmod psutil ];
+
+  meta = with stdenv.lib; {
+    description = "Synchronise btrfs snapshots";
+    longDescription = ''
+      ButterSink is like rsync, but for btrfs subvolumes instead of files,
+      which makes it much more efficient for things like archiving backup
+      snapshots. It is built on top of btrfs send and receive capabilities.
+      Sources and destinations can be local btrfs file systems, remote btrfs
+      file systems over SSH, or S3 buckets.
+    '';
+    homepage = https://github.com/AmesCornish/buttersink/wiki;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/cairosvg/default.nix
+++ b/pkgs/development/python-modules/cairosvg/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, cairocffi }:
+
+buildPythonPackage rec {
+  pname = "cairosvg";
+  version = "1.0.18";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "01lpm38qp7xlnv8jv7qg48j44p5088dwfsrcllgs5fz355lrfds1";
+  };
+
+  propagatedBuildInputs = [ cairocffi ];
+
+  meta = with stdenv.lib; {
+    homepage = https://cairosvg.org;
+    license = licenses.lgpl3;
+    description = "SVG converter based on Cairo";
+  };
+}

--- a/pkgs/development/python-modules/carrot/default.nix
+++ b/pkgs/development/python-modules/carrot/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, nose, amqplib, anyjson }:
+
+buildPythonPackage rec {
+  pname = "carrot";
+  version = "0.10.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0s14rs2fgp1s2qa0avn8gj33lwc3k1hd4y9a2h6mhg487i7kfinb";
+  };
+
+  buildInputs = [ nose ];
+  propagatedBuildInputs = [ amqplib anyjson ];
+
+  doCheck = false; # depends on the network
+
+  meta = with stdenv.lib; {
+    homepage = https://pypi.python.org/pypi/carrot;
+    description = "AMQP Messaging Framework for Python";
+  };
+}

--- a/pkgs/development/python-modules/case/default.nix
+++ b/pkgs/development/python-modules/case/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, six, nose, unittest2, mock }:
+
+buildPythonPackage rec {
+  pname = "case";
+  version = "1.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zbhbw87izcxj9rvqg432a7r69ps2ks20mqq3g3hgd42sckcy3ca";
+  };
+
+  propagatedBuildInputs = [ six nose unittest2 mock ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/celery/case;
+    description = "unittests utilities";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/cerberus/default.nix
+++ b/pkgs/development/python-modules/cerberus/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "Cerberus";
+  version = "0.9.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1km7hvns1snrmcwz58bssi4wv3gwd34zm1z1hwjylmpqrfrcf8mi";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://python-cerberus.org/;
+    description = "Lightweight, extensible schema and data validation tool for Python dictionaries";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/check-manifest/default.nix
+++ b/pkgs/development/python-modules/check-manifest/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "check-manifest";
+  version = "0.30";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0005vp3r7wh87pf41cr4rw015lbnzn228a607nx34r98p7cd17xi";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mgedmin/check-manifest;
+    description = "Check MANIFEST.in in a Python source package for completeness";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lewo ];
+  };
+}

--- a/pkgs/development/python-modules/circus/default.nix
+++ b/pkgs/development/python-modules/circus/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, iowait, psutil, pyzmq, tornado, mock }:
+
+buildPythonPackage rec {
+  pname = "circus";
+  version = "0.11.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ip87wlq864k2rhk2r0rqq12ard1iggb61r6dsga4gh7lm538mrp";
+  };
+
+  doCheck = false; # weird error
+
+  propagatedBuildInputs = [ iowait psutil pyzmq tornado mock ];
+}

--- a/pkgs/development/python-modules/cjson/default.nix
+++ b/pkgs/development/python-modules/cjson/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, isPyPy }:
+
+buildPythonPackage rec {
+  pname = "python-cjson";
+  version = "1.1.0";
+  disabled = isPy3k || isPyPy;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1cz87pd411h1fj5am99i19jp53yizcz9mkg1a7cc6a1pb6vsn7x0";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A very fast JSON encoder/decoder for Python";
+    homepage = http://ag-projects.com/;
+    license = licenses.lgpl2;
+  };
+}

--- a/pkgs/development/python-modules/clf/default.nix
+++ b/pkgs/development/python-modules/clf/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, docopt, requests, pygments }:
+
+buildPythonPackage rec {
+  pname = "clf";
+  version = "0.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04lqd2i4fjs606b0q075yi9xksk567m0sfph6v6j80za0hvzqyy5";
+  };
+
+  patchPhase = ''
+    sed -i 's/==/>=/' requirements.txt
+  '';
+
+  propagatedBuildInputs = [ docopt requests pygments ];
+
+  # Error when running tests:
+  # No local packages or download links found for requests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ncrocfer/clf;
+    description = "Command line tool to search snippets on Commandlinefu.com";
+    license = licenses.mit;
+    maintainers = with maintainers; [ koral ];
+  };
+}

--- a/pkgs/development/python-modules/click-log/default.nix
+++ b/pkgs/development/python-modules/click-log/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, click }:
+
+buildPythonPackage rec {
+  pname = "click-log";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1r1x85023cslb2pwldd089jjk573mk3w78cnashs77wrx7yz8fj9";
+  };
+
+  propagatedBuildInputs = [ click ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/click-contrib/click-log/;
+    description = "Logging integration for Click";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/click/5_1.nix
+++ b/pkgs/development/python-modules/click/5_1.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "click";
+  version = "5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0njsm0wn31l21bi118g5825ma5sa3rwn7v2x4wjd7yiiahkri337";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://click.pocoo.org/;
+    description = "Create beautiful command line interfaces in Python";
+    longDescription = ''
+      A Python package for creating beautiful command line interfaces in a
+      composable way, with as little code as necessary.
+    '';
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mog ];
+  };
+}

--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "click";
+  version = "6.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02qkfpykbq35id8glfgwc38yc430427yd05z1wc5cnld8zgicmgi";
+  };
+
+  buildInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test tests
+  '';
+
+  # https://github.com/pallets/click/issues/823
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://click.pocoo.org/;
+    description = "Create beautiful command line interfaces in Python";
+    longDescription = ''
+      A Python package for creating beautiful command line interfaces in a
+      composable way, with as little code as necessary.
+    '';
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/cloudpickle/default.nix
+++ b/pkgs/development/python-modules/cloudpickle/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, mock }:
+
+buildPythonPackage rec {
+  pname = "cloudpickle";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0x4fbycipkhfax7lydaxcnc14g42g274qba17j51shr5gbq6m8lx";
+  };
+
+  buildInputs = [ pytest mock ];
+
+  # See README for tests invocation
+  checkPhase = ''
+    PYTHONPATH=$PYTHONPATH:'.:tests' py.test
+  '';
+
+  # TypeError: cannot serialize '_io.FileIO' object
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Extended pickling support for Python objects";
+    homepage = https://github.com/cloudpipe/cloudpickle;
+    license = with licenses; [ bsd3 ];
+  };
+}

--- a/pkgs/development/python-modules/cmdline/default.nix
+++ b/pkgs/development/python-modules/cmdline/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "cmdline";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0sjkcfp4w3rxy2lm2n60dbfkc33kdb3f6254hrrvn4ci3rqv8b5y";
+  };
+
+  # No tests, https://github.com/rca/cmdline/issues/1
+  doCheck = false;
+  propagatedBuildInputs = [ pyyaml ];
+
+  meta = with stdenv.lib; {
+    description = "Utilities for consistent command line tools";
+    homepage = https://github.com/rca/cmdline;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/cogapp/default.nix
+++ b/pkgs/development/python-modules/cogapp/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "cogapp";
+  version = "2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gzmzbsk54r1qa6wd0yg4zzdxvn2f19ciprr2acldxaknzrpllnn";
+  };
+
+  # there are no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A code generator for executing Python snippets in source files";
+    homepage = http://nedbatchelder.com/code/cog;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovek323 ];
+  };
+}

--- a/pkgs/development/python-modules/coilmq/default.nix
+++ b/pkgs/development/python-modules/coilmq/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, stompclient, pythondaemon, redis, pid, pytest, six, click, coverage
+, sqlalchemy }:
+
+buildPythonPackage rec {
+  pname = "CoilMQ";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wwa6fsqw1mxsryvgp0yrdjil8axyj0kslzi7lr45cnhgp5ab375";
+  };
+
+  propagatedBuildInputs = [ stompclient pythondaemon redis pid ];
+  buildInputs = [ pytest six click coverage sqlalchemy ];
+
+  # The teste data is not included in the distribution
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Simple, lightweight, and easily extensible STOMP message broker";
+    homepage = http://code.google.com/p/coilmq/;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/colorclass/default.nix
+++ b/pkgs/development/python-modules/colorclass/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "colorclass";
+  version = "2.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b05c2a348dfc1aff2d502527d78a5b7b7e2f85da94a96c5081210d8e9ee8e18b";
+  };
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Robpol86/colorclass;
+    license = licenses.mit;
+    description = "Automatic support for console colors";
+  };
+}

--- a/pkgs/development/python-modules/colour/default.nix
+++ b/pkgs/development/python-modules/colour/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, d2to1 }:
+
+buildPythonPackage rec {
+  pname = "colour";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0w1j43l76zw10dvs2kk7jz7kqj2ss7gfgfdxyls27pckwin89gxb";
+  };
+
+  buildInputs = [ d2to1 ];
+
+  meta = with stdenv.lib; {
+    description = "Converts and manipulates common color representation (RGB, HSV, web, ...)";
+    homepage = https://github.com/vaab/colour;
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/development/python-modules/configobj/default.nix
+++ b/pkgs/development/python-modules/configobj/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "configobj";
+  version = "5.0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00h9rcmws03xvdlfni11yb60bz3kxfvsj6dg6nrpzj71f03nbxd2";
+  };
+
+  # error: invalid command 'test'
+  doCheck = false;
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Config file reading, writing and validation";
+    homepage = https://pypi.python.org/pypi/configobj;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ garbas ];
+  };
+}

--- a/pkgs/development/python-modules/configparser/default.nix
+++ b/pkgs/development/python-modules/configparser/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "configparser";
+  version = "3.5.0";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fi7vf09vi1588jd8f16a021m5y6ih2hy7rpbjb408xw45qb822k";
+  };
+
+  # No tests available
+  doCheck = false;
+
+  # Fix issue when used together with other namespace packages
+  # https://github.com/NixOS/nixpkgs/issues/23855
+  patches = [
+    ./0001-namespace-fix.patch
+  ];
+
+  meta = with stdenv.lib; {
+  };
+}

--- a/pkgs/development/python-modules/consul/default.nix
+++ b/pkgs/development/python-modules/consul/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, requests, six, pytest }:
+
+buildPythonPackage rec {
+  pname = "python-consul";
+  version = "0.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "18gs5myk9wkkq5zvj0n0s68ngj3mrbdcifshxfj1j0bgb1km0wpm";
+  };
+
+  buildInputs = [ requests six pytest ];
+
+  # No tests distributed. https://github.com/cablehead/python-consul/issues/133
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python client for Consul (https://www.consul.io/)";
+    homepage = https://github.com/cablehead/python-consul;
+    license = licenses.mit;
+    maintainers = with maintainers; [ desiderius ];
+  };
+}

--- a/pkgs/development/python-modules/contexter/default.nix
+++ b/pkgs/development/python-modules/contexter/default.nix
@@ -1,0 +1,14 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "contexter";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xrnkjya29ya0hkj8y4k9ni2mnr58i6r0xfqlj7wk07v4jfrkc8n";
+  };
+
+  meta = with stdenv.lib; {
+  };
+}

--- a/pkgs/development/python-modules/cookiecutter/default.nix
+++ b/pkgs/development/python-modules/cookiecutter/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy
+, itsdangerous, pytest, freezegun, docutils, jinja2, future, binaryornot, click
+, whichcraft, poyo, jinja2_time }:
+
+buildPythonPackage rec {
+  pname = "cookiecutter";
+  version = "1.4.0";
+
+  # not sure why this is broken
+  disabled = isPyPy;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1clxnabmc5s4b519r1sxyj1163x833ir8xcypmdfpf6r9kbb35vn";
+  };
+
+  buildInputs = [ itsdangerous pytest freezegun docutils ];
+  propagatedBuildInputs = [
+    jinja2 future binaryornot click whichcraft poyo jinja2_time
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/audreyr/cookiecutter;
+    description = "A command-line utility that creates projects from project templates";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kragniz ];
+  };
+}

--- a/pkgs/development/python-modules/cookies/default.nix
+++ b/pkgs/development/python-modules/cookies/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "cookies";
+  version = "2.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13pfndz8vbk4p2a44cfbjsypjarkrall71pgc97glk5fiiw9idnn";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Friendlier RFC 6265-compliant cookie parser/renderer";
+    homepage = https://github.com/sashahart/cookies;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/cov-core/default.nix
+++ b/pkgs/development/python-modules/cov-core/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi, coverage }:
+
+buildPythonPackage rec {
+  pname = "cov-core";
+  version = "1.15.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0k3np9ymh06yv1ib96sb6wfsxjkqhmik8qfsn119vnhga9ywc52a";
+  };
+
+  propagatedBuildInputs = [ coverage ];
+
+  meta = with stdenv.lib; {
+    description = "Plugin core for use by pytest-cov, nose-cov and nose2-cov";
+  };
+}

--- a/pkgs/development/python-modules/crcmod/default.nix
+++ b/pkgs/development/python-modules/crcmod/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "crcmod";
+  version = "1.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07k0hgr42vw2j92cln3klxka81f33knd7459cn3d8aszvfh52w6w";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Python module for generating objects that compute the Cyclic Redundancy Check (CRC)";
+    homepage = http://crcmod.sourceforge.net/;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/cryptacular/default.nix
+++ b/pkgs/development/python-modules/cryptacular/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, coverage, nose, pbkdf2 }:
+
+buildPythonPackage rec {
+  pname = "cryptacular";
+  version = "1.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "18fl7phl6r9xiwz8f1jpkahkv21wimmiq72gmrqncccv7z806gr7";
+  };
+
+  buildInputs = [ coverage nose ];
+  propagatedBuildInputs = [ pbkdf2 ];
+
+  # TODO: tests fail: TypeError: object of type 'NoneType' has no len()
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ domenkozar ];
+  };
+}

--- a/pkgs/development/python-modules/cssselect/default.nix
+++ b/pkgs/development/python-modules/cssselect/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "cssselect";
+  version = "0.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10h623qnp6dp1191jri7lvgmnd4yfkl36k9smqklp1qlf3iafd85";
+  };
+
+  # AttributeError: 'module' object has no attribute 'tests'
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+  };
+}

--- a/pkgs/development/python-modules/cssutils/default.nix
+++ b/pkgs/development/python-modules/cssutils/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, mock }:
+
+buildPythonPackage rec {
+  pname = "cssutils";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qwha9x1wml2qmipbcz03gndnlwhzrjdvw9i09si247a90l8p8fq";
+  };
+
+  buildInputs = [ mock ];
+
+  # couple of failing tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A Python package to parse and build CSS";
+    homepage = http://code.google.com/p/cssutils/;
+    license = licenses.lgpl3Plus;
+  };
+}

--- a/pkgs/development/python-modules/darcsver/default.nix
+++ b/pkgs/development/python-modules/darcsver/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, mock }:
+
+buildPythonPackage rec {
+  pname = "darcsver";
+  version = "1.7.4";
+
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yb1c3jxqvy4r3qiwvnb86qi5plw6018h15r3yk5ji3nk54qdcb6";
+  };
+
+  buildInputs = [ mock ];
+
+  # Note: We don't actually need to provide Darcs as a build input.
+  # Darcsver will DTRT when Darcs isn't available.  See news.gmane.org
+  # http://thread.gmane.org/gmane.comp.file-systems.tahoe.devel/3200 for a
+  # discussion.
+
+  # AttributeError: 'module' object has no attribute 'test_darcsver'
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Darcsver, generate a version number from Darcs history";
+    homepage = https://pypi.python.org/pypi/darcsver;
+    license = "BSD-style";
+  };
+}

--- a/pkgs/development/python-modules/datadog/default.nix
+++ b/pkgs/development/python-modules/datadog/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pillow, tox, mock, six, nose, requests, decorator, simplejson }:
+
+buildPythonPackage rec {
+  pname = "datadog";
+  version = "0.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0y2if4jj43n5jis20imragvhhyhr840w4m1g7j7fxh9bn7h273zp";
+  };
+
+  buildInputs = [ pillow tox mock six nose ];
+  propagatedBuildInputs = [ requests decorator simplejson ];
+
+  meta = with stdenv.lib; {
+    description = "The Datadog Python library";
+    license = licenses.bsd3;
+    homepage = https://github.com/DataDog/datadogpy;
+  };
+}

--- a/pkgs/development/python-modules/dateutil/1_5.nix
+++ b/pkgs/development/python-modules/dateutil/1_5.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, six }:
+
+buildPythonPackage rec {
+  pname = "python-dateutil";
+  version = "1.5";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02dhw57jf5kjcp7ng1if7vdrbnlpb9yjmz7wygwwvf3gni4766bg";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Powerful extensions to the standard datetime module";
+    homepage = https://pypi.python.org/pypi/python-dateutil;
+    license = "BSD-style";
+  };
+}

--- a/pkgs/development/python-modules/datrie/default.nix
+++ b/pkgs/development/python-modules/datrie/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, pytestrunner, hypothesis}:
+
+buildPythonPackage rec {
+  pname = "datrie";
+  version = "0.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08r0if7dry2q7p34gf7ffyrlnf4bdvnprxgydlfxgfnvq8f3f4bs";
+  };
+
+  buildInputs = [ pytest pytestrunner hypothesis ];
+
+  meta = with stdenv.lib; {
+    description = "Super-fast, efficiently stored Trie for Python";
+    homepage = "https://github.com/kmike/datrie";
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ lewo ];
+  };
+}

--- a/pkgs/development/python-modules/debian/default.nix
+++ b/pkgs/development/python-modules/debian/default.nix
@@ -1,0 +1,14 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, chardet, six}:
+
+buildPythonPackage rec {
+  pname = "python-debian";
+  version = "0.1.23";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "193faznwnjc3n5991wyzim6h9gyq1zxifmfrnpm3avgkh7ahyynh";
+  };
+
+  propagatedBuildInputs = [ chardet six ];
+}

--- a/pkgs/development/python-modules/defusedxml/default.nix
+++ b/pkgs/development/python-modules/defusedxml/default.nix
@@ -1,0 +1,11 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "defusedxml";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1x54n0h8hl92vvwyymx883fbqpqjwn2mc8fb383bcg3z9zwz5mr4";
+  };
+}

--- a/pkgs/development/python-modules/derpconf/default.nix
+++ b/pkgs/development/python-modules/derpconf/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "derpconf";
+  version = "0.4.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0si3xnhyjk8dykr377v35bldsjv1ikgx4ff3crizwxv47ag42aci";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "derpconf abstracts loading configuration files for your app";
+    homepage = https://github.com/globocom/derpconf;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/detox/default.nix
+++ b/pkgs/development/python-modules/detox/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, tox, py, eventlet }:
+
+buildPythonPackage rec {
+  pname = "detox";
+  version = "0.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1v5sq3ak1b6388k1q31cd4pds56z76l2myvj022ncwv5lp109drk";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ tox py eventlet ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  # eventlet timeout, and broken invokation 3.5
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "What is detox?";
+    homepage = https://bitbucket.org/hpk42/detox;
+  };
+}

--- a/pkgs/development/python-modules/digitalocean/default.nix
+++ b/pkgs/development/python-modules/digitalocean/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  pname = "python-digitalocean";
+  version = "1.10.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12qybflfnl08acspz7rpaprmlabgrzimacbd7gm9qs5537hl3qnp";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # Package doesn't distribute tests.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "digitalocean.com API to manage Droplets and Images";
+    homepage = https://pypi.python.org/pypi/python-digitalocean;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/development/python-modules/docker-pycreds/default.nix
+++ b/pkgs/development/python-modules/docker-pycreds/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "docker-pycreds";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0j3k5wk3bww5y0f2rvgzsin0q98k0i9j308vpsmxidw0y8n3m0wk";
+  };
+
+  # require docker-credential-helpers binaries
+  doCheck = false;
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Python bindings for the docker credentials store API.";
+    homepage = https://github.com/shin-/dockerpy-creds;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/docker-registry-core/default.nix
+++ b/pkgs/development/python-modules/docker-registry-core/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, boto, redis, setuptools, simplejson }:
+
+buildPythonPackage rec {
+  pname = "docker-registry-core";
+  version = "2.0.3";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0q036rr0b5734szkj883hkb2kjhgcc5pm3dz4yz8vcim3x7q0zil";
+  };
+
+  DEPS = "loose";
+
+  doCheck = false;
+  propagatedBuildInputs = [ boto redis setuptools simplejson ];
+
+  patchPhase = "> requirements/main.txt";
+
+  meta = with stdenv.lib; {
+    description = "Docker registry core package";
+    homepage = https://github.com/docker/docker-registry;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/dockerpty/default.nix
+++ b/pkgs/development/python-modules/dockerpty/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "dockerpty";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kjn64wx23jmr8dcc6g7bwlmrhfmxr77gh6iphqsl39sayfxdab9";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Functionality needed to operate the pseudo-tty (PTY) allocated to a docker container";
+    homepage = https://github.com/d11wtq/dockerpty;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/docopt/default.nix
+++ b/pkgs/development/python-modules/docopt/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "docopt";
+  version = "0.6.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14f4hn6d1j4b99svwbaji8n2zj58qicyz19mm0x6pmhb50jsics9";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Pythonic argument parser, that will make you smile";
+    homepage = http://docopt.org/;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/doctest-ignore-unicode/default.nix
+++ b/pkgs/development/python-modules/doctest-ignore-unicode/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "doctest-ignore-unicode";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1m9aa4qnyj21lbq4sbvmv1vcz7zksss4rz37ddf2hxv4hk8b547w";
+  };
+
+  propagatedBuildInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    description = "Add flag to ignore unicode literal prefixes in doctests";
+    license = with licenses; [ asl20 ];
+    homepage = https://github.com/gnublade/doctest-ignore-unicode;
+  };
+}

--- a/pkgs/development/python-modules/dogpile.core/default.nix
+++ b/pkgs/development/python-modules/dogpile.core/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "dogpile.core";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xpdvg4kr1isfkrh1rfsh7za4q5a5s6l2kf9wpvndbwf3aqjyrdy";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A 'dogpile' lock, typically used as a component of a larger caching solution";
+    homepage = https://bitbucket.org/zzzeek/dogpile.core;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytestrunner, requests, urllib3, mock, setuptools }:
+
+buildPythonPackage rec {
+  pname = "dropbox";
+  version = "8.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bixx80zjq0286dwm4zhg8bdhc8pqlrqy4n2jg7i6m6a4gv4gak5";
+  };
+
+  # Set DROPBOX_TOKEN environment variable to a valid token.
+  doCheck = false;
+
+  buildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ requests urllib3 mock setuptools ];
+
+  meta = with stdenv.lib; {
+    description = "A Python library for Dropbox's HTTP-based Core and Datastore APIs";
+    homepage = https://www.dropbox.com/developers/core/docs;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/dugong/default.nix
+++ b/pkgs/development/python-modules/dugong/default.nix
@@ -1,0 +1,13 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "dugong";
+  version = "3.5";
+
+  disabled = pythonOlder "3.3"; # Library does not support versions older than 3.3
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0y0rdxbiwm03zv6vpvapqilrird3h8ijz7xmb0j7ds5j4p6q3g24";
+  };
+}

--- a/pkgs/development/python-modules/easyprocess/default.nix
+++ b/pkgs/development/python-modules/easyprocess/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "EasyProcess";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07z6485bjxkmx26mp1p1ww19d10qavw0s006bidzailsvk543qll";
+  };
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Easy to use python subprocess interface";
+    homepage = https://github.com/ponty/EasyProcess;
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ layus ];
+  };
+}

--- a/pkgs/development/python-modules/heapdict/default.nix
+++ b/pkgs/development/python-modules/heapdict/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "HeapDict";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nhvxyjq6fp6zd7jzmk5x4fg6xhakqx9lhkp5yadzkqn0rlf7ja0";
+  };
+
+  doCheck = !isPy3k;
+
+  meta = with stdenv.lib; {
+    description = "a heap with decrease-key and increase-key operations.";
+    homepage = http://stutzbachenterprises.com;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/development/python-modules/howdoi/default.nix
+++ b/pkgs/development/python-modules/howdoi/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, six, requests-cache, pygments, pyquery }:
+
+buildPythonPackage rec {
+  pname = "howdoi";
+  version = "1.1.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dx9ms0b3z3bx02paj78cyi788d8l6cpd3jqbn3j88w736i4jknz";
+  };
+
+  propagatedBuildInputs = [ six requests-cache pygments pyquery ];
+
+  meta = with stdenv.lib; {
+    description = "Instant coding answers via the command line";
+    homepage = https://pypi.python.org/pypi/howdoi;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/iowait/default.nix
+++ b/pkgs/development/python-modules/iowait/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "iowait";
+  version = "0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16djvxd9sxm7cr57clhqkyrq3xvdzgwj803sy5hwyb62hkmw46xb";
+  };
+
+  meta = {
+    description = "Platform-independent module for I/O completion events";
+    homepage = https://launchpad.net/python-iowait;
+  };
+}

--- a/pkgs/development/python-modules/jdatetime/default.nix
+++ b/pkgs/development/python-modules/jdatetime/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "jdatetime";
+  version = "1.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b1ksspm86r272ar8v0v4ip1821i4azpix6xhxpb4l133iwsb2y0";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Jalali datetime binding for python";
+    homepage = https://pypi.python.org/pypi/jdatetime;
+    license = licenses.psfl;
+  };
+}

--- a/pkgs/development/python-modules/locket/default.nix
+++ b/pkgs/development/python-modules/locket/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "locket";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1d4z2zngrpqkrfhnd4yhysh66kjn4mblys2l06sh5dix2p0n7vhz";
+  };
+
+  buildInputs = [ pytest ];
+
+  # weird test requirements (spur.local>=0.3.7,<0.4)
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Locket implements a lock that can be used by multiple processes provided they use the same path.";
+    homepage = https://github.com/mwilliamson/locket.py;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/development/python-modules/neurotools/default.nix
+++ b/pkgs/development/python-modules/neurotools/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, scipy, numpy, matplotlib, tables, pyaml, urllib3, rpy2, mpi4py }:
+
+buildPythonPackage rec {
+  pname = "NeuroTools";
+  version = "0.3.1";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ly6qa87l3afhksab06vp1iimlbm1kdnsw98mxcnpzz9q07l4nd4";
+  };
+
+  # Tests are not automatically run
+  # Many tests fail (using py.test), and some need R
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    scipy
+    numpy
+    matplotlib
+    tables
+    pyaml
+    urllib3
+    rpy2
+    mpi4py
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Collection of tools to support analysis of neural activity";
+    homepage = https://pypi.python.org/pypi/NeuroTools;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ nico202 ];
+  };
+}

--- a/pkgs/development/python-modules/noise/default.nix
+++ b/pkgs/development/python-modules/noise/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "noise";
+  version = "1.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rcv40dcshqpchwkdlhsv3n68h9swm9fh4d1cgzr2hsp6rs7k8jp";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/caseman/noise;
+    description = "Native-code and shader implementations of Perlin noise";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/pbkdf2/default.nix
+++ b/pkgs/development/python-modules/pbkdf2/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pbkdf2";
+  version = "1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0yb99rl2mbsaamj571s1mf6vgniqh23v98k4632150hjkwv9fqxc";
+  };
+
+  # ImportError: No module named test
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ domenkozar ];
+  };
+}

--- a/pkgs/development/python-modules/pkginfo/default.nix
+++ b/pkgs/development/python-modules/pkginfo/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pkginfo";
+  version = "1.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qg4sq3m0pxvjahc3sncwhw42z5rfw22k0ybskmdqkl2agykay7q";
+  };
+
+  doCheck = false; # I don't know why, but with doCheck = true it fails.
+
+  meta = with stdenv.lib; {
+    homepage = https://pypi.python.org/pypi/pkginfo;
+    license = licenses.mit;
+    description = "Query metadatdata from sdists / bdists / installed packages";
+
+    longDescription = ''
+      This package provides an API for querying the distutils metadata
+      written in the PKG-INFO file inside a source distriubtion (an sdist)
+      or a binary distribution (e.g., created by running bdist_egg). It can
+      also query the EGG-INFO directory of an installed distribution, and the
+      *.egg-info stored in a “development checkout” (e.g, created by running
+      setup.py develop).
+    '';
+  };
+}

--- a/pkgs/development/python-modules/pretend/default.nix
+++ b/pkgs/development/python-modules/pretend/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pretend";
+  version = "1.0.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r5r7ygz9m6d2bklflbl84cqhjkc2q12xgis8268ygjh30g2q3wk";
+  };
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/alex/pretend;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/pycontracts/default.nix
+++ b/pkgs/development/python-modules/pycontracts/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, nose, pyparsing, decorator, six }:
+
+buildPythonPackage rec {
+  pname = "PyContracts";
+  version = "1.7.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rdc9pz08885vqkazjc3lyrrghmf3jzxnlsgpn8akl808x1qrfqf";
+  };
+
+  buildInputs = [ nose ];
+  propagatedBuildInputs = [ pyparsing decorator six ];
+
+  meta = with stdenv.lib; {
+    description = "Allows to declare constraints on function parameters and return values";
+    homepage = https://pypi.python.org/pypi/PyContracts;
+    license = licenses.lgpl2;
+  };
+}

--- a/pkgs/development/python-modules/pycparser/default.nix
+++ b/pkgs/development/python-modules/pycparser/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, python }:
+
+buildPythonPackage rec {
+  pname = "pycparser";
+  version = "2.14";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wvzyb6rxsfj3xcnpa4ynbh9qc7rrbk2277d5wqpphmx9akv8nbr";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "C parser in Python";
+    homepage = https://github.com/eliben/pycparser;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ domenkozar ];
+  };
+}

--- a/pkgs/development/python-modules/pyechonest/default.nix
+++ b/pkgs/development/python-modules/pyechonest/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "pyechonest";
+  version = "8.0.2";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "496265f4b7d33483ec153b9e1b8333fe959b115f7e781510089c8313b7d86560";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Tap into The Echo Nest's Musical Brain for the best music search, information, recommendations and remix tools on the web";
+    homepage = https://github.com/echonest/pyechonest;
+  };
+}

--- a/pkgs/development/python-modules/pytest-catchlog/default.nix
+++ b/pkgs/development/python-modules/pytest-catchlog/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, unzip }:
+
+buildPythonPackage rec {
+  pname = "pytest-catchlog";
+  version = "1.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1w7wxh27sbqwm4jgwrjr9c2gy384aca5jzw9c0wzhl0pmk2mvqab";
+    extension = "zip";
+  };
+
+  buildInputs = [ pytest unzip ];
+  checkPhase = "make test";
+
+  # Requires pytest < 3.1
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    homepage = https://pypi.python.org/pypi/pytest-catchlog/;
+    description = "py.test plugin to catch log messages. This is a fork of pytest-capturelog.";
+  };
+}

--- a/pkgs/development/python-modules/pytest-cov/default.nix
+++ b/pkgs/development/python-modules/pytest-cov/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, pytest_xdist, virtualenv, process-tests, coverage }:
+
+buildPythonPackage rec {
+  pname = "pytest-cov";
+  version = "2.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03c2qc42r4bczyw93gd7n0qi1h1jfhw7fnbhi33c3vp1hs81gm2k";
+  };
+
+  buildInputs = [ pytest pytest_xdist virtualenv process-tests ];
+  propagatedBuildInputs = [ coverage ];
+
+  # xdist related tests fail with the following error
+  # OSError: [Errno 13] Permission denied: 'py/_code'
+  doCheck = false;
+  checkPhase = ''
+    # allow to find the module helper during the test run
+    export PYTHONPATH=$PYTHONPATH:$PWD/tests
+    py.test tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Plugin for coverage reporting with support for both centralised and distributed testing, including subprocesses and multiprocessing";
+    homepage = https://github.com/pytest-dev/pytest-cov;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pytest-fixture-config/default.nix
+++ b/pkgs/development/python-modules/pytest-fixture-config/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, coverage, virtualenv, pytestcov, six }:
+
+buildPythonPackage rec {
+  pname = "pytest-fixture-config";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dpdf36hpkfhgmca4rwmf0vnzz7xqbiw479v11zp12pq4p5w2z3x";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ coverage virtualenv pytestcov six ];
+
+  checkPhase = ''
+    py.test -k "not test_yield_requires_config_doesnt_skip and not test_yield_requires_config_skips"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple configuration objects for Py.test fixtures. Allows you to skip tests when their required config variables aren’t set.";
+    homepage = https://github.com/manahl/pytest-plugins;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ryansydnor ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-flakes/default.nix
+++ b/pkgs/development/python-modules/pytest-flakes/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytestpep8, pytest, pyflakes, pytestcache }:
+
+buildPythonPackage rec {
+  pname = "pytest-flakes";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0flag3n33kbhyjrhzmq990rvg4yb8hhhl0i48q9hw0ll89jp28lw";
+  };
+
+  buildInputs = [ pytestpep8 pytest ];
+  propagatedBuildInputs = [ pyflakes pytestcache ];
+
+  checkPhase = ''
+    py.test test_flakes.py
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    homepage = https://pypi.python.org/pypi/pytest-flakes;
+    description = "pytest plugin to check source code with pyflakes";
+  };
+}

--- a/pkgs/development/python-modules/pytest-pep8/default.nix
+++ b/pkgs/development/python-modules/pytest-pep8/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, pytestcache, pep8 }:
+
+buildPythonPackage rec {
+  pname = "pytest-pep8";
+  version = "1.0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06032agzhw1i9d9qlhfblnl3dw5hcyxhagn7b120zhrszbjzfbh3";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ pytestcache pep8 ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  # Fails
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    homepage = https://pypi.python.org/pypi/pytest-pep8;
+    description = "pytest plugin to check PEP8 requirements";
+  };
+}

--- a/pkgs/development/python-modules/pytest-raisesregexp/default.nix
+++ b/pkgs/development/python-modules/pytest-raisesregexp/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, py, pytest }:
+
+buildPythonPackage rec {
+  pname = "pytest-raisesregexp";
+  version = "2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0q8yby4g3il86rp7rhk89792wm17cykzsqcwbxpbbyal3an8mphg";
+  };
+
+  buildInputs = [ py pytest ];
+
+  # https://github.com/kissgyorgy/pytest-raisesregexp/pull/3
+  prePatch = ''
+    sed -i '3i\import io' setup.py
+    substituteInPlace setup.py --replace "long_description=open('README.rst').read()," "long_description=io.open('README.rst', encoding='utf-8').read(),"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple pytest plugin to look for regex in Exceptions";
+    homepage = https://github.com/Walkman/pytest_raisesregexp;
+    license = with licenses; [ mit ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-server-fixtures/default.nix
+++ b/pkgs/development/python-modules/pytest-server-fixtures/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, setuptools-git, pytest-shutil, pytest-fixture-config, psutil
+, requests}:
+
+buildPythonPackage rec {
+  pname = "pytest-server-fixtures";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gs9qimcn8q6xi9d6i5624l0dziwvn6nj2rda07fg15g1cq66s8l";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ setuptools-git pytest-shutil pytest-fixture-config psutil requests ];
+
+  # RuntimeError: Unable to find a free server number to start Xvfb
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Extensible server fixures for py.test";
+    homepage  = "https://github.com/manahl/pytest-plugins";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nand0p ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-shutil/default.nix
+++ b/pkgs/development/python-modules/pytest-shutil/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, cmdline, pytestcov, coverage, setuptools-git, mock, pathpy, execnet
+, contextlib2 }:
+
+buildPythonPackage rec {
+  pname = "pytest-shutil";
+  version = "1.2.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gdzarg3l7d80lj0gh9bcsw9r12gmf306n4y2cb18y7kqfpcqjlj";
+  };
+
+  buildInputs = [ cmdline pytest ];
+  propagatedBuildInputs = [ pytestcov coverage setuptools-git mock pathpy execnet contextlib2 ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A goodie-bag of unix shell and environment tools for py.test";
+    homepage = https://github.com/manahl/pytest-plugins;
+    maintainers = with maintainers; [ ryansydnor ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pytest-subtesthack/default.nix
+++ b/pkgs/development/python-modules/pytest-subtesthack/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "pytest-subtesthack";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15kzcr5pchf3id4ikdvlv752rc0j4d912n589l4rifp8qsj19l1x";
+  };
+
+  buildInputs = [ pytest ];
+
+  # no upstream test
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Terrible plugin to set up and tear down fixtures within the test function itself";
+    homepage = https://github.com/untitaker/pytest-subtesthack;
+    license = licenses.publicDomain;
+  };
+}

--- a/pkgs/development/python-modules/pytest-virtualenv/default.nix
+++ b/pkgs/development/python-modules/pytest-virtualenv/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, pytestcov, mock, cmdline, pytest-fixture-config, pytest-shutil }:
+
+buildPythonPackage rec {
+  pname = "pytest-virtualenv";
+  version = "1.2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mb76zhlak4qjjq2h7kaxbihk1b9plmimbzcb8qv4906cxl69ysi";
+  };
+
+  buildInputs = [ pytest pytestcov mock cmdline ];
+  propagatedBuildInputs = [ pytest-fixture-config pytest-shutil ];
+  checkPhase = '' py.test tests/unit '';
+
+  meta = with stdenv.lib; {
+    description = "Create a Python virtual environment in your test that cleans up on teardown. The fixture has utility methods to install packages and list what’s installed.";
+    homepage = https://github.com/manahl/pytest-plugins;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ryansydnor ];
+  };
+}

--- a/pkgs/development/python-modules/pytestcache/default.nix
+++ b/pkgs/development/python-modules/pytestcache/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, execnet }:
+
+buildPythonPackage rec {
+  pname = "pytest-cache";
+  version = "1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1a873fihw4rhshc722j4h6j7g3nj7xpgsna9hhg3zn6ksknnhx5y";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ execnet ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  # Too many failing tests. Are they maintained?
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    homepage = https://pypi.python.org/pypi/pytest-cache/;
+    description = "pytest plugin with mechanisms for caching across test runs";
+  };
+}

--- a/pkgs/development/python-modules/requests-cache/default.nix
+++ b/pkgs/development/python-modules/requests-cache/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, mock, requests, six, urllib3 }:
+
+buildPythonPackage rec {
+  pname = "requests-cache";
+  version = "0.4.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "18jpyivnq5pjbkymk3i473rihpj2bgikafpha7xvr6w736hiqmpy";
+  };
+
+  buildInputs = [ mock ];
+  propagatedBuildInputs = [ requests six urllib3 ];
+
+  meta = with stdenv.lib; {
+    description = "Persistent cache for requests library";
+    homepage = https://pypi.python.org/pypi/requests-cache;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/responses/default.nix
+++ b/pkgs/development/python-modules/responses/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, cookies, mock, requests, six }:
+
+buildPythonPackage rec {
+  pname = "responses";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fs7a4cf4f12mjhcjd5vfh0f3ixcy2nawzxpgsfr3ahf0rg7ppx5";
+  };
+
+  propagatedBuildInputs = [ cookies mock requests six ];
+
+  doCheck = false;
+}

--- a/pkgs/development/python-modules/s3fs/default.nix
+++ b/pkgs/development/python-modules/s3fs/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, docutils, boto3 }:
+
+buildPythonPackage rec {
+  pname = "s3fs";
+  version = "0.0.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zbdzqrim0zig94fk1hswg4vfdjplw6jpx3pdi42qc830h0nscn8";
+  };
+
+  buildInputs = [ docutils ];
+  propagatedBuildInputs = [ boto3 ];
+
+  # Depends on `moto` which has a long dependency chain with exact
+  # version requirements that can't be made to work with current
+  # pythonPackages.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "S3FS builds on boto3 to provide a convenient Python filesystem interface for S3.";
+    homepage = http://github.com/dask/s3fs/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/development/python-modules/tblib/default.nix
+++ b/pkgs/development/python-modules/tblib/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "tblib";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02iahfkfa927hb4jq2bak36ldihwapzacfiq5lyxg8llwn98a1yi";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Traceback fiddling library. Allows you to pickle tracebacks.";
+    homepage = https://github.com/ionelmc/python-tblib;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/development/python-modules/zict/default.nix
+++ b/pkgs/development/python-modules/zict/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, heapdict }:
+
+buildPythonPackage rec {
+  pname = "zict";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12h95vbkbar1hc6cr1kpr6zr486grj3mpx4lznvmnai0iy6pbqp4";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ heapdict ];
+
+  meta = with stdenv.lib; {
+    description = "Mutable mapping tools.";
+    homepage = https://github.com/dask/zict;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1117,18 +1117,7 @@ in {
 
   cheroot = callPackage ../development/python-modules/cheroot {};
 
-  circus = buildPythonPackage rec {
-    name = "circus-0.11.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/circus/${name}.tar.gz";
-      sha256 = "3757344aa5073ea29e6e2607b3de8ba1652502c61964316116931884293fe846";
-    };
-
-    doCheck = false; # weird error
-
-    propagatedBuildInputs = with self; [ iowait psutil pyzmq tornado mock ];
-  };
+  circus = callPackage ../development/python-modules/circus {};
 
   colorclass = buildPythonPackage rec {
     pname = "colorclass";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1924,31 +1924,7 @@ in {
 
   pytest-django = callPackage ../development/python-modules/pytest-django { };
 
-  pytest-fixture-config = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "pytest-fixture-config";
-    version = "1.0.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
-      sha256 = "7d7cc1cb25f88a707f083b1dc2e3c2fdfc6f37709567a2587dd0cd0bcd70edb6";
-    };
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ coverage virtualenv pytestcov six ];
-
-    checkPhase = ''
-      py.test -k "not test_yield_requires_config_doesnt_skip and not test_yield_requires_config_skips"
-    '';
-
-    meta = {
-      description = "Simple configuration objects for Py.test fixtures. Allows you to skip tests when their required config variables aren’t set.";
-      homepage = https://github.com/manahl/pytest-plugins;
-      license = licenses.mit;
-      maintainers = with maintainers; [ ryansydnor ];
-      platforms   = platforms.all;
-    };
-  };
+  pytest-fixture-config = callPackage ../development/python-modules/pytest-fixture-config { };
 
   pytest-forked = callPackage ../development/python-modules/pytest-forked { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1645,29 +1645,7 @@ in {
 
   contextlib2 = callPackage ../development/python-modules/contextlib2 { };
 
-  cookiecutter = buildPythonPackage rec {
-    version = "1.4.0";
-    name = "cookiecutter-${version}";
-
-    # not sure why this is broken
-    disabled = isPyPy;
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/audreyr/cookiecutter/archive/${version}.tar.gz";
-      sha256 = "1clxnabmc5s4b519r1sxyj1163x833ir8xcypmdfpf6r9kbb35vn";
-    };
-
-    buildInputs = with self; [ itsdangerous pytest freezegun docutils ];
-    propagatedBuildInputs = with self; [
-          jinja2 future binaryornot click whichcraft poyo jinja2_time ];
-
-    meta = {
-      homepage = https://github.com/audreyr/cookiecutter;
-      description = "A command-line utility that creates projects from project templates";
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ kragniz ];
-    };
-  };
+  cookiecutter = callPackage ../development/python-modules/cookiecutter { };
 
   cookies = buildPythonPackage rec {
     name = "cookies-2.2.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -494,20 +494,7 @@ in {
 
   appdirs = callPackage ../development/python-modules/appdirs { };
 
-  application = buildPythonPackage rec {
-    pname = "python-application";
-    name = "${pname}-${version}";
-    version = "2.0.2";
-    disabled = isPy3k;
-
-    src = pkgs.fetchdarcs {
-      url = "http://devel.ag-projects.com/repositories/${pname}";
-      rev = "release-${version}";
-      sha256 = "19dszv44py8qrq0jcjdycxpa7z2p8hi3ijq9gnqdsazbbjzf9svn";
-    };
-    buildInputs = with self; [ zope_interface ];
-
-  };
+  application = callPackage ../development/python-modules/application { };
 
   appnope = buildPythonPackage rec {
     version = "0.1.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1193,24 +1193,7 @@ in {
     checkInputs = with self; [ pytest ];
   };
 
-  datadog = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "datadog";
-    version = "0.10.0";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/${pname}/${name}.tar.gz";
-      sha256 = "0y2if4jj43n5jis20imragvhhyhr840w4m1g7j7fxh9bn7h273zp";
-    };
-
-    buildInputs = with self; [ pillow tox mock six nose ];
-    propagatedBuildInputs = with self; [ requests decorator simplejson ];
-
-    meta = {
-      description = "The Datadog Python library ";
-      license = licenses.bsd3;
-      homepage = https://github.com/DataDog/datadogpy;
-    };
-  };
+  datadog = callPackage ../development/python-modules/datadog {};
 
   debian = buildPythonPackage rec {
     name = "${pname}-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1828,23 +1828,7 @@ in {
 
   pkginfo = callPackage ../development/python-modules/pkginfo { };
 
-  pretend = buildPythonPackage rec {
-    name = "pretend-1.0.8";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pretend/pretend-1.0.8.tar.gz";
-      sha256 = "0r5r7ygz9m6d2bklflbl84cqhjkc2q12xgis8268ygjh30g2q3wk";
-    };
-
-    # No tests in archive
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/alex/pretend;
-      license = licenses.bsd3;
-    };
-  };
-
+  pretend = callPackage ../development/python-modules/pretend { };
 
   detox = self.buildPythonPackage rec {
     name = "detox-0.10.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1538,33 +1538,7 @@ in {
 
   clf = callPackage ../development/python-modules/clf {};
 
-  click = buildPythonPackage rec {
-    name = "click-6.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/click/${name}.tar.gz";
-      sha256 = "02qkfpykbq35id8glfgwc38yc430427yd05z1wc5cnld8zgicmgi";
-    };
-
-    buildInputs = with self; [ pytest ];
-
-    checkPhase = ''
-      py.test tests
-    '';
-
-    # https://github.com/pallets/click/issues/823
-    doCheck = false;
-
-    meta = {
-      homepage = http://click.pocoo.org/;
-      description = "Create beautiful command line interfaces in Python";
-      longDescription = ''
-        A Python package for creating beautiful command line interfaces in a
-        composable way, with as little code as necessary.
-      '';
-      license = licenses.bsd3;
-    };
-  };
+  click = callPackage ../development/python-modules/click {};
 
   click_5 = buildPythonPackage rec {
     name = "click-5.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1641,16 +1641,7 @@ in {
 
   consul = callPackage ../development/python-modules/consul { };
 
-  contexter = buildPythonPackage rec {
-    name = "contexter-${version}";
-    version = "0.1.3";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/contexter/${name}.tar.gz";
-      sha256 = "0xrnkjya29ya0hkj8y4k9ni2mnr58i6r0xfqlj7wk07v4jfrkc8n";
-    };
-  };
-
+  contexter = callPackage ../development/python-modules/contexter { };
 
   contextlib2 = callPackage ../development/python-modules/contextlib2 { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1123,24 +1123,7 @@ in {
 
   colorlog = callPackage ../development/python-modules/colorlog { };
 
-  colour = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "colour";
-    version = "0.1.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/${pname}/${name}.tar.gz";
-      sha256 = "0w1j43l76zw10dvs2kk7jz7kqj2ss7gfgfdxyls27pckwin89gxb";
-    };
-
-    buildInputs = with self; [ d2to1 ];
-
-    meta = {
-      description = "Converts and manipulates common color representation (RGB, HSV, web, ...)";
-      homepage = https://github.com/vaab/colour;
-      license = licenses.bsd2;
-    };
-  };
+  colour = callPackage ../development/python-modules/colour {};
 
   constantly = callPackage ../development/python-modules/constantly { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1639,26 +1639,7 @@ in {
 
   construct = callPackage ../development/python-modules/construct {};
 
-  consul = buildPythonPackage (rec {
-    name = "python-consul-0.7.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-consul/${name}.tar.gz";
-      sha256 = "18gs5myk9wkkq5zvj0n0s68ngj3mrbdcifshxfj1j0bgb1km0wpm";
-    };
-
-    buildInputs = with self; [ requests six pytest ];
-
-    # No tests distributed. https://github.com/cablehead/python-consul/issues/133
-    doCheck = false;
-
-    meta = {
-      description = "Python client for Consul (https://www.consul.io/)";
-      homepage = https://github.com/cablehead/python-consul;
-      license = licenses.mit;
-      maintainers = with maintainers; [ desiderius ];
-    };
-  });
+  consul = callPackage ../development/python-modules/consul { };
 
   contexter = buildPythonPackage rec {
     name = "contexter-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1655,18 +1655,7 @@ in {
 
   covCore = callPackage ../development/python-modules/cov-core { };
 
-  crcmod = buildPythonPackage rec {
-    name = "crcmod-1.7";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/c/crcmod/crcmod-1.7.tar.gz;
-      sha256 = "07k0hgr42vw2j92cln3klxka81f33knd7459cn3d8aszvfh52w6w";
-    };
-    meta = {
-      description = "Python module for generating objects that compute the Cyclic Redundancy Check (CRC)";
-      homepage = http://crcmod.sourceforge.net/;
-      license = licenses.mit;
-    };
-  };
+  crcmod = callPackage ../development/python-modules/crcmod { };
 
   credstash = callPackage ../development/python-modules/credstash { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1842,26 +1842,7 @@ in {
 
   pycontracts = callPackage ../development/python-modules/pycontracts { };
 
-  pycparser = buildPythonPackage rec {
-    name = "pycparser-${version}";
-    version = "2.14";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pycparser/${name}.tar.gz";
-      sha256 = "7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73";
-    };
-
-    checkPhase = ''
-      ${python.interpreter} -m unittest discover -s tests
-    '';
-
-    meta = {
-      description = "C parser in Python";
-      homepage = https://github.com/eliben/pycparser;
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ domenkozar ];
-    };
-  };
+  pycparser = callPackage ../development/python-modules/pycparser { };
 
   pydub = callPackage ../development/python-modules/pydub {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -517,22 +517,7 @@ in {
 
   astor = callPackage ../development/python-modules/astor {};
 
-  asyncio = if (pythonAtLeast "3.3") then buildPythonPackage rec {
-    name = "asyncio-${version}";
-    version = "3.4.3";
-
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/asyncio/${name}.tar.gz";
-      sha256 = "0hfbqwk9y0bbfgxzg93s2wyk6gcjsdxlr5jwy97hx64ppkw0ydl3";
-    };
-
-    meta = {
-      description = "Reference implementation of PEP 3156";
-      homepage = http://www.python.org/dev/peps/pep-3156;
-      license = licenses.free;
-    };
-  } else null;
+  asyncio = callPackage ../development/python-modules/asyncio {};
 
   python-fontconfig = callPackage ../development/python-modules/python-fontconfig { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1542,24 +1542,7 @@ in {
 
   click_5 = callPackage ../development/python-modules/click/5_1.nix {};
 
-  click-log = buildPythonPackage rec {
-    version = "0.2.1";
-    name = "click-log-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/click-log/${name}.tar.gz";
-      sha256 = "1r1x85023cslb2pwldd089jjk573mk3w78cnashs77wrx7yz8fj9";
-    };
-
-    propagatedBuildInputs = with self; [ click ];
-
-    meta = {
-      homepage = https://github.com/click-contrib/click-log/;
-      description = "Logging integration for Click";
-      license = licenses.mit;
-      maintainers = with maintainers; [ ];
-    };
-  };
+  click-log = callPackage ../development/python-modules/click-log {};
 
   click-plugins = callPackage ../development/python-modules/click-plugins {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -921,26 +921,7 @@ in {
     };
   };
 
-  batinfo = buildPythonPackage rec {
-    version = "0.3";
-    name = "batinfo-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/batinfo/${name}.tar.gz";
-      sha256 = "0gyzkxzvj5l6qrw706bnm3cckqzzzbrjr7jkxc087d7775a73499";
-    };
-
-    # No tests included
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/nicolargo/batinfo;
-      description = "A simple Python lib to retrieve battery information";
-      license = licenses.lgpl3;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ koral ];
-    };
-  };
+  batinfo = callPackage ../development/python-modules/batinfo {};
 
   bcdoc = buildPythonPackage rec {
     name = "bcdoc-0.14.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -897,21 +897,7 @@ in {
 
   backports_unittest-mock = callPackage ../development/python-modules/backports_unittest-mock {};
 
-  babelfish = buildPythonPackage rec {
-    version = "0.5.5";
-    name = "babelfish-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/babelfish/${name}.tar.gz";
-      sha256 = "8380879fa51164ac54a3e393f83c4551a275f03617f54a99d70151358e444104";
-    };
-
-    meta = {
-      homepage = https://pypi.python.org/pypi/babelfish;
-      description = "A module to work with countries and languages";
-      license = licenses.bsd3;
-    };
-  };
+  babelfish = callPackage ../development/python-modules/babelfish {};
 
   basiciw = buildPythonPackage rec {
     name = "${pname}-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1536,32 +1536,7 @@ in {
 
   cld2-cffi = callPackage ../development/python-modules/cld2-cffi {};
 
-  clf = buildPythonPackage rec {
-    name = "clf-${version}";
-    version = "0.5.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/clf/${name}.tar.gz";
-      sha256 = "04lqd2i4fjs606b0q075yi9xksk567m0sfph6v6j80za0hvzqyy5";
-    };
-
-    patchPhase = ''
-      sed -i 's/==/>=/' requirements.txt
-    '';
-
-    propagatedBuildInputs = with self; [ docopt requests pygments ];
-
-    # Error when running tests:
-    # No local packages or download links found for requests
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/ncrocfer/clf;
-      description = "Command line tool to search snippets on Commandlinefu.com";
-      license = licenses.mit;
-      maintainers = with maintainers; [ koral ];
-    };
-  };
+  clf = callPackage ../development/python-modules/clf {};
 
   click = buildPythonPackage rec {
     name = "click-6.7";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1289,22 +1289,7 @@ in {
     };
   };
 
-  blinker = buildPythonPackage rec {
-    name = "blinker-${version}";
-    version = "1.4";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/blinker/${name}.tar.gz";
-      sha256 = "1dpq0vb01p36jjwbhhd08ylvrnyvcc82yxx3mwjx6awrycjyw6j7";
-    };
-
-    meta = {
-      homepage = http://pythonhosted.org/blinker/;
-      description = "Fast, simple object-to-object and broadcast signaling";
-      license = licenses.mit;
-      maintainers = with maintainers; [ garbas ];
-    };
-  };
+  blinker = callPackage ../development/python-modules/blinker { };
 
   blockdiag = callPackage ../development/python-modules/blockdiag { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -353,7 +353,7 @@ in {
 
   pyjwkest = callPackage ../development/python-modules/pyjwkest { };
 
-  pykde4 = callPackage ../development/python-modules/pykde4/default.nix {
+  pykde4 = callPackage ../development/python-modules/pykde4 {
     inherit (self) pyqt4;
     callPackage = pkgs.callPackage;
   };
@@ -1473,7 +1473,7 @@ in {
     };
   };
 
-  cccolutils = callPackage ../development/python-modules/cccolutils/default.nix {};
+  cccolutils = callPackage ../development/python-modules/cccolutils {};
 
   CDDB = buildPythonPackage rec {
     name = "CDDB-1.4";
@@ -1726,8 +1726,7 @@ in {
     pythonPackages = self;
   });
 
-  openidc-client = callPackage ../development/python-modules/openidc-client/default.nix {};
-
+  openidc-client = callPackage ../development/python-modules/openidc-client {};
 
   idna = callPackage ../development/python-modules/idna { };
 
@@ -2007,7 +2006,7 @@ in {
 
   pytest = self.pytest_34;
 
-  pytest_34 = callPackage ../development/python-modules/pytest/default.nix{
+  pytest_34 = callPackage ../development/python-modules/pytest {
     hypothesis = self.hypothesis.override {
       # hypothesis requires pytest that causes dependency cycle
       doCheck = false;
@@ -3901,9 +3900,9 @@ in {
     };
   };
 
-  idna-ssl = callPackage ../development/python-modules/idna-ssl/default.nix { };
+  idna-ssl = callPackage ../development/python-modules/idna-ssl { };
 
-  ijson = callPackage ../development/python-modules/ijson/default.nix {};
+  ijson = callPackage ../development/python-modules/ijson {};
 
   imagesize = buildPythonPackage rec {
     name = "imagesize-${version}";
@@ -7881,7 +7880,7 @@ in {
   keyutils = callPackage ../development/python-modules/keyutils { };
 
   klein = callPackage ../development/python-modules/klein { };
- 
+
   koji = callPackage ../development/python-modules/koji { };
 
   kombu = buildPythonPackage rec {
@@ -7914,13 +7913,13 @@ in {
 
   konfig = callPackage ../development/python-modules/konfig { };
 
-  kitchen = callPackage ../development/python-modules/kitchen/default.nix { };
+  kitchen = callPackage ../development/python-modules/kitchen { };
 
-  kubernetes = callPackage ../development/python-modules/kubernetes/default.nix { };
+  kubernetes = callPackage ../development/python-modules/kubernetes { };
 
-  pylast = callPackage ../development/python-modules/pylast/default.nix { };
+  pylast = callPackage ../development/python-modules/pylast { };
 
-  pylru = callPackage ../development/python-modules/pylru/default.nix { };
+  pylru = callPackage ../development/python-modules/pylru { };
 
   lark-parser = callPackage ../development/python-modules/lark-parser { };
 
@@ -8178,7 +8177,7 @@ in {
     };
   });
 
-  py_scrypt = callPackage ../development/python-modules/py_scrypt/default.nix { };
+  py_scrypt = callPackage ../development/python-modules/py_scrypt { };
 
   python_magic = callPackage ../development/python-modules/python-magic { };
 
@@ -8391,13 +8390,13 @@ in {
   };
 
 
-  matplotlib = callPackage ../development/python-modules/matplotlib/default.nix {
+  matplotlib = callPackage ../development/python-modules/matplotlib {
     stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
     enableGhostscript = true;
     inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
   };
 
-  matrix-client = callPackage ../development/python-modules/matrix-client/default.nix { };
+  matrix-client = callPackage ../development/python-modules/matrix-client { };
 
   maya = callPackage ../development/python-modules/maya { };
 
@@ -8425,7 +8424,7 @@ in {
     };
   });
 
-  MechanicalSoup = callPackage ../development/python-modules/MechanicalSoup/default.nix { };
+  MechanicalSoup = callPackage ../development/python-modules/MechanicalSoup { };
 
   meld3 = buildPythonPackage rec {
     name = "meld3-1.0.0";
@@ -12366,7 +12365,7 @@ in {
     };
   };
 
-  python_fedora = callPackage ../development/python-modules/python_fedora/default.nix {};
+  python_fedora = callPackage ../development/python-modules/python_fedora {};
 
   python-simple-hipchat = callPackage ../development/python-modules/python-simple-hipchat {};
   python_simple_hipchat = self.python-simple-hipchat;
@@ -13469,9 +13468,9 @@ in {
     };
   };
 
-  rpkg = callPackage ../development/python-modules/rpkg/default.nix {};
+  rpkg = callPackage ../development/python-modules/rpkg {};
 
-  rply = callPackage ../development/python-modules/rply/default.nix {};
+  rply = callPackage ../development/python-modules/rply {};
 
   rpm = toPythonModule (pkgs.rpm.override{inherit python;});
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1914,29 +1914,7 @@ in {
 
   pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
 
-  pytestcache = buildPythonPackage rec {
-    name = "pytest-cache-1.0";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-cache/pytest-cache-1.0.tar.gz";
-      sha256 = "1a873fihw4rhshc722j4h6j7g3nj7xpgsna9hhg3zn6ksknnhx5y";
-    };
-
-    buildInputs = with self; [ pytest];
-    propagatedBuildInputs = with self ; [ execnet ];
-
-    checkPhase = ''
-      py.test
-    '';
-
-    # Too many failing tests. Are they maintained?
-    doCheck = false;
-
-    meta = {
-      license = licenses.mit;
-      homepage = "https://pypi.python.org/pypi/pytest-cache/";
-      description = "pytest plugin with mechanisms for caching across test runs";
-    };
-  };
+  pytestcache = callPackage ../development/python-modules/pytestcache { };
 
   pytest-catchlog = buildPythonPackage rec {
     name = "pytest-catchlog-1.2.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1840,25 +1840,7 @@ in {
 
   pycollada = callPackage ../development/python-modules/pycollada { };
 
-  pycontracts = buildPythonPackage rec {
-    version = "1.7.9";
-    name = "PyContracts-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/P/PyContracts/${name}.tar.gz";
-      sha256 = "0rdc9pz08885vqkazjc3lyrrghmf3jzxnlsgpn8akl808x1qrfqf";
-    };
-
-    buildInputs = with self; [ nose ];
-
-    propagatedBuildInputs = with self; [ pyparsing decorator six ];
-
-    meta = {
-      description = "Allows to declare constraints on function parameters and return values";
-      homepage = https://pypi.python.org/pypi/PyContracts;
-      license = licenses.lgpl2;
-    };
-  };
+  pycontracts = callPackage ../development/python-modules/pycontracts { };
 
   pycparser = buildPythonPackage rec {
     name = "pycparser-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1580,26 +1580,7 @@ in {
 
   codecov = callPackage ../development/python-modules/codecov {};
 
-  cogapp = buildPythonPackage rec {
-    version = "2.3";
-    name    = "cogapp-${version}";
-
-    src = pkgs.fetchurl {
-      url    = "mirror://pypi/c/cogapp/${name}.tar.gz";
-      sha256 = "0gzmzbsk54r1qa6wd0yg4zzdxvn2f19ciprr2acldxaknzrpllnn";
-    };
-
-    # there are no tests
-    doCheck = false;
-
-    meta = {
-      description = "A code generator for executing Python snippets in source files";
-      homepage    = http://nedbatchelder.com/code/cog;
-      license     = licenses.mit;
-      maintainers = with maintainers; [ lovek323 ];
-      platforms   = platforms.unix;
-    };
-  };
+  cogapp = callPackage ../development/python-modules/cogapp {};
 
   colorama = callPackage ../development/python-modules/colorama { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1414,33 +1414,7 @@ in {
   #   };
   # });
 
-  bugzilla = buildPythonPackage rec {
-    name = "bugzilla-${version}";
-    version = "1.1.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-bugzilla/python-${name}.tar.gz";
-      sha256 = "11361635a4f1613803a0b9b93ba9126f7fd36180653f953e2590b1536d107d46";
-    };
-
-    patches = [ ../development/python-modules/bugzilla/checkPhase-fix-cookie-compare.patch ];
-
-    buildInputs = with self; [ pep8 coverage logilab_common ];
-    propagatedBuildInputs = [ self.requests ];
-
-    preCheck = ''
-      mkdir -p check-phase
-      export HOME=$(pwd)/check-phase
-    '';
-
-    meta = {
-      homepage = https://fedorahosted.org/python-bugzilla/;
-      description = "Bugzilla XMLRPC access module";
-      license = licenses.gpl2;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ pierron ];
-    };
-  };
+  bugzilla = callPackage ../development/python-modules/bugzilla { };
 
   check-manifest = buildPythonPackage rec {
     name = "check-manifest";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1119,25 +1119,7 @@ in {
 
   circus = callPackage ../development/python-modules/circus {};
 
-  colorclass = buildPythonPackage rec {
-    pname = "colorclass";
-    version = "2.2.0";
-    name = "${pname}-${version}";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "b05c2a348dfc1aff2d502527d78a5b7b7e2f85da94a96c5081210d8e9ee8e18b";
-    };
-
-    # No tests in archive
-    doCheck = false;
-
-    meta = {
-      homepage = "https://github.com/Robpol86/colorclass";
-      license = licenses.mit;
-      description = "Automatic support for console colors";
-    };
-  };
+  colorclass = callPackage ../development/python-modules/colorclass {};
 
   colorlog = callPackage ../development/python-modules/colorlog { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -959,25 +959,7 @@ in {
     };
   };
 
-  betamax = buildPythonPackage rec {
-    name = "betamax-0.8.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/betamax/${name}.tar.gz";
-      sha256 = "1hki1c2vs7adq7zr56wi6i5bhrkia4s2ywpv2c98ibnczz709w2v";
-    };
-
-    propagatedBuildInputs = [ self.requests ];
-
-    doCheck = false;
-
-    meta = with stdenv.lib; {
-      homepage = https://betamax.readthedocs.org/en/latest/;
-      description = "A VCR imitation for requests";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ pSub ];
-    };
-  };
+  betamax = callPackage ../development/python-modules/betamax {};
 
   betamax-matchers = callPackage ../development/python-modules/betamax-matchers { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1596,30 +1596,7 @@ in {
     };
   });
 
-
-  coilmq = buildPythonPackage (rec {
-    name = "CoilMQ-${version}";
-    version = "1.0.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/C/CoilMQ/${name}.tar.gz";
-      sha256 = "0wwa6fsqw1mxsryvgp0yrdjil8axyj0kslzi7lr45cnhgp5ab375";
-    };
-
-    propagatedBuildInputs = with self; [ stompclient pythondaemon redis pid];
-
-    buildInputs = with self; [ pytest six click coverage sqlalchemy ];
-
-    # The teste data is not included in the distribution
-    doCheck = false;
-
-    meta = {
-      description = "Simple, lightweight, and easily extensible STOMP message broker";
-      homepage = http://code.google.com/p/coilmq/;
-      license = licenses.asl20;
-    };
-  });
-
+  coilmq = callPackage ../development/python-modules/coilmq { };
 
   colander = callPackage ../development/python-modules/colander { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -625,22 +625,7 @@ in {
 
   awesome-slugify = callPackage ../development/python-modules/awesome-slugify {};
 
-  noise = buildPythonPackage rec {
-    name = "noise-${version}";
-    version = "1.2.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/n/noise/${name}.tar.gz";
-      sha256 = "0rcv40dcshqpchwkdlhsv3n68h9swm9fh4d1cgzr2hsp6rs7k8jp";
-    };
-
-    meta = with stdenv.lib; {
-      homepage = "https://github.com/caseman/noise";
-      description = "Native-code and shader implementations of Perlin noise";
-      license = licenses.mit;
-      platforms = platforms.all;
-    };
-  };
+  noise = callPackage ../development/python-modules/noise {};
 
   azure = buildPythonPackage rec {
     version = "0.11.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1416,24 +1416,7 @@ in {
 
   bugzilla = callPackage ../development/python-modules/bugzilla { };
 
-  check-manifest = buildPythonPackage rec {
-    name = "check-manifest";
-    version = "0.30";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/check-manifest/check-manifest-${version}.tar.gz";
-      sha256 = "b19fd0d8b9286532ba3dc0282484fd76d11200cf24b340dc3d08f293c7dd0500";
-    };
-
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/mgedmin/check-manifest;
-      description = "Check MANIFEST.in in a Python source package for completeness";
-      license = licenses.mit;
-      maintainers = with maintainers; [ lewo ];
-    };
-  };
+  check-manifest = callPackage ../development/python-modules/check-manifest { };
 
   devpi-common = callPackage ../development/python-modules/devpi-common { };
   # A patched version of buildout, useful for buildout based development on Nix

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1647,22 +1647,7 @@ in {
 
   cookiecutter = callPackage ../development/python-modules/cookiecutter { };
 
-  cookies = buildPythonPackage rec {
-    name = "cookies-2.2.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/cookies/${name}.tar.gz";
-      sha256 = "13pfndz8vbk4p2a44cfbjsypjarkrall71pgc97glk5fiiw9idnn";
-    };
-
-    doCheck = false;
-
-    meta = {
-      description = "Friendlier RFC 6265-compliant cookie parser/renderer";
-      homepage = https://github.com/sashahart/cookies;
-      license = licenses.mit;
-    };
-  };
+  cookies = callPackage ../development/python-modules/cookies { };
 
   coveralls = callPackage ../development/python-modules/coveralls { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1424,21 +1424,7 @@ in {
 
   zc_buildout = self.zc_buildout221;
 
-  zc_buildout221 = buildPythonPackage rec {
-    name = "zc.buildout-2.2.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/z/zc.buildout/${name}.tar.gz";
-      sha256 = "a6122ea5c06c6c044a9efce4a3df452c8573e1aebfda7b24262655daac894ef5";
-    };
-
-   meta = {
-      homepage = "http://www.buildout.org";
-      description = "A software build and configuration system";
-      license = licenses.zpl21;
-      maintainers = with maintainers; [ garbas ];
-    };
-  };
+  zc_buildout221 = callPackage ../development/python-modules/buildout { };
 
   bunch = buildPythonPackage (rec {
     name = "bunch-1.0.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1108,9 +1108,6 @@ in {
   cement = callPackage ../development/python-modules/cement {};
 
   cgroup-utils = callPackage ../development/python-modules/cgroup-utils {};
-    postPatch = ''
-      substituteInPlace setup.py --replace "argparse" ""
-    '';
 
   chainer = callPackage ../development/python-modules/chainer {
     cudaSupport = pkgs.config.cudaSupport or false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1653,17 +1653,7 @@ in {
 
   coverage = callPackage ../development/python-modules/coverage { };
 
-  covCore = buildPythonPackage rec {
-    name = "cov-core-1.15.0";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/cov-core/${name}.tar.gz";
-      sha256 = "4a14c67d520fda9d42b0da6134638578caae1d374b9bb462d8de00587dba764c";
-    };
-    meta = {
-      description = "Plugin core for use by pytest-cov, nose-cov and nose2-cov";
-    };
-    propagatedBuildInputs = with self; [ self.coverage ];
-  };
+  covCore = callPackage ../development/python-modules/cov-core { };
 
   crcmod = buildPythonPackage rec {
     name = "crcmod-1.7";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1601,34 +1601,7 @@ in {
   colander = callPackage ../development/python-modules/colander { };
 
   # Backported version of the ConfigParser library of Python 3.3
-  configparser = if isPy3k then null else buildPythonPackage rec {
-    name = "configparser-${version}";
-    version = "3.5.0";
-
-    # running install_egg_info
-    # error: [Errno 9] Bad file descriptor: '<stdout>'
-    disabled = isPyPy;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/configparser/${name}.tar.gz";
-      sha256 = "5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a";
-    };
-
-    # No tests available
-    doCheck = false;
-
-    # Fix issue when used together with other namespace packages
-    # https://github.com/NixOS/nixpkgs/issues/23855
-    patches = [
-      ./../development/python-modules/configparser/0001-namespace-fix.patch
-    ];
-
-    meta = {
-      maintainers = [ ];
-      platforms = platforms.all;
-    };
-  };
-
+  configparser = callPackage ../development/python-modules/configparser { };
 
   ColanderAlchemy = buildPythonPackage rec {
     name = "ColanderAlchemy-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -564,22 +564,7 @@ in {
 
   astroid = callPackage ../development/python-modules/astroid { };
 
-  attrdict = buildPythonPackage (rec {
-    name = "attrdict-2.0.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/attrdict/${name}.tar.gz";
-      sha256 = "86aeb6d3809e0344409f8148d7cac9eabce5f0b577c160b5e90d10df3f8d2ad3";
-    };
-
-    propagatedBuildInputs = with self; [ coverage nose six ];
-
-    meta = {
-      description = "A dict with attribute-style access";
-      homepage = https://github.com/bcj/AttrDict;
-      license = licenses.mit;
-    };
-  });
+  attrdict = callPackage ../development/python-modules/attrdict { };
 
   attrs = callPackage ../development/python-modules/attrs { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1224,19 +1224,7 @@ in {
 
   dugong = callPackage ../development/python-modules/dugong {};
 
-  iowait = buildPythonPackage rec {
-    name = "iowait-0.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/i/iowait/${name}.tar.gz";
-      sha256 = "ab1bc2eb84c22ccf61f17a0024f9fb6df781b39f1852764a66a7769d5adfb299";
-    };
-
-    meta = {
-      description = "Platform-independent module for I/O completion events";
-      homepage = https://launchpad.net/python-iowait;
-    };
-  };
+  iowait = callPackage ../development/python-modules/iowait {};
 
   responses = self.buildPythonPackage rec {
     name = "responses-0.4.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1240,26 +1240,7 @@ in {
 
   binaryornot = callPackage ../development/python-modules/binaryornot { };
 
-  bitbucket_api = buildPythonPackage rec {
-    name = "bitbucket-api-0.4.4";
-    # python3 does not support relative imports
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/bitbucket-api/${name}.tar.gz";
-      sha256 = "e890bc3893d59a6f203c1eb2bae60e78ac4d3869da7ea4fb104dca588aea85b2";
-    };
-
-    propagatedBuildInputs = with self; [ requests_oauthlib nose sh ];
-
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/Sheeprider/BitBucket-api;
-      description = "Python library to interact with BitBucket REST API";
-      license = licenses.mit;
-    };
-  };
+  bitbucket_api = callPackage ../development/python-modules/bitbucket-api { };
 
   # Should be moved out of python-packages.nix
   bitbucket-cli = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1226,19 +1226,7 @@ in {
 
   iowait = callPackage ../development/python-modules/iowait {};
 
-  responses = self.buildPythonPackage rec {
-    name = "responses-0.4.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/r/responses/${name}.tar.gz";
-      sha256 = "0fs7a4cf4f12mjhcjd5vfh0f3ixcy2nawzxpgsfr3ahf0rg7ppx5";
-    };
-
-    propagatedBuildInputs = with self; [ cookies mock requests six ];
-
-    doCheck = false;
-
-  };
+  responses = callPackage ../development/python-modules/responses {};
 
   rarfile = callPackage ../development/python-modules/rarfile { inherit (pkgs) libarchive; };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1222,17 +1222,7 @@ in {
     };
   };
 
-  dugong = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "dugong";
-    version = "3.5";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/${pname}/${name}.tar.bz2";
-      sha256 = "0y0rdxbiwm03zv6vpvapqilrird3h8ijz7xmb0j7ds5j4p6q3g24";
-    };
-
-    disabled = pythonOlder "3.3"; # Library does not support versions older than 3.3
-  };
+  dugong = callPackage ../development/python-modules/dugong {};
 
   iowait = buildPythonPackage rec {
     name = "iowait-0.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1436,24 +1436,7 @@ in {
 
   cairocffi = callPackage ../development/python-modules/cairocffi {};
 
-  cairosvg = buildPythonPackage rec {
-    version = "1.0.18";
-    name = "cairosvg-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/C/CairoSVG/CairoSVG-${version}.tar.gz";
-      sha256 = "01lpm38qp7xlnv8jv7qg48j44p5088dwfsrcllgs5fz355lrfds1";
-    };
-
-    propagatedBuildInputs = with self; [ cairocffi ];
-
-    meta = {
-      homepage = https://cairosvg.org;
-      license = licenses.lgpl3;
-      description = "SVG converter based on Cairo";
-    };
-  };
-
+  cairosvg = callPackage ../development/python-modules/cairosvg {};
 
   carrot = buildPythonPackage rec {
     name = "carrot-0.10.7";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1940,29 +1940,7 @@ in {
 
   pytest-warnings = callPackage ../development/python-modules/pytest-warnings { };
 
-  pytestpep8 = buildPythonPackage rec {
-    name = "pytest-pep8";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-pep8/pytest-pep8-1.0.6.tar.gz";
-      sha256 = "06032agzhw1i9d9qlhfblnl3dw5hcyxhagn7b120zhrszbjzfbh3";
-    };
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ pytestcache pep8 ];
-
-    checkPhase = ''
-      py.test
-    '';
-
-    # Fails
-    doCheck = false;
-
-    meta = {
-      license = licenses.mit;
-      homepage = "https://pypi.python.org/pypi/pytest-pep8";
-      description = "pytest plugin to check PEP8 requirements";
-    };
-  };
+  pytestpep8 = callPackage ../development/python-modules/pytest-pep8 { };
 
   pytest-pep257 = callPackage ../development/python-modules/pytest-pep257 { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1832,21 +1832,7 @@ in {
 
   detox = callPackage ../development/python-modules/detox { };
 
-  pbkdf2 = buildPythonPackage rec {
-    name = "pbkdf2-1.3";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pbkdf2/${name}.tar.gz";
-      sha256 = "ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979";
-    };
-
-    # ImportError: No module named test
-    doCheck = false;
-
-    meta = {
-      maintainers = with maintainers; [ domenkozar ];
-    };
-  };
+  pbkdf2 = callPackage ../development/python-modules/pbkdf2 { };
 
   bcrypt = callPackage ../development/python-modules/bcrypt { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1826,32 +1826,7 @@ in {
 
   portpicker = callPackage ../development/python-modules/portpicker { };
 
-  pkginfo = buildPythonPackage rec {
-    version = "1.3.2";
-    name = "pkginfo-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pkginfo/${name}.tar.gz";
-      sha256 = "0qg4sq3m0pxvjahc3sncwhw42z5rfw22k0ybskmdqkl2agykay7q";
-    };
-
-    doCheck = false; # I don't know why, but with doCheck = true it fails.
-
-    meta = {
-      homepage = https://pypi.python.org/pypi/pkginfo;
-      license = licenses.mit;
-      description = "Query metadatdata from sdists / bdists / installed packages";
-
-      longDescription = ''
-        This package provides an API for querying the distutils metadata
-        written in the PKG-INFO file inside a source distriubtion (an sdist)
-        or a binary distribution (e.g., created by running bdist_egg). It can
-        also query the EGG-INFO directory of an installed distribution, and the
-        *.egg-info stored in a “development checkout” (e.g, created by running
-        setup.py develop).
-      '';
-    };
-  };
+  pkginfo = callPackage ../development/python-modules/pkginfo { };
 
   pretend = buildPythonPackage rec {
     name = "pretend-1.0.8";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1195,16 +1195,7 @@ in {
 
   datadog = callPackage ../development/python-modules/datadog {};
 
-  debian = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "python-debian";
-    version = "0.1.23";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
-      sha256 = "193faznwnjc3n5991wyzim6h9gyq1zxifmfrnpm3avgkh7ahyynh";
-    };
-    propagatedBuildInputs = with self; [ chardet six ];
-  };
+  debian = callPackage ../development/python-modules/debian {};
 
   defusedxml = buildPythonPackage rec {
     name = "${pname}-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1663,24 +1663,7 @@ in {
 
   cytoolz = callPackage ../development/python-modules/cytoolz { };
 
-  cryptacular = buildPythonPackage rec {
-    name = "cryptacular-1.4.1";
-
-    buildInputs = with self; [ coverage nose ];
-    propagatedBuildInputs = with self; [ pbkdf2 ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/cryptacular/${name}.tar.gz";
-      sha256 = "273f03d03f9b316671ae4f1c1c6b8d3c883da19a5706873e8f3d6543e13dd4a1";
-    };
-
-    # TODO: tests fail: TypeError: object of type 'NoneType' has no len()
-    doCheck = false;
-
-    meta = {
-      maintainers = with maintainers; [ domenkozar ];
-    };
-  };
+  cryptacular = callPackage ../development/python-modules/cryptacular { };
 
   cryptography = callPackage ../development/python-modules/cryptography { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1440,24 +1440,7 @@ in {
 
   carrot = callPackage ../development/python-modules/carrot {};
 
-  case = buildPythonPackage rec {
-    name = "case-${version}";
-    version = "1.5.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/case/${name}.tar.gz";
-      sha256 = "1zbhbw87izcxj9rvqg432a7r69ps2ks20mqq3g3hgd42sckcy3ca";
-    };
-
-    propagatedBuildInputs = with self; [ six nose unittest2 mock ];
-
-    meta = {
-      homepage = https://github.com/celery/case;
-      description = "unittests utilities";
-      license = licenses.bsd3;
-    };
-
-  };
+  case = callPackage ../development/python-modules/case {};
 
   cassandra-driver = buildPythonPackage rec {
     name = "cassandra-driver-3.6.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1426,16 +1426,7 @@ in {
 
   zc_buildout221 = callPackage ../development/python-modules/buildout { };
 
-  bunch = buildPythonPackage (rec {
-    name = "bunch-1.0.1";
-    meta.maintainers = with maintainers; [ ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/bunch/${name}.tar.gz";
-      sha256 = "1akalx2pd1fjlvrq69plvcx783ppslvikqdm93z2sdybq07pmish";
-    };
-    doCheck = false;
-  });
+  bunch = callPackage ../development/python-modules/bunch { };
 
   can = callPackage ../development/python-modules/can {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1067,33 +1067,7 @@ in {
     enablePython = true;
   });
 
-  buttersink = buildPythonPackage rec {
-    name = "buttersink-0.6.8";
-
-    src = pkgs.fetchurl {
-      sha256 = "04gc63kfcqkw4qba5rijqk01xiphf04yk7hky9180ii64v2ip0j3";
-      url = "mirror://pypi/b/buttersink/${name}.tar.gz";
-    };
-
-    # Python 2 syntax
-    disabled = isPy3k;
-
-    meta = {
-      description = "Synchronise btrfs snapshots";
-      longDescription = ''
-        ButterSink is like rsync, but for btrfs subvolumes instead of files,
-        which makes it much more efficient for things like archiving backup
-        snapshots. It is built on top of btrfs send and receive capabilities.
-        Sources and destinations can be local btrfs file systems, remote btrfs
-        file systems over SSH, or S3 buckets.
-      '';
-      homepage = https://github.com/AmesCornish/buttersink/wiki;
-      license = licenses.gpl3;
-      platforms = platforms.linux;
-    };
-
-    propagatedBuildInputs = with self; [ boto crcmod psutil ];
-  };
+  buttersink = callPackage ../development/python-modules/buttersink {};
 
   cached-property = callPackage ../development/python-modules/cached-property { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -619,23 +619,7 @@ in {
 
   avro = callPackage ../development/python-modules/avro {};
 
-  avro3k = pkgs.lowPrio (buildPythonPackage (rec {
-    name = "avro3k-1.7.7-SNAPSHOT";
-
-    disabled = (!isPy3k);
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/avro3k/${name}.tar.gz";
-      sha256 = "15ahl0irwwj558s964abdxg4vp6iwlabri7klsm2am6q5r0ngsky";
-    };
-
-    doCheck = false;        # No such file or directory: './run_tests.py
-
-    meta = {
-      description = "A serialization and RPC framework";
-      homepage = "https://pypi.python.org/pypi/avro3k/";
-    };
-  }));
+  avro3k = callPackage ../development/python-modules/avro3k {};
 
   python-slugify = callPackage ../development/python-modules/python-slugify { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1438,28 +1438,7 @@ in {
 
   cairosvg = callPackage ../development/python-modules/cairosvg {};
 
-  carrot = buildPythonPackage rec {
-    name = "carrot-0.10.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/carrot/${name}.tar.gz";
-      sha256 = "cb46374f3c883c580d142a79d2609883713a867cc86e0514163adce784ce2468";
-    };
-
-    buildInputs = with self; [ self.nose ];
-
-    propagatedBuildInputs =
-      [ self.amqplib
-        self.anyjson
-      ];
-
-    doCheck = false; # depends on the network
-
-    meta = {
-      homepage = https://pypi.python.org/pypi/carrot;
-      description = "AMQP Messaging Framework for Python";
-    };
-  };
+  carrot = callPackage ../development/python-modules/carrot {};
 
   case = buildPythonPackage rec {
     name = "case-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1540,25 +1540,7 @@ in {
 
   click = callPackage ../development/python-modules/click {};
 
-  click_5 = buildPythonPackage rec {
-    name = "click-5.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/click/${name}.tar.gz";
-      sha256 = "0njsm0wn31l21bi118g5825ma5sa3rwn7v2x4wjd7yiiahkri337";
-    };
-
-    meta = {
-      homepage = http://click.pocoo.org/;
-      description = "Create beautiful command line interfaces in Python";
-      longDescription = ''
-        A Python package for creating beautiful command line interfaces in a
-        composable way, with as little code as necessary.
-      '';
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ mog ];
-    };
-  };
+  click_5 = callPackage ../development/python-modules/click/5_1.nix {};
 
   click-log = buildPythonPackage rec {
     version = "0.2.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1532,23 +1532,7 @@ in {
 
   cherrypy = callPackage ../development/python-modules/cherrypy {};
 
-  cjson = buildPythonPackage rec {
-    name = "python-cjson-${version}";
-    version = "1.1.0";
-    disabled = isPy3k || isPyPy;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-cjson/${name}.tar.gz";
-      sha256 = "a01fabb7593728c3d851e1cd9a3efbd18f72650a31a5aa8a74018640da3de8b3";
-    };
-
-    meta = {
-      description = "A very fast JSON encoder/decoder for Python";
-      homepage    = "http://ag-projects.com/";
-      license     = licenses.lgpl2;
-      platforms   = platforms.all;
-    };
-  };
+  cjson = callPackage ../development/python-modules/cjson { };
 
   cld2-cffi = callPackage ../development/python-modules/cld2-cffi {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -923,25 +923,7 @@ in {
 
   batinfo = callPackage ../development/python-modules/batinfo {};
 
-  bcdoc = buildPythonPackage rec {
-    name = "bcdoc-0.14.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/bcdoc/${name}.tar.gz";
-      sha256 = "1s2kdqs1n2mj7wq3w0pq30zs7vxq0l3abik2clqnc4hm2j7crbk8";
-    };
-
-    buildInputs = with self; [ docutils six ];
-
-    # Tests fail due to nix file timestamp normalization.
-    doCheck = false;
-
-    meta = {
-      homepage = https://github.com/botocore/bcdoc;
-      license = licenses.asl20;
-      description = "ReST document generation tools for botocore";
-    };
-  };
+  bcdoc = callPackage ../development/python-modules/bcdoc {};
 
   beautifulsoup4 = callPackage ../development/python-modules/beautifulsoup4 { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1394,32 +1394,7 @@ in {
 
   branca = callPackage ../development/python-modules/branca { };
 
-  bugwarrior = buildPythonPackage rec {
-    name = "bugwarrior-${version}";
-    version = "1.5.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/bugwarrior/${name}.tar.gz";
-      sha256 = "0kxknjbw5kchd88i577vlzibg8j60r7zzdhbnragj9wg5s3w60xb";
-    };
-
-    buildInputs = with self; [ mock unittest2 nose /* jira megaplan */ ];
-    propagatedBuildInputs = with self; [
-      twiggy requests offtrac bugzilla taskw dateutil pytz keyring six
-      jinja2 pycurl dogpile_cache lockfile click pyxdg future15
-    ];
-
-    # for the moment jira>=0.22 and megaplan>=1.4 are missing for running the test suite.
-    doCheck = false;
-
-    meta = {
-      homepage =  https://github.com/ralphbean/bugwarrior;
-      description = "Sync github, bitbucket, bugzilla, and trac issues with taskwarrior";
-      license = licenses.gpl3Plus;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ pierron ];
-    };
-  };
+  bugwarrior = callPackage ../development/python-modules/bugwarrior { };
 
   # bugz = buildPythonPackage (rec {
   #   name = "bugz-0.9.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1197,15 +1197,7 @@ in {
 
   debian = callPackage ../development/python-modules/debian {};
 
-  defusedxml = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "defusedxml";
-    version = "0.5.0";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/${pname}/${name}.tar.gz";
-      sha256 = "1x54n0h8hl92vvwyymx883fbqpqjwn2mc8fb383bcg3z9zwz5mr4";
-    };
-  };
+  defusedxml = callPackage ../development/python-modules/defusedxml {};
 
   dosage = buildPythonPackage rec {
     name = "${pname}-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1576,25 +1576,7 @@ in {
 
   cloudpickle = callPackage ../development/python-modules/cloudpickle { };
 
-  cmdline = buildPythonPackage rec {
-    pname = "cmdline";
-    version = "0.1.6";
-    name = "${pname}-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/${pname}/${name}.tar.gz";
-      sha256 = "be2cb4711e9111bb7386a408e3c66a730c36dd6ac05851a9f03d0f4eae63536a";
-    };
-
-    # No tests, https://github.com/rca/cmdline/issues/1
-    doCheck = false;
-    propagatedBuildInputs = with self; [ pyyaml ];
-    meta = {
-      description = "Utilities for consistent command line tools";
-      homepage = https://github.com/rca/cmdline;
-      license = licenses.asl20;
-    };
-  };
+  cmdline = callPackage ../development/python-modules/cmdline { };
 
   codecov = callPackage ../development/python-modules/codecov {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -555,25 +555,7 @@ in {
 
   asn1ate = callPackage ../development/python-modules/asn1ate { };
 
-  atomiclong = buildPythonPackage rec {
-    version = "0.1.1";
-    name = "atomiclong-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/atomiclong/atomiclong-${version}.tar.gz";
-      sha256 = "1gjbc9lvpkgg8vj7dspif1gz9aq4flkhxia16qj6yvb7rp27h4yb";
-    };
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ cffi ];
-
-    meta = {
-      description = "Long data type with atomic operations using CFFI";
-      homepage = https://github.com/dreid/atomiclong;
-      license = licenses.mit;
-      maintainers = with maintainers; [ robbinch ];
-    };
-
-  };
+  atomiclong = callPackage ../development/python-modules/atomiclong { };
 
   atomicwrites = buildPythonPackage rec {
     version = "0.1.9";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1364,25 +1364,7 @@ in {
 
   botocore = callPackage ../development/python-modules/botocore { };
 
-  bottle = buildPythonPackage rec {
-    version = "0.12.11";
-    name = "bottle-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/bottle/${name}.tar.gz";
-      sha256 = "0cd787lzggs933qfav6xicx5c78dz6npwgg3xc4rhah44nbqz5d1";
-    };
-
-    propagatedBuildInputs = with self; [ setuptools ];
-
-    meta = {
-      homepage = http://bottlepy.org;
-      description = "A fast and simple micro-framework for small web-applications";
-      license = licenses.mit;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ koral ];
-    };
-  };
+  bottle = callPackage ../development/python-modules/bottle { };
 
   box2d = buildPythonPackage rec {
     name = "box2d-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1234,19 +1234,7 @@ in {
 
   py4j = callPackage ../development/python-modules/py4j { };
 
-  pyechonest = self.buildPythonPackage rec {
-    name = "pyechonest-8.0.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pyechonest/pyechonest-8.0.2.tar.gz";
-      sha256 = "496265f4b7d33483ec153b9e1b8333fe959b115f7e781510089c8313b7d86560";
-    };
-
-    meta = {
-      description = "Tap into The Echo Nest's Musical Brain for the best music search, information, recommendations and remix tools on the web";
-      homepage = https://github.com/echonest/pyechonest;
-    };
-  };
+  pyechonest = callPackage ../development/python-modules/pyechonest { };
 
   billiard = buildPythonPackage rec {
     name = "billiard-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1236,25 +1236,7 @@ in {
 
   pyechonest = callPackage ../development/python-modules/pyechonest { };
 
-  billiard = buildPythonPackage rec {
-    name = "billiard-${version}";
-    version = "3.5.0.2";
-
-    disabled = isPyPy;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/b/billiard/${name}.tar.gz";
-      sha256 = "1anw68rkja1dbgvndxz5mq6f89hmxwaha0fjcdnsl5j1wj7imc1y";
-    };
-
-    buildInputs = with self; [ pytest case ];
-
-    meta = {
-      homepage = https://github.com/celery/billiard;
-      description = "Python multiprocessing fork with improvements and bugfixes";
-      license = licenses.bsd3;
-    };
-  };
+  billiard = callPackage ../development/python-modules/billiard { };
 
   binaryornot = callPackage ../development/python-modules/binaryornot { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1631,27 +1631,7 @@ in {
 
   conda = callPackage ../development/python-modules/conda { };
 
-  configobj = buildPythonPackage (rec {
-    name = "configobj-5.0.6";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/configobj/${name}.tar.gz";
-      sha256 = "a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902";
-    };
-
-    # error: invalid command 'test'
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ six ];
-
-    meta = {
-      description = "Config file reading, writing and validation";
-      homepage = https://pypi.python.org/pypi/configobj;
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ garbas ];
-    };
-  });
-
+  configobj = callPackage ../development/python-modules/configobj { };
 
   confluent-kafka = callPackage ../development/python-modules/confluent-kafka {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -557,22 +557,7 @@ in {
 
   atomiclong = callPackage ../development/python-modules/atomiclong { };
 
-  atomicwrites = buildPythonPackage rec {
-    version = "0.1.9";
-    name = "atomicwrites-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/atomicwrites/atomicwrites-${version}.tar.gz";
-      sha256 = "08s05h211r07vs66r4din3swrbzb344vli041fihpg34q3lcxpvw";
-    };
-
-    meta = {
-      description = "Atomic file writes on POSIX";
-      homepage = https://pypi.python.org/pypi/atomicwrites/0.1.0;
-      maintainers = with maintainers; [ matthiasbeyer ];
-    };
-
-  };
+  atomicwrites = callPackage ../development/python-modules/atomicwrites { };
 
   # argparse is part of stdlib in 2.7 and 3.2+
   argparse = null;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1574,31 +1574,7 @@ in {
     };
   };
 
-  cloudpickle = buildPythonPackage rec {
-    name = "cloudpickle-${version}";
-    version = "0.2.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/cloudpickle/${name}.tar.gz";
-      sha256 = "0x4fbycipkhfax7lydaxcnc14g42g274qba17j51shr5gbq6m8lx";
-    };
-
-    buildInputs = with self; [ pytest mock ];
-
-    # See README for tests invocation
-    checkPhase = ''
-      PYTHONPATH=$PYTHONPATH:'.:tests' py.test
-    '';
-
-    # TypeError: cannot serialize '_io.FileIO' object
-    doCheck = false;
-
-    meta = {
-      description = "Extended pickling support for Python objects";
-      homepage = https://github.com/cloudpipe/cloudpickle;
-      license = with licenses; [ bsd3 ];
-    };
-  };
+  cloudpickle = callPackage ../development/python-modules/cloudpickle { };
 
   cmdline = buildPythonPackage rec {
     pname = "cmdline";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1944,29 +1944,7 @@ in {
 
   pytest-pep257 = callPackage ../development/python-modules/pytest-pep257 { };
 
-  pytest-raisesregexp = buildPythonPackage rec {
-    name = "pytest-raisesregexp-${version}";
-    version = "2.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-raisesregexp/${name}.tar.gz";
-      sha256 = "0fde8aac1a54f9b56e5f9c61fda76727542ed24968c27c6e3688c6f1885f1e61";
-    };
-
-    buildInputs = with self; [ py pytest ];
-
-    # https://github.com/kissgyorgy/pytest-raisesregexp/pull/3
-    prePatch = ''
-      sed -i '3i\import io' setup.py
-      substituteInPlace setup.py --replace "long_description=open('README.rst').read()," "long_description=io.open('README.rst', encoding='utf-8').read(),"
-    '';
-
-    meta = {
-      description = "Simple pytest plugin to look for regex in Exceptions";
-      homepage = https://github.com/Walkman/pytest_raisesregexp;
-      license = with licenses; [ mit ];
-    };
-  };
+  pytest-raisesregexp = callPackage ../development/python-modules/pytest-raisesregexp { };
 
   pytestrunner = callPackage ../development/python-modules/pytestrunner { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1242,27 +1242,7 @@ in {
 
   bitbucket_api = callPackage ../development/python-modules/bitbucket-api { };
 
-  # Should be moved out of python-packages.nix
-  bitbucket-cli = buildPythonPackage rec {
-    name = "bitbucket-cli-0.5.1";
-    src = pkgs.fetchurl {
-       url = "mirror://pypi/b/bitbucket-cli/${name}.tar.gz";
-       sha256 = "d881e21ec7ebfa006cfca6d10a5b7229aa59990568f8c6b8e3364769fa38b6f6";
-    };
-
-    propagatedBuildInputs = [ self.requests ];
-
-    # No tests
-    doCheck = false;
-
-    disabled = isPy3k;
-
-    meta = {
-      description = "Bitbucket command line interface";
-      homepage = "https://bitbucket.org/zhemao/bitbucket-cli";
-      maintainers = with maintainers; [ refnil ];
-    };
-  };
+  bitbucket-cli = callPackage ../development/python-modules/bitbucket-cli { };
 
   bitstring = callPackage ../development/python-modules/bitstring { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -617,21 +617,7 @@ in {
     };
   };
 
-  avro = buildPythonPackage (rec {
-    name = "avro-1.7.6";
-
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/avro/${name}.tar.gz";
-      sha256 = "edf14143cabb2891f05a73d60a57a9fc5a9ebd305c2188abb3f5db777c707ad5";
-    };
-
-    meta = {
-      description = "A serialization and RPC framework";
-      homepage = "https://pypi.python.org/pypi/avro/";
-    };
-  });
+  avro = callPackage ../development/python-modules/avro {};
 
   avro3k = pkgs.lowPrio (buildPythonPackage (rec {
     name = "avro3k-1.7.7-SNAPSHOT";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1916,26 +1916,7 @@ in {
 
   pytestcache = callPackage ../development/python-modules/pytestcache { };
 
-  pytest-catchlog = buildPythonPackage rec {
-    name = "pytest-catchlog-1.2.2";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-catchlog/${name}.zip";
-      sha256 = "1w7wxh27sbqwm4jgwrjr9c2gy384aca5jzw9c0wzhl0pmk2mvqab";
-    };
-
-    buildInputs = with self; [ pytest ];
-
-    checkPhase = "make test";
-
-    # Requires pytest < 3.1
-    doCheck = false;
-
-    meta = {
-      license = licenses.mit;
-      homepage = https://pypi.python.org/pypi/pytest-catchlog/;
-      description = "py.test plugin to catch log messages. This is a fork of pytest-capturelog.";
-    };
-  };
+  pytest-catchlog = callPackage ../development/python-modules/pytest-catchlog { };
 
   pytest-cram = callPackage ../development/python-modules/pytest-cram { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1932,28 +1932,7 @@ in {
 
   pytest-flake8 = callPackage ../development/python-modules/pytest-flake8 { };
 
-  pytestflakes = buildPythonPackage rec {
-    name = "pytest-flakes-${version}";
-    version = "1.0.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-flakes/${name}.tar.gz";
-      sha256 = "9c2271654294020e134624020a2144cb93b7334809d70fb3f470cd31ec788a3a";
-    };
-
-    buildInputs = with self; [ pytestpep8 pytest ];
-    propagatedBuildInputs = with self; [ pyflakes pytestcache ];
-
-    checkPhase = ''
-      py.test test_flakes.py
-    '';
-
-    meta = {
-      license = licenses.mit;
-      homepage = "https://pypi.python.org/pypi/pytest-flakes";
-      description = "pytest plugin to check source code with pyflakes";
-    };
-  };
+  pytestflakes = callPackage ../development/python-modules/pytest-flakes { };
 
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1830,30 +1830,7 @@ in {
 
   pretend = callPackage ../development/python-modules/pretend { };
 
-  detox = self.buildPythonPackage rec {
-    name = "detox-0.10.0";
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ tox py eventlet ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/detox/${name}.tar.gz";
-      sha256 = "33b704c2a5657366850072fb2aa839df14dd2e692c0c1c2642c3ac30d5c0baec";
-    };
-
-    checkPhase = ''
-      py.test
-    '';
-
-    # eventlet timeout, and broken invokation 3.5
-    doCheck = false;
-
-    meta = {
-      description = "What is detox?";
-      homepage = https://bitbucket.org/hpk42/detox;
-    };
-  };
-
+  detox = callPackage ../development/python-modules/detox { };
 
   pbkdf2 = buildPythonPackage rec {
     name = "pbkdf2-1.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1522,21 +1522,7 @@ in {
 
   celery = callPackage ../development/python-modules/celery { pytest = self.pytest_32; };
 
-  cerberus = buildPythonPackage rec {
-    name = "Cerberus-${version}";
-    version = "0.9.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/C/Cerberus/${name}.tar.gz";
-      sha256 = "1km7hvns1snrmcwz58bssi4wv3gwd34zm1z1hwjylmpqrfrcf8mi";
-    };
-
-    meta = {
-      homepage = http://python-cerberus.org/;
-      description = "Lightweight, extensible schema and data validation tool for Python dictionaries";
-      license = licenses.mit;
-    };
-  };
+  cerberus = callPackage ../development/python-modules/cerberus { };
 
   certifi = callPackage ../development/python-modules/certifi { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -484,26 +484,7 @@ in {
 
   anyjson = callPackage ../development/python-modules/anyjson {};
 
-  amqp = buildPythonPackage rec {
-    name = "amqp-${version}";
-    version = "2.1.4";
-    disabled = pythonOlder "2.6";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/amqp/${name}.tar.gz";
-      sha256 = "1ybywzkd840v1qvb1p2bs08js260vq1jscjg8182hv7bmwacqy0k";
-    };
-
-    buildInputs = with self; [ pytest case ];
-    propagatedBuildInputs = with self; [ vine ];
-
-    meta = {
-      homepage = https://github.com/celery/py-amqp;
-      description = "Python client for the Advanced Message Queuing Procotol (AMQP). This is a fork of amqplib which is maintained by the Celery project";
-      license = licenses.lgpl21;
-    };
-  };
-
+  amqp = callPackage ../development/python-modules/amqp {};
 
   amqplib = callPackage ../development/python-modules/amqplib {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2053,30 +2053,7 @@ in {
 
   tblib = callPackage ../development/python-modules/tblib { };
 
-  s3fs = buildPythonPackage rec {
-    name = "s3fs-${version}";
-    version = "0.0.8";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/s3fs/${name}.tar.gz";
-      sha256 = "0zbdzqrim0zig94fk1hswg4vfdjplw6jpx3pdi42qc830h0nscn8";
-    };
-
-    buildInputs = with self; [ docutils ];
-    propagatedBuildInputs = with self; [ boto3 ];
-
-    # Depends on `moto` which has a long dependency chain with exact
-    # version requirements that can't be made to work with current
-    # pythonPackages.
-    doCheck = false;
-
-    meta = {
-      description = "S3FS builds on boto3 to provide a convenient Python filesystem interface for S3.";
-      homepage = "http://github.com/dask/s3fs/";
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ teh ];
-    };
-  };
+  s3fs = callPackage ../development/python-modules/s3fs { };
 
   datashape = callPackage ../development/python-modules/datashape { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2065,23 +2065,7 @@ in {
 
   neurotools = callPackage ../development/python-modules/neurotools {};
 
-  jdatetime = buildPythonPackage (rec {
-    name = "jdatetime-${version}";
-    version = "1.7.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/j/jdatetime/${name}.tar.gz";
-      sha256 = "c08ba5791c2350b26e87ddf478bf223108146e241b6c949538221b54afd633ac";
-    };
-
-    propagatedBuildInputs = with self; [ self.six ];
-
-    meta = {
-      description = "Jalali datetime binding for python";
-      homepage = https://pypi.python.org/pypi/jdatetime;
-      license = licenses.psfl;
-    };
-  });
+  jdatetime = callPackage ../development/python-modules/jdatetime {};
 
   daphne = callPackage ../development/python-modules/daphne { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2051,22 +2051,7 @@ in {
 
   locket = callPackage ../development/python-modules/locket { };
 
-  tblib = buildPythonPackage rec {
-    name = "tblib-${version}";
-    version = "1.3.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/tblib/${name}.tar.gz";
-      sha256 = "02iahfkfa927hb4jq2bak36ldihwapzacfiq5lyxg8llwn98a1yi";
-    };
-
-    meta = {
-      description = "Traceback fiddling library. Allows you to pickle tracebacks.";
-      homepage = "https://github.com/ionelmc/python-tblib";
-      license = licenses.bsd2;
-      maintainers = with maintainers; [ teh ];
-    };
-  };
+  tblib = callPackage ../development/python-modules/tblib { };
 
   s3fs = buildPythonPackage rec {
     name = "s3fs-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1958,25 +1958,7 @@ in {
 
   pytest-expect = callPackage ../development/python-modules/pytest-expect { };
 
-  pytest-virtualenv = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "pytest-virtualenv";
-    version = "1.2.7";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
-      sha256 = "51fb6468670624b2315aecaf1a2bbd698509e3ea6a1e28b094984c45e1376755";
-    };
-    buildInputs = with self; [ pytest pytestcov mock cmdline ];
-    propagatedBuildInputs = with self; [ pytest-fixture-config pytest-shutil ];
-    checkPhase = '' py.test tests/unit '';
-    meta = {
-      description = "Create a Python virtual environment in your test that cleans up on teardown. The fixture has utility methods to install packages and list what’s installed.";
-      homepage = https://github.com/manahl/pytest-plugins;
-      license = licenses.mit;
-      maintainers = with maintainers; [ ryansydnor ];
-      platforms   = platforms.all;
-    };
-  };
+  pytest-virtualenv = callPackage ../development/python-modules/pytest-virtualenv { };
 
   pytest_xdist = callPackage ../development/python-modules/pytest-xdist { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1954,32 +1954,7 @@ in {
 
   pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
 
-  pytestcov = buildPythonPackage rec {
-    name = "pytest-cov-2.4.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-cov/${name}.tar.gz";
-      sha256 = "03c2qc42r4bczyw93gd7n0qi1h1jfhw7fnbhi33c3vp1hs81gm2k";
-    };
-
-   buildInputs = with self; [ pytest pytest_xdist virtualenv process-tests ];
-   propagatedBuildInputs = with self; [ coverage ];
-
-   # xdist related tests fail with the following error
-   # OSError: [Errno 13] Permission denied: 'py/_code'
-   doCheck = false;
-   checkPhase = ''
-     # allow to find the module helper during the test run
-     export PYTHONPATH=$PYTHONPATH:$PWD/tests
-     py.test tests
-   '';
-
-    meta = {
-      description = "Plugin for coverage reporting with support for both centralised and distributed testing, including subprocesses and multiprocessing";
-      homepage = https://github.com/pytest-dev/pytest-cov;
-      license = licenses.mit;
-    };
-  };
+  pytestcov = callPackage ../development/python-modules/pytest-cov { };
 
   pytest-expect = callPackage ../development/python-modules/pytest-expect { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2136,30 +2136,7 @@ in {
 
   docker_pycreds = callPackage ../development/python-modules/docker-pycreds {};
 
-  docker_registry_core = buildPythonPackage rec {
-    name = "docker-registry-core-2.0.3";
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/docker-registry-core/${name}.tar.gz";
-      sha256 = "347e804f1f35b28dbe27bf8d7a0b630fca29d684032139bf26e3940572360360";
-    };
-
-    DEPS = "loose";
-
-    doCheck = false;
-    propagatedBuildInputs = with self; [
-      boto redis setuptools simplejson
-    ];
-
-    patchPhase = "> requirements/main.txt";
-
-    meta = {
-      description = "Docker registry core package";
-      homepage = https://github.com/docker/docker-registry;
-      license = licenses.asl20;
-    };
-  };
+  docker_registry_core = callPackage ../development/python-modules/docker-registry-core {};
 
   docker_registry = buildPythonPackage rec {
     name = "docker-registry-0.9.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2169,20 +2169,7 @@ in {
     };
   };
 
-  docopt = buildPythonPackage rec {
-    name = "docopt-0.6.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/docopt/${name}.tar.gz";
-      sha256 = "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491";
-    };
-
-    meta = {
-      description = "Pythonic argument parser, that will make you smile";
-      homepage = http://docopt.org/;
-      license = licenses.mit;
-    };
-  };
+  docopt = callPackage ../development/python-modules/docopt { };
 
   doctest-ignore-unicode = buildPythonPackage rec {
     name = "doctest-ignore-unicode-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2007,26 +2007,7 @@ in {
 
   heapdict = callPackage ../development/python-modules/heapdict { };
 
-  zict = buildPythonPackage rec {
-
-    name = "zict-${version}";
-    version = "0.1.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/z/zict/${name}.tar.gz";
-      sha256 = "12h95vbkbar1hc6cr1kpr6zr486grj3mpx4lznvmnai0iy6pbqp4";
-    };
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ heapdict ];
-
-    meta = {
-      description = "Mutable mapping tools.";
-      homepage = https://github.com/dask/zict;
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ teh ];
-    };
-  };
+  zict = callPackage ../development/python-modules/zict { };
 
   distributed = buildPythonPackage rec {
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2085,22 +2085,7 @@ in {
 
   demjson = callPackage ../development/python-modules/demjson { };
 
-  derpconf = self.buildPythonPackage rec {
-    name = "derpconf-0.4.9";
-
-    propagatedBuildInputs = with self; [ six ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/derpconf/${name}.tar.gz";
-      sha256 = "9129419e3a6477fe6366c339d2df8c614bdde82a639f33f2f40d4de9a1ed236a";
-    };
-
-    meta = {
-      description = "derpconf abstracts loading configuration files for your app";
-      homepage = https://github.com/globocom/derpconf;
-      license = licenses.mit;
-    };
-  };
+  derpconf = callPackage ../development/python-modules/derpconf { };
 
   deskcon = self.buildPythonPackage rec {
     name = "deskcon-0.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1950,30 +1950,7 @@ in {
 
   pytestquickcheck = callPackage ../development/python-modules/pytest-quickcheck { };
 
-  pytest-server-fixtures = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "pytest-server-fixtures";
-    version = "1.1.0";
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ setuptools-git pytest-shutil pytest-fixture-config psutil requests ];
-
-    meta = {
-      description = "Extensible server fixures for py.test";
-      homepage    = "https://github.com/manahl/pytest-plugins";
-      license     = licenses.mit;
-      maintainers = with maintainers; [ nand0p ];
-      platforms   = platforms.all;
-    };
-
-    doCheck = false;
-    # RuntimeError: Unable to find a free server number to start Xvfb
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
-      sha256 = "1gs9qimcn8q6xi9d6i5624l0dziwvn6nj2rda07fg15g1cq66s8l";
-    };
-  };
+  pytest-server-fixtures = callPackage ../development/python-modules/pytest-server-fixtures { };
 
   pytest-shutil = buildPythonPackage rec {
     name = "pytest-shutil-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2003,23 +2003,7 @@ in {
 
   dask = callPackage ../development/python-modules/dask { };
 
-  datrie = buildPythonPackage rec {
-    name = "datrie";
-    version = "0.7.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/datrie/datrie-${version}.tar.gz";
-      sha256 = "08r0if7dry2q7p34gf7ffyrlnf4bdvnprxgydlfxgfnvq8f3f4bs";
-    };
-
-    buildInputs = with self; [ pytest pytestrunner hypothesis ];
-    meta = {
-      description = "Super-fast, efficiently stored Trie for Python";
-      homepage = "https://github.com/kmike/datrie";
-      license = licenses.lgpl2;
-      maintainers = with maintainers; [ lewo ];
-    };
-  };
+  datrie = callPackage ../development/python-modules/datrie { };
 
   heapdict = buildPythonPackage rec {
     name = "HeapDict-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1999,33 +1999,7 @@ in {
 
   cssutils = callPackage ../development/python-modules/cssutils { };
 
-  darcsver = buildPythonPackage (rec {
-    name = "darcsver-1.7.4";
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/darcsver/${name}.tar.gz";
-      sha256 = "1yb1c3jxqvy4r3qiwvnb86qi5plw6018h15r3yk5ji3nk54qdcb6";
-    };
-
-    buildInputs = with self; [ self.mock ];
-
-    # Note: We don't actually need to provide Darcs as a build input.
-    # Darcsver will DTRT when Darcs isn't available.  See news.gmane.org
-    # http://thread.gmane.org/gmane.comp.file-systems.tahoe.devel/3200 for a
-    # discussion.
-
-    # AttributeError: 'module' object has no attribute 'test_darcsver'
-    doCheck = false;
-
-    meta = {
-      description = "Darcsver, generate a version number from Darcs history";
-
-      homepage = https://pypi.python.org/pypi/darcsver;
-
-      license = "BSD-style";
-    };
-  });
+  darcsver = callPackage ../development/python-modules/darcsver { };
 
   dask = callPackage ../development/python-modules/dask { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2063,39 +2063,7 @@ in {
 
   howdoi = callPackage ../development/python-modules/howdoi {};
 
-  neurotools = buildPythonPackage (rec {
-    name = "NeuroTools-${version}";
-    version = "0.3.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/N/NeuroTools/${name}.tar.gz";
-      sha256 = "0ly6qa87l3afhksab06vp1iimlbm1kdnsw98mxcnpzz9q07l4nd4";
-    };
-
-    disabled = isPy3k;
-
-    # Tests are not automatically run
-    # Many tests fail (using py.test), and some need R
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [
-      scipy
-      numpy
-      matplotlib
-      tables
-      pyaml
-      urllib3
-      rpy2
-      mpi4py
-    ];
-
-    meta = {
-      description = "Collection of tools to support analysis of neural activity";
-      homepage = https://pypi.python.org/pypi/NeuroTools;
-      license = licenses.gpl2;
-      maintainers = with maintainers; [ nico202 ];
-    };
-  });
+  neurotools = callPackage ../development/python-modules/neurotools {};
 
   jdatetime = buildPythonPackage (rec {
     name = "jdatetime-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2077,24 +2077,7 @@ in {
   dateutil = self.python-dateutil;
 
   # Buildbot 0.8.7p1 needs dateutil==1.5
-  dateutil_1_5 = buildPythonPackage (rec {
-    name = "dateutil-1.5";
-
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-dateutil/python-${name}.tar.gz";
-      sha256 = "02dhw57jf5kjcp7ng1if7vdrbnlpb9yjmz7wygwwvf3gni4766bg";
-    };
-
-    propagatedBuildInputs = with self; [ self.six ];
-
-    meta = {
-      description = "Powerful extensions to the standard datetime module";
-      homepage = https://pypi.python.org/pypi/python-dateutil;
-      license = "BSD-style";
-    };
-  });
+  dateutil_1_5 = callPackage ../development/python-modules/dateutil/1_5.nix { };
 
   decorator = callPackage ../development/python-modules/decorator { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1952,27 +1952,7 @@ in {
 
   pytest-server-fixtures = callPackage ../development/python-modules/pytest-server-fixtures { };
 
-  pytest-shutil = buildPythonPackage rec {
-    name = "pytest-shutil-${version}";
-    version = "1.2.8";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-shutil/${name}.tar.gz";
-      sha256 = "924accaec3f3781416139e580386ab4f849cb8662bc1072405a81d3a5e56bf3d";
-    };
-    buildInputs = with self; [ cmdline pytest ];
-    propagatedBuildInputs = with self; [ pytestcov coverage setuptools-git mock pathpy execnet contextlib2 ];
-    meta = {
-      description = "A goodie-bag of unix shell and environment tools for py.test";
-      homepage = https://github.com/manahl/pytest-plugins;
-      maintainers = with maintainers; [ ryansydnor ];
-      platforms   = platforms.all;
-      license = licenses.mit;
-    };
-
-    checkPhase = ''
-      py.test
-    '';
-  };
+  pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
 
   pytestcov = buildPythonPackage rec {
     name = "pytest-cov-2.4.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2061,23 +2061,7 @@ in {
 
   requests-unixsocket = callPackage ../development/python-modules/requests-unixsocket {};
 
-  howdoi = buildPythonPackage (rec {
-    name = "howdoi-${version}";
-    version = "1.1.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/h/howdoi/${name}.tar.gz";
-      sha256 = "df4e49a219872324875d588e7699a1a82174a267e8487505e86bfcb180aea9b7";
-    };
-
-    propagatedBuildInputs = with self; [ self.six requests-cache pygments pyquery ];
-
-    meta = {
-      description = "Instant coding answers via the command line";
-      homepage = https://pypi.python.org/pypi/howdoi;
-      license = licenses.mit;
-    };
-  });
+  howdoi = callPackage ../development/python-modules/howdoi {};
 
   neurotools = buildPythonPackage (rec {
     name = "NeuroTools-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2171,23 +2171,7 @@ in {
 
   docopt = callPackage ../development/python-modules/docopt { };
 
-  doctest-ignore-unicode = buildPythonPackage rec {
-    name = "doctest-ignore-unicode-${version}";
-    version = "0.1.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/doctest-ignore-unicode/${name}.tar.gz";
-      sha256= "fc90b2d0846477285c6b67fc4cb4d6f39fcf76d8752f4df0a241486f31512ad5";
-    };
-
-    propagatedBuildInputs = with self; [ nose ];
-
-    meta = {
-      description = "Add flag to ignore unicode literal prefixes in doctests";
-      license = with licenses; [ asl20 ];
-      homepage = https://github.com/gnublade/doctest-ignore-unicode;
-    };
-  };
+  doctest-ignore-unicode = callPackage ../development/python-modules/doctest-ignore-unicode { };
 
   dogpile_cache = callPackage ../development/python-modules/dogpile.cache { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2132,22 +2132,7 @@ in {
 
   docker = callPackage ../development/python-modules/docker {};
 
-  dockerpty = buildPythonPackage rec {
-    name = "dockerpty-0.4.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/dockerpty/${name}.tar.gz";
-      sha256 = "1kjn64wx23jmr8dcc6g7bwlmrhfmxr77gh6iphqsl39sayfxdab9";
-    };
-
-    propagatedBuildInputs = with self; [ six ];
-
-    meta = {
-      description = "Functionality needed to operate the pseudo-tty (PTY) allocated to a docker container";
-      homepage = https://github.com/d11wtq/dockerpty;
-      license = licenses.asl20;
-    };
-  };
+  dockerpty = callPackage ../development/python-modules/dockerpty {};
 
   docker_pycreds = buildPythonPackage rec {
     name = "docker-pycreds-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2037,26 +2037,7 @@ in {
     };
   };
 
-  digital-ocean = buildPythonPackage rec {
-    name = "python-digitalocean-1.10.1";
-
-    propagatedBuildInputs = with self; [ requests ];
-
-    # Package doesn't distribute tests.
-    doCheck = false;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-digitalocean/${name}.tar.gz";
-      sha256 = "12qybflfnl08acspz7rpaprmlabgrzimacbd7gm9qs5537hl3qnp";
-    };
-
-    meta = {
-      description = "digitalocean.com API to manage Droplets and Images";
-      homepage = https://pypi.python.org/pypi/python-digitalocean;
-      license = licenses.lgpl3;
-      maintainers = with maintainers; [ teh ];
-    };
-  };
+  digital-ocean = callPackage ../development/python-modules/digitalocean { };
 
   leather = callPackage ../development/python-modules/leather { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2134,27 +2134,7 @@ in {
 
   dockerpty = callPackage ../development/python-modules/dockerpty {};
 
-  docker_pycreds = buildPythonPackage rec {
-    name = "docker-pycreds-${version}";
-    version = "0.2.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/docker-pycreds/${name}.tar.gz";
-      sha256 = "0j3k5wk3bww5y0f2rvgzsin0q98k0i9j308vpsmxidw0y8n3m0wk";
-    };
-
-    doCheck = false; # require docker-credential-helpers binaries
-
-    propagatedBuildInputs = with self; [
-      six
-    ];
-
-    meta = {
-      description = "Python bindings for the docker credentials store API.";
-      homepage = https://github.com/shin-/dockerpy-creds;
-      license = licenses.asl20;
-    };
-  };
+  docker_pycreds = callPackage ../development/python-modules/docker-pycreds {};
 
   docker_registry_core = buildPythonPackage rec {
     name = "docker-registry-core-2.0.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2213,24 +2213,7 @@ in {
 
   easydict = callPackage ../development/python-modules/easydict { };
 
-  EasyProcess = buildPythonPackage rec {
-    name = "EasyProcess-0.2.3";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/E/EasyProcess/${name}.tar.gz";
-      sha256 = "94e241cadc9a46f55b5c06000df85618849602e7e1865b8de87576b90a22e61f";
-    };
-
-    # No tests
-    doCheck = false;
-
-    meta = {
-      description = "Easy to use python subprocess interface";
-      homepage = "https://github.com/ponty/EasyProcess";
-      license = licenses.bsdOriginal;
-      maintainers = with maintainers; [ layus ];
-    };
-  };
+  EasyProcess = callPackage ../development/python-modules/easyprocess { };
 
   easy-thumbnails = callPackage ../development/python-modules/easy-thumbnails { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2203,25 +2203,7 @@ in {
 
   urllib3 = callPackage ../development/python-modules/urllib3 {};
 
-  dropbox = buildPythonPackage rec {
-    name = "dropbox-${version}";
-    version = "8.0.0";
-    doCheck = false; # Set DROPBOX_TOKEN environment variable to a valid token.
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/dropbox/${name}.tar.gz";
-      sha256 = "0bixx80zjq0286dwm4zhg8bdhc8pqlrqy4n2jg7i6m6a4gv4gak5";
-    };
-
-    buildInputs = with self; [ pytestrunner ];
-    propagatedBuildInputs = with self; [ requests urllib3 mock setuptools ];
-
-    meta = {
-      description = "A Python library for Dropbox's HTTP-based Core and Datastore APIs";
-      homepage = https://www.dropbox.com/developers/core/docs;
-      license = licenses.mit;
-    };
-  };
+  dropbox = callPackage ../development/python-modules/dropbox {};
 
   ds4drv = callPackage ../development/python-modules/ds4drv {
     inherit (pkgs) fetchFromGitHub bluez;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2175,22 +2175,7 @@ in {
 
   dogpile_cache = callPackage ../development/python-modules/dogpile.cache { };
 
-  dogpile_core = buildPythonPackage rec {
-    name = "dogpile.core-0.4.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/dogpile.core/dogpile.core-0.4.1.tar.gz";
-      sha256 = "be652fb11a8eaf66f7e5c94d418d2eaa60a2fe81dae500f3743a863cc9dbed76";
-    };
-
-    doCheck = false;
-
-    meta = {
-      description = "A 'dogpile' lock, typically used as a component of a larger caching solution";
-      homepage = https://bitbucket.org/zzzeek/dogpile.core;
-      license = licenses.bsd3;
-    };
-  };
+  dogpile_core = callPackage ../development/python-modules/dogpile.core { };
 
   dopy = buildPythonPackage rec {
     version = "2016-01-04";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2005,22 +2005,7 @@ in {
 
   datrie = callPackage ../development/python-modules/datrie { };
 
-  heapdict = buildPythonPackage rec {
-    name = "HeapDict-${version}";
-    version = "1.0.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/H/HeapDict/${name}.tar.gz";
-      sha256 = "0nhvxyjq6fp6zd7jzmk5x4fg6xhakqx9lhkp5yadzkqn0rlf7ja0";
-    };
-    doCheck = !isPy3k;
-    meta = {
-      description = "a heap with decrease-key and increase-key operations.";
-      homepage = http://stutzbachenterprises.com;
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ teh ];
-    };
-  };
+  heapdict = callPackage ../development/python-modules/heapdict { };
 
   zict = buildPythonPackage rec {
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2057,25 +2057,7 @@ in {
 
   datashape = callPackage ../development/python-modules/datashape { };
 
-  requests-cache = buildPythonPackage (rec {
-    name = "requests-cache-${version}";
-    version = "0.4.13";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/r/requests-cache/${name}.tar.gz";
-      sha256 = "18jpyivnq5pjbkymk3i473rihpj2bgikafpha7xvr6w736hiqmpy";
-    };
-
-    buildInputs = with self; [ mock ];
-
-    propagatedBuildInputs = with self; [ requests six urllib3 ];
-
-    meta = {
-      description = "Persistent cache for requests library";
-      homepage = https://pypi.python.org/pypi/requests-cache;
-      license = licenses.bsd3;
-    };
-  });
+  requests-cache = callPackage ../development/python-modules/requests-cache { };
 
   requests-unixsocket = callPackage ../development/python-modules/requests-unixsocket {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1997,27 +1997,7 @@ in {
 
   cssselect = callPackage ../development/python-modules/cssselect { };
 
-  cssutils = buildPythonPackage (rec {
-    name = "cssutils-1.0.1";
-
-    src = pkgs.fetchurl {
-      url = mirror://pypi/c/cssutils/cssutils-1.0.1.tar.gz;
-      sha256 = "0qwha9x1wml2qmipbcz03gndnlwhzrjdvw9i09si247a90l8p8fq";
-    };
-
-    buildInputs = with self; [ self.mock ];
-
-    # couple of failing tests
-    doCheck = false;
-
-    meta = {
-      description = "A Python package to parse and build CSS";
-
-      homepage = http://code.google.com/p/cssutils/;
-
-      license = licenses.lgpl3Plus;
-    };
-  });
+  cssutils = callPackage ../development/python-modules/cssutils { };
 
   darcsver = buildPythonPackage (rec {
     name = "darcsver-1.7.4";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2049,28 +2049,7 @@ in {
 
   linuxfd = callPackage ../development/python-modules/linuxfd { };
 
-  locket = buildPythonPackage rec {
-    name = "locket-${version}";
-    version = "0.2.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/l/locket/${name}.tar.gz";
-      sha256 = "1d4z2zngrpqkrfhnd4yhysh66kjn4mblys2l06sh5dix2p0n7vhz";
-    };
-
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [  ];
-
-    # weird test requirements (spur.local>=0.3.7,<0.4)
-    doCheck = false;
-
-    meta = {
-      description = "Locket implements a lock that can be used by multiple processes provided they use the same path.";
-      homepage = "https://github.com/mwilliamson/locket.py";
-      license = licenses.bsd2;
-      maintainers = with maintainers; [ teh ];
-    };
-  };
+  locket = callPackage ../development/python-modules/locket { };
 
   tblib = buildPythonPackage rec {
     name = "tblib-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1995,17 +1995,7 @@ in {
     };
   };
 
-
-  cssselect = buildPythonPackage rec {
-    name = "cssselect-${version}";
-    version = "0.9.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/cssselect/${name}.tar.gz";
-      sha256 = "10h623qnp6dp1191jri7lvgmnd4yfkl36k9smqklp1qlf3iafd85";
-    };
-    # AttributeError: 'module' object has no attribute 'tests'
-    doCheck = false;
-  };
+  cssselect = callPackage ../development/python-modules/cssselect { };
 
   cssutils = buildPythonPackage (rec {
     name = "cssutils-1.0.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1964,26 +1964,7 @@ in {
 
   pytest-localserver = callPackage ../development/python-modules/pytest-localserver { };
 
-  pytest-subtesthack = buildPythonPackage rec {
-    name = "pytest-subtesthack-${version}";
-    version = "0.1.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pytest-subtesthack/${name}.tar.gz";
-      sha256 = "15kzcr5pchf3id4ikdvlv752rc0j4d912n589l4rifp8qsj19l1x";
-    };
-
-    buildInputs = with self; [ pytest ];
-
-    # no upstream test
-    doCheck = false;
-
-    meta = {
-      description = "Terrible plugin to set up and tear down fixtures within the test function itself";
-      homepage = https://github.com/untitaker/pytest-subtesthack;
-      license = licenses.publicDomain;
-    };
-  };
+  pytest-subtesthack = callPackage ../development/python-modules/pytest-subtesthack { };
 
   pytest-sugar = callPackage ../development/python-modules/pytest-sugar { };
 


### PR DESCRIPTION
###### Things done
Just a plain move and cleanup of each module file, also a check that this specific module builds. No upgrades. Some changes of hashes to use the shorter format. One package that didn't build with python 3k got a disable line for that.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

