### PR TITLE
dit: init at 0.4

### DIFF
--- a/pkgs/applications/editors/dit/default.nix
+++ b/pkgs/applications/editors/dit/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchurl, stdenv, coreutils, ncurses, lua }:
+
+stdenv.mkDerivation rec {
+  name = "dit-${version}";
+  version = "0.4";
+
+  src = fetchurl {
+    url = "https://hisham.hm/dit/releases/${version}/${name}.tar.gz";
+    sha256 = "0bwczbv7annbbpg7bgbsqd5kwypn81sza4v7v99fin94wwmcn784";
+  };
+
+  buildInputs = [ coreutils ncurses lua ];
+
+  prePatch = ''
+    patchShebangs tools/GenHeaders
+  '';
+
+  # needs GNU tail for tail -r
+  postPatch = ''
+    substituteInPlace Prototypes.h --replace 'tail' "$(type -P tail)"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A console text editor for Unix that you already know how to use";
+    homepage = https://hisham.hm/dit/;
+    license = licenses.gpl2;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ davidak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15213,6 +15213,8 @@ with pkgs;
 
   distrho = callPackage ../applications/audio/distrho {};
 
+  dit = callPackage ../applications/editors/dit { };
+
   djvulibre = callPackage ../applications/misc/djvulibre { };
 
   djvu2pdf = callPackage ../tools/typesetting/djvu2pdf { };


### PR DESCRIPTION
###### Motivation for this change

We don't have enough editors packaged. Just kidding.

I want to try this editor out which might be a good alternative to nano.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

