### PR TITLE
weechat: allow specifying dicts for spellchecking

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -83,25 +83,36 @@ in if configure == null then weechat else
     config = configure {
       availablePlugins = let
           simplePlugin = name: {pluginFile = "${weechat.${name}}/lib/weechat/plugins/${name}.so";};
-        in rec {
-          python = {
-            pluginFile = "${weechat.python}/lib/weechat/plugins/python.so";
-            withPackages = pkgsFun: (python // {
+        in
+          lib.optionalAttrs pythonSupport {
+            python = {
+              pluginFile = "${weechat.python}/lib/weechat/plugins/python.so";
+              withPackages = pkgsFun: (python // {
+                extraEnv = ''
+                  export PYTHONHOME="${pythonPackages.python.withPackages pkgsFun}"
+                '';
+              });
+            };
+          } //
+          lib.optionalAttrs perlSupport {
+            perl = (simplePlugin "perl") // {
               extraEnv = ''
-                export PYTHONHOME="${pythonPackages.python.withPackages pkgsFun}"
+                export PATH="${perlInterpreter}/bin:$PATH"
               '';
-            });
+            };
+          } //
+          lib.optionalAttrs tclSupport {
+            tcl = simplePlugin "tcl";
+          } //
+          lib.optionalAttrs rubySupport {
+            ruby = simplePlugin "ruby";
+          } //
+          lib.optionalAttrs guileSupport {
+            guile = simplePlugin "guile";
+          } //
+          lib.optionalAttrs luaSupport {
+            lua = simplePlugin "lua";
           };
-          perl = (simplePlugin "perl") // {
-            extraEnv = ''
-              export PATH="${perlInterpreter}/bin:$PATH"
-            '';
-          };
-          tcl = simplePlugin "tcl";
-          ruby = simplePlugin "ruby";
-          guile = simplePlugin "guile";
-          lua = simplePlugin "lua";
-        };
       };
 
     inherit (config) plugins;

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -80,6 +80,7 @@ let
 in if configure == null then weechat else
   let
     perlInterpreter = perl;
