### PR TITLE
psc-package: 0.3.2-pre -> 0.3.2

### DIFF
--- a/pkgs/development/compilers/purescript/psc-package/default.nix
+++ b/pkgs/development/compilers/purescript/psc-package/default.nix
@@ -4,13 +4,13 @@ with lib;
 
 mkDerivation rec {
   pname = "psc-package";
-  version = "0.3.2-pre";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "purescript";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vriyvq0mad3px4lhbqg6xrym2z6wnhr81101mx8cg1lgql1wgwk";
+    sha256 = "1zpzcyh82xl0grvgcj8b7yzh053i9z94kbym5qrv413pcx7w50cm";
   };
 
   isLibrary = false;


### PR DESCRIPTION
###### Motivation for this change
Update psc-package to [v0.3.2](https://github.com/purescript/psc-package/releases/tag/v0.3.2), this should close https://github.com/NixOS/nixpkgs/issues/37374

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

