### PR TITLE
k3b: fix build inputs and library/binary paths

### DIFF
--- a/pkgs/applications/kde/k3b.nix
+++ b/pkgs/applications/kde/k3b.nix
@@ -16,7 +16,7 @@ mkDerivation {
     platforms = platforms.linux;
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools makeWrapper ];
-  propagatedBuildInputs = [
+  buildInputs = [
     # qt
     qtwebkit
     # kde
@@ -32,11 +32,17 @@ mkDerivation {
   ];
   propagatedUserEnvPkgs = [ (lib.getBin kinit) ];
   postFixup =
-    let k3bPath = lib.makeBinPath [
-          cdrdao cdrtools dvdplusrwtools libburn normalize sox transcode
-          vcdimager
-        ];
+    let
+      binPath = lib.makeBinPath [
+        cdrdao cdrtools dvdplusrwtools libburn normalize sox transcode
+        vcdimager flac
+      ];
+      libraryPath = lib.makeLibraryPath [
+        cdparanoia
+      ];
     in ''
-      wrapProgram "$out/bin/k3b" --prefix PATH : "${k3bPath}"
+      wrapProgram "$out/bin/k3b"     \
+        --prefix PATH : "${binPath}" \
+        --prefix LD_LIBRARY_PATH : ${libraryPath}
     '';
 }


### PR DESCRIPTION

###### Motivation for this change

Fix #38325

I followed the instructions from this comment:
https://github.com/NixOS/nixpkgs/issues/38325#issuecomment-378574197

cc: @Mic92 

I'm not certain about the following matters:

- Should only libcdparanoia be in the library path, not flac?
- Should libcdparanoia or flac be removed from propagated build inputs?
- Are there some other libraries missing from the library path?
- Are there some other improvements that should be made?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

