### PR TITLE
pythonPackages.macpack: init at 1.0.3

### DIFF
--- a/pkgs/development/python-modules/macpack/default.nix
+++ b/pkgs/development/python-modules/macpack/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "macpack";
+  version = "1.0.3";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xa1ybrkjkbymjw0wrk9x2w03jck5z3330f5ns1g29hlv5yr7h83";
+  };
+
+  meta = {
+    description = "A utility that makes a macOS binary redistributable";
+    license = stdenv.lib.licenses.mit;
+    homepage = https://github.com/chearon/macpack;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3529,6 +3529,8 @@ in {
 
   m2r = callPackage ../development/python-modules/m2r { };
 
+  macpack = callPackage ../development/python-modules/macpack { };
+
   mailchimp = buildPythonPackage rec {
     version = "2.0.9";
     name = "mailchimp-${version}";


### PR DESCRIPTION
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).