### PR TITLE
[18.03] tdesktop: use wrapGAppsHook

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchgit, fetchpatch
-, pkgconfig, gyp, cmake, makeWrapper
+, pkgconfig, gyp, cmake, wrapGAppsHook
 , qtbase, qtimageformats, gtk3, libappindicator-gtk3, libnotify
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
 }:
@@ -36,7 +36,7 @@ mkDerivation rec {
     substituteInPlace Telegram/SourceFiles/platform/linux/linux_libnotify.cpp --replace '"notify"' '"${libnotify}/lib/libnotify.so"'
   '';
 
-  nativeBuildInputs = [ pkgconfig gyp cmake makeWrapper ];
+  nativeBuildInputs = [ pkgconfig gyp cmake wrapGAppsHook ];
 
   buildInputs = [
     qtbase qtimageformats gtk3 libappindicator-gtk3
@@ -112,11 +112,16 @@ mkDerivation rec {
     for icon_size in 16 32 48 64 128 256 512; do
       install -Dm644 "../../../Telegram/Resources/art/icon''${icon_size}.png" "$out/share/icons/hicolor/''${icon_size}x''${icon_size}/apps/telegram-desktop.png"
     done
+  '';
 
-    # This is necessary to run Telegram in a pure environment.
-    wrapProgram $out/bin/telegram-desktop \
-      --prefix QT_PLUGIN_PATH : "${qtbase}/${qtbase.qtPluginPrefix}" \
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix QT_PLUGIN_PATH : "${qtbase}/${qtbase.qtPluginPrefix}"
       --set XDG_RUNTIME_DIR "XDG-RUNTIME-DIR"
+    )
+  '';
+
+  postFixup = ''
     sed -i $out/bin/telegram-desktop \
       -e "s,'XDG-RUNTIME-DIR',\"\''${XDG_RUNTIME_DIR:-/run/user/\$(id --user)}\","
   '';


### PR DESCRIPTION
###### Motivation for this change

Mostly a backport of https://github.com/NixOS/nixpkgs/pull/37587, telegram-desktop crashes on choose file dialog (which is apparently required for account registration within the app).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

