### PR TITLE
nixos/rootston: Use an attribute set and the new keyboard configuration format

### DIFF
--- a/nixos/modules/programs/rootston.nix
+++ b/nixos/modules/programs/rootston.nix
@@ -26,10 +26,6 @@ in {
       type = types.lines;
       default = "";
       example = ''
-        # Define a keymap (US QWERTY is the default)
-        export XKB_DEFAULT_LAYOUT=de,us
-        export XKB_DEFAULT_VARIANT=nodeadkeys
-        export XKB_DEFAULT_OPTIONS=grp:alt_shift_toggle,caps:escape
       '';
       description = ''
         Shell commands executed just before rootston is started.
@@ -81,6 +77,22 @@ in {
       '';
     };
 
+    extraConfig = mkOption {
+      type = types.attrs;
+      default = { };
+      example = {
+        keyboard = {
+          layout = "de,us";
+          variant = "nodeadkeys";
+          options = "grp:alt_shift_toggle,caps:escape";
+        };
+      };
+      description = ''
+        Extra configuration options for rootston. These options will be merged
+        with the base configuration from config (overriding existing options).
+      '';
+    };
+
     configFile = mkOption {
       type = types.path;
       default = "/etc/rootston.ini";
@@ -94,7 +106,7 @@ in {
 
   config = mkIf cfg.enable {
     environment.etc."rootston.ini".text = lib.generators.toINI {}
-      cfg.config;
+      (lib.recursiveUpdate cfg.config cfg.extraConfig);
     environment.systemPackages = [ rootstonWrapped ] ++ cfg.extraPackages;
 
     hardware.opengl.enable = mkDefault true;

--- a/nixos/modules/programs/rootston.nix
+++ b/nixos/modules/programs/rootston.nix
@@ -53,26 +53,28 @@ in {
     };
 
     config = mkOption {
-      type = types.str;
-      default = ''
-        [keyboard]
-        meta-key = Logo
+      type = types.attrs;
+      default = {
+        keyboard = {
+          meta-key = "Logo";
+        };
 
-        # Sway/i3 like Keybindings
-        # Maps key combinations with commands to execute
-        # Commands include:
-        # - "exit" to stop the compositor
-        # - "exec" to execute a shell command
-        # - "close" to close the current view
-        # - "next_window" to cycle through windows
-        [bindings]
-        Logo+Shift+e = exit
-        Logo+q = close
-        Logo+m = maximize
-        Alt+Tab = next_window
-        Logo+Return = exec weston-terminal
-        Logo+d = exec rofi -show run
-      '';
+        bindings = {
+          # Sway/i3 like Keybindings
+          # Maps key combinations with commands to execute
+          # Commands include:
+          # - "exit" to stop the compositor
+          # - "exec" to execute a shell command
+          # - "close" to close the current view
+          # - "next_window" to cycle through windows
+          "Logo+Shift+e" = "exit";
+          "Logo+q" = "close";
+          "Logo+m" = "maximize";
+          "Alt+Tab" = "next_window";
+          "Logo+Return" = "exec weston-terminal";
+          "Logo+d" = "exec rofi -show run";
+        };
+      };
       description = ''
         Default configuration for rootston (used when called without any
         parameters).
@@ -91,7 +93,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    environment.etc."rootston.ini".text = cfg.config;
+    environment.etc."rootston.ini".text = lib.generators.toINI {}
+      cfg.config;
     environment.systemPackages = [ rootstonWrapped ] ++ cfg.extraPackages;
 
     hardware.opengl.enable = mkDefault true;


### PR DESCRIPTION
###### Motivation for this change

Rootston has a new preferred configuration format for the keyboard. E.g. with `sway` it works with environment variables like this:
```bash
export XKB_DEFAULT_LAYOUT=de,us
export XKB_DEFAULT_VARIANT=nodeadkeys
export XKB_DEFAULT_OPTIONS=grp:alt_shift_toggle,caps:escape
```

But the new preferred way is via the INI configuration file:
```ini
[keyboard]
layout=de,us
variant=nodeadkeys
options=grp:alt_shift_toggle,caps:escape
```

Because the keyboard section is already specified in the default configuration:
```ini
[keyboard]
meta-key=Logo
```
It probably makes sense to use an attrset instead. As a result `config` and `extraConfig` can be merged automatically and converted to the INI configuration format.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@gnidorah: Do you have an opinion on this approach? It makes it possible to extend and override the default configuration with extraConfig but it is probably a bit confusing (attrset vs INI), doesn't support comments (only within the Nix code), and doesn't look as nice in the configuration.nix man page (lib.generators.toPretty doesn't really help either).