### PR TITLE
iaca: init at 3.0, 2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1897,6 +1897,11 @@
     email = "info+nix@chmist.com";
     name = "karolchmist";
   };
+  kazcw = {
+    email = "kaz@lambdaverse.org";
+    github = "kazcw";
+    name = "Kaz Wesley";
+  };
   kentjames = {
     email = "jameschristopherkent@gmail.com";
     github = "kentjames";

--- a/pkgs/development/tools/iaca/2.1.nix
+++ b/pkgs/development/tools/iaca/2.1.nix
@@ -2,6 +2,7 @@
 assert stdenv.system == "x86_64-linux";
 with stdenv.lib;
 
+# v2.1: last version with NHM/WSM arch support
 stdenv.mkDerivation {
   name = "iaca-2.1";
   src = requireFile {

--- a/pkgs/development/tools/iaca/2.1.nix
+++ b/pkgs/development/tools/iaca/2.1.nix
@@ -1,0 +1,32 @@
+{ stdenv, makeWrapper, requireFile, patchelf, gcc, unzip }:
+assert stdenv.system == "x86_64-linux";
+with stdenv.lib;
+
+stdenv.mkDerivation {
+  name = "iaca-2.1";
+  src = requireFile {
+    name = "iaca-version-2.1-lin64.zip";
+    sha256 = "11s1134ijf66wrc77ksky9mnb0lq6ml6fzmr86a6p6r5xclzay2m";
+    url = "https://software.intel.com/en-us/articles/intel-architecture-code-analyzer-download";
+  };
+  unpackCmd = ''${unzip}/bin/unzip "$src" -x __MACOSX/ __MACOSX/iaca-lin64/ __MACOSX/iaca-lin64/._.DS_Store'';
+  nativeBuildInputs = [ makeWrapper ];
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    cp bin/iaca $out/bin/
+    cp lib/* $out/lib
+  '';
+  preFixup = let libPath = makeLibraryPath [ stdenv.cc.cc.lib gcc ]; in ''
+    patchelf \
+        --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 \
+        --set-rpath $out/lib:"${libPath}" \
+        $out/bin/iaca
+  '';
+  postFixup = ''wrapProgram $out/bin/iaca --set LD_LIBRARY_PATH $out/lib'';
+  meta = {
+    description = "Intel Architecture Code Analyzer";
+    homepage = https://software.intel.com/en-us/articles/intel-architecture-code-analyzer/;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/iaca/2.1.nix
+++ b/pkgs/development/tools/iaca/2.1.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation {
     homepage = https://software.intel.com/en-us/articles/intel-architecture-code-analyzer/;
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ kazcw ];
   };
 }

--- a/pkgs/development/tools/iaca/3.0.nix
+++ b/pkgs/development/tools/iaca/3.0.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation {
     homepage = https://software.intel.com/en-us/articles/intel-architecture-code-analyzer/;
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ kazcw ];
   };
 }

--- a/pkgs/development/tools/iaca/3.0.nix
+++ b/pkgs/development/tools/iaca/3.0.nix
@@ -1,0 +1,24 @@
+{ stdenv, requireFile, patchelf, unzip }:
+assert stdenv.system == "x86_64-linux";
+with stdenv.lib;
+
+stdenv.mkDerivation {
+  name = "iaca-3.0";
+  src = requireFile {
+    name = "iaca-version-v3.0-lin64.zip";
+    sha256 = "0qd81bxg269cwwvfmdp266kvhcl3sdvhrkfqdrbmanawk0w7lvp1";
+    url = "https://software.intel.com/en-us/articles/intel-architecture-code-analyzer-download";
+  };
+  unpackCmd = ''${unzip}/bin/unzip "$src"'';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp iaca $out/bin
+    patchelf --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 $out/bin/iaca
+  '';
+  meta = {
+    description = "Intel Architecture Code Analyzer";
+    homepage = https://software.intel.com/en-us/articles/intel-architecture-code-analyzer/;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7905,6 +7905,10 @@ with pkgs;
 
   hyenae = callPackage ../tools/networking/hyenae { };
 
+  iaca_2_1 = callPackage ../development/tools/iaca/2.1.nix { };
+  iaca_3_0 = callPackage ../development/tools/iaca/3.0.nix { };
+  iaca = iaca_3_0;
+
   icestorm = callPackage ../development/tools/icestorm { };
 
   icmake = callPackage ../development/tools/build-managers/icmake { };


### PR DESCRIPTION
###### Motivation for this change
Add packages for IACA (Intel Architecture Code Analyzer).

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).