### PR TITLE
pywal: init at 2.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -72,6 +72,11 @@
     github = "FireyFly";
     name = "Jonas Höglund";
   };
+  Fresheyeball = {
+    email = "fresheyeball@gmail.com";
+    github = "fresheyeball";
+    name = "Isaac Shapira";
+  };
   Gonzih = {
     email = "gonzih@gmail.com";
     github = "Gonzih";

--- a/pkgs/tools/graphics/pywal/default.nix
+++ b/pkgs/tools/graphics/pywal/default.nix
@@ -1,0 +1,28 @@
+{ lib, python3Packages, fetchFromGitHub, imagemagick, feh }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pywal";
+  version = "2.0.5";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "117f61db013409ee2657aab9230cc5c2cb2b428c17f7fbcf664909122962165e";
+  };
+
+  # necessary for imagemagick to be found during tests
+  buildInputs = [ imagemagick ];
+
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ imagemagick feh ]}" ];
+
+  preCheck = ''
+    mkdir tmp
+    HOME=$PWD/tmp
+  '';
+
+  meta = with lib; {
+    description = "Generate and change colorschemes on the fly. A 'wal' rewrite in Python 3.";
+    homepage = https://github.com/dylanaraps/pywal;
+    license = licenses.mit;
+    maintainers = with maintainers; [ Fresheyeball ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4427,6 +4427,8 @@ with pkgs;
 
   pytrainer = callPackage ../applications/misc/pytrainer { };
 
+  pywal = callPackage ../tools/graphics/pywal {};
+
   remarshal = callPackage ../development/tools/remarshal { };
 
   rtaudio = callPackage ../development/libraries/audio/rtaudio { };


### PR DESCRIPTION
###### Motivation for this change

I wanted nixos to be prettier

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

