### PR TITLE
purple-discord: init at 2018-04-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3411,6 +3411,11 @@
     github = "grwlf";
     name = "Sergey Mironov";
   };
+  sna = {
+    email = "abouzahra.9@wright.edu";
+    github = "s-na";
+    name = "S. Nordin Abouzahra";
+  };
   snyh = {
     email = "snyh@snyh.org";
     github = "snyh";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-discord/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, pkgconfig, pidgin, json_glib }:
+
+stdenv.mkDerivation rec {
+  name = "purple-discord-${version}";
+  version = "unstable-2018-04-10";
+
+  src = fetchFromGitHub {
+    owner = "EionRobb";
+    repo = "purple-discord";
+    rev = "9a97886d15a1f028de54b5e6fc54e784531063b0";
+    sha256 = "0dc344zh1v4yh9c8javcw5ylzwc1wpx0ih8bww8p8cjmhr8kcl32";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ pidgin json_glib ];
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+  ];
+
+  PKG_CONFIG_PURPLE_PLUGINDIR = "/lib/purple-2";
+  PKG_CONFIG_PURPLE_DATADIR = "/share";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/EionRobb/purple-discord;
+    description = "Discord plugin for Pidgin";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sna ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17258,6 +17258,8 @@ with pkgs;
 
   pidgin-window-merge = callPackage ../applications/networking/instant-messengers/pidgin-plugins/window-merge { };
 
+  purple-discord = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-discord { };
+
   purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };
 
   purple-matrix = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-matrix { };


### PR DESCRIPTION
###### Motivation for this change
Adds new pidgin plugin that brings Discord support. In addition, add myself to the maintainers list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@jtojnar mind reviewing this again? Sorry about the new pull request, did not know GitHub would close it, when I forced a push to squash my commits. Also thank you for telling me about `PKG_CONFIG_${package}_${variable}` it is awesome.