### PR TITLE
zn_poly: init at 0.9

### DIFF
--- a/pkgs/development/libraries/science/math/zn_poly/default.nix
+++ b/pkgs/development/libraries/science/math/zn_poly/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, fetchurl
+, gmp
+, python2
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.9";
+  pname = "zn_poly";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://web.maths.unsw.edu.au/~davidharvey/code/zn_poly/releases/zn_poly-${version}.tar.gz";
+    sha256 = "1kxl25av7i3v68k32hw5bayrfcvmahmqvs97mlh9g238gj4qb851";
+  };
+
+  buildInputs = [
+    gmp
+  ];
+
+  nativeBuildInputs = [
+    python2 # needed by ./configure to create the makefile
+  ];
+
+  libname = "libzn_poly${stdenv.targetPlatform.extensions.sharedLibrary}";
+
+  # Tuning (either autotuning or with hand-written paramters) is possible
+  # but not implemented here.
+  # It seems buggy anyways (see homepage).
+  buildFlags = [ "all" libname ];
+
+
+  # `make install` fails to install some header files and the lib file.
+  installPhase = ''
+    mkdir -p "$out/include/zn_poly"
+    mkdir -p "$out/lib"
+    cp "${libname}" "$out/lib"
+    cp include/*.h "$out/include/zn_poly"
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://web.maths.unsw.edu.au/~davidharvey/code/zn_poly/;
+    description = "Polynomial arithmetic over Z/nZ";
+    license = with licenses; [ gpl3 ];
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19832,6 +19832,8 @@ with pkgs;
 
   gmsh = callPackage ../applications/science/math/gmsh { };
 
+  zn_poly = callPackage ../development/libraries/science/math/zn_poly { };
+
   ### SCIENCE/MOLECULAR-DYNAMICS
 
   lammps = callPackage ../applications/science/molecular-dynamics/lammps {


### PR DESCRIPTION
###### Motivation for this change

Package zn_poly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

