### PR TITLE
Fix where Vulkan validation layer JSON files are placed by the nixpkgs install phase

### DIFF
--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -47,10 +47,11 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib $out/bin
     cp -d loader/libvulkan.so* $out/lib
     cp demos/vulkaninfo $out/bin
-    mkdir -p $out/lib $out/share/vulkan/explicit_layer.d
+    mkdir -p $out/etc/vulkan/explicit_layer.d
+    ln -s $out/etc $out/share
     cp -L layers/*.so $out/lib/
-    cp -L layers/*.json $out/share/vulkan/explicit_layer.d/
-    sed -i "s:\\./lib:$out/lib/lib:g" "$out/share/vulkan/"*/*.json
+    cp -L layers/*.json $out/etc/vulkan/explicit_layer.d/
+    sed -i "s:\\./lib:$out/lib/lib:g" "$out/etc/vulkan/"*/*.json
     mkdir -p $dev/include
     cp -rv ../include $dev/
     mkdir -p $demos/share/vulkan-demos


### PR DESCRIPTION
###### Motivation for this change
When Vulkan looks for validation layers, it looks for JSON files in several directories.  One of those directories is {vulkan-loader}/etc/vulkan/explicit_layer.d.  This appears to be because {vulkan-loader}/etc is specified in SYSCONFDIR, which is used [here in the Vulkan loader source](https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/72eb69da597fc245a607280e93212d658401eda2/loader/loader.c#L3172).  And according to [the Vulkan loader's BUILD.md file](https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/c2388b0c6daf4044947bee0f91806d7e310a9d8e/BUILD.md#linux-install-to-system-directories):  "You can further customize the installation directories by using the CMake variables CMAKE_INSTALL_SYSCONFDIR to rename the etc directory and CMAKE_INSTALL_DATADIR to rename the share directory".  It seems pretty clear that the vulkan/explicit_layer.d folder _should_ be in etc, not share.

As for how the current version seems to work already:  A later folder that it checks for these JSON files (after it fails to find anything at {vulkan-loader}/etc/vulkan/explicit_layer.d) is {user-profile}/share/vulkan/explicit_layer.d.  (No idea why it checks share instead of etc _here_, though.)  When you install vulkan-loader via nix-env, it seems to also copy the files to that folder, which allows Vulkan to find them.  However, in a context where you're running a nix-shell or nix-build _without_ already having vulkan-loader installed via nix-env, it fails to find the files anywhere.

###### Things done
Changed the install phase to place vulkan/explicit_layer.d under {vulkan-loader}/etc instead of {vulkan-loader}/share.

Caveat:  My only testing is that I ran vulkaninfo under nix-shell, with and without my change, and it worked (i.e. listed layers) only with my change.  I also ran my own tutorial-based Vulkan program, built with a dependency on vulkan-loader, and it failed to find any installed validation layers until my fix was applied.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))  **No such test exists for vulkan-loader**
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`  **Test failed, but I don't think it has anything to do with my change.  See below.**
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

