### PR TITLE
sleepyhead: init at 1.0.0-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1961,6 +1961,11 @@
     github = "kragniz";
     name = "Louis Taylor";
   };
+  krav = {
+    email = "kristoffer@microdisko.no";
+    github = "krav";
+    name = "Kristoffer Thømt Ravneberg";
+  };
   kristoff3r = {
     email = "k.soeholm@gmail.com";
     github = "kristoff3r";

--- a/pkgs/applications/misc/sleepyhead/default.nix
+++ b/pkgs/applications/misc/sleepyhead/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchgit, qt5, zlib, libGLU, libX11 }:
+
+let
+  name = "sleepyhead-${version}";
+  version = "1.0.0-beta-git";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchgit {
+    url = https://gitlab.com/sleepyhead/sleepyhead-code.git;
+    rev = "9e2329d8bca45693231b5e3dae80063717c24578";
+    sha256 = "0448z8gyaxpgpnksg34lzmffj36jdpm0ir4xxa5gvzagkx0wk07h";
+  };
+
+  buildInputs = [
+    qt5.qtbase qt5.qtwebkit qt5.qtserialport
+    zlib
+    libGLU
+    libX11
+  ];
+
+  patchPhase = ''
+    patchShebangs configure
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp sleepyhead/SleepyHead $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://sleepyhead.jedimark.net/;
+    description = "Review and explore data produced by CPAP and related machines";
+    longDescription = ''
+      SleepyHead is cross platform, opensource sleep tracking program for reviewing CPAP and Oximetry data, which are devices used in the treatment of Sleep Disorders like Obstructive Sleep Apnea.
+    '';
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.krav ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4843,6 +4843,8 @@ with pkgs;
 
   sleuthkit = callPackage ../tools/system/sleuthkit {};
 
+  sleepyhead = callPackage ../applications/misc/sleepyhead {};
+
   slimrat = callPackage ../tools/networking/slimrat {
     inherit (perlPackages) WWWMechanize LWP;
   };


### PR DESCRIPTION
###### Motivation for this change
This adds SleepyHead, a GUI tool to review and explore data produced by CPAP and related machines.

Note that this uses a git revision instead of a release since the latest tag 1.0.0-beta2 is over a year old and doesn't seem to build with the current qt5.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

