### PR TITLE
Increase max group name length to 32 characters

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -92,7 +92,7 @@ let
 
       group = mkOption {
         type = types.str;
-        apply = x: assert (builtins.stringLength x < 17 || abort "Group name '${x}' is longer than 16 characters which is not allowed!"); x;
+        apply = x: assert (builtins.stringLength x < 32 || abort "Group name '${x}' is longer than 31 characters which is not allowed!"); x;
         default = "nogroup";
         description = "The user's primary group.";
       };

--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -60,8 +60,10 @@ stdenv.mkDerivation rec {
     configureFlags="$configureFlags --with-xml-catalog=$PWD/xmlcatalog ";
   '';
 
-  configureFlags = " --enable-man "
-    + stdenv.lib.optionalString (hostPlatform.libc != "glibc") " --disable-nscd ";
+  configureFlags = [
+    "--enable-man"
+    "--with-group-name-max-length=32"
+  ] ++ stdenv.lib.optional (hostPlatform.libc != "glibc") "--disable-nscd";
 
   preBuild = stdenv.lib.optionalString (hostPlatform.libc == "glibc")
     ''


### PR DESCRIPTION
With #36556, a check was introduced to make sure the user and group names do not exceed their respective maximum length. This is in part because systemd also enforces that length, but only at runtime.

So in general it's a good idea to catch as much as we can during evaluation time, however the maximum length of the group name was set to 16 characters according `groupadd(8)`.

The maximum length of the group names however is a compile-time option and even systemd allows more than 16 characters. In the mentioned pull request (#36556) there was already a report that this has broken
evaluation for people out there.

I have also checked what other distributions are doing and they set the length to either 31 characters or 32 characters, the latter being more common.

Unfortunately there is a difference between the maximum length enforced by the `shadow` package and systemd, both for user name lengths and group name lengths. However, systemd enforces both length to have a maximum of 31 characters and I'm not sure if this is intended or just a off-by-one error in systemd.

Nevertheless, I choose 32 characters simply to bring it in par with the maximum user name length.

For the NixOS assertion however, I use a maximum length of 31 to make sure that nobody accidentally creates services that contain group names that systemd considers invalid because of a length of 32 characters.

~**Note:** I'm basing this on `master` instead of `staging`, because while it affects a lot of packages (not `stdenv` however), the change is rather trivial and needs to land in 18.03 ASAP as the change from #36556 breaks evaluation of systems out there which use group names with a length from 17 to 31 characters.~

Cc: @vcunat, @fpletz, @qknight