### PR TITLE
python27Packages.rootpy: fix build (tests)

### DIFF
--- a/pkgs/development/python-modules/rootpy/default.nix
+++ b/pkgs/development/python-modules/rootpy/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, isPy3k, buildPythonPackage, numpy, matplotlib, root, root_numpy, tables }:
+{ lib, fetchPypi, isPy3k, buildPythonPackage, numpy, matplotlib, root, root_numpy, tables, pytest }:
 
 buildPythonPackage rec {
   pname = "rootpy";
@@ -13,6 +13,14 @@ buildPythonPackage rec {
   disabled = isPy3k;
 
   propagatedBuildInputs = [ matplotlib numpy root root_numpy tables ];
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    # tests fail with /homeless-shelter
+    export HOME=$PWD
+    # skip problematic tests
+    py.test rootpy -k "not test_stl and not test_cpp and not test_xrootd_glob_single and not test_xrootd_glob_multiple"
+  '';
 
   meta = with lib; {
     homepage = http://www.rootpy.org;


### PR DESCRIPTION
###### Motivation for this change

Build failed because tests were not run properly. Fix them and skip a few problematic tests.

/cc ZHF #36453

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

