### PR TITLE
nixos/doc: fix instructions for nox-review usage

### DIFF
--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -317,11 +317,11 @@ Additional information.
     </para>
     <para>
       review uncommitted changes:
-      <screen>nix-shell -p nox --run nox-review wip</screen>
+      <screen>nix-shell -p nox --run "nox-review wip"</screen>
     </para>
     <para>
       review changes from pull request number 12345:
-      <screen>nix-shell -p nox --run nox-review pr 12345</screen>
+      <screen>nix-shell -p nox --run "nox-review pr 12345"</screen>
     </para>
   </section>
   <section>


### PR DESCRIPTION
###### Motivation for this change

I was submitting a change and the instructions in the manual for running `nox-review` did not work and I was uncertain why. Then I realized that the instructions in the template were slightly different, needing quotes after `--run` so I tried that and it worked. Fixing the manual instructions to match the PR template.

Relevant PR template part:

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`


