### PR TITLE
planarity: init at 3.0.0.5

### DIFF
--- a/pkgs/development/libraries/science/math/planarity/default.nix
+++ b/pkgs/development/libraries/science/math/planarity/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "planarity";
+  version = "3.0.0.5";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "graph-algorithms";
+    repo = "edge-addition-planarity-suite";
+    rev = "Version_${version}";
+    sha256 = "01cm7ay1njkfsdnmnvh5zwc7wg7x189hq1vbfhh9p3ihrbnmqzh8";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  doCheck = true;
+
+  patches = [
+    # declare variables declared in headers as extern, not yet merged upstream
+    (fetchpatch {
+      url = "https://github.com/graph-algorithms/edge-addition-planarity-suite/pull/3.patch";
+      sha256 = "1nqjc4clr326imz4jxqxcxv2hgh1sjgzll27k5cwkdin8lnmmil8";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/graph-algorithms/edge-addition-planarity-suite;
+    description = "A library for implementing graph algorithms";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19797,6 +19797,8 @@ with pkgs;
 
   openspecfun = callPackage ../development/libraries/science/math/openspecfun {};
 
+  planarity = callPackage ../development/libraries/science/math/planarity { };
+
   fenics = callPackage ../development/libraries/science/math/fenics {
     inherit (python3Packages) numpy ply pytest python six sympy;
     pythonPackages = python3Packages;


### PR DESCRIPTION
###### Motivation for this change

Package planarity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

