### PR TITLE
pythonPackages.flask-openid: init at 1.2.5

### DIFF
--- a/pkgs/development/python-modules/flask-openid/default.nix
+++ b/pkgs/development/python-modules/flask-openid/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, flask
+, python-openid
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-OpenID";
+  version = "1.2.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1aycwmwi7ilcaa5ab8hm0bp6323zl8z25q9ha0gwrl8aihfgx3ss";
+  };
+
+  propagatedBuildInputs = [
+    flask
+    python-openid
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Adds openid support to flask applications";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ timokau ];
+    homepage = https://pythonhosted.org/Flask-OpenID/;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5596,6 +5596,8 @@ in {
 
   flask_oauthlib = callPackage ../development/python-modules/flask-oauthlib { };
 
+  flask-openid = callPackage ../development/python-modules/flask-openid { };
+
   flask_principal = callPackage ../development/python-modules/flask-principal { };
 
   flask-pymongo = callPackage ../development/python-modules/Flask-PyMongo { };


### PR DESCRIPTION
###### Motivation for this change

**This depends on #38788, do not merge before that**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

