### PR TITLE
nixos/dhcp: fix permissions of statedir

### DIFF
--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -36,6 +36,7 @@ let
 
       preStart = ''
         mkdir -m 755 -p ${cfg.stateDir}
+        chown dhcpd:nogroup ${cfg.stateDir}
         touch ${cfg.stateDir}/dhcpd.leases
       '';
 


### PR DESCRIPTION
fix for https://github.com/NixOS/nixpkgs/issues/38424

(not tested)