### PR TITLE
webkitgtk: fix non-deterministic build failure

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.20.nix
+++ b/pkgs/development/libraries/webkitgtk/2.20.nix
@@ -39,6 +39,12 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
+  postConfigure = ''
+    # A stopgap for a non-deterministic build failure when using only one core
+    # Upstream bug: https://bugs.webkit.org/show_bug.cgi?id=183788#c4
+    ninja JavaScriptCoreForwardingHeaders WTFForwardingHeaders
+  '';
+
   cmakeFlags = [
   "-DPORT=GTK"
   "-DUSE_LIBHYPHEN=0"


### PR DESCRIPTION
###### Motivation for this change

The build sometimes fails, due to some necessary header files being generated too late. Building with `--cores 1` seems to always trigger the issue. See upstream bug: https://bugs.webkit.org/show_bug.cgi?id=183788

This is a stopgap which simply generates the header files before compilation starts (at `postConfigure`) and should be removed when the problem is fixed upstream. It might not be ideal, but seems far better than having `webkitgtk` hold up `nixos-unstable`, and in the best case causing manual labor restarting hydra jobs.

fixes  #37878 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

