### PR TITLE
gopass: Install shell completion scripts

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -20,6 +20,16 @@ buildGoPackage rec {
     gnupg
   ]);
 
+  postInstall = ''
+    mkdir -p \
+      $bin/share/bash-completion/completions \
+      $bin/share/zsh/site-functions \
+      $bin/share/fish/vendor_completions.d
+    $bin/bin/gopass completion bash > $bin/share/bash-completion/completions/_gopass
+    $bin/bin/gopass completion zsh  > $bin/share/zsh/site-functions/_gopass
+    $bin/bin/gopass completion fish > $bin/share/fish/vendor_completions.d/gopass.fish
+  '';
+
   postFixup = ''
     wrapProgram $bin/bin/gopass \
       --prefix PATH : "${wrapperPath}"


### PR DESCRIPTION
###### Motivation for this change
Install shell completion scripts for ZSH, Bash, Fish.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

