### PR TITLE
apg: Darwin support

### DIFF
--- a/pkgs/tools/security/apg/default.nix
+++ b/pkgs/tools/security/apg/default.nix
@@ -10,7 +10,10 @@ stdenv.mkDerivation rec {
   '';
   makeFlags = stdenv.lib.optionals stdenv.isDarwin ["CC=cc"];
 
-  patches = [ ./apg.patch ];
+  patches = [
+    ./apg.patch
+    ./phony-install-target.patch
+  ];
 
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i -e 's|APG_CLIBS += -lcrypt|APG_CLIBS += -L${openssl.out}/lib -lcrypto|' Makefile

--- a/pkgs/tools/security/apg/default.nix
+++ b/pkgs/tools/security/apg/default.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.adel.nursat.kz/apg/;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ astsmtl ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/security/apg/phony-install-target.patch
+++ b/pkgs/tools/security/apg/phony-install-target.patch
@@ -1,0 +1,11 @@
+diff -ur a/Makefile b/Makefile
+--- a/Makefile	2003-08-08 00:40:39.000000000 +0900
++++ b/Makefile	2018-04-05 22:29:39.284191020 +0900
+@@ -142,6 +142,7 @@
+ 	strip ${CS_PROGNAME}
+ 	strip ${BFM_PROGNAME}
+ 
++.PHONY: install
+ install:
+ 	if test -x ./apg; then \
+ ./mkinstalldirs ${INSTALL_PREFIX}${APG_BIN_DIR}; \


### PR DESCRIPTION
###### Motivation for this change

apg on macOS.

The `install` target will no-op on case-insensitive filesystems, which are typical of macOS, but possible on other platforms, so I applied the patch on all platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

