### PR TITLE
 go_1_{9,10}: disable problematic tests in net module

### DIFF
--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -77,6 +77,8 @@ stdenv.mkDerivation rec {
     sed -i '/TestRespectSetgidDir/areturn' src/cmd/go/internal/work/build_test.go
     # Remove cert tests that conflict with NixOS's cert resolution
     sed -i '/TestEnvVars/areturn' src/crypto/x509/root_unix_test.go
+    # TestWritevError hangs sometimes
+    sed -i '/TestWritevError/areturn' src/net/writev_test.go
 
     sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
     sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go

--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -79,6 +79,8 @@ stdenv.mkDerivation rec {
     sed -i '/TestEnvVars/areturn' src/crypto/x509/root_unix_test.go
     # TestWritevError hangs sometimes
     sed -i '/TestWritevError/areturn' src/net/writev_test.go
+    # TestVariousDeadlines fails sometimes
+    sed -i '/TestVariousDeadlines/areturn' src/net/timeout_test.go
 
     sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
     sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go

--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -77,6 +77,8 @@ stdenv.mkDerivation rec {
     sed -i '/TestRespectSetgidDir/areturn' src/cmd/go/internal/work/build_test.go
     # Remove cert tests that conflict with NixOS's cert resolution
     sed -i '/TestEnvVars/areturn' src/crypto/x509/root_unix_test.go
+    # TestWritevError hangs sometimes
+    sed -i '/TestWritevError/areturn' src/net/writev_test.go
 
     sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
     sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go

--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -79,6 +79,8 @@ stdenv.mkDerivation rec {
     sed -i '/TestEnvVars/areturn' src/crypto/x509/root_unix_test.go
     # TestWritevError hangs sometimes
     sed -i '/TestWritevError/areturn' src/net/writev_test.go
+    # TestVariousDeadlines fails sometimes
+    sed -i '/TestVariousDeadlines/areturn' src/net/timeout_test.go
 
     sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
     sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go


### PR DESCRIPTION
###### Motivation for this change

On a NixOS laptop ```TestWritevError``` sometimes hangs (#37704) and ```TestVariousDeadlines``` fails with

```
--- FAIL: TestVariousDeadlines (5.00s)
        timeout_test.go:878: 1ns run 1/1
        timeout_test.go:903: for 1ns run 1/1, good client timeout after 19.113µs, reading 0 bytes
        timeout_test.go:913: for 1ns run 1/1, server in 794.51µs wrote 393216: readfrom tcp4 127.0.0.1:43227->127.0.0.1:44660: write tcp4 127.0.0.1:43227->127.0.0.1:44660: write: connection reset by peer
        timeout_test.go:878: 2ns run 1/1
        timeout_test.go:903: for 2ns run 1/1, good client timeout after 4.91µs, reading 0 bytes
        timeout_test.go:917: for 2ns run 1/1, timeout waiting for server to finish writing
FAIL
FAIL    net     6.498s
```

So they are added to the list of problematic tests which do not run.


Fixes #37704