### PR TITLE
peg: 0.1.4 -> 0.1.18

### DIFF
--- a/pkgs/development/tools/parsing/peg/default.nix
+++ b/pkgs/development/tools/parsing/peg/default.nix
@@ -1,19 +1,14 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "peg-0.1.4";
+  name = "peg-0.1.18";
 
   src = fetchurl {
     url = "${meta.homepage}/${name}.tar.gz";
-    sha256 = "01agf4fbqv0r1xyqvj0va8kcrh3f2ka59f1aqvzfrabn7n5p8ik4";
+    sha256 = "114h1y4k8fwcq9m0hfk33dsp7ah8zxzjjzlk71x4iirzczfkn690";
   };
 
   preBuild="makeFlagsArray+=( PREFIX=$out )";
-
-  preInstall=''
-    mkdir -pv $out/bin $out/share/man/man1
-    cp -pv *.1 $out/share/man/man1
-  '';
 
   meta = {
     homepage = http://piumarta.com/software/peg/;


### PR DESCRIPTION
###### Motivation for this change

The package was extremely out of date.

###### Things done



- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

