### PR TITLE
zulu8: 8.21.0.1 -> 8.28.0.1 & openjdk: 8.0.131 -> 8.0.163

### DIFF
--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -4,11 +4,11 @@
 , swingSupport ? true }:
 
 let
-  version = "8.21.0.1";
-  openjdk = "8.0.131";
+  version = "8.28.0.1";
+  openjdk = "8.0.163";
 
-  sha256_linux = "0cr1wvk1ifdq69ia8sr6171yzciba8l5x7dszwa5g2v0vmmqq88p";
-  sha256_darwin = "0xq9bdzbdq8wq48gj6j56bw30l2iafz6sy1wdhrf92n9bnz5qmw7";
+  sha256_linux = "1z8s3a948nvv92wybnhkyr27ipibcy45k0zv5h5gp37ynd91df45";
+  sha256_darwin = "0i0prjijsgg0yyycplpp9rlfl428126rqz7bb31pchrhi6jhk699";
 
   platform = if stdenv.isDarwin then "macosx" else "linux";
   hash = if stdenv.isDarwin then sha256_darwin else sha256_linux;


### PR DESCRIPTION
###### Motivation for this change
The version in NixPKGS is pretty old.

###### Things done
I updated the version of `zulu8` and `openjdk` with their respective hashes.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

