### PR TITLE
WIP: packettracer: init at 7.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3601,6 +3601,11 @@
     github = "titanous";
     name = "Jonathan Rudenberg";
   };
+  tmplt = {
+    email = "tmplt@dragons.rocks";
+    github = "tmplt";
+    name = "Viktor";
+  };
   tnias = {
     email = "phil@grmr.de";
     github = "tnias";

--- a/pkgs/applications/misc/packettracer/builder.sh
+++ b/pkgs/applications/misc/packettracer/builder.sh
@@ -1,0 +1,56 @@
+# Adapted from <https://aur.archlinux.org/packages/packettracer/>
+
+source $stdenv/setup
+
+p=$out/opt/packettracer
+mkdir -p $p
+
+# XXX: when extracting some files we apparently lack permission? Why?
+echo "unpacking $src..."
+tar xvfa $src --directory $p > /dev/null || echo "some files could not be extracted, continuing..."
+
+# Mime Info for PKA, PKT, PKZ
+install -D -m644 "$p/bin/Cisco-pka.xml" "$out/usr/share/mime/packages/Ciso-pka.xml"
+install -D -m644 "$p/bin/Cisco-pkt.xml" "$out/usr/share/mime/packages/Ciso-pkt.xml"
+install -D -m644 "$p/bin/Cisco-pkz.xml" "$out/usr/share/mime/packages/Ciso-pkz.xml"
+
+# Install Mimetype Icons
+install -D -m644 "$p/art/pka.png" "$out/usr/share/icons/hicolor/48x48/mimetypes/application-x-pka.png"
+install -D -m644 "$p/art/pkt.png" "$out/usr/share/icons/hicolor/48x48/mimetypes/application-x-pkt.png"
+install -D -m644 "$p/art/pkz.png" "$out/usr/share/icons/hicolor/48x48/mimetypes/application-x-pkz.png"
+
+# EULA
+install -D -m644 "$p/eula.txt" "$out/usr/share/licenses/packettracer/eula.txt"
+
+# Add environment variable
+mkdir -p "$out/etc/profile.d"
+echo "export PT_HOME=$p" > "$out/etc/profile.d/packettracer.sh"
+
+# Remove unused files
+rm -r $p/lib $p/install
+
+# Patch binaries
+_patchelf() {
+    patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${libPath}" \
+        $1
+}
+
+echo "patching binaries..."
+_patchelf $p/bin/PacketTracer7
+_patchelf $p/bin/linguist
+_patchelf $p/bin/meta
+_patchelf $p/extensions/meta
+# _patchelf $p/extensions/upnp/upnp # verified with hash?
+
+# Symlink to /bin
+mkdir -p "$out/bin"
+ln -s "$p/bin/PacketTracer7" "$out/bin/PacketTracer7"
+ln -s "$p/bin/linguist" "$out/bin/linguist"
+ln -s "$p/bin/meta" "$out/bin/meta"
+
+# Install desktop file
+install -D -m644 "$p/bin/Cisco-PacketTracer.desktop" "$out/usr/share/applications/Cisco-PacketTracer.desktop"
+sed "s#/opt/pt/#$out/#g" -i "$out/usr/share/applications/Cisco-PacketTracer.desktop"
+rm "$p/bin/Cisco-PacketTracer.desktop"

--- a/pkgs/applications/misc/packettracer/default.nix
+++ b/pkgs/applications/misc/packettracer/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, requireFile, lib
+, openssl, qt56, xlibs, fontconfig, freetype, libpng12, zlib, glib }:
+
+stdenv.mkDerivation rec {
+  name = "packettracer-${version}";
+  version = "7.1.1";
+
+  src = requireFile {
+    name = "Packet_Tracer_${version}_for_Linux_64_bit.tar";
+    url = "http://www.netacad.com/about-networking-academy/packet-tracer";
+    sha256 = "8ee064c92f2465fd79017397750f4d12c212c591d8feb1d198863e992613b3b7";
+    message = ''
+      This nix expression required that Packet_Tracer_${version}_for_Linux_64_bit.tar is already part of the store.
+      Download it from http://www.netacad.com/about-networking-academy/packet-tracer and add it to the nix store with:
+
+          nix-store --add-fixed sha256 Packet_Tracer_${version}_for_Linux_64_bit.tar
+
+      This can't be done automatically because you need to create an account on
+      their website and agree to their license terms before you can download it.
+    '';
+  };
+
+  builder = ./builder.sh;
+
+  libPath = stdenv.lib.makeLibraryPath [
+    # Dependencies for bin/{PacketTracer7,linguist}
+    stdenv.cc.cc
+    openssl
+    qt56.full
+
+    # Dependencies for bin/meta
+    xlibs.libX11
+    xlibs.libXi
+    xlibs.libxcb
+    xlibs.xcbutilrenderutil
+    xlibs.xcbutilimage
+    xlibs.xcbutilwm
+    xlibs.xcbutilkeysyms
+    fontconfig
+    freetype
+    libpng12
+    zlib
+    # depends on libicui18n.so.52, replace with whatever icu59 has?
+    # depends on libicuuc.so.52, but no lib for it is found
+    glib
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.netacad.com/about-networking-academy/packet-tracer/;
+    description = "Network simulation and visualization tool from Cisco";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.tmplt ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2758,6 +2758,8 @@ with pkgs;
 
   partimage = callPackage ../tools/backup/partimage { };
 
+  packettracer = callPackage ../applications/misc/packettracer { };
+
   pgf_graphics = callPackage ../tools/graphics/pgf { };
 
   pgjwt = callPackage ../servers/sql/postgresql/pgjwt {};


### PR DESCRIPTION


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
**Not ready for merge!** Some quirks to figure out first.

This commit adds build files for Cisco's Packet Tracer.

This builds and runs when declared in an overlay (via `~/.config/nixpkgs/overlays/`), but when installed from this nixpkgs fork does not link against `libQt5{Multimedia,PrintSupport,Svg,Widgets,Gui,Network,Xml,Core}.so.5` , which can all be found in `qt56.full` according to `nix-locate`. I request some help with this.

Other than that, the `bin/meta` binary depends on `lib{icui18n,icuuc}.co.52`, neither of which can be found by `nix-locate`. Should they perhaps be replaced with the libraries from icu59?

Some files fails to extract from the tarball, but these are but saves; they are not required to run the program.

Lastly, the program will complain and not use the `extensions/upnp/upnp` binary if patched. I suspect it's checked against some hash behind the scenes. (Not that the unpatched binary can be used anyway..) Any case, the program appears to function without it.
