### PR TITLE
postgresql-jdbc: 9.3-1100 -> 42.2.2

### DIFF
--- a/pkgs/servers/sql/postgresql/jdbc/default.nix
+++ b/pkgs/servers/sql/postgresql/jdbc/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, fetchurl, ant, jdk }:
-
-let version = "9.3-1100"; in
+{ stdenv, fetchMavenArtifact }:
 
 stdenv.mkDerivation rec {
   name = "postgresql-jdbc-${version}";
+  version = "42.2.2";
 
-  src = fetchurl {
-    url = "http://jdbc.postgresql.org/download/postgresql-jdbc-${version}.src.tar.gz";
-    sha256 = "0mbdzhzg4ws0i7ps98rg0q5n68lsrdm2klj7y7skaix0rpa57gp6";
+  src = fetchMavenArtifact {
+    artifactId = "postgresql";
+    groupId = "org.postgresql";
+    sha256 = "0w7sfi1gmzqhyhr4iq9znv8hff41xwwqcblkyd9ph0m34r0555hr";
+    inherit version;
   };
 
-  buildInputs = [ ant jdk ];
+  phases = [ "installPhase" ];
 
-  buildPhase = "ant";
-
-  installPhase =
-    ''
-      mkdir -p $out/share/java
-      cp jars/*.jar $out/share/java
-    '';
+  installPhase = ''
+    mkdir -p $out/share/java
+    cp $src/share/java/*_postgresql-${version}.jar $_/postgresql-jdbc.jar
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://jdbc.postgresql.org/;

--- a/pkgs/servers/sql/postgresql/jdbc/default.nix
+++ b/pkgs/servers/sql/postgresql/jdbc/default.nix
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
   phases = [ "installPhase" ];
 
   installPhase = ''
-    mkdir -p $out/share/java
-    cp $src/share/java/*_postgresql-${version}.jar $_/postgresql-jdbc.jar
+    install -D $src/share/java/*_postgresql-${version}.jar $out/share/java/postgresql-jdbc.jar
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

9.3-1100 finally breaks in some cases on postgres 10.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

