### PR TITLE
openorienteering-mapper: 0.8.1 -> 0.8.1.2 and fix templates

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "OpenOrienteering-Mapper-${version}";
-  version = "0.8.1";
+  version = "0.8.1.2";
 
   buildInputs = [ gdal qtbase qttools qtlocation qtsensors clipper zlib proj doxygen cups];
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "OpenOrienteering";
     repo = "mapper";
     rev = "v${version}";
-    sha256 = "10viw8bddl76mc2gh84jsl7h237yzvh4nim61pbd63vg1hlqisi6";
+    sha256 = "0f7zxzl2n46qy86k6n3f6a7l1nhba58i28l8ngp3drf74qffaa33";
   };
 
   cmakeFlags =

--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchFromGitHub, gdal, cmake, ninja, proj, clipper, zlib, qtbase, qttools
-  , qtlocation, qtsensors, doxygen, cups, makeWrapper
+  , qtlocation, qtsensors, doxygen, cups, makeWrapper, qtimageformats
 }:
 
 stdenv.mkDerivation rec {
   name = "OpenOrienteering-Mapper-${version}";
   version = "0.8.1.2";
 
-  buildInputs = [ gdal qtbase qttools qtlocation qtsensors clipper zlib proj doxygen cups];
+  buildInputs = [ gdal qtbase qttools qtlocation qtimageformats
+                  qtsensors clipper zlib proj doxygen cups];
 
   nativeBuildInputs = [ cmake makeWrapper ninja ];
 
@@ -48,7 +49,8 @@ stdenv.mkDerivation rec {
     # Fixes "This application failed to start because it could not find or load the Qt
     # platform plugin "cocoa"."
     wrapProgram $out/Mapper.app/Contents/MacOS/Mapper \
-      --set QT_QPA_PLATFORM_PLUGIN_PATH ${qtbase.bin}/lib/qt-*/plugins/platforms
+      --set QT_QPA_PLATFORM_PLUGIN_PATH ${qtbase.bin}/lib/qt-*/plugins/platforms \
+      --set QT_PLUGIN_PATH ${qtbase.bin}/${qtbase.qtPluginPrefix}:${qtimageformats}/${qtbase.qtPluginPrefix}
     mkdir -p $out/bin
     ln -s $out/Mapper.app/Contents/MacOS/Mapper $out/bin/mapper
     '';

--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -55,14 +55,14 @@ stdenv.mkDerivation rec {
     ln -s $out/Mapper.app/Contents/MacOS/Mapper $out/bin/mapper
     '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = ''
       OpenOrienteering Mapper is an orienteering mapmaking program
       and provides a free alternative to the existing proprietary solution.
     '';
     homepage = https://www.openorienteering.org/apps/mapper/;
-    license = stdenv.lib.licenses.gpl3;
-    platforms = with stdenv.lib.platforms; darwin;
-    maintainers = with stdenv.lib.maintainers; [mpickering];
+    license = licenses.gpl3;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [mpickering];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump and fix an issue with reading template files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

