### PR TITLE
google-compute-image: provide correct MTU

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -75,6 +75,9 @@ in
 
   networking.usePredictableInterfaceNames = false;
 
+  # GC has 1460 MTU
+  networking.interfaces.eth0.mtu = 1460;
+
   # allow the google-accounts-daemon to manage users
   users.mutableUsers = true;
   # and allow users to sudo without password


### PR DESCRIPTION
Hopefully fixes #38543 but I don't know if eth0 is the correct name; there might also be extra interfaces that would also need this setting?