### PR TITLE
perlPackages.Socket6: fix sv_undef compilation error

### DIFF
--- a/pkgs/development/perl-modules/Socket6-sv_undef.patch
+++ b/pkgs/development/perl-modules/Socket6-sv_undef.patch
@@ -1,0 +1,27 @@
+From fe385e252507b510ce4f7eab7b55f692ef1d4f02 Mon Sep 17 00:00:00 2001
+From: Marius Bergmann <marius@yeai.de>
+Date: Fri, 30 Mar 2018 20:21:58 +0200
+Subject: [PATCH] b
+
+---
+ Socket6.xs | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/Socket6.xs b/Socket6.xs
+index 05c791c..058e9d9 100644
+--- a/Socket6.xs
++++ b/Socket6.xs
+@@ -105,10 +105,6 @@ const struct in6_addr in6addr_loopback = IN6ADDR_LOOPBACK_INIT;
+ #define	HAVE_INET_PTON		1
+ #endif
+ 
+-#ifndef HAVE_PL_SV_UNDEF
+-#define	PL_sv_undef		sv_undef
+-#endif
+-
+ static int
+ not_here(char *s)
+ {
+-- 
+2.16.3
+

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12464,6 +12464,7 @@ let self = _self // overrides; _self = with self; {
     };
     setOutputFlags = false;
     buildInputs = [ pkgs.which ];
+    patches = [ ../development/perl-modules/Socket6-sv_undef.patch ];
     meta = {
       description = "IPv6 related part of the C socket.h defines and structure manipulators";
       license = stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
###### Motivation for this change

Socket6.xs redefines `PV_sv_undef`, which breaks compilation from
306d5cdf03ad6375861a20b8885ef38699ca3c23.

###### Things done

 I added a patch to remove this
redefinition. Compilation is now working again.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

