### PR TITLE
rclone: 1.39 -> 1.40

### DIFF
--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "rclone-${version}";
-  version = "1.39";
+  version = "1.40";
 
   goPackagePath = "github.com/ncw/rclone";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "ncw";
     repo = "rclone";
     rev = "v${version}";
-    sha256 = "1x9qxhqkbyd7kd52ai9p996ppslh73xarn5w4ljaa97wwm5vwwsg";
+    sha256 = "01q9g5g4va1s91xzvxpq8lj9jcrbl66cik383cpxwmcv04qcqgw9";
   };
 
   outputs = [ "bin" "out" "man" ];


### PR DESCRIPTION
###### Motivation for this change
Backport rclone 1.40.
Has many useful features, no breaking changes and has been working fine for me on NixOS 18.03 for weeks.