### PR TITLE
m4ri: init at 20140914

### DIFF
--- a/pkgs/development/libraries/science/math/m4ri/default.nix
+++ b/pkgs/development/libraries/science/math/m4ri/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromBitbucket
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  version = "20140914";
+  name = "m4ri-${version}";
+
+  src = fetchFromBitbucket {
+    owner = "malb";
+    repo = "m4ri";
+    rev = "release-${version}";
+    sha256 = "0xfg6pffbn8r1s0y7bn9b8i55l00d41dkmhrpf7pwk53qa3achd3";
+  };
+
+  doCheck = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://malb.bitbucket.io/m4ri/;
+    description = "Library to do fast arithmetic with dense matrices over F_2";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19845,6 +19845,8 @@ with pkgs;
 
   liblbfgs = callPackage ../development/libraries/science/math/liblbfgs { };
 
+  m4ri = callPackage ../development/libraries/science/math/m4ri { };
+
   nasc = callPackage ../applications/science/math/nasc { };
 
   openblas = callPackage ../development/libraries/science/math/openblas { };


### PR DESCRIPTION
###### Motivation for this change

Package m4ri.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

