### PR TITLE
pythonPackages.flask-autoindex: init at 0.6

### DIFF
--- a/pkgs/development/python-modules/flask-autoindex/default.nix
+++ b/pkgs/development/python-modules/flask-autoindex/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, buildPythonPackage
+, fetchpatch
+, fetchPypi
+, flask
+, flask-silk
+, future
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-AutoIndex";
+  version = "0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19b10mb1nrqfjyafki6wnrbn8mqi30bbyyiyvp5xssc74pciyfqs";
+  };
+
+  propagatedBuildInputs = [
+    flask
+    flask-silk
+    future
+  ];
+
+  patches = [
+    # fix generated binary, see https://github.com/sublee/flask-autoindex/pull/32
+    (fetchpatch {
+      name = "fix_binary.patch";
+      url = "https://github.com/sublee/flask-autoindex/pull/32.patch";
+      sha256 = "1v2r0wvi7prhipjq89774svv6aqj0a13mdfj07pdlkpzfbf029dn";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "The mod_autoindex for Flask";
+    longDescription = ''
+      Flask-AutoIndex generates an index page for your Flask application automatically.
+      The result is just like mod_autoindex, but the look is more awesome!
+    '';
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ timokau ];
+    homepage = http://pythonhosted.org/Flask-AutoIndex/;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5533,6 +5533,8 @@ in {
 
   flask_assets = callPackage ../development/python-modules/flask-assets { };
 
+  flask-autoindex = callPackage ../development/python-modules/flask-autoindex { };
+
   flask-babel = callPackage ../development/python-modules/flask-babel { };
 
   flask_cache = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

~~Depends on #38783, do not merge before that.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

