### PR TITLE
mergerfs: 2.24.0 -> 2.24.2

### DIFF
--- a/pkgs/tools/filesystems/mergerfs/default.nix
+++ b/pkgs/tools/filesystems/mergerfs/default.nix
@@ -1,20 +1,27 @@
-{ stdenv, fetchgit, autoconf, automake, pkgconfig, gettext, libtool, git, pandoc, which, attr, libiconv }:
+{ stdenv, fetchFromGitHub, automake, autoconf, pkgconfig, gettext, libtool, pandoc, which, attr, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "mergerfs-${version}";
-  version = "2.24.0";
+  version = "2.24.2";
 
-  # not using fetchFromGitHub because of changelog being built with git log
-  src = fetchgit {
-    url = "https://github.com/trapexit/mergerfs";
-    rev = "refs/tags/${version}";
-    sha256 = "12ci1i5zkarl1rz0pq1ldw0fpp4yfj8vz36jij63am7w7gp7qly2";
-    deepClone = true;
-    leaveDotGit = true;
+  src = fetchFromGitHub {
+    owner = "trapexit";
+    repo = "mergerfs";
+    rev = version;
+    sha256 = "0i65v7900s7c9jkj3a4v44vf3r5mvjkbcic3df940nmk0clahhcs";
   };
 
-  nativeBuildInputs = [ autoconf automake pkgconfig gettext libtool git pandoc which ];
+  nativeBuildInputs = [
+    automake autoconf pkgconfig gettext libtool pandoc which
+  ];
   buildInputs = [ attr libiconv ];
+
+  preConfigure = ''
+    cat > src/version.hpp <<EOF
+    #pragma once
+    static const char MERGERFS_VERSION[] = "${version}";
+    EOF
+  '';
 
   makeFlags = [ "PREFIX=$(out)" "XATTR_AVAILABLE=1" ];
 


### PR DESCRIPTION
Remove .git because it tend to break hashes.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

