### PR TITLE
nixos/iftop: add module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -86,6 +86,7 @@
   ./programs/freetds.nix
   ./programs/gnupg.nix
   ./programs/gphoto2.nix
+  ./programs/iftop.nix
   ./programs/java.nix
   ./programs/kbdlight.nix
   ./programs/less.nix

--- a/nixos/modules/programs/iftop.nix
+++ b/nixos/modules/programs/iftop.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.iftop;
+in {
+  options = {
+    programs.iftop.enable = mkEnableOption "iftop + setcap wrapper";
+  };
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.iftop ];
+    security.wrappers.iftop = {
+      source = "${pkgs.iftop}/bin/iftop";
+      capabilities = "cap_net_raw+p";
+    };
+  };
+}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -295,6 +295,7 @@ in rec {
   tests.hound = callTest tests/hound.nix {};
   tests.hocker-fetchdocker = callTest tests/hocker-fetchdocker {};
   tests.i3wm = callTest tests/i3wm.nix {};
+  tests.iftop = callTest tests/iftop.nix {};
   tests.initrd-network-ssh = callTest tests/initrd-network-ssh {};
   tests.installer = callSubTests tests/installer.nix {};
   tests.influxdb = callTest tests/influxdb.nix {};

--- a/nixos/tests/iftop.nix
+++ b/nixos/tests/iftop.nix
@@ -1,0 +1,30 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+
+with lib;
+
+{
+  name = "iftop";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ ma27 ];
+
+  nodes = {
+    withIftop = {
+      imports = [ ./common/user-account.nix ];
+
+      programs.iftop.enable = true;
+    };
+    withoutIftop = {
+      imports = [ ./common/user-account.nix ];
+    };
+  };
+
+  testScript = ''
+    subtest "machine with iftop enabled", sub {
+      $withIftop->start;
+      $withIftop->succeed("su -l alice -c 'iftop -t -s 1'");
+    };
+    subtest "machine without iftop", sub {
+      $withoutIftop->start;
+      $withoutIftop->mustFail("su -l alice -c 'iftop -t -s 1'");
+    };
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

This patch is heavily inspired by bd0d8ed807d29faa3deee96bafcbbd76c8fa4060 which added
a setcap wrapper for `mtr` in order to allow running `mtr` without
`sudo`. The need for the capability `cap_net_raw` that can be registered using
`setcap` has been documented in the Arch Wiki: https://wiki.archlinux.org/index.php/Capabilities#iftop

A simple testcase has been added which starts two machines, one with a
setcap wrapper for `iftop`, one without. Both testcases monitor the
bandwidth usage of the machine using the options `-t -s 1` once, the
machine with setcap wrapper is expected to succeed, the `iftop` on the
machine without setcap wrapper is expected to return a non-zero exit
code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

