### PR TITLE
nginx: allow basic auth passwords to be specified in a file

### DIFF
--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -193,6 +193,14 @@ with lib;
       '';
     };
 
+    basicAuthFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Basic Auth password file for a vhost.
+      '';
+    };
+
     locations = mkOption {
       type = types.attrsOf (types.submodule (import ./location-options.nix {
         inherit lib;


### PR DESCRIPTION
###### Motivation for this change

Currently, basic auth passwords must be stored in plain text in the Nix store, which is insecure.

###### Things done

Adds an option to specify a htpasswd file for basic auth, which may be stored outside of the Nix store. Ideally, we would remove the ability to specify plain text basic auth passwords, and only allow hashed passwords or an external htpasswd, but this PR fixes the biggest issue. This will also check one of the boxes in #24288.

cc @globin 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

