### PR TITLE
CODEOWNERS: add Mic92/LnL7 for rustc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,6 +64,9 @@
 /pkgs/development/interpreters/ruby @zimbatm
 /pkgs/development/ruby-modules      @zimbatm
 
+# Rust
+/pkgs/development/compilers/rust @Mic92 @LnL7
+
 # Darwin-related
 /pkgs/stdenv/darwin         @NixOS/darwin-maintainers
 /pkgs/os-specific/darwin    @NixOS/darwin-maintainers


### PR DESCRIPTION
###### Motivation for this change

Mic92: linux-x86_64, linux-aarch64
LnL7: for macOS-x86_64

Rust gets too important, let's improve QA here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

