### PR TITLE
pcmanx-gtk2: fix build

### DIFF
--- a/pkgs/applications/misc/pcmanx-gtk2/default.nix
+++ b/pkgs/applications/misc/pcmanx-gtk2/default.nix
@@ -1,10 +1,14 @@
-{ stdenv, fetchurl, gtk2, libXft, intltool, automake, autoconf, libtool, pkgconfig }:
+{ stdenv, fetchFromGitHub, gtk2, libXft, intltool, automake, autoconf, libtool, pkgconfig }:
 
-stdenv.mkDerivation {
-  name = "pcmanx-gtk2-1.3";
-  src = fetchurl {
-    url = "https://github.com/pcman-bbs/pcmanx/archive/1.3.tar.gz";
-    sha256 = "2e5c59f6b568036f2ad6ac67ca2a41dfeeafa185451e507f9fb987d4ed9c4302";
+stdenv.mkDerivation rec {
+  name = "pcmanx-gtk2-${version}";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "pcman-bbs";
+    repo = "pcmanx";
+    rev = version;
+    sha256 = "0fbwd149wny67rfhczz4cbh713a1qnswjiz7b6c2bxfcwh51f9rc";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -12,6 +16,8 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     ./autogen.sh
+    # libtoolize generates configure script which uses older version of automake, we need to autoreconf it
+    cd libltdl; autoreconf; cd ..
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

It fails to build after automake updates to 1.16.

The reason is, libtoolize generated configure script have am__api_version hardcoded to version 1.15, so we need to run autoreconf to correct it.

Also uses `fetchFromGitHub` instead of `fetchurl`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

