### PR TITLE
cypari2: init at 1.1.4

### DIFF
--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, bootstrapped-pip
+, buildPythonPackage
+, python
+, fetchPypi
+, pari
+, gmp
+, cython
+, cysignals
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "cypari2";
+  version = "1.1.4"; # remove six dependency on upgrade to >1.1.4
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n0mp8qmvvzmfaawg39d3mkyzf65q2zkz7bnqyk4sfjbz4xwc6mb";
+  };
+
+  # This differs slightly from the default python installPhase in that it pip-installs
+  # "." instead of "*.whl".
+  # That is because while the default install phase succeeds to build the package,
+  # it fails to generate the file "auto_paridecl.pxd".
+  installPhase = ''
+    mkdir -p "$out/lib/${python.libPrefix}/site-packages"
+    export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+
+    # install "." instead of "*.whl"
+    ${bootstrapped-pip}/bin/pip install --no-index --prefix=$out --no-cache --build=tmpdir .
+  '';
+
+  buildInputs = [
+    pari
+    gmp
+  ];
+
+  propagatedBuildInputs = [
+    cysignals
+    cython
+    six # after 1.1.4: will not be needed
+  ];
+
+  checkPhase = ''
+    make check
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cython bindings for PARI";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ timokau ];
+    homepage = https://github.com/defeo/cypari2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1207,6 +1207,8 @@ in {
 
   cysignals = callPackage ../development/python-modules/cysignals { };
 
+  cypari2 = callPackage ../development/python-modules/cypari2 { };
+
   dlib = buildPythonPackage rec {
     inherit (pkgs.dlib) name src nativeBuildInputs meta;
 


### PR DESCRIPTION
###### Motivation for this change

~~This depends on #38781, do not merge before that~~

Package cypari2. The `installPhase` should probably be reviewed as it is non-standarad and I'm not entirely sure if thats the best way to do it. With the standard `installPhase` the required file `auto_paridecl.pxd` is not generated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

