### PR TITLE
nbstripout: fix tests

### DIFF
--- a/pkgs/applications/version-management/nbstripout/default.nix
+++ b/pkgs/applications/version-management/nbstripout/default.nix
@@ -1,4 +1,4 @@
-{lib, python2Packages, git, mercurial, coreutils}:
+{lib, python2Packages, fetchFromGitHub, fetchurl, git, mercurial, coreutils}:
 
 with python2Packages;
 buildPythonApplication rec {
@@ -12,10 +12,29 @@ buildPythonApplication rec {
   buildInputs = [ pytest pytest-flake8 pytest-cram git pytestrunner ];
   propagatedBuildInputs = [ ipython nbformat ];
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b997c99b8bbb865988202d2f005cdaabb2598b07dad891c302a147a5871a4a95";
+  # PyPI source is currently missing tests. Thus, use GitHub instead.
+  # See: https://github.com/kynan/nbstripout/issues/73
+  # Use PyPI again after it has been fixed in a release.
+  src = fetchFromGitHub {
+    owner = "kynan";
+    repo = pname;
+    rev = version;
+    sha256 = "1jifqmszjzyaqzaw2ir83k5fdb04iyxdad4lclawpb42hbink9ws";
   };
+
+  patches = [
+    (
+      # Fix git diff tests by using --no-index.
+      # See: https://github.com/kynan/nbstripout/issues/74
+      #
+      # Remove this patch once the pull request has been merged and a new
+      # release made.
+      fetchurl {
+        url = "https://github.com/jluttine/nbstripout/commit/03e28424fb788dd09a95e99814977b0d0846c0b4.patch";
+        sha256 = "09myfb77a2wh8lqqs9fcpam97vmaw8b7zbq8n5gwn6d80zbl7dn0";
+      }
+    )
+  ];
 
   # for some reason, darwin uses /bin/sh echo native instead of echo binary, so
   # force using the echo binary


### PR DESCRIPTION

###### Motivation for this change

Building of nbstripout has failed after the version was bumped to 0.3.1 because:
the test files were missing from the new release tarball. This adds tests by
using the release tarball from GitHub instead of PyPI.

However, these tests fail because of a bug in one test. Thus, a patch is used to
fix the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

