### PR TITLE
network-interfaces-scripted: wlanInterfaces have .device, …

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -68,8 +68,7 @@ let
              (hasAttr dev cfg.macvlans) ||
              (hasAttr dev cfg.sits) ||
              (hasAttr dev cfg.vlans) ||
-             (hasAttr dev cfg.vswitches) ||
-             (hasAttr dev cfg.wlanInterfaces)
+             (hasAttr dev cfg.vswitches)
           then [ "${dev}-netdev.service" ]
           else optional (dev != null && dev != "lo" && !config.boot.isContainer) (subsystemDevice dev);
 


### PR DESCRIPTION
…no "${dev}-netdev.service"

###### Motivation for this change

Let make 2 virtual wlan card out of a wifi card:
```
        networking.wlanInterfaces = {
          "wlan-station0" = { device = "wlp3s0";                            };
          "wlan-ap0"      = { device = "wlp3s0"; mac = "08:11:96:0e:08:0a"; };
        };
```

Obviously, ```wlan-ap0``` - the Access Point device, must have a static IP:
```
networking.interfaces.wlan-ap0.ipv4.addresses = [{ address = "192.168.11.1"; prefixLength = 24; }];
```

But this would fail because ```network-addresses-wlan-ap0.service``` depends on non-existent ```wlan-ap0-netdev.service``` instead of ```sys-subsystem-net-devices-wlan\x2dap0.device```
