### PR TITLE
Update OpenJDK 10 and Eclipse to GTK 3

### DIFF
--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -1,5 +1,5 @@
 { stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender
-, zlib, jdk, glib, gtk2, libXtst, gsettings-desktop-schemas, webkitgtk24x-gtk2
+, zlib, jdk, glib, gtk3, libXtst, gsettings-desktop-schemas, webkitgtk
 , makeWrapper, ... }:
 
 { name, src ? builtins.getAttr stdenv.system sources, sources ? null, description }:
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    fontconfig freetype glib gsettings-desktop-schemas gtk2 jdk libX11
+    fontconfig freetype glib gsettings-desktop-schemas gtk3 jdk libX11
     libXrender libXtst makeWrapper zlib
-  ] ++ stdenv.lib.optional (webkitgtk24x-gtk2 != null) webkitgtk24x-gtk2;
+  ] ++ stdenv.lib.optional (webkitgtk != null) webkitgtk;
 
   buildCommand = ''
     # Unpack tarball.
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper $out/eclipse/eclipse $out/bin/eclipse \
       --prefix PATH : ${jdk}/bin \
-      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk2 libXtst ] ++ stdenv.lib.optional (webkitgtk24x-gtk2 != null) webkitgtk24x-gtk2)} \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk3 libXtst ] ++ stdenv.lib.optional (webkitgtk != null) webkitgtk)} \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
       --add-flags "-configuration \$HOME/.eclipse/''${productId}_$productVersion/configuration"
 

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, makeDesktopItem, makeWrapper
 , freetype, fontconfig, libX11, libXext, libXrender, zlib
-, glib, gtk2, libXtst, jdk, gsettings-desktop-schemas
-, webkitgtk24x-gtk2 ? null  # for internal web browser
+, glib, gtk3, libXtst, jdk, gsettings-desktop-schemas
+, webkitgtk ? null  # for internal web browser
 , buildEnv, writeText, runCommand
 , callPackage
 }:
@@ -15,7 +15,7 @@ rec {
 
   buildEclipse = import ./build-eclipse.nix {
     inherit stdenv makeDesktopItem freetype fontconfig libX11 libXrender zlib
-            jdk glib gtk2 libXtst gsettings-desktop-schemas webkitgtk24x-gtk2
+            jdk glib gtk3 libXtst gsettings-desktop-schemas webkitgtk
             makeWrapper;
   };
 

--- a/pkgs/development/compilers/openjdk/10.nix
+++ b/pkgs/development/compilers/openjdk/10.nix
@@ -4,7 +4,7 @@
 , libjpeg, giflib
 , setJavaClassPath
 , minimal ? false
-, enableGnome2 ? true, gtk2, gnome_vfs, glib, GConf
+, enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
 let
@@ -38,7 +38,7 @@ let
       libjpeg giflib libX11 libICE libXext libXrender libXtst libXt libXtst
       libXi libXinerama libXcursor lndir fontconfig
     ] ++ lib.optionals (!minimal && enableGnome2) [
-      gtk2 gnome_vfs GConf glib
+      gtk3 gnome_vfs GConf glib
     ];
 
     patches = [
@@ -80,7 +80,7 @@ let
     NIX_LDFLAGS= lib.optionals (!minimal) [
       "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
     ] ++ lib.optionals (!minimal && enableGnome2) [
-      "-lgtk-x11-2.0" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
+      "-lgtk-3" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
     ];
 
     buildFlags = [ "all" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15236,7 +15236,9 @@ with pkgs;
 
   eaglemode = callPackage ../applications/misc/eaglemode { };
 
-  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse { webkitgtk24x-gtk2 = null; });
+  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse {
+    jdk = jdk10;
+  });
 
   ecs-agent = callPackage ../applications/virtualization/ecs-agent { };
 


### PR DESCRIPTION
###### Motivation for this change

Eclipse's built-in browser wants webkitgtk, but the current version of webkitgtk in nixpkgs is built on gtk3.  So, we need a version of the JDK that's built on gtk3 as well.

I've run with this for a couple of days at work and not noticed any problems with Eclipse.  I also confirmed that `jconsole`, a swing app bundled with the JDK, works.

This is the same change as discussed in #36703, just for Java 10 instead of Java 9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).