### PR TITLE
lib/debug.nix overhaul

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 /lib                        @edolstra @nbp
 /lib/systems                @nbp @ericson2314
 /lib/generators.nix         @edolstra @nbp @Profpatsch
+/lib/debug.nix              @edolstra @nbp @Profpatsch
 
 # Nixpkgs Internals
 /default.nix                          @nbp

--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -294,6 +294,22 @@ merge:"diff3"
 
 </section>
 
+<section xml:id="sec-debug">
+  <title>Debugging Nix Expressions</title>
+
+  <para>Nix is a unityped, dynamic language, this means every value can
+  potentially appear anywhere. Since it is also non-strict, evaluation order
+  and what ultimately is evaluated might surprise you. Therefore it is important
+  to be able to debug nix expressions.</para>
+
+
+  <para>In the <literal>lib/debug.nix</literal> file you will find a number of
+  functions that help (pretty-)printing values while evaluation is runnnig. You
+  can even specify how deep these values should be printed recursively, and
+  transform them on the fly. Please consult the docstrings in
+  <literal>lib/debug.nix</literal> for usage information.</para>
+</section>
+
 
 <section xml:id="sec-fhs-environments">
   <title>buildFHSUserEnv</title>

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -102,10 +102,6 @@ rec {
   # usage: { testX = allTrue [ true ]; }
   testAllTrue = expr: { inherit expr; expected = map (x: true) expr; };
 
-  strict = v:
-    trace "Warning: strict is deprecated and will be removed in the next release"
-      (builtins.seq v v);
-
   # example: (traceCallXml "myfun" id 3) will output something like
   # calling myfun arg 1: 3 result: 3
   # this forces deep evaluation of all arguments and the result!
@@ -119,10 +115,10 @@ rec {
       in (str: expr:
           if isFunction expr then
             (arg:
-              traceCallXml (builtins.add 1 nr) "${str}\n arg ${builtins.toString nr} is \n ${builtins.toXML (strict arg)}" (expr arg)
+              traceCallXml (builtins.add 1 nr) "${str}\n arg ${builtins.toString nr} is \n ${builtins.toXML (builtins.seq arg arg)}" (expr arg)
             )
           else
-            let r = strict expr;
+            let r = builtins.seq expr expr;
             in trace "${str}\n result:\n${builtins.toXML r}" r
       );
 }

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -17,7 +17,8 @@ rec {
 
   traceIf = p: msg: x: if p then trace msg x else x;
 
-  traceVal = x: trace x x;
+  traceValFn = f: x: trace (f x) x;
+  traceVal = traceValFn id;
   traceXMLVal = x: trace (builtins.toXML x) x;
   traceXMLValMarked = str: x: trace (str + builtins.toXML x) x;
 
@@ -44,9 +45,11 @@ rec {
                (modify depth snip x)) y;
 
   /* `traceSeq`, but the same value is traced and returned */
-  traceValSeq = v: traceVal (builtins.deepSeq v v);
+  traceValSeqFn = f: v: traceVal f (builtins.deepSeq v v);
+  traceValSeq = traceValSeqFn id;
   /* `traceValSeq` but with fixed depth */
-  traceValSeqN = depth: v: traceSeqN depth v v;
+  traceValSeqNFn = f: depth: v: traceSeqN depth (f v) v;
+  traceValSeqN = traceValSeqNFn id;
 
 
   # this can help debug your code as well - designed to not produce thousands of lines

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -11,10 +11,6 @@ in
 
 rec {
 
-  inherit (builtins) addErrorContext;
-
-  addErrorContextToAttrs = lib.mapAttrs (a: v: lib.addErrorContext "while evaluating ${a}" v);
-
   traceIf = p: msg: x: if p then trace msg x else x;
 
   traceValFn = f: x: trace (f x) x;
@@ -97,6 +93,12 @@ rec {
     trace ( "Warning: `traceValIfNot` is deprecated "
           + "and will be removed in the next release." )
     (if c x then true else traceSeq (showVal x) false);
+
+
+  addErrorContextToAttrs = attrs:
+    trace ( "Warning: `addErrorContextToAttrs` is deprecated "
+          + "and will be removed in the next release." )
+    (lib.mapAttrs (a: v: lib.addErrorContext "while evaluating ${a}" v) attrs);
 
   /* Evaluate a set of tests.  A test is an attribute set {expr,
      expected}, denoting an expression and its expected result.  The

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -117,7 +117,9 @@ rec {
 
   attrNamesToStr = a:
     trace ( "Warning: `attrNamesToStr` is deprecated "
-          + "and will be removed in the next release." )
+          + "and will be removed in the next release. "
+          + "Please use more specific concatenation "
+          + "for your uses (`lib.concat(Map)StringsSep`)." )
     (lib.concatStringsSep "; " (map (x: "${x}=") (attrNames a)));
 
   showVal = with lib;
@@ -142,11 +144,13 @@ rec {
 
   traceXMLVal = x:
     trace ( "Warning: `traceXMLVal` is deprecated "
-          + "and will be removed in the next release." )
+          + "and will be removed in the next release. "
+          + "Please use `traceValFn builtins.toXML`." )
     (trace (builtins.toXML x) x);
   traceXMLValMarked = str: x:
     trace ( "Warning: `traceXMLValMarked` is deprecated "
-          + "and will be removed in the next release." )
+          + "and will be removed in the next release. "
+          + "Please use `traceValFn (x: str + builtins.toXML x)`." )
     (trace (str + builtins.toXML x) x);
 
   # trace the arguments passed to function and its result
@@ -157,13 +161,15 @@ rec {
 
   traceValIfNot = c: x:
     trace ( "Warning: `traceValIfNot` is deprecated "
-          + "and will be removed in the next release." )
+          + "and will be removed in the next release. "
+          + "Please use `if/then/else` and `traceValSeq 1`.")
     (if c x then true else traceSeq (showVal x) false);
 
 
   addErrorContextToAttrs = attrs:
     trace ( "Warning: `addErrorContextToAttrs` is deprecated "
-          + "and will be removed in the next release." )
+          + "and will be removed in the next release. "
+          + "Please use `builtins.addErrorContext` directly." )
     (lib.mapAttrs (a: v: lib.addErrorContext "while evaluating ${a}" v) attrs);
 
   # example: (traceCallXml "myfun" id 3) will output something like
@@ -173,7 +179,8 @@ rec {
   #       args should be printed in any case
   traceCallXml = a:
     trace ( "Warning: `traceCallXml` is deprecated "
-          + "and will be removed in the next release." )
+          + "and will be removed in the next release. "
+          + "Please complain if you use the function regularly." )
     (if !isInt a then
       traceCallXml 1 "calling ${a}\n"
     else

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -128,7 +128,9 @@ rec {
   # note: if result doesn't evaluate you'll get no trace at all (FIXME)
   #       args should be printed in any case
   traceCallXml = a:
-    if !isInt a then
+    trace ( "Warning: `traceCallXml` is deprecated "
+          + "and will be removed in the next release." )
+    (if !isInt a then
       traceCallXml 1 "calling ${a}\n"
     else
       let nr = a;
@@ -140,5 +142,5 @@ rec {
           else
             let r = builtins.seq expr expr;
             in trace "${str}\n result:\n${builtins.toXML r}" r
-      );
+      ));
 }

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -19,9 +19,6 @@ rec {
 
   traceValFn = f: x: trace (f x) x;
   traceVal = traceValFn id;
-  traceXMLVal = x: trace (builtins.toXML x) x;
-  traceXMLValMarked = str: x: trace (str + builtins.toXML x) x;
-
   # strict trace functions (traced structure is fully evaluated and printed)
 
   /* `builtins.trace`, but the value is `builtins.deepSeq`ed first. */
@@ -55,7 +52,12 @@ rec {
   # this can help debug your code as well - designed to not produce thousands of lines
   traceShowVal = x: trace (showVal x) x;
   traceShowValMarked = str: x: trace (str + showVal x) x;
-  attrNamesToStr = a: lib.concatStringsSep "; " (map (x: "${x}=") (attrNames a));
+
+  attrNamesToStr = a:
+    trace ( "Warning: `attrNamesToStr` is deprecated "
+          + "and will be removed in the next release." )
+    (lib.concatStringsSep "; " (map (x: "${x}=") (attrNames a)));
+
   showVal = with lib;
     trace ( "Warning: `showVal` is deprecated "
           + "and will be removed in the next release, "
@@ -75,6 +77,15 @@ rec {
         { allowPrettyValues = true; }
         (modify x);
     in go);
+
+  traceXMLVal = x:
+    trace ( "Warning: `traceXMLVal` is deprecated "
+          + "and will be removed in the next release." )
+    (trace (builtins.toXML x) x);
+  traceXMLValMarked = str: x:
+    trace ( "Warning: `traceXMLValMarked` is deprecated "
+          + "and will be removed in the next release." )
+    (trace (str + builtins.toXML x) x);
 
   # trace the arguments passed to function and its result
   # maybe rewrite these functions in a traceCallXml like style. Then one function is enough

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -93,9 +93,10 @@ rec {
   traceCall2 = n: f: a: b: let t = n2: x: traceShowValMarked "${n} ${n2}:" x; in t "result" (f (t "arg 1" a) (t "arg 2" b));
   traceCall3 = n: f: a: b: c: let t = n2: x: traceShowValMarked "${n} ${n2}:" x; in t "result" (f (t "arg 1" a) (t "arg 2" b) (t "arg 3" c));
 
-  # FIXME: rename this?
   traceValIfNot = c: x:
-    if c x then true else trace (showVal x) false;
+    trace ( "Warning: `traceValIfNot` is deprecated "
+          + "and will be removed in the next release." )
+    (if c x then true else traceSeq (showVal x) false);
 
   /* Evaluate a set of tests.  A test is an attribute set {expr,
      expected}, denoting an expression and its expected result.  The

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -115,11 +115,12 @@ let
       unknownModule mkOption;
     inherit (types) isType setType defaultTypeMerge defaultFunctor
       isOptionType mkOptionType;
-    inherit (debug) addErrorContextToAttrs traceIf traceVal
+    inherit (debug) addErrorContextToAttrs traceIf traceVal traceValFn
       traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
-      traceValSeqN traceShowVal traceShowValMarked
-      showVal traceCall traceCall2 traceCall3 traceValIfNot runTests
-      testAllTrue strict traceCallXml attrNamesToStr;
+      traceValSeqFn traceValSeqN traceValSeqNFn traceShowVal
+      traceShowValMarked showVal traceCall traceCall2 traceCall3
+      traceValIfNot runTests testAllTrue strict traceCallXml
+      attrNamesToStr;
     inherit (misc) maybeEnv defaultMergeArg defaultMerge foldArgs
       defaultOverridableDelayableArgs composedArgsAndFun
       maybeAttrNullable maybeAttr ifEnable checkFlag getValue

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -119,7 +119,7 @@ let
       traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
       traceValSeqFn traceValSeqN traceValSeqNFn traceShowVal
       traceShowValMarked showVal traceCall traceCall2 traceCall3
-      traceValIfNot runTests testAllTrue strict traceCallXml
+      traceValIfNot runTests testAllTrue traceCallXml
       attrNamesToStr;
     inherit (misc) maybeEnv defaultMergeArg defaultMerge foldArgs
       defaultOverridableDelayableArgs composedArgsAndFun

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -159,7 +159,7 @@ rec {
       context = name: ''while evaluating the module argument `${name}' in "${key}":'';
       extraArgs = builtins.listToAttrs (map (name: {
         inherit name;
-        value = addErrorContext (context name)
+        value = builtins.addErrorContext (context name)
           (args.${name} or config._module.args.${name});
       }) requiredArgs);
 
@@ -309,7 +309,7 @@ rec {
           res.mergedValue;
 
     in opt //
-      { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
+      { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
         definitions = map (def: def.value) res.defsFinal;
         files = map (def: def.file) res.defsFinal;
         inherit (res) isDefined;

--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -58,6 +58,11 @@ following incompatible changes:</para>
 <itemizedlist>
   <listitem>
     <para>
+      <literal>lib.strict</literal> is removed. Use <literal>builtins.seq</literal> instead.
+    </para>
+  </listitem>
+  <listitem>
+    <para>
       The <literal>clementine</literal> package points now to the free derivation.
       <literal>clementineFree</literal> is removed now and <literal>clementineUnfree</literal>
       points to the package which is bundled with the unfree <literal>libspotify</literal> package.
@@ -77,6 +82,46 @@ following incompatible changes:</para>
 <itemizedlist>
   <listitem>
     <para>
+      <literal>lib.attrNamesToStr</literal> has been deprecated. Use
+      more specific concatenation (<literal>lib.concat(Map)StringsSep</literal>)
+      instead.
+    </para>
+  </listitem>
+  <listitem>
+    <para>
+      <literal>lib.addErrorContextToAttrs</literal> has been deprecated. Use
+      <literal>builtins.addErrorContext</literal> directly.
+    </para>
+  </listitem>
+  <listitem>
+    <para>
+      <literal>lib.showVal</literal> has been deprecated. Use
+      <literal>lib.traceSeqN</literal> instead.
+    </para>
+  </listitem>
+  <listitem>
+    <para>
+      <literal>lib.traceXMLVal</literal> has been deprecated. Use
+      <literal>lib.traceValFn builtins.toXml</literal> instead.
+    </para>
+  </listitem>
+  <listitem>
+    <para>
+      <literal>lib.traceXMLValMarked</literal> has been deprecated. Use
+      <literal>lib.traceValFn (x: str + builtins.toXML x)</literal> instead.
+    </para>
+  </listitem>
+  <listitem>
+    <para>
+      <literal>lib.traceValIfNot</literal> has been deprecated. Use
+      <literal>if/then/else</literal> and <literal>lib.traceValSeq</literal>
+      instead.
+    </para>
+  </listitem>
+  <listitem>
+    <para>
+      <literal>lib.traceCallXml</literal> has been deprecated. Please complain
+      if you use the function regularly.
     </para>
   </listitem>
 </itemizedlist>

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -33,7 +33,11 @@ let
   configType = mkOptionType {
     name = "nixpkgs-config";
     description = "nixpkgs config";
-    check = traceValIfNot isConfig;
+    check = x:
+      let traceXIfNot = c:
+            if c x then true
+            else lib.traceSeqN 1 x false;
+      in traceXIfNot isConfig;
     merge = args: fold (def: mergeConfig def.value) {};
   };
 

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -224,7 +224,7 @@ let
           else if builtins.isAttrs x && builtins ? out then toNix "${x}" # a derivation
           else if builtins.isAttrs x then "{${lib.concatStringsSep ", " (lib.mapAttrsToList (n: v: "${toNix n}: ${toNix v}") x)}}"
           else if builtins.isList x then "[${lib.concatMapStringsSep ", " toNix x}]"
-          else throw "turning ${lib.showVal x} into a VimL thing not implemented yet";
+          else throw "turning ${lib.generators.toPretty {} x} into a VimL thing not implemented yet";
 
       in assert builtins.hasAttr "vim-addon-manager" knownPlugins;
       ''


### PR DESCRIPTION
The `debug` module is very useful for day-to-day nix programming, but hasn’t seen a lot of care and aquired quite a lot of cruft.

Main changes:
* add `*Val*Fn` group of functions
* remove deprecated `strict` function
* deprecate the `showVal` group of functions because `traceSeqN` should be strictly more general
* deprecate the `Xml`-group of functions, because they are mostly trivial and/or overly specific
* deprecate `traceValIfNot` and `addErrorContextToAttrs`
* document the module and tracing functions

More detailed reasoning is included in each commit description.