### PR TITLE
[WIP] Refactor libprefixed packages to multioutput

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -14,7 +14,8 @@ let
 
   overriddenPackage = cfg.package.override
     (optionalAttrs hasZeroconf { zeroconfSupport = true; });
-  binary = "${getBin overriddenPackage}/bin/pulseaudio";
+  getDaemon = getOutput "daemon";  
+  binary = "${getDaemon overriddenPackage}/bin/pulseaudio";
   binaryNoDaemon = "${binary} --daemonize=no";
 
   # Forces 32bit pulseaudio and alsaPlugins to be built/supported for apps
@@ -144,9 +145,9 @@ in {
 
       package = mkOption {
         type = types.package;
-        default = pulseaudioLight;
-        defaultText = "pkgs.pulseaudioLight";
-        example = literalExample "pkgs.pulseaudioFull";
+        default = pulseaudio;
+        defaultText = "pkgs.pulseaudio";
+        example = literalExample "pkgs.pulseaudio.override {};";
         description = ''
           The PulseAudio derivation to use.  This can be used to enable
           features (such as JACK support, Bluetooth) via the
@@ -212,7 +213,9 @@ in {
     }
 
     (mkIf cfg.enable {
-      environment.systemPackages = [ overriddenPackage ];
+      environment.systemPackages = [ overriddenPackage ] 
+        # We won't pollute $PATH with server binaries, as long as we run it as system server
+        ++ optionals nonSystemWide [(getDaemon overridenPackage)];
 
       environment.etc = [
         { target = "asound.conf";

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -1,17 +1,11 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, python2, perl, yacc, flex
 , texinfo, perlPackages
 , openldap, libcap_ng, sqlite, openssl, db, libedit, pam
-
-# Extra Args
-, type ? ""
 }:
 
-let
-  libOnly = type == "lib";
-in
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "${type}heimdal-${version}";
+  name = "heimdal-${version}";
   version = "7.5.0";
 
   src = fetchFromGitHub {
@@ -21,14 +15,14 @@ stdenv.mkDerivation rec {
     sha256 = "1j38wjj4k0q8vx168k3d3k0fwa8j1q5q8f2688nnx1b9qgjd6w1d";
   };
 
+  outputs = [ "out" "bin" "dev" "man" ];
+
   patches = [ ./heimdal-make-missing-headers.patch ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig python2 perl yacc flex ]
-    ++ (with perlPackages; [ JSON ])
-    ++ optional (!libOnly) texinfo;
+  nativeBuildInputs = [ autoreconfHook pkgconfig python2 perl yacc flex texinfo ]
+    ++ (with perlPackages; [ JSON ]);
   buildInputs = optionals (!stdenv.isFreeBSD) [ libcap_ng db ]
-    ++ [ sqlite openssl libedit ]
-    ++ optionals (!libOnly) [ openldap pam ];
+    ++ [ sqlite openssl libedit openldap pam ];
 
   ## ugly, X should be made an option
   configureFlags = [
@@ -36,11 +30,13 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--enable-hdb-openldap-module"
     "--with-sqlite3=${sqlite.dev}"
-    "--with-libedit=${libedit}"
+
+  # ugly, --with-libedit is not enought, it fall back to bundled libedit
+    "--with-libedit-include=${libedit.dev}/include"
+    "--with-libedit-lib=${libedit}/lib"
     "--with-openssl=${openssl.dev}"
     "--without-x"
     "--with-berkeley-db=${db}"
-  ] ++ optionals (!libOnly) [
     "--with-openldap=${openldap.dev}"
   ] ++ optionals (!stdenv.isFreeBSD) [
     "--with-capng"
@@ -48,24 +44,17 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     sed -i '/^DEFAULT_INCLUDES/ s,$, -I..,' source/cf/Makefile.am.common
+    sed -i -e 's/date/date --date="@$SOURCE_DATE_EPOCH"/' source/configure.ac 
   '';
 
-  buildPhase = optionalString libOnly ''
-    (cd include; make -j $NIX_BUILD_CORES)
-    (cd lib; make -j $NIX_BUILD_CORES)
-    (cd tools; make -j $NIX_BUILD_CORES)
-    (cd include/hcrypto; make -j $NIX_BUILD_CORES)
-    (cd lib/hcrypto; make -j $NIX_BUILD_CORES)
-  '';
-
-  installPhase = optionalString libOnly ''
-    (cd include; make -j $NIX_BUILD_CORES install)
-    (cd lib; make -j $NIX_BUILD_CORES install)
-    (cd tools; make -j $NIX_BUILD_CORES install)
-    (cd include/hcrypto; make -j $NIX_BUILD_CORES install)
-    (cd lib/hcrypto; make -j $NIX_BUILD_CORES install)
-    rm -rf $out/{libexec,sbin,share}
-    find $out/bin -type f | grep -v 'krb5-config' | xargs rm
+  preConfigure = ''
+    configureFlagsArray+=(
+      "--bindir=$out/bin" # Put binaries to $out, then move them to $bin,
+                          # otherwise we go a cyclic dependecny
+      "--sbindir=$out/sbin"
+      "--mandir=$man/share/man"
+      "--infodir=$man/share/info"
+      "--includedir=$dev/include")
   '';
 
   # We need to build hcrypt for applications like samba
@@ -74,14 +63,27 @@ stdenv.mkDerivation rec {
     (cd lib/hcrypto; make -j $NIX_BUILD_CORES)
   '';
 
+  # FIXME: share/info hits $bin, IDK why, but I decide is to minor to block
   postInstall = ''
     # Install hcrypto
     (cd include/hcrypto; make -j $NIX_BUILD_CORES install)
     (cd lib/hcrypto; make -j $NIX_BUILD_CORES install)
 
+    # Do we need it?
+    rm $out/bin/su
+
     # Doesn't succeed with --libexec=$out/sbin, so
-    mv "$out/libexec/"* $out/sbin/
+    mkdir -p $dev/bin
+    mkdir -p $bin/{,s}bin
+    mv "$out/libexec/heimdal/"* $dev/bin/
+    rmdir $out/libexec/heimdal
+    mv "$out/libexec/"* $bin/sbin/
     rmdir $out/libexec
+
+    mkdir -p $dev/bin && mv $out/bin/krb5-config $dev/bin/
+
+    # Move remaining binaries to $bin
+    mv $out/bin/* $bin/bin/
   '';
 
   # Issues with hydra

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -1,11 +1,10 @@
 { stdenv, fetchFromGitHub, pkgconfig, python2Packages, makeWrapper
 , bash, libsamplerate, libsndfile, readline, eigen, celt
+, dbus, libffado, alsaLib, libopus
 # Darwin Dependencies
 , aften, AudioToolbox, CoreAudio, CoreFoundation
 
 # Optional Dependencies
-, dbus ? null, libffado ? null, alsaLib ? null
-, libopus ? null
 , darwin
 
 # Extra options
@@ -17,12 +16,10 @@ let
   inherit (python2Packages) python dbus-python;
   shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
 
-  libOnly = prefix == "lib";
-
   optDbus = if stdenv.isDarwin then null else shouldUsePkg dbus;
-  optPythonDBus = if libOnly then null else shouldUsePkg dbus-python;
-  optLibffado = if libOnly then null else shouldUsePkg libffado;
-  optAlsaLib = if libOnly then null else shouldUsePkg alsaLib;
+  optPythonDBus = shouldUsePkg dbus-python;
+  optLibffado = shouldUsePkg libffado;
+  optAlsaLib =  shouldUsePkg alsaLib;
   optLibopus = shouldUsePkg libopus;
 in
 stdenv.mkDerivation rec {
@@ -35,6 +32,8 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0ynpyn0l77m94b50g7ysl795nvam3ra65wx5zb46nxspgbf6wnkh";
   };
+
+  outputs = [ "out" "bin" "dev"];
 
   nativeBuildInputs = [ pkgconfig python makeWrapper ];
   buildInputs = [ libsamplerate libsndfile readline eigen celt
@@ -59,7 +58,8 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     runHook preConfigure
 
-    python waf configure --prefix=$out \
+    python waf configure --prefix=$bin \
+      --libdir=$out/lib \
       ${optionalString (optDbus != null) "--dbus"} \
       --classic \
       ${optionalString (optLibffado != null) "--firewire"} \
@@ -75,12 +75,13 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     python waf install
-  '' + (if libOnly then ''
-    rm -rf $out/{bin,share}
-    rm -rf $out/lib/{jack,libjacknet*,libjackserver*}
-  '' else ''
-    wrapProgram $out/bin/jack_control --set PYTHONPATH $PYTHONPATH
-  '');
+    
+    # Move drivers from $out to $bin
+    mkdir -p $bin/lib/jack && mv $out/lib/jack $bin/lib/jack
+    wrapProgram $bin/bin/jackd --set JACK_DRIVER_DIR $bin/lib/jack
+    wrapProgram $bin/bin/jackdbus --set JACK_DRIVER_DIR $bin/lib/jack
+    wrapProgram $bin/bin/jack_control --set PYTHONPATH $PYTHONPATH
+  '';
 
   meta = {
     description = "JACK audio connection kit, version 2 with jackdbus";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12527,11 +12527,7 @@ with pkgs;
 
   # Name is changed to prevent use in packages;
   # please use libpulseaudio instead.
-  pulseaudioLight = callPackage ../servers/pulseaudio {
-    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
-  };
-
-  pulseaudioFull = callPackage ../servers/pulseaudio {
+  pulseaudio = callPackage ../servers/pulseaudio {
     gconf = gnome3.gconf;
     x11Support = true;
     jackaudioSupport = true;
@@ -12545,10 +12541,7 @@ with pkgs;
 
   # libpulse implementations
 
-  libpulseaudio-vanilla = callPackage ../servers/pulseaudio {
-    libOnly = true;
-    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
-  };
+  libpulseaudio-vanilla = pulseaudio;
 
   apulse = callPackage ../misc/apulse { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20480,11 +20480,12 @@ with pkgs;
   # using the new configuration style proposal which is unstable
   jack1 = callPackage ../misc/jackaudio/jack1.nix { };
 
-  jack2Full = callPackage ../misc/jackaudio {
+  jack2 = callPackage ../misc/jackaudio {
     libopus = libopus.override { withCustomModes = true; };
     inherit (darwin.apple_sdk.frameworks) AudioToolbox CoreAudio CoreFoundation;
   };
-  libjack2 = jack2Full.override { prefix = "lib"; };
+  libjack2 = jack2;
+  jack2Full = jack2;
 
   keynav = callPackage ../tools/X11/keynav { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9302,7 +9302,7 @@ with pkgs;
   kerberos = libkrb5;
 
   heimdalFull = callPackage ../development/libraries/kerberos/heimdal.nix { };
-  libheimdal = heimdalFull.override { type = "lib"; };
+  libheimdal = heimdalFull;
 
   harfbuzz = callPackage ../development/libraries/harfbuzz { };
   harfbuzz-icu = callPackage ../development/libraries/harfbuzz {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13127,7 +13127,7 @@ with pkgs;
   ffadoFull = callPackage ../os-specific/linux/ffado {
     inherit (python2Packages) python pyqt4 dbus-python;
   };
-  libffado = ffadoFull.override { prefix = "lib"; };
+  libffado = ffadoFull.override { libOnly = true; };
 
   fbterm = callPackage ../os-specific/linux/fbterm { };
 


### PR DESCRIPTION
###### Motivation for this change

Say "farewell" to long-lived ad-hoc hack, when we had two derivations for one package -- one for library-only version, second one with server/utils built.

See #14693 for problem history and details.

Done (Minimum to be done)
  - [x] ffado (complete, moved to own PR #42294 )
  - [x] ffado (aka ffadoFull ---  `ffado-mixer` moved to own derivation, and included in PR above)
  - [x] jack2 (waiting jack1 and own RP)
  - [  ] jack
  - [  ] pulseaudio (Work-in-progress, I still have some plans to split tools and daemon to own outputs)
  - [x] heimdal (done, own PR #42295 )

Not sure about this two, my expertise can be not enough. If I fail to refactor them, I'll create separate issues
  - [  ] krb5

At least volunters for testing would be needed, I haven't any ffado compatible hardware, and can test stuff only  for "just executed and shows version". Also I can't check darwin build myself.

I am sure, that is a mass-rebuild, so eventually this PR will be altered to be against staging. One of reasons, why I open PR early -- is prevend duplications of work, and use `ofborg` to look how much stuff affected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

