### PR TITLE
Monthly update for Gambit and Gerbil

### DIFF
--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -1,0 +1,70 @@
+{ stdenv, git, openssl, autoconf, pkgs, makeStaticLibraries, version, git-version, SRC }:
+
+stdenv.mkDerivation rec {
+  name    = "gambit-${version}";
+  src     = SRC;
+
+  bootstrap = import ./bootstrap.nix ( pkgs );
+
+  # Use makeStaticLibraries to enable creation of statically linked binaries
+  buildInputs = [ git autoconf bootstrap openssl (makeStaticLibraries openssl)];
+
+  configurePhase = ''
+    options=(
+      --prefix=$out
+      --enable-single-host
+      --enable-c-opt=-O2
+      --enable-gcc-opts
+      --enable-shared
+      --enable-absolute-shared-libs # Yes, NixOS will want an absolute path, and fix it.
+      --enable-poll
+      --enable-openssl
+      --enable-default-runtime-options="f8,-8,t8" # Default to UTF-8 for source and all I/O
+      #--enable-debug # Nope: enables plenty of good stuff, but also the costly console.log
+
+      #--enable-multiple-versions # Nope, NixOS already does version multiplexing
+      #--enable-guide
+      #--enable-track-scheme
+      #--enable-high-res-timing
+      #--enable-max-processors=4
+      #--enable-multiple-vms
+      #--enable-dynamic-tls
+      #--enable-multiple-vms
+      #--enable-multiple-threaded-vms  ## when SMP branch is merged in
+      #--enable-thread-system=posix    ## default when --enable-multiple-vms is on.
+      #--enable-profile
+      #--enable-coverage
+      #--enable-inline-jumps
+      #--enable-char-size=1" ; default is 4
+    )
+    ./configure ''${options[@]}
+  '';
+
+  buildPhase = ''
+    # Make bootstrap compiler, from release bootstrap
+    mkdir -p boot &&
+    cp -rp ${bootstrap}/. boot/. &&
+    chmod -R u+w boot &&
+    cd boot &&
+    cp ../gsc/makefile.in ../gsc/*.scm gsc && # */
+    ./configure &&
+    for i in lib gsi gsc ; do (cd $i ; make ) ; done &&
+    cd .. &&
+    cp boot/gsc/gsc gsc-boot &&
+
+    # Now use the bootstrap compiler to build the real thing!
+    make -j2 from-scratch
+  '';
+
+  doCheck = true;
+
+  meta = {
+    description = "Optimizing Scheme to C compiler";
+    homepage    = "http://gambitscheme.org";
+    license     = stdenv.lib.licenses.lgpl2;
+    # NB regarding platforms: only actually tested on Linux, *should* work everywhere,
+    # but *might* need adaptation e.g. on macOS.
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ thoughtpolice raskin fare ];
+  };
+}

--- a/pkgs/development/compilers/gambit/default.nix
+++ b/pkgs/development/compilers/gambit/default.nix
@@ -1,75 +1,13 @@
-{ stdenv, fetchurl, fetchgit, git, openssl, autoconf, pkgs, makeStaticLibraries }:
+{ callPackage, fetchgit }:
 
