### PR TITLE
nixos/minidlna: add loglevel config

### DIFF
--- a/nixos/modules/services/networking/minidlna.nix
+++ b/nixos/modules/services/networking/minidlna.nix
@@ -1,23 +1,16 @@
 # Module for MiniDLNA, a simple DLNA server.
-
 { config, lib, pkgs, ... }:
 
 with lib;
 
 let
-
   cfg = config.services.minidlna;
-
   port = 8200;
-
 in
 
 {
-
   ###### interface
-
   options = {
-
     services.minidlna.enable = mkOption {
       type = types.bool;
       default = false;
@@ -43,24 +36,48 @@ in
         '';
     };
 
+    services.minidlna.loglevel = mkOption {
+      type = types.str;
+      default = "warn";
+      example = "general,artwork,database,inotify,scanner,metadata,http,ssdp,tivo=warn";
+      description =
+        ''
+          Defines the type of messages that should be logged, and down to
+          which level of importance they should be considered.
+
+          The possible types are “artwork”, “database”, “general”, “http”,
+          “inotify”, “metadata”, “scanner”, “ssdp” and “tivo”.
+
+          The levels are “off”, “fatal”, “error”, “warn”, “info” and
+          “debug”, listed here in order of decreasing importance.  “off”
+          turns off logging messages entirely, “fatal” logs the most
+          critical messages only, and so on down to “debug” that logs every
+          single messages.
+
+          The types are comma-separated, followed by an equal sign (‘=’),
+          followed by a level that applies to the preceding types. This can
+          be repeated, separating each of these constructs with a comma.
+
+          Defaults to “general,artwork,database,inotify,scanner,metadata,
+          http,ssdp,tivo=warn” which logs every type of message at the
+          “warn” level.
+        '';
+    };
+
     services.minidlna.config = mkOption {
       type = types.lines;
       description = "The contents of MiniDLNA's configuration file.";
     };
-
   };
 
-
   ###### implementation
-
   config = mkIf cfg.enable {
-
     services.minidlna.config =
       ''
         port=${toString port}
         friendly_name=${config.networking.hostName} MiniDLNA
         db_dir=/var/cache/minidlna
-        log_level=warn
+        log_level=${cfg.loglevel}
         inotify=yes
         ${concatMapStrings (dir: ''
           media_dir=${dir}
@@ -98,7 +115,5 @@ in
               " -f ${pkgs.writeText "minidlna.conf" cfg.config}";
           };
       };
-
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

Adds ability to control loglevel on minidlna

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

