### PR TITLE
librsvg: 2.42.2 → 2.42.3

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -9,24 +9,16 @@
 
 assert glSupport -> libGL != null;
 
-let inherit (stdenv.lib) optional optionals; in
-
-stdenv.mkDerivation rec {
-  name = "cairo-1.14.10";
+let
+  version = "1.15.10";
+  inherit (stdenv.lib) optional optionals;
+in stdenv.mkDerivation rec {
+  name = "cairo-${version}";
 
   src = fetchurl {
-    url = "http://cairographics.org/releases/${name}.tar.xz";
-    sha256 = "02banr0wxckq62nbhc3mqidfdh2q956i2r7w2hd9bjgjb238g1vy";
+    url = "http://cairographics.org/${if stdenv.lib.mod (builtins.fromJSON (stdenv.lib.versions.minor version)) 2 == 0 then "releases" else "snapshots"}/${name}.tar.xz";
+    sha256 = "14l3jll98pjdlpm8f972v0spzcsf6y5nz85y2k8iybyg6ihj5jk2";
   };
-
-  patches = [
-    # from https://bugs.freedesktop.org/show_bug.cgi?id=98165
-    (fetchpatch {
-      name = "cairo-CVE-2016-9082.patch";
-      url = "https://bugs.freedesktop.org/attachment.cgi?id=127421";
-      sha256 = "03sfyaclzlglip4pvfjb4zj4dmm8mlphhxl30mb6giinkc74bfri";
-    })
-  ];
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev"; # very small

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -5,14 +5,14 @@
 
 let
   pname = "librsvg";
-  version = "2.42.2";
+  version = "2.42.3";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "0c550a0bffef768a436286116c03d9f6cd3f97f5021c13e7f093b550fac12562";
+    sha256 = "0mz6rdxpnnjnk15nahlwpa2gba0ws1hs2dnyk1agqw5ip522qkvh";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -2,8 +2,7 @@
 
 buildPythonPackage rec {
   pname = "pycairo";
-  version = "1.15.4";
-  name = "${pname}-${version}";
+  version = "1.16.3";
 
   disabled = isPyPy;
 
@@ -11,13 +10,21 @@ buildPythonPackage rec {
     owner = "pygobject";
     repo = "pycairo";
     rev = "v${version}";
-    sha256 = "02vzmfxx8nl6dbwzc911wcj7hqspgqz6v9xmq6579vwfla0vaglv";
+    sha256 = "0clk6wrfls3fa1xrn844762qfaw6gs4ivwkrfysidbzmlbxhpngl";
   };
 
-  postPatch = ''
-    # we are unable to pass --prefix to bdist_wheel
-    # see https://github.com/NixOS/nixpkgs/pull/32034#discussion_r153285955
-    substituteInPlace setup.py --replace '"prefix": self.install_base' "'prefix': '$out'"
+  # We need to create the pkgconfig file but it cannot be installed as a wheel since wheels
+  # are supposed to be relocatable and do not support --prefix option
+  buildPhase = ''
+    ${python.interpreter} setup.py build
+  '';
+
+  installPhase = ''
+    ${python.interpreter} setup.py install --skip-build --prefix="$out" --optimize=1
+  '';
+
+  checkPhase = ''
+    ${python.interpreter} setup.py test
   '';
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
librsvg 2.42.3 needs development version of libcairo but it should be fine, Arch is using it too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

