### PR TITLE
pythonPackages.ewmh: init at 0.1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -517,6 +517,11 @@
     email = "sivaraman.balaji@gmail.com";
     name = "Balaji Sivaraman";
   };
+  bandresen = {
+    email = "bandresen@gmail.com";
+    github = "bandresen";
+    name = "Benjamin Andresen";
+  };
   barrucadu = {
     email = "mike@barrucadu.co.uk";
     github = "barrucadu";

--- a/pkgs/development/python-modules/ewmh/default.nix
+++ b/pkgs/development/python-modules/ewmh/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, xlib }:
+
+buildPythonPackage rec {
+  pname = "ewmh";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0g9l14my3v8zlgq1yd8wh5gpara0qcapsfmvg7lq2lapglzhjsy5";
+  };
+
+  propagatedBuildInputs = [ xlib ];
+
+  # No tests included
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/parkouss/pyewmh;
+    description = "An implementation of EWMH (Extended Window Manager Hints), based on Xlib";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ bandresen ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -233,6 +233,8 @@ in {
 
   email_validator = callPackage ../development/python-modules/email-validator { };
 
+  ewmh = callPackage ../development/python-modules/ewmh { };
+
   dbus-python = callPackage ../development/python-modules/dbus {
     dbus = pkgs.dbus;
   };


### PR DESCRIPTION
###### Motivation for this change
Include pyewmh library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

