### PR TITLE
lrcalc: init at 1.2

### DIFF
--- a/pkgs/applications/science/math/lrcalc/default.nix
+++ b/pkgs/applications/science/math/lrcalc/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromBitbucket
+, fetchpatch
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.2";
+  pname = "lrcalc";
+  name = "${pname}-${version}";
+
+  src = fetchFromBitbucket {
+    owner = "asbuch";
+    repo = "lrcalc";
+    rev = "lrcalc-${version}";
+    sha256 = "1c12d04jdyxkkav4ak8d1aqrv594gzihwhpxvc6p9js0ry1fahss";
+  };
+
+  doCheck = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  patches = [
+    # Fix include syntax:
+    # For private includes, use `#include "..."` instead of `#include <...>`
+    (fetchpatch {
+      url = "https://bitbucket.org/asbuch/lrcalc/commits/226981a0/raw/";
+      sha256 = "02kaqx5s3l642rhh28kn2wg9wr098vzpknxyl4pv627lqa3lv9vm";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Littlewood-Richardson calculator";
+    homepage = http://math.rutgers.edu/~asbuch/lrcalc/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19864,6 +19864,8 @@ with pkgs;
     docs = true;
   };
 
+  lrcalc = callPackage ../applications/science/math/lrcalc { };
+
   lie = callPackage ../applications/science/math/LiE { };
 
   magma = callPackage ../development/libraries/science/math/magma { };


### PR DESCRIPTION
###### Motivation for this change

Package lrcalc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