-# TODO: distinct packages for gambit-release and gambit-devel
-
-stdenv.mkDerivation rec {
-  name    = "gambit-${version}";
+callPackage ./build.nix {
   version = "4.8.9";
-  bootstrap = import ./bootstrap.nix ( pkgs );
+  # TODO: for next version, prefer the unpatched tarball for the stable/default gambit.
+  git-version = "4.8.9-8-g793679bd";
 
-  src = fetchgit {
+  SRC = fetchgit {
     url = "https://github.com/feeley/gambit.git";
     rev = "dd54a71dfc0bd09813592f1645d755867a02195d";
     sha256 = "120kg73k39gshrwas8a3xcrxgnq1c7ww92wgy4d3mmrwy3j9nzzc";
-  };
-
-  # Use makeStaticLibraries to enable creation of statically linked binaries
-  buildInputs = [ git autoconf bootstrap openssl (makeStaticLibraries openssl)];
-
-  configurePhase = ''
-    options=(
-      --prefix=$out
-      --enable-single-host
-      --enable-c-opt=-O2
-      --enable-gcc-opts
-      --enable-shared
-      --enable-absolute-shared-libs # Yes, NixOS will want an absolute path, and fix it.
-      --enable-poll
-      --enable-openssl
-      --enable-default-runtime-options="f8,-8,t8" # Default to UTF-8 for source and all I/O
-      #--enable-debug # Nope: enables plenty of good stuff, but also the costly console.log
-
-      #--enable-multiple-versions # Nope, NixOS already does version multiplexing
-      #--enable-guide
-      #--enable-track-scheme
-      #--enable-high-res-timing
-      #--enable-max-processors=4
-      #--enable-multiple-vms
-      #--enable-dynamic-tls
-      #--enable-multiple-vms
-      #--enable-multiple-threaded-vms  ## when SMP branch is merged in
-      #--enable-thread-system=posix    ## default when --enable-multiple-vms is on.
-      #--enable-profile
-      #--enable-coverage
-      #--enable-inline-jumps
-      #--enable-char-size=1" ; default is 4
-    )
-    ./configure ''${options[@]}
-  '';
-
-  buildPhase = ''
-    # Make bootstrap compiler, from release bootstrap
-    mkdir -p boot &&
-    cp -rp ${bootstrap}/. boot/. &&
-    chmod -R u+w boot &&
-    cd boot &&
-    cp ../gsc/makefile.in ../gsc/*.scm gsc && # */
-    ./configure &&
-    for i in lib gsi gsc ; do (cd $i ; make ) ; done &&
-    cd .. &&
-    cp boot/gsc/gsc gsc-boot &&
-
-    # Now use the bootstrap compiler to build the real thing!
-    make -j2 from-scratch
-  '';
-
-  doCheck = true;
-
-  meta = {
-    description = "Optimizing Scheme to C compiler";
-    homepage    = "http://gambitscheme.org";
-    license     = stdenv.lib.licenses.lgpl2;
-    platforms   = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ thoughtpolice raskin fare ];
   };
 }

--- a/pkgs/development/compilers/gambit/unstable.nix
+++ b/pkgs/development/compilers/gambit/unstable.nix
@@ -1,0 +1,11 @@
+{ callPackage, fetchgit }:
+
+callPackage ./build.nix {
+  version = "unstable-2018-03-26";
+  git-version = "4.8.9-8-g793679bd";
+  SRC = fetchgit {
+    url = "https://github.com/feeley/gambit.git";
+    rev = "793679bd57eb6275cb06e6570b05f4a78df61bf9";
+    sha256 = "0bippvmrc8vcaa6ka3mhzfgkagb6a1616g7nxk0i0wapxai5cngj";
+  };
+}

--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -1,0 +1,88 @@
+{ stdenv, lib, makeStaticLibraries,
+  coreutils, rsync, bash,
+  openssl, zlib, sqlite, libxml2, libyaml, mysql, lmdb, leveldb, postgresql,
+  version, git-version, GAMBIT, SRC }:
+
+# TODO: distinct packages for gerbil-release and gerbil-devel
+# TODO: make static compilation work
+
+stdenv.mkDerivation rec {
+  name    = "gerbil-${version}";
+  src     = SRC;
+
+  # Use makeStaticLibraries to enable creation of statically linked binaries
+  buildInputs_libraries = [ openssl zlib sqlite libxml2 libyaml mysql.connector-c lmdb leveldb postgresql ];
+  buildInputs_staticLibraries = map makeStaticLibraries buildInputs_libraries;
+
+  buildInputs = [ GAMBIT coreutils rsync bash ]
+    ++ buildInputs_libraries ++ buildInputs_staticLibraries;
+
+  NIX_CFLAGS_COMPILE = [ "-I${mysql.connector-c}/include/mysql" "-L${mysql.connector-c}/lib/mysql" ];
+
+  postPatch = ''
+    echo '(define (gerbil-version-string) "v${git-version}")' > src/gerbil/runtime/gx-version.scm
+
+    patchShebangs .
+
+    find . -type f -executable -print0 | while IFS= read -r -d ''$'\0' f; do
+      substituteInPlace "$f" --replace '#!/usr/bin/env' '#!${coreutils}/bin/env'
+    done
+
+    cat > etc/gerbil_static_libraries.sh <<EOF
+#OPENSSL_LIBCRYPTO=${makeStaticLibraries openssl}/lib/libcrypto.a # MISSING!
+#OPENSSL_LIBSSL=${makeStaticLibraries openssl}/lib/libssl.a # MISSING!
+ZLIB=${makeStaticLibraries zlib}/lib/libz.a
+# SQLITE=${makeStaticLibraries sqlite}/lib/sqlite.a # MISSING!
+# LIBXML2=${makeStaticLibraries libxml2}/lib/libxml2.a # MISSING!
+# YAML=${makeStaticLibraries libyaml}/lib/libyaml.a # MISSING!
+MYSQL=${makeStaticLibraries mysql.connector-c}/lib/mariadb/libmariadb.a
+# LMDB=${makeStaticLibraries lmdb}/lib/mysql/libmysqlclient_r.a # MISSING!
+LEVELDB=${makeStaticLibraries lmdb}/lib/libleveldb.a
+EOF
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Enable all optional libraries
+    substituteInPlace "src/std/build-features.ss" --replace '#f' '#t'
+
+    # gxprof testing uses $HOME/.cache/gerbil/gxc
+    export HOME=$$PWD
+
+    # Build, replacing make by build.sh
+    ( cd src && sh build.sh )
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/
+    cp -fa bin lib etc doc $out/
+
+    cat > $out/bin/gxi <<EOF
+#!${bash}/bin/bash -e
+export GERBIL_HOME=$out
+case "\$1" in -:*) GSIOPTIONS=\$1 ; shift ;; esac
+if [[ \$# = 0 ]] ; then
+  exec ${GAMBIT}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init \$GERBIL_HOME/lib/gxi-interactive - ;
+else
+  exec ${GAMBIT}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init "\$@"
+fi
+EOF
+    runHook postInstall
+  '';
+
+  dontStrip = true;
+
+  meta = {
+    description = "Gerbil Scheme";
+    homepage    = "https://github.com/vyzo/gerbil";
+    license     = stdenv.lib.licenses.lgpl2;
+    # NB regarding platforms: only actually tested on Linux, *should* work everywhere,
+    # but *might* need adaptation e.g. on macOS. Please report success and/or failure to fare.
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ fare ];
+  };
+}

--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -1,91 +1,11 @@
-{ stdenv, lib, fetchurl, fetchgit, makeStaticLibraries, gambit,
-  coreutils, rsync, bash,
-  openssl, zlib, sqlite, libxml2, libyaml, mysql, lmdb, leveldb, postgresql }:
+{ callPackage, fetchurl, gambit }:
 
-# TODO: distinct packages for gerbil-release and gerbil-devel
-# TODO: make static compilation work
-
-stdenv.mkDerivation rec {
-  name    = "gerbil-${version}";
-
+callPackage ./build.nix {
   version = "0.12-RELEASE";
-  src = fetchgit {
-    url = "https://github.com/vyzo/gerbil.git";
-    rev = "5618892d7939e1cb4ef5247912e0bc1ec99f6b52";
-    sha256 = "0b2valahf5k81r4sp6y12d44fb286p92s7k6dphij0kmvg0dp818";
-  };
-
-  # Use makeStaticLibraries to enable creation of statically linked binaries
-  buildInputs_libraries = [ openssl zlib sqlite libxml2 libyaml mysql.connector-c lmdb leveldb postgresql ];
-  buildInputs_staticLibraries = map makeStaticLibraries buildInputs_libraries;
-
-  buildInputs = [ gambit coreutils rsync bash ]
-    ++ buildInputs_libraries ++ buildInputs_staticLibraries;
-
-  NIX_CFLAGS_COMPILE = [ "-I${mysql.connector-c}/include/mysql" "-L${mysql.connector-c}/lib/mysql" ];
-
-  postPatch = ''
-    echo '(define (gerbil-version-string) "v${version}")' > src/gerbil/runtime/gx-version.scm
-
-    patchShebangs .
-
-    find . -type f -executable -print0 | while IFS= read -r -d ''$'\0' f; do
-      substituteInPlace "$f" --replace '#!/usr/bin/env' '#!${coreutils}/bin/env'
-    done
-
-    cat > etc/gerbil_static_libraries.sh <<EOF
-#OPENSSL_LIBCRYPTO=${makeStaticLibraries openssl}/lib/libcrypto.a # MISSING!
-#OPENSSL_LIBSSL=${makeStaticLibraries openssl}/lib/libssl.a # MISSING!
-ZLIB=${makeStaticLibraries zlib}/lib/libz.a
-# SQLITE=${makeStaticLibraries sqlite}/lib/sqlite.a # MISSING!
-# LIBXML2=${makeStaticLibraries libxml2}/lib/libxml2.a # MISSING!
-# YAML=${makeStaticLibraries libyaml}/lib/libyaml.a # MISSING!
-MYSQL=${makeStaticLibraries mysql.connector-c}/lib/mariadb/libmariadb.a
-# LMDB=${makeStaticLibraries lmdb}/lib/mysql/libmysqlclient_r.a # MISSING!
-LEVELDB=${makeStaticLibraries lmdb}/lib/libleveldb.a
-EOF
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-
-    # Enable all optional libraries
-    substituteInPlace "src/std/build-features.ss" --replace '#f' '#t'
-
-    # gxprof testing uses $HOME/.cache/gerbil/gxc
-    export HOME=$$PWD
-
-    # Build, replacing make by build.sh
-    ( cd src && sh build.sh )
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/
-    cp -fa bin lib etc doc $out/
-
-    cat > $out/bin/gxi <<EOF
-#!${bash}/bin/bash -e
-export GERBIL_HOME=$out
-case "\$1" in -:*) GSIOPTIONS=\$1 ; shift ;; esac
-if [[ \$# = 0 ]] ; then
-  exec ${gambit}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init \$GERBIL_HOME/lib/gxi-interactive - ;
-else
-  exec ${gambit}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init "\$@"
-fi
-EOF
-    runHook postInstall
-  '';
-
-  dontStrip = true;
-
-  meta = {
-    description = "Gerbil Scheme";
-    homepage    = "https://github.com/vyzo/gerbil";
-    license     = stdenv.lib.licenses.lgpl2;
-    platforms   = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ fare ];
+  git-version = "0.12";
+  GAMBIT = gambit;
+  SRC = fetchurl {
+    url = "https://github.com/vyzo/gerbil/archive/v0.12.tar.gz";
+    sha256 = "0nigr3mgrzai57q2jqac8f39zj8rcmic3277ynyzlgm8hhps71pq";
   };
 }

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,0 +1,12 @@
+{ callPackage, fetchgit, gambit-unstable }:
+
+callPackage ./build.nix {
+  version = "unstable-2018-04-03";
+  git-version = "0.13-DEV-357-ge61318dc";
+  GAMBIT = gambit-unstable;
+  SRC = fetchgit {
+    url = "https://github.com/vyzo/gerbil.git";
+    rev = "e61318dcaa3a9c843e2cf259e67851f240e4beda";
+    sha256 = "1xd7yxiramifdxgp6b3s24z6nkkmy5h4a6pkchvy4w358qv1vqin";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5966,6 +5966,7 @@ with pkgs;
   fpc = callPackage ../development/compilers/fpc { };
 
   gambit = callPackage ../development/compilers/gambit { };
+  gambit-unstable = callPackage ../development/compilers/gambit/unstable.nix { };
   gerbil = callPackage ../development/compilers/gerbil { };
 
   gccFun = callPackage ../development/compilers/gcc/7;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5968,6 +5968,7 @@ with pkgs;
   gambit = callPackage ../development/compilers/gambit { };
   gambit-unstable = callPackage ../development/compilers/gambit/unstable.nix { };
   gerbil = callPackage ../development/compilers/gerbil { };
+  gerbil-unstable = callPackage ../development/compilers/gerbil/unstable.nix { };
 
   gccFun = callPackage ../development/compilers/gcc/7;
   gcc = gcc7;


### PR DESCRIPTION
###### Motivation for this change

Monthly update with regular progress on Gerbil and a few bug fixes for Gambit.

Introduce gambit-unstable and gerbil-unstable with date-based names that fit the nixpkgs convention.

Have gerbil-unstable use gambit-unstable.

Make gambit (stable, default) exactly match upstream 4.8.9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
