### PR TITLE
meta: Don't bypass unsupported platforms with allowBroken.

### DIFF
--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -14,6 +14,8 @@ true:</para>
   its <literal>meta.broken</literal> set to
   <literal>true</literal>.</para></listitem>
 
+  <listitem><para>The package isn't intended to run on the given system, as none of its <literal>meta.platforms</literal> match the given system.</para></listitem>
+
   <listitem><para>The package's <literal>meta.license</literal> is set
   to a license which is considered to be unfree.</para></listitem>
 
@@ -86,6 +88,42 @@ distributing the software.</para>
 </programlisting>
     </para></listitem>
   </itemizedlist>
+</section>
+
+<section xml:id="sec-allow-unsupported-system">
+  <title>Installing packages on unsupported systems</title>
+
+
+  <para>
+    There are also two ways to try compiling a package which has been marked as unsuported for the given system.
+  </para>
+
+  <itemizedlist>
+    <listitem><para>
+      For allowing the build of a broken package once, you can use an environment variable for a single invocation of the nix tools:
+
+      <programlisting>$ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1</programlisting>
+    </para></listitem>
+
+    <listitem>
+      <para>
+        For permanently allowing broken packages to be built, you may add <literal>allowUnsupportedSystem = true;</literal> to your user's configuration file, like this:
+
+<programlisting>
+{
+  allowUnsupportedSystem = true;
+}
+</programlisting>
+      </para>
+    </listitem>
+  </itemizedlist>
+
+  <para>
+    The difference between an a package being unsupported on some system and being broken is admittedly a bit fuzzy.
+    If a program <emphasis>ought</emphasis> to work on a certain platform, but doesn't, the platform should be included in <literal>meta.platforms</literal>, but marked as broken with e.g. <literal>meta.broken = !hostPlatform.isWindows</literal>.
+    Of course, this begs the question of what "ought" means exactly.
+    That is left to the package maintainer.
+  </para>
 </section>
 
 <section xml:id="sec-allow-unfree">
@@ -397,7 +435,7 @@ fi
     </para>
 
   </section>
-    
+
   <section xml:id="sec-gnu-info-setup">
     <title>GNU info setup</title>
 

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -75,6 +75,7 @@ let
   remediation = {
     unfree = remediate_whitelist "Unfree";
     broken = remediate_whitelist "Broken";
+    unsupported = remediate_whitelist "UnsupportedSystem";
     blacklisted = x: "";
     insecure = remediate_insecure;
     unknown-meta = x: "";
@@ -192,8 +193,8 @@ let
       { valid = false; reason = "blacklisted"; errormsg = "has a blacklisted license (‘${showLicense attrs.meta.license}’)"; }
     else if !allowBroken && attrs.meta.broken or false then
       { valid = false; reason = "broken"; errormsg = "is marked as broken"; }
-    else if !allowUnsupportedSystem && !allowBroken && !(checkPlatform attrs) then
-      { valid = false; reason = "broken"; errormsg = "is not supported on ‘${hostPlatform.config}’"; }
+    else if !allowUnsupportedSystem && !(checkPlatform attrs) then
+      { valid = false; reason = "unsupported"; errormsg = "is not supported on ‘${hostPlatform.config}’"; }
     else if !(hasAllowedInsecure attrs) then
       { valid = false; reason = "insecure"; errormsg = "is marked as insecure"; }
     else let res = checkMeta (attrs.meta or {}); in if res != [] then

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -8,7 +8,8 @@ let
   # for why this defaults to false, but I (@copumpkin) want to default it to true soon.
   shouldCheckMeta = config.checkMeta or false;
 
-  allowUnfree = config.allowUnfree or false || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+  allowUnfree = config.allowUnfree or false
+    || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
 
   whitelist = config.whitelistedLicenses or [];
   blacklist = config.blacklistedLicenses or [];
@@ -35,9 +36,11 @@ let
   hasBlacklistedLicense = assert areLicenseListsValid; attrs:
     hasLicense attrs && builtins.elem attrs.meta.license blacklist;
 
-  allowBroken = config.allowBroken or false || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
+  allowBroken = config.allowBroken or false
+    || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
 
-  allowUnsupportedSystem = config.allowUnsupportedSystem or false;
+  allowUnsupportedSystem = config.allowUnsupportedSystem or false
+    || builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
 
   isUnfree = licenses: lib.lists.any (l:
     !l.free or true || l == "unfree" || l == "unfree-redistributable") licenses;


### PR DESCRIPTION
Our platforms are open-world oriented these days, and anyway there's allowUnsupportedSystem.