### PR TITLE
enyo-doom: init at 1.05

### DIFF
--- a/pkgs/games/enyo-doom/default.nix
+++ b/pkgs/games/enyo-doom/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitLab, cmake, qtbase }:
+
+stdenv.mkDerivation rec {
+  name = "enyo-doom-${version}";
+  version = "1.05";
+
+  src = fetchFromGitLab {
+    owner = "sdcofer70";
+    repo = "enyo-doom";
+    rev = version;
+    sha256 = "1bmpgqwcp7640dbq1w8bkbk6mkn4nj5yxkvmjrl5wnlg0m1g0jr7";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ qtbase ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "https://gitlab.com/sdcofer70/enyo-doom";
+    description = "Frontend for Doom engines";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.tadfisher ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18937,6 +18937,8 @@ with pkgs;
 
   endless-sky = callPackage ../games/endless-sky { };
 
+  enyo-doom = libsForQt5.callPackage ../games/enyo-doom { };
+
   eternity = callPackage ../games/eternity-engine { };
 
   extremetuxracer = callPackage ../games/extremetuxracer {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

[`enyo-doom`](https://gitlab.com/sdcofer70/enyo-doom) is a convenient frontend for various Doom engines.