### PR TITLE
ocamlPackages.ocsigen_deriving: 0.7.1 -> 0.8.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
@@ -1,15 +1,30 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, oasis, ocaml_optcomp, camlp4 }:
+{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, oasis, ocaml_optcomp, camlp4
+, num
+}:
 
-let version = "0.7.1"; in
+let param =
+  if stdenv.lib.versionAtLeast ocaml.version "4.03"
+  then {
+    version = "0.8.1";
+    sha256 = "03vzrybdpjydbpil97zmir71kpsn2yxkjnzysma7fvybk8ll4zh9";
+    buildInputs = [ num ];
+  } else {
+    version = "0.7.1";
+    sha256 = "0gg3nr3iic4rwqrcc0qvfm9x0x57zclvdsnpy0z8rv2fl5isbzms";
+  };
+in
+
+let inherit (param) version; in
 
 stdenv.mkDerivation {
   name = "ocsigen-deriving-${version}";
   src = fetchzip {
     url = "https://github.com/ocsigen/deriving/archive/${version}.tar.gz";
-    sha256 = "0gg3nr3iic4rwqrcc0qvfm9x0x57zclvdsnpy0z8rv2fl5isbzms";
-    };
+    inherit (param) sha256;
+  };
 
-  buildInputs = [ ocaml findlib ocamlbuild oasis ocaml_optcomp camlp4 ];
+  buildInputs = [ ocaml findlib ocamlbuild oasis ocaml_optcomp camlp4 ]
+  ++ (param.buildInputs or []);
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/optcomp/META
+++ b/pkgs/development/ocaml-modules/optcomp/META
@@ -1,0 +1,12 @@
+# OASIS_START
+# DO NOT EDIT (digest: ec844fa3189acb2a866b89a69d111ba4)
+version = "1.6"
+description = "Optional compilation with cpp-like directives"
+requires = "camlp4"
+archive(syntax, preprocessor) = "optcomp.cma"
+archive(syntax, toploop) = "optcomp.cma"
+archive(syntax, preprocessor, native) = "optcomp.cmxa"
+archive(syntax, preprocessor, native, plugin) = "optcomp.cmxs"
+exists_if = "optcomp.cma"
+# OASIS_STOP
+

--- a/pkgs/development/ocaml-modules/optcomp/default.nix
+++ b/pkgs/development/ocaml-modules/optcomp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, camlp4 }:
+{ stdenv, fetchurl, fetchpatch, ocaml, findlib, ocamlbuild, camlp4 }:
 
 stdenv.mkDerivation {
   name = "ocaml-optcomp-1.6";
@@ -6,11 +6,33 @@ stdenv.mkDerivation {
     url = https://github.com/diml/optcomp/archive/1.6.tar.gz;
     sha256 = "0hhhb2gisah1h22zlg5iszbgqxdd7x85cwd57bd4mfkx9l7dh8jh";
   };
+
+  patches =
+    let inherit (stdenv.lib) optional versionAtLeast; in
+    optional (versionAtLeast ocaml.version "4.02") (fetchpatch {
+      url = "https://github.com/diml/optcomp/commit/b7f809360c9794b383a4bc0492f6df381276b429.patch";
+      sha256 = "1n095lk94jq1rwi0l24g2wbgms7249wdd31n0ji895dr6755s93y";
+    })
+  ;
   
   createFindlibDestdir = true;
 
   buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
 
+  configurePhase = ''
+    cp ${./META} META
+  '';
+
+  buildPhase = ''
+    ocamlbuild src/optcomp.cmxs src/optcomp.cma src/optcomp_o.native src/optcomp_r.native
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp _build/src/optcomp_o.native $out/bin/optcomp-o
+    cp _build/src/optcomp_r.native $out/bin/optcomp-r
+    ocamlfind install optcomp META _build/src/optcomp.{a,cma,cmxa,cmxs} _build/src/pa_optcomp.{cmi,cmx,mli}
+  '';
 
   meta =  {
     homepage = https://github.com/diml/optcomp;


### PR DESCRIPTION
###### Motivation for this change

Fix build with OCaml 4.06.

Also fixes `optcomp` and its build system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

