### PR TITLE
amazonka: fix build after hackage update

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1009,3 +1009,20 @@ self: super: {
   pure-zlib = doJailbreak super.pure-zlib;
 
 }
+
+//
+
+(let
+  amazonkaOverrides = self: super: {
+    conduit = self.conduit_1_2_13_1;
+    conduit-extra = self.conduit-extra_1_2_3_2;
+    resourcet = self.resourcet_1_1_11;
+    xml-conduit = self.xml-conduit_1_7_1_2;
+    http-conduit = self.http-conduit_2_2_4;
+  };
+  amazonka-core = super.amazonka-core.overrideScope amazonkaOverrides;
+  amazonka = super.amazonka.overrideScope amazonkaOverrides;
+  amazonka-test = super.amazonka-test.overrideScope amazonkaOverrides;
+in {
+  inherit amazonka amazonka-core amazonka-test;
+})


### PR DESCRIPTION
fixes #38306

Note that this partially resurrects an approach that was abandoned in #6584, so it may or may not be okay.  cc @peti, @shlevy, and @fmap.

I got some leads about what direction to flail in from the "Journey into the Haskell NG infrastructure" postings, but I'm definitely still a newbie at the Haskell infrastructure, so might be missing something obvious.  :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).