### PR TITLE
jmol: init at 14.29.12

### DIFF
--- a/pkgs/applications/science/chemistry/jmol/default.nix
+++ b/pkgs/applications/science/chemistry/jmol/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchurl
+, unzip
+, jre
+}:
+
+stdenv.mkDerivation rec {
+  version = "${baseVersion}.${patchVersion}";
+  baseVersion = "14.29";
+  patchVersion = "12";
+  pname = "jmol";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/jmol/Jmol/Version%20${baseVersion}/Jmol%20${version}/Jmol-${version}-binary.tar.gz";
+    sha256 = "1ndq9am75janshrnk26334z1nmyh3k4bp20napvf2zv0lfp8k3bv";
+  };
+
+  buildInputs = [
+    jre
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/share/jmol"
+    mkdir -p "$out/bin"
+
+    ${unzip}/bin/unzip jsmol.zip -d "$out/share/"
+
+    sed -i -e 's|command=java|command=${jre}/bin/java|' jmol.sh
+    cp *.jar jmol.sh "$out/share/jmol"
+    ln -s $out/share/jmol/jmol.sh "$out/bin/jmol"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+     description = "A Java 3D viewer for chemical structures";
+     homepage = https://sourceforge.net/projects/jmol;
+     license = licenses.lgpl2;
+     platforms = platforms.all;
+     maintainers = with maintainers; [ timokau ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3102,6 +3102,8 @@ with pkgs;
 
   jmespath = callPackage ../development/tools/jmespath { };
 
+  jmol = callPackage ../applications/science/chemistry/jmol { };
+
   jmtpfs = callPackage ../tools/filesystems/jmtpfs { };
 
   jnettop = callPackage ../tools/networking/jnettop { };


### PR DESCRIPTION
###### Motivation for this change

jmol was not packaged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

