### PR TITLE
shaarli-material: 0.9.1 -> 0.9.5

### DIFF
--- a/pkgs/servers/web-apps/shaarli/material-theme.nix
+++ b/pkgs/servers/web-apps/shaarli/material-theme.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "shaarli-material-${version}";
-  version = "0.9.1";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "kalvn";
     repo = "Shaarli-Material";
     rev = "v${version}";
-    sha256 = "0x8d9425n3jrwzsyxclbxfspvi91v1klq8r3m6wcj81kys7vmzgh";
+    sha256 = "1bxw74ksvfv46995iwc7jhvl78hd84lcq3h9iyxvs8gpkhkapv55";
   };
 
   patchPhase = ''
     for f in material/*.html
     do
       substituteInPlace $f \
-        --replace '.min.css"' '.min.css#"' \
-        --replace '.min.js"'  '.min.js#"' \
+        --replace '.min.css?v={$version_hash}"' '.min.css#"' \
+        --replace '.min.js?v={$version_hash}"'  '.min.js#"' \
         --replace '.png"'     '.png#"'
     done
   '';


### PR DESCRIPTION
###### Motivation for this change
Updated the shaarli material theme to its latest release.
Fixed the asset link replacement: The hash at the end makes the template engine resolve a relative path (`src="/images/logo.png"` instead of `src="/nix/store/d9pi3la5slpkjbd46b51qkmcwl4kl6l9-shaarli-material-0.9.5/images/logo.png"`). That did not work with the version hash at the end so I removed it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

