### PR TITLE
scheherazade: init at 2.100

### DIFF
--- a/pkgs/data/fonts/scheherazade/default.nix
+++ b/pkgs/data/fonts/scheherazade/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchzip }:
+
+let
+  version = "2.100";
+in fetchzip rec {
+  name = "scheherazade-${version}";
+
+  url = "http://software.sil.org/downloads/r/scheherazade/Scheherazade-${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -l $downloadedFile
+    unzip -j $downloadedFile \*.ttf                        -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*/FONTLOG.txt  \*/README.txt -d $out/share/doc/${name}
+    unzip -j $downloadedFile \*/documentation/\*           -d $out/share/doc/${name}/documentation
+  '';
+
+  sha256 = "1g5f5f9gzamkq3kqyf7vbzvl4rdj3wmjf6chdrbxksrm3rnb926z";
+
+  meta = with stdenv.lib; {
+    homepage = https://software.sil.org/scheherazade/;
+    description = "A font designed in a similar style to traditional Naskh typefaces";
+    longDescription = ''
+      Scheherazade, named after the heroine of the classic Arabian Nights tale,
+      is designed in a similar style to traditional typefaces such as Monotype
+      Naskh, extended to cover the Unicode Arabic repertoire through Unicode
+      8.0.
+
+      Scheherazade provides a “simplified” rendering of Arabic script, using
+      basic connecting glyphs but not including a wide variety of additional
+      ligatures or contextual alternates (only the required lam-alef
+      ligatures). This simplified style is often preferred for clarity,
+      especially in non-Arabic languages, but may not be considered appropriate
+      in situations where a more elaborate style of calligraphy is preferred.
+
+      This package contains the regular and bold styles for the Scheherazade
+      font family, along with documentation.
+    '';
+    downloadPage = "https://software.sil.org/scheherazade/download/";
+    license = licenses.ofl;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14459,6 +14459,8 @@ with pkgs;
 
   shared_desktop_ontologies = callPackage ../data/misc/shared-desktop-ontologies { };
 
+  scheherazade = callPackage ../data/fonts/scheherazade { };
+
   signwriting = callPackage ../data/fonts/signwriting { };
 
   soundfont-fluid = callPackage ../data/soundfonts/fluid { };


### PR DESCRIPTION
###### Motivation for this change

Add the Scheherazade Arabic font made by SIL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

