### PR TITLE
testssl: 2.9.5-3 -> 2.9.5-4

### DIFF
--- a/pkgs/applications/networking/testssl/default.nix
+++ b/pkgs/applications/networking/testssl/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgs }:
 
 let
-  version = "2.9.5-3";
+  version = "2.9.5-4";
   pwdBinPath = "${stdenv.lib.makeBinPath (with pkgs; [ coreutils ])}/pwd";
   opensslBinPath = "${stdenv.lib.makeBinPath (with pkgs; [ openssl ])}/openssl";
 
@@ -12,16 +12,16 @@ in stdenv.mkDerivation rec {
     owner = "drwetter";
     repo = "testssl.sh";
     rev = "v${version}";
-    sha256 = "07vlmf3gn2xa4wam2sql6c1s1hvj5adzd6l1fl12lq066v0k7r7n";
+    sha256 = "0pfp7r4jhvkh06vawqlvq7vp4imwp6dpq6jx8m0k3j85ywwp45pd";
   };
 
   patches = [ ./testssl.patch ];
 
   postPatch = ''
-    sed -i -e "s|/bin/pwd|${pwdBinPath}|g"                                     \
-           -e "s|TESTSSL_INSTALL_DIR:-\"\"|TESTSSL_INSTALL_DIR:-\"$out\"|g"    \
-           -e "s|OPENSSL:-\"\"|OPENSSL:-\"${opensslBinPath}\"|g" \
-           testssl.sh
+    substituteInPlace testssl.sh                                               \
+      --replace /bin/pwd                    ${pwdBinPath}                      \
+      --replace TESTSSL_INSTALL_DIR:-\"\"   TESTSSL_INSTALL_DIR:-\"$out\"      \
+      --replace @@openssl-path@@            ${opensslBinPath}
   '';
 
   installPhase = ''

--- a/pkgs/applications/networking/testssl/testssl.patch
+++ b/pkgs/applications/networking/testssl/testssl.patch
@@ -4,7 +4,7 @@
  # following variables make use of $ENV, e.g. OPENSSL=<myprivate_path_to_openssl> ./testssl.sh <host>
  # 0 means (normally) true here. Some of the variables are also accessible with a command line switch, see --help
  declare -x OPENSSL OPENSSL_TIMEOUT
-+OPENSSL=${OPENSSL:-""}
++OPENSSL=${OPENSSL:-"@@openssl-path@@"}
  FAST_SOCKET=${FAST_SOCKET:-false}       # EXPERIMENTAL feature to accelerate sockets -- DO NOT USE it for production
  COLOR=${COLOR:-2}                       # 2: Full color, 1: b/w+positioning, 0: no ESC at all
  COLORBLIND=${COLORBLIND:-false}         # if true, swap blue and green in the output


### PR DESCRIPTION
###### Motivation for this change
Changelog:
https://github.com/drwetter/testssl.sh/releases/tag/v2.9.5-4

Also improved the expression to be more readable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

