### PR TITLE
rdnssd: fix service

### DIFF
--- a/nixos/modules/services/networking/rdnssd.nix
+++ b/nixos/modules/services/networking/rdnssd.nix
@@ -42,13 +42,14 @@ in
 
       preStart = ''
         # Create the proper run directory
-        mkdir -p /run/rdnssd
-        touch /run/rdnssd/resolv.conf
-        chown -R rdnssd /run/rdnssd
+        mkdir -p /run/rdnssd/resolv
+        touch /run/rdnssd/resolv/resolv.conf
+        chown root /run/rdnssd
+        chown -R rdnssd /run/rdnssd/resolv
 
         # Link the resolvconf interfaces to rdnssd
         rm -f /run/resolvconf/interfaces/rdnssd
-        ln -s /run/rdnssd/resolv.conf /run/resolvconf/interfaces/rdnssd
+        ln -s /run/rdnssd/resolv/resolv.conf /run/resolvconf/interfaces/rdnssd
         ${mergeHook}
       '';
 
@@ -58,7 +59,7 @@ in
       '';
 
       serviceConfig = {
-        ExecStart = "@${pkgs.ndisc6}/bin/rdnssd rdnssd -p /run/rdnssd/rdnssd.pid -r /run/rdnssd/resolv.conf -u rdnssd -H ${mergeHook}";
+        ExecStart = "@${pkgs.ndisc6}/bin/rdnssd rdnssd -p /run/rdnssd/rdnssd.pid -r /run/rdnssd/resolv/resolv.conf -u rdnssd -H ${mergeHook}";
         Type = "forking";
         PIDFile = "/run/rdnssd/rdnssd.pid";
       };


### PR DESCRIPTION
rdnssd did not start properly in 18.03:

  Starting RDNSS daemon...
  rdnssd.service: Permission denied while opening PID file or unsafe symlink chain: /run/rdnssd/rdnssd.pid
  rdnssd.service: Start operation timed out. Terminating.
  rdnssd.service: Failed with result 'timeout'.
  Failed to start RDNSS daemon.

Leaving /run/rdnssd owned by root and moving resolv.conf into a separate
subdir owned by rdnssd fixes this.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

