### PR TITLE
doc: Fixes in-text callouts and screen callouts.

### DIFF
--- a/doc/overrides.css
+++ b/doc/overrides.css
@@ -1,4 +1,5 @@
-
+.docbook .xref img[src^=images\/callouts\/],
+.screen img,
 .programlisting img {
     width: 1em;
 }


### PR DESCRIPTION
##### Motivation for this change

Inline and in `screen` output callouts did not have the proper rules applied. This made them comically big.

###### Before

![20180407153754](https://user-images.githubusercontent.com/132835/38460015-dc385bb4-3a7f-11e8-83b4-0f0b65c9e7c1.png)

![20180407153731](https://user-images.githubusercontent.com/132835/38460024-ed89ce16-3a7f-11e8-91e0-7fbc81a08d05.png)


###### After

![20180407153800](https://user-images.githubusercontent.com/132835/38460017-e4d658d4-3a7f-11e8-8313-ff51b333d894.png)

![20180407153738](https://user-images.githubusercontent.com/132835/38460025-f0ef42fc-3a7f-11e8-8a38-edf8698e9c47.png)


**This will need to be cherry-picked appropriately for 18.03**, thanks!

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Built using `nixos-homepage` pointing to my nixpkgs checkout.
---

