### PR TITLE
tamarin-prover: install vim syntax highlighting files

### DIFF
--- a/pkgs/applications/science/logic/tamarin-prover/default.nix
+++ b/pkgs/applications/science/logic/tamarin-prover/default.nix
@@ -70,6 +70,9 @@ mkDerivation (common "tamarin-prover" src // {
   postInstall = ''
     wrapProgram $out/bin/tamarin-prover \
       --prefix PATH : ${lib.makeBinPath [ which maude graphviz sapic ]}
+    # so that the package can be used as a vim plugin to install syntax coloration
+    install -Dt $out/share/vim-plugins/tamarin-prover/syntax/ etc/{spthy,sapic}.vim 
+    install etc/filetype.vim -D $out/share/vim-plugins/tamarin-prover/ftdetect/tamarin.vim
   '';
 
   checkPhase = "./dist/build/tamarin-prover/tamarin-prover test";


### PR DESCRIPTION
note that this was tested on 13e74a838db27825c88be99b1a21fbee33aa6803
because tamarin-prover does not build on master...

###### Motivation for this change

Vim syntax highlighting files were not installed.

###### Things done

Tested as follows:
```
environment.etc.vimrc.source =
  let vimrcConfig = {
     packages.myVimPackages = {
        start = [ pkgs.tamarin-prover ];
    };
  };
  in 
  "${pkgs.vimUtils.vimrcFile vimrcConfig}";
```

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

