### PR TITLE
maxima: add various fixes, re-add ecl support

### DIFF
--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, sbcl, texinfo, perl, python, makeWrapper, rlwrap ? null,
-tk ? null, gnuplot ? null, ecl ? null, ecl-fasl ? false
+{ stdenv, fetchurl, fetchpatch, sbcl, texinfo, perl, python, makeWrapper, rlwrap ? null
+, tk ? null, gnuplot ? null, ecl ? null, ecl-fasl ? false
 }:
 
 let
@@ -11,6 +11,7 @@ let
       (stdenv.lib.filter (x: x != null) [ sbcl ecl rlwrap tk gnuplot ]);
 in
 stdenv.mkDerivation ({
+  inherit version;
   name = "${name}-${version}";
 
   src = fetchurl {
@@ -18,8 +19,9 @@ stdenv.mkDerivation ({
     sha256 = "0x0n81z0s4pl8nwpf7ivlsbvsdphm9w42250g7qdkizl0132by6s";
   };
 
-  buildInputs = stdenv.lib.filter (x: x != null)
-    [sbcl ecl texinfo perl python makeWrapper];
+  buildInputs = stdenv.lib.filter (x: x != null) [
+    sbcl ecl texinfo perl python makeWrapper
+  ];
 
   postInstall = ''
     # Make sure that maxima can find its runtime dependencies.
@@ -35,6 +37,39 @@ stdenv.mkDerivation ({
      cp src/binary-ecl/maxima.fas* "$out/lib/maxima/${version}/binary-ecl/"
    '')
   ;
+
+  patches = [
+    # fix path to info dir (see https://trac.sagemath.org/ticket/11348)
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/infodir.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "09v64n60f7i6frzryrj0zd056lvdpms3ajky4f9p6kankhbiv21x";
+    })
+
+    # fix https://sourceforge.net/p/maxima/bugs/2596/
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/matrixexp.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "06961hn66rhjijfvyym21h39wk98sfxhp051da6gz0n9byhwc6zg";
+    })
+
+    # undo https://sourceforge.net/p/maxima/code/ci/f5e9b0f7eb122c4e48ea9df144dd57221e5ea0ca, see see https://trac.sagemath.org/ticket/13364#comment:93
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/undoing_true_false_printing_patch.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "0fvi3rcjv6743sqsbgdzazy9jb6r1p1yq63zyj9fx42wd1hgf7yx";
+    })
+
+    # upstream bug https://sourceforge.net/p/maxima/bugs/2520/ (not fixed)
+    # introduced in https://trac.sagemath.org/ticket/13364
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/0001-taylor2-Avoid-blowing-the-stack-when-diff-expand-isn.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "0xa0b6cr458zp7lc7qi0flv5ar0r3ivsqhjl0c3clv86di2y522d";
+    })
+  ] ++ stdenv.lib.optionals ecl-fasl [
+    # build fasl, needed for ECL support
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/maxima.system.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "18zafig8vflhkr80jq2ivk46k92dkszqlyq8cfmj0b2vcfjwwbar";
+    })
+  ];
 
   # Failures in the regression test suite won't abort the build process. We run
   # the suite only so that potential errors show up in the build log. See also:
@@ -57,10 +92,5 @@ stdenv.mkDerivation ({
 
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.peti ];
-    broken = ecl != null;
   };
-} // (stdenv.lib.optionalAttrs ecl-fasl {
-  preConfigure = ''
-    sed -e '/c::build-program "binary-ecl\/maxima"/i(c::build-fasl "binary-ecl\/maxima.fasl" :lisp-files obj :ld-flags (let ((x (symbol-value (find-symbol "*AUTOCONF-LD-FLAGS*" (find-package "MAXIMA"))))) (if (and x (not (string= x ""))) (list x))))' -i src/maxima.system
-  '';
-}))
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20144,6 +20144,7 @@ with pkgs;
   };
   maxima-ecl = callPackage ../applications/science/math/maxima {
     ecl = ecl_16_1_2;
+    ecl-fasl = true;
     sbcl = null;
   };
 


### PR DESCRIPTION
###### Motivation for this change

- re-add ecl support (there is one failing test, but it "basically works")
- add varioius patches that fix unresolved upstream issues (see individual comments)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

