### PR TITLE
react-native-debugger: init at 0.7.18

### DIFF
--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -1,0 +1,83 @@
+{ stdenv, fetchurl, unzip, cairo, xorg, gdk_pixbuf, fontconfig, pango, gnome2, atk, gtk2, glib
+, freetype, dbus, nss, nspr, alsaLib, cups, expat, libudev, makeDesktopItem
+}:
+
+let
+  rpath = stdenv.lib.makeLibraryPath [
+    cairo
+    stdenv.cc.cc
+    gdk_pixbuf
+    fontconfig
+    pango
+    atk
+    gtk2
+    glib
+    freetype
+    dbus
+    nss
+    nspr
+    alsaLib
+    cups
+    expat
+    libudev
+
+    gnome2.GConf
+
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXtst
+    xorg.libxcb
+    xorg.libXext
+    xorg.libXi
+    xorg.libXdamage
+    xorg.libXrandr
+    xorg.libXcomposite
+    xorg.libXfixes
+    xorg.libXrender
+    xorg.libXScrnSaver
+  ];
+in stdenv.mkDerivation rec {
+  name = "react-native-debugger-${version}";
+  version = "0.7.18";
+
+  src = fetchurl {
+    url = "https://github.com/jhen0409/react-native-debugger/releases/download/v${version}/rn-debugger-linux-x64.zip";
+    sha256 = "186n438sy9wzrx2zdw4qq4hsz89wiy01bpfa6fdjisvxgz6r8sgw";
+  };
+
+  buildInputs = [ unzip ];
+  buildCommand = ''
+    shopt -s extglob
+    mkdir -p $out
+    unzip $src -d $out
+
+    mkdir $out/{lib,bin,share}
+    mv $out/lib{node,ffmpeg}.so $out/lib
+    mv $out/!(lib|share|bin) $out/share
+
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      --set-rpath ${rpath}:$out/lib \
+      $out/share/React\ Native\ Debugger
+
+    ln -s $out/share/React\ Native\ Debugger $out/bin/React\ Native\ Debugger
+
+    install -Dm644 "${desktopItem}/share/applications/"* \
+      -t $out/share/applications/
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = "rndebugger";
+    exec = "React\\ Native\\ Debugger";
+    desktopName = "React Native Debugger";
+    genericName = "React Native Debugger";
+    categories = "Development;Tools;";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jhen0409/react-native-debugger;
+    license = licenses.mit;
+    description = "The standalone app based on official debugger of React Native, and includes React Inspector / Redux DevTools";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4506,6 +4506,8 @@ with pkgs;
 
   rdma-core = callPackage ../os-specific/linux/rdma-core { };
 
+  react-native-debugger = callPackage ../development/tools/react-native-debugger { };
+
   read-edid = callPackage ../os-specific/linux/read-edid { };
 
   redir = callPackage ../tools/networking/redir { };


### PR DESCRIPTION
###### Motivation for this change

Electron application that can be used to debug React Native applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

