### PR TITLE
Revert "zfs, spl: 0.7.6 -> 0.7.7"

### DIFF
--- a/pkgs/os-specific/linux/spl/const.patch
+++ b/pkgs/os-specific/linux/spl/const.patch
@@ -1,0 +1,13 @@
+diff --git a/module/spl/spl-proc.c b/module/spl/spl-proc.c
+index eb00505..6f38cef 100644
+--- a/module/spl/spl-proc.c
++++ b/module/spl/spl-proc.c
+@@ -36,7 +36,7 @@
+ #include <linux/uaccess.h>
+ #include <linux/version.h>
+ 
+-#if defined(CONSTIFY_PLUGIN) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0)
++#if defined(CONSTIFY_PLUGIN)
+ typedef struct ctl_table __no_const spl_ctl_table;
+ #else
+ typedef struct ctl_table spl_ctl_table;

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -20,7 +20,7 @@ let
         inherit rev sha256;
       };
 
-      patches = [ ./install_prefix.patch ];
+      patches = [ ./const.patch ./install_prefix.patch ];
 
       nativeBuildInputs = [ autoreconfHook ] ++ kernel.moduleBuildDependencies;
 
@@ -61,8 +61,8 @@ in
   assert kernel != null;
 {
     splStable = common {
-      version = "0.7.7";
-      sha256 = "0mq7827x4173wdbpj361gvxvk8j9r96363gka75smzsc31i2wa5x";
+      version = "0.7.6";
+      sha256 = "1l641d89k48ngmarx9mxh8gw2zzrf7fw7n8zmslhz4h1152plddb";
     };
 
     splUnstable = common {

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, utillinux, nukeReferences, coreutils
-, perl, fetchpatch
+{ stdenv, fetchFromGitHub, autoreconfHook, utillinux, nukeReferences, coreutils, fetchpatch
 , configFile ? "all"
 
 # Userspace dependencies
@@ -40,12 +39,8 @@ let
 
       patches = extraPatches;
 
-      postPatch = optionalString buildKernel ''
-        patchShebangs scripts
-      '';
-
       nativeBuildInputs = [ autoreconfHook nukeReferences ]
-         ++ optional buildKernel (kernel.moduleBuildDependencies ++ [ perl ]);
+         ++ optional buildKernel kernel.moduleBuildDependencies;
       buildInputs =
            optionals buildKernel [ spl ]
         ++ optionals buildUser [ zlib libuuid python attr ]
@@ -147,9 +142,9 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to the latest release.
-    version = "0.7.7";
+    version = "0.7.6";
 
-    sha256 = "0lrzy27sh1cinkf04ki2vfjrgpgbiza2s59i2by45qdd8kmkcc5r";
+    sha256 = "1k3a69zfdk4ia4z2l69lbz0mj26bwdanxd2wynkdpm2kl3zjj18h";
 
     extraPatches = [
       (fetchpatch {


### PR DESCRIPTION
This reverts commit 8c3cb029e0f4b771676d1e291f1316353ec9a0eb.

See issues #38666 and zfsonlinux/zfs#7401. Untested - but hopefully okay to go in 18.03.
