### PR TITLE
Add stubby resolver daemon service module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -41,6 +41,7 @@
   ./hardware/pcmcia.nix
   ./hardware/raid/hpsa.nix
   ./hardware/usb-wwan.nix
+  ./hardware/onlykey.nix
   ./hardware/video/amdgpu.nix
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/ati.nix
@@ -58,6 +59,7 @@
   ./installer/tools/tools.nix
   ./misc/assertions.nix
   ./misc/crashdump.nix
+  ./misc/documentation.nix
   ./misc/extra-arguments.nix
   ./misc/ids.nix
   ./misc/lib.nix
@@ -85,12 +87,11 @@
   ./programs/freetds.nix
   ./programs/gnupg.nix
   ./programs/gphoto2.nix
-  ./programs/info.nix
+  ./programs/iftop.nix
   ./programs/java.nix
   ./programs/kbdlight.nix
   ./programs/less.nix
   ./programs/light.nix
-  ./programs/man.nix
   ./programs/mosh.nix
   ./programs/mtr.nix
   ./programs/nano.nix
@@ -104,6 +105,7 @@
   ./programs/shadow.nix
   ./programs/shell.nix
   ./programs/spacefm.nix
+  ./programs/singularity.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
   ./programs/sysdig.nix
@@ -157,9 +159,9 @@
   ./services/audio/slimserver.nix
   ./services/audio/squeezelite.nix
   ./services/audio/ympd.nix
-  ./services/backup/almir.nix
   ./services/backup/bacula.nix
   ./services/backup/borgbackup.nix
+  ./services/backup/duplicati.nix
   ./services/backup/crashplan.nix
   ./services/backup/crashplan-small-business.nix
   ./services/backup/mysql-backup.nix
@@ -325,6 +327,7 @@
   #./services/misc/gitit.nix
   #./services/misc/gitlab.nix
   ./services/misc/gitolite.nix
+  ./services/misc/gitweb.nix
   ./services/misc/gogs.nix
   ./services/misc/gollum.nix
   ./services/misc/gpsd.nix
@@ -362,6 +365,7 @@
   ./services/misc/rippled.nix
   ./services/misc/ripple-data-api.nix
   ./services/misc/rogue.nix
+  ./services/misc/serviio.nix
   ./services/misc/siproxd.nix
   ./services/misc/snapper.nix
   ./services/misc/sonarr.nix
@@ -631,7 +635,6 @@
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/frab.nix
   ./services/web-apps/mattermost.nix
-  ./services/web-apps/nixbot.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/pgpkeyserver-lite.nix
   ./services/web-apps/matomo.nix
@@ -651,6 +654,7 @@
   ./services/web-servers/mighttpd2.nix
   ./services/web-servers/minio.nix
   ./services/web-servers/nginx/default.nix
+  ./services/web-servers/nginx/gitweb.nix
   ./services/web-servers/phpfpm/default.nix
   ./services/web-servers/shellinabox.nix
   ./services/web-servers/tomcat.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -41,7 +41,6 @@
   ./hardware/pcmcia.nix
   ./hardware/raid/hpsa.nix
   ./hardware/usb-wwan.nix
-  ./hardware/onlykey.nix
   ./hardware/video/amdgpu.nix
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/ati.nix
@@ -59,7 +58,6 @@
   ./installer/tools/tools.nix
   ./misc/assertions.nix
   ./misc/crashdump.nix
-  ./misc/documentation.nix
   ./misc/extra-arguments.nix
   ./misc/ids.nix
   ./misc/lib.nix
@@ -87,11 +85,12 @@
   ./programs/freetds.nix
   ./programs/gnupg.nix
   ./programs/gphoto2.nix
-  ./programs/iftop.nix
+  ./programs/info.nix
   ./programs/java.nix
   ./programs/kbdlight.nix
   ./programs/less.nix
   ./programs/light.nix
+  ./programs/man.nix
   ./programs/mosh.nix
   ./programs/mtr.nix
   ./programs/nano.nix
@@ -105,7 +104,6 @@
   ./programs/shadow.nix
   ./programs/shell.nix
   ./programs/spacefm.nix
-  ./programs/singularity.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
   ./programs/sysdig.nix
