### PR TITLE
lumo: init at 1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28,6 +28,11 @@
     github = "AndersonTorres";
     name = "Anderson Torres";
   };
+  andreivolt = {
+    email = "andrei@avolt.net";
+    github = "andreivolt";
+    name = "Andrei Vladescu-Olt";
+  };
   Baughn = {
     email = "sveina@gmail.com";
     github = "Baughn";

--- a/pkgs/development/interpreters/clojure/lumo.nix
+++ b/pkgs/development/interpreters/clojure/lumo.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, boot, nodejs-8_x, yarn, python }:
+
+stdenv.mkDerivation rec {
+  name = "lumo-${version}";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "anmonteiro";
+    repo = "lumo";
+    rev = "fb97ce5086928252b8dd5b862a2d62d5e3daf825";
+    sha256 = "0ci9rgpaww558sbvxkpf69rlkc4029ih70rja9vlr9a2nsp72cqp";
+  };
+
+  nativeBuildInputs = [
+    boot
+    nodejs-8_x
+    python
+    yarn
+  ];
+
+  buildPhase = ''
+     # remove audible build notifications
+     sed -i '/notify :audible true/d' build.boot
+
+     mkdir boot_home m2_home
+
+     BOOT_HOME=boot_home BOOT_LOCAL_REPO=m2_home \
+       boot release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/lumo $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/anmonteiro/lumo/;
+    description = "Fast, cross-platform, standalone ClojureScript environment";
+    maintainers = [ maintainers.andreivolt ];
+    license = licenses.epl10;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6934,6 +6934,8 @@ with pkgs;
 
   dhall = callPackage ../development/interpreters/dhall { };
 
+  lumo = callPackage ../development/interpreters/clojure/lumo.nix { };
+
   dhall-nix = haskell.lib.justStaticExecutables haskellPackages.dhall-nix;
 
   dhall-bash = haskell.lib.justStaticExecutables haskellPackages.dhall-bash;


### PR DESCRIPTION
@jgertm had a [previous attempt](https://github.com/NixOS/nixpkgs/pull/33691) at packaging lumo (a ClojureScript runtime) using the release binary and patchElf.

Unfortunately, that approach gives errors, so I went with a local build and it works perfectly, albeit with some hacks...

While the build requirements are pretty heavy (JDK + all project deps), this approach works and has no runtime deps.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---