### PR TITLE
altcoins.mist: init at 0.10.0

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -51,6 +51,8 @@ rec {
   memorycoin  = callPackage ./memorycoin.nix { boost = boost165; withGui = true; };
   memorycoind = callPackage ./memorycoin.nix { boost = boost165; withGui = false; };
 
+  mist = callPackage ./mist.nix { };
+
   namecoin  = callPackage ./namecoin.nix  { withGui = true; };
   namecoind = callPackage ./namecoin.nix { withGui = false; };
 

--- a/pkgs/applications/altcoins/mist.nix
+++ b/pkgs/applications/altcoins/mist.nix
@@ -1,0 +1,71 @@
+{ stdenv, lib, makeWrapper, fetchurl, unzip, atomEnv, makeDesktopItem, buildFHSUserEnv }:
+
+let
+  version = "0.10.0";
+  name = "mist-${version}";
+
+  throwSystem = throw "Unsupported system: ${stdenv.system}";
+
+  meta = with stdenv.lib; {
+    description = "Browse and use Ðapps on the Ethereum network";
+    homepage = https://github.com/ethereum/mist;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+
+  urlVersion = builtins.replaceStrings ["."] ["-"] version;
+
+  desktopItem = makeDesktopItem rec {
+    name = "Mist";
+    exec = "mist";
+    icon = "mist";
+    desktopName = name;
+    genericName = "Mist Browser";
+    categories = "Network;";
+  };
+
+  mist = stdenv.mkDerivation {
+    inherit name version;
+
+    src = {
+      i686-linux = fetchurl {
+        url = "https://github.com/ethereum/mist/releases/download/v${version}/Mist-linux32-${urlVersion}.zip";
+        sha256 = "01hvxlm9w522pwvsjdy18gsrapkfjr7d1jjl4bqjjysxnjaaj2lk";
+      };
+      x86_64-linux = fetchurl {
+        url = "https://github.com/ethereum/mist/releases/download/v${version}/Mist-linux64-${urlVersion}.zip";
+        sha256 = "01k17j7fdfhxfd26njdsiwap0xnka2536k9ydk32czd8db7ya9zi";
+      };
+    }.${stdenv.system} or throwSystem;
+
+    buildInputs = [ unzip makeWrapper ];
+
+    buildCommand = ''
+      mkdir -p $out/lib/mist $out/bin
+      unzip -d $out/lib/mist $src
+      ln -s $out/lib/mist/mist $out/bin
+      fixupPhase
+      mkdir -p $out/share/applications
+      ln -s ${desktopItem}/share/applications/* $out/share/applications
+      patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${atomEnv.libPath}:$out/lib/mist" \
+        $out/lib/mist/mist
+    '';
+  };
+in
+buildFHSUserEnv {
+  name = "mist";
+
+  targetPkgs = pkgs: with pkgs; [
+     mist
+  ];
+
+  extraInstallCommands = ''
+    mkdir -p "$out/share/applications"
+    cp "${desktopItem}/share/applications/"* $out/share/applications
+  '';
+
+  runScript = "mist";
+}


### PR DESCRIPTION
###### Motivation for this change

Having an available package for the Ethereum Mist browser.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

At first I attempted to package it using node2nix, however ran into some issues. Currently, it is using the binary releases, patching the ELF, but it still needs to run inside an FHS user env because the program attempts to download the `geth` binary to the home directory, which is linked to the standard `/usr/lib` paths. Specifying a geth binary is currently not working [[1]] [[2]].

I've tested it on my system running 18.03 with Gnome 3.

It should be possible to add a Mac build as well, but I do not have a Mac available to test and so did not.

I did not add myself as a maintainer because I'm not sure if I'll be able to maintain it going forward. Please let me know how to proceed, if I should add it anyway or if someone else is interested in adopting it.

[1]: https://github.com/ethereum/mist/issues/3077
[2]: https://github.com/ethereum/mist/issues/3078