### PR TITLE
pythonPackages.python-openid: init at 2.2.5

### DIFF
--- a/pkgs/development/python-modules/python-openid/default.nix
+++ b/pkgs/development/python-modules/python-openid/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, python-openid
+, django
+, nose
+, twill
+, pycrypto
+}:
+
+buildPythonPackage rec {
+  pname = "python-openid";
+  version = "2.2.5";
+
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vvhxlghjan01snfdc4k7ykd80vkyjgizwgg9bncnin8rqz1ricj";
+  };
+
+  propagatedBuildInputs = [
+    django
+    twill
+    pycrypto
+  ];
+
+  # Cannot access the djopenid example module.
+  # I don't know how to fix that (adding the examples dir to PYTHONPATH doesn't work)
+  doCheck = false;
+  checkInputs = [ nose ];
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OpenID library for Python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ timokau ];
+    homepage = https://github.com/openid/python-openid/;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7118,6 +7118,8 @@ in {
 
   python_openzwave = callPackage ../development/python-modules/python_openzwave { };
 
+  python-openid = callPackage ../development/python-modules/python-openid { };
+
   python-Levenshtein = buildPythonPackage rec {
     name = "python-Levenshtein-${version}";
     version = "0.12.0";


### PR DESCRIPTION
###### Motivation for this change

Package `python-openid`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

