### PR TITLE
pinentry_mac: enable xcbuild on darwin

### DIFF
--- a/pkgs/tools/security/pinentry-mac/default.nix
+++ b/pkgs/tools/security/pinentry-mac/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ xcbuild libiconv Cocoa ncurses ];
 
-  dontUseXcbuild = true;
-
   installPhase = ''
     mkdir -p $out/Applications
     mv Products/Release/pinentry-mac.app $out/Applications


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

