### PR TITLE
nixos/acme: Service should not fail when no renewal is necessary

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -225,11 +225,15 @@ in
                     simp_le ${escapeShellArgs cmdline}
                     EXITCODE=$?
                     set -e
-                    echo "$EXITCODE" > /tmp/lastExitCode
-                    exit "$EXITCODE"
+                    echo "$EXITCODE" > /tmp/lastSimpleExitCode
+                    if [ "$EXITCODE" = "1" ]; then
+                      exit 0
+                    else
+                      exit "$EXITCODE"
+                    fi
                   '';
                   postStop = ''
-                    if [ -e /tmp/lastExitCode ] && [ "$(cat /tmp/lastExitCode)" = "0" ]; then
+                    if [ -e /tmp/lastSimpleExitCode ] && [ "$(cat /tmp/lastSimpleExitCode)" = "0" ]; then
                       echo "Executing postRun hook..."
                       ${data.postRun}
                     fi


### PR DESCRIPTION
###### Motivation for this change

The acme service script re-uses the exit code of the simp_le program which is 0 on successful change, 1 if no renewal is necessary, and 2 on error. This causes the service to end up in failed status when no renewal is necessary, which is wrong.

With this patch the exit code from the acme script is 0 when simp_le returns 1 and otherwise the same as returned by simp_le.

###### Things done

Tested in QA environment at work.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


