### PR TITLE
pythonPackages.python-gnupg: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -3,11 +3,11 @@
 buildPythonPackage rec {
   name    = "${pname}-${version}";
   pname   = "python-gnupg";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06hfw9cmiw5306fyisp3kzg1hww260qzip829g7y7pj1mwpb0izg";
+    sha256 = "0wzvx8y4ii1y1vch28a0m6f2y4px9r7qd8fpimsx6y5z4pfscm2s";
   };
 
   propagatedBuildInputs = [ gnupg1 ];


### PR DESCRIPTION
###### Motivation for this change

ZHF #36453. Build [failed on python27](https://hydra.nixos.org/build/72118481), fixed by bump.

/cc maintainer @copumpkin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

