### PR TITLE
Refactor TeX Gyre package sets

### DIFF
--- a/pkgs/data/fonts/tex-gyre-math/default.nix
+++ b/pkgs/data/fonts/tex-gyre-math/default.nix
@@ -1,4 +1,4 @@
-{ variant, stdenv, fetchzip }:
+{ stdenv, fetchzip }:
 
 let
   variants = {
@@ -27,40 +27,43 @@ let
       outputHash = "0pa433cgshlypbyrrlp3qq0wg972rngcp37pr8pxdfshgz13q1mm";
     };
   };
-  current = variants."${variant}";
-  dotless_version = builtins.replaceStrings ["."] [""] current.version;
-in stdenv.mkDerivation rec {
-  name = "tex-gyre-${variant}-math-${current.version}";
-  version = "${current.version}";
 
-  src = fetchzip {
-    url = "www.gust.org.pl/projects/e-foundry/tg-math/download/texgyre${variant}-math-${dotless_version}.zip";
-    sha256 = current.sha256;
-  };
+  mkVariant = variant: current:
+    let dotless_version = builtins.replaceStrings ["."] [""] current.version; in
+    stdenv.mkDerivation rec {
+      name = "tex-gyre-${variant}-math-${current.version}";
+      version = "${current.version}";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/opentype/
-    mkdir -p $out/share/doc/${name}/
-    cp -v opentype/*.otf $out/share/fonts/opentype/
-    cp -v doc/*.txt $out/share/doc/${name}/
-  '';
+      src = fetchzip {
+        url = "www.gust.org.pl/projects/e-foundry/tg-math/download/texgyre${variant}-math-${dotless_version}.zip";
+        sha256 = current.sha256;
+      };
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = current.outputHash;
+      installPhase = ''
+        mkdir -p $out/share/fonts/opentype/
+        mkdir -p $out/share/doc/${name}/
+        cp -v opentype/*.otf $out/share/fonts/opentype/
+        cp -v doc/*.txt $out/share/doc/${name}/
+      '';
 
-  meta = with stdenv.lib; {
-    longDescription = ''
-      TeX Gyre ${current.displayName} Math is a math companion for the TeX Gyre
-      ${current.displayName} family of fonts (see
-      http://www.gust.org.pl/projects/e-foundry/tex-gyre/) in the OpenType format.
-    '';
-    homepage = http://www.gust.org.pl/projects/e-foundry/tg-math;
-    # "The TeX Gyre Math fonts are licensed under the GUST Font License (GFL),
-    # which is a free license, legally equivalent to the LaTeX Project Public
-    # License (LPPL), version 1.3c or later." - GUST website
-    license = licenses.lppl13c;
-    maintainers = with maintainers; [ siddharthist ];
-    platforms = platforms.all;
-  };
-}
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+      outputHash = current.outputHash;
+
+      meta = with stdenv.lib; {
+        longDescription = ''
+          TeX Gyre ${current.displayName} Math is a math companion for the TeX Gyre
+          ${current.displayName} family of fonts (see
+          http://www.gust.org.pl/projects/e-foundry/tex-gyre/) in the OpenType format.
+        '';
+        homepage = http://www.gust.org.pl/projects/e-foundry/tg-math;
+        # "The TeX Gyre Math fonts are licensed under the GUST Font License (GFL),
+        # which is a free license, legally equivalent to the LaTeX Project Public
+        # License (LPPL), version 1.3c or later." - GUST website
+        license = licenses.lppl13c;
+        maintainers = with maintainers; [ siddharthist ];
+        platforms = platforms.all;
+      };
+    };
+in
+  stdenv.lib.mapAttrs mkVariant variants

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -212,6 +212,10 @@ mapAliases (rec {
   telepathy_qt = telepathy-qt; # added 2018-02-25
   telepathy_qt5 = libsForQt5.telepathy;  # added 2015-12-19
   telepathy_salut = telepathy-salut; # added 2018-02-25
+  tex-gyre-bonum-math = tex-gyre-math.bonum; # added 2018-04-03
+  tex-gyre-pagella-math = tex-gyre-math.pagella; # added 2018-04-03
+  tex-gyre-schola-math = tex-gyre-math.schola; # added 2018-04-03
+  tex-gyre-termes-math = tex-gyre-math.termes; # added 2018-04-03
   tftp_hpa = tftp-hpa; # added 2015-04-03
   transmission_gtk = transmission-gtk; # added 2018-01-06
   transmission_remote_gtk = transmission-remote-gtk; # added 2018-01-06

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14539,13 +14539,7 @@ with pkgs;
 
   tex-gyre = callPackages ../data/fonts/tex-gyre { };
 
-  tex-gyre-bonum-math = callPackage ../data/fonts/tex-gyre-math { variant = "bonum"; };
-
-  tex-gyre-pagella-math = callPackage ../data/fonts/tex-gyre-math { variant = "pagella"; };
-
-  tex-gyre-schola-math = callPackage ../data/fonts/tex-gyre-math { variant = "schola"; };
-
-  tex-gyre-termes-math = callPackage ../data/fonts/tex-gyre-math { variant = "termes"; };
+  tex-gyre-math = callPackages ../data/fonts/tex-gyre-math { };
 
   tipa = callPackage ../data/fonts/tipa { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14537,7 +14537,7 @@ with pkgs;
 
   terminus_font_ttf = callPackage ../data/fonts/terminus-font-ttf { };
 
-  tex-gyre = callPackage ../data/fonts/tex-gyre { };
+  tex-gyre = callPackages ../data/fonts/tex-gyre { };
 
   tex-gyre-bonum-math = callPackage ../data/fonts/tex-gyre-math { variant = "bonum"; };
 


### PR DESCRIPTION
### Motivation

tex-gyre: use `callPackages`

Using `callPackages` instead of `callPackage` adds an `override` attribute to
each individual package instead of the set. Each member of the set is then just
a package so that `lib.attrValues tex-gyre` gives a list of packages that can be
installed.


tex-gyre-*-math: Move to `tex-gyre-math` package set

The `tex-gyre-*-math` fonts are moved to the `tex-gyre-math` set for consistency
with `tex-gyre` and to allow them to be easily installed together. Aliases are
created for backwards-compatibility.


### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @siddharthist 