### PR TITLE
ocamlPackages.ocamlnet: fix build with OCaml 4.06

### DIFF
--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig, ncurses, ocaml, findlib, ocaml_pcre, camlzip
-, gnutls, nettle }:
+, gnutls, nettle, fetchpatch
+}:
 
 let version = "4.1.5"; in
 
@@ -10,6 +11,12 @@ stdenv.mkDerivation {
     url = "http://download.camlcity.org/download/ocamlnet-${version}.tar.gz";
     sha256 = "1ppcd2zjhj6s3ib9q8dngnr53qlmkhvv7a8hzp88r79k6jygn4cm";
   };
+
+  patches = [ (fetchpatch {
+      url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/ocamlnet/ocamlnet.4.1.5/files/netgzip.patch";
+      sha256 = "1say7zzgk24qcy9m91gcfgvz4fv7nksx4j5qnbxyq8wqw0g88ba0";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses ocaml findlib ocaml_pcre camlzip gnutls nettle ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

