### PR TITLE
rsibreak: init at 0.12.8

### DIFF
--- a/pkgs/applications/misc/rsibreak/default.nix
+++ b/pkgs/applications/misc/rsibreak/default.nix
@@ -1,0 +1,28 @@
+{
+  mkDerivation, fetchurl, lib,
+  extra-cmake-modules, kdoctools,
+  knotifyconfig, kidletime, kwindowsystem, ktextwidgets, kcrash
+}:
+
+let
+  pname = "rsibreak";
+  version = "0.12";
+  revision = ".8";
+in mkDerivation rec {
+  name = "rsibreak-${version}${revision}";
+
+  src = fetchurl {
+    url = "https://download.kde.org/stable/${pname}/${version}/${name}.tar.xz";
+    sha256 = "1qn9xdjx9zzw47jsj7f4nkqmrangfhdgafm2jxm7cm6z6kcvzr28";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [ knotifyconfig kidletime kwindowsystem ktextwidgets kcrash ];
+
+  meta = with lib; {
+    description = "RSIBreak takes care of your health and regularly breaks your work to avoid repetitive strain injury (RSI)";
+    license = licenses.gpl2;
+    homepage = https://www.kde.org/applications/utilities/rsibreak/;
+    maintainers = with maintainers; [ vandenoever ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4641,6 +4641,8 @@ with pkgs;
 
   rrdtool = callPackage ../tools/misc/rrdtool { };
 
+  rsibreak = libsForQt5.callPackage ../applications/misc/rsibreak { };
+
   rss2email = callPackage ../applications/networking/feedreaders/rss2email {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

A useful application that works well: RSIbreak.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

