### PR TITLE
handbrake: move FDK codec to optional choice

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -13,13 +13,13 @@
   python2, pkgconfig, yasm, harfbuzz, zlib,
   autoconf, automake, cmake, libtool, m4, jansson,
   libass, libiconv, libsamplerate, fribidi, libxml2, bzip2,
-  libogg, libopus, libtheora, libvorbis, libdvdcss, a52dec, fdk_aac,
+  libogg, libopus, libtheora, libvorbis, libdvdcss, a52dec,
   lame, ffmpeg, libdvdread, libdvdnav, libbluray,
   mp4v2, mpeg2dec, x264, x265, libmkv,
   fontconfig, freetype, hicolor-icon-theme,
   glib, gtk3, intltool, libnotify,
   gst_all_1, dbus-glib, udev, libgudev, libvpx,
-  useGtk ? true, wrapGAppsHook ? null, libappindicator-gtk3 ? null
+  useGtk ? true, wrapGAppsHook ? null, libappindicator-gtk3 ? null, useFdk ? false, fdk_aac ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -42,13 +42,13 @@ stdenv.mkDerivation rec {
   buildInputs = [
     fribidi fontconfig freetype jansson zlib
     libass libiconv libsamplerate libxml2 bzip2
-    libogg libopus libtheora libvorbis libdvdcss a52dec libmkv fdk_aac
+    libogg libopus libtheora libvorbis libdvdcss a52dec libmkv
     lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264 x265 libvpx
   ] ++ (lib.optionals useGtk [
     glib gtk3 libappindicator-gtk3 libnotify
     gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
     libgudev
-  ]);
+  ]) ++ (lib.optionals useFdk [fdk_aac]);
 
   dontUseCmakeConfigure = true;
 
@@ -75,8 +75,8 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--disable-df-fetch"
     "--disable-df-verify"
-    "--enable-fdk-aac"
     (if useGtk then "--disable-gtk-update-checks" else "--disable-gtk")
+    (if useFdk then "--enable-fdk-aac"            else "")
   ];
 
   NIX_LDFLAGS = [


### PR DESCRIPTION
###### Motivation for this change

1. Enabling FDK by default violates GPL2 license of HandBrake.
https://github.com/HandBrake/HandBrake/issues/1273#issuecomment-380541329

2. They had skew back in time: https://forum.handbrake.fr/viewtopic.php?f=33&t=34143
This is a very serious question for them throught the years.

3. Nix HandBrake is marked GPL2. And as such also allowed in free NixOS space. FDK codec has a weird non-free license that is not compatible with GPL2.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---