### PR TITLE
onestepback: init at 0.98

### DIFF
--- a/pkgs/misc/themes/onestepback/default.nix
+++ b/pkgs/misc/themes/onestepback/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchzip }:
+
+let
+  version = "0.98";
+
+in fetchzip {
+  name = "onestepback-${version}";
+
+  url = "http://www.vide.memoire.free.fr/perso/OneStepBack/OneStepBack-v${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/themes
+    unzip $downloadedFile -x OneStepBack/LICENSE -d $out/share/themes
+  '';
+
+  sha256 = "0sjacvx7020lzc89r5310w83wclw96gzzczy3mss54ldkgmnd0mr";
+
+  meta = with stdenv.lib; {
+    description = "Gtk theme inspired by the NextStep look";
+    homepage = https://www.opendesktop.org/p/1013663/;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19609,6 +19609,8 @@ with pkgs;
 
   numix-sx-gtk-theme = callPackage ../misc/themes/numix-sx { };
 
+  onestepback = callPackage ../misc/themes/onestepback { };
+
   theme-vertex = callPackage ../misc/themes/vertex { };
 
   rox-filer = callPackage ../desktops/rox/rox-filer {


### PR DESCRIPTION
###### Motivation for this change

Add the package [`OneStepBack`](https://www.opendesktop.org/p/1013663/), a Gtk 2 and 3 theme with some colors and embossed widgets inspired by the good old NextStep look.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).