### PR TITLE
linuxPackages.zfs{Stable,Unstable}: Enospec fix

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -11,6 +11,7 @@ let
     , sha256
     , rev ? "spl-${version}"
     , broken ? false
+    , patches ? []
     } @ args : stdenv.mkDerivation rec {
       name = "spl-${version}-${kernel.version}";
 
@@ -20,7 +21,7 @@ let
         inherit rev sha256;
       };
 
-      patches = [ ./install_prefix.patch ];
+      inherit patches;
 
       nativeBuildInputs = [ autoreconfHook ] ++ kernel.moduleBuildDependencies;
 
@@ -61,14 +62,16 @@ in
   assert kernel != null;
 {
     splStable = common {
-      version = "0.7.7";
-      sha256 = "0mq7827x4173wdbpj361gvxvk8j9r96363gka75smzsc31i2wa5x";
+      version = "0.7.8";
+      sha256 = "0ypyy7ij280n7rly6ifrvna9k55gxwdx9a7lalf4r1ka714379fi";
+      patches = [ ./install_prefix-0.7.8.patch ];
     };
 
     splUnstable = common {
-      version = "2018-03-09";
-      rev = "43983eb2024ec6b3280e6e06a6fb621ee3bb2a41";
-      sha256 = "00h7z30hzxd09cfa44w7yv7zympvdwzdximfgjvpa1layzppjpsh";
+      version = "2018-04-10";
+      rev = "9125f8f5bdb36bfbd2d816d30b6b29b9f89ae3d8";
+      sha256 = "00zrbca906rzjd62m4khiw3sdv8x18dapcmvkyaawripwvzc4iri";
+      patches = [ ./install_prefix.patch ];
     };
 
     splLegacyCrypto = common {

--- a/pkgs/os-specific/linux/spl/install_prefix-0.7.8.patch
+++ b/pkgs/os-specific/linux/spl/install_prefix-0.7.8.patch
@@ -112,6 +112,18 @@ index 581083e..0c35fb7 100644
 +kerneldir = @prefix@/libexec/spl/include/sys/fs
  kernel_HEADERS = $(KERNEL_H)
  endif
+diff --git a/include/sys/sysevent/Makefile.am b/include/sys/sysevent/Makefile.am
+index 63d9af3..de1aa18 100644
+--- a/include/sys/sysevent/Makefile.am
++++ b/include/sys/sysevent/Makefile.am
+@@ -8,6 +8,6 @@ USER_H =
+ EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
+ 
+ if CONFIG_KERNEL
+-kerneldir = @prefix@/src/spl-$(VERSION)/include/sys/sysevent
++kerneldir = @prefix@/libexec/spl/include/sys/sysevent
+ kernel_HEADERS = $(KERNEL_H)
+ endif
 diff --git a/include/util/Makefile.am b/include/util/Makefile.am
 index e2bf09f..3f5d6ce 100644
 --- a/include/util/Makefile.am

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -147,9 +147,9 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to the latest release.
-    version = "0.7.7";
+    version = "0.7.8";
 
-    sha256 = "0lrzy27sh1cinkf04ki2vfjrgpgbiza2s59i2by45qdd8kmkcc5r";
+    sha256 = "0m7j5cpz81lqcfbh4w3wvqjjka07wickl27klgy1zplv6vr0baix";
 
     extraPatches = [
       (fetchpatch {
@@ -166,10 +166,10 @@ in {
     incompatibleKernelVersion = "4.16";
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2018-04-04";
+    version = "2018-04-10";
 
-    rev = "1724eb62debfaa48f5861660615d49a994945d94";
-    sha256 = "1adnmpn7b8zi5rq9r71flwx237vbysss1wywbck8407mcnrfaxzf";
+    rev = "74df0c5e251a920a1966a011c16f960cd7ba562e";
+    sha256 = "1x3mipj3ryznnd7kx84r3n607hv6jqs66mb61g3zcdmvk6al4yq4";
     isUnstable = true;
 
     extraPatches = [


### PR DESCRIPTION
###### Motivation for this change

Replaces https://github.com/NixOS/nixpkgs/pull/38668

Fixes major regression: https://github.com/zfsonlinux/zfs/issues/7401

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

