### PR TITLE
shogun: disable parallel building

### DIFF
--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -47,6 +47,10 @@ stdenv.mkDerivation rec {
     ++ (optional (opencvSupport) "-DOpenCV=ON")
     ;
 
+  # Previous attempts to fix parallel builds (see patch above) were not entirely successful.
+  # Sporadic build failures still exist. Dislable parallel builds for now.
+  enableParallelBuilding = false;
+
   meta = with stdenv.lib; {
     description = "A toolbox which offers a wide range of efficient and unified machine learning methods";
     homepage = "http://shogun-toolbox.org/";


### PR DESCRIPTION
###### Motivation for this change

ZHF #36453

Despite a previous attempt to fix parallel building (see #32271), `shogun` still has sporadic build failures like [this](https://hydra.nixos.org/build/72382019) that I could not reproduce locally. Looking at the logs, this is likely due to an incorrect build sequence. Disable parallel building for now.

I based this PR on 18.03 because currently `liblapack`, a dependency of `shogun`, doesn't build on master. The change should be picked to master later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

