### PR TITLE
gem: better error when multiple gemspecs found

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -203,6 +203,11 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
 
     # write out metadata and binstubs
     spec=$(echo $out/${ruby.gemPath}/specifications/*.gemspec)
+    if [[ "$spec" =~ ( ) ]]; then
+      echo "failure: detected multiple gemspecs for $gempkg.  This can happen when not all dependencies are declared."
+      echo "gemspecs found: $spec"
+      exit 1
+    fi
     ruby ${./gem-post-build.rb} "$spec"
     ''}
 


### PR DESCRIPTION
###### Motivation for this change

If there are multiple gemspec files in
$out/${ruby.gemPath}/specifications/*.gemspec, the gem-post-build.rb
script fails with a confusing error message like this:

```
/nix/store/l5d3c049z5r1rgkavamz78g0p3r95w2z-gem-post-build.rb:19:in `read': No such file or directory @ rb_sysopen - /nix/store/qbr7dbshjbf64bfamy6987dmvr9h8znk-ruby2.4.3-keyring-0.4.1/lib/ruby/gems/2.4.0/specifications/gir_ffi-gnome_keyring-0.0.8.gemspec /nix/store/qbr7dbshjbf64bfamy6987dmvr9h8znk-ruby2.4.3-keyring-0.4.1/lib/ruby/gems/2.4.0/specifications/keyring-0.4.1.gemspec (Errno::ENOENT)
```

The problem is that it's been given a parameter which is several
filenames separated by spaces, but it's treating it as if it's one long
filename.

Under normal conditions, there should be exactly one gemspec, so this
isn't normally a problem.  However, if you don't declare all
dependencies correctly, `gem install` will detect missing dependencies
and tries to install them itself into the $out directory, resulting in
the multiple gemspecs problem.

This commit tries to make a clear error message, both stating the
symptom (multiple gemspecs) and possible cause (missing dependencies).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

