### PR TITLE
sweep-visualizer: init at 0.15.0

### DIFF
--- a/pkgs/tools/misc/sweep-visualizer/default.nix
+++ b/pkgs/tools/misc/sweep-visualizer/default.nix
@@ -54,7 +54,7 @@
       homepage = https://support.scanse.io/hc/en-us/articles/115006008948-Visualizer-Overview;
       description = "A minimal desktop application for interfacing with the Sweep device";
       license = licenses.proprietary;
-      platforms = platforms.linux;
+      platforms = [ "x86_64-linux" ];
       maintainers = [ mt-caret ];
     };
   }

--- a/pkgs/tools/misc/sweep-visualizer/default.nix
+++ b/pkgs/tools/misc/sweep-visualizer/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, makeWrapper, fetchurl,
+  alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk_pixbuf, glib,
+  gnome2, gtk2-x11, nspr, nss,
+  libX11, libxcb, libXcomposite, libXcursor, libXdamage, libXext, libXfixes,
+  libXi, libXrandr, libXrender, libXScrnSaver, libXtst,
+  libudev0-shim
+}:
+  stdenv.mkDerivation rec {
+    name = "sweep-visualizer-${version}";
+    version = "0.15.0";
+
+    src = fetchurl {
+      url = "https://s3.amazonaws.com/scanse/Visualizer/v${version}/sweepvisualizer_${version}_amd64.deb";
+      sha256 = "1k6rdjw2340qrzafv6hjxvbvyh3s1wad6d3629nchdcrpyx9xy1c";
+    };
+    
+    nativeBuildInputs = [ makeWrapper ];
+
+    sourceRoot = ".";
+    unpackCmd = ''
+      ar p "$src" data.tar.xz | tar xJ
+    '';
+
+    buildPhase = ":";
+
+    installPhase = ''
+      mkdir -p $out/lib $out/bin $out/share/sweep-visualizer
+      mv usr/share/* $out/share
+      mv opt/Sweep\ Visualizer\ BETA/* $out/share/sweep-visualizer/
+      mv $out/share/sweep-visualizer/*.so $out/lib/
+      ln -s $out/share/sweep-visualizer/sweep_visualizer $out/bin/sweep_visualizer
+    '';
+
+    preFixup = let
+      libPath = lib.makeLibraryPath [
+        alsaLib atk cairo cups.lib dbus.lib expat fontconfig.lib freetype 
+        gdk_pixbuf glib gnome2.GConf gnome2.pango gtk2-x11 nspr nss stdenv.cc.cc.lib
+        libX11 libxcb libXcomposite libXcursor libXdamage libXext libXfixes
+        libXi libXrandr libXrender libXScrnSaver libXtst
+      ];
+      runtimeLibs = lib.makeLibraryPath [ libudev0-shim ];
+    in ''
+      for lib in $out/lib/*.so; do
+        patchelf --set-rpath "$out/lib:${libPath}" $lib
+      done
+      patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "$out/lib:${libPath}" \
+        $out/share/sweep-visualizer/sweep_visualizer
+      wrapProgram "$out/bin/sweep_visualizer" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = https://support.scanse.io/hc/en-us/articles/115006008948-Visualizer-Overview;
+      description = "A minimal desktop application for interfacing with the Sweep device";
+      license = licenses.proprietary;
+      platforms = platforms.linux;
+      maintainers = [ mt-caret ];
+    };
+  }

--- a/pkgs/tools/misc/sweep-visualizer/default.nix
+++ b/pkgs/tools/misc/sweep-visualizer/default.nix
@@ -53,7 +53,7 @@
     meta = with stdenv.lib; {
       homepage = https://support.scanse.io/hc/en-us/articles/115006008948-Visualizer-Overview;
       description = "A minimal desktop application for interfacing with the Sweep device";
-      license = licenses.proprietary;
+      license = licenses.unfree;
       platforms = [ "x86_64-linux" ];
       maintainers = with maintainers; [ mt-caret ];
     };

--- a/pkgs/tools/misc/sweep-visualizer/default.nix
+++ b/pkgs/tools/misc/sweep-visualizer/default.nix
@@ -55,6 +55,6 @@
       description = "A minimal desktop application for interfacing with the Sweep device";
       license = licenses.proprietary;
       platforms = [ "x86_64-linux" ];
-      maintainers = [ mt-caret ];
+      maintainers = with maintainers; [ mt-caret ];
     };
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1356,6 +1356,8 @@ with pkgs;
 
   bash-supergenpass = callPackage ../tools/security/bash-supergenpass { };
 
+  sweep-visualizer = callPackage ../tools/misc/sweep-visualizer { };
+
   syscall_limiter = callPackage ../os-specific/linux/syscall_limiter {};
 
   syslogng = callPackage ../tools/system/syslog-ng { };


### PR DESCRIPTION
Adds Sweep Visualizer, a tool that lets you interface with the Sweep LIDAR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

