### PR TITLE
libqtxdg: fix pkgconfig files

### DIFF
--- a/pkgs/desktops/lxqt/base/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/base/libqtxdg/default.nix
@@ -16,7 +16,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ qt5.qtbase qt5.qtsvg ];
 
   preConfigure = ''
-    cmakeFlags+=" -DQTXDGX_ICONENGINEPLUGIN_INSTALL_PATH=$out/$qtPluginPrefix"
+    cmakeFlagsArray+=(
+    "-DQTXDGX_ICONENGINEPLUGIN_INSTALL_PATH=$out/$qtPluginPrefix"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    )
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Tried to build an out of tree package that depends on libqtxdg and it couldn't find the library using pkgconfig because of some incorrect paths in the pkgconfig files, see the commit message for details.
I admit I'm not quite sure if this is correct way to fix this but worked for my specific use case and doesn't seem to affect compilation of in-tree packages that depend on this library.

/cc @romildo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

