### PR TITLE
Introducing NetBSD userland

### DIFF
--- a/pkgs/build-support/fetchcvs/builder.sh
+++ b/pkgs/build-support/fetchcvs/builder.sh
@@ -1,5 +1,11 @@
 source $stdenv/setup
 
+(echo '#!/usr/bin/env sh'; \
+ echo 'echo $@'; \
+ echo 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$@"') > ssh
+chmod +x ssh
+export CVS_RSH=$PWD/ssh
+
 # creating the export drictory and checking out there only to be able to
 # move the content without the root directory into $out ...
 # cvs -f -d "$url" export $tag -d "$out" "$module"

--- a/pkgs/build-support/fetchcvs/builder.sh
+++ b/pkgs/build-support/fetchcvs/builder.sh
@@ -1,7 +1,6 @@
 source $stdenv/setup
 
 (echo '#!/usr/bin/env sh'; \
- echo 'echo $@'; \
  echo 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$@"') > ssh
 chmod +x ssh
 export CVS_RSH=$PWD/ssh

--- a/pkgs/build-support/fetchcvs/default.nix
+++ b/pkgs/build-support/fetchcvs/default.nix
@@ -3,18 +3,18 @@
 # tag="<tagname>" (get version by tag name)
 # If you don't specify neither one date="NOW" will be used (get latest)
 
-{stdenvNoCC, cvs}:
+{stdenvNoCC, cvs, openssh}:
 
 {cvsRoot, module, tag ? null, date ? null, sha256}:
 
 stdenvNoCC.mkDerivation {
   name = "cvs-export";
   builder = ./builder.sh;
-  nativeBuildInputs = [cvs];
+  nativeBuildInputs = [cvs openssh];
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
   outputHash = sha256;
-  
+
   inherit cvsRoot module sha256 tag date;
 }

--- a/pkgs/os-specific/bsd/default.nix
+++ b/pkgs/os-specific/bsd/default.nix
@@ -1,0 +1,8 @@
+{ callPackages, recurseIntoAttrs }:
+
+rec {
+  netbsd = recurseIntoAttrs (callPackages ./netbsd {});
+  openbsd = recurseIntoAttrs (callPackages ./openbsd {
+    inherit (netbsd) compat netBSDDerivation libcurses;
+  });
+}

--- a/pkgs/os-specific/bsd/netbsd/compat-setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/compat-setup-hook.sh
@@ -1,0 +1,18 @@
+setupCompatFlags() {
+    # The `depHostOffset` describes how the host platform of the dependencies
+    # are slid relative to the depending package. It is brought into scope of
+    # the environment hook defined as the role of the dependency being applied.
+    case $depHostOffset in
+        -1) local role='BUILD_' ;;
+        0)  local role='' ;;
+        1)  local role='TARGET_' ;;
+        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
+            return 1 ;;
+    esac
+
+    export NIX_${role}LDFLAGS+=" -lnbcompat"
+    export NIX_${role}CFLAGS_COMPILE+=" -DHAVE_NBTOOL_CONFIG_H"
+    export NIX_${role}CFLAGS_COMPILE+=" -include nbtool_config.h"
+}
+
+addEnvHooks "$hostOffset" setupCompatFlags

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,0 +1,404 @@
+{ stdenv, hostPlatform, fetchcvs, lib, groff, mandoc, zlib, coreutils
+, yacc, flex, libressl, bash }:
+
+let
+  fetchNetBSD = path: version: sha256: fetchcvs {
+    cvsRoot = ":pserver:anoncvs@anoncvs.NetBSD.org:/cvsroot";
+    module = "src/${path}";
+    inherit sha256;
+    tag = "netbsd-${builtins.replaceStrings ["."] ["-"] version}-RELEASE";
+  };
+
+  netBSDDerivation = attrs: stdenv.mkDerivation ((rec {
+    name = "${attrs.pname or (baseNameOf attrs.path)}-netbsd-${attrs.version}";
+    src = fetchNetBSD attrs.path attrs.version attrs.sha256;
+
+    extraPaths = [ ];
+
+    nativeBuildInputs = [ makeMinimal mandoc groff install yacc flex ];
+    buildInputs = [ compat ];
+    installFlags = [ "includes" ];
+
+    # These should be coverd in nbcompat, but are missing, sadly
+    NIX_CFLAGS_COMPILE = [
+      "-D__noinline="
+      "-D__warn_references(a,b)="
+      "-D__strong_alias(a,b)="
+      "-D__va_list=va_list"
+    ];
+
+    # Definitions passed to share/mk/*.mk. Should be pretty simple -
+    # eventually maybe move it to a configure script.
+    DESTDIR = "$(out)";
+    TOOLDIR = "$(out)";
+    USETOOLS = "never";
+    NOCLANGERROR="yes";
+    NOGCCERROR="yes";
+    LEX = "flex";
+
+    # libs will be provided by cc-wrapper
+    LIBCRT0="";
+    LIBCRTI="";
+    LIBCRTEND="";
+    LIBCRTBEGIN="";
+    LIBC="";
+    LIBUTIL="";
+    LIBSSL = "";
+    LIBCRYPTO = "";
+    LIBCURSES = "";
+    "LIBDO.terminfo" = "_external";
+    _GCC_CRTBEGIN = "";
+    _GCC_CRTBEGINS = "";
+    _GCC_CRTEND = "";
+    _GCC_CRTENDS = "";
+    _GCC_LIBGCCDIR = "";
+    _GCC_CRTI = "";
+    _GCC_CRTDIR = "";
+    _GCC_CRTN = "";
+
+    # all dirs will be prefixed with DESTDIR
+    BINDIR = "/bin";
+    LIBDIR = "/lib";
+    SHLIBDIR = "/lib";
+    MANDIR = "/share/man";
+    INFODIR = "/share/info";
+    DOCDIR = "/share/doc";
+    LOCALEDIR = "/share/locale";
+    X11BINDIR = "/bin";
+    X11USRLIBDIR = "/lib";
+    X11MANDIR = "/share/man";
+    SHLINKDIR = "/usr/libexec";
+
+    HOST_SH = "${bash}/bin/sh";
+
+    # not using bsd binutils
+    SHLIB_WARNTEXTREL = "no";
+    SHLIB_MKMAP = "no";
+    OBJCOPY = "true";
+    PRESERVE = "-p";
+
+    MACHINE_ARCH = hostPlatform.parsed.cpu.name;
+    MACHINE_CPU = hostPlatform.parsed.cpu.name;
+
+    # NetBSD makefiles should be able to detect this
+    # but without they end up using gcc on Darwin stdenv
+    preConfigure = ''
+      export HAVE_${if stdenv.cc.isGNU then "GCC" else "LLVM"}=${lib.head (lib.splitString "." (lib.getVersion stdenv.cc.cc))}
+    '' + lib.optionalString (!builtins.hasAttr "nativeBuildInputs" attrs) ''
+      # hack until #38657 is fixed
+      export PATH=${install}/bin:$PATH
+    '';
+
+    postUnpack = ''
+      # merge together all extra paths
+      # there should be a better way to do this
+      sourceRoot=$PWD/$sourceRoot
+      export NETBSDSRCDIR=$sourceRoot
+      export BSDSRCDIR=$NETBSDSRCDIR
+      chmod -R u+w $sourceRoot
+      for path in $extraPaths; do
+        cd $path
+        find . -type d -exec mkdir -p $sourceRoot/\{} \;
+        find . -type f -exec cp -pr \{} $sourceRoot/\{} \;
+        chmod -R u+w $sourceRoot
+      done
+
+      cd $sourceRoot
+      if [ -d ${attrs.path} ]
+        then sourceRoot=$sourceRoot/${attrs.path}
+      fi
+    '';
+
+    # need to create directories for xinstall to work
+    preInstall = ''
+      mkdir -p $out$BINDIR $out$LIBDIR $out$INFODIR \
+               $out$DOCDIR $out$LOCALEDIR
+      for i in 1 2 3 4 5 6 7 8 9; do
+        mkdir -p $out$MANDIR/man$i $out$MANDIR/html$i
+      done
+      mkdir -p $out/usr/include
+    '';
+
+    postInstall = ''
+      # Remove lingering /usr references
+      if [ -d $out/usr ]; then
+        cd $out/usr
+        find . -type d -exec mkdir -p $out/\{} \;
+        find . -type f -exec mv \{} $out/\{} \;
+        find . -type d -delete
+      fi
+
+      find $out -type d -empty -delete
+    '';
+
+    meta = with lib; {
+      maintainers = with maintainers; [matthewbauer];
+      platforms = platforms.unix;
+      license = licenses.bsd2;
+    };
+  }) // attrs);
+
+  # BOOTSTRAPPING
+  makeMinimal = netBSDDerivation rec {
+    path = "tools/make";
+    sha256 = "0l4794zwj2haark3azf9xwcwqlkbrifhb2glaa9iba4dkg2mklsb";
+    version = "7.1.2";
+
+    buildInputs = [];
+    nativeBuildInputs = [];
+    NIX_CFLAGS_COMPILE = "";
+    NIX_LDFLAGS = "";
+
+    patchPhase = ''
+      patchShebangs configure
+      ${make.patchPhase}
+    '';
+    buildPhase = "sh ./buildmake.sh";
+    installPhase = ''
+      install -D nbmake $out/bin/nbmake
+      ln -s $out/bin/nbmake $out/bin/make
+      mkdir -p $out/share
+      cp -r ../../share/mk $out/share/mk
+    '';
+    extraPaths = [ make.src ] ++ make.extraPaths;
+  };
+
+  compat = netBSDDerivation {
+    path = "tools/compat";
+    sha256 = "17phkfafybxwhzng44k5bhmag6i55br53ky1nwcmw583kg2fa86z";
+    version = "7.1.2";
+
+    setupHook = ./compat-setup-hook.sh;
+
+    # override defaults to prevent infinite recursion
+    nativeBuildInputs = [ makeMinimal ];
+    buildInputs = [ zlib ];
+    NIX_CFLAGS_COMPILE = "";
+    NIX_LDFLAGS = "";
+
+    # temporarily use gnuinstall for bootstrapping
+    # bsdinstall will be built later
+    makeFlags = "INSTALL=${coreutils}/bin/install";
+    RENAME = "-D";
+
+    postInstall = ''
+      mv $out/include/compat/* $out/include
+      rmdir $out/include/compat
+
+      # why aren't these installed by netbsd?
+      install -D compat_defs.h $out/include/compat_defs.h
+      install -D $NETBSDSRCDIR/include/cdbw.h $out/include/cdbw.h
+      install -D $NETBSDSRCDIR/sys/sys/cdbr.h $out/include/cdbr.h
+      install -D $NETBSDSRCDIR/sys/sys/featuretest.h \
+                 $out/include/sys/featuretest.h
+      install -D $NETBSDSRCDIR/sys/sys/md5.h $out/include/md5.h
+      install -D $NETBSDSRCDIR/sys/sys/rmd160.h $out/include/rmd160.h
+      install -D $NETBSDSRCDIR/sys/sys/sha1.h $out/include/sha1.h
+      install -D $NETBSDSRCDIR/sys/sys/sha2.h $out/include/sha2.h
+    '';
+    extraPaths = [ libc.src libutil.src
+      (fetchNetBSD "include" "7.1.2" "1vc58xrhrp202biiv1chhlh0jwnjr7k3qq91pm46k6v5j95j0qwp")
+      (fetchNetBSD "external/bsd/flex" "7.1.2" "0m0m72r3zzc9gi432h3xkqdzspr4n0hj4m8h7j74pwbvpfg9d9qq")
+      (fetchNetBSD "sys/sys" "7.1.2" "1vwnv5nk7rlgn5w9nkdqj9652hmwmfwqxj3ymcz0zk10abbaib93")
+    ] ++ libutil.extraPaths ++ libc.extraPaths;
+  };
+
+  install = netBSDDerivation {
+    path = "usr.bin/xinstall";
+    version = "7.1.2";
+    sha256 = "0nzhyh714m19h61m45gzc5dszkbafp5iaphbp5mza6w020fzf2y8";
+    extraPaths = [ mtree.src make.src ];
+    nativeBuildInputs = [ makeMinimal mandoc groff compat ];
+    RENAME = "-D";
+  };
+  # END BOOTSTRAPPING
+
+  libutil = netBSDDerivation {
+    path = "lib/libutil";
+    version = "7.1.2";
+    sha256 = "12848ynizz13mvn2kndrkq482xhkw323b7c8fg0zli1nhfsmwsm8";
+    extraPaths = [
+      (fetchNetBSD "common/lib/libutil" "7.1.2" "0q3ixrf36lip1dx0gafs0a03qfs5cs7n0myqq7af4jpjd6kh1831")
+    ];
+  };
+
+  libc = netBSDDerivation {
+    path = "lib/libc";
+    version = "7.1.2";
+    sha256 = "13rcx3mbx2644z01zgk9gggdfr0hqdbsvd7zrsm2l13yf9aix6pg";
+    extraPaths = [
+      (fetchNetBSD "common/lib/libc" "7.1.2" "1va8zd4lqyrc1d0c9q04r8y88cfxpkhwcxasggxxvhksd3khkpha")
+    ];
+  };
+
+  make = netBSDDerivation {
+    path = "usr.bin/make";
+    sha256 = "0srkkg6qdzqlccfi4xh19gl766ks6hpss76bnfvwmd0zg4q4zdar";
+    version = "7.1.2";
+    patchPhase = ''
+      # make needs this to pick up our sys make files
+      NIX_CFLAGS_COMPILE+=" -D_PATH_DEFSYSPATH=\"$out/share/mk\""
+
+      # can't set owner or group in Nix build
+      # maybe there is a better way to trick it?
+      substituteInPlace $NETBSDSRCDIR/share/mk/bsd.prog.mk \
+        --replace '-o ''${SCRIPTSOWN_''${.ALLSRC:T}:U''${SCRIPTSOWN}}' "" \
+        --replace '-g ''${SCRIPTSGRP_''${.ALLSRC:T}:U''${SCRIPTSGRP}}' "" \
+        --replace '-o ''${RUMPBINOWN} -g ''${RUMPBINGRP}' "" \
+        --replace '-o ''${BINOWN} -g ''${BINGRP}' "" \
+        --replace '-o ''${RUMPBINOWN} -g ''${RUMPBINGRP}' "" \
+        --replace '-o ''${DEBUGOWN} -g ''${DEBUGGRP}' ""
+      substituteInPlace $NETBSDSRCDIR/share/mk/bsd.doc.mk \
+        --replace '-o ''${DOCOWN} -g ''${DOCGRP}' ""
+      substituteInPlace $NETBSDSRCDIR/share/mk/bsd.man.mk \
+        --replace '-o ''${MANOWN} -g ''${MANGRP}' ""
+      substituteInPlace $NETBSDSRCDIR/share/mk/bsd.files.mk \
+        --replace '-o ''${FILESOWN_''${.ALLSRC:T}:U''${FILESOWN}}' "" \
+        --replace '-g ''${FILESGRP_''${.ALLSRC:T}:U''${FILESGRP}}' ""
+      substituteInPlace $NETBSDSRCDIR/share/mk/bsd.inc.mk \
+        --replace '-o ''${BINOWN} -g ''${BINGRP}' ""
+      substituteInPlace $NETBSDSRCDIR/share/mk/bsd.lib.mk \
+        --replace '-o ''${DEBUGOWN} -g ''${DEBUGGRP}' "" \
+        --replace '-o ''${LIBOWN} -g ''${LIBGRP}' ""
+
+      substituteInPlace $NETBSDSRCDIR/share/mk/Makefile \
+        --replace /usr/share/mk /share/mk
+      substituteInPlace $NETBSDSRCDIR/share/mk/bsd.sys.mk \
+        --replace '-Wl,--fatal-warnings' ""
+      substituteInPlace $NETBSDSRCDIR/share/mk/bsd.lib.mk \
+        --replace ' ''${_ARFL} ''${.TARGET} `NM=''${NM} ''${LORDER} ''${.ALLSRC:M*o} | ''${TSORT}`' ' ''${_ARFL} ''${.TARGET} ''${.ALLSRC:M*o}' \
+        --replace '-Wl,-soname,''${_LIB}.so.''${SHLIB_SOVERSION}' "" \
+        --replace '-Wl,--whole-archive' "" \
+        --replace '-Wl,--no-whole-archive' ""
+    '';
+    postInstall = ''
+      (cd $NETBSDSRCDIR/share/mk && make install)
+    '';
+    extraPaths = [
+      (fetchNetBSD "share/mk" "7.1.2" "0570v0siv0wygn8ygs1yy9pgk9xjw9x1axr5qg4xrddv3lskf9xa")
+    ];
+  };
+
+  mtree = netBSDDerivation {
+    path = "usr.sbin/mtree";
+    version = "7.1.2";
+    sha256 = "1dhsyfvcm67kf5zdbg5dmx5y8fimnbll6qxwp3gjfmbxqigmc52m";
+  };
+
+in rec {
+  inherit compat libc libutil install make mtree netBSDDerivation;
+
+  getent = netBSDDerivation {
+    path = "usr.bin/getent";
+    sha256 = "1ylhw4dnpyrmcy8n5kjcxywm8qc9p124dqnm17x4magiqx1kh9iz";
+    version = "7.1.2";
+    patches = [ ./getent.patch ];
+  };
+
+  getconf = netBSDDerivation {
+    path = "usr.bin/getconf";
+    sha256 = "122vslz4j3h2mfs921nr2s6m078zcj697yrb75rwp2hnw3qz4s8q";
+    version = "7.1.2";
+  };
+
+  fts = netBSDDerivation {
+    pname = "fts";
+    path = "include/fts.h";
+    sha256 = "01d4fpxvz1pgzfk5xznz5dcm0x0gdzwcsfm1h3d0xc9kc6hj2q77";
+    version = "7.1.2";
+    nativeBuildInputs = [ ];
+    extraPaths = [
+      (fetchNetBSD "lib/libc/gen/fts.c" "7.1.2" "1yfd2liypj6xky2h0mgxi5lgpflmkkg4zf3ii3apz5cf8jq9gmn9")
+      (fetchNetBSD "lib/libc/include/namespace.h" "7.1.2" "0kwd4v8y0mfjhmwplsk52pvzbcpvpp2qy2g8c0jmfraam63q6q1y")
+      (fetchNetBSD "lib/libc/gen/fts.3" "7.1.2" "1asxw0n3fhjdadwkkq3xplfgqgl3q32w1lyrvbakfa3gs0wz5zc1")
+    ];
+    buildPhase = ''
+      cc  -c -Iinclude -Ilib/libc/include lib/libc/gen/fts.c \
+          -o lib/libc/gen/fts.o
+      ar -rsc libfts.a lib/libc/gen/fts.o
+    '';
+    installPhase = ''
+      install -D lib/libc/gen/fts.3 $out/share/man/man3/fts.3
+      install -D include/fts.h $out/include/fts.h
+      install -D lib/libc/include/namespace.h $out/include/namespace.h
+      install -D libfts.a $out/lib/libfts.a
+    '';
+    setupHook = ./fts-setup-hook.sh;
+  };
+
+  games = netBSDDerivation {
+    path = "games";
+    sha256 = "04wjsang8f8kxsifiayklbxaaxmm3vx9rfr91hfbxj4hk8gkqzy1";
+    version = "7.1.2";
+    patchPhase = ''
+      sed -i '1i #include <time.h>' adventure/save.c
+    '';
+  };
+
+  who = netBSDDerivation {
+    path = "usr.bin/who";
+    version = "7.1.2";
+    sha256 = "17ffwww957m3qw0b6fkgjpp12pd5ydg2hs9dxkkw0qpv11j00d88";
+  };
+
+  finger = netBSDDerivation {
+    path = "usr.bin/finger";
+    sha256 = "0jl672z50f2yf7ikp682b3xrarm6bnrrx9vi94xnp2fav8m8zfyi";
+    version = "7.1.2";
+    extraPaths = [ who.src ];
+  };
+
+  fingerd = netBSDDerivation {
+    path = "usr.bin/fingerd";
+    sha256 = "04wjsang8f8kxsifiayklbxaaxmm3vx9rfr91hfbxj4hk8gkqz00";
+    version = "7.1.2";
+  };
+
+  libedit = netBSDDerivation {
+    path = "lib/libedit";
+    buildInputs = [ compat libterminfo ];
+    patchPhase = ''
+      sed -i '1i #undef bool_t' el.h
+    '';
+    version = "7.1.2";
+    sha256 = "0qvr52j4qih10m7fa8nddn1psyjy9l0pa4ix02acyssjvgbz2kca";
+  };
+
+  libterminfo = netBSDDerivation {
+    path = "lib/libterminfo";
+    version = "7.1.2";
+    sha256 = "06plg0bjqgbb0aghpb9qlk8wkp1l2izdlr64vbr5laqyw8jg84zq";
+    buildInputs = [ compat tic nbperf ];
+    extraPaths = [
+      (fetchNetBSD "share/terminfo" "7.1.2" "1z5vzq8cw24j05r6df4vd6r57cvdbv7vbm4h962kplp14xrbg2h3")
+    ];
+  };
+
+  libcurses = netBSDDerivation {
+    path = "lib/libcurses";
+    version = "7.1.2";
+    sha256 = "04djah9dadzw74nswn0xydkxn900kav8xdvxlxdl50nbrynxg9yf";
+    buildInputs = [ compat libterminfo ];
+    MKDOC = "no"; # missing vfontedpr
+  };
+
+  nbperf = netBSDDerivation {
+    path = "usr.bin/nbperf";
+    version = "7.1.2";
+    sha256 = "0gzm0zv2400lasnsswnjw9bwzyizhxzdbrcjwcl1k65aj86aqyqb";
+  };
+
+  tic = netBSDDerivation {
+    path = "tools/tic";
+    version = "7.1.2";
+    sha256 = "092y7db7k4kh2jq8qc55126r5qqvlb8lq8mhmy5ipbi36hwb4zrz";
+    HOSTPROG = "tic";
+    buildInputs = [ compat nbperf ];
+    extraPaths = [
+      libterminfo.src
+      (fetchNetBSD "usr.bin/tic" "7.1.2" "1ghwsaag4gbwvgp3lfxscnh8hn27n8cscwmgjwp3bkx5vl85nfsa")
+      (fetchNetBSD "tools/Makefile.host" "7.1.2" "076r3amivb6xranpvqjmg7x5ibj4cbxaa3z2w1fh47h7d55dw9w8")
+    ];
+  };
+
+}

--- a/pkgs/os-specific/bsd/netbsd/fts-setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/fts-setup-hook.sh
@@ -1,0 +1,16 @@
+ftsLdflags() {
+    # The `depHostOffset` describes how the host platform of the dependencies
+    # are slid relative to the depending package. It is brought into scope of
+    # the environment hook defined as the role of the dependency being applied.
+    case $depHostOffset in
+        -1) local role='BUILD_' ;;
+        0)  local role='' ;;
+        1)  local role='TARGET_' ;;
+        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
+            return 1 ;;
+    esac
+
+    export NIX_${role}LDFLAGS+=" -lfts"
+}
+
+addEnvHooks "$hostOffset" ftsLdflags

--- a/pkgs/os-specific/bsd/netbsd/getent.patch
+++ b/pkgs/os-specific/bsd/netbsd/getent.patch
@@ -1,0 +1,455 @@
+Author: Matthew Bauer
+Description: Remove unavailable getent databases
+Version: 7.1.2
+--- a/getent.c	2018-04-16 13:33:49.000000000 -0500
++++ b/getent.c	2018-04-16 13:29:30.000000000 -0500
+@@ -42,7 +42,6 @@
+ #include <grp.h>
+ #include <limits.h>
+ #include <netdb.h>
+-#include <netgroup.h>
+ #include <pwd.h>
+ #include <stdio.h>
+ #include <stdarg.h>
+@@ -57,27 +56,16 @@
+ #include <arpa/nameser.h>
+ 
+ #include <net/if.h>
+-#include <net/if_ether.h>
+ 
+ #include <netinet/in.h>		/* for INET6_ADDRSTRLEN */
+ 
+-#include <rpc/rpcent.h>
+-
+-#include <disktab.h>
+-
+ static int	usage(void) __attribute__((__noreturn__));
+ static int	parsenum(const char *, unsigned long *);
+-static int	disktab(int, char *[]);
+-static int	gettytab(int, char *[]);
+-static int	ethers(int, char *[]);
+ static int	group(int, char *[]);
+ static int	hosts(int, char *[]);
+-static int	netgroup(int, char *[]);
+ static int	networks(int, char *[]);
+ static int	passwd(int, char *[]);
+-static int	printcap(int, char *[]);
+ static int	protocols(int, char *[]);
+-static int	rpc(int, char *[]);
+ static int	services(int, char *[]);
+ static int	shells(int, char *[]);
+ 
+@@ -92,17 +80,11 @@
+ 	const char	*name;
+ 	int		(*callback)(int, char *[]);
+ } databases[] = {
+-	{	"disktab",	disktab,	},
+-	{	"ethers",	ethers,		},
+-	{	"gettytab",	gettytab,	},
+ 	{	"group",	group,		},
+ 	{	"hosts",	hosts,		},
+-	{	"netgroup",	netgroup,	},
+ 	{	"networks",	networks,	},
+ 	{	"passwd",	passwd,		},
+-	{	"printcap",	printcap,	},
+ 	{	"protocols",	protocols,	},
+-	{	"rpc",		rpc,		},
+ 	{	"services",	services,	},
+ 	{	"shells",	shells,		},
+ 
+@@ -195,49 +177,6 @@
+ 	(void)printf("\n");
+ }
+ 
+-
+-		/*
+-		 * ethers
+-		 */
+-
+-static int
+-ethers(int argc, char *argv[])
+-{
+-	char		hostname[MAXHOSTNAMELEN + 1], *hp;
+-	struct ether_addr ea, *eap;
+-	int		i, rv;
+-
+-	assert(argc > 1);
+-	assert(argv != NULL);
+-
+-#define ETHERSPRINT	(void)printf("%-17s  %s\n", ether_ntoa(eap), hp)
+-
+-	rv = RV_OK;
+-	if (argc == 2) {
+-		warnx("Enumeration not supported on ethers");
+-		rv = RV_NOENUM;
+-	} else {
+-		for (i = 2; i < argc; i++) {
+-			if ((eap = ether_aton(argv[i])) == NULL) {
+-				eap = &ea;
+-				hp = argv[i];
+-				if (ether_hostton(hp, eap) != 0) {
+-					rv = RV_NOTFOUND;
+-					break;
+-				}
+-			} else {
+-				hp = hostname;
+-				if (ether_ntohost(hp, eap) != 0) {
+-					rv = RV_NOTFOUND;
+-					break;
+-				}
+-			}
+-			ETHERSPRINT;
+-		}
+-	}
+-	return rv;
+-}
+-
+ 		/*
+ 		 * group
+ 		 */
+@@ -298,7 +237,7 @@
+ hosts(int argc, char *argv[])
+ {
+ 	struct hostent	*he;
+-	char		addr[IN6ADDRSZ];
++	char		addr[NS_IN6ADDRSZ];
+ 	int		i, rv;
+ 
+ 	assert(argc > 1);
+@@ -312,9 +251,9 @@
+ 	} else {
+ 		for (i = 2; i < argc; i++) {
+ 			if (inet_pton(AF_INET6, argv[i], (void *)addr) > 0)
+-				he = gethostbyaddr(addr, IN6ADDRSZ, AF_INET6);
++				he = gethostbyaddr(addr, NS_IN6ADDRSZ, AF_INET6);
+ 			else if (inet_pton(AF_INET, argv[i], (void *)addr) > 0)
+-				he = gethostbyaddr(addr, INADDRSZ, AF_INET);
++				he = gethostbyaddr(addr, NS_INADDRSZ, AF_INET);
+ 			else
+ 				he = gethostbyname(argv[i]);
+ 			if (he != NULL)
+@@ -330,48 +269,6 @@
+ }
+ 
+ 		/*
+-		 * netgroup
+-		 */
+-static int
+-netgroup(int argc, char *argv[])
+-{
+-	int		rv, i;
+-	bool		first;
+-	const char	*host, *user, *domain;
+-
+-	assert(argc > 1);
+-	assert(argv != NULL);
+-
+-#define NETGROUPPRINT(s)	(((s) != NULL) ? (s) : "")
+-
+-	rv = RV_OK;
+-	if (argc == 2) {
+-		warnx("Enumeration not supported on netgroup");
+-		rv = RV_NOENUM;
+-	} else {
+-		for (i = 2; i < argc; i++) {
+-			setnetgrent(argv[i]);
+-			first = true;
+-			while (getnetgrent(&host, &user, &domain) != 0) {
+-				if (first) {
+-					first = false;
+-					(void)fputs(argv[i], stdout);
+-				}
+-				(void)printf(" (%s,%s,%s)",
+-				    NETGROUPPRINT(host),
+-				    NETGROUPPRINT(user),
+-				    NETGROUPPRINT(domain));
+-			}
+-			if (!first)
+-				(void)putchar('\n');
+-			endnetgrent();
+-		}
+-	}
+-
+-	return rv;
+-}
+-
+-		/*
+ 		 * networks
+ 		 */
+ 
+@@ -464,227 +361,6 @@
+ 	return rv;
+ }
+ 
+-static char *
+-mygetent(const char * const * db_array, const char *name)
+-{
+-	char *buf = NULL;
+-	int error;
+-
+-	switch (error = cgetent(&buf, db_array, name)) {
+-	case -3:
+-		warnx("tc= loop in record `%s' in `%s'", name, db_array[0]);
+-		break;
+-	case -2:
+-		warn("system error fetching record `%s' in `%s'", name,
+-		    db_array[0]);
+-		break;
+-	case -1:
+-	case 0:
+-		break;
+-	case 1:
+-		warnx("tc= reference not found in record for `%s' in `%s'",
+-		    name, db_array[0]);
+-		break;
+-	default:
+-		warnx("unknown error %d in record `%s' in `%s'", error, name,
+-		    db_array[0]);
+-		break;
+-	}
+-	return buf;
+-}
+-
+-static char *
+-mygetone(const char * const * db_array, int first)
+-{
+-	char *buf = NULL;
+-	int error;
+-
+-	switch (error = (first ? cgetfirst : cgetnext)(&buf, db_array)) {
+-	case -2:
+-		warnx("tc= loop in `%s'", db_array[0]);
+-		break;
+-	case -1:
+-		warn("system error fetching record in `%s'", db_array[0]);
+-		break;
+-	case 0:
+-	case 1:
+-		break;
+-	case 2:
+-		warnx("tc= reference not found in `%s'", db_array[0]);
+-		break;
+-	default:
+-		warnx("unknown error %d in `%s'", error, db_array[0]);
+-		break;
+-	}
+-	return buf;
+-}
+-
+-static void
+-capprint(const char *cap)
+-{
+-	char *c = strchr(cap, ':');
+-	if (c)
+-		if (c == cap)
+-			(void)printf("true\n");
+-		else {
+-			int l = (int)(c - cap);
+-			(void)printf("%*.*s\n", l, l, cap);
+-		}
+-	else
+-		(void)printf("%s\n", cap);
+-}
+-
+-static void
+-prettyprint(char *b)
+-{
+-#define TERMWIDTH 65
+-	int did = 0;
+-	size_t len;
+-	char *s, c;
+-
+-	for (;;) {
+-		len = strlen(b);
+-		if (len <= TERMWIDTH) {
+-done:
+-			if (did)
+-				printf("\t:");
+-			printf("%s\n", b);
+-			return;
+-		}
+-		for (s = b + TERMWIDTH; s > b && *s != ':'; s--)
+-			continue;
+-		if (*s++ != ':')
+-			goto done;
+-		c = *s;
+-		*s = '\0';
+-		if (did)
+-			printf("\t:");
+-		did++;
+-		printf("%s\\\n", b);
+-		*s = c;
+-		b = s;
+-	}
+-}
+-
+-static void
+-handleone(const char * const *db_array, char *b, int recurse, int pretty,
+-    int level)
+-{
+-	char *tc;
+-
+-	if (level && pretty)
+-		printf("\n");
+-	if (pretty)
+-		prettyprint(b);
+-	else
+-		printf("%s\n", b);
+-	if (!recurse || cgetstr(b, "tc", &tc) <= 0)
+-		return;
+-
+-	b = mygetent(db_array, tc);
+-	free(tc);
+-
+-	if (b == NULL)
+-		return;
+-
+-	handleone(db_array, b, recurse, pretty, ++level);
+-	free(b);
+-}
+-
+-static int
+-handlecap(const char *db, int argc, char *argv[])
+-{
+-	static const char sfx[] = "=#:";
+-	const char *db_array[] = { db, NULL };
+-	char	*b, *cap;
+-	int	i, rv, c;
+-	size_t	j;
+-	int	expand = 1, recurse = 0, pretty = 0;
+-
+-	assert(argc > 1);
+-	assert(argv != NULL);
+-
+-	argc--;
+-	argv++;
+-	while ((c = getopt(argc, argv, "pnr")) != -1)
+-		switch (c) {
+-		case 'n':
+-			expand = 0;
+-			break;
+-		case 'r':
+-			expand = 0;
+-			recurse = 1;
+-			break;
+-		case 'p':
+-			pretty = 1;
+-			break;
+-		default:
+-			usage();
+-			break;
+-		}
+-
+-	argc -= optind;
+-	argv += optind;
+-	csetexpandtc(expand);
+-	rv = RV_OK;
+-	if (argc == 0) {
+-		for (b = mygetone(db_array, 1); b; b = mygetone(db_array, 0)) {
+-			handleone(db_array, b, recurse, pretty, 0);
+-			free(b);
+-		}
+-	} else {
+-		if ((b = mygetent(db_array, argv[0])) == NULL)
+-			return RV_NOTFOUND;
+-		if (argc == 1)
+-			handleone(db_array, b, recurse, pretty, 0);
+-		else {
+-			for (i = 2; i < argc; i++) {
+-				for (j = 0; j < sizeof(sfx) - 1; j++) {
+-					cap = cgetcap(b, argv[i], sfx[j]);
+-					if (cap) {
+-						capprint(cap);
+-						break;
+-					} 
+-				}
+-				if (j == sizeof(sfx) - 1)
+-					printf("false\n");
+-			}
+-		}
+-		free(b);
+-	}
+-	return rv;
+-}
+-
+-		/*
+-		 * gettytab
+-		 */
+-
+-static int
+-gettytab(int argc, char *argv[])
+-{
+-	return handlecap(_PATH_GETTYTAB, argc, argv);
+-}
+-
+-		/*
+-		 * printcap
+-		 */
+-
+-static int
+-printcap(int argc, char *argv[])
+-{
+-	return handlecap(_PATH_PRINTCAP, argc, argv);
+-}
+-
+-		/*
+-		 * disktab
+-		 */
+-
+-static int
+-disktab(int argc, char *argv[])
+-{
+-	return handlecap(_PATH_DISKTAB, argc, argv);
+-}
+-
+ 		/*
+ 		 * protocols
+ 		 */
+@@ -726,47 +402,6 @@
+ }
+ 
+ 		/*
+-		 * rpc
+-		 */
+-
+-static int
+-rpc(int argc, char *argv[])
+-{
+-	struct rpcent	*re;
+-	unsigned long	id;
+-	int		i, rv;
+-	
+-	assert(argc > 1);
+-	assert(argv != NULL);
+-
+-#define RPCPRINT	printfmtstrings(re->r_aliases, "  ", " ", \
+-				"%-16s  %6d", \
+-				re->r_name, re->r_number)
+-
+-	setrpcent(1);
+-	rv = RV_OK;
+-	if (argc == 2) {
+-		while ((re = getrpcent()) != NULL)
+-			RPCPRINT;
+-	} else {
+-		for (i = 2; i < argc; i++) {
+-			if (parsenum(argv[i], &id))
+-				re = getrpcbynumber((int)id);
+-			else
+-				re = getrpcbyname(argv[i]);
+-			if (re != NULL)
+-				RPCPRINT;
+-			else {
+-				rv = RV_NOTFOUND;
+-				break;
+-			}
+-		}
+-	}
+-	endrpcent();
+-	return rv;
+-}
+-
+-		/*
+ 		 * services
+ 		 */
+ 

