### PR TITLE
procps-ng: 3.3.12 -> 3.3.13

### DIFF
--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -1,18 +1,32 @@
-{ lib, stdenv, fetchFromGitLab, ncurses, libtool, gettext, autoconf, automake, pkgconfig }:
+{ lib, stdenv, fetchFromGitLab, fetchpatch, ncurses, libtool, gettext, autoconf, automake, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "procps-${version}";
-  version = "3.3.12";
+  version = "3.3.13";
 
   src = fetchFromGitLab {
     owner ="procps-ng";
     repo = "procps";
     rev = "v${version}";
-    sha256 = "0k5vvvjn954xqnhk97j62ilwmipbi4gqjcznllmk6ilfmszqczzz";
+    sha256 = "0r3h9adhqi5fi62lx65z839fww35lfh2isnknhkaw71xndjpzr0q";
   };
 
   buildInputs = [ ncurses ];
   nativeBuildInputs = [ libtool gettext autoconf automake pkgconfig ];
+
+  # https://gitlab.com/procps-ng/procps/issues/88
+  # Patches needed for musl and glibc 2.28
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.com/procps-ng/procps/uploads/f91ff094be1e4638aeffb67bdbb751ba/numa.h.diff";
+      sha256 = "16r537d2wfrvbv6dg9vyfck8n31xa58903mnssw1s4kb5ap83yd5";
+      extraPrefix = "";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/procps-ng/procps/uploads/6a7bdea4d82ba781451316fda74192ae/libio_detection.diff";
+      sha256 = "0qp0j60kiycjsv213ih10imjirmxz8zja3rk9fq5lr5xf7k2lr3p";
+    })
+  ];
 
   # autoreconfHook doesn't quite get, what procps-ng buildprocss does
   # with po/Makefile.in.in and stuff.


### PR DESCRIPTION
https://gitlab.com/procps-ng/procps/tags/v3.3.13

Patch to fix new version w/musl (and glibc 2.28, apparently).




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---