### PR TITLE
click: init at 0.3.1

### DIFF
--- a/pkgs/applications/networking/cluster/click/default.nix
+++ b/pkgs/applications/networking/cluster/click/default.nix
@@ -1,0 +1,28 @@
+{ darwin, fetchFromGitHub, rustPlatform, stdenv }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "click-${version}";
+  version = "0.3.1";
+  rev = "b5dfb4a8f8344330a098cb61523695dfe0fd296a";
+
+  src = fetchFromGitHub {
+    owner = "databricks";
+    repo = "click";
+    sha256 = "0a2hq4hcxkkx7gs5dv7sr3j5jy2dby4r6y090z7zl2xy5wydr7bi";
+    inherit rev;
+  };
+
+  cargoSha256 = "03vgbkv9xsnx44vivbbhjgxv9drp0yjnimgy6hwm32x74r00k3hj";
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+
+  meta = with stdenv.lib; {
+    description = ''The "Command Line Interactive Controller for Kubernetes"'';
+    homepage = https://github.com/databricks/click;
+    license = [ licenses.asl20 ];
+    maintainers = [ maintainers.mbode ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20290,6 +20290,8 @@ with pkgs;
 
   calaos_installer = libsForQt5.callPackage ../misc/calaos/installer {};
 
+  click = callPackage ../applications/networking/cluster/click { };
+
   cups = callPackage ../misc/cups {
     libusb = libusb1;
   };


### PR DESCRIPTION
###### Motivation for this change
Add [click](https://github.com/databricks/click).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