@@ -159,9 +157,9 @@
   ./services/audio/slimserver.nix
   ./services/audio/squeezelite.nix
   ./services/audio/ympd.nix
+  ./services/backup/almir.nix
   ./services/backup/bacula.nix
   ./services/backup/borgbackup.nix
-  ./services/backup/duplicati.nix
   ./services/backup/crashplan.nix
   ./services/backup/crashplan-small-business.nix
   ./services/backup/mysql-backup.nix
@@ -327,7 +325,6 @@
   #./services/misc/gitit.nix
   #./services/misc/gitlab.nix
   ./services/misc/gitolite.nix
-  ./services/misc/gitweb.nix
   ./services/misc/gogs.nix
   ./services/misc/gollum.nix
   ./services/misc/gpsd.nix
@@ -365,7 +362,6 @@
   ./services/misc/rippled.nix
   ./services/misc/ripple-data-api.nix
   ./services/misc/rogue.nix
-  ./services/misc/serviio.nix
   ./services/misc/siproxd.nix
   ./services/misc/snapper.nix
   ./services/misc/sonarr.nix
@@ -558,6 +554,7 @@
   ./services/networking/ssh/sshd.nix
   ./services/networking/strongswan.nix
   ./services/networking/stunnel.nix
+  ./services/networking/stubby.nix
   ./services/networking/supplicant.nix
   ./services/networking/supybot.nix
   ./services/networking/syncthing.nix
@@ -634,6 +631,7 @@
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/frab.nix
   ./services/web-apps/mattermost.nix
+  ./services/web-apps/nixbot.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/pgpkeyserver-lite.nix
   ./services/web-apps/matomo.nix
@@ -653,7 +651,6 @@
   ./services/web-servers/mighttpd2.nix
   ./services/web-servers/minio.nix
   ./services/web-servers/nginx/default.nix
-  ./services/web-servers/nginx/gitweb.nix
   ./services/web-servers/phpfpm/default.nix
   ./services/web-servers/shellinabox.nix
   ./services/web-servers/tomcat.nix

--- a/nixos/modules/services/networking/stubby.nix
+++ b/nixos/modules/services/networking/stubby.nix
@@ -161,20 +161,6 @@ in
         '';
       };
 
-      enableNetBindService = mkOption {
-        default = true;
-        type = types.bool;
-        description = ''
-          This option enables or disables the "CAP_NET_BIND_SERVICE"
-          capability for the daemon process. This capability is necessary in the
-          default configuration (localhost listening on port 853), but is not 
-          necessary if the user chooses to bind to ports higher than 1024 
-          and can safely be disabled in this case for increased security. 
-          See <citerefentry><refentrytitle> capabilities</refentrytitle>
-          <manvolnum>7</manvolnum> </citerefentry> for more information.
-        '';
-      };
-
       extraConfig = mkOption {
         default = "";
         type = types.lines;
@@ -195,8 +181,8 @@ in
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
-        AmbientCapabilities = "${optionalString cfg.enableNetBindService "CAP_NET_BIND_SERVICE"}";
-        CapabilitiesBoundingSet = "${optionalString cfg.enableNetBindService "CAP_NET_BIND_SERVICE"}";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        CapabilitiesBoundingSet = "CAP_NET_BIND_SERVICE";
         ExecStart = "${pkgs.stubby}/bin/stubby -C ${confFile}";
         DynamicUser = true;
       };

--- a/nixos/modules/services/networking/stubby.nix
+++ b/nixos/modules/services/networking/stubby.nix
@@ -5,7 +5,6 @@ with lib;
 let
   cfg = config.services.stubby;
 
-  stateDir = "/var/lib/stubby";
   fallbacks = concatMapStringsSep "\n  " (x: "- ${x}") cfg.fallbackProtocols;
   listeners = concatMapStringsSep "\n  " (x: "- ${x}") cfg.listenAddresses;
 
