### PR TITLE
hangups: 0.4.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/hangups/default.nix
+++ b/pkgs/applications/networking/instant-messengers/hangups/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, python3 }:
+let 
+  packageOverrides = self: super:{
+
+    ConfigArgParse = super.ConfigArgParse.overridePythonAttrs (oldAttrs: rec {
+      version = "0.11.0";
+      src = oldAttrs.src.override {
+        inherit version; 
+        sha256 = "12dcl0wdsjxgphxadyz9bdzbvlwfaqgvba9s59ghajw4yqiyi2kc";
+      };
+    });
+
+    aiohttp = super.aiohttp.overridePythonAttrs (oldAttrs: rec {
+      version = "2.3.10";
+      src = oldAttrs.src.override {
+        inherit version;
+        sha256 = "0r0955ar0yiwbp3war35z8zncs01nq84wdwk0v3s8f547dcadpca";
+      };
+    }); 
+
+    MechanicalSoup = super.MechanicalSoup.overridePythonAttrs (oldAttrs: rec {
+      version = "0.6.0";
+      src = oldAttrs.src.override {
+        inherit version;
+        extension = "zip";
+        sha256 = "0ka3nximli7wcpy381grn6d75fnpf91050iwdcj4shf53z0m1fg2";
+      };
+    }); 
+  };
+  pythonPackages = (python3.override { inherit packageOverrides; }).pkgs;
+
+in pythonPackages.buildPythonApplication rec {
+  pname = "hangups";
+  version = "0.4.4";
+  disabled = !pythonPackages.isPy3k;
+
+  propagatedBuildInputs = with pythonPackages; [ 
+    ConfigArgParse 
+    requests
+    aiohttp
+    ReParser
+    appdirs
+    urwid
+    protobuf3_1
+    readlike
+    MechanicalSoup
+  ];
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "1sm8c9mfcdyhlb6k2cq1r4j3zpc4z47z7zs8yycmf45nmv0vg0h9";
+  };
+
+  checkInputs = [ 
+    pythonPackages.docutils
+    pythonPackages.pytest
+  ];
+  
+  checkPhase = ''
+    python3 setup.py check --metadata --restructuredtext --strict
+  '';
+
+  doCheck = true;
+ 
+  meta = with stdenv.lib; {
+    description = "The first third-party instant messaging client for Google Hangouts";
+    homepage = http://github.com/tdryer/hangups;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/ReParser/default.nix
+++ b/pkgs/development/python-modules/ReParser/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchPypi 
+}:
+
+buildPythonPackage rec {
+  pname = "ReParser";
+  version = "1.4.3";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nniqb69xr0fv7ydlmrr877wyyjb61nlayka7xr08vlxl9caz776";
+  };
+
+  name = "${pname}-${version}";
+
+  meta = {
+    homepage = https://github.com/xmikos/reparser;
+    description = "Simple regex-based lexer/parser for inline markup";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/ReParser/default.nix
+++ b/pkgs/development/python-modules/ReParser/default.nix
@@ -14,8 +14,6 @@ buildPythonPackage rec {
     sha256 = "0nniqb69xr0fv7ydlmrr877wyyjb61nlayka7xr08vlxl9caz776";
   };
 
-  name = "${pname}-${version}";
-
   meta = {
     homepage = https://github.com/xmikos/reparser;
     description = "Simple regex-based lexer/parser for inline markup";

--- a/pkgs/development/python-modules/readlike/default.nix
+++ b/pkgs/development/python-modules/readlike/default.nix
@@ -1,0 +1,20 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "readlike";
+  version = "0.1.2";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ck65ycw51f4xnbh4sg9axgbl81q3azpzvd5f2nvrv2fla9m8r08";
+  };
+  name = "${pname}-${version}";
+ 
+  meta = {
+    homepage = http://jangler.info/code/readlike;
+    description = "GNU Readline-like line editing module";
+    license = lib.licenses.mit;
+  };
+}  

--- a/pkgs/development/python-modules/readlike/default.nix
+++ b/pkgs/development/python-modules/readlike/default.nix
@@ -10,7 +10,6 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1ck65ycw51f4xnbh4sg9axgbl81q3azpzvd5f2nvrv2fla9m8r08";
   };
-  name = "${pname}-${version}";
  
   meta = {
     homepage = http://jangler.info/code/readlike;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2801,6 +2801,8 @@ with pkgs;
 
   hardinfo = callPackage ../tools/system/hardinfo { };
 
+  hangups = callPackage ../applications/networking/instant-messengers/hangups { };
+
   hdapsd = callPackage ../os-specific/linux/hdapsd { };
 
   hddtemp = callPackage ../tools/misc/hddtemp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -400,6 +400,8 @@ in {
 
   relatorio = callPackage ../development/python-modules/relatorio { };
 
+  readlike = callPackage  ../development/python-modules/readlike { };
+
   pyzufall = callPackage ../development/python-modules/pyzufall { };
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl {});

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -402,6 +402,8 @@ in {
 
   readlike = callPackage  ../development/python-modules/readlike { };
 
+  ReParser = callPackage ../development/python-modules/ReParser { };
+
   pyzufall = callPackage ../development/python-modules/pyzufall { };
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl {});


### PR DESCRIPTION
###### Motivation for this change

Addition of hangups application/library and required dependencies to nixpkgs.
Allows use of Google hangouts in terminal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

