### PR TITLE
python: pytest: 3.4.1 -> 3.4.2

### DIFF
--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -2,7 +2,7 @@
 , setuptools_scm, setuptools, six, pluggy, funcsigs, isPy3k
 }:
 buildPythonPackage rec {
-  version = "3.4.1";
+  version = "3.4.2";
   pname = "pytest";
 
   preCheck = ''
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9ddcb879c8cc859d2540204b5399011f842e5e8823674bf429f70ada281b3cc6";
+    sha256 = "1idq7s8da2p82ynf9fcg77rzj1dsagg3bpsrlslf31x7q4vasyqi";
   };
 
   checkInputs = [ hypothesis ];


### PR DESCRIPTION
###### Motivation for this change
Fixes the buku build for now because https://github.com/jarun/Buku/pull/254 updated the pytest requirement from `>=3.4.0` to `==3.4.2`, and nixpkgs only had 3.4.1 before. So this will break buku again if pytest gets an update before buku, as @jarun has [pushed a fix](https://github.com/jarun/Buku/commit/71881b451c442e42b9e67fd1d4741864474a9dce) already.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---