### PR TITLE
libseccomp: only on Linux

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -87,5 +87,5 @@ rec {
         else { parsed = elem; };
     in lib.matchAttrs pattern platform;
 
-  enableIfAvailable = p: if p.meta.available or true then [ p ] else [];
+  enableIfAvailable = p: if builtins.isAttrs p && p.meta.available or true then [ p ] else [];
 }

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -60,7 +60,7 @@ let
           hostPlatform != buildPlatform && hostPlatform ? nix && hostPlatform.nix ? system
       ) ''--with-system=${hostPlatform.nix.system}''
          # RISC-V support in progress https://github.com/seccomp/libseccomp/pull/50
-      ++ lib.optional (!libseccomp.meta.available) "--disable-seccomp-sandboxing";
+      ++ lib.optional (!(builtins.isAttrs libseccomp && libseccomp.meta.available)) "--disable-seccomp-sandboxing";
 
     makeFlags = "profiledir=$(out)/etc/profile.d";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9821,7 +9821,7 @@ with pkgs;
 
   libgroove = callPackage ../development/libraries/libgroove { };
 
-  libseccomp = callPackage ../development/libraries/libseccomp { };
+  libseccomp = if stdenv.isLinux then callPackage ../development/libraries/libseccomp { } else null;
 
   libsecret = callPackage ../development/libraries/libsecret { };
 


### PR DESCRIPTION
Enable libseccomp only on Linux, make it null on other platforms, as
it was before the previous change.

###### Motivation for this change

nixUnstable is broken on Darwin, because libseccomp was accidentally
enabled in commit 26e8d58cb545004acb7cbd00db81a402923a2445 (merged in commit cd7047c46169b935719ed5f19f693d97bd760ec7).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [✓] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [✓] macOS
   - [✓] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [✓] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [✓] Tested execution of all binary files (usually in `./result/bin/`)
- [✓] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

