### PR TITLE
linux kernel generic: use passAsFile for kernelConfig

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -77,6 +77,7 @@ let
     generateConfig = ./generate-config.pl;
 
     kernelConfig = kernelConfigFun config;
+    passAsFile = [ "kernelConfig" ];
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];
     nativeBuildInputs = [ perl ]
@@ -104,7 +105,7 @@ let
 
       # Create the config file.
       echo "generating kernel configuration..."
-      echo "$kernelConfig" > "$buildRoot/kernel-config"
+      ln -s "$kernelConfigPath" "$buildRoot/kernel-config"
       DEBUG=1 ARCH=$kernelArch KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
            PREFER_BUILTIN=$preferBuiltin BUILD_ROOT="$buildRoot" SRC=. perl -w $generateConfig
     '';


### PR DESCRIPTION
Otherwise get the error 'Argument list too long' when running builder
with a very long kernelConfig

###### Motivation for this change
I have a Very Big kernelConfig, because I want DEBUG_INFO so need to rebuild but don't want to spend too long rebuilding (so doing a minimalistic kernel with thousands of 'foo n' options) and that seemed simpler than manual-config.nix at the time.

Also, hi! Nix looks great except for building a custom kernel :P
I couldn't find any "proper" test for this but I think that won't cause too many side effect out of the building the kernel config itself, which appears to work for me (still fiddling with the config itself but it finds the file etc)
The only arguable point is that I make a hardlink (cp -l), not sure what's recommended there but it should work on all platforms nix targets, probably?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] (probably) Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

