### PR TITLE
pythonPackages.apsw: 3.9.2-r1 -> 3.22.0-r1

### DIFF
--- a/pkgs/development/python-modules/apsw/default.nix
+++ b/pkgs/development/python-modules/apsw/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchFromGitHub
 , sqlite, isPyPy }:
 
 buildPythonPackage rec {
   pname = "apsw";
-  version = "3.9.2-r1";
+  version = "3.22.0-r1";
 
   disabled = isPyPy;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "dab96fd164dde9e59f7f27228291498217fa0e74048e2c08c7059d7e39589270";
+  src = fetchFromGitHub {
+    owner = "rogerbinns";
+    repo = "apsw";
+    rev = version;
+    sha256 = "02ldvshcgr4c7c8anp4flfnw8g8ys5bflkb8b51rb618qxhhwyak";
   };
 
   buildInputs = [ sqlite ];
 
-  # python: double free or corruption (fasttop): 0x0000000002fd4660 ***
-#   doCheck = false;
-
   meta = with stdenv.lib; {
     description = "A Python wrapper for the SQLite embedded relational database engine";
-    homepage = http://code.google.com/p/apsw/;
+    homepage = https://github.com/rogerbinns/apsw;
+    license = licenses.zlib;
   };
 }


### PR DESCRIPTION
Replaced fetchPypi with fetchFromGitHub because no new version has been uploaded to pypi since 2016, but there are new releases on github.

We need a recent version for new tribler versions to work.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This PR does not fit CONTRIBUTING.md because meta.maintainers is not set.
