### PR TITLE
nixos/cockroachdb: create service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -306,6 +306,7 @@
       monero = 287;
       ceph = 288;
       duplicati = 289;
+      cockroachdb = 290;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -580,6 +581,7 @@
       monero = 287;
       ceph = 288;
       duplicati = 289;
+      cockroachdb = 290;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -192,6 +192,7 @@
   ./services/databases/4store-endpoint.nix
   ./services/databases/4store.nix
   ./services/databases/clickhouse.nix
+  ./services/databases/cockroachdb.nix
   ./services/databases/couchdb.nix
   ./services/databases/firebird.nix
   ./services/databases/hbase.nix

--- a/nixos/modules/services/databases/cockroachdb.nix
+++ b/nixos/modules/services/databases/cockroachdb.nix
@@ -1,0 +1,162 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.cockroachdb;
+
+  cockroachdb = cfg.package;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.cockroachdb = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "
+          Whether to enable the CockroachDB server.
+        ";
+      };
+
+      package = mkOption {
+        type = types.package;
+        example = literalExample "pkgs.cockroachdb";
+        description = "
+          Which CockroachDB derivation to use.
+        ";
+      };
+
+      cache = mkOption {
+        type = types.str;
+        default = "25%";
+        description = "The total size for caches. This can be a percentage or any bytes-based unit.";
+      };
+
+      certsDir = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "The path to the certificate directory.";
+      };
+
+      httpHost = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "The host to bind to for Admin UI HTTP requests.";
+      };
+
+      httpPort = mkOption {
+        type = types.int;
+        default = 8080;
+        description = "The port to bind to for Admin UI HTTP requests.";
+      };
+
+      host = mkOption {
+        type = types.nullOr types.str;
+        default = "localhost";
+        description = "The hostname or IP address to listen on for intra-cluster and client communication.";
+      };
+
+      insecure = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Run in insecure mode.";
+      };
+
+      join = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "The addresses for connecting the node to a cluster.";
+      };
+
+      maxSqlMemory = mkOption {
+        type = types.str;
+        default = "25%";
+        description =
+          ''
+            The maximum in-memory storage capacity available to store temporary data for SQL queries.
+            This can be a percentage or any bytes-based unit.
+          '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 26257;
+        description = "The port to bind to for internal and client communication.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "cockroachdb";
+        description = "User account under which CockroachDB runs";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "cockroachdb";
+        description = "User account under which CockroachDB runs";
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/cockroachdb";
+        example = "/var/lib/cockroachdb";
+        description = "Location where MySQL stores its table files";
+      };
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.cockroachdb.enable {
+
+    users.extraUsers.cockroachdb = {
+      description = "CockroachDB server user";
+      group = "cockroachdb";
+      uid = config.ids.uids.cockroachdb;
+    };
+
+    users.extraGroups.cockroachdb.gid = config.ids.gids.cockroachdb;
+
+    environment.systemPackages = [ cockroachdb ];
+
+    systemd.services.cockroachdb =
+      { description = "CockroachDB Server";
+
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        unitConfig.RequiresMountsFor = "${cfg.dataDir}";
+
+        preStart =
+          ''
+            if ! test -e ${cfg.dataDir}; then
+                mkdir -m 0700 -p ${cfg.dataDir}
+                chown -R ${cfg.user} ${cfg.dataDir}
+            fi
+          '';
+
+        serviceConfig =
+          { ExecStart = "${cockroachdb}/bin/cockroach start --logtostderr --cache=${cfg.cache} "
+                      + "--http-host=${cfg.httpHost} --http-port=${toString cfg.httpPort} "
+                      + "--max-sql-memory=${cfg.maxSqlMemory} --port=${toString cfg.port} "
+                      + (optionalString (!isNull cfg.host) "--host=${cfg.host} ")
+                      + (optionalString (!isNull cfg.join) "--join=${cfg.join} ")
+                      + (if cfg.insecure then "--insecure " else "--certs-dir=${cfg.certsDir} ")
+                      + "--store=${cfg.dataDir} ";
+            User = cfg.user;
+            PermissionsStartOnly = true;
+          };
+      };
+  };
+
+}

--- a/nixos/tests/cockroachdb.nix
+++ b/nixos/tests/cockroachdb.nix
@@ -1,0 +1,24 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "cockroachdb";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ ];
+  };
+
+  nodes = {
+    master =
+      { pkgs, config, ... }:
+
+      {
+        services.cockroachdb.enable = true;
+        services.cockroachdb.package = pkgs.cockroachdb;
+      };
+  };
+
+  testScript = ''
+    startAll;
+
+    $master->waitForUnit("cockroachdb");
+    $master->sleep(10); # Hopefully this is long enough!!
+    $master->succeed("cockroach sql --insecure -e 'SHOW ALL CLUSTER SETTINGS'");
+  '';
+})

--- a/nixos/tests/cockroachdb.nix
+++ b/nixos/tests/cockroachdb.nix
@@ -11,6 +11,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       {
         services.cockroachdb.enable = true;
         services.cockroachdb.package = pkgs.cockroachdb;
+        services.cockroachdb.insecure = true;
       };
   };
 
@@ -18,7 +19,6 @@ import ./make-test.nix ({ pkgs, ...} : {
     startAll;
 
     $master->waitForUnit("cockroachdb");
-    $master->sleep(10); # Hopefully this is long enough!!
     $master->succeed("cockroach sql --insecure -e 'SHOW ALL CLUSTER SETTINGS'");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Ease of configuring CockroachDB on NixOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Naming isn't quite consistent - the binary is called `cockroach` but the package is called `cockroachdb`. For consistency, I've used `cockroachdb` in all cases here.

I added one very basic test that checks if an insecure single-node cluster can boot and run `SHOW ALL CLUSTER SETTINGS`.

I wasn't quite sure who to put as the maintainer.