### PR TITLE
platformio: 3.5.1 -> 3.5.2

### DIFF
--- a/pkgs/development/python-modules/platformio/default.nix
+++ b/pkgs/development/python-modules/platformio/default.nix
@@ -9,12 +9,12 @@ buildPythonPackage rec {
   disabled = isPy3k || isPyPy;
 
   pname = "platformio";
-  version="3.5.1";
+  version="3.5.2";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0cc15mzh7p1iykip0jpxldz81yz946vrgvhwmfl8w3z5kgjjgx3n";
+    sha256 = "1v74qb7jlfw7kbbb8wi4zcr3cyl8lhk1c1y28ny9ab7ip3jiqcdv";
   };
 
   propagatedBuildInputs =  [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

