### PR TITLE
Mark packages as broken for 18.03 (generic+x86_64)

### DIFF
--- a/pkgs/applications/altcoins/dcrd.nix
+++ b/pkgs/applications/altcoins/dcrd.nix
@@ -29,5 +29,6 @@ buildGoPackage rec {
     homepage = "https://decred.org";
     description = "Decred daemon in Go (golang)";
     license = with lib.licenses; [ isc ];
+    broken = stdenv.isLinux; # 2018-04-10
   };
 }

--- a/pkgs/applications/altcoins/dcrwallet.nix
+++ b/pkgs/applications/altcoins/dcrwallet.nix
@@ -38,5 +38,6 @@ buildGoPackage rec {
     homepage = "https://decred.org";
     description = "Decred daemon in Go (golang)";
     license = with lib.licenses; [ isc ];
+    broken = stdenv.isLinux; # 2018-04-10
   };
 }

--- a/pkgs/applications/altcoins/hevm.nix
+++ b/pkgs/applications/altcoins/hevm.nix
@@ -55,6 +55,7 @@ lib.overrideDerivation (mkDerivation rec {
   description = "Ethereum virtual machine evaluator";
   license = stdenv.lib.licenses.agpl3;
   maintainers = [stdenv.lib.maintainers.dbrock];
+  broken = true; # 2018-04-10
 }) (attrs: {
   buildInputs = attrs.buildInputs ++ [solc];
   nativeBuildInputs = attrs.nativeBuildInputs ++ [makeWrapper];

--- a/pkgs/applications/audio/mi2ly/default.nix
+++ b/pkgs/applications/audio/mi2ly/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/applications/graphics/ao/default.nix
+++ b/pkgs/applications/graphics/ao/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus ; # Some parts can be extracted and used under LGPL2+
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/applications/graphics/meshlab/default.nix
+++ b/pkgs/applications/graphics/meshlab/default.nix
@@ -61,5 +61,6 @@ in stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [viric];
     platforms = with stdenv.lib.platforms; linux;
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/applications/graphics/rapcad/default.nix
+++ b/pkgs/applications/graphics/rapcad/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
     description = ''Constructive solid geometry package'';
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/applications/misc/cpp-ethereum/default.nix
+++ b/pkgs/applications/misc/cpp-ethereum/default.nix
@@ -80,5 +80,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ artuuge ];
     platforms = platforms.linux;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/applications/science/machine-learning/torch/torch-distro.nix
+++ b/pkgs/applications/science/machine-learning/torch/torch-distro.nix
@@ -131,6 +131,7 @@ let
       name = "sundown";
       src = "${distro_src}/pkg/sundown";
       rockspec = "rocks/${name}-scm-1.rockspec";
+      meta.broken = true; # 2018-04-11
     };
 
     cwrap = buildLuaRocks rec {
@@ -289,6 +290,7 @@ let
         rev = "1e9e4f1e0bf589a0ed39f58acc185ec5e213d207";
         sha256 = "1i1fpy9v6r4w3lrmz7bmf5ppq65925rv90gx39b3pykfmn0hcb9c";
       };
+      meta.broken = true; # 2018-04-11
     };
 
     luuid = stdenv.mkDerivation rec {

--- a/pkgs/applications/science/misc/openmvg/default.nix
+++ b/pkgs/applications/science/misc/openmvg/default.nix
@@ -46,5 +46,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.mpl20;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ mdaiter ];
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/applications/video/avxsynth/default.nix
+++ b/pkgs/applications/video/avxsynth/default.nix
@@ -38,5 +38,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ codyopel viric ];
     platforms = platforms.linux;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/applications/video/dvb-apps/default.nix
