### PR TITLE
lib: make extensible

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -5,9 +5,11 @@
  */
 let
 
-  callLibs = file: import file { inherit lib; };
+  inherit (import ./fixed-points.nix {}) makeExtensible;
 
-  lib = rec {
+  lib = makeExtensible (self: let
+    callLibs = file: import file { lib = self; };
+  in with self; {
 
     # often used, or depending on very little
     trivial = callLibs ./trivial.nix;
@@ -128,5 +130,5 @@ let
       mergeAttrsNoOverride mergeAttrByFunc mergeAttrsByFuncDefaults
       mergeAttrsByFuncDefaultsClean mergeAttrBy
       prepareDerivationArgs nixType imap overridableDelayableArgs;
-  };
+  });
 in lib

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -59,7 +59,7 @@ rec {
         };
       };
 
-      closed = closeModules (modules ++ [ internalModule ]) ({ inherit config options; lib = import ./.; } // specialArgs);
+      closed = closeModules (modules ++ [ internalModule ]) ({ inherit config options lib; } // specialArgs);
 
       options = mergeModules prefix (reverseList (filterModules (specialArgs.modulesPath or "") closed));
 


### PR DESCRIPTION
This allows the lib fixed point to be extended with

```nix
myLib = lib.extend (self: super: {
  foo = "foo";
})
```

With this it's possible to have the new modified lib attrset available to all
modules when using evalModules

```nix
myLib.evalModules {
  modules = [ ({ lib, ... }: {
    options.bar = lib.mkOption {
      default = lib.foo;
    };
  }) ];
}
```
=>
```nix
{ config = { bar = "foo"; ... }; options = ...; }
```

###### Motivation for this change
This will be useful for projects like @rycee [home-manager](https://github.com/rycee/home-manager) that use the module system themselves without the ability to modify `nixpkgs/lib` directly. Currently home-manager needs to [use](https://github.com/rycee/home-manager/blob/7c9278bd92a067832c421e79f25401a9791aaddd/modules/modules.nix#L93) the [prone to infinite recursion](https://github.com/rycee/home-manager/pull/160) lib module that just adds a `lib` option. Stuff like `with config.lib;` at the top of the file will give you infinite recursion in general though.

Another instance is @LnL7's [nix-darwin](https://github.com/LnL7/nix-darwin) which currently [imports its lib directly](https://github.com/LnL7/nix-darwin/blob/master/modules/launchd/default.nix#L3) in every file that needs it (which is what home-manager used previously).

@LnL7 @rycee @Profpatsch @edolstra @shlevy 

###### Things done

Other than running a few very basic commands like the one above I haven't tested this very well. But I'm 99% sure this can't break anything and is fully backwards compatible. Will test it more in a bit.