### PR TITLE
tealdeer: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/tealdeer/default.nix
+++ b/pkgs/tools/misc/tealdeer/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, rustPlatform, fetchFromGitHub, pkgconfig, openssl, cacert, curl }:
+
+rustPlatform.buildRustPackage rec {
+  name = "tealdeer-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dbrgn";
+    repo = "tealdeer";
+    rev = "v${version}";
+    sha256 = "0mkcja9agkbj2i93hx01r77w66ca805v4wvivcnrqmzid001717v";
+  };
+
+  cargoSha256 = "1qrvic7b6g3f3gjzx7x97ipp7ppa79c0aawn0lsav0c9xxzl44jq";
+
+  buildInputs = [ openssl cacert curl ];
+
+  nativeBuildInputs = [ pkgconfig ];
+  
+  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  # disable tests for now since one needs network
+  # what is unavailable in sandbox build
+  # and i can't disable just this one
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "An implementation of tldr in Rust";
+    homepage = "https://github.com/dbrgn/tealdeer";
+    maintainers = with maintainers; [ davidak ];
+    license = with licenses; [ asl20 mit ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2089,6 +2089,8 @@ with pkgs;
 
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
+  tealdeer = callPackage ../tools/misc/tealdeer/default.nix { };
+
   uudeview = callPackage ../tools/misc/uudeview { };
 
   uutils-coreutils = callPackage ../tools/misc/uutils-coreutils {


### PR DESCRIPTION
###### Motivation for this change

fastest implementation of tldr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