+++ b/pkgs/applications/video/dvb-apps/default.nix
@@ -19,5 +19,6 @@ stdenv.mkDerivation {
     homepage = https://linuxtv.org/;
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -99,5 +99,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ the-kenny ];
     platforms   = platforms.linux;
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -164,6 +164,7 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
-    broken = stdenv.isi686;
+    #broken = stdenv.isi686;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/development/libraries/agda/pretty/default.nix
+++ b/pkgs/development/libraries/agda/pretty/default.nix
@@ -21,5 +21,6 @@ agda.mkDerivation (self: rec {
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with maintainers; [ fuuzetsu ];
+    broken = true; # 2018-04-11
   };
 })

--- a/pkgs/development/libraries/audio/jamomacore/default.nix
+++ b/pkgs/development/libraries/audio/jamomacore/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];
     platforms = stdenv.lib.platforms.linux;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/development/libraries/ignition-transport/generic.nix
+++ b/pkgs/development/libraries/ignition-transport/generic.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ pxc ];
     platforms = platforms.all;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/development/libraries/ndn-cxx/default.nix
+++ b/pkgs/development/libraries/ndn-cxx/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation {
     license = licenses.lgpl3;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ maintainers.sjmackenzie ];
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
@@ -27,6 +27,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.bugworm ];
-    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.bugworm ];
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -158,4 +158,9 @@ $out/lib/common-lisp/query-fs"
     deps = pkgs.lib.filter (x: x.name != quicklisp-to-nix-packages.buildnode-xhtml.name) x.deps;
     parasites = pkgs.lib.filter (x: x!= "buildnode-test") x.parasites;
   };
+  postmodern = x: {
+    overrides = y : (x.overrides y) // {
+      meta.broken = true; # 2018-04-10
+    };
+  };
 }

--- a/pkgs/development/python-modules/pyocr/default.nix
+++ b/pkgs/development/python-modules/pyocr/default.nix
@@ -1,11 +1,12 @@
 { lib, fetchFromGitHub, buildPythonPackage, pillow, six
-, tesseract, cuneiform
+, tesseract, cuneiform, isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "pyocr";
   version = "0.4.7";
   name = pname + "-" + version;
+  disabled = !isPy3k;
 
   # Don't fetch from PYPI because it doesn't contain tests.
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/serversyncstorage/default.nix
+++ b/pkgs/development/python-modules/serversyncstorage/default.nix
@@ -35,4 +35,8 @@ buildPythonPackage rec {
     pyramid sqlalchemy simplejson mozsvc cornice pyramid_hawkauth pymysql
     pymysqlsa umemcache WSGIProxy requests pybrowserid
   ];
+
+  meta = {
+    broken = true; # 2018-11-04
+  };
 }

--- a/pkgs/development/python-modules/weboob/default.nix
+++ b/pkgs/development/python-modules/weboob/default.nix
@@ -33,6 +33,7 @@ buildPythonPackage rec {
     homepage = http://weboob.org;
     description = "Collection of applications and APIs to interact with websites without requiring the user to open a browser";
     license = stdenv.lib.licenses.agpl3;
+    broken = true; # 2018-04-11
   };
 }
 

--- a/pkgs/development/tools/analysis/retdec/default.nix
+++ b/pkgs/development/tools/analysis/retdec/default.nix
@@ -116,5 +116,6 @@ in stdenv.mkDerivation rec {
     homepage = https://retdec.com;
     license = licenses.mit;
     maintainers = with maintainers; [ dtzWill ];
+    broken = withPEPatterns; # retdec-full is broken, 2018-04-11
   };
 }

--- a/pkgs/development/tools/imatix_gsl/default.nix
+++ b/pkgs/development/tools/imatix_gsl/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     description = "A universal code generator";
     platforms = platforms.unix;
     maintainers = [ maintainers.moosingin3space ];
+    broken = stdenv.isLinux; # 2018-04-10
   };
 }

--- a/pkgs/development/tools/misc/avarice/default.nix
+++ b/pkgs/development/tools/misc/avarice/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/avarice/files/avarice/;
     maintainers = [ stdenv.lib.maintainers.smironov ];
     platforms = stdenv.lib.platforms.linux;
+    broken = true; # 2018-04-10
   };
 }
 

