### PR TITLE
nix-review: init at 0.1.0

### DIFF
--- a/pkgs/tools/package-management/nix-review/default.nix
+++ b/pkgs/tools/package-management/nix-review/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, python3
+, fetchFromGitHub
+, nix
+, makeWrapper
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "nix-review";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "nix-review";
+    rev = version;
+    sha256 = "1kafp3x95dklydy5224w0a292rd8pv30lz6z5ddk6y7zg3fsxrcr";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  preFixup = ''
+    wrapProgram $out/bin/nix-review --prefix PATH : ${nix}/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Review pull-requests on https://github.com/NixOS/nixpkgs";
+    homepage = https://github.com/Mic92/nix-review;
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20542,6 +20542,8 @@ with pkgs;
 
   nix-repl = callPackage ../tools/package-management/nix-repl { nix = nix1; };
 
+  nix-review = callPackage ../tools/package-management/nix-review { };
+
   nix-serve = callPackage ../tools/package-management/nix-serve { };
 
   nixos-artwork = callPackage ../data/misc/nixos-artwork { };


### PR DESCRIPTION
###### Motivation for this change

- so people don't have to maintain overlays or clone my dotfiles
- because it is fast.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using ~`nix-shell -p nox --run "nox-review wip"`~  `nix-shell -p nix-review --run "nix-review pr 38430"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

