### PR TITLE
Fix gnome-shell-extensions-3.28.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, meson, ninja, gettext, pkgconfig, spidermonkey_52, glib, gnome3 }:
+{ stdenv, fetchurl, meson, ninja, gettext, pkgconfig, spidermonkey_52, glib
+, gnome3, substituteAll }:
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extensions-${version}";
@@ -15,6 +16,13 @@ stdenv.mkDerivation rec {
       attrPath = "gnome3.gnome-shell-extensions";
     };
   };
+
+  patches = [
+    (substituteAll {
+      src = ./fix_gmenu.patch;
+      gmenu_path = "${gnome3.gnome-menus}/lib/girepository-1.0";
+    })
+  ];
 
   doCheck = true;
 

--- a/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
@@ -23,6 +23,28 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [ "-Dextension_set=all" ];
 
+  preFixup = ''
+    # The meson build doesn't compile the schemas.
+    # Fixup adapted from export-zips.sh in the source.
+
+    extensiondir=$out/share/gnome-shell/extensions
+    schemadir=$out/share/gsettings-schemas/gnome-shell-extensions-3.28.0/glib-2.0/schemas/
+
+    glib-compile-schemas $schemadir
+
+    for f in $extensiondir/*; do
+      name=`basename ''${f%%@*}`
+      uuid=$name@gnome-shell-extensions.gcampax.github.com
+      schema=$schemadir/org.gnome.shell.extensions.$name.gschema.xml
+
+      if [ -f $schema ]; then
+        mkdir $f/schemas
+        ln -s $schema $f/schemas;
+        glib-compile-schemas $f/schemas
+      fi
+    done
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/GnomeShell/Extensions;
     description = "Modify and extend GNOME Shell functionality and behavior";

--- a/pkgs/desktops/gnome-3/core/gnome-shell-extensions/fix_gmenu.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-shell-extensions/fix_gmenu.patch
@@ -1,0 +1,24 @@
+From f72924a59d4a30daefccf84526bd854ebbe65ac8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Hedin=20Br=C3=B8nner?= <torhedinbronner@gmail.com>
+Date: Tue, 3 Apr 2018 14:13:12 +0200
+Subject: [PATCH] Fix gmenu typelib path
+
+---
+ extensions/apps-menu/extension.js | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/extensions/apps-menu/extension.js b/extensions/apps-menu/extension.js
+index 5b38213..d706f64 100644
+--- a/extensions/apps-menu/extension.js
++++ b/extensions/apps-menu/extension.js
+@@ -1,5 +1,7 @@
+ /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
+ 
++imports.gi.GIRepository.Repository.prepend_search_path('@gmenu_path@');
++
+ const Atk = imports.gi.Atk;
+ const DND = imports.ui.dnd;
+ const GMenu = imports.gi.GMenu;
+-- 
+2.16.2
+

--- a/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
@@ -24,6 +24,8 @@ in stdenv.mkDerivation rec {
     libsoup gnome3.gnome-settings-daemon gnome3.nautilus
     gnome3.mutter gnome3.gnome-desktop gobjectIntrospection
     gnome3.nautilus
+    # Makes it possible to select user themes through the `user-theme` extension
+    gnome3.gnome-shell-extensions
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

This fixes three problems that surfaced when upgrading to gnome 3.28

1. The new meson build doesn't compile the schema files.

2. The `apps-menu` extension broke by `gnome-shell` no longer depending on `gnome-menus`.

3. Lastly `gnome-tweaks` didn't find the necessary files to let users change themes when the `user-theme` extension was enabled.

cc @jtojnar 

fixes #38377 

###### Things done

Light testing of the changes in a VM on top of `nixos-unstable`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

