### PR TITLE
Enable libtorrent and xmlrpc-c on darwin

### DIFF
--- a/pkgs/development/libraries/xmlrpc-c/default.nix
+++ b/pkgs/development/libraries/xmlrpc-c/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     # <xmlrpc-c>/doc/COPYING also lists "Expat license",
     # "ABYSS Web Server License" and "Python 1.5.2 License"
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/tools/networking/p2p/libtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "http://rtorrent.net/downloads/";
     description = "A BitTorrent library written in C++ for *nix, with focus on high performance and good code";
 
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ ebzzry codyopel ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

libtorrent and xmlrpc-c can be build on darwin, this change moves out rtorrent from broken packages in darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

