### PR TITLE
masterpdfeditor: 4.3.82 -> 4.3.89

### DIFF
--- a/pkgs/applications/misc/masterpdfeditor/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, glibc, sane-backends, qtbase, qtsvg, libXext, libX11, libXdmcp, libXau, libxcb }:
   let
-    version = "4.3.82";
+    version = "4.3.89";
   in
     stdenv.mkDerivation {
       name = "masterpdfeditor-${version}";
       src = fetchurl {
         url = "http://get.code-industry.net/public/master-pdf-editor-${version}_qt5.amd64.tar.gz";
-        sha256 = "0bfqnpg2p5jxygcahqqljyb0gd2z28hj5n1j9g1x7px8f7wwiwl4";
+        sha256 = "0k5bzlhqglskiiq86nmy18mnh5bf2w3mr9cq3pibrwn5pisxnxxc";
       };
       libPath = stdenv.lib.makeLibraryPath [
         stdenv.cc.cc


### PR DESCRIPTION
Changelog:

```
Version 4.3.89
March, 21h, 2018

Fixed issue with application’s settings reset.

Version 4.3.88
March, 20h, 2018

Improved printing system and fixed some related errors.
Fixed several crash-related bugs.
Linux version is optimized for later distros.
Extended application localization. Added Finnish language.
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

