### PR TITLE
godot: add application metadata and man page to share

### DIFF
--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -42,6 +42,19 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp bin/godot.x11.tools.* $out/bin/godot
+
+    mkdir -p "$out/share/applications"
+    cp misc/dist/linux/godot.desktop "$out/share/applications/"
+    substituteInPlace "$out/share/applications/godot.desktop" \
+                      --replace "Exec=godot" \
+                      "Exec=$out/bin/godot"
+
+    mkdir -p "$out/share/icons/hicolor/scalable/apps/"
+    cp icon.svg "$out/share/icons/hicolor/scalable/apps/godot.svg"
+    cp icon.png "$out/share/icons/godot.png"
+
+    mkdir -p "$out/share/man/man6"
+    cp misc/dist/linux/godot.6 "$out/share/man/man6/"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

1. missing "Godot" in desktop application menu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

