### PR TITLE
nmon: init at 16g

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3421,6 +3421,11 @@
     github = "suvash";
     name = "Suvash Thapaliya";
   };
+  sveitser = {
+    email = "sveitser@gmail.com";
+    github = "sveitser";
+    name = "Mathis Antony";
+  };
   svsdep = {
     email = "svsdep@gmail.com";
     github = "svsdep";

--- a/pkgs/os-specific/linux/nmon/default.nix
+++ b/pkgs/os-specific/linux/nmon/default.nix
@@ -1,0 +1,27 @@
+{ fetchurl, stdenv, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "nmon-${version}";
+  version = "16g";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/nmon/lmon${version}.c";
+    sha256 = "127n8xvmg7byp42sm924mdr7hd3bsfsxpryzahl0cfsh7dlxv0ns";
+  };
+
+  buildInputs = [ ncurses ];
+  unpackPhase = ":";
+  buildPhase = "cc -o nmon ${src} -g -O2 -D JFS -D GETUSER -Wall -D LARGEMEM -lncurses -lm -g -D X86";
+  installPhase = ''
+    mkdir -p $out/bin
+    cp nmon $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "AIX & Linux Performance Monitoring tool";
+    homepage = "http://nmon.sourceforge.net";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sveitser ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13203,6 +13203,8 @@ with pkgs;
     inherit (darwin) IOKit;
   };
 
+  nmon = callPackage ../os-specific/linux/nmon { };
+
   # GNU/Hurd core packages.
   gnu = recurseIntoAttrs (callPackage ../os-specific/gnu {
     inherit platform;


### PR DESCRIPTION
###### Motivation for this change
Previous PR for `nmon` #33285. This PR doesn't use a custom builder script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

