### PR TITLE
backintime-qt4: package is broken

### DIFF
--- a/pkgs/applications/networking/sync/backintime/qt4.nix
+++ b/pkgs/applications/networking/sync/backintime/qt4.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, makeWrapper, gettext, pkgconfig, libtool, backintime-common, python3, python3Packages }:
 
 stdenv.mkDerivation rec {
-  inherit (backintime-common) version src installFlags meta;
+  inherit (backintime-common) version src installFlags;
 
   name = "backintime-qt4-${version}";
 
@@ -22,4 +22,7 @@ stdenv.mkDerivation rec {
         --prefix PATH : "${backintime-common}/bin:$PATH"
     '';
 
+  meta = with stdenv.lib; {
+    broken = true;
+  };
 }


### PR DESCRIPTION
the install phase writes into /nix :

```
<snip>
install -d
/nix/store/1kc8xcni0wp4y35vafh03rdxvqkrsxvl-backintime-qt4-1.1.24/../etc/dbus-1/system.d
install --mode=644 net.launchpad.backintime.serviceHelper.conf
/nix/store/1kc8xcni0wp4y35vafh03rdxvqkrsxvl-backintime-qt4-1.1.24/../etc/dbus-1/system.d
<snap>
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

