### PR TITLE
darwin.opencflite: fix build

### DIFF
--- a/pkgs/os-specific/darwin/opencflite/default.nix
+++ b/pkgs/os-specific/darwin/opencflite/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jgmzs0ycl930hmzcvx0ykryik56704yw62w394q1q3xw5kkjn9v";
   };
 
-  configureFlags = [ "--with-uuid=${libuuid}" ];
+  configureFlags = [ "--with-uuid=${libuuid.dev}" ];
   buildInputs = [ icu tzdata.dev ];
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
ZHF-18.03: #36453 
See: https://hydra.nixos.org/job/nixos/release-18.03/nixpkgs.darwin.opencflite.x86_64-linux
Please backport to 18.03. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

