### PR TITLE
cvxopt: 1.1.7 -> 1.1.9, add optional extensions

### DIFF
--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPyPy
+, python
+, openblasCompat # build segfaults with regular openblas
+, suitesparse
+, glpk ? null
+, gsl ? null
+, fftw ? null
+, withGlpk ? true
+, withGsl ? true
+, withFftw ? true
+}:
+
+buildPythonPackage rec {
+  pname = "cvxopt";
+  version = "1.1.9";
+
+  disabled = isPyPy; # hangs at [translation:info]
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gcqq8ymjxv8qa5ss2pdhsj5bahvdxa6h2rlpp51520mjxrpw5cg";
+  };
+
+  # similar to Gsl, glpk, fftw there is also a dsdp interface
+  # but dsdp is not yet packaged in nixpkgs
+  preConfigure = ''
+    export CVXOPT_BLAS_LIB_DIR=${openblasCompat}/lib
+    export CVXOPT_BLAS_LIB=openblas
+    export CVXOPT_LAPACK_LIB=openblas
+    export CVXOPT_SUITESPARSE_LIB_DIR=${suitesparse}/lib
+    export CVXOPT_SUITESPARSE_INC_DIR=${suitesparse}/include
+  '' + lib.optionalString withGsl ''
+    export CVXOPT_BUILD_GSL=1
+    export CVXOPT_GSL_LIB_DIR=${gsl}/lib
+    export CVXOPT_GSL_INC_DIR=${gsl}/include
+  '' + lib.optionalString withGlpk ''
+    export CVXOPT_BUILD_GLPK=1
+    export CVXOPT_GLPK_LIB_DIR=${glpk}/lib
+    export CVXOPT_GLPK_INC_DIR=${glpk}/include
+  '' + lib.optionalString withFftw ''
+    export CVXOPT_BUILD_FFTW=1
+    export CVXOPT_FFTW_LIB_DIR=${fftw}/lib
+    export CVXOPT_FFTW_INC_DIR=${fftw.dev}/include
+  '';
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s tests
+  '';
+
+  meta = {
+    homepage = http://cvxopt.org/;
+    description = "Python Software for Convex Optimization";
+    longDescription = ''
+      CVXOPT is a free software package for convex optimization based on the
+      Python programming language. It can be used with the interactive
+      Python interpreter, on the command line by executing Python scripts,
+      or integrated in other software via Python extension modules. Its main
+      purpose is to make the development of software for convex optimization
+      applications straightforward by building on Python's extensive
+      standard library and on the strengths of Python as a high-level
+      programming language.
+    '';
+    maintainers = with lib.maintainers; [ edwtjo ];
+    license = lib.licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1173,29 +1173,7 @@ in {
 
   cx_oracle = callPackage ../development/python-modules/cx_oracle {};
 
-  cvxopt = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "cvxopt";
-    version = "1.1.7";
-    disabled = isPyPy;
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/c/${pname}/${name}.tar.gz";
-      sha256 = "f856ea2e9e2947abc1a6557625cc6b0e45228984f397a90c420b2f468dc4cb97";
-    };
-    doCheck = false;
-    buildInputs = with pkgs; [ openblasCompat ];
-    preConfigure = ''
-      export CVXOPT_BLAS_LIB_DIR=${pkgs.openblasCompat}/lib
-      export CVXOPT_BLAS_LIB=openblas
-      export CVXOPT_LAPACK_LIB=openblas
-    '';
-    meta = {
-      homepage = "http://cvxopt.org/";
-      description = "Python Software for Convex Optimization";
-      maintainers = with maintainers; [ edwtjo ];
-      license = licenses.gpl3Plus;
-    };
-  };
+  cvxopt = callPackage ../development/python-modules/cvxopt { };
 
   cycler = callPackage ../development/python-modules/cycler { };
 


### PR DESCRIPTION
###### Motivation for this change

- update cvxopt to the latest version
- add support for optional extensions: glpk, gsl, fftw
- move out of `python-packages`
- run tests

Maintainer: @edwtjo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

