### PR TITLE
pure: 0.66 -> 0.68

### DIFF
--- a/pkgs/development/interpreters/pure/default.nix
+++ b/pkgs/development/interpreters/pure/default.nix
@@ -3,14 +3,12 @@
 
 stdenv.mkDerivation rec {
   baseName="pure";
-  project="pure-lang";
-  version="0.66";
+  version="0.68";
   name="${baseName}-${version}";
-  extension="tar.gz";
 
   src = fetchurl {
-    url="https://bitbucket.org/purelang/${project}/downloads/${name}.${extension}";
-    sha256="42df6832476e8bee3a7ca179671284c1edd7bc82b71062fa0de62fd2117ee676";
+    url="https://github.com/agraef/pure-lang/releases/download/${name}/${name}.tar.gz";
+    sha256="0px6x5ivcdbbp2pz5n1r1cwg1syadklhjw8piqhl63n91i4r7iyb";
   };
 
   buildInputs = [ bison flex makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Update Pure to latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

