### PR TITLE
Remove maintainership

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -52,7 +52,7 @@ with python3.pkgs; buildPythonApplication rec {
     homepage = https://github.com/jarun/Buku;
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ matthiasbeyer infinisil ];
+    maintainers = with maintainers; [ infinisil ];
   };
 }
 

--- a/pkgs/applications/misc/cataract/build.nix
+++ b/pkgs/applications/misc/cataract/build.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = http://cgg.bzatek.net/;
     description = "a simple static web photo gallery, designed to be clean and easily usable";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/cli-visualizer/default.nix
+++ b/pkgs/applications/misc/cli-visualizer/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/dpayne/cli-visualizer;
     description = "CLI based audio visualizer";
     license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/applications/misc/ctodo/default.nix
+++ b/pkgs/applications/misc/ctodo/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = http://ctodo.apakoh.dk/;
     description = "A simple ncurses-based task list manager";
     license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/misc/haxor-news/default.nix
+++ b/pkgs/applications/misc/haxor-news/default.nix
@@ -32,7 +32,7 @@ buildPythonApplication rec {
     homepage = https://github.com/donnemartin/haxor-news;
     description = "Browse Hacker News like a haxor";
     license = licenses.asl20;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/applications/misc/hr/default.nix
+++ b/pkgs/applications/misc/hr/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/LuRsT/hr;
     description = "A horizontal bar for your terminal";
     license = licenses.mit;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/hstr/default.nix
+++ b/pkgs/applications/misc/hstr/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/dvorka/hstr;
     description = "Shell history suggest box - easily view, navigate, search and use your command history";
     license = stdenv.lib.licenses.asl20;
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = with stdenv.lib.platforms; linux; # Cannot test others
   };
 

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -40,6 +40,6 @@ buildPythonApplication rec {
     homepage = http://lostpackets.de/khal/;
     description = "CLI calendar application";
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer jgeerds ];
+    maintainers = with maintainers; [ jgeerds ];
   };
 }

--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -31,6 +31,6 @@ python3Packages.buildPythonApplication rec {
     homepage = https://github.com/scheibler/khard;
     description = "Console carddav client";
     license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
   };
 }

--- a/pkgs/applications/misc/mdp/default.nix
+++ b/pkgs/applications/misc/mdp/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/visit1985/mdp;
     description = "A command-line based markdown presentation tool";
-    maintainers = with maintainers; [ matthiasbeyer vrthra ];
+    maintainers = with maintainers; [ vrthra ];
     license = licenses.gpl3;
     platforms = with platforms; unix;
   };

--- a/pkgs/applications/misc/mwic/default.nix
+++ b/pkgs/applications/misc/mwic/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     homepage = http://jwilk.net/software/mwic;
     description = "spell-checker that groups possible misspellings and shows them in their contexts";
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
   };
 }
 

--- a/pkgs/applications/misc/rtv/default.nix
+++ b/pkgs/applications/misc/rtv/default.nix
@@ -48,6 +48,6 @@ buildPythonApplication rec {
     homepage = https://github.com/michael-lazar/rtv;
     description = "Browse Reddit from your Terminal";
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer jgeerds wedens ];
+    maintainers = with maintainers; [ jgeerds wedens ];
   };
 }

--- a/pkgs/applications/misc/sc-im/default.nix
+++ b/pkgs/applications/misc/sc-im/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/andmarti1424/sc-im;
     description = "SC-IM - Spreadsheet Calculator Improvised - SC fork";
     license = licenses.bsdOriginal;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
     platforms = platforms.linux; # Cannot test others
   };
 

--- a/pkgs/applications/misc/sigal/default.nix
+++ b/pkgs/applications/misc/sigal/default.nix
@@ -27,7 +27,7 @@ buildPythonApplication rec {
     description = "Yet another simple static gallery generator";
     homepage    = http://sigal.saimon.org/en/latest/index.html;
     license     = licenses.mit;
-    maintainers = with maintainers; [ domenkozar matthiasbeyer ];
+    maintainers = with maintainers; [ domenkozar ];
   };
 }
 

--- a/pkgs/applications/misc/stag/default.nix
+++ b/pkgs/applications/misc/stag/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     homepage = https://github.com/seenaburns/stag;
     description = "Terminal streaming bar graph passed through stdin";
     license = stdenv.lib.licenses.bsdOriginal;
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/misc/tasknc/default.nix
+++ b/pkgs/applications/misc/tasknc/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/lharding/tasknc;
     description = "A ncurses wrapper around taskwarrior";
-    maintainers = with maintainers; [ matthiasbeyer infinisil ];
+    maintainers = with maintainers; [ infinisil ];
     platforms = platforms.linux; # Cannot test others
   };
 }

