### PR TITLE
raspberrypifw: 1.20171029 -> 1.20180313

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "raspberrypi-firmware-${version}";
-  version = "1.20171029";
+  version = "1.20180313";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
     rev = version;
-    sha256 = "12aisha8rlr28310hakps04z9p45kd2wvks0w1vxw1kwfh1ncy9s";
+    sha256 = "0h6zbkwm5n640vap4zs9fwplfq13cqnsksw46sxijzg9g0jhlv9n";
   };
 
   dontStrip = true;    # Stripping breaks some of the binaries


### PR DESCRIPTION
###### Motivation for this change

Update to the latest version.

#22014 also mentiones the camera is working with this fw.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

