### PR TITLE
handbrake: switch to libav_12

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -14,12 +14,14 @@
   autoconf, automake, cmake, libtool, m4, jansson,
   libass, libiconv, libsamplerate, fribidi, libxml2, bzip2,
   libogg, libopus, libtheora, libvorbis, libdvdcss, a52dec,
-  lame, ffmpeg, libdvdread, libdvdnav, libbluray,
+  lame, libdvdread, libdvdnav, libbluray,
   mp4v2, mpeg2dec, x264, x265, libmkv,
   fontconfig, freetype, hicolor-icon-theme,
   glib, gtk3, intltool, libnotify,
   gst_all_1, dbus-glib, udev, libgudev, libvpx,
-  useGtk ? true, wrapGAppsHook ? null, libappindicator-gtk3 ? null, useFdk ? false, fdk_aac ? null
+  useGtk ? true, wrapGAppsHook ? null, libappindicator-gtk3 ? null,
+  useFfmpeg ? false, libav_12 ? null, ffmpeg ? null,
+  useFdk ? false, fdk_aac ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -43,12 +45,13 @@ stdenv.mkDerivation rec {
     fribidi fontconfig freetype jansson zlib
     libass libiconv libsamplerate libxml2 bzip2
     libogg libopus libtheora libvorbis libdvdcss a52dec libmkv
-    lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264 x265 libvpx
-  ] ++ (lib.optionals useGtk [
+    lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264 x265 libvpx]
+    ++ lib.optionals useGtk [
     glib gtk3 libappindicator-gtk3 libnotify
     gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
-    libgudev
-  ]) ++ (lib.optionals useFdk [fdk_aac]);
+    libgudev]
+    ++ (if useFfmpeg then [ffmpeg] else [libav_12])
+    ++ lib.optional useFdk fdk_aac;
 
   dontUseCmakeConfigure = true;
 

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -37,21 +37,21 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake python2 pkgconfig yasm autoconf automake libtool m4
-  ] ++ (lib.optionals useGtk [
+  ] ++ lib.optionals useGtk [
     intltool wrapGAppsHook
-  ]);
+  ];
 
   buildInputs = [
     fribidi fontconfig freetype jansson zlib
     libass libiconv libsamplerate libxml2 bzip2
     libogg libopus libtheora libvorbis libdvdcss a52dec libmkv
-    lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264 x265 libvpx]
-    ++ lib.optionals useGtk [
+    lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264 x265 libvpx
+  ] ++ lib.optionals useGtk [
     glib gtk3 libappindicator-gtk3 libnotify
     gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
-    libgudev]
-    ++ (if useFfmpeg then [ffmpeg] else [libav_12])
-    ++ lib.optional useFdk fdk_aac;
+    libgudev
+  ] ++ (if useFfmpeg then [ ffmpeg ] else [ libav_12 ])
+  ++ lib.optional useFdk fdk_aac;
 
   dontUseCmakeConfigure = true;
 


### PR DESCRIPTION
###### Motivation for this change

Main contributors of HandBrake say that project is developed for `libav`:
https://github.com/HandBrake/HandBrake/issues/1273#issuecomment-380541329

It was tested that HandBrake works with never `libav_12` in our repositories.
Alternative to use `ffmpeg` included.
 
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---