### PR TITLE
openshift: Fix binary paths for oc cluster up to work

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, removeReferencesTo, which, go_1_9, go-bindata, makeWrapper, rsync
+{ stdenv, lib, fetchFromGitHub, fetchpatch, removeReferencesTo, which, go_1_9, go-bindata, makeWrapper, rsync, utillinux
 , iptables, coreutils, kerberos, clang
 , components ? [
   "cmd/oc"
@@ -37,6 +37,18 @@ in stdenv.mkDerivation rec {
 
   patchPhase = ''
     patchShebangs ./hack
+
+    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt findmnt' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/findmnt'
+
+    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mount' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/mount'
+
+    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mkdir' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/mount'
   '';
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change
When upgrading to newer release (#37882) I messed up the "oc cluster up" by removing the patch section. Bringing back this functionality.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

