### PR TITLE
gron: init at 0.5.1

### DIFF
--- a/pkgs/development/tools/gron/default.nix
+++ b/pkgs/development/tools/gron/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "gron-${version}";
+  version = "0.5.1";
+
+  owner = "tomnomnom";
+  repo = "gron";
+  goPackagePath = "github.com/${owner}/${repo}";
+
+  src = fetchFromGitHub {
+    inherit owner repo;
+    rev = "v${version}";
+    sha256 = "1s688ynjddchviwbiggnfbw28s4wsff2941f4b1q1j7mfak7iym2";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Make JSON greppable!";
+    longDescription = ''
+      gron transforms JSON into discrete assignments to make it easier to grep
+      for what you want and see the absolute 'path' to it. It eases the
+      exploration of APIs that return large blobs of JSON but have terrible
+      documentation.
+    '';
+    homepage = "https://github.com/tomnomnom/gron";
+    license = licenses.mit;
+    maintainers = [ maintainers.fgaz ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/development/tools/gron/deps.nix
+++ b/pkgs/development/tools/gron/deps.nix
@@ -1,0 +1,35 @@
+[
+  rec {
+    owner = "fatih";
+    repo = "color";
+    goPackagePath = "github.com/${owner}/${repo}";
+    fetch = {
+      type = "git";
+      url = "https://github.com/${owner}/${repo}";
+      rev = "v1.6.0";
+      sha256 = "0k1v9dkhrxiqhg48yqkwzpd7x40xx38gv2pgknswbsy4r8w644i7";
+    };
+  }
+  rec {
+    owner = "nwidger";
+    repo = "jsoncolor";
+    goPackagePath = "github.com/${owner}/${repo}";
+    fetch = {
+      type = "git";
+      url = "https://github.com/${owner}/${repo}";
+      rev = "75a6de4340e59be95f0884b9cebdda246e0fdf40";
+      sha256 = "0aiv42xijrqgrxfx6pfyrndpwqv8i1qwsk190jdczyjxlnki2nki";
+    };
+  }
+  rec {
+    owner = "pkg";
+    repo = "errors";
+    goPackagePath = "github.com/${owner}/${repo}";
+    fetch = {
+      type = "git";
+      url = "https://github.com/${owner}/${repo}";
+      rev = "v0.8.0";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2667,6 +2667,8 @@ with pkgs;
     inherit (xorg) libXdmcp;
   };
 
+  gron = callPackage ../development/tools/gron { };
+
   groonga = callPackage ../servers/search/groonga { };
 
   grub = callPackage_i686 ../tools/misc/grub {


### PR DESCRIPTION
###### Motivation for this change

Gron is a tool that makes json greppable

https://github.com/tomnomnom/gron

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

