### PR TITLE
m4rie: init at 20150908

### DIFF
--- a/pkgs/development/libraries/science/math/m4rie/default.nix
+++ b/pkgs/development/libraries/science/math/m4rie/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchFromBitbucket
+, autoreconfHook
+, m4ri
+}:
+
+stdenv.mkDerivation rec {
+  version = "20150908";
+  name = "m4rie-${version}";
+
+  src = fetchFromBitbucket {
+    owner = "malb";
+    repo = "m4rie";
+    rev = "release-${version}";
+    sha256 = "0r8lv46qx5mkz5kp3ay2jnsp0mbhlqr5z2z220wdk73wdshcznss";
+  };
+
+  doCheck = true;
+
+  buildInputs = [
+    m4ri
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://malb.bitbucket.io/m4rie/;
+    description = "Library for matrix multiplication, reduction and inversion over GF(2^k) for 2 <= k <= 10";
+    longDescription = ''
+      M4RIE is a library for fast arithmetic with dense matrices over small finite fields of even characteristic.
+      It uses the M4RI library, implementing the same operations over the finite field F2.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19783,6 +19783,8 @@ with pkgs;
 
   m4ri = callPackage ../development/libraries/science/math/m4ri { };
 
+  m4rie = callPackage ../development/libraries/science/math/m4rie { };
+
   nasc = callPackage ../applications/science/math/nasc { };
 
   openblas = callPackage ../development/libraries/science/math/openblas { };


### PR DESCRIPTION
###### Motivation for this change

~~This depends on #38762, do not merge before that.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

