### PR TITLE
tt-rss: 2018-01-05 -> 2018-04-05

### DIFF
--- a/pkgs/servers/tt-rss/default.nix
+++ b/pkgs/servers/tt-rss/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "tt-rss-${version}";
-  version = "2018-01-05";
-  rev = "c30f5e18119d1935e8fe6d422053b127e8f4f1b3";
+  version = "2018-04-05";
+  rev = "963c22646b3e1bd544bd957bf34175b996bd6e53";
 
   src = fetchurl {
     url = "https://git.tt-rss.org/git/tt-rss/archive/${rev}.tar.gz";
-    sha256 = "18pc1l0dbjr7d5grcrb70y6j7cr2zb9575yqmy6zfwzrlvw0pa0l";
+    sha256 = "02vjw5cag5x0rpiqalfrqf7iz21rp8ml5wnfd8pdkxbr8182bw3h";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Just a regular update, since the release model of tt-rss is a rolling master branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

