### PR TITLE
docker-tools: add a test for permissions issues with AUFS/overlay

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -266,6 +266,7 @@ in rec {
   tests.couchdb = callTest tests/couchdb.nix {};
   tests.docker = callTestOnMatchingSystems ["x86_64-linux"] tests/docker.nix {};
   tests.docker-tools = callTestOnMatchingSystems ["x86_64-linux"] tests/docker-tools.nix {};
+  tests.docker-tools-overlay = callTestOnMatchingSystems ["x86_64-linux"] tests/docker-tools-overlay.nix {};
   tests.docker-edge = callTestOnMatchingSystems ["x86_64-linux"] tests/docker-edge.nix {};
   tests.dovecot = callTest tests/dovecot.nix {};
   tests.dnscrypt-proxy = callTestOnMatchingSystems ["x86_64-linux"] tests/dnscrypt-proxy.nix {};

--- a/nixos/tests/docker-tools-overlay.nix
+++ b/nixos/tests/docker-tools-overlay.nix
@@ -1,0 +1,32 @@
+# this test creates a simple GNU image with docker tools and sees if it executes
+
+import ./make-test.nix ({ pkgs, ... }:
+{
+  name = "docker-tools-overlay";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ lnl7 ];
+  };
+
+  nodes = {
+    docker =
+      { config, pkgs, ... }:
+      {
+        virtualisation.docker.enable = true;
+        virtualisation.docker.storageDriver = "overlay";  # defaults to overlay2
+      };
+  };
+
+  testScript =
+    ''
+      $docker->waitForUnit("sockets.target");
+
+      $docker->succeed("docker load --input='${pkgs.dockerTools.examples.bash}'");
+      $docker->succeed("docker run --rm ${pkgs.dockerTools.examples.bash.imageName} bash --version");
+
+      # Check if the nix store has correct user permissions depending on what
+      # storage driver is used, incorrectly built images can show up as readonly.
+      # drw-------  3 0 0   3 Apr 14 11:36 /nix
+      # drw------- 99 0 0 100 Apr 14 11:36 /nix/store
+      $docker->succeed("docker run --rm -u 1000:1000 ${pkgs.dockerTools.examples.bash.imageName} bash --version");
+    '';
+})

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -3,7 +3,7 @@
 import ./make-test.nix ({ pkgs, ... }: {
   name = "docker-tools";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ ];
+    maintainers = [ lnl7 ];
   };
 
   nodes = {
@@ -21,12 +21,12 @@ import ./make-test.nix ({ pkgs, ... }: {
       $docker->waitForUnit("sockets.target");
 
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.bash}'");
-      $docker->succeed("docker run --rm ${pkgs.dockerTools.examples.bash.imageName} /bin/bash --version");
+      $docker->succeed("docker run --rm ${pkgs.dockerTools.examples.bash.imageName} bash --version");
       $docker->succeed("docker rmi ${pkgs.dockerTools.examples.bash.imageName}");
 
       # Check if the nix store is correctly initialized by listing dependencies of the installed Nix binary
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.nix}'");
-      $docker->succeed("docker run --rm ${pkgs.dockerTools.examples.nix.imageName} /bin/nix-store -qR ${pkgs.nix}");
+      $docker->succeed("docker run --rm ${pkgs.dockerTools.examples.nix.imageName} nix-store -qR ${pkgs.nix}");
       $docker->succeed("docker rmi ${pkgs.dockerTools.examples.nix.imageName}");
 
       # To test the pullImage tool


### PR DESCRIPTION
###### Motivation for this change

Add a test for #38835

```
docker# [   11.054736] d24d6cdd57c9[763]: /bin/bash: error while loading
shared libraries: libreadline.so.7: cannot open shared object file:
Permission denied
docker# /bin/bash: error while loading shared libraries:
libreadline.so.7: cannot open shared object file: Permission denied
docker: exit status 127
docker: output:
error: command `docker run --rm -u 1000:1000 bash /bin/bash --version'
did not succeed (exit code 127)
command `docker run --rm -u 1000:1000 bash /bin/bash --version' did not
succeed (exit code 127)
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
