### PR TITLE
linuxPackages.splLegacyCrypto: fix build

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -78,5 +78,6 @@ in
       version = "2018-01-24";
       rev = "23602fdb39e1254c669707ec9d2d0e6bcdbf1771";
       sha256 = "09py2dwj77f6s2qcnkwdslg5nxb3hq2bq39zpxpm6msqyifhl69h";
+      patches = [ ./install_prefix.patch ];
     };
 }


### PR DESCRIPTION
###### Motivation for this change

`linuxPackages.splLegacyCrypto` didn't build. Add missing patch (same as `splUnstable`).

Please backport to 18.03.

/cc @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

