### PR TITLE
brial: init at 1.2.3

### DIFF
--- a/pkgs/development/libraries/science/math/brial/default.nix
+++ b/pkgs/development/libraries/science/math/brial/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, boost
+, m4ri
+, gd
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.2.3";
+  name = "brial-${version}";
+
+  src = fetchFromGitHub {
+    owner = "BRiAl";
+    repo = "BRiAl";
+    rev = version;
+    sha256 = "0qy4cwy7qrk4zg151cmws5cglaa866z461cnj9wdnalabs7v7qbg";
+  };
+
+  # FIXME package boost-test and enable checks
+  doCheck = false;
+
+  configureFlags = [
+    "--with-boost-unit-test-framework=no"
+  ];
+
+  buildInputs = [
+    boost
+    m4ri
+    gd
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/BRiAl/BRiAl;
+    description = "Legacy version of PolyBoRi maintained by sagemath developers";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19947,6 +19947,8 @@ with pkgs;
 
   blas = callPackage ../development/libraries/science/math/blas { };
 
+  brial = callPackage ../development/libraries/science/math/brial { };
+
   clblas = callPackage ../development/libraries/science/math/clblas {
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo OpenCL;
   };


### PR DESCRIPTION
###### Motivation for this change

~~This depends on #38762, do not merge before that~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

