### PR TITLE
avidemux: fix build with glibc 2.27

### DIFF
--- a/pkgs/applications/video/avidemux/default.nix
+++ b/pkgs/applications/video/avidemux/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, cmake, pkgconfig, lndir
+{ stdenv, lib, fetchurl, fetchpatch, cmake, pkgconfig, lndir
 , zlib, gettext, libvdpau, libva, libXv, sqlite
 , yasm, freetype, fontconfig, fribidi
 , makeWrapper, libXext, libGLU, qttools, qtbase
@@ -32,7 +32,15 @@ stdenv.mkDerivation rec {
     sha256 = "1bf4l9qwxq3smc1mx5pybydc742a4qqsk17z50j9550d9iwnn7gy";
   };
 
-  patches = [ ./dynamic_install_dir.patch ./bootstrap_logging.patch ];
+  patches = [
+    ./dynamic_install_dir.patch
+    ./bootstrap_logging.patch
+    # glibc 2.27 compat
+    (fetchpatch {
+      url = https://github.com/mean00/avidemux2/commit/afdd9c4b876d77a4974d3fa7d9f25caeffbdf13d.patch;
+      sha256 = "0mf8vpfdqybziqsfyvxwcdm3zsmnp64293icinhvfpq9xp5b6vn6";
+    })
+  ];
 
   nativeBuildInputs = [ yasm cmake pkgconfig ];
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Doesn't build with glibc 2.27.

/cc @abbradar @Ma27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