--- a/pkgs/servers/misc/client-ip-echo/client-ip-echo.nix
+++ b/pkgs/servers/misc/client-ip-echo/client-ip-echo.nix
@@ -13,4 +13,5 @@ mkDerivation {
   executableHaskellDepends = [ base bytestring network ];
   description = "accepts TCP connections and echoes the client's IP address back to it";
   license = stdenv.lib.licenses.lgpl3;
+  broken = true; # 2018-04-10
 }

--- a/pkgs/servers/sql/percona/5.6.x.nix
+++ b/pkgs/servers/sql/percona/5.6.x.nix
@@ -57,5 +57,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2;
     maintainers = with maintainers; [ grahamc ];
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/tools/backup/ori/default.nix
+++ b/pkgs/tools/backup/ori/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     homepage = http://ori.scs.stanford.edu/;
     license = licenses.mit;
     platforms = platforms.unix;
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/tools/misc/antimicro/default.nix
+++ b/pkgs/tools/misc/antimicro/default.nix
@@ -22,5 +22,6 @@ mkDerivation rec {
     maintainers = with maintainers; [ jb55 ];
     license = licenses.gpl3;
     platforms = with platforms; linux;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/tools/misc/gnokii/default.nix
+++ b/pkgs/tools/misc/gnokii/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnokii.org;
     maintainers = [ stdenv.lib.maintainers.raskin ];
     platforms = stdenv.lib.platforms.linux;
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/tools/misc/mht2htm/default.nix
+++ b/pkgs/tools/misc/mht2htm/default.nix
@@ -39,5 +39,6 @@ in stdenv.mkDerivation rec {
     license     = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.all;
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/tools/misc/mstflint/default.nix
+++ b/pkgs/tools/misc/mstflint/default.nix
@@ -15,5 +15,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ wkennington ];
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/tools/networking/p2p/seeks/default.nix
+++ b/pkgs/tools/networking/p2p/seeks/default.nix
@@ -64,5 +64,6 @@ stdenv.mkDerivation {
       stdenv.lib.maintainers.matejc
     ];
     platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/tools/security/gencfsm/default.nix
+++ b/pkgs/tools/security/gencfsm/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.spacefrogg ];
+    broken = true; # 2018-04-10
   };
 }

--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -75,5 +75,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];
+    broken = true; # 2018-04-11
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3395,6 +3395,7 @@ in {
     pname = "lightblue";
     version = "0.4";
     name = "${pname}-${version}";
+    disabled = isPy3k; # build fails, 2018-04-11
 
     src = pkgs.fetchurl {
       url = "mirror://sourceforge/${pname}/${name}.tar.gz";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10511,6 +10511,7 @@ in {
     meta = {
       description = "Interface for working with block devices";
       license = licenses.gpl2Plus;
+      broken = isPy3k; # doesn't build on python 3, 2018-04-11
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8888,7 +8888,7 @@ in {
   dynd = buildPythonPackage rec {
     version = "0.7.2";
     name = "dynd-${version}";
-    disabled = isPyPy;
+    disabled = isPyPy || !isPy3k; # tests fail on python2, 2018-04-11
 
     src = pkgs.fetchFromGitHub {
       owner = "libdynd";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10572,6 +10572,7 @@ in {
       license = licenses.bsd2;
       platforms = platforms.all;
       homepage = "http://jparyani.github.io/pycapnp/index.html";
+      broken = true; # 2018-04-11
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1034,6 +1034,7 @@ in {
 
       homepage = https://github.com/skarra/CalDAVClientLibrary/tree/asynkdev/;
       maintainers = with maintainers; [ pjones ];
+      broken = true; # 2018-04-11
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Cleanup for 18.03, see ZHF #36453 - please backport.

Mark remaining packages that haven't built on 18.03 for a while as broken.
This PR only includes packages that don't build on master either, hence it targets master.
Any packages that build on master but not on 18.03 will be dealt with separately.

Packages will be incrementally added here.

/cc @vcunat @fpletz 