### PR TITLE
nodejs: 9.10.1 -> 9.11.1

### DIFF
--- a/pkgs/development/web/nodejs/v9.nix
+++ b/pkgs/development/web/nodejs/v9.nix
@@ -5,7 +5,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "9.10.1";
-    sha256 = "1widvxbc8sp8p8vp7q38b3zy0w1nx4iaqmp81s6bvaqs08h7wfy9";
+    version = "9.11.1";
+    sha256 = "0k4xkcymf4y3k2bxjryb2lj97bxnng75x7a77i2wgx94749kvp13";
     patches = lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];
   }


### PR DESCRIPTION
###### Motivation for this change

Upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

