### PR TITLE
cockroachdb: 1.1.5 -> 2.0.0

### DIFF
--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, buildGoPackage, fetchurl, cmake, xz, which, autoconf }:
+{ stdenv, buildGoPackage, fetchurl, cmake, xz, which, autoconf, ncurses6 }:
 
 buildGoPackage rec {
   name = "cockroach-${version}";
-  version = "1.1.5";
+  version = "2.0.0";
 
   goPackagePath = "github.com/cockroachdb/cockroach";
 
   src = fetchurl {
     url = "https://binaries.cockroachdb.com/cockroach-v${version}.src.tgz";
-    sha256 = "0i2lg60424i1yg9dhapfsy3majnlbad2wlf93d9l161jf5lp9a2d";
+    sha256 = "0x8hf5qwvgb2w6dcnvy20v77nf19f0l1pb40jf31rm72xhk3bwvy";
   };
 
+  buildInputs = [ ncurses6 ];
   nativeBuildInputs = [ cmake xz which autoconf ];
 
   buildPhase = ''

--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchurl, cmake, xz, which, autoconf, ncurses6 }:
+{ stdenv, buildGoPackage, fetchurl, cmake, xz, which, autoconf, ncurses6, libedit }:
 
 buildGoPackage rec {
   name = "cockroach-${version}";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     sha256 = "0x8hf5qwvgb2w6dcnvy20v77nf19f0l1pb40jf31rm72xhk3bwvy";
   };
 
-  buildInputs = [ ncurses6 ];
+  buildInputs = [ (if stdenv.isDarwin then libedit else ncurses6) ];
   nativeBuildInputs = [ cmake xz which autoconf ];
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Lots of shiny new features: https://www.cockroachlabs.com/docs/releases/v2.0.0.html#core-features

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

One of the dependencies failed to build without `-ltinfo`, so I've added `ncurses6` to the `buildInputs`.
