### PR TITLE
rust: drop obsolete patch (now included in upstream sources)

### DIFF
--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -1,5 +1,4 @@
 { stdenv, callPackage, recurseIntoAttrs, makeRustPlatform, llvm, fetchurl
-, fetchpatch
 , targets ? []
 , targetToolchains ? []
 , targetPatches ? []
@@ -23,11 +22,6 @@ in rec {
 
     patches = [
       ./patches/0001-Disable-fragile-tests-libstd-net-tcp-on-Darwin-Linux.patch
-      # Adapted from https://github.com/rust-lang/rust/pull/47912
-      (fetchpatch {
-        url = "https://src.fedoraproject.org/rpms/rust/raw/1bb4d24c060915c304c9a9f86a438388e599f9c6/f/0002-Use-a-range-to-identify-SIGSEGV-in-stack-guards.patch";
-        sha256 = "16hc170qzzcb9lcabk0ln005zji2h1gq0knbr9avbbzlbg9jha2q";
-      })
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch
       # https://github.com/rust-lang/rust/issues/45410
       ++ stdenv.lib.optional stdenv.isAarch64 ./patches/aarch64-disable-test_loading_cosine.patch;


### PR DESCRIPTION
###### Motivation for this change

rust doesn't build on staging after master merge that brought in a rust update - https://hydra.nixos.org/build/72651247/nixlog/1 The change that added the patch was applied on staging and never reached master so the issue is not present there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

