### PR TITLE
eli: init at 4.8.1

### DIFF
--- a/pkgs/development/compilers/eli/default.nix
+++ b/pkgs/development/compilers/eli/default.nix
@@ -1,0 +1,91 @@
+{ stdenv
+, fetchurl
+, symlinkJoin
+, makeWrapper
+, tcl
+, fontconfig
+, tk
+, ncurses
+, xorg
+, file
+}:
+
+let
+  # eli derives the location of the include folder from the location of the lib folder
+  tk_combined = symlinkJoin {
+    name = "tk_combined";
+    paths = [
+      tk
+      tk.dev
+    ];
+  };
+  curses_combined = symlinkJoin {
+    name = "curses_combined";
+    paths = [
+      ncurses
+      ncurses.dev
+    ];
+  };
+in
+stdenv.mkDerivation rec {
+  name = "eli";
+  version = "4.8.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/eli-project/Eli/Eli%20${version}/eli-${version}.tar.bz2";
+    sha256="1vran8583hbwrr5dciji4zkhz3f88w4mn8n9sdpr6zw0plpf1whj";
+  };
+
+  buildInputs = [
+    ncurses
+    fontconfig
+  ] ++ (with xorg; [
+    libX11.dev
+    libXt.dev
+    libXaw.dev
+    libXext.dev
+  ]);
+
+  nativeBuildInputs = [
+    file
+    makeWrapper
+  ];
+
+  # skip interactive browser check
+  buildFlags = "nobrowsers";
+
+
+  preConfigure=''
+    configureFlagsArray=(
+      --with-tcltk="${tcl} ${tk_combined}"
+      --with-curses="${curses_combined}"
+    )
+    export ODIN_LOCALIPC=1
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/eli" \
+      --set ODIN_LOCALIPC 1
+  '';
+
+  # Test if eli starts
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export HOME="$TMP/home"
+    mkdir -p "$HOME"
+    $out/bin/eli "!ls"
+  '';
+
+  meta = {
+    description = "Translator Construction Made Easy";
+    longDescription = ''
+      Eli is a programming environment that supports all phases of translator
+      construction with extensive libraries implementing common tasks, yet handling
+      arbitrary special cases. Output is the C subset of C++.
+    '';
+    homepage = http://eli-project.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ timokau ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5986,6 +5986,8 @@ with pkgs;
   ecl = callPackage ../development/compilers/ecl { };
   ecl_16_1_2 = callPackage ../development/compilers/ecl/16.1.2.nix { };
 
+  eli = callPackage ../development/compilers/eli { };
+
   eql = callPackage ../development/compilers/eql {};
 
   elmPackages = recurseIntoAttrs (callPackage ../development/compilers/elm { });


### PR DESCRIPTION
###### Motivation for this change

I need eli for an university class.

I'm not sure about the location in the nixpkgs tree: It is not a compiler, but intended for compiler development.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

