### PR TITLE
nixos/less: add configFile option

### DIFF
--- a/nixos/modules/programs/less.nix
+++ b/nixos/modules/programs/less.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.programs.less;
 
-  configFile = ''
+  configText = if (cfg.configFile != null) then (builtins.readFile cfg.configFile) else ''
     #command
     ${concatStringsSep "\n"
       (mapAttrsToList (command: action: "${command} ${action}") cfg.commands)
@@ -25,7 +25,7 @@ let
   '';
 
   lessKey = pkgs.runCommand "lesskey"
-            { src = pkgs.writeText "lessconfig" configFile; }
+            { src = pkgs.writeText "lessconfig" configText; }
             "${pkgs.less}/bin/lesskey -o $out $src";
 
 in
@@ -36,6 +36,19 @@ in
     programs.less = {
 
       enable = mkEnableOption "less";
+
+      configFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = literalExample "$${pkgs.my-configs}/lesskey";
+        description = ''
+          Path to lesskey configuration file.
+
+          <option>configFile</option> takes precedence over <option>commands</option>,
+          <option>clearDefaultCommands</option>, <option>lineEditingKeys</option>, and
+          <option>envVariables</option>.
+        '';
+      };
 
       commands = mkOption {
         type = types.attrsOf types.str;


### PR DESCRIPTION
Expose the path to a lesskey file as a module option.

###### Motivation for this change

This makes it possible to maintain a single lesskey file, used for both NixOS and non-nix systems. An example of how this can be done follows.

1. Write a derivation that fetches lesskey from a known location:
``` nix
{ stdenv, fetchgit }:
stdenv.mkDerivation {
  name = "foo";
  src = fetchgit { .. };
  phases = [ "unpackPhase" "installPhase" ];
  installPhase = "mkdir -p $out && cp $src/lesskey $out/lesskey";
}
```
2. Set `configFile` option to the corresponding path:
```
programs.less = {
  enable = true;
  configFile = "${pkgs.foo}/lesskey";
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

