### PR TITLE
mesos: fix on darwin by disabling java interface

### DIFF
--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -15,7 +15,12 @@ stdenv.mkDerivation rec {
     make all leveldbutil libmemenv.a
   '';
 
-  installPhase = "
+  installPhase = (stdenv.lib.optionalString stdenv.isDarwin ''
+    for file in *.dylib*; do
+      install_name_tool -id $out/lib/$file $file
+    done
+  '') + # XXX consider removing above after transition to cmake in the next release
+  "
     mkdir -p $out/{bin,lib,include}
 
     cp -r include $out

--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, findutils
+{ stdenv, fetchurl, findutils, fixDarwinDylibNames
 , sslSupport? true, openssl
 }:
 
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   buildInputs = []
     ++ stdenv.lib.optional sslSupport openssl
     ++ stdenv.lib.optional stdenv.isCygwin findutils
+    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames
     ;
 
   postInstall = stdenv.lib.optionalString sslSupport ''


### PR DESCRIPTION
###### Motivation for this change

Provide spark on darwin (pyspark works).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

