### PR TITLE
top-level: apply platform config to cross system

### DIFF
--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -53,15 +53,15 @@ in let
     then configExpr { inherit pkgs; }
     else configExpr;
 
+  # Allow setting the platform in the config file. This take precedence over
+  # the inferred platform, but not over an explicitly passed-in one.
+  configPlatform = builtins.intersectAttrs { platform = null; } config;
+
   # From a minimum of `system` or `config` (actually a target triple, *not*
   # nixpkgs configuration), infer the other one and platform as needed.
-  localSystem = lib.systems.elaborate (
-    # Allow setting the platform in the config file. This take precedence over
-    # the inferred platform, but not over an explicitly passed-in one.
-    builtins.intersectAttrs { platform = null; } config
-    // args.localSystem);
+  localSystem = lib.systems.elaborate ((if crossSystem0 == null then configPlatform else {}) // args.localSystem);
 
-  crossSystem = lib.mapNullable lib.systems.elaborate crossSystem0;
+  crossSystem = lib.mapNullable lib.systems.elaborate (if crossSystem0 != null then crossSystem0 // configPlatform else null);
 
   # A few packages make a new package set to draw their dependencies from.
   # (Currently to get a cross tool chain, or forced-i686 package.) Rather than


### PR DESCRIPTION
###### Motivation for this change

It is impossible to use the option `nixpkgs.config.platform` to set the platform when cross compiling, because it is not passed to `crossSystem`.

###### Things done

This PR elaborates `crossSystem` using `config.platform` when `crossSystem` is not null, and retains the current behavior when it is null. Someone who knows more about the internals of nixpkgs may have a more elegant way of doing this, but this solution solves the problem for me.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

