### PR TITLE
lib: `compose` and `pipe` functions

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -54,8 +54,8 @@ let
       getAttr hasAttr head isAttrs isBool isInt isList
       isString length lessThan listToAttrs pathExists readFile
       replaceStrings seq stringLength sub substring tail;
-    inherit (trivial) id const concat or and boolToString mergeAttrs
-      flip mapNullable inNixShell min max importJSON warn info
+    inherit (trivial) id const compose pipe concat or and boolToString
+      mergeAttrs flip mapNullable inNixShell min max importJSON warn info
       nixpkgsVersion mod compare splitByAndCompare
       functionArgs setFunctionArgs isFunction;
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -19,6 +19,18 @@ rec {
   */
   const = x: y: x;
 
+  /* Right-to-left composition of a pair of unary functions.
+
+     Type: compose :: (b -> c) -> (a -> b) -> a -> c
+  */
+  compose = f: g: x: f (g x);
+
+  /* Perform a left-to-right composition across a list of functions.
+
+     Type: pipe :: [(a -> b), (b -> c), ..., (y -> z)] -> a -> z
+  */
+  pipe = builtins.foldl' (flip compose) id;
+
 
   ## Named versions corresponding to some builtin operators.
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -3,7 +3,7 @@
 let
   inherit (args) stdenv makeWrapper;
   inherit (stdenv) lib isDarwin;
-  inherit (lib) overrideDerivation;
+  inherit (lib) overrideDerivation compose;
 
   setMalloc0ReturnsNullCrossCompiling = ''
     if test -n "$crossConfig"; then
@@ -20,8 +20,6 @@ let
     buildInputs = attrs.buildInputs ++ [ xorg.utilmacros  ];
     preConfigure = (attrs.preConfigure or "") + "\n./autogen.sh";
   };
-
-  compose = f: g: x: f (g x);
 in
 {
   bdftopcf = attrs: attrs // {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -3,7 +3,7 @@
 let
   inherit (args) stdenv makeWrapper;
   inherit (stdenv) lib isDarwin;
-  inherit (lib) overrideDerivation compose;
+  inherit (lib) overrideDerivation;
 
   setMalloc0ReturnsNullCrossCompiling = ''
     if test -n "$crossConfig"; then


### PR DESCRIPTION
Provide base functions for function composition.

###### Motivation for this change
Just a couple of low level primitives that are likely useful across various modules / packages.

Rather than implementing these everywhere they're needed, it probably makes sense to include them here. I had a quick grep through the repo and could only find a single current implementation, which I've redirected back to this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxicomposeng ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

