### PR TITLE
nixos/zsh: do not set ZSH prompt to the 'walters' style

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -69,7 +69,7 @@ in
 
       promptInit = mkOption {
         default = ''
-          autoload -U promptinit && promptinit && prompt walters
+          autoload -U promptinit && promptinit
         '';
         description = ''
           Shell script code used to initialise the zsh prompt.


### PR DESCRIPTION
This is not the default upstream and causes differences in behavior for users compared to other distros.

The commit introducing this default was the one introducing support for zsh, without any justification at the time.

In addition to having surprising effects on user configurations, the prompt is currently buggy and can hide command output: https://github.com/NixOS/nixpkgs/issues/30121

###### Motivation for this change

Other distros do not change the default zsh prompt theme, and it changes the behavior of any user configuration that does not explicitly override all settings set in the 'walters' theme. In addition, the current prompt theme is buggy and hides the last line of output from commands that do not terminate their output with a newline.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

