### PR TITLE
r17.09: aws-auth:  unstable-2017-07-24 -> unstable-2018-04-04 

### DIFF
--- a/pkgs/tools/admin/aws-auth/default.nix
+++ b/pkgs/tools/admin/aws-auth/default.nix
@@ -1,25 +1,23 @@
-{ stdenv, fetchFromGitHub, makeWrapper, jq, awscli }:
+{ stdenv, fetchFromGitHub, makeWrapper, jq, awscli, openssl }:
 
 stdenv.mkDerivation rec {
-  version = "unstable-2017-07-24";
+  version = "unstable-2018-04-04";
   name = "aws-auth-${version}";
 
   src = fetchFromGitHub {
     owner = "alphagov";
     repo = "aws-auth";
-    rev = "5a4c9673f9f00ebaa4bb538827e1c2f277c475e1";
-    sha256 = "095j9zqxra8hi2iyz0y4azs9yigy5f6alqkfmv180pm75nbc031g";
+    rev = "03e3eb2a0e89c6d55f0721462a6bc077aa4668bf";
+    sha256 = "0r89kvkcjsz6v9r2pk45v82v623y334b0hfvdvzfnls3j7d23m2p";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-
-  dontBuild = true;
 
   # copy script and set $PATH
   installPhase = ''
     install -D $src/aws-auth.sh $out/bin/aws-auth
     wrapProgram $out/bin/aws-auth \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ awscli jq ]}
+      --prefix PATH : ${stdenv.lib.makeBinPath [ awscli jq openssl ]}
   '';
 
   meta = {


### PR DESCRIPTION
Also re-enable for _continuity_ on stable branch. This (perhaps final) release should at least *work* with the rest of release-17.09 but will probably see no further development and should remain "dropped" in master.

###### Motivation for this change

It's not nice for stable users to have a package disappear from under their feet if we have an alternative.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @globin 
