### PR TITLE
buildGoPackage: use a separator when joining extraSrcPaths together

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -98,7 +98,7 @@ go.stdenv.mkDerivation (
     rmdir goPath
 
   '') + (lib.optionalString (extraSrcPaths != []) ''
-    ${rsync}/bin/rsync -a ${lib.concatMapStrings (p: "${p}/src") extraSrcPaths} go
+    ${rsync}/bin/rsync -a ${lib.concatMapStringsSep " " (p: "${p}/src") extraSrcPaths} go
 
   '') + ''
     export GOPATH=$NIX_BUILD_TOP/go:$GOPATH


### PR DESCRIPTION
Otherwise they get mashed together into a single string.

/cc @fpletz 