### PR TITLE
cryptsetup: 1.7.5 -> 2.0.2

### DIFF
--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -1,6 +1,5 @@
 { stdenv, fetchurl, devicemapper, json_c, openssl, libuuid, pkgconfig, popt
-, enablePython ? false, python2 ? null
-}:
+, enablePython ? false, python2 ? null }:
 
 assert enablePython -> python2 != null;
 
@@ -12,12 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "15wyjfgcqjf0wy5gxnmjj8aah33csv5v6n1hv9c8sxdzygbhb0ag";
   };
 
-  configureFlags = [ "--enable-cryptsetup-reencrypt" "--with-crypto_backend=openssl" ]
-                ++ stdenv.lib.optional enablePython "--enable-python";
+  NIX_LDFLAGS = "-lgcc_s";
+
+  configureFlags = [
+    "--disable-kernel_crypto"
+    "--enable-cryptsetup-reencrypt"
+    "--with-crypto_backend=openssl"
+  ] ++ stdenv.lib.optional enablePython "--enable-python";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ devicemapper json_c openssl libuuid popt ]
-             ++ stdenv.lib.optional enablePython python2;
+    ++ stdenv.lib.optional enablePython python2;
 
   meta = {
     homepage = https://gitlab.com/cryptsetup/cryptsetup/;

--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchurl, devicemapper, openssl, libuuid, pkgconfig, popt
+{ stdenv, fetchurl, devicemapper, json_c, openssl, libuuid, pkgconfig, popt
 , enablePython ? false, python2 ? null
 }:
 
 assert enablePython -> python2 != null;
 
 stdenv.mkDerivation rec {
-  name = "cryptsetup-1.7.5";
+  name = "cryptsetup-2.0.2";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/utils/cryptsetup/v1.7/${name}.tar.xz";
-    sha256 = "1gail831j826lmpdx2gsc83lp3br6wfnwh3vqwxaa1nn1lfwsc1b";
+    url = "mirror://kernel/linux/utils/cryptsetup/v2.0/${name}.tar.xz";
+    sha256 = "15wyjfgcqjf0wy5gxnmjj8aah33csv5v6n1hv9c8sxdzygbhb0ag";
   };
 
   configureFlags = [ "--enable-cryptsetup-reencrypt" "--with-crypto_backend=openssl" ]
                 ++ stdenv.lib.optional enablePython "--enable-python";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ devicemapper openssl libuuid popt ]
+  buildInputs = [ devicemapper json_c openssl libuuid popt ]
              ++ stdenv.lib.optional enablePython python2;
 
   meta = {


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

