### PR TITLE
sigal: add ffmpeg to PATH

### DIFF
--- a/pkgs/applications/misc/sigal/default.nix
+++ b/pkgs/applications/misc/sigal/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonApplication, fetchPypi, pythonPackages }:
+{ lib, buildPythonApplication, fetchPypi, pythonPackages, ffmpeg }:
 
 buildPythonApplication rec {
   version = "1.4.0";
@@ -19,6 +19,8 @@ buildPythonApplication rec {
     click
     blinker
   ];
+
+  makeWrapperArgs = [ "--prefix PATH : ${ffmpeg}/bin" ];
 
   # No tests included
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
ffmpeg is needed for video conversion

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @domenkozar 