### PR TITLE
dwarf-fortress: Provide package with plugins

### DIFF
--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -22,6 +22,16 @@ let
       };
     };
 
+    hacked = callPackage ./wrapper {
+      enableDFHack = true;
+      enableSoundSense = true;
+      enableStoneSense = true;
+      themes = {
+        "phoebus" = phoebus-theme;
+        "cla" = cla-theme;
+      };
+    };
+
     dwarf-therapist-original = pkgs.qt5.callPackage ./dwarf-therapist {
       texlive = pkgs.texlive.combine {
         inherit (pkgs.texlive) scheme-basic float caption wrapfig adjmulticol sidecap preprint enumitem;


### PR DESCRIPTION
This package calls the existing wrapper enabling all available plugins:

* DFHack
* SoundSense
* StoneSense

###### Motivation for this change
To provide a package for dwarf fortress that enables the above plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

