### PR TITLE
restic-rest-server: init at 0.9.7

### DIFF
--- a/pkgs/tools/backup/restic/rest-server.nix
+++ b/pkgs/tools/backup/restic/rest-server.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "restic-rest-server-${version}";
+  version = "0.9.7";
+
+  goPackagePath = "github.com/restic/rest-server";
+
+  src = fetchFromGitHub {
+    owner = "restic";
+    repo = "rest-server";
+    rev = "v${version}";
+    sha256 = "1g47ly1pxwn0znbj3v5j6kqhn66d4wf0d5gjqzig75pzknapv8qj";
+  };
+
+  buildPhase = ''
+    cd go/src/${goPackagePath}
+    go run build.go
+  '';
+
+  installPhase = ''
+    install -Dt $bin/bin rest-server
+  '';
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "A high performance HTTP server that implements restic's REST backend API";
+    platforms = platforms.unix;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12769,6 +12769,8 @@ with pkgs;
 
   restic = callPackage ../tools/backup/restic { };
 
+  restic-rest-server = callPackage ../tools/backup/restic/rest-server.nix { };
+
   restya-board = callPackage ../servers/web-apps/restya-board { };
 
   rethinkdb = callPackage ../servers/nosql/rethinkdb {


### PR DESCRIPTION
Package is named as the OpenBSD one: https://repology.org/metapackage/restic-rest-server.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @mbrgm 