### PR TITLE
flintqs: init at 1.0

### DIFF
--- a/pkgs/development/libraries/science/math/flintqs/default.nix
+++ b/pkgs/development/libraries/science/math/flintqs/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, gmp
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.0";
+  pname = "flintqs";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "sagemath";
+    repo = "FlintQS";
+    rev = "v${version}";
+    sha256 = "1f0lnayz6j6qgasx8pbq61d2fqam0wwhsmh6h15l4vq58l1vvbwj";
+  };
+
+  preAutoreconf = ''
+    touch ChangeLog
+  '';
+
+  buildInputs = [
+    gmp
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/sagemath/FlintQS;
+    description = "Highly optimized multi-polynomial quadratic sieve for integer factorization";
+    license = with licenses; [ gpl2 ];
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19769,6 +19769,8 @@ with pkgs;
 
   clblas = callPackage ../development/libraries/science/math/clblas { };
 
+  flintqs = callPackage ../development/libraries/science/math/flintqs { };
+
   jags = callPackage ../applications/science/math/jags { };
 
 


### PR DESCRIPTION
###### Motivation for this change

Package flintqs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

