### PR TITLE
qt5/webengine: refactor qmake flags

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -69,13 +69,10 @@ qtModule {
     if [ -d "$PWD/tools/qmake" ]; then
         QMAKEPATH="$PWD/tools/qmake''${QMAKEPATH:+:}$QMAKEPATH"
     fi
- '';
-
-  qmakeFlags =
-    [
-      # Use system Ninja because bootstrapping it is fragile
-      "WEBENGINE_CONFIG+=use_system_ninja"
-    ] ++ optional enableProprietaryCodecs "WEBENGINE_CONFIG+=use_proprietary_codecs";
+  ''
+  + optionalString (enableProprietaryCodecs) ''
+    qmakeFlags="$qmakeFlags -- -webengine-proprietary-codecs"
+  '';
 
   propagatedBuildInputs = [
     # Image formats


### PR DESCRIPTION
###### Motivation for this change
`WEBENGINE_CONFIG` was removed, and replaced with `./configure` flags which must be passed as raw arguments to `qmake` when compiling Qt submodules individually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

