### PR TITLE
Allow setting cargoSha256 to null.

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -4,7 +4,7 @@ let
     inherit stdenv cacert git rust cargo-vendor;
   };
 in
-{ name, cargoSha256 ? null
+{ name, cargoSha256 ? "unset"
 , src ? null
 , srcs ? null
 , sourceRoot ? null
@@ -17,7 +17,7 @@ in
 , cargoVendorDir ? null
 , ... } @ args:
 
-assert cargoVendorDir == null -> cargoSha256 != null;
+assert cargoVendorDir == null -> cargoSha256 != "unset";
 
 let
   lib = stdenv.lib;


### PR DESCRIPTION
Setting the hash to null is a convenient way to bypass the hash check
while developing. It looks like the ability to do this was inadvertently
removed while adding vendor directory support.

This still checks that the user is explicitly setting the value but
allows null as a valid option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

