### PR TITLE
busybox: 1.28.2 -> 1.28.3

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -33,14 +33,14 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "busybox-1.28.2";
+  name = "busybox-1.28.3";
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
   # still builds after the update.
   src = fetchurl {
     url = "http://busybox.net/downloads/${name}.tar.bz2";
-    sha256 = "03abp2n08xk32x8lhdinpxb8gk3faxjmgrv0xqw6ijbp12k98jmn";
+    sha256 = "0via6faqj9xcyi8r39r4n0wxlk8r2292yk0slzwrdri37w1j43dd";
   };
 
   hardeningDisable = [ "format" ] ++ lib.optionals enableStatic [ "fortify" ];


### PR DESCRIPTION
From website:

> Bug fix release. 1.28.3 has fixes for ash and hush (do not leave stray open file destriptors in children), cpio (fix for symlink extraction), grep ("grep -Fw a" was matching "aa").


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---