### PR TITLE
home-assistant: 0.66.1 -> 0.67.0

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.66.1";
+  version = "0.67.0";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
@@ -59,6 +59,7 @@
     "coinbase" = ps: with ps; [  ];
     "comfoconnect" = ps: with ps; [  ];
     "config.config_entries" = ps: with ps; [  ];
+    "cover.gogogate2" = ps: with ps; [  ];
     "cover.myq" = ps: with ps; [  ];
     "daikin" = ps: with ps; [  ];
     "datadog" = ps: with ps; [ datadog ];
@@ -71,6 +72,7 @@
     "device_tracker.bluetooth_tracker" = ps: with ps; [  ];
     "device_tracker.cisco_ios" = ps: with ps; [ pexpect ];
     "device_tracker.fritz" = ps: with ps; [ fritzconnection ];
+    "device_tracker.google_maps" = ps: with ps; [  ];
     "device_tracker.icloud" = ps: with ps; [  ];
     "device_tracker.linksys_ap" = ps: with ps; [ beautifulsoup4 ];
     "device_tracker.mikrotik" = ps: with ps; [  ];
@@ -84,6 +86,7 @@
     "device_tracker.unifi" = ps: with ps; [ pyunifi ];
     "device_tracker.unifi_direct" = ps: with ps; [ pexpect ];
     "device_tracker.upc_connect" = ps: with ps; [ defusedxml ];
+    "device_tracker.xiaomi_miio" = ps: with ps; [  ];
     "digital_ocean" = ps: with ps; [ digital-ocean ];
     "discovery" = ps: with ps; [ netdisco ];
     "dominos" = ps: with ps; [  ];
@@ -99,6 +102,7 @@
     "fan.xiaomi_miio" = ps: with ps; [ construct ];
     "feedreader" = ps: with ps; [ feedparser ];
     "ffmpeg" = ps: with ps; [ ha-ffmpeg ];
+    "folder_watcher" = ps: with ps; [ watchdog ];
     "frontend" = ps: with ps; [  ];
     "gc100" = ps: with ps; [  ];
     "goalfeed" = ps: with ps; [  ];
@@ -139,6 +143,7 @@
     "light.lifx_legacy" = ps: with ps; [  ];
     "light.limitlessled" = ps: with ps; [  ];
     "light.mystrom" = ps: with ps; [  ];
+    "light.nanoleaf_aurora" = ps: with ps; [  ];
     "light.osramlightify" = ps: with ps; [  ];
     "light.piglow" = ps: with ps; [  ];
     "light.rpi_gpio_pwm" = ps: with ps; [  ];
@@ -205,7 +210,6 @@
     "media_player.yamaha_musiccast" = ps: with ps; [  ];
     "media_player.ziggo_mediabox_xl" = ps: with ps; [  ];
     "melissa" = ps: with ps; [  ];
-    "mercedesme" = ps: with ps; [  ];
     "mochad" = ps: with ps; [  ];
     "modbus" = ps: with ps; [  ];
     "mqtt" = ps: with ps; [ paho-mqtt ];
@@ -230,6 +234,7 @@
     "notify.kodi" = ps: with ps; [ jsonrpc-async ];
     "notify.lametric" = ps: with ps; [  ];
     "notify.mailgun" = ps: with ps; [  ];
+    "notify.mastodon" = ps: with ps; [  ];
     "notify.matrix" = ps: with ps; [ matrix-client ];
     "notify.message_bird" = ps: with ps; [  ];
     "notify.pushbullet" = ps: with ps; [ pushbullet ];
@@ -375,6 +380,7 @@
     "sensor.ups" = ps: with ps; [  ];
     "sensor.vasttrafik" = ps: with ps; [  ];
     "sensor.waqi" = ps: with ps; [  ];
+    "sensor.waze_travel_time" = ps: with ps; [  ];
     "sensor.whois" = ps: with ps; [  ];
     "sensor.xbox_live" = ps: with ps; [  ];
     "sensor.xiaomi_miio" = ps: with ps; [ construct ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -8,10 +8,10 @@ let
   py = python3.override {
     packageOverrides = self: super: {
       aiohttp = super.aiohttp.overridePythonAttrs (oldAttrs: rec {
-        version = "3.0.9";
+        version = "3.1.1";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "281a9fa56b5ce587a2147ec285d18a224942f7e020581afa6cc44d7caecf937b";
+          sha256 = "dc5cab081d4b334d0440b019edf24fe1cb138b8114e0e22d2b0661284bc1775f";
         };
       });
       pytest = super.pytest.overridePythonAttrs (oldAttrs: rec {
@@ -58,7 +58,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.66.1";
+  hassVersion = "0.67.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -73,7 +73,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "16yz5mfzpfms22f8linw1k3wjp3jpwj270vy2rc893x9bzsppfl0";
+    sha256 = "00y7sm6nsyxxl98izxxmg2nwi76kxb7p47hv07y04fs45lnvr61s";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

