### PR TITLE
home-assistant: requirement parser would ignore requirements specified with url

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -71,7 +71,7 @@
     "device_tracker.bluetooth_le_tracker" = ps: with ps; [  ];
     "device_tracker.bluetooth_tracker" = ps: with ps; [  ];
     "device_tracker.cisco_ios" = ps: with ps; [ pexpect ];
-    "device_tracker.fritz" = ps: with ps; [  ];
+    "device_tracker.fritz" = ps: with ps; [ fritzconnection ];
     "device_tracker.icloud" = ps: with ps; [  ];
     "device_tracker.linksys_ap" = ps: with ps; [ beautifulsoup4 ];
     "device_tracker.mikrotik" = ps: with ps; [  ];
@@ -100,7 +100,7 @@
     "fan.xiaomi_miio" = ps: with ps; [  ];
     "feedreader" = ps: with ps; [ feedparser ];
     "ffmpeg" = ps: with ps; [ ha-ffmpeg ];
-    "frontend" = ps: with ps; [ user-agents ];
+    "frontend" = ps: with ps; [  ];
     "gc100" = ps: with ps; [  ];
     "goalfeed" = ps: with ps; [  ];
     "google" = ps: with ps; [ google_api_python_client oauth2client ];
@@ -123,7 +123,7 @@
     "joaoapps_join" = ps: with ps; [  ];
     "juicenet" = ps: with ps; [  ];
     "keyboard" = ps: with ps; [  ];
-    "keyboard_remote" = ps: with ps; [  ];
+    "keyboard_remote" = ps: with ps; [ evdev ];
     "kira" = ps: with ps; [  ];
     "knx" = ps: with ps; [  ];
     "lametric" = ps: with ps; [  ];
@@ -196,7 +196,7 @@
     "media_player.songpal" = ps: with ps; [  ];
     "media_player.sonos" = ps: with ps; [  ];
     "media_player.soundtouch" = ps: with ps; [ libsoundtouch ];
-    "media_player.spotify" = ps: with ps; [  ];
+    "media_player.spotify" = ps: with ps; [ spotipy ];
     "media_player.vizio" = ps: with ps; [  ];
     "media_player.vlc" = ps: with ps; [  ];
     "media_player.webostv" = ps: with ps; [ websockets ];
@@ -278,7 +278,7 @@
     "sensor.coinmarketcap" = ps: with ps; [  ];
     "sensor.cpuspeed" = ps: with ps; [  ];
     "sensor.crimereports" = ps: with ps; [  ];
-    "sensor.cups" = ps: with ps; [  ];
+    "sensor.cups" = ps: with ps; [ pycups ];
     "sensor.darksky" = ps: with ps; [  ];
     "sensor.deluge" = ps: with ps; [ deluge-client ];
     "sensor.deutsche_bahn" = ps: with ps; [  ];
@@ -298,8 +298,8 @@
     "sensor.fido" = ps: with ps; [  ];
     "sensor.fitbit" = ps: with ps; [  ];
     "sensor.fixer" = ps: with ps; [  ];
-    "sensor.fritzbox_callmonitor" = ps: with ps; [  ];
-    "sensor.fritzbox_netmonitor" = ps: with ps; [  ];
+    "sensor.fritzbox_callmonitor" = ps: with ps; [ fritzconnection ];
+    "sensor.fritzbox_netmonitor" = ps: with ps; [ fritzconnection ];
     "sensor.gearbest" = ps: with ps; [  ];
     "sensor.geizhals" = ps: with ps; [ beautifulsoup4 ];
     "sensor.geo_rss_events" = ps: with ps; [ feedparser ];

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -43,6 +43,9 @@ def fetch_reqs(version='master'):
                 if component not in requirements:
                     requirements[component] = []
             elif line[0] != '#':
+                # Some requirements are specified by url, e.g. https://example.org/foobar#xyz==1.0.0
+                # Therefore, if there's a "#" in the line, only take the part after it
+                line = line[line.find('#') + 1:]
                 for component in components:
                     requirements[component].append(line)
     return requirements

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -22,7 +22,8 @@ import json
 import re
 from pkg_resources import Requirement, RequirementParseError
 
-PREFIX = '# homeassistant.components.'
+GENERAL_PREFIX = '# homeassistant.'
+COMPONENT_PREFIX = GENERAL_PREFIX + 'components.'
 PKG_SET = 'python3Packages'
 
 def get_version():
@@ -37,12 +38,16 @@ def fetch_reqs(version='master'):
         for line in response.read().decode().splitlines():
             if line == '':
                 components = []
-            elif line[:len(PREFIX)] == PREFIX:
-                component = line[len(PREFIX):]
+            elif line[:len(COMPONENT_PREFIX)] == COMPONENT_PREFIX:
+                component = line[len(COMPONENT_PREFIX):]
                 components.append(component)
                 if component not in requirements:
                     requirements[component] = []
-            elif line[0] != '#':
+            elif line[:len(GENERAL_PREFIX)] != GENERAL_PREFIX: # skip lines like "# homeassistant.scripts.xyz"
+                # Some dependencies are commented out because they don't build on all platforms
+                # Since they are still required for running the component, don't skip them
+                if line[:2] == '# ':
+                    line = line[2:]
                 # Some requirements are specified by url, e.g. https://example.org/foobar#xyz==1.0.0
                 # Therefore, if there's a "#" in the line, only take the part after it
                 line = line[line.find('#') + 1:]


### PR DESCRIPTION
###### Motivation for this change

```parse-requirements.py``` would ignore packages specified at url. Now we strip the URL so the package can still be used if found in ```pythonPackages```.

If the package in question then works with hass is something completely different...

Usual "non-python-programmer" caveat applies.

Cc: @dotlambda @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

