### PR TITLE
nixos-shell: init at 0.0.1

### DIFF
--- a/pkgs/tools/virtualization/nixos-shell/default.nix
+++ b/pkgs/tools/virtualization/nixos-shell/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, bash, nix, fetchFromGitHub, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "nixos-shell-${version}";
+  version = "0.0.1";
+
+  buildInputs = [ bash ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "nixos-shell";
+    sha256 = "1rdv55s3597xyxc2rxc96wswcydh62h9jlrcnwhzrpdinzikafny";
+    rev = version;
+  };
+
+  preConfigure = ''
+    export PREFIX=$out
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nixos-shell \
+      --prefix PATH : "${nix}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Spawns lightweight nixos vms in a shell";
+    homepage = https://github.com/Mic92/nixos-shell;
+    license = licenses.mit;
+    maintainers = with maintainers; [ mic92 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -612,7 +612,7 @@ with pkgs;
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };
 
   cconv = callPackage ../tools/text/cconv { };
-  
+
   chkcrontab = callPackage ../tools/admin/chkcrontab { };
 
   djmount = callPackage ../tools/filesystems/djmount { };
@@ -20551,6 +20551,8 @@ with pkgs;
   nixos-icons = callPackage ../data/misc/nixos-artwork/icons.nix { };
 
   nixos-container = callPackage ../tools/virtualization/nixos-container { };
+
+  nixos-shell = callPackage ../tools/virtualization/nixos-shell { };
 
   norwester-font = callPackage ../data/fonts/norwester  {};
 


### PR DESCRIPTION
###### Motivation for this change

* procrastinating hard during a delayed flight.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

