### PR TITLE
nixos/buildkite-agent: fix variable expansion in hook scripts

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -17,7 +17,7 @@ let
 
   hooksDir = let
     mkHookEntry = name: value: ''
-      cat > $out/${name} <<EOF
+      cat > $out/${name} <<'EOF'
       #! ${pkgs.runtimeShell}
       set -e
       ${value}


### PR DESCRIPTION
###### Motivation for this change

@cleverca22 found this bug in the declarative hooks config. Any shell variables referenced in a hook script would get expanded by the hooks directory builder.

Prevent variable expansion by quoting the here doc limit string.

/cc @cleverca22 @zimbatm @domenkozar 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested manually by inspection of hooks directory.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
