### PR TITLE
alot: Put included themes where alot will find them

### DIFF
--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -19,12 +19,6 @@ buildPythonPackage rec {
     sha256 = "1y932smng7qx7ybmqw4qh75b0lv9imfs5ak9fd0qhysij8kpmdhi";
   };
 
-  postPatch = ''
-    substituteInPlace alot/defaults/alot.rc.spec \
-      --replace "themes_dir = string(default=None)" \
-                "themes_dir = string(default='$out/share/themes')"
-  '';
-
   nativeBuildInputs = lib.optional withManpage sphinx;
 
   propagatedBuildInputs = [
@@ -50,8 +44,8 @@ buildPythonPackage rec {
     cp -r docs/build/man $out/man
   ''
   + ''
-    mkdir -p $out/share/applications
-    cp -r extra/themes $out/share
+    mkdir -p $out/share/{applications,alot}
+    cp -r extra/themes $out/share/alot
 
     sed "s,/usr/bin,$out/bin,g" extra/alot.desktop > $out/share/applications/alot.desktop
   '';


### PR DESCRIPTION
###### Motivation for this change
Instead of putthing them in the wrong place and then pointing alog at it
via default config, put them in the right place and don't touch the
default config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

