### PR TITLE
python3Packages.black: init at 18.4a0

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -14,8 +14,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ attrs click ];
 
   meta = with stdenv.lib; {
-    description = "The uncompromising Python code formatter.";
-    homepage    = "https://github.com/ambv/black";
+    description = "The uncompromising Python code formatter";
+    homepage    = https://github.com/ambv/black;
     license     = licenses.mit;
     maintainers = with maintainers; [ sveitser ];
   };

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, attrs, click }:
+
+buildPythonPackage rec {
+  pname = "black";
+  version = "18.4a0";
+  name = "${pname}-${version}";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04dffr4wmzs4vf2xj0cxp03hv04x0kk06qyzx6jjrp1mq0z3n2rr";
+  };
+
+  propagatedBuildInputs = [ attrs click ];
+
+  meta = with stdenv.lib; {
+    description = "The uncompromising Python code formatter.";
+    homepage    = "https://github.com/ambv/black";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ sveitser ];
+  };
+
+}

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "black";
   version = "18.4a0";
-  name = "${pname}-${version}";
 
   disabled = pythonOlder "3.6";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20174,6 +20174,8 @@ EOF
 
   yapf = callPackage ../development/python-modules/yapf { };
 
+  black = callPackage ../development/python-modules/black { };
+
   autobahn = callPackage ../development/python-modules/autobahn { };
 
   jsonref = callPackage ../development/python-modules/jsonref { };


### PR DESCRIPTION
###### Motivation for this change
Add python code formatter `black`: https://github.com/ambv/black.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