--- a/pkgs/applications/misc/tasksh/default.nix
+++ b/pkgs/applications/misc/tasksh/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "REPL for taskwarrior";
     homepage = http://tasktools.org;
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "A command-line time tracker";
     homepage = https://tasktools.org/projects/timewarrior.html;
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer mrVanDalo ];
+    maintainers = with maintainers; [ mrVanDalo ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/misc/toot/default.nix
+++ b/pkgs/applications/misc/toot/default.nix
@@ -24,7 +24,7 @@ python3Packages.buildPythonApplication rec {
     description = "Mastodon CLI interface";
     homepage    = "https://github.com/ihabunek/toot";
     license     = licenses.mit;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
   };
 
 }

--- a/pkgs/applications/misc/vit/default.nix
+++ b/pkgs/applications/misc/vit/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Visual Interactive Taskwarrior";
-    maintainers = with pkgs.lib.maintainers; [ matthiasbeyer ];
+    maintainers = with pkgs.lib.maintainers; [ ];
     platforms = pkgs.lib.platforms.linux;
     license = pkgs.lib.licenses.gpl3;
   };

--- a/pkgs/applications/misc/weather/default.nix
+++ b/pkgs/applications/misc/weather/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
         homepage = http://fungi.yuggoth.org/weather;
         description = "Quick access to current weather conditions and forecasts";
         license = stdenv.lib.licenses.isc;
-        maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+        maintainers = with stdenv.lib.maintainers; [ ];
         platforms = with stdenv.lib.platforms; linux; # my only platform
     };
 }

--- a/pkgs/applications/misc/yaft/default.nix
+++ b/pkgs/applications/misc/yaft/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/uobikiemukot/yaft;
     description = "Yet another framebuffer terminal";
     license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/applications/office/beancount/bean-add.nix
+++ b/pkgs/applications/office/beancount/bean-add.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     # The (only) source file states:
     #   License: "Do what you feel is right, but don't be a jerk" public license.
 
-    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
   };
 }
 

--- a/pkgs/applications/office/beancount/default.nix
+++ b/pkgs/applications/office/beancount/default.nix
@@ -38,7 +38,7 @@ pythonPackages.buildPythonApplication rec {
         generate a variety of reports from them, and provides a web interface.
     '';
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
   };
 }
 

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -23,7 +23,7 @@ buildPythonApplication rec {
     homepage = https://beancount.github.io/fava;
     description = "Web interface for beancount";
     license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
   };
 }
 

--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     description = "Text-based word processor";
     homepage = https://cowlark.com/wordgrinder;
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/version-management/bugseverywhere/default.nix
+++ b/pkgs/applications/version-management/bugseverywhere/default.nix
@@ -28,7 +28,7 @@ pythonPackages.buildPythonApplication rec {
         homepage = http://www.bugseverywhere.org/;
         license = licenses.gpl2Plus;
         platforms = platforms.all;
-        maintainers = [ maintainers.matthiasbeyer ];
+        maintainers = [ ];
     };
 }
 

--- a/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
@@ -41,6 +41,6 @@ buildRustPackage rec {
     inherit (src.meta) homepage;
     description = "Decentralized Issue Tracking for git";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ Profpatsch matthiasbeyer ];
+    maintainers = with maintainers; [ Profpatsch ];
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Mailwatch plugin for Xfce panel";
     platforms = platforms.linux;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "MPD plugin for Xfce panel";
     platforms = platforms.linux;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     description = "Battery plugin for Xfce panel";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/zlog/default.nix
+++ b/pkgs/development/libraries/zlog/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = http://hardysimpson.github.com/zlog;
     license = licenses.lgpl21;
     platforms = platforms.linux; # cannot test on something else
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
   };
 
 }

--- a/pkgs/development/misc/loc/default.nix
+++ b/pkgs/development/misc/loc/default.nix
@@ -19,7 +19,7 @@ buildRustPackage rec {
     homepage = https://github.com/cgag/loc;
     description = "Count lines of code quickly";
     license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/development/python-modules/pygraphviz/default.nix
+++ b/pkgs/development/python-modules/pygraphviz/default.nix
@@ -22,6 +22,6 @@ buildPythonPackage rec {
     description = "Python interface to Graphviz graph drawing package";
     homepage = https://github.com/pygraphviz/pygraphviz;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/requests-toolbelt/default.nix
+++ b/pkgs/development/python-modules/requests-toolbelt/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
   meta = {
     description = "A toolbelt of useful classes and functions to be used with python-requests";
     homepage = http://toolbelt.rtfd.org;
-    maintainers = with lib.maintainers; [ matthiasbeyer jgeerds ];
+    maintainers = with lib.maintainers; [ jgeerds ];
   };
 }

--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -33,7 +33,7 @@ mkDerivation rec {
     description = "DB Browser for SQLite";
     homepage = http://sqlitebrowser.org/;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux; # can only test on linux
   };
 }

