### PR TITLE
acme.sh: init at 2.7.8

### DIFF
--- a/pkgs/tools/admin/acme.sh/default.nix
+++ b/pkgs/tools/admin/acme.sh/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, curl, openssl, socat, iproute }:
+stdenv.mkDerivation rec {
+  name = "acme.sh-${version}";
+  version = "2.7.8";
+
+  src = fetchFromGitHub {
+    owner = "Neilpang";
+    repo = "acme.sh";
+    rev = version;
+    sha256 = "0zm64z7av63xi7yjhljab2i8q1vx4q1mpcmcm58jm6k4babalxrf";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out $out/bin $out/lib
+    cp -R $src/* $_
+    makeWrapper $out/lib/acme.sh $out/bin/acme.sh \
+      --prefix PATH : "${lib.makeBinPath [ socat openssl curl iproute ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A pure Unix shell script implementing ACME client protocol";
+    homepage = https://acme.sh/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.yorickvp ];
+  };
+}

--- a/pkgs/tools/admin/acme.sh/default.nix
+++ b/pkgs/tools/admin/acme.sh/default.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out $out/bin $out/lib
+    mkdir -p $out $out/bin $out/libexec
     cp -R $src/* $_
-    makeWrapper $out/lib/acme.sh $out/bin/acme.sh \
+    makeWrapper $out/libexec/acme.sh $out/bin/acme.sh \
       --prefix PATH : "${lib.makeBinPath [ socat openssl curl iproute ]}"
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -414,6 +414,8 @@ with pkgs;
 
   acct = callPackage ../tools/system/acct { };
 
+  acme-sh = callPackage ../tools/admin/acme.sh { };
+
   acoustidFingerprinter = callPackage ../tools/audio/acoustid-fingerprinter {
     ffmpeg = ffmpeg_1;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

