### PR TITLE
ixgbevf: 4.3.3 -> 4.3.4

### DIFF
--- a/pkgs/os-specific/linux/ixgbevf/default.nix
+++ b/pkgs/os-specific/linux/ixgbevf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ixgbevf-${version}-${kernel.version}";
-  version = "4.3.3";
+  version = "4.3.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/e1000/ixgbevf-${version}.tar.gz";
-    sha256 = "0kq8y0944kaprw445wb8iswdck2jmc0xpkx0iv6idy3r5cc4hvyg";
+    sha256 = "122zn9nd8f95bpidiiinc8xaizypkirqs8vlmsdy2iv3w65md9k3";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
###### Motivation for this change

4.3.3 didn't build with linux 4.15. 
ZHF #36453 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

