### PR TITLE
Revert "radare2: 2.4.0 -> 2.5.0"

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -13,7 +13,7 @@ let
   inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
-  version = "2.5.0";
+  version = "2.4.0";
   name = "radare2-${version}";
 
   src = fetchFromGitHub {
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     capstone = fetchgit {
       url = "https://github.com/aquynh/capstone.git";
       rev = cs_tip;
-      sha256 = "19vfgdfykmi3cfs4x1acxy0gnwggjjc8qq46pybqvcksbi11nw1k";
+      sha256 = "1b126npshdbwh5y7rafmb9w4dzlvxsf4ca6bx4zs2y7kbk48jyn8";
       leaveDotGit = true;
     };
   in ''


### PR DESCRIPTION
Reverts NixOS/nixpkgs#38753

No update was actually performed, see: https://github.com/NixOS/nixpkgs/pull/38753#issuecomment-380537696