### PR TITLE
Add TLAPS and TLA+ Toolbox

### DIFF
--- a/pkgs/applications/science/logic/tlaplus/tlaps.nix
+++ b/pkgs/applications/science/logic/tlaplus/tlaps.nix
@@ -1,0 +1,56 @@
+{ lib
+, fetchurl
+, makeWrapper
+, stdenv
+, ocaml, gawk, isabelle, cvc3, perl, wget, which
+}:
+
+stdenv.mkDerivation rec {
+  name = "tlaps-${version}";
+  version = "1.4.3";
+  src = fetchurl {
+    url = "https://tla.msr-inria.inria.fr/tlaps/dist/current/tlaps-${version}.tar.gz";
+    sha256 = "1w5z3ns5xxmhmp8r4x2kjmy3clqam935gmvx82imyxrr1bamx6gf";
+  };
+
+  buildInputs = [ ocaml isabelle cvc3 perl wget which ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -pv "$out"
+    export HOME="$out"
+    export PATH=$out/bin:$PATH
+
+    pushd zenon
+    ./configure --prefix $out
+    make
+    make install
+    popd
+
+    pushd isabelle
+    isabelle build -b Pure
+    popd
+
+    pushd tlapm
+    ./configure --prefix $out
+    make all
+    make install
+  '';
+
+  meta = {
+    description = "Mechanically check TLA+ proofs";
+    longDescription = ''
+      TLA+ is a general-purpose formal specification language that is
+      particularly useful for describing concurrent and distributed
+      systems. The TLA+ proof language is declarative, hierarchical,
+      and scalable to large system specifications. It provides a
+      consistent abstraction over the various “backend” verifiers.
+    '';
+    homepage    = https://tla.msr-inria.inria.fr/tlaps/content/Home.html;
+    license     = stdenv.lib.licenses.bsd2;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.badi ];
+  };
+
+}

--- a/pkgs/applications/science/logic/tlaplus/toolbox.nix
+++ b/pkgs/applications/science/logic/tlaplus/toolbox.nix
@@ -1,0 +1,77 @@
+{ lib, fetchzip, makeWrapper, makeDesktopItem, stdenv
+, jre, swt, gtk, libXtst, glib
+}:
+
+let
+  version = "1.5.6";
+  arch = "x86_64";
+
+  desktopItem = makeDesktopItem rec {
+    name = "TLA+Toolbox";
+    exec = "tla-toolbox";
+    icon = "tla-toolbox";
+    comment = "IDE for TLA+";
+    desktopName = name;
+    genericName = comment;
+    categories = "Application;Development";
+    extraEntries = ''
+      StartupWMClass=TLA+ Toolbox
+    '';
+  };
+
+
+in stdenv.mkDerivation {
+  name = "tla-toolbox-${version}";
+  src = fetchzip {
+    url = "https://tla.msr-inria.inria.fr/tlatoolbox/products/TLAToolbox-${version}-linux.gtk.${arch}.zip";
+    sha256 = "1h63mcbrkf4jcg6qncpqffdi0x665z0wlfdq43d67p411xcqmbw9";
+  };
+
+  buildInputs = [ makeWrapper  ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp -r "$src" "$out/toolbox"
+    chmod +w "$out/toolbox" "$out/toolbox/toolbox"
+
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      "$out/toolbox/toolbox"
+
+    makeWrapper $out/toolbox/toolbox $out/bin/tla-toolbox \
+      --run "set -x; cd $out/toolbox" \
+      --add-flags "-data ~/.tla-toolbox" \
+      --prefix PATH : "${jre}/bin" \
+      --prefix LD_LIBRARY_PATH : "${swt}/lib:${gtk}/lib:${libXtst}/lib:${glib}/lib"
+
+    echo -e "\nCreating TLA Toolbox icons..."
+    pushd "$src"
+    for icon_in in $(find . -path "./plugins/*/icons/full/etool16/tla_launch_check_wiz_*.png")
+    do
+      icon_size=$(echo $icon_in | grep -Po "wiz_\K[0-9]+")
+      icon_out="$out/share/icons/hicolor/$icon_size""x$icon_size/apps/tla-toolbox.png"
+      mkdir -p "$(dirname $icon_out)"
+      cp "$icon_in" "$icon_out"
+    done
+    popd
+
+    echo -e "\nCreating TLA Toolbox desktop entry..."
+    cp -r "${desktopItem}/share/applications"* "$out/share/applications"
+  '';
+
+  meta = {
+    homepage = http://research.microsoft.com/en-us/um/people/lamport/tla/toolbox.html;
+    description = "IDE for the TLA+ tools";
+    longDescription = ''
+      Integrated development environment for the TLA+ tools, based on Eclipse. You can use it
+      to create and edit your specs, run the PlusCal translator, view the pretty-printed
+      versions of your modules, run the TLC model checker, and run TLAPS, the TLA+ proof system.
+    '';
+    # http://lamport.azurewebsites.net/tla/license.html
+    license = with lib.licenses; [ mit ];
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.badi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20029,6 +20029,8 @@ with pkgs;
   z3 = callPackage ../applications/science/logic/z3 { python = python2; };
 
   tlaplus = callPackage ../applications/science/logic/tlaplus {};
+  tlaps = callPackage ../applications/science/logic/tlaplus/tlaps.nix {};
+
 
   aiger = callPackage ../applications/science/logic/aiger {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20030,6 +20030,7 @@ with pkgs;
 
   tlaplus = callPackage ../applications/science/logic/tlaplus {};
   tlaps = callPackage ../applications/science/logic/tlaplus/tlaps.nix {};
+  tlaplusToolbox = callPackage ../applications/science/logic/tlaplus/toolbox.nix {gtk = gtk2;};
 
 
   aiger = callPackage ../applications/science/logic/aiger {};


### PR DESCRIPTION
###### Motivation for this change
This attempts to address #18640.

Testing:
- `tlaplusToolbox`: I've been using this without unexpected issues (pdf generation needs `pdflatex` in the `PATH`). 
- `tlaps`: Both `tlapm` and `zenon` run and produce their usage information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

