### PR TITLE
nix-pin: init at 0.1.2

### DIFF
--- a/pkgs/tools/package-management/nix-pin/default.nix
+++ b/pkgs/tools/package-management/nix-pin/default.nix
@@ -1,0 +1,32 @@
+{ pkgs, stdenv, fetchFromGitHub, mypy, python3 }:
+let self = stdenv.mkDerivation rec {
+  name = "nix-pin-${version}";
+  version = "0.1.2";
+  src = fetchFromGitHub {
+    owner = "timbertson";
+    repo = "nix-pin";
+    rev = "version-0.1.2";
+    sha256 = "1zwfb5198qzbjwivgiaxbwva9frgrrqaj92nw8vz95yi08pijssh";
+  };
+  buildInputs = [ python3 mypy ];
+  buildPhase = ''
+    mypy bin/*
+  '';
+  installPhase = ''
+    mkdir "$out"
+    cp -r bin share "$out"
+  '';
+  passthru = {
+    callWithPins = path: args:
+      import "${self}/share/nix/call.nix" {
+        inherit pkgs path args;
+      };
+  };
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/timbertson/nix-pin";
+    description = "nixpkgs development utility";
+    license = licenses.mit;
+    maintainers = [ maintainers.timbertson ];
+    platforms = platforms.all;
+  };
+}; in self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20509,6 +20509,8 @@ with pkgs;
 
   nix-index = callPackage ../tools/package-management/nix-index { };
 
+  nix-pin = callPackage ../tools/package-management/nix-pin { };
+
   inherit (callPackages ../tools/package-management/nix-prefetch-scripts { })
     nix-prefetch-bzr
     nix-prefetch-cvs


### PR DESCRIPTION
###### Motivation for this change

Introduces nix pin (https://github.com/timbertson/nix-pin) at 0.1.2.

Nix pin is a development utility for "pinning" individual nixpkgs derivations to in-development versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

