### PR TITLE
dovecot module: test dovecot's LDA

### DIFF
--- a/nixos/tests/dovecot.nix
+++ b/nixos/tests/dovecot.nix
@@ -18,6 +18,18 @@ import ./make-test.nix {
         MAIL
       '';
 
+      sendTestMailViaDeliveryAgent = pkgs.writeScriptBin "send-lda" ''
+        #!${pkgs.stdenv.shell}
+
+        exec ${pkgs.dovecot}/libexec/dovecot/deliver -d bob <<MAIL
+        From: root@localhost
+        To: bob@localhost
+        Subject: Something else...
+
+        I'm running short of ideas!
+        MAIL
+      '';
+
       testImap = pkgs.writeScriptBin "test-imap" ''
         #!${pkgs.python3.interpreter}
         import imaplib
@@ -39,24 +51,25 @@ import ./make-test.nix {
 
         pop = poplib.POP3('localhost')
         try:
-          pop.user('alice')
+          pop.user('bob')
           pop.pass_('foobar')
           assert len(pop.list()[1]) == 1
           status, fullmail, size = pop.retr(1)
           assert status.startswith(b'+OK ')
           body = b"".join(fullmail[fullmail.index(b""):]).strip()
-          assert body == b'Hello world!'
+          assert body == b"I'm running short of ideas!"
         finally:
           pop.quit()
       '';
 
-    in [ sendTestMail testImap testPop ];
+    in [ sendTestMail sendTestMailViaDeliveryAgent testImap testPop ];
   };
 
   testScript = ''
     $machine->waitForUnit('postfix.service');
     $machine->waitForUnit('dovecot2.service');
     $machine->succeed('send-testmail');
+    $machine->succeed('send-lda');
     $machine->waitUntilFails('[ "$(postqueue -p)" != "Mail queue is empty" ]');
     $machine->succeed('test-imap');
     $machine->succeed('test-pop');


### PR DESCRIPTION
###### Motivation for this change

That's apparently not enough to catch the bug I ran into with the update to 2.3.1, but at least it will check the LDA appears to work.

If possible, I think a backport to 18.03 would be useful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