@@ -93,21 +92,29 @@ in
 
       fallbackProtocols = mkOption {
         default = [ "GETDNS_TRANSPORT_TLS" ];
-        type = with types; listOf (enum [ "GETDNS_TRANSPORT_TLS" "GETDNS_TRANSPORT_TCP" "GETDNS_TRANSPORT_UDP" ]);
+        type = with types; listOf (enum [
+          "GETDNS_TRANSPORT_TLS"
+          "GETDNS_TRANSPORT_TCP"
+          "GETDNS_TRANSPORT_UDP"
+        ]);
         description = ''
           Ordered list composed of one or more transport protocols.
-          Strict mode should only use GETDNS_TRANSPORT_TLS.
-          Other options are GETDNS_TRANSPORT_UDP and GETDNS_TRANSPORT_TCP.
+          Strict mode should only use <literal>GETDNS_TRANSPORT_TLS</literal>.
+          Other options are <literal>GETDNS_TRANSPORT_UDP</literal> and
+          <literal>GETDNS_TRANSPORT_TCP</literal>.
         '';
       };
 
       authenticationMode = mkOption {
         default = "GETDNS_AUTHENTICATION_REQUIRED";
-        type = types.enum [ "GETDNS_AUTHENTICATION_REQUIRED" "GETDNS_AUTHENTICATION_NONE" ];
+        type = types.enum [
+          "GETDNS_AUTHENTICATION_REQUIRED"
+          "GETDNS_AUTHENTICATION_NONE"
+        ];
         description = ''
           Selects the Strict or Opportunistic usage profile.
-          For strict, set to GETDNS_AUTHENTICATION_REQUIRED.
-          for opportunistic, use GETDNS_AUTHENTICATION_NONE.
+          For strict, set to <literal>GETDNS_AUTHENTICATION_REQUIRED</literal>.
+          for opportunistic, use <literal>GETDNS_AUTHENTICATION_NONE</literal>.
         '';
       };
 
@@ -123,14 +130,17 @@ in
         default = true;
         type = types.bool;
         description = ''
-          EDNS0 option for ECS client privacy. Default is true.
+          EDNS0 option for ECS client privacy. Default is
+          <literal>true</literal>. If set, this option prevents the client
+          subnet from being sent to authoritative nameservers.
         '';
       };
 
       idleTimeout = mkOption {
         default = 10000;
         type = types.int;
-        description = "EDNS0 option for keepalive idle timeout in milliseconds.";
+        description = "EDNS0 option for keepalive idle timeout expressed in
+        milliseconds.";
       };
 
       listenAddresses = mkOption {
@@ -147,8 +157,9 @@ in
         default = true;
         type = types.bool;
         description = ''
-          Instructs stubby to distribute queries across all available name servers.
-          Default is true. Set to false in order to use the first available.
+          Instructs stubby to distribute queries across all available name
+          servers. Default is <literal>true</literal>. Set to
+          <literal>false</literal> in order to use the first available.
         '';
       };
 
@@ -156,16 +167,19 @@ in
         default = defaultUpstream;
         type = types.lines;
         description = ''
-          Add additional upstreams see <citerefentry><refentrytitle>stubby
+          Add additional upstreams. See <citerefentry><refentrytitle>stubby
           </refentrytitle><manvolnum>1</manvolnum></citerefentry> for an
