### PR TITLE
balsa: init at 2.5.5

### DIFF
--- a/pkgs/applications/networking/mailreaders/balsa/default.nix
+++ b/pkgs/applications/networking/mailreaders/balsa/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchurl, pkgconfig, intltool, glib, gtk3, gmime, gnutls,
+  webkitgtk, libesmtp, openssl, libnotify, enchant, gpgme,
+  libcanberra-gtk3, libsecret, gtksourceview, gobjectIntrospection,
+  hicolor-icon-theme, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  name = "balsa-${version}";
+  version = "2.5.5";
+
+  src = fetchurl {
+    url = "https://pawsa.fedorapeople.org/balsa/${name}.tar.bz2";
+    sha256 = "0p4w81wvdxqhynkninzglsgqk6920x1zif2zmw8bml410lav2azz";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    gobjectIntrospection
+    hicolor-icon-theme
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gmime
+    gnutls
+    webkitgtk
+    openssl
+    libnotify
+    enchant
+    gpgme
+    libcanberra-gtk3
+    gtksourceview
+    libsecret
+    libesmtp
+  ];
+
+  configureFlags = [
+    "--with-canberra"
+    "--with-gpgme"
+    "--with-gtksourceview"
+    "--with-libsecret"
+    "--with-ssl"
+    "--with-unique"
+    "--without-gnome"
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://pawsa.fedorapeople.org/balsa/;
+    description = "An e-mail client for GNOME";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14834,6 +14834,8 @@ with pkgs;
 
   backintime = backintime-qt4;
 
+  balsa = callPackage ../applications/networking/mailreaders/balsa { };
+
   bandwidth = callPackage ../tools/misc/bandwidth { };
 
   baresip = callPackage ../applications/networking/instant-messengers/baresip {


### PR DESCRIPTION
###### Motivation for this change

Add [balsa](https://pawsa.fedorapeople.org/balsa/), an e-mail client highly configurable and incorporating all the features you would expect in a robust mail client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).