### PR TITLE
pytorch: 0.2.0 → 0.3.1 with CUDA and cuDNN

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -1,27 +1,34 @@
-{ buildPythonPackage, fetchFromGitHub, lib, numpy, pyyaml, cffi, cmake,
-  git, stdenv }:
+{ buildPythonPackage,
+  cudaSupport ? false, cudatoolkit ? null, cudnn ? null,
+  fetchFromGitHub, lib, numpy, pyyaml, cffi, cmake,
+  git, stdenv,
+  utillinux, which }:
+
+assert cudnn == null || cudatoolkit != null;
+assert !cudaSupport || cudatoolkit != null;
 
 buildPythonPackage rec {
-  version = "0.2.0";
+  version = "0.3.0";
   pname = "pytorch";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner  = "pytorch";
     repo   = "pytorch";
-    rev    = "v${version}";
-    sha256 = "1s3f46ga1f4lfrcj3lpvvhgkdr1pi8i2hjd9xj9qiz3a9vh2sj4n";
+    rev    = "af3964a8725236c78ce969b827fdeee1c5c54110";
+    fetchSubmodules = true;
+    sha256 = "0zbndardq3fpvxfa9qamkms0x7kxla4657lccrpyymydn97n888a";
   };
 
-  checkPhase = ''
-    ${stdenv.shell} test/run_test.sh
-  '';
+  preConfigure = lib.optionalString (cudnn != null) "export CUDNN_INCLUDE_DIR=${cudnn}/include";
 
   buildInputs = [
      cmake
      git
      numpy.blas
-  ];
+     utillinux
+     which
+  ] ++ lib.optionals cudaSupport [cudatoolkit cudnn];
 
   propagatedBuildInputs = [
     cffi
@@ -29,9 +36,11 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  preConfigure = ''
-    export NO_CUDA=1
+  checkPhase = ''
+    ${stdenv.shell} test/run_test.sh
   '';
+
+  doCheck = false; # for some unknown reason doesn't detect cuda if run from builder user
 
   meta = {
     description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration.";

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     ${stdenv.shell} test/run_test.sh
   '';
 
-  doCheck = false; # for some unknown reason doesn't detect cuda if run from builder user
+  doCheck = !cudaSupport; # for some unknown reason doesn't detect cuda if run from builder user
 
   meta = {
     description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration.";

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -1,13 +1,19 @@
 { buildPythonPackage,
   cudaSupport ? false, cudatoolkit ? null, cudnn ? null,
   fetchFromGitHub, lib, numpy, pyyaml, cffi, cmake,
-  git, stdenv,
+  git, stdenv, symlinkJoin,
   utillinux, which }:
 
 assert cudnn == null || cudatoolkit != null;
 assert !cudaSupport || cudatoolkit != null;
 
-buildPythonPackage rec {
+let
+  cudatoolkit_joined = symlinkJoin {
+    name = "${cudatoolkit.name}-unsplit";
+    paths = [ cudatoolkit.out cudatoolkit.lib ];
+  };
+
+in buildPythonPackage rec {
   version = "0.3.0";
   pname = "pytorch";
   name = "${pname}-${version}";
@@ -32,7 +38,7 @@ buildPythonPackage rec {
      numpy.blas
      utillinux
      which
-  ] ++ lib.optionals cudaSupport [cudatoolkit cudnn];
+  ] ++ lib.optionals cudaSupport [cudatoolkit_joined cudnn];
 
   propagatedBuildInputs = [
     cffi

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -38,6 +38,12 @@ in buildPythonPackage rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace test/run_test.sh --replace \
+      "INIT_METHOD='file://'\$TEMP_DIR'/shared_init_file' \$PYCMD ./test_distributed.py" \
+      "echo Skipped for Nix package"
+  '';
+
   preConfigure = lib.optionalString cudaSupport ''
     export CC=${cudatoolkit.cc}/bin/gcc
   '' + lib.optionalString (cudaSupport && cudnn != null) ''

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -14,16 +14,16 @@ let
   };
 
 in buildPythonPackage rec {
-  version = "0.3.0";
+  version = "0.3.1";
   pname = "pytorch";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner  = "pytorch";
     repo   = "pytorch";
-    rev    = "af3964a8725236c78ce969b827fdeee1c5c54110";
+    rev    = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0zbndardq3fpvxfa9qamkms0x7kxla4657lccrpyymydn97n888a";
+    sha256 = "1k8fr97v5pf7rni5cr2pi21ixc3pdj3h3lkz28njbjbgkndh7mr3";
   };
 
   preConfigure = lib.optionalString cudaSupport ''

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -20,7 +20,9 @@ buildPythonPackage rec {
     sha256 = "0zbndardq3fpvxfa9qamkms0x7kxla4657lccrpyymydn97n888a";
   };
 
-  preConfigure = lib.optionalString (cudaSupport && cudnn != null) ''
+  preConfigure = lib.optionalString cudaSupport ''
+    export CC=${cudatoolkit.cc}/bin/gcc
+  '' + lib.optionalString (cudaSupport && cudnn != null) ''
     export CUDNN_INCLUDE_DIR=${cudnn}/include
   '';
 

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -1,6 +1,6 @@
 { buildPythonPackage,
   cudaSupport ? false, cudatoolkit ? null, cudnn ? null,
-  fetchFromGitHub, lib, numpy, pyyaml, cffi, cmake,
+  fetchFromGitHub, fetchpatch, lib, numpy, pyyaml, cffi, cmake,
   git, stdenv, symlinkJoin,
   utillinux, which }:
 
@@ -25,6 +25,18 @@ in buildPythonPackage rec {
     fetchSubmodules = true;
     sha256 = "1k8fr97v5pf7rni5cr2pi21ixc3pdj3h3lkz28njbjbgkndh7mr3";
   };
+
+  patches = [
+    (fetchpatch {
+      # make sure stdatomic.h is included when checking for ATOMIC_INT_LOCK_FREE
+      # Fixes this test failure:
+      # RuntimeError: refcounted file mapping not supported on your system at /tmp/nix-build-python3.6-pytorch-0.3.0.drv-0/source/torch/lib/TH/THAllocator.c:525
+      url = "https://github.com/pytorch/pytorch/commit/502aaf39cf4a878f9e4f849e5f409573aa598aa9.patch";
+      stripLen = 3;
+      extraPrefix = "torch/lib/";
+      sha256 = "1miz4lhy3razjwcmhxqa4xmlcmhm65lqyin1czqczj8g16d3f62f";
+    })
+  ];
 
   preConfigure = lib.optionalString cudaSupport ''
     export CC=${cudatoolkit.cc}/bin/gcc

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -20,7 +20,9 @@ buildPythonPackage rec {
     sha256 = "0zbndardq3fpvxfa9qamkms0x7kxla4657lccrpyymydn97n888a";
   };
 
-  preConfigure = lib.optionalString (cudnn != null) "export CUDNN_INCLUDE_DIR=${cudnn}/include";
+  preConfigure = lib.optionalString (cudaSupport && cudnn != null) ''
+    export CUDNN_INCLUDE_DIR=${cudnn}/include
+  '';
 
   buildInputs = [
      cmake

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8469,7 +8469,17 @@ in {
     };
   };
 
-  pytorch = callPackage ../development/python-modules/pytorch { };
+  pytorch = callPackage ../development/python-modules/pytorch {
+    cudaSupport = pkgs.config.cudaSupport or false;
+  };
+
+  pytorchWithCuda = self.pytorch.override {
+    cudaSupport = true;
+  };
+
+  pytorchWithoutCuda = self.pytorch.override {
+    cudaSupport = false;
+  };
 
   python2-pythondialog = buildPythonPackage rec {
     name = "python2-pythondialog-${version}";


### PR DESCRIPTION
###### Motivation for this change

This upgrades PyTorch and adds CUDA and cuDNN support. It’s an updated version of #32438 “pytorch-0.3 with cuda and cudnn” and includes those commits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

