### PR TITLE
{cc,bintools}-wrapper: fix removal of unsupported hardening flags

### DIFF
--- a/pkgs/build-support/bintools-wrapper/add-hardening.sh
+++ b/pkgs/build-support/bintools-wrapper/add-hardening.sh
@@ -11,7 +11,7 @@ done
 
 # Remove unsupported flags.
 for flag in @hardening_unsupported_flags@; do
-  unset -v hardeningEnableMap["$flag"]
+  unset -v "hardeningEnableMap[$flag]"
 done
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -11,7 +11,7 @@ done
 
 # Remove unsupported flags.
 for flag in @hardening_unsupported_flags@; do
-  unset -v hardeningEnableMap["$flag"]
+  unset -v "hardeningEnableMap[$flag]"
 done
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then


### PR DESCRIPTION
###### Motivation for this change

`add-hardening.sh` is sourced with `nullglob` in effect, this apparently causes `unset -v hardeningEnableMap["$flag"]` to expand to `unset -v ` and the unsupported flags aren't removed as a result, causing build failures like so https://hydra.nixos.org/build/72810060/nixlog/1

I only verified this change by injecting `set -x` into the bintools wrapper and inspecting the results, and rebuilding a small part of x86_64-{linux,darwin} stdenv.

I'm also far from a bash expert so please review with that in mind.

/cc @Ericson2314 @cstrahan 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

