### PR TITLE
pynac: init at 0.7.19

### DIFF
--- a/pkgs/applications/science/math/pynac/default.nix
+++ b/pkgs/applications/science/math/pynac/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, flint
+, gmp
+, python2
+, singular
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.7.19";
+  name = "pynac-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pynac";
+    repo = "pynac";
+    rev = "pynac-${version}";
+    sha256 = "132bibvapm245c5xy29j3xmjs0pawvw7lv05374m8vv1m39127d3";
+  };
+
+  buildInputs = [
+    flint
+    gmp
+    singular
+    singular
+    python2
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Python is Not a CAS -- modified version of Ginac";
+    longDescription = ''
+      Pynac -- "Python is Not a CAS" is a modified version of Ginac that
+      replaces the depency of GiNaC on CLN by a dependency instead of Python.
+      It is a lite version of GiNaC as well, not implementing all the features
+      of the full GiNaC, and it is *only* meant to be used as a Python library.
+    '';
+    homepage    = http://pynac.org;
+    maintainers = with maintainers; [ timokau ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20170,6 +20170,8 @@ with pkgs;
     inherit (gnome3) gtksourceview;
   };
 
+  pynac = callPackage ../applications/science/math/pynac { };
+
   singular = callPackage ../applications/science/math/singular { };
 
   scilab = callPackage ../applications/science/math/scilab {


### PR DESCRIPTION
###### Motivation for this change

~~Depends on #38768, do not merge before that is merged~~

Package pynac.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

