### PR TITLE
dragonfly-reverb: init at 0.9.1

### DIFF
--- a/pkgs/applications/audio/dragonfly-reverb/default.nix
+++ b/pkgs/applications/audio/dragonfly-reverb/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, libjack2, libGL, pkgconfig, xorg }:
+
+stdenv.mkDerivation rec {
+  name = "dragonfly-reverb-${src.rev}";
+
+  src = fetchgit {
+    url = "https://github.com/michaelwillis/dragonfly-reverb";
+    rev = "0.9.1";
+    sha256 = "1dbykx044h768bbzabdagl4jh65gqgfsxsrarjrkp07sqnhlnhpd";
+  };
+
+  patchPhase = ''
+    patchShebangs dpf/utils/generate-ttl.sh
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    libjack2 xorg.libX11 libGL
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2/
+    cp -a bin/DragonflyReverb.lv2/ $out/lib/lv2/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/michaelwillis/dragonfly-reverb;
+    description = "A hall-style reverb based on freeverb3 algorithms";
+    maintainers = [ maintainers.magnetophon ];
+    license = licenses.gpl2;
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15269,6 +15269,8 @@ with pkgs;
 
   draftsight = callPackage ../applications/graphics/draftsight { };
 
+  dragonfly-reverb = callPackage ../applications/audio/dragonfly-reverb { };
+
   droopy = callPackage ../applications/networking/droopy {
     inherit (python3Packages) wrapPython;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

