### PR TITLE
rpiboot-unstable: init at 2018-03-27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -695,6 +695,11 @@
     github = "carlsverre";
     name = "Carl Sverre";
   };
+  cartr = {
+    email = "carter.sande@duodecima.technology";
+    github = "cartr";
+    name = "Carter Sande";
+  };
   casey = {
     email = "casey@rodarmor.net";
     github = "casey";

--- a/pkgs/development/misc/rpiboot/unstable.nix
+++ b/pkgs/development/misc/rpiboot/unstable.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, libusb1 }:
+
+let
+  version = "2018-03-27";
+  name = "rpiboot-unstable-${version}";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = "usbboot";
+    rev = "fb86716935f2e820333b037a2ff93a338ad9b695";
+    sha256 = "163g7iw7kf6ra71adx6lf1xzf3kv20bppva15ljwn54jlah5mv98";
+  };
+
+  nativeBuildInputs = [ libusb1 ];
+  
+  patchPhase = ''
+    sed -i "s@/usr/@$out/@g" main.c
+  '';
+  
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/rpiboot
+    cp rpiboot $out/bin
+    cp -r msd $out/share/rpiboot
+  '';
+
+  meta = {
+    homepage = https://github.com/raspberrypi/usbboot;
+    description = "Utility to boot a Raspberry Pi CM/CM3/Zero over USB";
+    maintainers = [ stdenv.lib.maintainers.cartr ];
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4646,6 +4646,8 @@ with pkgs;
   rowhammer-test = callPackage ../tools/system/rowhammer-test { };
 
   rpPPPoE = callPackage ../tools/networking/rp-pppoe { };
+  
+  rpiboot-unstable = callPackage ../development/misc/rpiboot/unstable.nix { };
 
   rpm = callPackage ../tools/package-management/rpm { };
 


### PR DESCRIPTION
###### Motivation for this change

The `rpiboot` utility is used to boot Raspberry Pi devices from USB. It's the officially-supported way to [flash the onboard eMMC](https://www.raspberrypi.org/documentation/hardware/computemodule/cm-emmc-flashing.md) on the Raspberry Pi Compute Module, and it's also useful when developing bare-metal software for the Pi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

