### PR TITLE
Elm break fix

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -91,6 +91,8 @@ let
         # https://github.com/elm-lang/elm-compiler/issues/1566
         indents = hlib.overrideCabal super.indents (drv: {
           version = "0.3.3";
+          #test dep tasty has a version mismatch
+          doCheck = false;
           sha256 = "16lz21bp9j14xilnq8yym22p3saxvc9fsgfcf5awn2a6i6n527xn";
           libraryHaskellDepends = drv.libraryHaskellDepends ++ [super.concatenative];
         });

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -74,6 +74,16 @@ let
             elm-format = self.callPackage ./packages/elm-format.nix { };
             elm-interface-to-json = self.callPackage ./packages/elm-interface-to-json.nix {
               aeson-pretty = self.aeson-pretty_0_7_2;
+              either = hlib.overrideCabal self.either (drv :{
+                jailbreak = true;
+                version = "4.4.1.1";
+                sha256 = "1lrlwqqnm6ibfcydlv5qvvssw7bm0c6yypy0rayjzv1znq7wp1xh";
+                libraryHaskellDepends = drv.libraryHaskellDepends or [] ++ [
+                  self.exceptions self.free self.mmorph self.monad-control
+                  self.MonadRandom self.profunctors self.transformers
+                  self.transformers-base
+                ];
+              });
             };
           };
       in elmPkgs // {

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -79,15 +79,6 @@ let
       in elmPkgs // {
         inherit elmPkgs;
         elmVersion = elmRelease.version;
-        # needed for elm-package
-        http-client = hlib.overrideCabal super.http-client (drv: {
-          version = "0.4.31.2";
-          sha256 = "12yq2l6bvmxg5w6cw5ravdh39g8smwn1j44mv36pfmkhm5402h8n";
-        });
-        http-client-tls = hlib.overrideCabal super.http-client-tls (drv: {
-          version = "0.2.4.1";
-          sha256 = "18wbca7jg15p0ds3339f435nqv2ng0fqc4bylicjzlsww625ij4d";
-        });
         # https://github.com/elm-lang/elm-compiler/issues/1566
         indents = hlib.overrideCabal super.indents (drv: {
           version = "0.3.3";

--- a/pkgs/development/compilers/elm/packages/elm-package.nix
+++ b/pkgs/development/compilers/elm/packages/elm-package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, aeson-pretty_0_7_2, ansi-wl-pprint, base, binary
 , bytestring, containers, directory, edit-distance, elm-compiler
-, fetchgit, filepath, HTTP, http-client, http-client-tls
+, fetchgit, fetchurl, filepath, HTTP, http-client, http-client-tls
 , http-types, mtl, network, optparse-applicative, parallel-io
 , pretty, stdenv, text, time, unordered-containers, vector
 , zip-archive
@@ -12,6 +12,10 @@ mkDerivation {
     url = "https://github.com/elm-lang/elm-package";
     sha256 = "19krnkjvfk02gmmic5h5i1i0lw7s30927bnd5g57cj8nqbigysv7";
     rev = "8bd150314bacab5b6fc451927aa01deec2276fbf";
+  };
+  patches = fetchurl {
+    url = https://github.com/jerith666/elm-package/commit/40bab60c2fbff70812cc24cdd97f5e09db3844ad.patch;
+    sha256 = "0j6pi6cv3h9s6vz68bh0c73fysvk83yhhk56kgshvnrmnpcb3jib";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -66,6 +66,13 @@ self: super: {
   inline-c = super.inline-c_0_5_6_1;
   inline-c-cpp = super.inline-c-cpp_0_1_0_0;
 
+  # test dep hedgehog pulls in concurrent-output, which does not build
+  # due to processing version mismatch
+  either = dontCheck super.either;
+
+  # test dep tasty has a version mismatch
+  indents = dontCheck super.indents;
+
   # Newer versions require GHC 8.2.
   haddock-api = self.haddock-api_2_17_4;
   haddock = self.haddock_2_17_5;


### PR DESCRIPTION
###### Motivation for this change

fixes #38023 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm pretty unfamiliar with the haskell infrastructure, just want to keep compiling my elm code.  :)  so please let me know if any of this is off-base!

cc @domenkozar @flokli @pbogdan @peti 