+    pythonInterpreter = python;
     config = configure {
       availablePlugins = let
           simplePlugin = name: {pluginFile = "${weechat.${name}}/lib/weechat/plugins/${name}.so";};
@@ -87,6 +88,9 @@ in if configure == null then weechat else
           lib.optionalAttrs pythonSupport {
             python = {
               pluginFile = "${weechat.python}/lib/weechat/plugins/python.so";
+              extraEnv = ''
+                export PATH="${pythonInterpreter}/bin:$PATH"
+              '';
               withPackages = pkgsFun: (python // {
                 extraEnv = ''
                   export PYTHONHOME="${pythonPackages.python.withPackages pkgsFun}"

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, lib
+{ stdenv, fetchurl, lib
 , ncurses, openssl, aspell, gnutls
 , zlib, curl, pkgconfig, libgcrypt
 , cmake, makeWrapper, libobjc, libresolv, libiconv

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -12,13 +12,13 @@
 , pythonSupport ? true, pythonPackages
 , rubySupport ? true, ruby
 , tclSupport ? true, tcl
-, weechatEnchantHunspellDicts ? [] # A list of derivations from pkgs.hunspellDicts
-, useEnchant ? (weechatEnchantHunspellDicts != [])
+, enchantHunspellDicts ? [] # A list of derivations from pkgs.hunspellDicts
+, useEnchant ? (enchantHunspellDicts != [])
 , extraBuildInputs ? []
 , configure ? { availablePlugins, ... }: { plugins = builtins.attrValues availablePlugins; }
 , runCommand }:
 
-assert (weechatEnchantHunspellDicts != []) -> useEnchant;
+assert (enchantHunspellDicts != []) -> useEnchant;
 
 let
   inherit (pythonPackages) python pycrypto pync;
@@ -34,7 +34,7 @@ let
 
   enchantHunspellDictEnv = buildEnv{
     name = "weechat-enchant-hunspell-dicts";
-    paths = weechatEnchantHunspellDicts;
+    paths = enchantHunspellDicts;
   };
 
   weechat =
@@ -61,7 +61,7 @@ let
         "-DENABLE_ENCHANT=${if useEnchant then "ON" else "OFF"}"
         "-DASPELL_DICT_DIR=\"${aspell}/lib/aspell\""
       ]
-        ++ optional (weechatEnchantHunspellDicts != []) "-DENCHANT_MYSPELL_DICT_DIR=\"${enchantHunspellDictEnv}/share/hunspell\""
+        ++ optional (enchantHunspellDicts != []) "-DENCHANT_MYSPELL_DICT_DIR=\"${enchantHunspellDictEnv}/share/hunspell\""
         ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib" "-DCMAKE_FIND_FRAMEWORK=LAST"]
         ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins
         ;

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -12,14 +12,12 @@
 , pythonSupport ? true, pythonPackages
 , rubySupport ? true, ruby
 , tclSupport ? true, tcl
-, weechatAspellDicts ? [] # A list of derivations from pkgs.aspellDicts
 , weechatEnchantHunspellDicts ? [] # A list of derivations from pkgs.hunspellDicts
 , useEnchant ? (weechatEnchantHunspellDicts != [])
 , extraBuildInputs ? []
 , configure ? { availablePlugins, ... }: { plugins = builtins.attrValues availablePlugins; }
 , runCommand }:
 
-assert (weechatAspellDicts != []) -> !useEnchant;
 assert (weechatEnchantHunspellDicts != []) -> useEnchant;
 
 let
@@ -33,11 +31,6 @@ let
     { name = "python"; enabled = pythonSupport; cmakeFlag = "ENABLE_PYTHON"; buildInputs = [ python ]; }
   ];
   enabledPlugins = builtins.filter (p: p.enabled) plugins;
-
-  aspellDictEnv = buildEnv{
-    name = "weechat-aspell-dicts";
-    paths = weechatAspellDicts;
-  };
 
   enchantHunspellDictEnv = buildEnv{
     name = "weechat-enchant-hunspell-dicts";
@@ -66,8 +59,8 @@ let
         "-DENABLE_MAN=ON"
         "-DENABLE_DOC=ON"
         "-DENABLE_ENCHANT=${if useEnchant then "ON" else "OFF"}"
+        "-DASPELL_DICT_DIR=\"${aspell}/lib/aspell\""
       ]
-        ++ optional (weechatAspellDicts != []) "-DASPELL_DICT_DIR=\"${aspellDictEnv}/lib/aspell\""
         ++ optional (weechatEnchantHunspellDicts != []) "-DENCHANT_MYSPELL_DICT_DIR=\"${enchantHunspellDictEnv}/share/hunspell\""
         ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib" "-DCMAKE_FIND_FRAMEWORK=LAST"]
         ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins

--- a/pkgs/applications/networking/irc/weechat/dict-dir.patch
+++ b/pkgs/applications/networking/irc/weechat/dict-dir.patch
@@ -1,0 +1,85 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7fb7d0620..e59a36c47 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -114,6 +114,14 @@ option(ENABLE_MAN        "Enable build of man page"                  OFF)
+ option(ENABLE_DOC        "Enable build of documentation"             OFF)
+ option(ENABLE_TESTS      "Enable tests"                              OFF)
+ 
++if(DEFINED ASPELL_DICT_DIR)
++  add_definitions(-DASPELL_DICT_DIR=${ASPELL_DICT_DIR})
++endif()
++
++if(DEFINED ENCHANT_MYSPELL_DICT_DIR)
++  add_definitions(-DENCHANT_MYSPELL_DICT_DIR=${ENCHANT_MYSPELL_DICT_DIR})
++endif()
++
+ # option WEECHAT_HOME
+ if(NOT DEFINED WEECHAT_HOME OR "${WEECHAT_HOME}" STREQUAL "")
+   set(WEECHAT_HOME "~/.weechat")
+diff --git a/src/plugins/aspell/weechat-aspell-command.c b/src/plugins/aspell/weechat-aspell-command.c
+index 5d4c0cc6c..fcae73ac9 100644
+--- a/src/plugins/aspell/weechat-aspell-command.c
++++ b/src/plugins/aspell/weechat-aspell-command.c
+@@ -159,6 +159,9 @@ weechat_aspell_command_speller_list_dicts ()
+                                NULL);
+ #else
+     config = new_aspell_config();
++#ifdef ASPELL_DICT_DIR
++    aspell_config_replace (config, "dict-dir", ASPELL_DICT_DIR);
++#endif
+     list = get_aspell_dict_info_list (config);
+     elements = aspell_dict_info_list_elements (list);
+ 
+diff --git a/src/plugins/aspell/weechat-aspell-completion.c b/src/plugins/aspell/weechat-aspell-completion.c
+index 12a8f1470..a6c43d907 100644
+--- a/src/plugins/aspell/weechat-aspell-completion.c
++++ b/src/plugins/aspell/weechat-aspell-completion.c
+@@ -107,6 +107,9 @@ weechat_aspell_completion_dicts_cb (const void *pointer, void *data,
+                                completion);
+ #else
+     config = new_aspell_config ();
++#ifdef ASPELL_DICT_DIR
++    aspell_config_replace (config, "dict-dir", ASPELL_DICT_DIR);
++#endif
+     list = get_aspell_dict_info_list (config);
+     elements = aspell_dict_info_list_elements (list);
+ 
+diff --git a/src/plugins/aspell/weechat-aspell-speller.c b/src/plugins/aspell/weechat-aspell-speller.c
+index 52bde0163..7d1917de6 100644
+--- a/src/plugins/aspell/weechat-aspell-speller.c
++++ b/src/plugins/aspell/weechat-aspell-speller.c
+@@ -65,6 +65,9 @@ weechat_aspell_speller_dict_supported (const char *lang)
+     rc = 0;
+ 
+     config = new_aspell_config ();
++#ifdef ASPELL_DICT_DIR
++    aspell_config_replace (config, "dict-dir", ASPELL_DICT_DIR);
++#endif
+     list = get_aspell_dict_info_list (config);
+     elements = aspell_dict_info_list_elements (list);
+ 
+@@ -163,6 +166,9 @@ weechat_aspell_speller_new (const char *lang)
+     /* create a speller instance for the newly created cell */
+     config = new_aspell_config();
+     aspell_config_replace (config, "lang", lang);
++#ifdef ASPELL_DICT_DIR
++    aspell_config_replace (config, "dict-dir", ASPELL_DICT_DIR);
++#endif
+ #endif /* USE_ENCHANT */
+ 
+     /* apply all options */
+diff --git a/src/plugins/aspell/weechat-aspell.c b/src/plugins/aspell/weechat-aspell.c
+index 376762b3a..4aee18b6a 100644
+--- a/src/plugins/aspell/weechat-aspell.c
++++ b/src/plugins/aspell/weechat-aspell.c
+@@ -1049,6 +1049,9 @@ weechat_plugin_init (struct t_weechat_plugin *plugin, int argc, char *argv[])
+     broker = enchant_broker_init ();
+     if (!broker)
+         return WEECHAT_RC_ERROR;
++#ifdef ENCHANT_MYSPELL_DICT_DIR
++    enchant_broker_set_param(broker, "enchant.myspell.dictionary.path", ENCHANT_MYSPELL_DICT_DIR);
++#endif
+ #endif /* USE_ENCHANT */
+ 
+     if (!weechat_aspell_speller_init ())


### PR DESCRIPTION
Use as so:

```nix 
weechat = super.weechat.override {
 weechatEnchantHunspellDicts = [pkgs.hunspellDicts.en-us];
}
```

```nix 
weechat = super.weechat.override {
 weechatAspellDicts = [pkgs.aspellDicts.en];
}
```