### PR TITLE
scallion: init at 2.1

### DIFF
--- a/pkgs/tools/security/scallion/default.nix
+++ b/pkgs/tools/security/scallion/default.nix
@@ -26,11 +26,6 @@ stdenv.mkDerivation rec {
       --add-flags $out/share/scallion.exe
   '';
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/scallion -l  # list OpenCL devices (at least CPU to be found)
-  '';
-
   meta = with stdenv.lib; {
     description = "GPU-based tor hidden service name generator";
     homepage = src.meta.homepage;

--- a/pkgs/tools/security/scallion/default.nix
+++ b/pkgs/tools/security/scallion/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, makeWrapper, mono, openssl, ocl-icd }:
+
+stdenv.mkDerivation rec {
+  version = "2.1";
+  name = "scallion-${version}";
+
+  src = fetchFromGitHub {
+    owner = "lachesis";
+    repo = "scallion";
+    rev = "v${version}";
+    sha256 = "1l9aj101xpsaaa6kmmhmq68m6z8gzli1iaaf8xaxbivq0i7vka9k";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ mono ];
+
+  buildPhase = ''
+    xbuild scallion.sln
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp scallion/bin/Debug/* $out/share/
+    makeWrapper ${mono}/bin/mono $out/bin/scallion \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl ocl-icd ]} \
+      --add-flags $out/share/scallion.exe
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/scallion -l  # list OpenCL devices (at least CPU to be found)
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GPU-based tor hidden service name generator";
+    homepage = src.meta.homepage;
+    license = licenses.free;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ volth ];
+  };
+}

--- a/pkgs/tools/security/scallion/default.nix
+++ b/pkgs/tools/security/scallion/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "GPU-based tor hidden service name generator";
     homepage = src.meta.homepage;
-    license = licenses.free;
+    license = licenses.mit;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ volth ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4733,6 +4733,8 @@ with pkgs;
 
   sasview = callPackage ../applications/science/misc/sasview {};
 
+  scallion = callPackage ../tools/security/scallion { };
+
   scanbd = callPackage ../tools/graphics/scanbd { };
 
   screen = callPackage ../tools/misc/screen {


### PR DESCRIPTION
###### Motivation for this change

A GPU-based tor hidden service name generator
We have  ```eschalot``` here, which is CPU-only

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

