### PR TITLE
iamy: init at 2.1.1

### DIFF
--- a/pkgs/tools/admin/iamy/default.nix
+++ b/pkgs/tools/admin/iamy/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "iamy-${version}";
+  version = "2.1.1";
+
+  goPackagePath = "github.com/99designs/iamy";
+
+  src = fetchFromGitHub {
+    owner = "99designs";
+    repo = "iamy";
+    rev = "v${version}";
+    sha256 = "0b55hxcvgil8rl6zh2kyndfi7s5nzclawjb0sby14wpys3v08bjf";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A cli tool for importing and exporting AWS IAM configuration to YAML files";
+    homepage = https://github.com/99designs/iamy;
+    license = licenses.mit;
+    maintainers = with maintainers; [ suvash ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -563,6 +563,8 @@ with pkgs;
 
   aws-vault = callPackage ../tools/admin/aws-vault { };
 
+  iamy = callPackage ../tools/admin/iamy { };
+
   azure-cli = nodePackages.azure-cli;
 
   azure-vhd-utils  = callPackage ../tools/misc/azure-vhd-utils { };


### PR DESCRIPTION
Add iamy package - maintains aws iam in yaml format

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

