### PR TITLE
pythonPackages.flask-silk: init at 0.2

### DIFF
--- a/pkgs/development/python-modules/flask-silk/default.nix
+++ b/pkgs/development/python-modules/flask-silk/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, flask
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-Silk";
+  version = "0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gjzighx4f0w39sq9xvzr1kwb4y7yv9qrgzvli1p89gy16piz8l0";
+  };
+
+  propagatedBuildInputs = [
+    flask
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Adds silk icons to your Flask application or module, or extension";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ timokau ];
+    homepage = https://github.com/sublee/flask-silk;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5606,6 +5606,8 @@ in {
 
   flask_script = callPackage ../development/python-modules/flask-script { };
 
+  flask-silk = callPackage ../development/python-modules/flask-silk { };
+
   flask_sqlalchemy = buildPythonPackage rec {
     name = "Flask-SQLAlchemy-${version}";
     version = "2.1";


### PR DESCRIPTION
###### Motivation for this change

Package `flask-silk`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

