### PR TITLE
home-assistant: make hass cloud integration work

### DIFF
--- a/pkgs/development/python-modules/envs/default.nix
+++ b/pkgs/development/python-modules/envs/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, click, jinja2, terminaltables }:
+
+buildPythonPackage rec {
+  pname = "envs";
+  version = "1.2.4";
+
+  # move to fetchPyPi when https://github.com/capless/envs/issues/8 is fixed
+  src = fetchFromGitHub {
+    owner  = "capless";
+    repo   = "envs";
+    rev    = "e1f6cbad7f20316fc44324d2c50826d57c2817a8";
+    sha256 = "0p88a79amj0jxll3ssq1dzg78y7zwgc8yqyr7cf53nv2i7kmpakv";
+  };
+
+  checkInputs = [ click jinja2 terminaltables ];
+
+  meta = with lib; {
+    description = "Easy access to environment variables from Python";
+    homepage = https://github.com/capless/envs;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/warrant/default.nix
+++ b/pkgs/development/python-modules/warrant/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchFromGitHub, fetchPypi
+, mock
+, boto3, envs, python-jose, requests }:
+
+buildPythonPackage rec {
+  pname = "warrant";
+  version = "0.6.1";
+
+  # move to fetchPyPi when https://github.com/capless/warrant/issues/97 is fixed
+  src = fetchFromGitHub {
+    owner  = "capless";
+    repo   = "warrant";
+    rev    = "ff2e4793d8479e770f2461ef7cbc0c15ee784395";
+    sha256 = "0gw3crg64p1zx3k5js0wh0x5bldgs7viy4g8hld9xbka8q0374hi";
+  };
+
+  # this needs to go when 0.6.2 or later is released
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "python-jose-cryptodome>=1.3.2" "python-jose>=2.0.0"
+  '';
+
+  checkInputs = [ mock ];
+
+  propagatedBuildInputs = [ boto3 envs python-jose requests ];
+
+  # all the checks are failing
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python library for using AWS Cognito with support for SRP";
+    homepage = https://github.com/capless/warrant;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -55,7 +55,7 @@
     "climate.sensibo" = ps: with ps; [  ];
     "climate.touchline" = ps: with ps; [  ];
     "climate.venstar" = ps: with ps; [  ];
-    "cloud" = ps: with ps; [  ];
+    "cloud" = ps: with ps; [ warrant ];
     "coinbase" = ps: with ps; [  ];
     "comfoconnect" = ps: with ps; [  ];
     "config.config_entries" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1646,6 +1646,8 @@ in {
 
   curtsies = callPackage ../development/python-modules/curtsies { };
 
+  envs = callPackage ../development/python-modules/envs { };
+
   jsonrpc-async = callPackage ../development/python-modules/jsonrpc-async { };
 
   jsonrpc-base = callPackage ../development/python-modules/jsonrpc-base { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18275,6 +18275,8 @@ EOF
 
   sseclient = callPackage ../development/python-modules/sseclient { };
 
+  warrant = callPackage ../development/python-modules/warrant { };
+
   textacy = callPackage ../development/python-modules/textacy { };
 
   pyemd  = callPackage ../development/python-modules/pyemd { };


### PR DESCRIPTION
###### Motivation for this change

I'd like to use my "Amazon ~~~spy-device~~~ Echo" to control home assistant.

I haven't actually tried to use it to control HA yet but at least it's connecting.

Should I separate out the pycryptodome override into its own file?

Cc: @dotlambda @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

