### PR TITLE
radare2-cutter: 1.1 -> 1.3

### DIFF
--- a/pkgs/development/tools/analysis/radare2-cutter/default.nix
+++ b/pkgs/development/tools/analysis/radare2-cutter/default.nix
@@ -3,34 +3,16 @@
 
 stdenv.mkDerivation rec {
   name = "radare2-cutter-${version}";
-  version = "1.1";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "radareorg";
     repo = "cutter";
     rev = "v${version}";
-    sha256 = "02m5sf45n455hn34y7hrqanj830rc5xhz2ppp1z3mzbz0s515pfl";
+    sha256 = "1z76yz2i9k8mxjk85k2agdj941szdbl2gi66p3dh50878zqavfrr";
   };
 
   postUnpack = "export sourceRoot=$sourceRoot/src";
-
-  patches = [
-    # Fixup version number :D
-    (fetchpatch {
-      url = "https://github.com/radareorg/cutter/commit/69506b64600df632afdca8b680baa7d946c78644.patch";
-      sha256 = "0ks3ixz8bycjcfi26bd0p6z7qaplhq00alw44hsfzpdm4bmr01x0";
-    })
-    (fetchpatch {
-      url = "https://github.com/radareorg/cutter/commit/8b52c66f4f0091cd9d97389b32aa519c2c602e2b.patch";
-      sha256 = "0wcdn35lx2943pfzm7mkg4sr82pm0qz3yxf74m8fxbd70s3w0gkm";
-    })
-
-    # case-insensitive filtering
-    (fetchpatch {
-      url = "https://github.com/radareorg/cutter/commit/0ebd34370bcaed00000168147572bb78106eeab1.patch";
-      sha256 = "0sc50jwhncfnd2i5mlyld4dbdzi2ws7nh4yglkhlap9l9h1jxn20";
-    })
-  ];
 
   patchFlags = [ "-p2" ];
 

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -1,9 +1,10 @@
-{stdenv, fetchFromGitHub, fetchgit, fetchurl, fetchpatch, pkgconfig, libusb, readline, libewf, perl, zlib, openssl, git,
-gtk2 ? null, vte ? null, gtkdialog ? null,
-python ? null,
-ruby ? null,
-lua ? null,
-useX11, rubyBindings, pythonBindings, luaBindings}:
+{stdenv, fetchFromGitHub, pkgconfig, libusb, readline, libewf, perl, zlib, openssl
+, gtk2 ? null, vte ? null, gtkdialog ? null
+, python ? null
+, ruby ? null
+, lua ? null
+, useX11, rubyBindings, pythonBindings, luaBindings
+}:
 
 assert useX11 -> (gtk2 != null && vte != null && gtkdialog != null);
 assert rubyBindings -> ruby != null;
@@ -23,13 +24,16 @@ stdenv.mkDerivation rec {
     sha256 = "07x94chkhpn3wgw4pypn35psxq370j6xwmhf1mh5z27cqkq7c2yd";
   };
 
+  # do not try to update capstone
+  WITHOUT_PULL=1;
+
   postPatch = let
     cs_tip = "4a1b580d069c82d60070d0869a87000db7cdabe2"; # version from $sourceRoot/shlr/Makefile
-    capstone = fetchgit {
-      url = "https://github.com/aquynh/capstone.git";
+    capstone = fetchFromGitHub {
+      owner = "aquynh";
+      repo = "capstone";
       rev = cs_tip;
-      sha256 = "1b126npshdbwh5y7rafmb9w4dzlvxsf4ca6bx4zs2y7kbk48jyn8";
-      leaveDotGit = true;
+      sha256 = "0v6rxfpxjq0hf40qn1n5m5wsv1dv6p1j8vm94a708lhvcbk9nkv8";
     };
   in ''
     if ! grep -F "CS_TIP=${cs_tip}" shlr/Makefile; then echo "CS_TIP mismatch"; exit 1; fi
@@ -39,7 +43,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig git ];
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ readline libusb libewf perl zlib openssl]
     ++ optional useX11 [gtkdialog vte gtk2]
     ++ optional rubyBindings [ruby]


### PR DESCRIPTION
###### Motivation for this change

we now have both a new version of cutter and radare2. Are the bugs fixed all now, you had before @dtzWill ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

