### PR TITLE
beluga: init at 20180403

### DIFF
--- a/pkgs/applications/science/logic/beluga/default.nix
+++ b/pkgs/applications/science/logic/beluga/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, ocamlPackages, omake }:
+
+stdenv.mkDerivation {
+  name = "beluga-20180403";
+
+  src = fetchFromGitHub {
+    owner  = "Beluga-lang";
+    repo   = "Beluga";
+    rev    = "046aa59f008be70a7c4700b723bed0214ea8b687";
+    sha256 = "0m68y0r0wdw3mg2jks68bihaww7sg305zdfnic1rkndq2cxv0mld";
+  };
+
+  nativeBuildInputs = with ocamlPackages; [ findlib ocamlbuild omake ];
+  buildInputs = with ocamlPackages; [ ocaml ulex ocaml_extlib ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r bin $out/
+
+    mkdir -p $out/share/beluga
+    cp -r tools/ examples/ $out/share/beluga
+
+    mkdir -p $out/share/emacs/site-lisp/beluga/
+    cp -r tools/beluga-mode.el $out/share/emacs/site-lisp/beluga
+  '';
+
+  meta = {
+    description = "A functional language for reasoning about formal systems";
+    homepage    = http://complogic.cs.mcgill.ca/beluga/;
+    license     = stdenv.lib.licenses.gpl3Plus;
+    maintainers = [ stdenv.lib.maintainers.bcdarwin ];
+    platforms   = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19859,6 +19859,8 @@ with pkgs;
 
   aspino = callPackage ../applications/science/logic/aspino {};
 
+  beluga = callPackage ../applications/science/logic/beluga { };
+
   boogie = dotnetPackages.Boogie;
 
   inherit (callPackage ./coq-packages.nix {})


### PR DESCRIPTION
###### Motivation for this change

adding new package ...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

