### PR TITLE
xen-4.8: fix qemu-xen build error in memfd.c

### DIFF
--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -41,6 +41,12 @@ let
     sha256 = "1ki295pymbcfc64sjb9wqfwpv19p8vwgmnxankada3vm4fxg2rhq";
   });
 
+  qemuMemfdBuildFix = fetchpatch {
+    name = "xen-4.8-memfd-build-fix.patch";
+    url = https://github.com/qemu/qemu/commit/75e5b70e6b5dcc4f2219992d7cffa462aa406af0.patch;
+    sha256 = "0gaz93kb33qc0jx6iphvny0yrd17i8zhcl3a9ky5ylc2idz0wiwa";
+  };
+
   qemuDeps = [
     udev pciutils xorg.libX11 SDL pixman acl glusterfs spice-protocol usbredir
     alsaLib
@@ -63,6 +69,9 @@ callPackage (import ./generic.nix (rec {
         rev = "refs/tags/qemu-xen-${version}";
         sha256 = "0lb7zd5nvr6znx47z93nbq4gj8xfb3622s8r2cvmpqmwnmlc3nd4";
       };
+      patches = [
+        qemuMemfdBuildFix
+      ];
       buildInputs = qemuDeps;
       meta.description = "Xen's fork of upstream Qemu";
     };


### PR DESCRIPTION
Apply https://github.com/qemu/qemu/commit/75e5b70e6b5dcc4f2219992d7cffa462aa406af0
see also https://www.mail-archive.com/xen-devel@lists.xenproject.org/msg08648.html

cc @eelco @tstrobel @oxij

###### Motivation for this change

This fixes [this hydra failure](https://hydra.nixos.org/build/72692475) on my machine

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

