### PR TITLE
jetty: 9.3.10.v20160621 -> 9.4.8.v20171121

### DIFF
--- a/pkgs/servers/http/jetty/default.nix
+++ b/pkgs/servers/http/jetty/default.nix
@@ -2,19 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "jetty-${version}";
-  version = "9.3.10.v20160621";
-
+  version = "9.4.8.v20171121";
   src = fetchurl {
     url = "http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${version}/jetty-distribution-${version}.tar.gz";
     name = "jetty-distribution-${version}.tar.gz";
-    sha256 = "0xqv7bp82i95gikma70kyi91nlgsj5zabzg59ly9ga4mqf5y0zbz";
+    sha256 = "0bvwi70vdk468yqgvgq99lwrpy2y5znrl0b1cr8j6ygmsgnvvmjh";
   };
 
   phases = [ "unpackPhase" "installPhase" ];
 
   installPhase = ''
     mkdir -p $out
-    mv etc lib modules start.jar $out
+    mv etc lib modules start.ini start.jar $out
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

