### PR TITLE
gmrender-resurrect: init

### DIFF
--- a/pkgs/tools/networking/gmrender-resurrect/default.nix
+++ b/pkgs/tools/networking/gmrender-resurrect/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig, makeWrapper
+, gstreamer, gst-plugins-base, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-libav, libupnp }:
+
+let version = "4f221e6b85abf85957b547436e982d7a501a1718"; in
+
+stdenv.mkDerivation {
+  name = "gmrender-resurrect-${version}";
+
+  src = fetchFromGitHub {
+    owner = "hzeller";
+    repo = "gmrender-resurrect";
+    rev = "${version}";
+    sha256 = "1dmdhyz27bh74qmvncfd3kw7zqwnd05bhxcfjjav98z5qrxdygj4";
+  };
+
+  preConfigurePhases = "autoconfPhase";
+
+  autoconfPhase = "./autogen.sh";
+
+  buildInputs = [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav libupnp ];
+  nativeBuildInputs = [ autoconf automake pkgconfig makeWrapper ];
+
+  postInstall = ''
+    for prog in "$out/bin/"*; do
+        wrapProgram "$prog" --suffix GST_PLUGIN_SYSTEM_PATH : "${gst-plugins-base}/lib/gstreamer-1.0:${gst-plugins-good}/lib/gstreamer-1.0:${gst-plugins-bad}/lib/gstreamer-1.0:${gst-plugins-ugly}/lib/gstreamer-1.0:${gst-libav}/lib/gstreamer-1.0"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Resource efficient UPnP/DLNA renderer, optimal for Raspberry Pi, CuBox or a general MediaServer";
+    homepage = https://github.com/hzeller/gmrender-resurrect;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.koral ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2513,6 +2513,10 @@ with pkgs;
 
   glxinfo = callPackage ../tools/graphics/glxinfo { };
 
+  gmrender-resurrect = callPackage ../tools/networking/gmrender-resurrect {
+    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav;
+  };
+
   gmvault = callPackage ../tools/networking/gmvault { };
 
   gnash = callPackage ../misc/gnash { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

