### PR TITLE
rtkit: fix build

### DIFF
--- a/pkgs/os-specific/linux/rtkit/default.nix
+++ b/pkgs/os-specific/linux/rtkit/default.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation rec {
       url = "http://git.0pointer.net/rtkit.git/patch/?id=88d4082ef6caf6b071d749dca1c50e7edde914cc";
       sha256 = "0hp1blbi359qz8fmr6nj4w9yc0jf3dd176f8pn25wdj38n13qkix";
     })
+    (fetchpatch {
+      url = "https://salsa.debian.org/multimedia-team/rtkit/raw/5594f371aff655ce6d2f016b38e5cb2da7dec677/debian/patches/0006-fix-format-strings.patch";
+      sha256 = "09mr89lh16jvz6cqw00zmh0xk919bjfhjkvna1czwmafwy9p7kgp";
+    })
   ];
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Doesn't build after dbus update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

