### PR TITLE
guake: 0.8.3 → 3.1.0

### DIFF
--- a/pkgs/applications/misc/guake/default.nix
+++ b/pkgs/applications/misc/guake/default.nix
@@ -1,76 +1,46 @@
-/* Beware!
-After starting Guake it will give the error message "Guake can not init! Gconf Error. Have you installed guake.schemas properly?",
-which will have to be resolved manually, because I have not found a way to automate this, without being impure.
-
-If you have Guake installed, you can use `nix-build -A gnome3.guake` to get the path to the build directory in the nix store,
-which then can be used in the following command to install the schemas file of Guake:
-gconftool-2 --install-schema-file /path/returned/by/nix-build/share/gconf/schemas/guake.schemas
-
-It can be removed again by the following command:
-gconftool-2 --recursive-unset /apps/guake
-*/
-{ stdenv, fetchurl, lib
-, pkgconfig, libtool, intltool, makeWrapper
-, dbus, gtk2, gconf, python2Packages, libutempter, vte, keybinder, gnome2, gnome3 }:
-
-with lib;
+{ stdenv, fetchFromGitHub, fetchpatch, python3, gettext, gobjectIntrospection, wrapGAppsHook, glibcLocales
+, gtk3, keybinder3, libnotify, libutempter, vte }:
 
 let
-  inherit (python2Packages) python;
-  inputs = [ dbus gtk2 gconf python libutempter vte keybinder gnome3.gnome-common ];
-  pyPath = makeSearchPathOutput "lib" python.sitePackages (attrVals [ "dbus-python" "notify" "pyGtkGlade" "pyxdg" ] python2Packages ++ [ gnome2.gnome_python ]);
- in stdenv.mkDerivation rec {
+  version = "3.1.0";
+in python3.pkgs.buildPythonApplication rec {
   name = "guake-${version}";
-  version = "0.8.3";
+  format = "other";
 
-  src = fetchurl {
-    url = "https://github.com/Guake/guake/archive/${version}.tar.gz";
-    sha256 = "1lbmdz3i9a97840h8239s360hd37nmhy3hs6kancxbzl1512ak1y";
+  src = fetchFromGitHub {
+    owner = "Guake";
+    repo = "guake";
+    rev = version;
+    sha256 = "0wyis7vxfhwrpq5r72c58k7hqzbk0f5ilm1zffcmbryvy11abgmx";
   };
 
-  nativeBuildInputs = [ pkgconfig libtool intltool makeWrapper ];
-
-  buildInputs = inputs ++ (with python2Packages; [ pyGtkGlade pyxdg ]);
-
-  propagatedUserEnvPkgs = [ gconf.out ];
-
-  patchPhase = ''
-    patchShebangs .
-  '';
-
-  configureScript = "./autogen.sh";
-
-  configureFlags = [
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-    "--disable-schemas-install"
+  patches = [
+    # https://github.com/Guake/guake/issues/1264
+    (fetchpatch {
+      url = https://github.com/Guake/guake/commit/f289aa381bc5fffe83b1ba385c606a2e5cdc94a8.patch;
+      sha256 = "038niw44q14fs34nha1lz9vmxhf0l766ni8nsdxpid4crra2wjd3";
+    })
   ];
 
-  installFlags = [
-    # Configuring the installation to not install gconf schemas is not always supported,
-    # therefore gconftool-2 has this variable, which will make gconftool-2 not update any of the databases.
-    "GCONF_DISABLE_MAKEFILE_SCHEMA_INSTALL=1"
-    "sysconfdir=\${out}/etc"
-    "localstatedir=\${TMPDIR}"
+  nativeBuildInputs = [ gettext gobjectIntrospection wrapGAppsHook python3.pkgs.pip glibcLocales ];
+
+  buildInputs = [ gtk3 keybinder3 libnotify python3 vte ];
+
+  propagatedBuildInputs = with python3.pkgs; [ dbus-python pbr pycairo pygobject3 ];
+
+  LC_ALL = "en_US.UTF-8"; # fixes weird encoding error, see https://github.com/NixOS/nixpkgs/pull/38642#issuecomment-379727699
+
+  PBR_VERSION = version; # pbr needs either .git directory, sdist, or env var
+
+  makeFlags = [
+    "prefix=$(out)"
   ];
 
-  postInstall = ''
-    mkdir -p $out/share/gconf/schemas
-    cp data/guake.schemas $out/share/gconf/schemas
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ libutempter ]}")
   '';
 
-  postFixup = ''
-    for bin in $out/bin/{guake,guake-prefs}; do
-      substituteInPlace $bin \
-        --replace '/usr/bin/env python2' ${python.interpreter}
-      wrapProgram $bin \
-        --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-        --prefix LD_LIBRARY_PATH : ${makeLibraryPath inputs} \
-        --prefix PYTHONPATH : "$out/${python.sitePackages}:${pyPath}:$PYTHONPATH"
-    done
-  '';
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "Drop-down terminal for GNOME";
     homepage = http://guake-project.org;
     license = licenses.gpl2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16050,8 +16050,7 @@ with pkgs;
   };
 
   guake = callPackage ../applications/misc/guake {
-    gconf = gnome2.GConf;
-    vte = gnome2.vte.override { pythonSupport = true; };
+    inherit (gnome3) vte;
   };
 
   guitone = callPackage ../applications/version-management/guitone {


### PR DESCRIPTION
###### Motivation for this change
Another step in getting nixpkgs rid of `GConf`, `gtk2` and other archaisms.

Closes: https://github.com/NixOS/nixpkgs/issues/19576, https://github.com/NixOS/nixpkgs/issues/38634

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

