### PR TITLE
rankwidth: init at 0.7

### DIFF
--- a/pkgs/development/libraries/science/math/rankwidth/default.nix
+++ b/pkgs/development/libraries/science/math/rankwidth/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rankwidth";
+  version = "0.7";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://mirrors.mit.edu/sage/spkg/upstream/rw/rw-${version}.tar.gz";
+    sha256 = "1rv2v42x2506x7f10349m1wpmmfxrv9l032bkminni2gbip9cjg0";
+  };
+
+  configureFlags = [
+    "--enable-executable=no" # no igraph dependency
+  ];
+
+  # check phase is empty for now (as of version 0.7)
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Calculates rank-width and rank-decompositions";
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19904,6 +19904,8 @@ with pkgs;
 
   planarity = callPackage ../development/libraries/science/math/planarity { };
 
+  rankwidth = callPackage ../development/libraries/science/math/rankwidth { };
+
   fenics = callPackage ../development/libraries/science/math/fenics {
     inherit (python3Packages) numpy ply pytest python six sympy;
     pythonPackages = python3Packages;


### PR DESCRIPTION
###### Motivation for this change

Package rankwidth.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

