### PR TITLE
pythonPackages.jupyterlab: 0.4.1 -> 0.31.12

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5208,6 +5208,26 @@ in {
     };
   };
 
+  jupyterlab_launcher = buildPythonPackage rec {
+    name = "jupyterlab_launcher-${version}";
+    version = "0.10.5";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/j/jupyterlab_launcher/${name}.tar.gz";
+      sha256 = "1v1ir182zm2dl14lqvqjhx2x40wnp0i32n6rldxnm1allfpld1n7";
+    };
+
+    propagatedBuildInputs = with self; [ notebook jsonschema ];
+
+    doCheck = false;
+
+    meta = {
+      description = "This package is used to launch an application built using JupyterLab.";
+      license = with licenses; [ bsd3 ];
+      homepage = "http://jupyter.org/";
+    };
+  };
+
   PyLTI = callPackage ../development/python-modules/pylti { };
 
   lmdb = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5189,16 +5189,15 @@ in {
 
   jupyterlab = buildPythonPackage rec {
     name = "jupyterlab-${version}";
-    version = "0.4.1";
+    version = "0.31.12";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/j/jupyterlab/${name}.tar.gz";
-      sha256 = "91dc4d7dfb1e6ab97e28d6e3a2fc38f5f65d368201c00fd0ed077519258e67bb";
+      sha256 = "1hp6p9bsr863glildgs2iy1a4l99m7rxj2sy9fmkxp5zhyhqvsrz";
     };
 
-    propagatedBuildInputs = with self; [ notebook ];
+    propagatedBuildInputs = with self; [ notebook jupyterlab_launcher ];
 
-    # No tests in archive
     doCheck = false;
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

Jupyterlab was horrendously out-of-date.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

