### PR TITLE
faust: add more faust2appl scripts

### DIFF
--- a/pkgs/applications/audio/faust/faust1.nix
+++ b/pkgs/applications/audio/faust/faust1.nix
@@ -49,7 +49,7 @@ let
     # faust.wrapWithBuildEnv.
     postInstall = ''
       # syntax error when eval'd directly
-      pattern="faust2!(svg)"
+      pattern="faust2!(*@(atomsnippets|graph|graphviewer|md|plot|sig|sigviewer|svg))"
       (shopt -s extglob; rm "$out"/bin/$pattern)
     '';
 

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -78,7 +78,7 @@ let
     # faust.wrapWithBuildEnv.
     postInstall = ''
       # syntax error when eval'd directly
-      pattern="faust2!(svg)"
+      pattern="faust2!(*@(atomsnippets|graph|graphviewer|md|plot|sig|sigviewer|svg))"
       (shopt -s extglob; rm "$out"/bin/$pattern)
     '';
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

