### PR TITLE
dbeaver: 4.3.3 -> 5.0.1 (18.03)

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   name = "dbeaver-ce-${version}";
-  version = "4.3.3";
+  version = "5.0.1";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.jkiss.org/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "063h2za2m33b4k9s756lwicxwszzsqr2sqr2gi4ai05dqkgkw951";
+    sha256 = "0211aw3rhxyka7006y6ny8xzf4l2yn77zmgdxhmi69ywjp12lql7";
   };
 
   installPhase = ''


### PR DESCRIPTION
(cherry picked from commit 4ae8a448b89e818bf573e51b3e18e44239f76848)

Reason: Updates software as needed.

* * *

 * [Updates dbeaver 5.0.0](https://dbeaver.jkiss.org/2018/03/19/dbeaver-5-0-1/).
 * [Updates dbeaver 5.0.1](https://dbeaver.jkiss.org/2018/03/19/dbeaver-5-0-1/).

As explained on #36362

> While the major version number is increasing, it doesn't seem to include any breaking change. The version increased since it's the release of the new *Mock data generator extension*.

Furthermore, I missed updating 18.03's version to 5.0.0, I wasn't entirely sure the protocol for cherry-picking updates to software to the stable branch. [I have since informed myself](https://logs.nix.samueldr.com/nixos-dev/2018-03-07#1520461616-1520461747;).


###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

> *As a side note, #34182 is still open and I will still gladly accept any help in figuring out how to build this using the source release.*

