### PR TITLE
pythonPackages.flask-oldsessions: init at 0.10

### DIFF
--- a/pkgs/development/python-modules/flask-oldsessions/default.nix
+++ b/pkgs/development/python-modules/flask-oldsessions/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, flask
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-OldSessions";
+  version = "0.10";
+
+  # no artifact on pypi: https://github.com/mitsuhiko/flask-oldsessions/issues/1
+  src = fetchFromGitHub {
+    owner = "mitsuhiko";
+    repo = "flask-oldsessions";
+    rev = "${version}";
+    sha256 = "04b5m8njjiwld9a0zw55iqwvyjgwcpdbhz1cic8nyhgcmypbicqn";
+  };
+
+  propagatedBuildInputs = [
+    flask
+  ];
+
+  # missing module flask.testsuite, probably assumes an old version of flask
+  doCheck = false;
+  checkPhase = ''
+    ${python.interpreter} run-tests.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Provides a session class that works like the one in Flask before 0.10.";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ timokau ];
+    homepage = https://github.com/mitsuhiko/flask-oldsessions;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5596,6 +5596,8 @@ in {
 
   flask_oauthlib = callPackage ../development/python-modules/flask-oauthlib { };
 
+  flask-oldsessions = callPackage ../development/python-modules/flask-oldsessions { };
+
   flask_principal = callPackage ../development/python-modules/flask-principal { };
 
   flask-pymongo = callPackage ../development/python-modules/Flask-PyMongo { };


### PR DESCRIPTION
###### Motivation for this change

Package `flask-oldsessions`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

