### PR TITLE
Fix stdenv-native and fix rebasing on cygwin

### DIFF
--- a/pkgs/stdenv/cygwin/rebase-x86_64.sh
+++ b/pkgs/stdenv/cygwin/rebase-x86_64.sh
@@ -8,7 +8,7 @@ _cygwinFixAutoImageBase() {
         if [ -f /etc/rebasenix.nextbase ]; then
             NEXTBASE="$(</etc/rebasenix.nextbase)"
         fi
-        NEXTBASE=${NEXTBASE:-0x200000000}
+        NEXTBASE=${NEXTBASE:-0x200000001}
 
         REBASE=(`/bin/rebase -i $DLL`)
         BASE=${REBASE[2]}

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -119,14 +119,23 @@ in
     };
     stdenvNoCC = stdenv;
 
-    cc = import ../../build-support/cc-wrapper {
-      name = "cc-native";
-      nativeTools = true;
-      nativeLibc = true;
+    cc = let
       nativePrefix = { # switch
         "i686-solaris" = "/usr/gnu";
         "x86_64-solaris" = "/opt/local/gcc47";
       }.${system} or "/usr";
+    in
+    import ../../build-support/cc-wrapper {
+      name = "cc-native";
+      nativeTools = true;
+      nativeLibc = true;
+      inherit nativePrefix;
+      bintools = import ../../build-support/bintools-wrapper {
+        name = "bintools";
+        inherit stdenvNoCC nativePrefix;
+        nativeTools = true;
+        nativeLibc = true;
+      };
       inherit stdenvNoCC;
     };
 


### PR DESCRIPTION
###### Motivation for this change

As described in issue #38825, `stdenv-native` is broken on master and `release-18.03` because the mandatory `bintools` parameter is not propagated. This pull requests fixes this.

Furthermore, on Cygwin rebasing is also broken. When I try to build any package on Cygwin, it will show:

```
rebase: Invalid Baseaddress 0x200000000, must be > 0x200000000
```

It appears that increasing the base offset by 1 seems to do the trick.

In addition to merging this to master, you probably want to cherry pick and apply this to `release-18.03` as well -- it has exactly the same problem.

###### Things done

Compose a bintools package, change the base offset

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

