### PR TITLE
singular: 3.1.7 -> 4.1.1

### DIFF
--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -1,23 +1,52 @@
 { stdenv, fetchurl, gmp, bison, perl, autoconf, ncurses, readline, coreutils, pkgconfig
-, asLibsingular ? false
+, autoreconfHook
+, flint
+, ntl
+, cddlib
+, enableFactory ? true
+, enableGfanlib ? true
 }:
 
 stdenv.mkDerivation rec {
-  name = "singular-${version}";
-  version="3-1-7";
+  name = "singular-${version}${patchVersion}";
+  version = "4.1.1";
+  patchVersion = "p1";
 
+  urlVersion = builtins.replaceStrings [ "." ] [ "-" ] version;
   src = fetchurl {
-    url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${version}/Singular-${version}.tar.gz";
-    sha256 = "1j4mcpnwzdp3h4qspk6ww0m67rmx4s11cy17pvzbpf70lm0jzzh2";
+    url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${urlVersion}/singular-${version}${patchVersion}.tar.gz";
+    sha256 = "0wvgz7l1b7zkpmim0r3mvv4fp8xnhlbz4c7hc90rn30snlansnf1";
   };
 
-  buildInputs = [ gmp perl ncurses readline ];
-  nativeBuildInputs = [ autoconf bison pkgconfig ];
+  configureFlags = stdenv.lib.optionals enableFactory [
+    "--enable-factory"
+  ] ++ stdenv.lib.optionals enableGfanlib [
+    "--enable-gfanlib"
+  ];
+
+  postUnpack = ''
+    patchShebangs .
+  '';
+
+  # For reference (last checked on commit 75f460d):
+  # https://github.com/Singular/Sources/blob/spielwiese/doc/Building-Singular-from-source.md
+  # https://github.com/Singular/Sources/blob/spielwiese/doc/external-packages-dynamic-modules.md
+  buildInputs = [
+    # necessary
+    gmp
+    # by upstream recommended but optional
+    ncurses
+    readline
+    ntl
+    flint
+  ] ++ stdenv.lib.optionals enableGfanlib [
+    cddlib
+  ];
+  nativeBuildInputs = [ autoconf bison perl pkgconfig autoreconfHook ];
 
   preConfigure = ''
     find . -type f -exec sed -e 's@/bin/rm@${coreutils}&@g' -i '{}' ';'
     find . -type f -exec sed -e 's@/bin/uname@${coreutils}&@g' -i '{}' ';'
-    ${stdenv.lib.optionalString asLibsingular ''NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -DLIBSINGULAR"''}
   '';
 
   hardeningDisable = stdenv.lib.optional stdenv.isi686 "stackprotector";
@@ -27,17 +56,21 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p "$out"
-    cp -r Singular/LIB "$out/LIB"
-    make install${stdenv.lib.optionalString asLibsingular "-libsingular"}
+    cp -r Singular/LIB "$out/lib"
+    make install
 
-    binaries="$(find "$out"/* \( -type f -o -type l \) -perm -111 \! -name '*.so' -maxdepth 1)"
-    ln -s "$out"/*/{include,lib} "$out"
-    mkdir -p "$out/bin"
-    for b in $binaries; do
-      bbn="$(basename "$b")"
-      echo -e '#! ${stdenv.shell}\n"'"$b"'" "$@"' > "$out/bin/$bbn"
-      chmod a+x "$out/bin/$bbn"
-    done
+    # Make sure patchelf picks up the right libraries
+    rm -rf libpolys factory resources omalloc Singular
+  '';
+
+  # simple test to make sure singular starts and finds its libraries
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/Singular -c 'LIB "freegb.lib"; exit;'
+    if [ $? -ne 0 ]; then
+        echo >&2 "Error loading the freegb library in Singular."
+        exit 1
+    fi
   '';
 
   enableParallelBuilding = true;
@@ -47,7 +80,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ raskin ];
     platforms = subtractLists platforms.i686 platforms.linux;
     license = licenses.gpl3; # Or GPLv2 at your option - but not GPLv4
-    homepage = http://www.singular.uni-kl.de/index.php;
+    homepage = http://www.singular.uni-kl.de;
     downloadPage = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/";
   };
 }

--- a/pkgs/development/libraries/flint/default.nix
+++ b/pkgs/development/libraries/flint/default.nix
@@ -26,6 +26,9 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals withBlas [
     openblas
   ];
+  propagatedBuildInputs = [
+    mpfr # flint.h includes mpfr.h
+  ];
   configureFlags = [
     "--with-gmp=${gmp}"
     "--with-mpir=${mpir}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20229,13 +20229,7 @@ with pkgs;
     inherit (gnome3) gtksourceview;
   };
 
-  singular = callPackage ../applications/science/math/singular {
-    stdenv = overrideCC stdenv gcc5;
-  };
-  libsingular = callPackage ../applications/science/math/singular {
-    asLibsingular = true;
-    stdenv = overrideCC stdenv gcc5;
-  };
+  singular = callPackage ../applications/science/math/singular { };
 
   scilab = callPackage ../applications/science/math/scilab {
     withXaw3d = false;


### PR DESCRIPTION
###### Motivation for this change

- update singular
- add factory and gfanlib support (apparently does not increase package size, although gfanlib does add one new (small) dependency)
- add semi-optional dependencies suggested by upstream (ntl, flint)
- copy into `$out/lib` instead of `$out/LIB` (which conflicts with `$out/lib` and results in weird `nix~case~hack` stuff when building remotely)
- add a simple install check that starts singular and tries to load a package
- adds mpfr as a propagated build input for flint (listed as a dependency at http://www.flintlib.org/ and flint.h imports mpfr.h)

Maintainer: @7c6f434c (who apparently is the maintainer for all the software I touch, sorry).

~~I still have to `nox-review` (`nox-review wip` doesn't work for some reason and I want to test on another PC than I developed on anyways, which is why I didn't do it before submitting the PR).~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

