### PR TITLE
linux module handling: support kernels without modules

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -1,5 +1,19 @@
 source $stdenv/setup
 
+# When no modules are built, the $out/lib/modules directory will not
+# exist. Because the rest of the script assumes it does exist, we
+# handle this special case first.
+if ! test -d "$out/lib/modules"; then
+    if test -z "$rootModules" || test -n "$allowMissing"; then
+        mkdir -p "$out"
+        exit 0
+    else
+        echo "Required modules: $rootModules"
+        echo "Can not derive a closure of kernel modules because no modules were provided."
+        exit 1
+    fi
+fi
+
 version=$(cd $kernel/lib/modules && ls -d *)
 
 echo "kernel version is $version"

--- a/pkgs/os-specific/linux/kmod/aggregator.nix
+++ b/pkgs/os-specific/linux/kmod/aggregator.nix
@@ -9,6 +9,12 @@ buildEnv {
     ''
       source ${stdenv}/setup
 
+      if ! test -d "$out/lib/modules"; then
+        echo "No modules found."
+        # To support a kernel without modules
+        exit 0
+      fi
+
       kernelVersion=$(cd $out/lib/modules && ls -d *)
       if test "$(echo $kernelVersion | wc -w)" != 1; then
          echo "inconsistent kernel versions: $kernelVersion"


### PR DESCRIPTION
###### Motivation for this change

A kernel without any modules used to be a problem. With this change you can make it work. Going without modules improves security and performance in specialized applications.

Example:

    boot.kernelPackages = yourKernelPackagesWithoutModules;

    boot.initrd.kernelModules = lib.mkForce [];
    boot.initrd.availableKernelModules = lib.mkForce [];
    boot.kernelModules = lib.mkForce [];

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

