### PR TITLE
crip: init at 3.9; perlPackages.CDDB_get: init at 2.28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1196,6 +1196,11 @@
     github = "ElvishJerricco";
     name = "Will Fancher";
   };
+  endgame = {
+    email = "jack@jackkelly.name";
+    github = "endgame";
+    name = "Jack Kelly";
+  };
   enzime = {
     email = "enzime@users.noreply.github.com";
     github = "enzime";

--- a/pkgs/applications/audio/crip/default.nix
+++ b/pkgs/applications/audio/crip/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, fetchurl
+, makeWrapper
+
+, perl
+, perlPackages
+
+, cdparanoia
+, coreutils
+, eject
+, flac
+, gnugrep
+, nano
+, sox
+, vorbis-tools
+, vorbisgain
+, which
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "crip-3.9";
+  src = fetchurl {
+    url = "http://bach.dynet.com/crip/src/${name}.tar.gz";
+    sha256 = "0pk9152wll6fmkj1pki3fz3ijlf06jyk32v31yarwvdkwrk7s9xz";
+  };
+
+  buildInputs = [ perl perlPackages.CDDB_get ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  toolDeps = makeBinPath [
+    cdparanoia
+    coreutils
+    eject
+    flac
+    gnugrep
+    sox
+    vorbis-tools
+    vorbisgain
+    which
+  ];
+
+  scripts = [ "crip" "editcomment" "editfilenames" ];
+
+  installPhase = ''
+    mkdir -p $out/bin/
+
+    for script in ${escapeShellArgs scripts}; do
+      cp $script $out/bin/
+
+      substituteInPlace $out/bin/$script \
+        --replace '$editor = "vim";' '$editor = "${nano}/bin/nano";'
+
+      wrapProgram $out/bin/$script \
+        --set PERL5LIB "${makePerlPath [ perlPackages.CDDB_get ]}" \
+        --set PATH "${toolDeps}"
+    done
+  '';
+
+  meta = {
+    homepage = http://bach.dynet.com/crip/;
+    description = "Terminal-based ripper/encoder/tagger tool for creating Ogg Vorbis/FLAC files";
+    license = stdenv.lib.licenses.gpl1;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ maintainers.endgame ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1053,6 +1053,8 @@ with pkgs;
 
   cri-tools = callPackage ../tools/virtualization/cri-tools {};
 
+  crip = callPackage ../applications/audio/crip { };
+
   crunch = callPackage ../tools/security/crunch { };
 
   crudini = callPackage ../tools/misc/crudini { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1658,6 +1658,21 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  CDDB_get = buildPerlPackage rec {
+    name = "CDDB_get-2.28";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/F/FO/FONKIE/${name}.tar.gz";
+      sha256 = "1jfrwvfasylcafbvb0jjm94ad4v6k99a7rf5i4qwzhg4m0gvmk5x";
+    };
+    meta = {
+      homepage = https://metacpan.org/module/CDDB_get;
+      description = "Get the CDDB info for an audio cd";
+      license = stdenv.lib.licenses.artistic1;
+      platforms = stdenv.lib.platforms.linux;
+      maintainers = [ maintainers.endgame ];
+    };
+  };
+
   CGI = buildPerlPackage rec {
     name = "CGI-4.38";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

I want to rip my music CDs on my NixOS box.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions (ubuntu 16.04.4, sandbox = true)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [?] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Notes:

* No maintainers are set - I'm happy to maintain these if you want; they're finished packages, really. If so, I'll add fields and rebase.