### PR TITLE
py3status: 3.7 -> 3.8; add pytz tzlocal deps

### DIFF
--- a/pkgs/development/python-modules/py3status/default.nix
+++ b/pkgs/development/python-modules/py3status/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, requests
+, pytz
+, tzlocal
+
+, file
+, acpi
+, coreutils
+, alsaUtils
+, i3
+, procps
+, lm_sensors
+, libnotify
+, xorg
+}:
+
+buildPythonPackage rec {
+  pname = "py3status";
+  version = "3.8";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1izjpf9q768m3j95y328vbdh7rycglqlslyd777b12c13i6zs6cb";
+  };
+  doCheck = false;
+  propagatedBuildInputs = [ pytz requests tzlocal ];
+  buildInputs = [ file ];
+  prePatch = ''
+    sed -i -e "s|'file|'${file}/bin/file|" py3status/parse_config.py
+    sed -i -e "s|\[\"acpi\"|\[\"${acpi}/bin/acpi\"|" py3status/modules/battery_level.py
+    sed -i -e "s|notify-send|${libnotify}/bin/notify-send|" py3status/modules/battery_level.py
+    sed -i -e "s|/usr/bin/whoami|${coreutils}/bin/whoami|" py3status/modules/external_script.py
+    sed -i -e "s|'amixer|'${alsaUtils}/bin/amixer|" py3status/modules/volume_status.py
+    sed -i -e "s|'i3-nagbar|'${i3}/bin/i3-nagbar|" py3status/modules/pomodoro.py
+    sed -i -e "s|'free|'${procps}/bin/free|" py3status/modules/sysdata.py
+    sed -i -e "s|'sensors|'${lm_sensors}/bin/sensors|" py3status/modules/sysdata.py
+    sed -i -e "s|'setxkbmap|'${xorg.setxkbmap}/bin/setxkbmap|" py3status/modules/keyboard_layout.py
+    sed -i -e "s|'xset|'${xorg.xset}/bin/xset|" py3status/modules/keyboard_layout.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Extensible i3status wrapper";
+    license = licenses.bsd3;
+    homepage = https://github.com/ultrabug/py3status;
+    maintainers = with maintainers; [ garbas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6218,34 +6218,7 @@ in {
 
   };
 
-  py3status = buildPythonPackage rec {
-    version = "3.8";
-    name = "py3status-${version}";
-    src = pkgs.fetchFromGitHub {
-      owner = "ultrabug";
-      repo = "py3status";
-      rev = version;
-      sha256 = "0454g6zmhgpaag5cj16jarp9bm6h0cf9r3pbkjq2j9wa7rynp3l4";
-    };
-    doCheck = false;
-    propagatedBuildInputs = with self; [ pytz requests tzlocal ];
-    buildInputs = with pkgs; [ file ];
-    prePatch = ''
-      sed -i -e "s|'file|'${pkgs.file}/bin/file|" py3status/parse_config.py
-      sed -i -e "s|\[\"acpi\"|\[\"${pkgs.acpi}/bin/acpi\"|" py3status/modules/battery_level.py
-      sed -i -e "s|notify-send|${pkgs.libnotify}/bin/notify-send|" py3status/modules/battery_level.py
-      sed -i -e "s|/usr/bin/whoami|${pkgs.coreutils}/bin/whoami|" py3status/modules/external_script.py
-      sed -i -e "s|'amixer|'${pkgs.alsaUtils}/bin/amixer|" py3status/modules/volume_status.py
-      sed -i -e "s|'i3-nagbar|'${pkgs.i3}/bin/i3-nagbar|" py3status/modules/pomodoro.py
-      sed -i -e "s|'free|'${pkgs.procps}/bin/free|" py3status/modules/sysdata.py
-      sed -i -e "s|'sensors|'${pkgs.lm_sensors}/bin/sensors|" py3status/modules/sysdata.py
-      sed -i -e "s|'setxkbmap|'${pkgs.xorg.setxkbmap}/bin/setxkbmap|" py3status/modules/keyboard_layout.py
-      sed -i -e "s|'xset|'${pkgs.xorg.xset}/bin/xset|" py3status/modules/keyboard_layout.py
-    '';
-    meta = {
-      maintainers = with maintainers; [ garbas ];
-    };
-  };
+  py3status = callPackage ../development/python-modules/py3status {};
 
   multi_key_dict = buildPythonPackage rec {
     name = "multi_key_dict-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6219,16 +6219,16 @@ in {
   };
 
   py3status = buildPythonPackage rec {
-    version = "3.7";
+    version = "3.8";
     name = "py3status-${version}";
     src = pkgs.fetchFromGitHub {
       owner = "ultrabug";
       repo = "py3status";
       rev = version;
-      sha256 = "1khrvxjjcm1bsswgrdgvyrdrimxx92yhql4gmji6a0kpp59dp541";
+      sha256 = "0454g6zmhgpaag5cj16jarp9bm6h0cf9r3pbkjq2j9wa7rynp3l4";
     };
     doCheck = false;
-    propagatedBuildInputs = with self; [ requests ];
+    propagatedBuildInputs = with self; [ pytz requests tzlocal ];
     buildInputs = with pkgs; [ file ];
     prePatch = ''
       sed -i -e "s|'file|'${pkgs.file}/bin/file|" py3status/parse_config.py


### PR DESCRIPTION
  * Bump version to 3.8
  * Add `pytz` and `tzlocal` to the dependencies in order to make the
    `clock` module work properly.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
