### PR TITLE
duplicati: init at 2.0.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2639,6 +2639,11 @@
     github = "nthorne";
     name = "Niklas Thörne";
   };
+  nyanloutre = {
+    email = "paul@nyanlout.re";
+    github = "nyanloutre";
+    name = "Paul Trehiou";
+  };
   nyarly = {
     email = "nyarly@gmail.com";
     github = "nyarly";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -305,6 +305,7 @@
       hass = 286;
       monero = 287;
       ceph = 288;
+      duplicati = 289;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -578,6 +579,7 @@
       hass = 286;
       monero = 287;
       ceph = 288;
+      duplicati = 289;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -159,6 +159,7 @@
   ./services/audio/ympd.nix
   ./services/backup/bacula.nix
   ./services/backup/borgbackup.nix
+  ./services/backup/duplicati.nix
   ./services/backup/crashplan.nix
   ./services/backup/crashplan-small-business.nix
   ./services/backup/mysql-backup.nix

--- a/nixos/modules/services/backup/duplicati.nix
+++ b/nixos/modules/services/backup/duplicati.nix
@@ -1,0 +1,40 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.duplicati;
+in
+{
+  options = {
+    services.duplicati = {
+      enable = mkEnableOption "Duplicati";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.duplicati ];
+
+    systemd.services.duplicati = {
+      description = "Duplicati backup";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        User = "duplicati";
+        Group = "duplicati";
+        ExecStart = "${pkgs.duplicati}/bin/duplicati-server --webservice-interface=any --webservice-port=8200 --server-datafolder=/var/lib/duplicati";
+        Restart = "on-failure";
+      };
+    };
+
+    users.extraUsers.duplicati = {
+      uid = config.ids.uids.duplicati;
+      home = "/var/lib/duplicati";
+      createHome = true;
+      group = "duplicati";
+    };
+    users.extraGroups.duplicati.gid = config.ids.gids.duplicati;
+
+  };
+}
+

--- a/pkgs/tools/backup/duplicati/default.nix
+++ b/pkgs/tools/backup/duplicati/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchzip, mono, sqlite, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "duplicati-${version}";
+  version = "2.0.3.3";
+  channel = "beta";
+  build_date = "2018-04-02";
+
+  src = fetchzip {
+    url = "https://github.com/duplicati/duplicati/releases/download/v${version}-${version}_${channel}_${build_date}/duplicati-${version}_${channel}_${build_date}.zip";
+    sha256 = "0hwdpsgrvm3gq648mg9g0z0rk49g71dd8r5i1a8w83pwdqv0hn9c";
+    stripRoot = false;
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/${name}}
+    cp -r * $out/share/${name}
+    makeWrapper "${mono}/bin/mono" $out/bin/duplicati-cli \
+      --add-flags "$out/share/${name}/Duplicati.CommandLine.exe" \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [
+          sqlite ]}
+    makeWrapper "${mono}/bin/mono" $out/bin/duplicati-server \
+      --add-flags "$out/share/${name}/Duplicati.Server.exe" \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [
+          sqlite ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A free backup client that securely stores encrypted, incremental, compressed backups on cloud storage services and remote file servers";
+    homepage = https://www.duplicati.com/;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ nyanloutre ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2035,6 +2035,8 @@ with pkgs;
 
   duo-unix = callPackage ../tools/security/duo-unix { };
 
+  duplicati = callPackage ../tools/backup/duplicati { };
+
   duplicity = callPackage ../tools/backup/duplicity {
     gnupg = gnupg1;
   };


### PR DESCRIPTION
###### Motivation for this change
Creation of a Duplicati package, a very nice backup tool that I use regularly.
This is my first package pull request so I might have forgotten some things.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

