### PR TITLE
tome4: disable parallel build

### DIFF
--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -32,7 +32,8 @@ in stdenv.mkDerivation rec {
     libGLU openal libpng libvorbis SDL2 SDL2_ttf SDL2_image
   ];
 
-  enableParallelBuilding = true;
+  # disable parallel building as it caused sporadic build failures
+  enableParallelBuilding = false;
 
   NIX_CFLAGS_COMPILE = [
     "-I${SDL2_image}/include/SDL2"

--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -82,6 +82,6 @@ in stdenv.mkDerivation rec {
     homepage = https://te4.org/;
     license = licenses.gpl3;
     maintainers = with maintainers; [ chattered peterhoeg ];
-    platforms = platforms.linux;
+    platforms = subtractLists ["aarch64-linux"] platforms.linux;
   };
 }


### PR DESCRIPTION
tome4 has had sporadic, hydra build failures like [this](https://hydra.nixos.org/build/72378255) that I could not reproduce locally. Comparing build logs shows that these are likely caused by parallel building with underspecified internal dependencies .

/cc ZHF #36453 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

