### PR TITLE
steamcmd: init at 20180104

### DIFF
--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -19,6 +19,7 @@ let
         then pkgs.pkgsi686Linux.steamPackages.steam-runtime-wrapped
         else null;
     };
+    steamcmd = callPackage ./steamcmd.nix { };
   };
 
 in self

--- a/pkgs/games/steam/steamcmd.nix
+++ b/pkgs/games/steam/steamcmd.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, steam-run, bash
+, steamRoot ? "~/.local/share/Steam"
+}:
+
+stdenv.mkDerivation rec {
+  name = "steamcmd-${version}";
+  version = "20180104"; # According to steamcmd_linux.tar.gz mtime
+
+  src = fetchurl {
+    url = https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz;
+    sha256 = "0z0y0zqvhydmfc9y9vg5am0vz7m3gbj4l2dwlrfz936hpx301gyf";
+  };
+
+  # The source tarball does not have a single top-level directory.
+  preUnpack = ''
+    mkdir $name
+    cd $name
+    sourceRoot=.
+  '';
+
+  buildInputs = [ bash steam-run ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/steamcmd/linux32
+    install -Dm755 steamcmd.sh $out/share/steamcmd/steamcmd.sh
+    install -Dm755 linux32/* $out/share/steamcmd/linux32
+
+    mkdir -p $out/bin
+    substitute ${./steamcmd.sh} $out/bin/steamcmd \
+      --subst-var shell \
+      --subst-var out \
+      --subst-var-by steamRoot "${steamRoot}" \
+      --subst-var-by steamRun ${steam-run}
+    chmod 0755 $out/bin/steamcmd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Steam command-line tools";
+    homepage = "https://developer.valvesoftware.com/wiki/SteamCMD";
+    platforms = platforms.linux;
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ tadfisher ];
+  };
+}

--- a/pkgs/games/steam/steamcmd.sh
+++ b/pkgs/games/steam/steamcmd.sh
@@ -1,0 +1,24 @@
+#!@bash@/bin/bash -e
+
+# Always run steamcmd in the user's Steam root.
+STEAMROOT=@steamRoot@
+
+# Create a facsimile Steam root if it doesn't exist.
+if [ ! -e "$STEAMROOT" ]; then
+  mkdir -p "$STEAMROOT"/{appcache,config,logs,Steamapps/common}
+  mkdir -p ~/.steam
+  ln -sf "$STEAMROOT" ~/.steam/root
+  ln -sf "$STEAMROOT" ~/.steam/steam
+fi
+
+# Copy the system steamcmd install to the Steam root. If we don't do
+# this, steamcmd assumes the path to `steamcmd` is the Steam root.
+# Note that symlinks don't work here.
+if [ ! -e "$STEAMROOT/steamcmd.sh" ]; then
+  mkdir -p "$STEAMROOT/linux32"
+  # steamcmd.sh will replace these on first use
+  cp @out@/share/steamcmd/steamcmd.sh "$STEAMROOT/."
+  cp @out@/share/steamcmd/linux32/* "$STEAMROOT/linux32/."
+fi
+
+@steamRun@/bin/steam-run "$STEAMROOT/steamcmd.sh" "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20210,6 +20210,8 @@ with pkgs;
     nativeOnly = true;
   }).run;
 
+  steamcmd = steamPackages.steamcmd;
+
   linux-steam-integration = callPackage ../games/linux-steam-integration {
     gtk = pkgs.gtk3;
   };


### PR DESCRIPTION
###### Motivation for this change

Package the `steamcmd` utility for NixOS.

Curiously, `steamcmd.sh` and its libraries *must* reside in a Steam root such that it can overwrite itself at runtime. So I've adapted the [debian wrapper](https://anonscm.debian.org/cgit/pkg-games/steamcmd.git/tree/debian/scripts/steamcmd) which basically copies the system install over to the user's Steam root if it doesn't exist.

An interesting possibility could be to use this tool to install Steam games to the Nix store. It would be of limited use for packaging, however, because Steam games aren't versioned.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

