### PR TITLE
yquake2: init at 7.20

### DIFF
--- a/pkgs/games/quake2/yquake2/default.nix
+++ b/pkgs/games/quake2/yquake2/default.nix
@@ -1,0 +1,93 @@
+{ stdenv, lib, fetchFromGitHub, buildEnv, cmake, makeWrapper
+, SDL2, libGL
+, oggSupport ? true, libogg, libvorbis
+, openalSupport ? true, openal
+, zipSupport ? true, zlib
+}:
+
+let
+  mkFlag = b: if b then "ON" else "OFF";
+
+  games = import ./games.nix { inherit stdenv lib fetchFromGitHub cmake; };
+
+  wrapper = import ./wrapper.nix { inherit stdenv lib buildEnv makeWrapper yquake2; };
+
+  yquake2 = stdenv.mkDerivation rec {
+    name = "yquake2-${version}";
+    version = "7.20";
+
+    src = fetchFromGitHub {
+      owner = "yquake2";
+      repo = "yquake2";
+      rev = "QUAKE2_${builtins.replaceStrings ["."] ["_"] version}";
+      sha256 = "1yrmn8vajab3zd0fni029s6wrvv2ljn1kyhaiw02wm1dc5yyzb2g";
+    };
+
+    enableParallelBuilding = true;
+
+    nativeBuildInputs = [ cmake ];
+
+    buildInputs = [ SDL2 libGL ]
+      ++ lib.optionals oggSupport [ libogg libvorbis ]
+      ++ lib.optional openalSupport openal
+      ++ lib.optional zipSupport zlib;
+
+    cmakeFlags = [
+      "-DCMAKE_BUILD_TYPE=Release"
+      "-DOGG_SUPPORT=${mkFlag oggSupport}"
+      "-DOPENAL_SUPPORT=${mkFlag openalSupport}"
+      "-DZIP_SUPPORT=${mkFlag zipSupport}"
+      "-DSYSTEMWIDE_SUPPORT=ON"
+    ];
+
+    preConfigure = ''
+      # Since we can't expand $out in `cmakeFlags`
+      cmakeFlags="$cmakeFlags -DSYSTEMDIR=$out/share/games/quake2"
+    '';
+
+    installPhase = ''
+      # Yamagi Quake II expects all binaries (executables and libs) to be in the
+      # same directory.
+      mkdir -p $out/bin $out/lib/yquake2 $out/share/games/quake2
+      cp -r release/* $out/lib/yquake2
+      ln -s $out/lib/yquake2/quake2 $out/bin/yquake2
+      ln -s $out/lib/yquake2/q2ded $out/bin/yq2ded
+      cp $src/stuff/yq2.cfg $out/share/games/quake2
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Yamagi Quake II client";
+      homepage = "https://www.yamagi.org/quake2/";
+      license = licenses.gpl2;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ tadfisher ];
+    };
+  };
+
+in rec {
+  inherit yquake2;
+
+  yquake2-ctf = wrapper {
+    games = [ games.ctf ];
+    name = "yquake2-ctf";
+    inherit (games.ctf) description;
+  };
+
+  yquake2-ground-zero = wrapper {
+    games = [ games.ground-zero ];
+    name = "yquake2-ground-zero";
+    inherit (games.ground-zero) description;
+  };
+
+  yquake2-the-reckoning = wrapper {
+    games = [ games.the-reckoning ];
+    name = "yquake2-the-reckoning";
+    inherit (games.the-reckoning) description;
+  };
+
+  yquake2-all-games = wrapper {
+    games = lib.attrValues games;
+    name = "yquake2-all-games";
+    description = "Yamagi Quake II with all add-on games";
+  };
+}

--- a/pkgs/games/quake2/yquake2/games.nix
+++ b/pkgs/games/quake2/yquake2/games.nix
@@ -1,0 +1,59 @@
+{ stdenv, lib, fetchFromGitHub, cmake }:
+
+let
+  games = {
+    ctf = {
+      id = "ctf";
+      version = "1.05";
+      description = "'Capture The Flag' for Yamagi Quake II";
+      sha256 = "15ihspyshls645ig0gq6bwdzvghyyysqk60g6ad3n4idb2ms52md";
+    };
+
+    ground-zero = {
+      id = "rogue";
+      version = "2.04";
+      description = "'Ground Zero' for Yamagi Quake II";
+      sha256 = "0x1maaycrxv7d3xvvk1ih2zymhvcd3jnab7g3by8qh6g5y33is5l";
+    };
+
+    the-reckoning = {
+      id = "xatrix";
+      version = "2.05";
+      description = "'The Reckoning' for Yamagi Quake II";
+      sha256 = "0gf2ryhgz8nw1mb1arlbriihjsx09fa0wmkgcayc8ijignfi1qkh";
+    };
+  };
+
+  toDrv = title: data: stdenv.mkDerivation rec {
+    inherit (data) id version description sha256;
+    inherit title;
+
+    name = "yquake2-${title}-${version}";
+
+    src = fetchFromGitHub {
+      inherit sha256;
+      owner = "yquake2";
+      repo = data.id;
+      rev = "${lib.toUpper id}_${builtins.replaceStrings ["."] ["_"] version}";
+    };
+
+    enableParallelBuilding = true;
+
+    nativeBuildInputs = [ cmake ];
+
+    installPhase = ''
+      mkdir -p $out/lib/yquake2/${id}
+      cp Release/* $out/lib/yquake2/${id}
+    '';
+
+    meta = with stdenv.lib; {
+      inherit (data) description;
+      homepage = "https://www.yamagi.org/quake2/";
+      license = licenses.unfree;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ tadfisher ];
+    };
+  };
+
+in
+  lib.mapAttrs toDrv games

--- a/pkgs/games/quake2/yquake2/wrapper.nix
+++ b/pkgs/games/quake2/yquake2/wrapper.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, buildEnv, makeWrapper, yquake2 }:
+
+{ games
+, name
+, description
+}:
+
+let
+  env = buildEnv {
+    name = "${name}-env";
+    paths = [ yquake2 ] ++ games;
+  };
+
+in stdenv.mkDerivation {
+  inherit name;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildCommand = ''
+    mkdir -p $out/bin
+  '' + lib.concatMapStringsSep "\n" (game: ''
+    makeWrapper ${env}/bin/yquake2 $out/bin/yquake2-${game.title} \
+      --add-flags "+set game ${game.id}"
+    makeWrapper ${env}/bin/yq2ded $out/bin/yq2ded-${game.title} \
+      --add-flags "+set game ${game.id}"
+  '') games;
+
+  meta = {
+    inherit description;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19556,6 +19556,13 @@ with pkgs;
 
   xsokoban = callPackage ../games/xsokoban { };
 
+  inherit (callPackage ../games/quake2/yquake2 { })
+    yquake2
+    yquake2-ctf
+    yquake2-ground-zero
+    yquake2-the-reckoning
+    yquake2-all-games;
+
   zandronum = callPackage ../games/zandronum { };
 
   zandronum-server = zandronum.override {


### PR DESCRIPTION
###### Motivation for this change

Package the Yamagi Quake II client and its related add-on game libraries.

I nested this under `pkgs/games/quake2` to accommodate other Quake II engines and hopefully game/demo asset packages in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