--- a/pkgs/os-specific/bsd/openbsd/default.nix
+++ b/pkgs/os-specific/bsd/openbsd/default.nix
@@ -1,0 +1,42 @@
+{ fetchcvs, netBSDDerivation, compat, libcurses, libressl }:
+
+let
+  fetchOpenBSD = path: version: sha256: fetchcvs {
+    cvsRoot = "anoncvs@anoncvs.ca.openbsd.org:/cvs";
+    module = "src/${path}";
+    inherit sha256;
+    tag = "OPENBSD_${builtins.replaceStrings ["."] ["_"] version}";
+  };
+
+  # OpenBSD is a fork of NetBSD
+  # We can build it with minimal changes
+  openBSDDerivation = attrs: netBSDDerivation (attrs // {
+    name = "${attrs.pname or (baseNameOf attrs.path)}-openbsd-${attrs.version}";
+    src = fetchOpenBSD attrs.path attrs.version attrs.sha256;
+  });
+
+in {
+
+  mg = openBSDDerivation {
+    path = "usr.bin/mg";
+    version = "6.3";
+    sha256 = "0n3hwa81c2mcjwbmidrbvi1l25jh8hy939kqrigbv78jixpynffc";
+    buildInputs = [ compat libcurses ];
+    patchPhase = ''
+      NIX_CFLAGS_COMPILE+=" -I$BSDSRCDIR/sys"
+    '';
+    extraPaths = [
+      (fetchOpenBSD "sys/sys/tree.h" "6.3" "0rimh41wn9wz5m510zk9i27z3s450qqgq2k5xn8kp3885hygbcj9")
+      (fetchOpenBSD "sys/sys/_null.h" "6.3" "0l2rgg9ai4ivfl07zmbqli19vnm3lj7qkxpikqplmzrfp36qpzgr")
+    ];
+  };
+
+  nc = openBSDDerivation {
+    path = "usr.bin/nc";
+    version = "6.3";
+    sha256 = "0fmnh6ccxab0qvhmgspyd3wra1ps2516i0j6hwkvna2lcny20xvr";
+    patches = [ ./nc.patch ];
+    buildInputs = [ compat libressl ];
+  };
+
+}

