### PR TITLE
exfat-utils, fuse_exfat -> exfat

### DIFF
--- a/nixos/modules/tasks/filesystems/exfat.nix
+++ b/nixos/modules/tasks/filesystems/exfat.nix
@@ -5,7 +5,7 @@ with lib;
 {
   config = mkIf (any (fs: fs == "exfat") config.boot.supportedFilesystems) {
 
-    system.fsPackages = [ pkgs.exfat-utils pkgs.fuse_exfat ];
+    system.fsPackages = [ pkgs.exfat ];
 
   };
 }


### PR DESCRIPTION
```exfat-utils``` and ```fuse_exfat``` are both aliases of ```exfat```
