### PR TITLE
nheko: init at 0.3.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -1,0 +1,83 @@
+{ stdenv, fetchFromGitHub, fetchurl, cmake, doxygen, lmdb, qt5 }:
+
+let
+  json_hpp = fetchurl {
+    url = https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp;
+    sha256 = "fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733";
+  };
+
+  variant_hpp = fetchurl {
+    url = https://github.com/mpark/variant/releases/download/v1.3.0/variant.hpp;
+    sha256 = "1vjiz1x5l8ynqqyb5l9mlrzgps526v45hbmwjilv4brgyi5445fq";
+  };
+
+  matrix-structs = stdenv.mkDerivation rec {
+    name = "matrix-structs-git";
+
+    src = fetchFromGitHub {
+      owner = "mujx";
+      repo = "matrix-structs";
+      rev = "91bb2b85a75d664007ef81aeb500d35268425922";
+      sha256 = "1v544pv18sd91gdrhbk0nm54fggprsvwwrkjmxa59jrvhwdk7rsx";
+    };
+
+    postUnpack = ''
+      cp ${json_hpp} "$sourceRoot/include/json.hpp"
+      cp ${variant_hpp} "$sourceRoot/include/variant.hpp"
+    '';
+
+    patches = [ ./fetchurls.patch ];
+
+    nativeBuildInputs = [ cmake doxygen ];
+  };
+
+  tweeny = fetchFromGitHub {
+    owner = "mobius3";
+    repo = "tweeny";
+    rev = "b94ce07cfb02a0eb8ac8aaf66137dabdaea857cf";
+    sha256 = "1wyyq0j7dhjd6qgvnh3knr70li47hmf5394yznkv9b1indqjx4mi";
+  };
+
+  lmdbxx = fetchFromGitHub {
+    owner = "bendiken";
+    repo = "lmdbxx";
+    rev = "0b43ca87d8cfabba392dfe884eb1edb83874de02";
+    sha256 = "1whsc5cybf9rmgyaj6qjji03fv5jbgcgygp956s3835b9f9cjg1n";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "nheko-${version}";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "mujx";
+    repo = "nheko";
+    rev = "v${version}";
+    sha256 = "178z64vkl7nmr1amgsgvdcwipj8czp7vbvidxllxiwal21yvqpky";
+  };
+
+  # This patch is likely not strictly speaking needed, but will help detect when
+  # a dependency is updated, so that the fetches up there can be updated too
+  patches = [ ./external-deps.patch ];
+
+  cmakeFlags = [
+    "-DMATRIX_STRUCTS_LIBRARY=${matrix-structs}/lib/static/libmatrix_structs.a"
+    "-DMATRIX_STRUCTS_INCLUDE_DIR=${matrix-structs}/include/matrix_structs"
+    "-DTWEENY_INCLUDE_DIR=${tweeny}/include"
+    "-DLMDBXX_INCLUDE_DIR=${lmdbxx}"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    lmdb lmdbxx matrix-structs qt5.qtbase qt5.qtmultimedia qt5.qttools tweeny
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Desktop client for the Matrix protocol";
+    maintainers = with maintainers; [ ekleog ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/nheko/external-deps.patch
+++ b/pkgs/applications/networking/instant-messengers/nheko/external-deps.patch
@@ -1,0 +1,94 @@
+diff --git a/cmake/LMDBXX.cmake b/cmake/LMDBXX.cmake
+index 3b9817d..e69de29 100644
+--- a/cmake/LMDBXX.cmake
++++ b/cmake/LMDBXX.cmake
+@@ -1,23 +0,0 @@
+-include(ExternalProject)
+-
+-#
+-# Build lmdbxx.
+-#
+-
+-set(THIRD_PARTY_ROOT ${CMAKE_SOURCE_DIR}/.third-party)
+-set(LMDBXX_ROOT ${THIRD_PARTY_ROOT}/lmdbxx)
+-
+-set(LMDBXX_INCLUDE_DIR ${LMDBXX_ROOT})
+-
+-ExternalProject_Add(
+-  lmdbxx
+-
+-  GIT_REPOSITORY https://github.com/bendiken/lmdbxx
+-  GIT_TAG 0b43ca87d8cfabba392dfe884eb1edb83874de02
+-
+-  BUILD_IN_SOURCE 1
+-  SOURCE_DIR ${LMDBXX_ROOT}
+-  CONFIGURE_COMMAND ""
+-  BUILD_COMMAND ""
+-  INSTALL_COMMAND ""
+-)
+diff --git a/cmake/MatrixStructs.cmake b/cmake/MatrixStructs.cmake
+index cef00f6..e69de29 100644
+--- a/cmake/MatrixStructs.cmake
++++ b/cmake/MatrixStructs.cmake
+@@ -1,33 +0,0 @@
+-include(ExternalProject)
+-
+-#
+-# Build matrix-structs.
+-#
+-
+-set(THIRD_PARTY_ROOT ${CMAKE_SOURCE_DIR}/.third-party)
+-set(MATRIX_STRUCTS_ROOT ${THIRD_PARTY_ROOT}/matrix_structs)
+-set(MATRIX_STRUCTS_INCLUDE_DIR ${MATRIX_STRUCTS_ROOT}/include)
+-set(MATRIX_STRUCTS_LIBRARY matrix_structs)
+-
+-link_directories(${MATRIX_STRUCTS_ROOT})
+-
+-set(WINDOWS_FLAGS "")
+-
+-if(MSVC)
+-    set(WINDOWS_FLAGS "-DCMAKE_GENERATOR_PLATFORM=x64")
+-endif()
+-
+-ExternalProject_Add(
+-  MatrixStructs
+-
+-  GIT_REPOSITORY https://github.com/mujx/matrix-structs
+-  GIT_TAG 91bb2b85a75d664007ef81aeb500d35268425922
+-
+-  BUILD_IN_SOURCE 1
+-  SOURCE_DIR ${MATRIX_STRUCTS_ROOT}
+-  CONFIGURE_COMMAND ${CMAKE_COMMAND}
+-    -DCMAKE_BUILD_TYPE=Release ${MATRIX_STRUCTS_ROOT}
+-    ${WINDOWS_FLAGS}
+-  BUILD_COMMAND ${CMAKE_COMMAND} --build ${MATRIX_STRUCTS_ROOT} --config Release
+-  INSTALL_COMMAND ""
+-)
+diff --git a/cmake/Tweeny.cmake b/cmake/Tweeny.cmake
+index 537ac92..e69de29 100644
+--- a/cmake/Tweeny.cmake
++++ b/cmake/Tweeny.cmake
+@@ -1,23 +0,0 @@
+-include(ExternalProject)
+-
+-#
+-# Build tweeny
+-#
+-
+-set(THIRD_PARTY_ROOT ${CMAKE_SOURCE_DIR}/.third-party)
+-set(TWEENY_ROOT ${THIRD_PARTY_ROOT}/tweeny)
+-
+-set(TWEENY_INCLUDE_DIR ${TWEENY_ROOT}/include)
+-
+-ExternalProject_Add(
+-  Tweeny
+-
+-  GIT_REPOSITORY https://github.com/mobius3/tweeny
+-  GIT_TAG b94ce07cfb02a0eb8ac8aaf66137dabdaea857cf
+-
+-  BUILD_IN_SOURCE 1
+-  SOURCE_DIR ${TWEENY_ROOT}
+-  CONFIGURE_COMMAND ""
+-  BUILD_COMMAND ""
+-  INSTALL_COMMAND ""
+-)

--- a/pkgs/applications/networking/instant-messengers/nheko/fetchurls.patch
+++ b/pkgs/applications/networking/instant-messengers/nheko/fetchurls.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 077ac37..c639d71 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,16 +18,6 @@ include(Doxygen)
+ #
+ include(CompilerFlags)
+ 
+-file(DOWNLOAD
+-    "https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp"
+-    ${PROJECT_SOURCE_DIR}/include/json.hpp
+-    EXPECTED_HASH SHA256=fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733)
+-
+-file(DOWNLOAD
+-    "https://github.com/mpark/variant/releases/download/v1.3.0/variant.hpp"
+-    ${PROJECT_SOURCE_DIR}/include/variant.hpp
+-    EXPECTED_MD5 "be0ce322cdd408e1b347b9f1d59ea67a")
+-
+ include_directories(include)
+ 
+ set(SRC

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16969,6 +16969,8 @@ with pkgs;
 
   nedit = callPackage ../applications/editors/nedit { };
 
+  nheko = callPackage ../applications/networking/instant-messengers/nheko { };
+
   nomacs = libsForQt5.callPackage ../applications/graphics/nomacs { };
 
   notepadqq = libsForQt5.callPackage ../applications/editors/notepadqq { };


### PR DESCRIPTION
###### Motivation for this change

Add the nheko matrix client to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

