### PR TITLE
grepcidr: Init at 2.0

### DIFF
--- a/pkgs/applications/search/grepcidr/default.nix
+++ b/pkgs/applications/search/grepcidr/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "grepcidr-${version}";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "http://www.pc-tools.net/files/unix/${name}.tar.gz";
+    sha256 = "1yzpa1nigmmp4hir6377hrkpp0z6jnxgccaw2jbqgydbglvnm231";
+  };
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Filter IPv4 and IPv6 addresses matching CIDR patterns";
+    homepage = http://www.pc-tools.net/unix/grepcidr/;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.fadenb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15708,6 +15708,8 @@ with pkgs;
 
   grass = callPackage ../applications/gis/grass { };
 
+  grepcidr = callPackage ../applications/search/grepcidr { };
+
   grepm = callPackage ../applications/search/grepm { };
 
   grip = callPackage ../applications/misc/grip {


### PR DESCRIPTION
###### Motivation for this change
grepcidr was not available on NixOS: http://www.pc-tools.net/unix/grepcidr/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

