### PR TITLE
ocamlPackages.js_of_ocaml-camlp4: add deriving support

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/camlp4.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/camlp4.nix
@@ -1,5 +1,5 @@
 { stdenv, ocaml, findlib, jbuilder, js_of_ocaml-compiler
-, camlp4
+, camlp4, ocsigen_deriving
 }:
 
 stdenv.mkDerivation rec {
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
 	inherit (js_of_ocaml-compiler) version src installPhase meta;
 
-	buildInputs = [ ocaml findlib jbuilder camlp4 ];
+	buildInputs = [ ocaml findlib jbuilder camlp4 ocsigen_deriving ];
 
 	buildPhase = "jbuilder build -p js_of_ocaml-camlp4";
 }


### PR DESCRIPTION
###### Motivation for this change

Needed to update `ocsigen-start`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

