### PR TITLE
clementine: provide free derivation by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -58,6 +58,9 @@ following incompatible changes:</para>
 <itemizedlist>
   <listitem>
     <para>
+      The <literal>clementine</literal> package points now to the free derivation.
+      <literal>clementineFree</literal> is removed now and <literal>clementineUnfree</literal>
+      points to the package which is bundled with the unfree <literal>libspotify</literal> package.
     </para>
   </listitem>
 </itemizedlist>

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "chromaprint-${version}";
-  version = "1.4.3";
+  version = "1.3.2";
 
   src = fetchurl {
-    url = "https://github.com/acoustid/chromaprint/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "10kz8lncal4s2rp2rqpgc6xyjp0jzcrihgkx7chf127vfs5n067a";
+    url = "http://bitbucket.org/acoustid/chromaprint/downloads/${name}.tar.gz";
+    sha256 = "0lln8dh33gslb9cbmd1hcv33pr6jxdwipd8m8gbsyhksiq6r1by3";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1603,7 +1603,7 @@ with pkgs;
       with gst_all_1; [ gst-plugins-base gst-plugins-good gst-plugins-ugly gst-libav ];
   };
 
-  clementineFree = clementine.free;
+  clementineUnfree = clementine.unfree;
 
   ciopfs = callPackage ../tools/filesystems/ciopfs { };
 


### PR DESCRIPTION
###### Motivation for this change

The `clementine` package is actually released under Apache license, but
requires the unfree `libspotify` package to build.

Now `nixpkgs.clementine` points to the free derivation and
`nixpkgs.clementineUnfree` has been introduced for the package bundled
with spotify support.

Fixes #38315 

__Note:__ I had to revert commit ca54d50 as it broke `clementine` previously (see the Hydra logs at https://hydra.nixos.org/build/72403466)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

