### PR TITLE
cysignals init

### DIFF
--- a/pkgs/development/python-modules/cysignals/default.nix
+++ b/pkgs/development/python-modules/cysignals/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, cython
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "cysignals";
+  version = "1.6.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "003invnixqy1h4lb358vwrxykxzp15csaddkgq3pqqmswnva5908";
+  };
+
+  hardeningDisable = [
+    "fortify"
+  ];
+
+  # currently fails, probably because of formatting changes in gdb 8.0
+  doCheck = false;
+
+  preCheck = ''
+    # Make sure cysignals-CSI is in PATH
+    export PATH="$out/bin:$PATH"
+  '';
+
+  propagatedBuildInputs = [
+    cython
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Interrupt and signal handling for Cython";
+    homepage = https://github.com/sagemath/cysignals/;
+    maintainers = with lib.maintainers; [ timokau ];
+    license = lib.licenses.lgpl3Plus;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1199,6 +1199,8 @@ in {
 
   cycler = callPackage ../development/python-modules/cycler { };
 
+  cysignals = callPackage ../development/python-modules/cysignals { };
+
   dlib = buildPythonPackage rec {
     inherit (pkgs.dlib) name src nativeBuildInputs meta;
 


### PR DESCRIPTION
###### Motivation for this change

Package cysignals.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

