### PR TITLE
xmrig-proxy: init at 2.5.2

### DIFF
--- a/pkgs/applications/misc/xmrig-proxy/default.nix
+++ b/pkgs/applications/misc/xmrig-proxy/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libuv libmicrohttpd libuuid ];
 
+  # Set default donation level to 0%. Can be increased at runtime via --donate-level option.
   postPatch = ''
     substituteInPlace src/donate.h --replace "kDonateLevel = 2;" "kDonateLevel = ${toString donateLevel};"
   '';

--- a/pkgs/applications/misc/xmrig-proxy/default.nix
+++ b/pkgs/applications/misc/xmrig-proxy/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub, cmake, libuv, libmicrohttpd, libuuid
+, donateLevel ? 0
+}:
+
+stdenv.mkDerivation rec {
+  name = "xmrig-proxy-${version}";
+  version = "2.5.2";
+
+  src = fetchFromGitHub {
+    owner = "xmrig";
+    repo = "xmrig-proxy";
+    rev = "v${version}";
+    sha256 = "1x10mrr58lc207zppzkjnhwah83kpxrqpa3idv01lyasv8mfkxzc";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libuv libmicrohttpd libuuid ];
+
+  postPatch = ''
+    substituteInPlace src/donate.h --replace "kDonateLevel = 2;" "kDonateLevel = ${toString donateLevel};"
+  '';
+
+  installPhase = ''
+    install -vD xmrig-proxy $out/bin/xmrig-proxy
+  '';
+
+  meta = with lib; {
+    description = "Monero (XMR) Stratum protocol proxy";
+    homepage = "https://github.com/xmrig/xmrig-proxy";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ aij ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16790,6 +16790,8 @@ with pkgs;
 
   xmrig = callPackage ../applications/misc/xmrig { };
 
+  xmrig-proxy = callPackage ../applications/misc/xmrig-proxy { };
+
   monkeysAudio = callPackage ../applications/audio/monkeys-audio { };
 
   monkeysphere = callPackage ../tools/security/monkeysphere { };


### PR DESCRIPTION
###### Motivation for this change

xmrig-proxy can proxy a bunch of crypnonight miners, reducing connection count and/or making them easier to manage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

