### PR TITLE
xaw3d: use an https download url

### DIFF
--- a/pkgs/development/libraries/Xaw3d/default.nix
+++ b/pkgs/development/libraries/Xaw3d/default.nix
@@ -3,9 +3,7 @@
 stdenv.mkDerivation {
   name = "Xaw3d-1.6.2";
   src = fetchurl {
-    urls = [ 
-      ftp://ftp.x.org/pub/xorg/individual/lib/libXaw3d-1.6.2.tar.bz2
-      ];
+    url = https://www.x.org/releases/individual/lib/libXaw3d-1.6.2.tar.bz2;
     sha256 = "0awplv1nf53ywv01yxphga3v6dcniwqnxgnb0cn4khb121l12kxp";
   };
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