--- a/pkgs/os-specific/bsd/openbsd/nc.patch
+++ b/pkgs/os-specific/bsd/openbsd/nc.patch
@@ -1,0 +1,421 @@
+--- a/nc.1
++++ b/nc.1
+@@ -204,9 +204,6 @@ Proxy authentication is only supported f
+ Specifies the source port
+ .Nm
+ should use, subject to privilege restrictions and availability.
+-It is an error to use this option in conjunction with the
+-.Fl l
+-option.
+ .It Fl R Ar CAfile
+ Specifies the filename from which the root CA bundle for certificate
+ verification is loaded, in PEM format.
+@@ -258,6 +255,7 @@ For IPv4 TOS value
+ may be one of
+ .Ar critical ,
+ .Ar inetcontrol ,
++.Ar lowcost ,
+ .Ar lowdelay ,
+ .Ar netcontrol ,
+ .Ar throughput ,
+--- a/netcat.c
++++ b/netcat.c
+@@ -32,6 +32,8 @@
+  * *Hobbit* <hobbit@avian.org>.
+  */
+ 
++#define _GNU_SOURCE
++
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <sys/uio.h>
+@@ -41,6 +43,49 @@
+ #include <netinet/tcp.h>
+ #include <netinet/ip.h>
+ #include <arpa/telnet.h>
++#ifdef __linux__
++# include <linux/in6.h>
++#endif
++
++#ifndef IPTOS_LOWDELAY
++# define IPTOS_LOWDELAY 0x10
++# define IPTOS_THROUGHPUT 0x08
++# define IPTOS_RELIABILITY 0x04
++# define IPTOS_LOWCOST 0x02
++# define IPTOS_MINCOST IPTOS_LOWCOST
++#endif /* IPTOS_LOWDELAY */
++
++# ifndef IPTOS_DSCP_AF11
++# define	IPTOS_DSCP_AF11		0x28
++# define	IPTOS_DSCP_AF12		0x30
++# define	IPTOS_DSCP_AF13		0x38
++# define	IPTOS_DSCP_AF21		0x48
++# define	IPTOS_DSCP_AF22		0x50
++# define	IPTOS_DSCP_AF23		0x58
++# define	IPTOS_DSCP_AF31		0x68
++# define	IPTOS_DSCP_AF32		0x70
++# define	IPTOS_DSCP_AF33		0x78
++# define	IPTOS_DSCP_AF41		0x88
++# define	IPTOS_DSCP_AF42		0x90
++# define	IPTOS_DSCP_AF43		0x98
++# define	IPTOS_DSCP_EF		0xb8
++#endif /* IPTOS_DSCP_AF11 */
++
++#ifndef IPTOS_DSCP_CS0
++# define	IPTOS_DSCP_CS0		0x00
++# define	IPTOS_DSCP_CS1		0x20
++# define	IPTOS_DSCP_CS2		0x40
++# define	IPTOS_DSCP_CS3		0x60
++# define	IPTOS_DSCP_CS4		0x80
++# define	IPTOS_DSCP_CS5		0xa0
++# define	IPTOS_DSCP_CS6		0xc0
++# define	IPTOS_DSCP_CS7		0xe0
++#endif /* IPTOS_DSCP_CS0 */
++
++#ifndef IPTOS_DSCP_EF
++# define	IPTOS_DSCP_EF		0xb8
++#endif /* IPTOS_DSCP_EF */
++
+ 
+ #include <err.h>
+ #include <errno.h>
+@@ -268,10 +315,14 @@ main(int argc, char *argv[])
+ 			uflag = 1;
+ 			break;
+ 		case 'V':
++# if defined(RT_TABLEID_MAX)
+ 			rtableid = (int)strtonum(optarg, 0,
+ 			    RT_TABLEID_MAX, &errstr);
+ 			if (errstr)
+ 				errx(1, "rtable %s: %s", errstr, optarg);
++# else
++			errx(1, "no alternate routing table support available");
++# endif
+ 			break;
+ 		case 'v':
+ 			vflag = 1;
+@@ -320,7 +371,11 @@ main(int argc, char *argv[])
+ 			oflag = optarg;
+ 			break;
+ 		case 'S':
++# if defined(TCP_MD5SIG)
+ 			Sflag = 1;
++# else
++			errx(1, "no TCP MD5 signature support available");
++# endif
+ 			break;
+ 		case 'T':
+ 			errstr = NULL;
+@@ -345,35 +400,23 @@ main(int argc, char *argv[])
+ 	argc -= optind;
+ 	argv += optind;
+ 
++# if defined(RT_TABLEID_MAX)
+ 	if (rtableid >= 0)
+ 		if (setrtable(rtableid) == -1)
+ 			err(1, "setrtable");
+-
+-	if (family == AF_UNIX) {
+-		if (pledge("stdio rpath wpath cpath tmppath unix", NULL) == -1)
+-			err(1, "pledge");
+-	} else if (Fflag && Pflag) {
+-		if (pledge("stdio inet dns sendfd tty", NULL) == -1)
+-			err(1, "pledge");
+-	} else if (Fflag) { 
+-		if (pledge("stdio inet dns sendfd", NULL) == -1)
+-			err(1, "pledge");
+-	} else if (Pflag && usetls) {
+-		if (pledge("stdio rpath inet dns tty", NULL) == -1)
+-			err(1, "pledge");
+-	} else if (Pflag) {
+-		if (pledge("stdio inet dns tty", NULL) == -1)
+-			err(1, "pledge");
+-	} else if (usetls) {
+-		if (pledge("stdio rpath inet dns", NULL) == -1)
+-			err(1, "pledge");
+-	} else if (pledge("stdio inet dns", NULL) == -1)
+-		err(1, "pledge");
++# endif
+ 
+ 	/* Cruft to make sure options are clean, and used properly. */
+ 	if (argv[0] && !argv[1] && family == AF_UNIX) {
+ 		host = argv[0];
+ 		uport = NULL;
++	} else if (!argv[0] && lflag) {
++		if (sflag)
++			errx(1, "cannot use -s and -l");
++		if (pflag)
++			errx(1, "cannot use -p and -l");
++		if (zflag)
++			errx(1, "cannot use -z and -l");
+ 	} else if (argv[0] && !argv[1]) {
+ 		if (!lflag)
+ 			usage(1);
+@@ -385,12 +428,6 @@ main(int argc, char *argv[])
+ 	} else
+ 		usage(1);
+ 
+-	if (lflag && sflag)
+-		errx(1, "cannot use -s and -l");
+-	if (lflag && pflag)
+-		errx(1, "cannot use -p and -l");
+-	if (lflag && zflag)
+-		errx(1, "cannot use -z and -l");
+ 	if (!lflag && kflag)
+ 		errx(1, "must use -l with -k");
+ 	if (uflag && usetls)
+@@ -425,8 +462,8 @@ main(int argc, char *argv[])
+ 		} else {
+ 			strlcpy(unix_dg_tmp_socket_buf, "/tmp/nc.XXXXXXXXXX",
+ 			    UNIX_DG_TMP_SOCKET_SIZE);
+-			if (mktemp(unix_dg_tmp_socket_buf) == NULL)
+-				err(1, "mktemp");
++			if (mkstemp(unix_dg_tmp_socket_buf) == -1)
++				err(1, "mkstemp");
+ 			unix_dg_tmp_socket = unix_dg_tmp_socket_buf;
+ 		}
+ 	}
+@@ -901,8 +938,10 @@ remote_connect(const char *host, const c
+ 		if (sflag || pflag) {
+ 			struct addrinfo ahints, *ares;
+ 
++# if defined (SO_BINDANY)
+ 			/* try SO_BINDANY, but don't insist */
+ 			setsockopt(s, SOL_SOCKET, SO_BINDANY, &on, sizeof(on));
++# endif
+ 			memset(&ahints, 0, sizeof(struct addrinfo));
+ 			ahints.ai_family = res->ai_family;
+ 			ahints.ai_socktype = uflag ? SOCK_DGRAM : SOCK_STREAM;
+@@ -994,9 +1033,15 @@ local_listen(char *host, char *port, str
+ 		    res->ai_protocol)) < 0)
+ 			continue;
+ 
++		ret = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &x, sizeof(x));
++		if (ret == -1)
++			err(1, NULL);
++
++# if defined(SO_REUSEPORT)
+ 		ret = setsockopt(s, SOL_SOCKET, SO_REUSEPORT, &x, sizeof(x));
+ 		if (ret == -1)
+ 			err(1, NULL);
++# endif
+ 
+ 		set_common_sockopts(s, res->ai_family);
+ 
+@@ -1452,11 +1497,13 @@ set_common_sockopts(int s, int af)
+ {
+ 	int x = 1;
+ 
++# if defined(TCP_MD5SIG)
+ 	if (Sflag) {
+ 		if (setsockopt(s, IPPROTO_TCP, TCP_MD5SIG,
+ 			&x, sizeof(x)) == -1)
+ 			err(1, NULL);
+ 	}
++# endif
+ 	if (Dflag) {
+ 		if (setsockopt(s, SOL_SOCKET, SO_DEBUG,
+ 			&x, sizeof(x)) == -1)
+@@ -1467,9 +1514,14 @@ set_common_sockopts(int s, int af)
+ 		    IP_TOS, &Tflag, sizeof(Tflag)) == -1)
+ 			err(1, "set IP ToS");
+ 
++#if defined(IPV6_TCLASS)
+ 		else if (af == AF_INET6 && setsockopt(s, IPPROTO_IPV6,
+ 		    IPV6_TCLASS, &Tflag, sizeof(Tflag)) == -1)
+ 			err(1, "set IPv6 traffic class");
++#else
++		else if (af == AF_INET6)
++			errx(1, "can't set IPv6 traffic class (unavailable)");
++#endif
+ 	}
+ 	if (Iflag) {
+ 		if (setsockopt(s, SOL_SOCKET, SO_RCVBUF,
+@@ -1487,19 +1539,34 @@ set_common_sockopts(int s, int af)
+ 		    IP_TTL, &ttl, sizeof(ttl)))
+ 			err(1, "set IP TTL");
+ 
++#if defined(IPV6_UNICAST_HOPS)
+ 		else if (af == AF_INET6 && setsockopt(s, IPPROTO_IPV6,
+ 		    IPV6_UNICAST_HOPS, &ttl, sizeof(ttl)))
+ 			err(1, "set IPv6 unicast hops");
++#else
++		else if (af == AF_INET6)
++			errx(1, "can't set IPv6 unicast hops (unavailable)");
++#endif
+ 	}
+ 
+ 	if (minttl != -1) {
++#if defined(IP_MINTTL)
+ 		if (af == AF_INET && setsockopt(s, IPPROTO_IP,
+ 		    IP_MINTTL, &minttl, sizeof(minttl)))
+ 			err(1, "set IP min TTL");
++#else
++		if (af == AF_INET)
++			errx(1, "can't set IP min TTL (unavailable)");
++#endif
+ 
++#if defined(IPV6_MINHOPCOUNT)
+ 		else if (af == AF_INET6 && setsockopt(s, IPPROTO_IPV6,
+ 		    IPV6_MINHOPCOUNT, &minttl, sizeof(minttl)))
+ 			err(1, "set IPv6 min hop count");
++#else
++		else if (af == AF_INET6)
++			errx(1, "can't set IPv6 min hop count (unavailable)");
++#endif
+ 	}
+ }
+ 
+@@ -1534,6 +1601,7 @@ process_tos_opt(char *s, int *val)
+ 		{ "cs7",		IPTOS_DSCP_CS7 },
+ 		{ "ef",			IPTOS_DSCP_EF },
+ 		{ "inetcontrol",	IPTOS_PREC_INTERNETCONTROL },
++		{ "lowcost",		IPTOS_LOWCOST },
+ 		{ "lowdelay",		IPTOS_LOWDELAY },
+ 		{ "netcontrol",		IPTOS_PREC_NETCONTROL },
+ 		{ "reliability",	IPTOS_RELIABILITY },
+@@ -1741,7 +1812,7 @@ help(void)
+ 	\t-Z		Peer certificate file\n\
+ 	\t-z		Zero-I/O mode [used for scanning]\n\
+ 	Port numbers can be individual or ranges: lo-hi [inclusive]\n");
+-	exit(1);
++	exit(0);
+ }
+ 
+ void
+--- a/socks.c
++++ b/socks.c
+@@ -219,11 +219,11 @@ socks_connect(const char *host, const ch
+ 		buf[2] = SOCKS_NOAUTH;
+ 		cnt = atomicio(vwrite, proxyfd, buf, 3);
+ 		if (cnt != 3)
+-			err(1, "write failed (%zu/3)", cnt);
++			err(1, "write failed (%zu/3)", (size_t)cnt);
+ 
+ 		cnt = atomicio(read, proxyfd, buf, 2);
+ 		if (cnt != 2)
+-			err(1, "read failed (%zu/3)", cnt);
++			err(1, "read failed (%zu/3)", (size_t)cnt);
+ 
+ 		if (buf[1] == SOCKS_NOMETHOD)
+ 			errx(1, "authentication method negotiation failed");
+@@ -272,11 +272,11 @@ socks_connect(const char *host, const ch
+ 
+ 		cnt = atomicio(vwrite, proxyfd, buf, wlen);
+ 		if (cnt != wlen)
+-			err(1, "write failed (%zu/%zu)", cnt, wlen);
++			err(1, "write failed (%zu/%zu)", (size_t)cnt, (size_t)wlen);
+ 
+ 		cnt = atomicio(read, proxyfd, buf, 4);
+ 		if (cnt != 4)
+-			err(1, "read failed (%zu/4)", cnt);
++			err(1, "read failed (%zu/4)", (size_t)cnt);
+ 		if (buf[1] != 0) {
+ 			errx(1, "connection failed, SOCKSv5 error: %s",
+ 			    socks5_strerror(buf[1]));
+@@ -285,12 +285,12 @@ socks_connect(const char *host, const ch
+ 		case SOCKS_IPV4:
+ 			cnt = atomicio(read, proxyfd, buf + 4, 6);
+ 			if (cnt != 6)
+-				err(1, "read failed (%zu/6)", cnt);
++				err(1, "read failed (%zu/6)", (size_t)cnt);
+ 			break;
+ 		case SOCKS_IPV6:
+ 			cnt = atomicio(read, proxyfd, buf + 4, 18);
+ 			if (cnt != 18)
+-				err(1, "read failed (%zu/18)", cnt);
++				err(1, "read failed (%zu/18)", (size_t)cnt);
+ 			break;
+ 		default:
+ 			errx(1, "connection failed, unsupported address type");
+@@ -310,11 +310,11 @@ socks_connect(const char *host, const ch
+ 
+ 		cnt = atomicio(vwrite, proxyfd, buf, wlen);
+ 		if (cnt != wlen)
+-			err(1, "write failed (%zu/%zu)", cnt, wlen);
++			err(1, "write failed (%zu/%zu)", (size_t)cnt, (size_t)wlen);
+ 
+ 		cnt = atomicio(read, proxyfd, buf, 8);
+ 		if (cnt != 8)
+-			err(1, "read failed (%zu/8)", cnt);
++			err(1, "read failed (%zu/8)", (size_t)cnt);
+ 		if (buf[1] != 90) {
+ 			errx(1, "connection failed, SOCKSv4 error: %s",
+ 			    socks4_strerror(buf[1]));
+@@ -328,39 +328,39 @@ socks_connect(const char *host, const ch
+ 
+ 		/* Try to be sane about numeric IPv6 addresses */
+ 		if (strchr(host, ':') != NULL) {
+-			r = snprintf(buf, sizeof(buf),
++			r = snprintf((char*)buf, sizeof(buf),
+ 			    "CONNECT [%s]:%d HTTP/1.0\r\n",
+ 			    host, ntohs(serverport));
+ 		} else {
+-			r = snprintf(buf, sizeof(buf),
++			r = snprintf((char*)buf, sizeof(buf),
+ 			    "CONNECT %s:%d HTTP/1.0\r\n",
+ 			    host, ntohs(serverport));
+ 		}
+ 		if (r == -1 || (size_t)r >= sizeof(buf))
+ 			errx(1, "hostname too long");
+-		r = strlen(buf);
++		r = strlen((char*)buf);
+ 
+ 		cnt = atomicio(vwrite, proxyfd, buf, r);
+ 		if (cnt != r)
+-			err(1, "write failed (%zu/%d)", cnt, r);
++			err(1, "write failed (%zu/%d)", (size_t)cnt, (int)r);
+ 
+ 		if (authretry > 1) {
+ 			char resp[1024];
+ 
+ 			proxypass = getproxypass(proxyuser, proxyhost);
+-			r = snprintf(buf, sizeof(buf), "%s:%s",
++			r = snprintf((char*)buf, sizeof(buf), "%s:%s",
+ 			    proxyuser, proxypass);
+ 			if (r == -1 || (size_t)r >= sizeof(buf) ||
+-			    b64_ntop(buf, strlen(buf), resp,
++			    b64_ntop(buf, strlen((char*)buf), resp,
+ 			    sizeof(resp)) == -1)
+ 				errx(1, "Proxy username/password too long");
+-			r = snprintf(buf, sizeof(buf), "Proxy-Authorization: "
++			r = snprintf((char*)buf, sizeof(buf), "Proxy-Authorization: "
+ 			    "Basic %s\r\n", resp);
+ 			if (r == -1 || (size_t)r >= sizeof(buf))
+ 				errx(1, "Proxy auth response too long");
+-			r = strlen(buf);
++			r = strlen((char*)buf);
+ 			if ((cnt = atomicio(vwrite, proxyfd, buf, r)) != r)
+-				err(1, "write failed (%zu/%d)", cnt, r);
++				err(1, "write failed (%zu/%d)", (size_t)cnt, r);
+ 		}
+ 
+ 		/* Terminate headers */
+@@ -368,22 +368,22 @@ socks_connect(const char *host, const ch
+ 			err(1, "write failed (%zu/2)", cnt);
+ 
+ 		/* Read status reply */
+-		proxy_read_line(proxyfd, buf, sizeof(buf));
++		proxy_read_line(proxyfd, (char*)buf, sizeof(buf));
+ 		if (proxyuser != NULL &&
+-		    strncmp(buf, "HTTP/1.0 407 ", 12) == 0) {
++		    strncmp((char*)buf, "HTTP/1.0 407 ", 12) == 0) {
+ 			if (authretry > 1) {
+ 				fprintf(stderr, "Proxy authentication "
+ 				    "failed\n");
+ 			}
+ 			close(proxyfd);
+ 			goto again;
+-		} else if (strncmp(buf, "HTTP/1.0 200 ", 12) != 0 &&
+-		    strncmp(buf, "HTTP/1.1 200 ", 12) != 0)
++		} else if (strncmp((char*)buf, "HTTP/1.0 200 ", 12) != 0 &&
++		    strncmp((char*)buf, "HTTP/1.1 200 ", 12) != 0)
+ 			errx(1, "Proxy error: \"%s\"", buf);
+ 
+ 		/* Headers continue until we hit an empty line */
+ 		for (r = 0; r < HTTP_MAXHDRS; r++) {
+-			proxy_read_line(proxyfd, buf, sizeof(buf));
++			proxy_read_line(proxyfd, (char*)buf, sizeof(buf));
+ 			if (*buf == '\0')
+ 				break;
+ 		}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21301,4 +21301,7 @@ with pkgs;
   unixtools = recurseIntoAttrs (callPackages ./unix-tools.nix { });
   inherit (unixtools) hexdump ps logger eject umount
                       mount wall hostname more sysctl;
+
+  inherit (recurseIntoAttrs (callPackages ../os-specific/bsd { }))
+          netbsd openbsd;
 }


### PR DESCRIPTION
This adds some NetBSD userland into Nixpkgs. The main goal is to create some tools that will make adding more of NetBSD easier. The NetBSD tree is pulled from CVS directly and only needed paths are downloaded. FreeBSD and OpenBSD can use similar approaches.

This replaces the "musl-*" stuff that was really just hacked up versions of NetBSD sources. Hoping it doesn't break anything. It finally gave me an excuse to add my NetBSD work though.

/cc @dtzWill