### PR TITLE
nixos/prosody: add dataDir option

### DIFF
--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -295,6 +295,12 @@ in
         '';
       };
 
+      dataDir = mkOption {
+        type = types.string;
+        description = "Directory where Prosody stores its data";
+        default = "/var/lib/prosody";
+      };
+
       allowRegistration = mkOption {
         type = types.bool;
         default = false;
@@ -421,11 +427,11 @@ in
 
     environment.etc."prosody/prosody.cfg.lua".text = ''
 
-      pidfile = "/var/lib/prosody/prosody.pid"
+      pidfile = "${cfg.dataDir}/prosody.pid"
 
       log = "*syslog"
 
-      data_path = "/var/lib/prosody"
+      data_path = "${cfg.dataDir}"
       plugin_paths = {
         ${lib.concatStringsSep ", " (map (n: "\"${n}\"") cfg.extraPluginPaths) }
       }
@@ -474,7 +480,7 @@ in
       description = "Prosody user";
       createHome = true;
       group = "prosody";
-      home = "/var/lib/prosody";
+      home = "${cfg.dataDir}";
     };
 
     users.extraGroups.prosody = {
@@ -490,7 +496,7 @@ in
       serviceConfig = {
         User = "prosody";
         Type = "forking";
-        PIDFile = "/var/lib/prosody/prosody.pid";
+        PIDFile = "${cfg.dataDir}/prosody.pid";
         ExecStart = "${cfg.package}/bin/prosodyctl start";
       };
     };


### PR DESCRIPTION
###### Motivation for this change

It is useful to store mutable state for services in a non-default path, for backup and space allocation purposes. The `prosody` service did not have a configurable data storage directory.

###### Things done

Added `services.prososdy.dataDir` nixos configuration option, made all paths in the prosody module relative to it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

