### PR TITLE
go_1_10: 1.10 -> 1.10.1, g_1_9: 1.9.4 -> 1.9.5

### DIFF
--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.10";
+  version = "1.10.1";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "1dzs1mz3zxgg1qyi2lrlxdz1lsvazxvmj9cb69pgqnwjlh3jpw0l";
+    sha256 = "1wqwy52ibb343a4v7b9q26xa6r5jk4khfxd90wbpcayws8cxly8m";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.9.4";
+  version = "1.9.5";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "15d9lfiy1cjfz6nqnig5884ykqckx58cynd1bva1xna7bwcwwp2r";
+    sha256 = "15dx1b71xv7b265gqk9nv02pirggpw7d83apikhrza2qkj64ydd0";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
###### Motivation for this change

This updates go to the latest version of the golang 1.9 & 1.10 branches.
A few minor (but important) things are fixed in this version(s).

Below are the details for the 1.10 changes. Read the commit message for details about the 1.9 changes.

* CVE-2018-7187 - arbitrary code execution in `go get` (when used with
  --insecure) [1]
* Extended Key Usage verification in client certificate scenarios [3]
* a bunch of stability changes

The full list of changes can se been on GitHub [2] & [4].

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7187
[2] https://github.com/golang/go/issues?q=milestone%3AGo1.10.1
[3] https://github.com/golang/go/issues/23884
[4] https://github.com/golang/go/issues/24563

Currently running a (re)build of all affected expressions on x86_64-linux.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

