### PR TITLE
Add mopidy-mpris

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3631,6 +3631,11 @@
     github = "ctheune";
     name = "Christian Theune";
   };
+  thorerik = {
+    name = "Thor Erik Lie";
+    email = "thor@thorerik.com";
+    github = "thorerik";
+  };
   thoughtpolice = {
     email = "aseipp@pobox.com";
     github = "thoughtpolice";

--- a/pkgs/applications/audio/mopidy-mpris/default.nix
+++ b/pkgs/applications/audio/mopidy-mpris/default.nix
@@ -1,20 +1,25 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+{ stdenv, pythonPackages, mopidy, gst_all_1, glib-networking, gobjectIntrospection }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-mpris-${version}";
-
+  pname = "Mopidy-MPRIS";
   version = "1.4.0";
 
-  src = fetchFromGitHub {
-    owner = "mopidy";
-    repo = "mopidy-mpris";
-    rev = "v${version}";
-    sha256 = "0a8hd7vcvy2whmb9qamafx787rjnvnkz4z36ncnydi0dirbnc3d1";
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "0y90k3yzv8lq5g3lxfh4fys7bsmdvqgnwx2kjr00w5j3zrhmfcpa";
   };
+
+  buildInputs = with gst_all_1; [
+    gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad
+    glib-networking gobjectIntrospection
+  ];
 
   propagatedBuildInputs = with pythonPackages; [ mopidy ];
 
-  doCheck = false;
+  checkInputs = with pythonPackages; [ pytest mock gst-python pygobject3 pykka tornado requests ];
+  checkPhase = ''
+    py.test
+  '';
 
   meta = with stdenv.lib; {
     description = "Mopidy extension for controlling Mopidy via dbus";

--- a/pkgs/applications/audio/mopidy-mpris/default.nix
+++ b/pkgs/applications/audio/mopidy-mpris/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "mopidy-mpris-${version}";
+
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "mopidy";
+    repo = "mopidy-mpris";
+    rev = "v${version}";
+    sha256 = "0a8hd7vcvy2whmb9qamafx787rjnvnkz4z36ncnydi0dirbnc3d1";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ mopidy ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Mopidy extension for controlling Mopidy via dbus";
+    license = licenses.asl20;
+    maintainers = [ maintainers.thorerik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16772,6 +16772,8 @@ with pkgs;
 
   mopidy-mopify = callPackage ../applications/audio/mopidy-mopify { };
 
+  mopidy-mpris = callPackage ../applications/audio/mopidy-mpris { };
+
   mopidy-spotify-tunigo = callPackage ../applications/audio/mopidy-spotify-tunigo { };
 
   mopidy-youtube = callPackage ../applications/audio/mopidy-youtube { };


### PR DESCRIPTION
###### Motivation for this change
Add mopidy-mpris so that it can easily be installed with mopidy

closes #38758

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

