### PR TITLE
firefox: fix wrapper to make proper symlink to icon

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -132,7 +132,7 @@ let
         else
             for res in 16 32 48 64 128; do
             mkdir -p "$out/share/icons/hicolor/''${res}x''${res}/apps"
-            ln -s "${browser}/lib/${browserName}/browser/chrome/icons/default/default''${res}.png" \
+            ln -s "${browser}/lib/"*"/browser/chrome/icons/default/default''${res}.png" \
                 "$out/share/icons/hicolor/''${res}x''${res}/apps/${browserName}.png"
             done
         fi


### PR DESCRIPTION
###### Motivation for this change

The symbolic link `/nix/store/...-firefox-bin-59.0.2/share/icons/hicolor/128x128/apps/firefox.png` points to `/nix/store/...-firefox-release-bin-unwrapped-59.0.2/lib/firefox/browser/chrome/icons/default/default128.png`, but it should be `/nix/store/...-firefox-release-bin-unwrapped-59.0.2/lib/firefox-bin-59.0.2/browser/chrome/icons/default/default128.png`.

Because of this, `nix-env -i firefox-bin` results in error with 18.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

