### PR TITLE
Add user channels to the default nix path

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -20,10 +20,21 @@ has the following highlights: </para>
 <itemizedlist>
   <listitem>
     <para>
-      TODO
+      User channels are now in the default <literal>NIX_PATH</literal>,
+      allowing users to use their personal <command>nix-channel</command>
+      defined channels in <command>nix-build</command> and
+      <command>nix-shell</command> commands, as well as in imports like
+      <code>import &lt;mychannel&gt;</code>.
     </para>
+    <para>For example</para>
+    <programlisting>
+$ nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgsunstable
+$ nix-channel --update
+$ nix-build '&lt;nixpkgsunstable&gt;' -A gitFull
+$ nix run -f '&lt;nixpkgsunstable&gt;' gitFull
+$ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
+</programlisting>
   </listitem>
-
 </itemizedlist>
 
 </section>

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -338,7 +338,9 @@ in
       nixPath = mkOption {
         type = types.listOf types.str;
         default =
-          [ "nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos/nixpkgs"
+          [
+            "$HOME/.nix-defexpr/channels"
+            "nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos/nixpkgs"
             "nixos-config=/etc/nixos/configuration.nix"
             "/nix/var/nix/profiles/per-user/root/channels"
           ];


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nix/issues/2033

I'll backport upon merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
$ nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgsunstable

$ nix-channel --update
unpacking channels...
created 5 symlinks in user environment

$ nix-build '<nixpkgsunstable>' -A gitFull            
/nix/store/9i8vdd4757xnvyflf0fhszjw74cy74ib-git-2.16.2

$ nix run -f '<nixpkgsunstable>' gitFull  

[grahamc@Morbo:~]$ which git
/nix/store/9i8vdd4757xnvyflf0fhszjw74cy74ib-git-2.16.2/bin/git

[grahamc@Morbo:~]$ exit

$ nix-instantiate -E '(import <nixpkgsunstable> {}).gitFull'
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
/nix/store/2iz7n7x4rldrn4dg9s5bg6a3qlxna7ms-git-2.16.2.drv
```