### PR TITLE
Revert "git: 2.16.3 -> 2.17.0"

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  version = "2.17.0";
+  version = "2.16.3";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "1ismz7nsz8dgjmk782xr9s0mr2qh06f72pdcgbxfmnw1bvlya5p9";
+    sha256 = "0j1dwvg5llnj3g0fp8hdgpms4hp90qw9f6509vqw30dhwplrjpfn";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#38354

Apologies, folks!

2.17.0 changes some things regarding its perl usage:

* $out/lib/perl5 is no longer populated, particularly $out/lib/perl5/site_perl
* We may want to set `NO_PERL_CPAN_FALLBACKS`, see [2.17.0 release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.17.0.txt)

My usage only encountered minor strangeness but until this is revisited and vetted to be handled properly I think it should be reverted.