### PR TITLE
pythonPackages.flask-babel: init at 0.11.2

### DIFF
--- a/pkgs/development/python-modules/flask-babel/default.nix
+++ b/pkgs/development/python-modules/flask-babel/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flask
+, Babel
+, jinja2
+, pytz
+, speaklater
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-Babel";
+  version = "0.11.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ff9n165vhf1nhv6807ckhpp224jw7k7sd7jz5kfh3sbpl85gmy0";
+  };
+
+  propagatedBuildInputs = [
+    flask
+    Babel
+    jinja2
+    pytz
+    speaklater
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Adds i18n/l10n support to Flask applications";
+    longDescription = ''
+      Implements i18n and l10n support for Flask.
+      This is based on the Python babel module as well as pytz both of which are
+      installed automatically for you if you install this library.
+    '';
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ timokau ];
+    homepage = https://github.com/python-babel/flask-babel;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5557,6 +5557,8 @@ in {
 
   flask_assets = callPackage ../development/python-modules/flask-assets { };
 
+  flask-babel = callPackage ../development/python-modules/flask-babel { };
+
   flask_cache = buildPythonPackage rec {
     name = "Flask-Cache-0.13.1";
 


### PR DESCRIPTION
###### Motivation for this change

Package flask-babel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

