### PR TITLE
remake: enable on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/remake/default.nix
+++ b/pkgs/development/tools/build-managers/remake/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     homepage = http://bashdb.sourceforge.net/remake/;
     license = stdenv.lib.licenses.gpl3;
     description = "GNU Make with comprehensible tracing and a debugger";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     maintainers = with stdenv.lib.maintainers; [ bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

remake works fine for me on mac.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

