### PR TITLE
Update shadowsocks-libuv and add shadowsocks service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -547,6 +547,7 @@
   ./services/networking/searx.nix
   ./services/networking/seeks.nix
   ./services/networking/skydns.nix
+  ./services/networking/shadowsocks.nix
   ./services/networking/shairport-sync.nix
   ./services/networking/shout.nix
   ./services/networking/sniproxy.nix

--- a/nixos/modules/services/networking/shadowsocks.nix
+++ b/nixos/modules/services/networking/shadowsocks.nix
@@ -1,0 +1,112 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.shadowsocks;
+
+  opts = {
+    server = cfg.localAddress;
+    server_port = cfg.port;
+    method = cfg.encryptionMethod;
+    mode = cfg.mode;
+    user = "nobody";
+    fast_open = true;
+  } // optionalAttrs (cfg.password != null) { password = cfg.password; };
+
+  configFile = pkgs.writeText "shadowsocks.json" (builtins.toJSON opts);
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.shadowsocks = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to run shadowsocks-libev shadowsocks server.
+        '';
+      };
+
+      localAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        description = ''
+          Local address to which the server binds.
+        '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 8388;
+        description = ''
+          Port which the server uses.
+        '';
+      };
+
+      password = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Password for connecting clients.
+        '';
+      };
+
+      passwordFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Password file with a password for connecting clients.
+        '';
+      };
+
+      mode = mkOption {
+        type = types.enum [ "tcp_only" "tcp_and_udp" "udp_only" ];
+        default = "tcp_and_udp";
+        description = ''
+          Relay protocols.
+        '';
+      };
+
+      encryptionMethod = mkOption {
+        type = types.str;
+        default = "chacha20-ietf-poly1305";
+        description = ''
+          Encryption method. See <link xlink:href="https://github.com/shadowsocks/shadowsocks-org/wiki/AEAD-Ciphers"/>.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    assertions = singleton
+      { assertion = cfg.password == null || cfg.passwordFile == null;
+        message = "Cannot use both password and passwordFile for shadowsocks-libev";
+      };
+
+    systemd.services.shadowsocks-libev = {
+      description = "shadowsocks-libev Daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.shadowsocks-libev ] ++ optional (cfg.passwordFile != null) pkgs.jq;
+      serviceConfig.PrivateTmp = true;
+      script = ''
+        ${optionalString (cfg.passwordFile != null) ''
+          cat ${configFile} | jq --arg password "$(cat "${cfg.passwordFile}")" '. + { password: $password }' > /tmp/shadowsocks.json
+        ''}
+        exec ss-server -c ${if cfg.passwordFile != null then "/tmp/shadowsocks.json" else configFile}
+      '';
+    };
+  };
+}

--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -1,47 +1,32 @@
-{ withMbedTLS ? true
-, enableSystemSharedLib ? true
-, stdenv, fetchurl, zlib
-, openssl ? null
-, mbedtls ? null
-, libev ? null
-, libsodium ? null
-, udns ? null
-, asciidoc
-, xmlto
-, docbook_xml_dtd_45
-, docbook_xsl
-, libxslt
-, pcre
+{ stdenv, fetchurl, fetchgit, cmake
+, libsodium, mbedtls, libev, c-ares, pcre
+, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, libxslt
 }:
-
-let
-
-  version = "2.5.5";
-  sha256 = "46a72367b7301145906185f1e4136e39d6792d27643826e409ab708351b6d0dd";
-
-in
-
-with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "shadowsocks-libev-${version}";
-  src = fetchurl {
-    url = "https://github.com/shadowsocks/shadowsocks-libev/archive/v${version}.tar.gz";
-    inherit sha256;
+  version = "3.1.3";
+
+  # Git tag includes CMake build files which are much more convenient.
+  # fetchgit because submodules.
+  src = fetchgit {
+    url = "https://github.com/shadowsocks/shadowsocks-libev";
+    rev = "refs/tags/v${version}";
+    sha256 = "16q91xh6ixfv7b5rl31an11101irv08119klfx5qgj4i6h7c41s7";
   };
 
-  buildInputs = [ zlib asciidoc xmlto docbook_xml_dtd_45 docbook_xsl libxslt pcre ]
-                ++ optional (!withMbedTLS) openssl
-                ++ optional withMbedTLS mbedtls
-                ++ optionals enableSystemSharedLib [libev libsodium udns];
+  buildInputs = [ libsodium mbedtls libev c-ares pcre ];
+  nativeBuildInputs = [ cmake asciidoc xmlto docbook_xml_dtd_45 docbook_xsl libxslt ];
 
-  configureFlags = optional withMbedTLS
-                     [ "--with-crypto-library=mbedtls"
-                       "--with-mbedtls=${mbedtls}"
-                     ]
-                   ++ optional enableSystemSharedLib "--enable-system-shared-lib";
+  cmakeFlags = [ "-DWITH_STATIC=OFF" ];
 
-  meta = {
+  postInstall = ''
+    cp lib/* $out/lib
+    chmod +x $out/bin/*
+    mv $out/pkgconfig $out/lib
+  '';
+
+  meta = with stdenv.lib; {
     description = "A lightweight secured SOCKS5 proxy";
     longDescription = ''
       Shadowsocks-libev is a lightweight secured SOCKS5 proxy for embedded devices and low-end boxes.
@@ -50,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/shadowsocks/shadowsocks-libev;
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.nfjinjing ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://www.theverge.com/2018/4/13/17233112/russia-telegram-ban-court-ruling

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested with an Android client.