### PR TITLE
Add documentation for weechat

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -713,12 +713,22 @@ the <literal>inotify.py</literal> script in weechat-scripts requires
 D-Bus or libnotify, and the <literal>fish.py</literal> script requires
 pycrypto. To use these scripts, use the <literal>python</literal>
 plugin's <literal>withPackages</literal> attribute:
-<programlisting>weechat.override {configure = {availablePlugins, ...}: {
+<programlisting>weechat.override { configure = {availablePlugins, ...}: {
     plugins = with availablePlugins; [
             (python.withPackages (ps: with ps; [ pycrypto python-dbus ]))
         ];
     }
 }
+</programlisting>
+</para>
+<para>
+In order to also keep all default plugins installed, it is possible to use
+the following method:
+<programlisting>weechat.override { configure = { availablePlugins, ... }: {
+  plugins = builtins.attrValues (availablePlugins // {
+    python = availablePlugins.python.withPackages (ps: with ps; [ pycrypto python-dbus ]);
+  });
+}; }
 </programlisting>
 </para>
 </section>

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -72,6 +72,11 @@ let
       meta = {
         homepage = http://www.weechat.org/;
         description = "A fast, light and extensible chat client";
+        longDescription = ''
+          You can find more documentation as to how to customize this package
+          (eg. adding python modules for scripts that would require them, etc.)
+          on https://nixos.org/nixpkgs/manual/#sec-weechat .
+        '';
         license = stdenv.lib.licenses.gpl3;
         maintainers = with stdenv.lib.maintainers; [ lovek323 garbas the-kenny lheckemann ];
         platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -122,4 +122,7 @@ in if configure == null then weechat else
     export WEECHAT_EXTRA_LIBDIR=${pluginsDir}
     ${lib.concatMapStringsSep "\n" (p: lib.optionalString (p ? extraEnv) p.extraEnv) plugins}
     exec ${weechat}/bin/weechat "$@"
-  '') // { unwrapped = weechat; }
+  '') // {
+    unwrapped = weechat;
+    meta = weechat.meta;
+  }


### PR DESCRIPTION
###### Motivation for this change

It took me quite some time to understand there actually was documentation for `weechat`, so here are a few more pointers to the right place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

