### PR TITLE
 git: 2.16.2 -> 2.17.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  version = "2.16.3";
+  version = "2.17.0";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "0j1dwvg5llnj3g0fp8hdgpms4hp90qw9f6509vqw30dhwplrjpfn";
+    sha256 = "1ismz7nsz8dgjmk782xr9s0mr2qh06f72pdcgbxfmnw1bvlya5p9";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  version = "2.16.2";
+  version = "2.16.3";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "05y7480f2p7fkncbhf08zz56jbykcp0ia5gl6y3djs0lsa5mfq2m";
+    sha256 = "0j1dwvg5llnj3g0fp8hdgpms4hp90qw9f6509vqw30dhwplrjpfn";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/version-management/git-and-tools/git/docbook2texi.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/docbook2texi.patch
@@ -2,19 +2,19 @@ This patch does two things: (1) use the right name for `docbook2texi',
 and (2) make sure `gitman.info' isn't produced since it's broken (duplicate
 node names).
 
-diff -ru git-1.8.4-orig/Documentation/Makefile git-1.8.4/Documentation/Makefile
---- git-1.8.4-orig/Documentation/Makefile	2013-08-23 21:38:43.000000000 +0200
-+++ git-1.8.4/Documentation/Makefile	2013-09-30 14:48:51.532890378 +0200
-@@ -101,7 +101,7 @@
+diff --git a/Documentation/Makefile b/Documentation/Makefile
+--- a/Documentation/Makefile
++++ b/Documentation/Makefile
+@@ -122,7 +122,7 @@
  
  MAKEINFO = makeinfo
  INSTALL_INFO = install-info
 -DOCBOOK2X_TEXI = docbook2x-texi
 +DOCBOOK2X_TEXI = docbook2texi
  DBLATEX = dblatex
- ifndef PERL_PATH
- 	PERL_PATH = /usr/bin/perl
-@@ -205,7 +205,7 @@
+ ASCIIDOC_DBLATEX_DIR = /etc/asciidoc/dblatex
+ DBLATEX_COMMON = -p $(ASCIIDOC_DBLATEX_DIR)/asciidoc-dblatex.xsl -s $(ASCIIDOC_DBLATEX_DIR)/asciidoc-dblatex.sty
+@@ -240,7 +240,7 @@
  man5: $(DOC_MAN5)
  man7: $(DOC_MAN7)
  
@@ -23,7 +23,7 @@ diff -ru git-1.8.4-orig/Documentation/Makefile git-1.8.4/Documentation/Makefile
  
  pdf: user-manual.pdf
  
-@@ -221,10 +221,9 @@
+@@ -256,10 +256,9 @@
  
  install-info: info
  	$(INSTALL) -d -m 755 $(DESTDIR)$(infodir)

--- a/pkgs/applications/version-management/git-and-tools/git/git-send-email-honor-PATH.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-send-email-honor-PATH.patch
@@ -1,22 +1,20 @@
 diff --git a/Documentation/git-send-email.txt b/Documentation/git-send-email.txt
-index 8060ea35c..c81067a19 100644
 --- a/Documentation/git-send-email.txt
 +++ b/Documentation/git-send-email.txt
-@@ -203,8 +203,7 @@ a password is obtained using 'git-credential'.
+@@ -208,8 +208,7 @@ a password is obtained using 'git-credential'.
  	specify a full pathname of a sendmail-like program instead;
  	the program must support the `-i` option.  Default value can
  	be specified by the `sendemail.smtpServer` configuration
 -	option; the built-in default is to search for `sendmail` in
 -	`/usr/sbin`, `/usr/lib` and $PATH if such program is
-+        option; the built-in default is to search in $PATH if such program is
++	option; the built-in default is to search in $PATH if such program is
  	available, falling back to `localhost` otherwise.
 
  --smtp-server-port=<port>::
 diff --git a/git-send-email.perl b/git-send-email.perl
-index edcc6d346..8e357aeab 100755
 --- a/git-send-email.perl
 +++ b/git-send-email.perl
-@@ -885,8 +885,7 @@ if (defined $initial_reply_to) {
+@@ -944,8 +944,7 @@ if (defined $reply_to) {
  }
 
  if (!defined $smtp_server) {

--- a/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
@@ -6,15 +6,15 @@
 
 -# First decide what scheme to use...
 -GIT_INTERNAL_GETTEXT_SH_SCHEME=fallthrough
--if test -n "@@USE_GETTEXT_SCHEME@@"
+-if test -n "$GIT_GETTEXT_POISON"
+-then
+-	GIT_INTERNAL_GETTEXT_SH_SCHEME=poison
+-elif test -n "@@USE_GETTEXT_SCHEME@@"
 -then
 -	GIT_INTERNAL_GETTEXT_SH_SCHEME="@@USE_GETTEXT_SCHEME@@"
 -elif test -n "$GIT_INTERNAL_GETTEXT_TEST_FALLBACKS"
 -then
 -	: no probing necessary
--elif test -n "$GIT_GETTEXT_POISON"
--then
--	GIT_INTERNAL_GETTEXT_SH_SCHEME=poison
 -elif type gettext.sh >/dev/null 2>&1
 -then
 -	# GNU libintl's gettext.sh

--- a/pkgs/applications/version-management/git-and-tools/git/symlinks-in-bin.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/symlinks-in-bin.patch
@@ -1,7 +1,7 @@
-diff -ru -x '*~' git-1.8.2.1-orig/Makefile git-1.8.2.1/Makefile
---- git-1.8.2.1-orig/Makefile	2013-04-08 00:52:04.000000000 +0200
-+++ git-1.8.2.1/Makefile	2013-04-22 15:46:42.906026940 +0200
-@@ -2319,8 +2319,7 @@
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -2609,8 +2609,7 @@
  	{ test "$$bindir/" = "$$execdir/" || \
  	  for p in git$X $(filter $(install_bindir_programs),$(ALL_PROGRAMS)); do \
  		$(RM) "$$execdir/$$p" && \


### PR DESCRIPTION
Fixed the perl lib path issues detected in #38636

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).