### PR TITLE
python.pkgs: pip 9.0.3 -> 10.0.1

### DIFF
--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -14,14 +14,6 @@ let
     sha256 = "8010754433e3211b9cdbbf784b50f30e80bf40fc6b05eb5f865fab83300599b8";
   };
 
-  # TODO: Shouldn't be necessary anymore for pip >= 10!
-  # https://github.com/NixOS/nixpkgs/issues/26392
-  # https://github.com/pypa/setuptools/issues/885
-  pkg_resources = fetchurl {
-    url = "https://raw.githubusercontent.com/pypa/setuptools/v36.0.1/pkg_resources/__init__.py";
-    sha256 = "1wdnq3mammk75mifkdmmjx7yhnpydvnvi804na8ym4mj934l2jkv";
-  };
-
 in stdenv.mkDerivation rec {
   pname = "pip";
   version = "10.0.1";
@@ -38,8 +30,6 @@ in stdenv.mkDerivation rec {
     unzip -d $out/${python.sitePackages} $src
     unzip -d $out/${python.sitePackages} ${setuptools_source}
     unzip -d $out/${python.sitePackages} ${wheel_source}
-    # TODO: Shouldn't be necessary anymore for pip >= 10!
-    cp ${pkg_resources} $out/${python.sitePackages}/pip/_vendor/pkg_resources/__init__.py
   '';
 
   patchPhase = ''

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -3,9 +3,9 @@
 let
   wheel_source = fetchPypi {
     pname = "wheel";
-    version = "0.30.0";
+    version = "0.31.0";
     format = "wheel";
-    sha256 = "e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64";
+    sha256 = "9cdc8ab2cc9c3c2e2727a4b67c22881dbb0e1c503d592992594c5e131c867107";
   };
   setuptools_source = fetchPypi {
     pname = "setuptools";

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -24,13 +24,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "pip";
-  version = "9.0.3";
+  version = "10.0.1";
   name = "${python.libPrefix}-bootstrapped-${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     format = "wheel";
-    sha256 = "c3ede34530e0e0b2381e7363aded78e0c33291654937e7373032fda04e8803e5";
+    sha256 = "717cdffb2833be8409433a93746744b59505f42146e8d37de6c62b430e25d6d7";
   };
 
   unpackPhase = ''
@@ -53,7 +53,7 @@ in stdenv.mkDerivation rec {
 
     # install pip binary
     echo '#!${python.interpreter}' > $out/bin/pip
-    echo 'import sys;from pip import main' >> $out/bin/pip
+    echo 'import sys;from pip._internal import main' >> $out/bin/pip
     echo 'sys.exit(main())' >> $out/bin/pip
     chmod +x $out/bin/pip
 

--- a/pkgs/development/python-modules/docker-pycreds/default.nix
+++ b/pkgs/development/python-modules/docker-pycreds/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "docker-pycreds";
-  version = "0.2.2";
+  version = "0.2.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c7ab85de2894baff6ee8f15160cbbfa2fd3a04e56f0372c5793d24060687b299";
+    sha256 = "e3732a03610a00461a716997670c7010bf1c214a3edc440f7d6a2a3a830ecd9d";
   };
 
   # require docker-credential-helpers binaries

--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -3,12 +3,12 @@
 , ipaddress, backports_ssl_match_hostname, docker_pycreds
 }:
 buildPythonPackage rec {
-  version = "3.2.1";
+  version = "3.3.0";
   pname = "docker";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0d698c3dc4df66c988de5df21a62cdc3450de2fa8523772779e5e23799c41f43";
+    sha256 = "dc5cc0971a0d36fe94c5ce89bd4adb6c892713500af7b0818708229c3199911a";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/flake8-future-import/default.nix
+++ b/pkgs/development/python-modules/flake8-future-import/default.nix
@@ -3,27 +3,18 @@
 
 buildPythonPackage rec {
   pname = "flake8-future-import";
-  name = "${pname}-${version}";
-  version = "0.4.3";
+  version = "0.4.5";
+
   # PyPI tarball doesn't include the test suite
   src = fetchFromGitHub {
     owner = "xZise";
     repo = "flake8-future-import";
     rev = version;
-    sha256 = "0622bdcfa588m7g8igag6hf4rhjdwh74yfnrjwlxw4vlqhg344k4";
+    sha256 = "00fpxa6g8cabybnciwnpsbg60zhgydc966jgwyyggw1pcg0frdqr";
   };
 
-  patches = [
-    # Tests in 0.4.3 are broken. We can remove this patch after
-    # the next release.
-    (fetchurl {
-      url = "https://github.com/xZise/flake8-future-import/commit/b4f5a06b22c574fb5270574d1420715667768d5c.patch";
-      sha256 = "06n9ggz9p9kiwjb3vmaj44pm5vi4nhgzjfn7i730m85xn67xzmyn";
-    })
-  ];
-
-
   propagatedBuildInputs = [ flake8 six ];
+
   meta = {
     homepage = https://github.com/xZise/flake8-future-import;
     description = "A flake8 extension to check for the imported __future__ modules to make it easier to have a consistent code base";

--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -3,12 +3,12 @@
 
 buildPythonPackage rec {
   pname = "pip-tools";
-  version = "1.11.0";
+  version = "2.0.1";
   name = pname + "-" + version;
 
   src = fetchurl {
     url = "mirror://pypi/p/pip-tools/${name}.tar.gz";
-    sha256 = "ba427b68443466c389e3b0b0ef55f537ab39344190ea980dfebb333d0e6a50a3";
+    sha256 = "81abea4ba206051ddaf90854b7302849002fdd0084450d2dd7f5c44a6d0ddf16";
   };
 
   LC_ALL = "en_US.UTF-8";
@@ -22,6 +22,8 @@ buildPythonPackage rec {
     "test_generate_hashes_without_interfering_with_each_other"
     "test_realistic_complex_sub_dependencies"
     "test_generate_hashes_with_editable"
+    "test_filter_pip_markes"
+    "test_get_hashes_local_repository_cache_miss"
     # Expect specific version of "six":
     "test_editable_package"
     "test_input_file_without_extension"

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "pip";
-  version = "9.0.3";
+  version = "10.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7bf48f9a693be1d58f49f7af7e0ae9fe29fd671cde8a55e6edca3581c4ef5796";
+    sha256 = "f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68";
   };
 
   # pip detects that we already have bootstrapped_pip "installed", so we need

--- a/pkgs/development/python-modules/tweepy/default.nix
+++ b/pkgs/development/python-modules/tweepy/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, requests, six, requests_oauthlib }:
+{ lib, buildPythonPackage, fetchPypi, fetchpatch, requests, six, requests_oauthlib }:
 
 buildPythonPackage rec {
   pname = "tweepy";
@@ -7,6 +7,13 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "901500666de5e265d93e611dc05066bb020481c85550d6bcbf8030212938902c";
+  };
+
+  # Fix build with pip 10
+  # https://github.com/tweepy/tweepy/pull/1030
+  patches = fetchpatch {
+    url = "${meta.homepage}/commit/778bd7a31d2f5fae98652735e7844533589ca221.patch";
+    sha256 = "1sqmjn0ngiynhfkdkcs33qmvl49ysfp8522hvxjk8bx252y9qw2h";
   };
 
   doCheck = false;

--- a/pkgs/development/python-modules/tweepy/default.nix
+++ b/pkgs/development/python-modules/tweepy/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, requests, six, requests_oauthlib }:
+
+buildPythonPackage rec {
+  pname = "tweepy";
+  version = "3.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n2shilamgwhzmvf534xg7f6hrnznbixyl5pw2f5a3f391gwy37h";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [ requests six requests_oauthlib ];
+
+  meta = with lib; {
+    homepage = https://github.com/tweepy/tweepy;
+    description = "Twitter library for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ garbas ];
+  };
+}

--- a/pkgs/development/python-modules/tweepy/default.nix
+++ b/pkgs/development/python-modules/tweepy/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "tweepy";
-  version = "3.5.0";
+  version = "3.6.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0n2shilamgwhzmvf534xg7f6hrnznbixyl5pw2f5a3f391gwy37h";
+    sha256 = "901500666de5e265d93e611dc05066bb020481c85550d6bcbf8030212938902c";
   };
 
   doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14387,25 +14387,7 @@ in {
 
   TurboCheetah = callPackage ../development/python-modules/TurboCheetah { };
 
-  tweepy = buildPythonPackage (rec {
-    name = "tweepy-3.5.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/tweepy/${name}.tar.gz";
-      sha256 = "0n2shilamgwhzmvf534xg7f6hrnznbixyl5pw2f5a3f391gwy37h";
-    };
-
-    doCheck = false;
-    propagatedBuildInputs = with self; [ requests six requests_oauthlib ];
-
-    meta = {
-      homepage = "https://github.com/tweepy/tweepy";
-      description = "Twitter library for python";
-      license = licenses.mit;
-      maintainers = with maintainers; [ garbas ];
-      platforms = platforms.linux;
-    };
-  });
+  tweepy = callPackage ../development/python-modules/tweepy { };
 
   twiggy = buildPythonPackage rec {
     name = "Twiggy-${version}";


### PR DESCRIPTION
###### Motivation for this change

Pip 10 has been released. I think the most interesting improvement for us is that the `RECORD` file in `dist-info` is now generated deterministically.

https://hydra.nixos.org/eval/1448410

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

