### PR TITLE
gvfs: fix non-deterministic build failure

### DIFF
--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -5,7 +5,16 @@
 , gnomeSupport ? false, gnome, makeWrapper
 , libimobiledevice, libbluray, libcdio-paranoia, libnfs, openssh
 , libsecret, libgdata
+# Remove when switching back to meson
+, autoreconfHook, lzma, bzip2
 }:
+
+# TODO: switch to meson when upstream fixes a non-deterministic build failure
+# See https://bugzilla.gnome.org/show_bug.cgi?id=794549
+
+# Meson specific things are commented out and annotated, so switching back
+# should simply require deleting autotools specific things and adding back meson
+# flags etc.
 
 let
   pname = "gvfs";
@@ -19,13 +28,15 @@ stdenv.mkDerivation rec {
     sha256 = "1fsn6aa9a68cfbna9s00l1ry4ym1fr7ii2f45hzj2fipxfpqihwy";
   };
 
-  postPatch = ''
-    chmod +x meson_post_install.py # patchShebangs requires executable file
-    patchShebangs meson_post_install.py
-  '';
+  # Uncomment when switching back to meson
+  # postPatch = ''
+  #   chmod +x meson_post_install.py # patchShebangs requires executable file
+  #   patchShebangs meson_post_install.py
+  # '';
 
   nativeBuildInputs = [
-    meson ninja
+    autoreconfHook # Remove when switching to meson
+    # meson ninja
     pkgconfig gettext makeWrapper
     libxml2 libxslt docbook_xsl docbook_xml_dtd_42
   ];
@@ -35,24 +46,30 @@ stdenv.mkDerivation rec {
       libgphoto2 avahi libarchive fuse libcdio
       samba libmtp libcap polkit libimobiledevice libbluray
       libcdio-paranoia libnfs openssh
+      # Remove when switching back to meson
+      lzma bzip2
       # ToDo: a ligther version of libsoup to have FTP/HTTP support?
     ] ++ stdenv.lib.optionals gnomeSupport (with gnome; [
       libsoup gcr
       gnome-online-accounts libsecret libgdata
     ]);
 
-  mesonFlags = [
-    "-Dgio_module_dir=lib/gio/modules"
-    "-Dsystemduserunitdir=lib/systemd/user"
-    "-Ddbus_service_dir=share/dbus-1/services"
-    "-Dtmpfilesdir=no"
-  ] ++ stdenv.lib.optionals (!gnomeSupport) [
-    "-Dgcr=false" "-Dgoa=false" "-Dkeyring=false" "-Dhttp=false"
-    "-Dgoogle=false"
-  ] ++ stdenv.lib.optionals (samba == null) [
-    # Xfce don't want samba
-    "-Dsmb=false"
-  ];
+  # Remove when switching back to meson
+  configureFlags = stdenv.lib.optional (!gnomeSupport) "--disable-gcr";
+
+  # Uncomment when switching back to meson
+  # mesonFlags = [
+  #   "-Dgio_module_dir=lib/gio/modules"
+  #   "-Dsystemduserunitdir=lib/systemd/user"
+  #   "-Ddbus_service_dir=share/dbus-1/services"
+  #   "-Dtmpfilesdir=no"
+  # ] ++ stdenv.lib.optionals (!gnomeSupport) [
+  #   "-Dgcr=false" "-Dgoa=false" "-Dkeyring=false" "-Dhttp=false"
+  #   "-Dgoogle=false"
+  # ] ++ stdenv.lib.optionals (samba == null) [
+  #   # Xfce don't want samba
+  #   "-Dsmb=false"
+  # ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Building `gvfs` with meson causes non-deterministic build failures so switch back to autotools until upstream fixes meson properly. See upstream bug: https://bugzilla.gnome.org/show_bug.cgi?id=794549

fixes #38378 

###### Things done

I opted for commenting out meson specific lines and annotating what needs to be deleted/uncommented when switching back to meson.

Tested out with a VM running gnome-shell, and things seemed to work.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

