### PR TITLE
easytag: add opus support

### DIFF
--- a/pkgs/applications/audio/easytag/default.nix
+++ b/pkgs/applications/audio/easytag/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk3, glib, libid3tag, id3lib, taglib
-, libvorbis, libogg, flac, itstool, libxml2, gsettings-desktop-schemas
+, libvorbis, libogg, opusfile, flac, itstool, libxml2, gsettings-desktop-schemas
 , gnome3, wrapGAppsHook
 }:
 
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool itstool libxml2 wrapGAppsHook ];
   buildInputs = [
-    gtk3 glib libid3tag id3lib taglib libvorbis libogg flac
+    gtk3 glib libid3tag id3lib taglib libvorbis libogg opusfile flac
     gsettings-desktop-schemas gnome3.defaultIconTheme
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Add support for Opus files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @Fuuzetsu
