### PR TITLE
xmlcopyeditor: init at 1.2.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -690,6 +690,11 @@
     github = "campadrenalin";
     name = "Philip Horger";
   };
+  candeira = {
+    email = "javier@candeira.com";
+    github = "candeira";
+    name = "Javier Candeira";
+  };
   canndrew = {
     email = "shum@canndrew.org";
     github = "canndrew";

--- a/pkgs/applications/editors/xmlcopyeditor/default.nix
+++ b/pkgs/applications/editors/xmlcopyeditor/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgs, aspell, boost, expat, expect, intltool, libxml, libxslt, pcre, xercesc, wxwidgets }:
+
+stdenv.mkDerivation rec {
+  name = "xmlcopyeditor-${version}";
+  version = "1.2.1.3";
+
+  src = fetchurl {
+    name = "${name}.tar.gz";
+    url = "https://sourceforge.net/projects/xml-copy-editor/files/xmlcopyeditor-linux/${version}/${name}.tar.gz/download";
+    sha256 = "0bwxn89600jbrkvlwyawgc0c0qqxpl453mbgcb9qbbxl8984ns4v";
+  };
+
+  buildInputs = [ aspell boost expat expect intltool libxml libxslt pcre xercesc wxwidgets ];
+
+  C_INCLUDE_PATH = "${pkgs.libxml2.dev}/include/libxml2";
+  CPLUS_INCLUDE_PATH = "${pkgs.libxml2.dev}/include/libxml2";
+
+  patches = [ ./xmlcopyeditor.patch ];
+
+  meta = with stdenv.lib; {
+    description = "A fast, free, validating XML editor";
+    homepage = http://xml-copy-editor.sourceforge.net/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ candeira ];
+  };
+}

--- a/pkgs/applications/editors/xmlcopyeditor/default.nix
+++ b/pkgs/applications/editors/xmlcopyeditor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgs, aspell, boost, expat, expect, intltool, libxml, libxslt, pcre, xercesc, wxwidgets }:
+{ stdenv, fetchurl, aspell, boost, expat, expect, intltool, libxml2, libxslt, pcre, wxGTK, xercesc }:
 
 stdenv.mkDerivation rec {
   name = "xmlcopyeditor-${version}";
@@ -6,16 +6,17 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     name = "${name}.tar.gz";
-    url = "https://sourceforge.net/projects/xml-copy-editor/files/xmlcopyeditor-linux/${version}/${name}.tar.gz/download";
+    url = "mirror://sourceforge/xml-copy-editor/${name}.tar.gz";
     sha256 = "0bwxn89600jbrkvlwyawgc0c0qqxpl453mbgcb9qbbxl8984ns4v";
   };
 
-  buildInputs = [ aspell boost expat expect intltool libxml libxslt pcre xercesc wxwidgets ];
-
-  C_INCLUDE_PATH = "${pkgs.libxml2.dev}/include/libxml2";
-  CPLUS_INCLUDE_PATH = "${pkgs.libxml2.dev}/include/libxml2";
-
   patches = [ ./xmlcopyeditor.patch ];
+  CPLUS_INCLUDE_PATH = "${libxml2.dev}/include/libxml2";
+
+  nativeBuildInputs = [ intltool ];
+  buildInputs = [ aspell boost expat libxml2 libxslt pcre wxGTK xercesc ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "A fast, free, validating XML editor";

--- a/pkgs/applications/editors/xmlcopyeditor/xmlcopyeditor.patch
+++ b/pkgs/applications/editors/xmlcopyeditor/xmlcopyeditor.patch
@@ -1,0 +1,36 @@
+From 626c385ba141c6abcff01bef4451fcad062d232c Mon Sep 17 00:00:00 2001
+From: Javier Candeira <javier@candeira.com>
+Date: Sat, 7 Apr 2018 20:21:45 +1000
+Subject: [PATCH] nixpckgs patches
+
+---
+ src/Makefile.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/Makefile.in b/src/Makefile.in
+index e75918f..e04703b 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -283,8 +283,8 @@ top_srcdir = @top_srcdir@
+ # these are the headers for your project
+ noinst_HEADERS = $(srcdir)/*.h
+ xmlcopyeditordir = ${prefix}/share/xmlcopyeditor
+-pixmapdir = /usr/share/pixmaps
+-applicationsdir = /usr/share/applications
++pixmapdir = ${prefix}/share/pixmaps
++applicationsdir = ${prefix}/share/applications
+ 
+ # the application source, library search path, and link libraries
+ xmlcopyeditor_SOURCES = aboutdialog.cpp associatedialog.cpp binaryfile.cpp \
+@@ -357,7 +357,7 @@ EXTRA_DIST = \
+ 	$(srcdir)/xmlcopyeditor.rc \
+ 	$(srcdir)/xmlschemaparser.cpp
+ 
+-AM_CPPFLAGS = -I/usr/include/libxml2 $(ENCHANT_CFLAGS) $(GTK_CFLAGS)
++AM_CPPFLAGS = -I$(CPLUS_INCLUDE_PATH) $(ENCHANT_CFLAGS) $(GTK_CFLAGS)
+ all: all-am
+ 
+ .SUFFIXES:
+-- 
+2.16.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18690,6 +18690,11 @@ with pkgs;
 
   xmacro = callPackage ../tools/X11/xmacro { };
 
+  xmlcopyeditor = callPackage ../applications/editors/xmlcopyeditor {
+    libxml = libxml2;
+    wxwidgets = wxGTK;
+  };
+
   xmove = callPackage ../applications/misc/xmove { };
 
   xmp = callPackage ../applications/audio/xmp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18690,10 +18690,7 @@ with pkgs;
 
   xmacro = callPackage ../tools/X11/xmacro { };
 
-  xmlcopyeditor = callPackage ../applications/editors/xmlcopyeditor {
-    libxml = libxml2;
-    wxwidgets = wxGTK;
-  };
+  xmlcopyeditor = callPackage ../applications/editors/xmlcopyeditor { };
 
   xmove = callPackage ../applications/misc/xmove { };
 


### PR DESCRIPTION
###### Motivation for this change

I use xmlcopyeditor, and it's not present in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

