### PR TITLE
nvidia-x11: 390.25 -> 390.48

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -17,11 +17,13 @@ in
 rec {
   # Policy: use the highest stable version as the default (on our master).
   stable = generic {
-    version = "390.25";
-    sha256_32bit = "0fkbpx01l46pprrd4nlc2y6hfmkb55ddlwm1r84kr6j08qmmb0qi";
-    sha256_64bit = "0whsls1mm6vkll5qmxnyz8vjgspp1rmqpsampgi83k62n514c08r";
-    settingsSha256 = "1jhbr68z36s3fr9vx3ga2f6yrzlwpc0j5mw8h12g65p7wdsbk6y7";
-    persistencedSha256 = "033azbhi50f1b0lw759sncgf7ckh2m2c0khj5v15sch9kl1fzk8i";
+    version = "390.48";
+    sha256_32bit = "1y6n2hfz9vd0h7gd31fgxcl76s5pjf8afwqyq5slqpcxpd78j5ai";
+    sha256_64bit = "16a3blvizcksmaxr644s857yanw3i3vcvqvn7qnwbsbqpmxga09c";
+    settingsSha256 = "058xaiw5g0kxrvc3lvy4424fqbjkvmsznj2v73cgbm25i1m83krl";
+    persistencedSha256 = "0y86bhzl42lqyrbibqzf8a8yd49zbq3ryb78vgsl13i44f9sl79k";
+
+    patches = [ ./fix_missing_symbol.patch ];
   };
 
   beta = stable; # not enough interest to maintain beta ATM

--- a/pkgs/os-specific/linux/nvidia-x11/fix_missing_symbol.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/fix_missing_symbol.patch
@@ -1,0 +1,19 @@
+https://devtalk.nvidia.com/default/topic/1030082/linux/kernel-4-16-rc1-breaks-latest-drivers-unknown-symbol-swiotlb_map_sg_attrs-/
+--- a/kernel/common/inc/nv-linux.h~     2018-01-25 06:09:41.000000000 +0100
++++ b/kernel/common/inc/nv-linux.h      2018-03-05 13:58:17.746725638 +0100
+@@ -1209,6 +1209,7 @@ static inline NvU32 nv_alloc_init_flags(
+ static inline NvBool nv_dma_maps_swiotlb(struct pci_dev *dev)
+ {
+     NvBool swiotlb_in_use = NV_FALSE;
++#if 0
+ #if defined(CONFIG_SWIOTLB)
+   #if defined(NV_DMA_OPS_PRESENT) || defined(NV_GET_DMA_OPS_PRESENT)
+     /*
+@@ -1251,7 +1252,7 @@ static inline NvBool nv_dma_maps_swiotlb
+     swiotlb_in_use = (swiotlb == 1);
+   #endif
+ #endif
+-
++#endif
+     return swiotlb_in_use;
+ }


### PR DESCRIPTION
Also fixes missing symbol error with kernel 4.16.

###### Motivation for this change

There is another pr updating the nvidia driver: https://github.com/NixOS/nixpkgs/pull/38450

This pull request also contains a patch that solves the error on kernel 4.16: https://devtalk.nvidia.com/default/topic/1030082/linux/kernel-4-16-rc1-breaks-latest-drivers-unknown-symbol-swiotlb_map_sg_attrs-/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

