### PR TITLE
monero-gui: 2018-03-31 -> 0.12.0.0

### DIFF
--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -12,13 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "monero-gui-${version}";
-  version = "2018-03-31";
+  version = "0.12.0.0";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
-    rev    = "fbe5ba831795008361f4de4347e7ecb6d868b4eb";
-    sha256 = "06cncwk4mxfw1rqwlwisasvangl73xyqwj4g6r9j85j5x4xy0k5s";
+    rev    = "v${version}";
+    sha256 = "1mg5ival8a2wdp14yib4wzqax4xyvd40zjy9anhszljds1439jhl";
   };
 
   nativeBuildInputs = [ qmake pkgconfig ];

--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -6,6 +6,7 @@
 , qtwebengine, qtx11extras, qtxmlpatterns
 , monero, unbound, readline, boost, libunwind
 , pcsclite, zeromq, cppzmq, pkgconfig
+, CoreData
 }:
 
 with stdenv.lib;
@@ -30,7 +31,7 @@ stdenv.mkDerivation rec {
     qtxmlpatterns monero unbound readline
     boost libunwind pcsclite zeromq cppzmq
     makeWrapper
-  ];
+  ] ++ stdenv.lib.optional stdenv.isDarwin CoreData;
 
   patches = [
     ./move-log-file.patch

--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -6,7 +6,6 @@
 , qtwebengine, qtx11extras, qtxmlpatterns
 , monero, unbound, readline, boost, libunwind
 , pcsclite, zeromq, cppzmq, pkgconfig
-, CoreData
 }:
 
 with stdenv.lib;
@@ -31,7 +30,7 @@ stdenv.mkDerivation rec {
     qtxmlpatterns monero unbound readline
     boost libunwind pcsclite zeromq cppzmq
     makeWrapper
-  ] ++ stdenv.lib.optional stdenv.isDarwin CoreData;
+  ];
 
   patches = [
     ./move-log-file.patch

--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, git
 , boost, miniupnpc, openssl, unbound, cppzmq
 , zeromq, pcsclite, readline
-, IOKit ? null
+, IOKit
+, CoreData
 }:
 
 assert stdenv.isDarwin -> IOKit != null;
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost miniupnpc openssl unbound
     cppzmq zeromq pcsclite readline
-  ] ++ optional stdenv.isDarwin IOKit;
+  ] ++ optionals stdenv.isDarwin [ IOKit CoreData ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"

--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -1,8 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, git
 , boost, miniupnpc, openssl, unbound, cppzmq
 , zeromq, pcsclite, readline
-, IOKit
-, CoreData
+, CoreData, IOKit, PCSC
 }:
 
 assert stdenv.isDarwin -> IOKit != null;
@@ -25,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost miniupnpc openssl unbound
     cppzmq zeromq pcsclite readline
-  ] ++ optionals stdenv.isDarwin [ IOKit CoreData ];
+  ] ++ optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16706,6 +16706,7 @@ with pkgs;
   };
 
   monero-gui = libsForQt5.callPackage ../applications/altcoins/monero-gui {
+    inherit (darwin.apple_sdk.frameworks) CoreData;
     boost = boost15x;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -612,7 +612,7 @@ with pkgs;
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };
 
   cconv = callPackage ../tools/text/cconv { };
-  
+
   chkcrontab = callPackage ../tools/admin/chkcrontab { };
 
   djmount = callPackage ../tools/filesystems/djmount { };
@@ -16701,12 +16701,11 @@ with pkgs;
   mod-distortion = callPackage ../applications/audio/mod-distortion { };
 
   monero = callPackage ../applications/altcoins/monero {
-    inherit (darwin.apple_sdk.frameworks) IOKit;
+    inherit (darwin.apple_sdk.frameworks) IOKit CoreData;
     boost = boost15x;
   };
 
   monero-gui = libsForQt5.callPackage ../applications/altcoins/monero-gui {
-    inherit (darwin.apple_sdk.frameworks) CoreData;
     boost = boost15x;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16701,7 +16701,7 @@ with pkgs;
   mod-distortion = callPackage ../applications/audio/mod-distortion { };
 
   monero = callPackage ../applications/altcoins/monero {
-    inherit (darwin.apple_sdk.frameworks) IOKit CoreData;
+    inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;
     boost = boost15x;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Use official release

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

