### PR TITLE
xbursttools: Fix build

### DIFF
--- a/pkgs/tools/misc/xburst-tools/default.nix
+++ b/pkgs/tools/misc/xburst-tools/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation {
     "--enable-firmware CROSS_COMPILE=${crossPrefix}-"
     else "";
 
+  hardeningDisable = [ "pic" "stackprotector" ];
+
   # Not to strip cross build binaries (this is for the gcc-cross-wrapper)
   dontCrossStrip = true;
 


### PR DESCRIPTION
###### Motivation for this change
Was a long-standing failing test on Hydra. Should be backported to 18.03 as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

