### PR TITLE
spin: fix build

### DIFF
--- a/pkgs/development/tools/analysis/spin/default.nix
+++ b/pkgs/development/tools/analysis/spin/default.nix
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
 
   src = requireFile {
     name = "spin${url-version}.tar.gz";
-    sha256 = "1rpazi5fj772121cn7r85fxypmaiv0x6x2l82b5y1xqzyf0fi4ph";
+    sha256 = "1rvamdsf0igzpndlr4ck7004jw9x1bg4xyf78zh5k9sp848vnd80";
     message = ''
       reCAPTCHA is preventing us to download the file for you.
       Please download it at http://spinroot.com/spin/Src/index.html
@@ -24,12 +24,6 @@ in stdenv.mkDerivation rec {
   buildInputs = [ yacc ];
 
   sourceRoot = "Spin/Src${version}";
-
-  unpackPhase = ''
-    # The archive is compressed twice
-    gunzip -c $src > spin.tar.gz
-    tar -xzf spin.tar.gz
-  '';
 
   installPhase = ''
     install -Dm755 spin $out/bin/spin


### PR DESCRIPTION
###### Motivation for this change

It looks like upstream have fixed the issue that archive was compressed twice

cc @pSub 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

