### PR TITLE
python-docx: init at 0.8.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -305,6 +305,11 @@
     github = "akru";
     name = "Alexander Krupenkin ";
   };
+  alexchapman = {
+    name = "Alex Chapman";
+    email = "alex@farfromthere.net";
+    github = "AJChapman";
+  };
   alexvorobiev = {
     email = "alexander.vorobiev@gmail.com";
     github = "alexvorobiev";

--- a/pkgs/development/python-modules/python-docx/default.nix
+++ b/pkgs/development/python-modules/python-docx/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, behave
+, buildPythonPackage
+, fetchPypi
+, lxml
+, pytest
+, pyparsing
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "python-docx";
+  version = "0.8.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "117i84s6fcdsrfckbvznnqgqwhnf1x0523ps16cki8sg9byydv2m";
+  };
+
+  checkInputs = [ behave mock pyparsing pytest ];
+  propagatedBuildInputs = [ lxml ];
+
+  checkPhase = ''
+    py.test tests
+  '';
+
+  meta = {
+    description = "Create and update Microsoft Word .docx files";
+    homepage = https://python-docx.readthedocs.io/en/latest/;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.alexchapman ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18361,6 +18361,8 @@ EOF
   wsproto = callPackage ../development/python-modules/wsproto { };
 
   h11 = callPackage ../development/python-modules/h11 { };
+
+  python-docx = callPackage ../development/python-modules/python-docx { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change
This library is a required dependency for something I need to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

