### PR TITLE
binutils: No more darwin conditionals

### DIFF
--- a/pkgs/development/compilers/emscripten-fastcomp/default.nix
+++ b/pkgs/development/compilers/emscripten-fastcomp/default.nix
@@ -1,4 +1,4 @@
-{ newScope, stdenv, binutils-raw, wrapCCWith, symlinkJoin }:
+{ newScope, stdenv, binutils, wrapCCWith, symlinkJoin }:
 let
   callPackage = newScope (self // {inherit stdenv;});
 
@@ -7,7 +7,7 @@ let
     emscriptenfastcomp-wrapped = wrapCCWith {
       cc = self.emscriptenfastcomp-unwrapped;
       # Never want Apple's cctools for WASM target
-      bintools = binutils-raw;
+      bintools = binutils;
       libc = stdenv.cc.libc;
       extraBuildCommands = ''
         # hardening flags break WASM support

--- a/pkgs/development/libraries/libbfd/default.nix
+++ b/pkgs/development/libraries/libbfd/default.nix
@@ -1,17 +1,15 @@
 { stdenv, buildPackages
-, fetchurl, fetchpatch, gnu-config, autoreconfHook264, bison
+, fetchurl, fetchpatch, gnu-config, autoreconfHook264, bison, binutils-unwrapped
 , libiberty, zlib
 }:
 
-let inherit (buildPackages.buildPackages) binutils-raw; in
-
 stdenv.mkDerivation rec {
   name = "libbfd-${version}";
-  inherit (binutils-raw.bintools) version src;
+  inherit (binutils-unwrapped) version src;
 
   outputs = [ "out" "dev" ];
 
-  patches = binutils-raw.bintools.patches ++ [
+  patches = binutils-unwrapped.patches ++ [
     ../../tools/misc/binutils/build-components-separately.patch
     (fetchpatch {
       url = "https://raw.githubusercontent.com/mxe/mxe/e1d4c144ee1994f70f86cf7fd8168fe69bd629c6/src/bfd-1-disable-subdir-doc.patch";

--- a/pkgs/development/libraries/libopcodes/default.nix
+++ b/pkgs/development/libraries/libopcodes/default.nix
@@ -1,15 +1,15 @@
 { stdenv, buildPackages
-, fetchurl, autoreconfHook264, bison, binutils-raw
+, fetchurl, autoreconfHook264, bison, binutils-unwrapped
 , libiberty, libbfd
 }:
 
 stdenv.mkDerivation rec {
   name = "libopcodes-${version}";
-  inherit (binutils-raw.bintools) version src;
+  inherit (binutils-unwrapped) version src;
 
   outputs = [ "out" "dev" ];
 
-  patches = binutils-raw.bintools.patches ++ [
+  patches = binutils-unwrapped.patches ++ [
     ../../tools/misc/binutils/build-components-separately.patch
   ];
 

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, binutils-raw, cctools
+{ stdenv, binutils-unwrapped, cctools
 , hostPlatform, targetPlatform
 }:
 
 # Make sure both underlying packages claim to have prepended their binaries
 # with the same targetPrefix.
-assert binutils-raw.targetPrefix == cctools.targetPrefix;
+assert binutils-unwrapped.targetPrefix == cctools.targetPrefix;
 
 let
-  inherit (binutils-raw) targetPrefix;
+  inherit (binutils-unwrapped) targetPrefix;
   cmds = [
     "ar" "ranlib" "as" "dsymutil" "install_name_tool"
     "ld" "strip" "otool" "lipo" "nm" "strings" "size"
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   buildCommand = ''
     mkdir -p $out/bin $out/include
 
-    ln -s ${binutils-raw.bintools.out}/bin/${targetPrefix}c++filt $out/bin/${targetPrefix}c++filt
+    ln -s ${binutils-unwrapped.out}/bin/${targetPrefix}c++filt $out/bin/${targetPrefix}c++filt
 
     # We specifically need:
     # - ld: binutils doesn't provide it on darwin
@@ -38,15 +38,15 @@ stdenv.mkDerivation {
       ln -sf "${cctools}/bin/$i" "$out/bin/$i"
     done
 
-    ln -s ${binutils-raw.bintools.out}/share $out/share
+    ln -s ${binutils-unwrapped.out}/share $out/share
 
     ln -s ${cctools}/libexec $out/libexec
 
     mkdir -p "$info/nix-support" "$man/nix-support"
-    printWords ${binutils-raw.bintools.info} \
+    printWords ${binutils-unwrapped.info} \
       >> $info/nix-support/propagated-build-inputs
     # FIXME: cctools missing man pages
-    printWords ${binutils-raw.bintools.man} \
+    printWords ${binutils-unwrapped.man} \
       >> $man/nix-support/propagated-build-inputs
   '';
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -321,11 +321,11 @@ in rec {
       darwin = super.darwin // {
         inherit (darwin) dyld ICU Libsystem libiconv;
       } // lib.optionalAttrs (super.targetPlatform == localSystem) {
-        inherit (darwin) cctools;
+        inherit (darwin) binutils cctools;
       };
     } // lib.optionalAttrs (super.targetPlatform == localSystem) {
       # Need to get rid of these when cross-compiling.
-      inherit binutils binutils-raw;
+      inherit binutils binutils-unwrapped;
     };
   in import ../generic rec {
     name = "stdenv-darwin";
@@ -380,7 +380,7 @@ in rec {
       bzip2.bin llvmPackages.llvm llvmPackages.llvm.lib zlib.out zlib.dev libffi.out coreutils ed diffutils gnutar
       gzip ncurses.out ncurses.dev ncurses.man gnused bash gawk
       gnugrep llvmPackages.clang-unwrapped llvmPackages.clang-unwrapped.lib patch pcre.out gettext
-      binutils-raw.bintools binutils binutils.bintools
+      binutils.bintools darwin.binutils darwin.binutils.bintools
       cc.expand-response-params
     ]) ++ (with pkgs.darwin; [
       dyld Libsystem CF cctools ICU libiconv locale

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -374,7 +374,7 @@ in
         ${localSystem.libc} = getLibc prevStage;
       } // lib.optionalAttrs (super.targetPlatform == localSystem) {
         # Need to get rid of these when cross-compiling.
-        inherit (prevStage) binutils binutils-raw;
+        inherit (prevStage) binutils binutils-unwrapped;
         gcc = cc;
       };
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7464,22 +7464,17 @@ with pkgs;
 
   bin_replace_string = callPackage ../development/tools/misc/bin_replace_string { };
 
-  binutils =
-    if targetPlatform.isDarwin
-    then darwin.binutils
-    else binutils-raw;
-
   binutils-unwrapped = callPackage ../development/tools/misc/binutils {
     # FHS sys dirs presumably only have stuff for the build platform
     noSysDirs = (targetPlatform != buildPlatform) || noSysDirs;
   };
-  binutils-raw = wrapBintoolsWith {
+  binutils = wrapBintoolsWith {
     libc = if targetPlatform != hostPlatform then libcCross else stdenv.cc.libc;
     bintools = binutils-unwrapped;
   };
-
-  binutils_nogold = lowPrio (binutils-raw.override {
-    bintools = binutils-raw.bintools.override {
+  binutils_nogold = lowPrio (wrapBintoolsWith {
+    libc = if targetPlatform != hostPlatform then libcCross else stdenv.cc.libc;
+    bintools = binutils-unwrapped.override {
       gold = false;
     };
   });


### PR DESCRIPTION
###### Motivation for this change

Since at least d7bddc27b23da8ce7bc19cfeeeb0cbebdb5a4410, we've had a
situation where one should depend on:

 - `stdenv.cc.bintools`: for executables at build time
 - `libbfd` or `libiberty`: for those libraries
 - `targetPackages.cc.bintools`: for exectuables at *run* time
 - `binutils`: only for specifically GNU Binutils's executables,
   regardless of the host platform, at run time.

and that commit cleaned up this usage to reflect that. This PR flips the
switch so that:

 - `binutils` is indeed unconditionally GNU Binutils
 - `binutils-raw`, which previously served that role, is gone.

so that the correct usage will be enforced going forward and everything
is simple.

N.B In a few cases `binutils-unwrapped` (which before and now was
unconditionally actual GNU binutils), rather than `binutils` was used to
replace old `binutils-raw` as it is friendly towards some cross
compilation usage by avoiding a reference to the next bootstrapping
change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @kmicklas @nixos/darwin-maintainers
