### PR TITLE
Use lib/purple-2 directory instead of lib/pidgin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/telegram-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/telegram-purple/default.nix
@@ -16,14 +16,14 @@ stdenv.mkDerivation rec {
   buildInputs = [ pidgin libwebp libgcrypt gettext ];
 
   preConfigure = ''
-    sed -i "s|/etc/telegram-purple/server.tglpub|$out/lib/pidgin/server.tglpub|g" telegram-purple.c
+    sed -i "s|/etc/telegram-purple/server.tglpub|$out/lib/purple-2/server.tglpub|g" telegram-purple.c
     echo "#define GIT_COMMIT \"${builtins.substring 0 10 src.rev}\"" > commit.h
   '';
 
   installPhase = ''
-    mkdir -p $out/lib/pidgin/
-    cp bin/*.so $out/lib/pidgin/ #*/
-    cp tg-server.tglpub $out/lib/pidgin/server.tglpub
+    mkdir -p $out/lib/purple-2/
+    cp bin/*.so $out/lib/purple-2/ #*/
+    cp tg-server.tglpub $out/lib/purple-2/server.tglpub
     mkdir -p $out/pixmaps/pidgin/protocols/{16,22,48}
     cp imgs/telegram16.png $out/pixmaps/pidgin/protocols/16
     cp imgs/telegram22.png $out/pixmaps/pidgin/protocols/22


### PR DESCRIPTION
###### Motivation for this change
This plugin should be available for all libpurple applications, but currently it is only available for pidgin

###### Things done
Changed output directory to $out/lib/purple-2 (e.g. as in nixpkgs.pidgin-opensteamworks)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