-          example of the entry formatting.
+          example of the entry formatting. In Strict mode, at least one of the
+          following settings must be supplied for each nameserver:
+          <literal>tls_auth_name</literal> or
+          <literal>tls_pubkey_pinset</literal>.
         '';
       };
 
       debugLogging = mkOption {
         default = false;
         type = types.bool;
-        description = "enable debug level logging.";
+        description = "Enable or disable debug level logging.";
       };
 
       extraConfig = mkOption {

--- a/nixos/modules/services/networking/stubby.nix
+++ b/nixos/modules/services/networking/stubby.nix
@@ -8,6 +8,7 @@ let
   stateDir = "/var/lib/stubby";
   fallbacks = concatMapStringsSep "\n  " (x: "- ${x}") cfg.fallbackProtocols;
   listeners = concatMapStringsSep "\n  " (x: "- ${x}") cfg.listenAddresses;
+
   # By default, the recursive resolvers maintained by the getdns
   # project itself are enabled. More information about both getdns's servers, # as well as third party options for upstream resolvers, can be found here:
   # https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Test+Servers
@@ -92,7 +93,7 @@ in
 
       fallbackProtocols = mkOption {
         default = [ "GETDNS_TRANSPORT_TLS" ];
-        type = types.listOf types.str;
+        type = with types; listOf (enum [ "GETDNS_TRANSPORT_TLS" "GETDNS_TRANSPORT_TCP" "GETDNS_TRANSPORT_UDP" ]);
         description = ''
           Ordered list composed of one or more transport protocols.
           Strict mode should only use GETDNS_TRANSPORT_TLS.
@@ -102,7 +103,7 @@ in
 
       authenticationMode = mkOption {
         default = "GETDNS_AUTHENTICATION_REQUIRED";
-        type = types.str;
+        type = types.enum [ "GETDNS_AUTHENTICATION_REQUIRED" "GETDNS_AUTHENTICATION_NONE" ];
         description = ''
           Selects the Strict or Opportunistic usage profile.
           For strict, set to GETDNS_AUTHENTICATION_REQUIRED.
@@ -129,12 +130,12 @@ in
       idleTimeout = mkOption {
         default = 10000;
         type = types.int;
-        description = "EDNS0 option for keepalive idle timeout expressed in milliseconds.";
+        description = "EDNS0 option for keepalive idle timeout in milliseconds.";
       };
 
       listenAddresses = mkOption {
         default = [ "127.0.0.1" "0::1" ];
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = ''
           Sets the listen address for the stubby daemon.
           Uses port 53 by default.
@@ -189,7 +190,7 @@ in
 
       serviceConfig = {
         AmbientCapabilities = "CAP_NET_BIND_SERVICE";
-        CapabilitiesBoundingSet = "CAP_NET_BIND_SERVICE";
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
         ExecStart = "${pkgs.stubby}/bin/stubby -C ${confFile} ${optionalString cfg.debugLogging "-l"}";
         DynamicUser = true;
       };

--- a/nixos/modules/services/networking/stubby.nix
+++ b/nixos/modules/services/networking/stubby.nix
@@ -9,7 +9,8 @@ let
   listeners = concatMapStringsSep "\n  " (x: "- ${x}") cfg.listenAddresses;
 
   # By default, the recursive resolvers maintained by the getdns
-  # project itself are enabled. More information about both getdns's servers, # as well as third party options for upstream resolvers, can be found here:
+  # project itself are enabled. More information about both getdns's servers,
+  # # as well as third party options for upstream resolvers, can be found here:
   # https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Test+Servers
   #
   # You can override these values by supplying a yaml-formatted array of your

--- a/nixos/modules/services/networking/stubby.nix
+++ b/nixos/modules/services/networking/stubby.nix
@@ -129,7 +129,7 @@ in
       idleTimeout = mkOption {
         default = 10000;
         type = types.int;
-        description = "EDNS0 option for keepalive idle timeout.";
+        description = "EDNS0 option for keepalive idle timeout expressed in milliseconds.";
       };
 
       listenAddresses = mkOption {
@@ -184,6 +184,7 @@ in
     systemd.services.stubby = {
       description = "Stubby local DNS resolver";
       after = [ "network.target" ];
+      before = [ "nss-lookup.target" ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {

--- a/nixos/modules/services/networking/stubby.nix
+++ b/nixos/modules/services/networking/stubby.nix
@@ -161,6 +161,12 @@ in
         '';
       };
 
+      debugLogging = mkOption {
+        default = false;
+        type = types.bool;
+        description = "enable debug level logging.";
+      };
+
       extraConfig = mkOption {
         default = "";
         type = types.lines;
@@ -183,7 +189,7 @@ in
       serviceConfig = {
         AmbientCapabilities = "CAP_NET_BIND_SERVICE";
         CapabilitiesBoundingSet = "CAP_NET_BIND_SERVICE";
-        ExecStart = "${pkgs.stubby}/bin/stubby -C ${confFile}";
+        ExecStart = "${pkgs.stubby}/bin/stubby -C ${confFile} ${optionalString cfg.debugLogging "-l"}";
         DynamicUser = true;
       };
     };

--- a/nixos/modules/services/networking/stubby.nix
+++ b/nixos/modules/services/networking/stubby.nix
@@ -1,0 +1,205 @@
+{ config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  cfg = config.services.stubby;
+
+  stateDir = "/var/lib/stubby";
+  fallbacks = concatMapStringsSep "\n  " (x: "- ${x}") cfg.fallbackProtocols;
+  listeners = concatMapStringsSep "\n  " (x: "- ${x}") cfg.listenAddresses;
+  # By default, the recursive resolvers maintained by the getdns
+  # project itself are enabled. More information about both getdns's servers, # as well as third party options for upstream resolvers, can be found here:
+  # https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Test+Servers
+  #
+  # You can override these values by supplying a yaml-formatted array of your
+  # preferred upstream resolvers in the following format:
+  #
+  # 106 # - address_data: IPv4 or IPv6 address of the upstream
+  #   port: Port for UDP/TCP (default is 53)
+  #   tls_auth_name: Authentication domain name checked against the server
+  #                  certificate
+  #   tls_pubkey_pinset: An SPKI pinset verified against the keys in the server
+  #                      certificate
+  #     - digest: Only "sha256" is currently supported
+  #       value: Base64 encoded value of the sha256 fingerprint of the public
+  #              key
+  #   tls_port: Port for TLS (default is 853)
+
+  defaultUpstream = ''
+    - address_data: 145.100.185.15
+      tls_auth_name: "dnsovertls.sinodun.com"
+      tls_pubkey_pinset:
+        - digest: "sha256"
+          value: 62lKu9HsDVbyiPenApnc4sfmSYTHOVfFgL3pyB+cBL4=
+    - address_data: 145.100.185.16
+      tls_auth_name: "dnsovertls1.sinodun.com"
+      tls_pubkey_pinset:
+        - digest: "sha256"
+          value: cE2ecALeE5B+urJhDrJlVFmf38cJLAvqekONvjvpqUA=
+    - address_data: 185.49.141.37
+      tls_auth_name: "getdnsapi.net"
+      tls_pubkey_pinset:
+        - digest: "sha256"
+          value: foxZRnIh9gZpWnl+zEiKa0EJ2rdCGroMWm02gaxSc9Q=
+    - address_data: 2001:610:1:40ba:145:100:185:15
+      tls_auth_name: "dnsovertls.sinodun.com"
+      tls_pubkey_pinset:
+        - digest: "sha256"
+          value: 62lKu9HsDVbyiPenApnc4sfmSYTHOVfFgL3pyB+cBL4=
+    - address_data: 2001:610:1:40ba:145:100:185:16
+      tls_auth_name: "dnsovertls1.sinodun.com"
+      tls_pubkey_pinset:
+        - digest: "sha256"
+          value: cE2ecALeE5B+urJhDrJlVFmf38cJLAvqekONvjvpqUA=
+    - address_data: 2a04:b900:0:100::38
+      tls_auth_name: "getdnsapi.net"
+      tls_pubkey_pinset:
+        - digest: "sha256"
+          value: foxZRnIh9gZpWnl+zEiKa0EJ2rdCGroMWm02gaxSc9Q=
+  '';
+
+  # Resolution type is not changeable here because it is required per the
+  # stubby documentation:
+  #
+  # "resolution_type: Work in stub mode only (not recursive mode) - required for Stubby
+  # operation."
+  #
+  # https://dnsprivacy.org/wiki/display/DP/Configuring+Stubby
+
+  confFile = pkgs.writeText "stubby.yml" ''
+    resolution_type: GETDNS_RESOLUTION_STUB
+    dns_transport_list:
+      ${fallbacks}
+    tls_authentication: ${cfg.authenticationMode}
+    tls_query_padding_blocksize: ${toString cfg.queryPaddingBlocksize}
+    edns_client_subnet_private: ${if cfg.subnetPrivate then "1" else "0"}
+    idle_timeout: ${toString cfg.idleTimeout}
+    listen_addresses:
+      ${listeners}
+    round_robin_upstreams: ${if cfg.roundRobinUpstreams then "1" else "0"}
+    ${cfg.extraConfig}
+    upstream_recursive_servers:
+    ${cfg.upstreamServers}
+  '';
+in
+
+{
+  options = {
+    services.stubby = {
+
+      enable = mkEnableOption "Stubby DNS resolver";
+
+      fallbackProtocols = mkOption {
+        default = [ "GETDNS_TRANSPORT_TLS" ];
+        type = types.listOf types.str;
+        description = ''
+          Ordered list composed of one or more transport protocols.
+          Strict mode should only use GETDNS_TRANSPORT_TLS.
+          Other options are GETDNS_TRANSPORT_UDP and GETDNS_TRANSPORT_TCP.
+        '';
+      };
+
+      authenticationMode = mkOption {
+        default = "GETDNS_AUTHENTICATION_REQUIRED";
+        type = types.str;
+        description = ''
+          Selects the Strict or Opportunistic usage profile.
+          For strict, set to GETDNS_AUTHENTICATION_REQUIRED.
+          for opportunistic, use GETDNS_AUTHENTICATION_NONE.
+        '';
+      };
+
+      queryPaddingBlocksize = mkOption {
+        default = 128;
+        type = types.int;
+        description = ''
+          EDNS0 option to pad the size of the DNS query to the given blocksize.
+        '';
+      };
+
+      subnetPrivate = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          EDNS0 option for ECS client privacy. Default is true.
+        '';
+      };
+
+      idleTimeout = mkOption {
+        default = 10000;
+        type = types.int;
+        description = "EDNS0 option for keepalive idle timeout.";
+      };
+
+      listenAddresses = mkOption {
+        default = [ "127.0.0.1" "0::1" ];
+        type = types.listOf types.str;
+        description = ''
+          Sets the listen address for the stubby daemon.
+          Uses port 53 by default.
+          Ise IP@port to specify a different port.
+        '';
+      };
+
+      roundRobinUpstreams = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Instructs stubby to distribute queries across all available name servers.
+          Default is true. Set to false in order to use the first available.
+        '';
+      };
+
+      upstreamServers = mkOption {
+        default = defaultUpstream;
+        type = types.lines;
+        description = ''
+          Add additional upstreams see <citerefentry><refentrytitle>stubby
+          </refentrytitle><manvolnum>1</manvolnum></citerefentry> for an
+          example of the entry formatting.
+        '';
+      };
+
+      enableNetBindService = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          This option enables or disables the "CAP_NET_BIND_SERVICE"
+          capability for the daemon process. This capability is necessary in the
+          default configuration (localhost listening on port 853), but is not 
+          necessary if the user chooses to bind to ports higher than 1024 
+          and can safely be disabled in this case for increased security. 
+          See <citerefentry><refentrytitle> capabilities</refentrytitle>
+          <manvolnum>7</manvolnum> </citerefentry> for more information.
+        '';
+      };
+
+      extraConfig = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Add additional configuration options. see <citerefentry>
+          <refentrytitle>stubby</refentrytitle><manvolnum>1</manvolnum>
+          </citerefentry>for more options.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.stubby ];
+    systemd.services.stubby = {
+      description = "Stubby local DNS resolver";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        AmbientCapabilities = "${optionalString cfg.enableNetBindService "CAP_NET_BIND_SERVICE"}";
+        CapabilitiesBoundingSet = "${optionalString cfg.enableNetBindService "CAP_NET_BIND_SERVICE"}";
+        ExecStart = "${pkgs.stubby}/bin/stubby -C ${confFile}";
+        DynamicUser = true;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/stubby.nix
+++ b/nixos/modules/services/networking/stubby.nix
@@ -10,7 +10,7 @@ let
 
   # By default, the recursive resolvers maintained by the getdns
   # project itself are enabled. More information about both getdns's servers,
-  # # as well as third party options for upstream resolvers, can be found here:
+  # as well as third party options for upstream resolvers, can be found here:
   # https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Test+Servers
   #
   # You can override these values by supplying a yaml-formatted array of your


### PR DESCRIPTION
This change implements [stubby](https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby), the DNS-over-TLS stub resolver daemon.
The package itself is maintained by @leenaars.

The motivation for this change was the desire to use `stubby`'s
DNS-over-TLS functionality in tandem with unbound, which requires
passing certain configuration parameters. This module implements those
config parameters by exposing them for use in `configuration.nix.`

This is a reopening of PR #38586, which was based on the incorrect branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

