### PR TITLE
bepasty: make it a package again

### DIFF
--- a/pkgs/tools/misc/bepasty/default.nix
+++ b/pkgs/tools/misc/bepasty/default.nix
@@ -4,7 +4,10 @@
 
 with python.pkgs;
 
-buildPythonApplication rec {
+#We need to use buildPythonPackage here to get the PYTHONPATH build correctly.
+#This is needed for services.bepasty
+#https://github.com/NixOS/nixpkgs/pull/38300
+buildPythonPackage rec {
   pname = "bepasty";
   version = "0.4.0";
   name = "${pname}-${version}";


### PR DESCRIPTION
this fixes running bepasty with gunicorn, which is needed for
services.bepasty

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

