### PR TITLE
heptio-ark: init at 0.7.1

### DIFF
--- a/pkgs/applications/networking/cluster/heptio-ark/default.nix
+++ b/pkgs/applications/networking/cluster/heptio-ark/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "heptio-ark-${version}";
+  version = "0.7.1";
+
+  goPackagePath = "github.com/heptio/ark";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "heptio";
+    repo = "ark";
+    sha256 = "0j3x9zxcffxhlw0fxq2cw9ph37bqw90cbmf9xshmnj8yl9rbxp7y";
+  };
+
+  postInstall = "rm $bin/bin/generate";
+
+  meta = with stdenv.lib; {
+    description = "A utility for managing disaster recovery, specifically for your Kubernetes cluster resources and persistent volumes";
+    homepage = https://heptio.github.io/ark/;
+    license = licenses.asl20;
+    maintainers = [maintainers.mbode];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20445,6 +20445,8 @@ with pkgs;
 
   helm = callPackage ../applications/audio/helm { };
 
+  heptio-ark = callPackage ../applications/networking/cluster/heptio-ark { };
+
   hplip = callPackage ../misc/drivers/hplip { };
 
   hplipWithPlugin = hplip.override { withPlugin = true; };


### PR DESCRIPTION
###### Motivation for this change
Add [ark](https://heptio.github.io/ark/v0.7.1/), a tool for Kubernetes backups.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

