### PR TITLE
dnsdist: init at 1.3.0

### DIFF
--- a/pkgs/servers/dns/dnsdist/default.nix
+++ b/pkgs/servers/dns/dnsdist/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, pkgconfig, systemd
+, boost, libsodium, libedit, re2
+, net_snmp, lua, protobuf, openssl }: stdenv.mkDerivation rec {
+  name = "dnsdist-${version}";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "https://downloads.powerdns.com/releases/dnsdist-${version}.tar.bz2";
+    sha256 = "025sgvpi3ps0n4mzfwkk6a5ang90a3c7s2fi9vni6jj0p16wsrxa";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ systemd boost libsodium libedit re2 net_snmp lua protobuf openssl ];
+
+  configureFlags = [
+    "--enable-libsodium"
+    "--enable-re2"
+    "--enable-dnscrypt"
+    "--enable-dns-over-tls"
+    "--with-protobuf=yes"
+    "--with-net-snmp"
+    "--disable-dependency-tracking"
+    "--enable-unit-tests"
+    "--enable-systemd"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "DNS Loadbalancer";
+    homepage = "https://dnsdist.org";
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13887,6 +13887,8 @@ with pkgs;
 
   powerdns = callPackage ../servers/dns/powerdns { };
 
+  dnsdist = callPackage ../servers/dns/dnsdist { };
+
   pdns-recursor = callPackage ../servers/dns/pdns-recursor { };
 
   powertop = callPackage ../os-specific/linux/powertop { };


### PR DESCRIPTION
###### Motivation for this change

nix(os) was lacking dnsdist

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