--- a/pkgs/misc/screensavers/pipes/default.nix
+++ b/pkgs/misc/screensavers/pipes/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/pipeseroni/pipes.sh;
     description = "Animated pipes terminal screensaver";
     license = licenses.mit;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/misc/taskserver/default.nix
+++ b/pkgs/servers/misc/taskserver/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = http://taskwarrior.org;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer makefu ];
+    maintainers = with stdenv.lib.maintainers; [ makefu ];
   };
 }

--- a/pkgs/servers/web-apps/klaus/default.nix
+++ b/pkgs/servers/web-apps/klaus/default.nix
@@ -35,6 +35,6 @@ python.pkgs.buildPythonApplication rec {
     description = "The first Git web viewer that Just Works";
     homepage    = https://github.com/jonashaag/klaus;
     license     = licenses.isc;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/misc/mpdscribble/default.nix
+++ b/pkgs/tools/misc/mpdscribble/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "A Music Player Daemon (MPD) client which submits information about tracks beeing played to a scrobbler (e.g. last.fm)";
     homepage = http://mpd.wikia.com/wiki/Client:mpdscribble;
     license = licenses.gpl2;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/multitail/default.nix
+++ b/pkgs/tools/misc/multitail/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.vanheusden.com/multitail/;
     description = "tail on Steroids";
-    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/misc/smenu/default.nix
+++ b/pkgs/tools/misc/smenu/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
       your selection will be sent to standard output.
     '';
     license     = licenses.gpl2;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
     platforms   = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -33,7 +33,7 @@ pythonPackages.buildPythonApplication rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/pimutils/vdirsyncer;
     description = "Synchronize calendars and contacts";
-    maintainers = with maintainers; [ matthiasbeyer jgeerds ];
+    maintainers = with maintainers; [ jgeerds ];
     platforms = platforms.all;
     license = licenses.mit;
   };

--- a/pkgs/tools/misc/vimer/default.nix
+++ b/pkgs/tools/misc/vimer/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       in an existing instance of GVim or MacVim.
     '';
     license = licenses.mit;
-    maintainers = [ maintainers.matthiasbeyer ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/tools/networking/http-prompt/default.nix
+++ b/pkgs/tools/networking/http-prompt/default.nix
@@ -28,7 +28,7 @@ pythonPackages.buildPythonApplication rec {
     description = "An interactive command-line HTTP client featuring autocomplete and syntax highlighting";
     homepage = https://github.com/eliangcs/http-prompt;
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux; # can only test on linux
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -634,7 +634,7 @@ in {
     meta = {
       description = "Atomic file writes on POSIX";
       homepage = https://pypi.python.org/pypi/atomicwrites/0.1.0;
-      maintainers = with maintainers; [ matthiasbeyer ];
+      maintainers = with maintainers; [ ];
     };
 
   };
@@ -4759,7 +4759,7 @@ in {
       description = "Python humanize utilities";
       homepage = https://github.com/jmoiron/humanize;
       license = licenses.mit;
-      maintainers = with maintainers; [ matthiasbeyer ];
+      maintainers = with maintainers; [ ];
       platforms = platforms.linux; # can only test on linux
     };
 
@@ -4847,7 +4847,7 @@ in {
       description = "WSGI HTTP Digest Authentication middleware";
       homepage = https://github.com/jonashaag/httpauth;
       license = licenses.bsd2;
-      maintainers = with maintainers; [ matthiasbeyer ];
+      maintainers = with maintainers; [ ];
     };
   };
 
@@ -16738,7 +16738,7 @@ in {
       homepage = https://github.com/uri-templates/uritemplate-py;
       description = "Python implementation of URI Template";
       license = licenses.asl20;
-      maintainers = with maintainers; [ matthiasbeyer ];
+      maintainers = with maintainers; [ ];
     };
   };
 


### PR DESCRIPTION
With this patch I remove myself as a maintainer for all packages I
currently maintain.

This is due the fact that I will be basically off the grid from May 2018
until early 2019, as I will be on a trip through north america.

I will revert this patch as soon as I'm back, as I plan to continue
contributing to nixpkgs then.
But as I cannot maintain anything during that time, I'd like to get this
patch merged.

Signed-off-by: Matthias Beyer <mail@beyermatthias.de>

---

I want to get this merged now, not in May, so that I can focus on some private stuff I have to get ready until May.

Pinging other maintainers of the packages here, so they know what's happening:

@jgeerds @Profpatsch @Infinisil @domenkozar @mrVanDalo @makefu 