### PR TITLE
mate/mate-screensaver: fixed unixAuth

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -108,6 +108,8 @@ in
     services.gnome3.gnome-keyring.enable = true;
     services.upower.enable = config.powerManagement.enable;
 
+    security.pam.services."mate-screensaver".unixAuth = true;
+
     environment.pathsToLink = [ "/share" ];
   };
 


### PR DESCRIPTION
Without this fix, it's not possible to unlock the mate-screensaver.