### PR TITLE
cliquer: init at 1.21

### DIFF
--- a/pkgs/development/libraries/science/math/cliquer/default.nix
+++ b/pkgs/development/libraries/science/math/cliquer/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.21";
+  name = "cliquer-${version}";
+
+  # autotoolized version of the original cliquer
+  src = fetchFromGitHub {
+    owner = "dimpase";
+    repo = "autocliquer";
+    rev = "v${version}";
+    sha256 = "180i4qj1a25qfp75ig2d3144xfpb1dgcgpha0iqqghd7di4awg7z";
+  };
+
+  doCheck = true;
+
+  buildInputs = [
+    autoreconfHook
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://users.aalto.fi/~pat/cliquer.html;
+    downloadPage = src.meta.homepage; # autocliquer
+    description = "Routines for clique searching";
+    longDescription = ''
+      Cliquer is a set of C routines for finding cliques in an arbitrary weighted graph.
+      It uses an exact branch-and-bound algorithm developed by Patric Östergård.
+      It is designed with the aim of being efficient while still being flexible and
+      easy to use.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19769,6 +19769,8 @@ with pkgs;
 
   clblas = callPackage ../development/libraries/science/math/clblas { };
 
+  cliquer = callPackage ../development/libraries/science/math/cliquer { };
+
   jags = callPackage ../applications/science/math/jags { };
 
 


### PR DESCRIPTION
###### Motivation for this change

Package cliquer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

