### PR TITLE
i3pystatus: 3.35 -> unstable

### DIFF
--- a/pkgs/applications/window-managers/i3/pystatus.nix
+++ b/pkgs/applications/window-managers/i3/pystatus.nix
@@ -20,7 +20,8 @@ python3Packages.buildPythonApplication rec {
 
   libpulseaudioPath = stdenv.lib.makeLibraryPath [ libpulseaudio ];
   ldWrapperSuffix = "--suffix LD_LIBRARY_PATH : \"${libpulseaudioPath}\"";
-  makeWrapperArgs = [ ldWrapperSuffix ]; # libpulseaudio.so is loaded manually
+  # LC_TIME != C results in locale.Error: unsupported locale setting
+  makeWrapperArgs = [ "--set LC_TIME C" ldWrapperSuffix ]; # libpulseaudio.so is loaded manually
 
   postInstall = ''
     makeWrapper ${python3Packages.python.interpreter} $out/bin/${pname}-python-interpreter \

--- a/pkgs/applications/window-managers/i3/pystatus.nix
+++ b/pkgs/applications/window-managers/i3/pystatus.nix
@@ -1,14 +1,18 @@
-{ stdenv, fetchurl, libpulseaudio, python3Packages, extraLibs ? [] }:
+{ stdenv, fetchFromGitHub, libpulseaudio, python3Packages, extraLibs ? [] }:
 
 python3Packages.buildPythonApplication rec {
-  name = "${pname}-${version}";
-  version = "3.35";
+  # i3pystatus moved to rolling release:
+  # https://github.com/enkore/i3pystatus/issues/584
+  version = "unstable-2018-04-11";
   pname = "i3pystatus";
   disabled = !python3Packages.isPy3k;
 
-  src = fetchurl {
-    url = "mirror://pypi/i/${pname}/${name}.tar.gz";
-    sha256 = "0g5m05rbqvq1qrspm6fyzky9xfhaz5pvc4hfzgdxrzijn8nfc860";
+  src = fetchFromGitHub
+  {
+    owner = "enkore";
+    repo = "i3pystatus";
+    rev = "3efbd56bb7a851f16173ec6f0eef472b6e96c7cc";
+    sha256 = "0r4mc23chxlaym7jcjnflw7mn5nbw3q8q4ix0nim7lh98yfndd3b";
   };
 
   propagatedBuildInputs = with python3Packages; [ keyring colour netifaces praw psutil basiciw ] ++

--- a/pkgs/development/python-modules/keyring/default.nix
+++ b/pkgs/development/python-modules/keyring/default.nix
@@ -17,7 +17,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ entrypoints ] ++ stdenv.lib.optional stdenv.isLinux secretstorage;
 
-  doCheck = !stdenv.isDarwin;
+  # all tests with flake8 are broken right now
+  # https://github.com/tholo/pytest-flake8/issues/45
+  doCheck = false;
 
   checkPhase = ''
     py.test

--- a/pkgs/development/python-modules/praw/default.nix
+++ b/pkgs/development/python-modules/praw/default.nix
@@ -14,6 +14,11 @@ buildPythonPackage rec {
     sha256 = "13vbh2r952ai2m6sc79psfwaj5fc8cssdg2pqpizg2mwd0l1s6lb";
   };
 
+  postPatch = ''
+    # drop upper bound of prawcore requirement
+    sed -ri "s/'(prawcore >=.+), <.+'/'\1'/" setup.py
+  '';
+
   propagatedBuildInputs = [
     requests
     decorator

--- a/pkgs/development/python-modules/praw/default.nix
+++ b/pkgs/development/python-modules/praw/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonPackage rec {
   pname = "praw";
-  version = "5.2.0";
+  version = "5.4.0";
 
   src = fetchFromGitHub {
     owner = "praw-dev";
     repo = "praw";
     rev = "v${version}";
-    sha256 = "0nwfadczxa1fyq65zc3sfv8g2r4w3xrx3bdi5fv9xpn97wh2ifgw";
+    sha256 = "13vbh2r952ai2m6sc79psfwaj5fc8cssdg2pqpizg2mwd0l1s6lb";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

no official release since 2016/08
current rev has a few new plugins available

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

