### PR TITLE
unixtools.modprobe: fix

### DIFF
--- a/pkgs/top-level/unix-tools.nix
+++ b/pkgs/top-level/unix-tools.nix
@@ -64,7 +64,7 @@ in rec {
     linux = pkgs.utillinux;
   };
   modprobe = singleBinary "modprobe" {
-    linux = pkgs.utillinux;
+    linux = pkgs.kmod;
   };
   more = singleBinary "more" {
     linux = pkgs.utillinux;


### PR DESCRIPTION
###### Motivation for this change

There's no `modprobe` in `utillinux`.

/cc @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

