### PR TITLE
openzwave & pythonPackages.python_openzwave: init at 20180404 and 0.4.4

### DIFF
--- a/pkgs/development/libraries/openzwave/default.nix
+++ b/pkgs/development/libraries/openzwave/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchFromGitHub
+, doxygen, fontconfig, graphviz-nox, libxml2, pkgconfig, which
+, systemd }:
+
+let
+  version = "2018-04-04";
+
+in stdenv.mkDerivation rec {
+  name = "openzwave-${version}";
+
+  src = fetchFromGitHub {
+    owner = "OpenZWave";
+    repo = "open-zwave";
+    rev = "ab5fe966fee882bb9e8d78a91db892a60a1863d9";
+    sha256 = "0yby8ygzjn5zp5vhysxaadbzysqanwd2zakz379299qs454pr2h9";
+  };
+
+  nativeBuildInputs = [ doxygen fontconfig graphviz-nox libxml2 pkgconfig which ];
+
+  buildInputs = [ systemd ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    DESTDIR=$out PREFIX= pkgconfigdir=lib/pkgconfig make install $installFlags
+
+    runHook postInstall
+  '';
+
+  FONTCONFIG_FILE="${fontconfig.out}/etc/fonts/fonts.conf";
+  FONTCONFIG_PATH="${fontconfig.out}/etc/fonts/";
+
+  postPatch = ''
+    substituteInPlace cpp/src/Options.cpp \
+      --replace /etc/openzwave $out/etc/openzwave
+  '';
+
+  fixupPhase = ''
+    substituteInPlace $out/lib/pkgconfig/libopenzwave.pc \
+      --replace prefix= prefix=$out \
+      --replace dir=    dir=$out
+
+    substituteInPlace $out/bin/ozw_config \
+      --replace pcfile=${pkgconfig} pcfile=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "C++ library to control Z-Wave Networks via a USB Z-Wave Controller";
+    homepage = http://www.openzwave.net/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/python_openzwave/default.nix
+++ b/pkgs/development/python-modules/python_openzwave/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, pkgconfig
+, systemd, libyaml, openzwave, cython
+, six, pydispatcher, urwid }:
+
+buildPythonPackage rec {
+  pname = "python_openzwave";
+  version = "0.4.4";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17wdgwg212agj1gxb2kih4cvhjb5bprir4x446s8qwx0mz03azk2";
+    extension = "zip";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ systemd libyaml openzwave cython ];
+  propagatedBuildInputs = [ six urwid pydispatcher ];
+
+  # primary location for the .xml files is in /etc/openzwave so we override the
+  # /usr/local/etc lookup instead as that allows us to dump new .xml files into
+  # /etc/openzwave if needed
+  postPatch = ''
+    substituteInPlace src-lib/libopenzwave/libopenzwave.pyx \
+      --replace /usr/local/etc/openzwave ${openzwave}/etc/openzwave
+  '';
+
+  # no tests available
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python wrapper for the OpenZWave C++ library";
+    homepage = https://github.com/OpenZWave/python-openzwave;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ etu ];
+    inherit (openzwave.meta) platforms;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -112,8 +112,8 @@
     "hue" = ps: with ps; [  ];
     "ifttt" = ps: with ps; [  ];
     "ihc" = ps: with ps; [  ];
-    "image_processing.dlib_face_detect" = ps: with ps; [  ];
-    "image_processing.dlib_face_identify" = ps: with ps; [  ];
+    "image_processing.dlib_face_detect" = ps: with ps; [ face_recognition ];
+    "image_processing.dlib_face_identify" = ps: with ps; [ face_recognition ];
     "image_processing.opencv" = ps: with ps; [ numpy ];
     "influxdb" = ps: with ps; [ influxdb ];
     "insteon_local" = ps: with ps; [  ];
@@ -172,7 +172,7 @@
     "media_player.dunehd" = ps: with ps; [  ];
     "media_player.emby" = ps: with ps; [  ];
     "media_player.frontier_silicon" = ps: with ps; [  ];
-    "media_player.gpmdp" = ps: with ps; [  ];
+    "media_player.gpmdp" = ps: with ps; [ websocket_client ];
     "media_player.gstreamer" = ps: with ps; [  ];
     "media_player.kodi" = ps: with ps; [ jsonrpc-async jsonrpc-websocket ];
     "media_player.lg_netcast" = ps: with ps; [  ];
@@ -447,6 +447,6 @@
     "zeroconf" = ps: with ps; [ zeroconf ];
     "zha" = ps: with ps; [  ];
     "zigbee" = ps: with ps; [  ];
-    "zwave" = ps: with ps; [ pydispatcher ];
+    "zwave" = ps: with ps; [ pydispatcher python_openzwave ];
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -45,7 +45,7 @@ let
 
   getPackages = component: builtins.getAttr component componentPackages.components;
 
-  componentBuildInputs = map (component: getPackages component py.pkgs) extraComponents;
+  componentBuildInputs = lib.concatMap (component: getPackages component py.pkgs) extraComponents;
 
   # Ensure that we are using a consistent package set
   extraBuildInputs = extraPackages py.pkgs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20532,6 +20532,8 @@ with pkgs;
 
   moltengamepad = callPackage ../misc/drivers/moltengamepad { };
 
+  openzwave = callPackage ../development/libraries/openzwave { };
+
   mongoc = callPackage ../development/libraries/mongoc { };
 
   mupen64plus = callPackage ../misc/emulators/mupen64plus { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8935,6 +8935,8 @@ in {
 
   python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
 
+  python_openzwave = callPackage ../development/python-modules/python_openzwave { };
+
   python-Levenshtein = buildPythonPackage rec {
     name = "python-Levenshtein-${version}";
     version = "0.12.0";


### PR DESCRIPTION
###### Motivation for this change
OpenZWave can be used with a wide range of USB-Sticks used to controll Z-Wave devices.

Python_OpenZWave can be used with homeassistant that is already packaged to be able to control and script Z-Wave devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

