### PR TITLE
c14: 2017-05-15 -> 0.3

### DIFF
--- a/pkgs/applications/networking/c14/default.nix
+++ b/pkgs/applications/networking/c14/default.nix
@@ -1,9 +1,9 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "c14-cli-unstable-${version}";
-  version = "2017-05-15";
-  rev = "97f437ef5133f73edd551c883db3076c76cb1f6b";
+  name = "c14-cli-${version}";
+  version = "0.3";
+  rev = "a9c2cd8";
 
   goPackagePath = "github.com/online-net/c14-cli";
 
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "online-net";
     repo = "c14-cli";
     inherit rev;
-    sha256 = "1b44bh0zhh6rhw4d3nprnnxhjgaskl9kzp2cvwwyli5svhjxrfdj";
+    sha256 = "0b1piviy6vvdbak8y8bc24rk3c1fi67vv3352pmnzvrhsar2r5yf";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/networking/c14/default.nix
+++ b/pkgs/applications/networking/c14/default.nix
@@ -3,14 +3,13 @@
 buildGoPackage rec {
   name = "c14-cli-${version}";
   version = "0.3";
-  rev = "a9c2cd8";
 
   goPackagePath = "github.com/online-net/c14-cli";
 
   src = fetchFromGitHub {
     owner = "online-net";
     repo = "c14-cli";
-    inherit rev;
+    rev = "${version}";
     sha256 = "0b1piviy6vvdbak8y8bc24rk3c1fi67vv3352pmnzvrhsar2r5yf";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Up from unstable git rev to 0.3 tag

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

