### PR TITLE
WIP: pipenv: 10.1.2 -> 11.9.0

### DIFF
--- a/pkgs/development/libraries/xalanc/default.nix
+++ b/pkgs/development/libraries/xalanc/default.nix
@@ -13,12 +13,11 @@ in stdenv.mkDerivation rec {
     sha256 = "0a3a2b15vpacnqgpp6fiy1pwyc8q6ywzvyb5445f6wixfdspypjg";
   };
 
-  # TODO: should we really be putting outputs in $out/usr? I'd expect -P$out below
   configurePhase = ''
     export XALANCROOT=`pwd`/c
     cd `pwd`/c
-    mkdir -p $out/usr
-    ./runConfigure -p ${platform} -c cc -x c++ -P$out/usr
+    mkdir -p $out
+    ./runConfigure -p ${platform} -c cc -x c++ -P$out
   '';
 
   buildInputs = [ xercesc getopt ];


### PR DESCRIPTION
Also avoid propagating python libraries to keep nix-shell environments
clean.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

