### PR TITLE
stdenv: introduce meta.supported

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -87,5 +87,5 @@ rec {
         else { parsed = elem; };
     in lib.matchAttrs pattern platform;
 
-  enableIfAvailable = p: if p.meta.available or true then [ p ] else [];
+  enableIfSupported = p: lib.optional (p.meta.supported or true) p;
 }

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -42,8 +42,8 @@ in stdenv.mkDerivation rec {
     [ linuxHeaders libcap kmod xz pam acl
       /* cryptsetup */ libuuid glib libgcrypt libgpgerror libidn2
       libmicrohttpd ] ++
-      stdenv.lib.meta.enableIfAvailable kexectools ++
-      stdenv.lib.meta.enableIfAvailable libseccomp ++
+      stdenv.lib.meta.enableIfSupported kexectools ++
+      stdenv.lib.meta.enableIfSupported libseccomp ++
     [ libffi audit lz4 bzip2 libapparmor
       iptables gnu-efi
       # This is actually native, but we already pull it from buildPackages

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -158,6 +158,7 @@ let
     outputsToInstall = listOf str;
     position = str;
     available = bool;
+    supported = bool;
     repositories = attrsOf str;
     isBuildPythonPackage = platforms;
     schedulingPriority = int;
@@ -182,7 +183,7 @@ let
   # Check if a derivation is valid, that is whether it passes checks for
   # e.g brokenness or license.
   #
-  # Return { valid: Bool } and additionally
+  # Return { valid: Bool, supported: Bool } and additionally
   # { reason: String; errormsg: String } if it is not valid, where
   # reason is one of "unfree", "blacklisted" or "broken".
   checkValidity = attrs:
@@ -198,7 +199,7 @@ let
       { valid = false; reason = "insecure"; errormsg = "is marked as insecure"; }
     else let res = checkMeta (attrs.meta or {}); in if res != [] then
       { valid = false; reason = "unknown-meta"; errormsg = "has an invalid meta attrset:${lib.concatMapStrings (x: "\n\t - " + x) res}"; }
-    else { valid = true; };
+    else { valid = true; supported = checkPlatform attrs; };
 
   assertValidity = attrs: let
       validity = checkValidity attrs;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -241,6 +241,7 @@ rec {
                    && (if config.checkMetaRecursively or false
                        then lib.all (d: d.meta.available or true) references
                        else true);
+          supported = validity.supported or false;
         };
 
     in

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -30,7 +30,7 @@ let
     buildInputs = [ curl openssl sqlite xz bzip2 ]
       ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
       ++ lib.optionals is20 [ brotli ] # Since 1.12
-      ++ lib.meta.enableIfAvailable libseccomp
+      ++ lib.meta.enableIfSupported libseccomp
       ++ lib.optional ((stdenv.isLinux || stdenv.isDarwin) && is20)
           (aws-sdk-cpp.override {
             apis = ["s3"];


### PR DESCRIPTION
###### Motivation for this change

Fixes enableIfAvailable when config.allowBroken is set.

/cc @shlevy


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

