### PR TITLE
git: add install checks

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/installCheck-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/installCheck-path.patch
@@ -1,0 +1,12 @@
+diff --git a/t/test-lib.sh b/t/test-lib.sh
+--- a/t/test-lib.sh
++++ b/t/test-lib.sh
+@@ -923,7 +923,7 @@
+ then
+ 	GIT_EXEC_PATH=$($GIT_TEST_INSTALLED/git --exec-path)  ||
+ 	error "Cannot run git from $GIT_TEST_INSTALLED."
+-	PATH=$GIT_TEST_INSTALLED:$GIT_BUILD_DIR:$PATH
++	PATH=$GIT_TEST_INSTALLED:$GIT_BUILD_DIR/t/helper:$GIT_BUILD_DIR:$PATH
+ 	GIT_EXEC_PATH=${GIT_TEST_EXEC_PATH:-$GIT_EXEC_PATH}
+ else # normal case, use ../bin-wrappers only unless $with_dashes:
+ 	git_bin_dir="$GIT_BUILD_DIR/bin-wrappers"


### PR DESCRIPTION
After the epic failure of reverting three times the update to 2.17.0, I decided to add install checks to git.
This was quite a feat, and also increases the build time significantly.

Please do not merge this before proper testing on MacOS. Only tests are added, so it should be e very low impact PR, but git is quite central to nix{,pkgs}.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---