### PR TITLE
caps: fix build with glibc 2.27

### DIFF
--- a/pkgs/applications/audio/caps/default.nix
+++ b/pkgs/applications/audio/caps/default.nix
@@ -9,8 +9,12 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchurl {
-      url = "https://anonscm.debian.org/cgit/pkg-multimedia/caps.git/plain/debian/patches/0001-Avoid-ambiguity-in-div-invocation.patch";
+      url = "https://salsa.debian.org/multimedia-team/caps/raw/9a99c225/debian/patches/0001-Avoid-ambiguity-in-div-invocation.patch";
       sha256 = "1b1pb5yfskiw8zi1lkj572l2ajpirh4amq538vggwvlpv1fqfway";
+    })
+    (fetchurl {
+      url = "https://salsa.debian.org/multimedia-team/caps/raw/a411203d/debian/patches/0002-Use-standard-exp10f-instead-of-pow10f.patch";
+      sha256 = "18ciklnscabr77l8b89xmbagkk79w4iqfpzr2yhn2ywv2jp8akx9";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Doesn't build with glibc 2.27.

/cc @astsmtl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

