### PR TITLE
buildkite-agent: 2.6.9 -> 2.6.10

### DIFF
--- a/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, coreutils, git, openssh, bash, gnused, gnugrep }:
 let
-  version = "2.6.9";
+  version = "2.6.10";
   goPackagePath = "github.com/buildkite/agent";
 in
 buildGoPackage {
@@ -12,7 +12,7 @@ buildGoPackage {
     owner = "buildkite";
     repo = "agent";
     rev = "v${version}";
-    sha256 = "0rlinj7dcr8vzl1pb15nfny8jkvvj50i8czf4ahv26avnfycm4pz";
+    sha256 = "07065hhhb418w5qlqnyiap45r59paysysbwz1l7dmaw3j4q8m8rg";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

New upstream release.

https://github.com/buildkite/agent/releases/tag/v2.6.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
