### PR TITLE
nixos/prosody: add user/group options, fix pidfile path

### DIFF
--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -439,7 +439,7 @@ in
 
     environment.etc."prosody/prosody.cfg.lua".text = ''
 
-      pidfile = "${cfg.dataDir}/prosody.pid"
+      pidfile = "/run/prosody/prosody.pid"
 
       log = "*syslog"
 
@@ -509,7 +509,8 @@ in
         User = cfg.user;
         Group = cfg.group;
         Type = "forking";
-        PIDFile = "${cfg.dataDir}/prosody.pid";
+        RuntimeDirectory = [ "prosody" ];
+        PIDFile = "/run/prosody/prosody.pid";
         ExecStart = "${cfg.package}/bin/prosodyctl start";
       };
     };

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -301,6 +301,18 @@ in
         default = "/var/lib/prosody";
       };
 
+      user = mkOption {
+        type = types.str;
+        default = "prosody";
+        description = "User account under which prosody runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "prosody";
+        description = "Group account under which prosody runs.";
+      };
+
       allowRegistration = mkOption {
         type = types.bool;
         default = false;
@@ -475,15 +487,15 @@ in
         '') cfg.virtualHosts) }
     '';
 
-    users.extraUsers.prosody = {
+    users.extraUsers.prosody = mkIf (cfg.user == "prosody") {
       uid = config.ids.uids.prosody;
       description = "Prosody user";
       createHome = true;
-      group = "prosody";
+      inherit (cfg) group;
       home = "${cfg.dataDir}";
     };
 
-    users.extraGroups.prosody = {
+    users.extraGroups.prosody = mkIf (cfg.group == "prosody") {
       gid = config.ids.gids.prosody;
     };
 
@@ -494,7 +506,8 @@ in
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ config.environment.etc."prosody/prosody.cfg.lua".source ];
       serviceConfig = {
-        User = "prosody";
+        User = cfg.user;
+        Group = cfg.group;
         Type = "forking";
         PIDFile = "${cfg.dataDir}/prosody.pid";
         ExecStart = "${cfg.package}/bin/prosodyctl start";


### PR DESCRIPTION
###### Motivation for this change

Prosody service options needed improvement
- There were no user/group setting
- The pidfile was in the `dataDir`, not under `/run` as usual

###### Things done

- added `services.prosody.user` and `services.prosody.group` options and implementation
- changed pidfile path, added `RuntimeDirectory` to systemd service config

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

