### PR TITLE
node2nix: add nix as dependency (fix for #38946)

### DIFF
--- a/pkgs/development/node-packages/default-v6.nix
+++ b/pkgs/development/node-packages/default-v6.nix
@@ -24,13 +24,13 @@ nodePackages // {
   phantomjs = nodePackages.phantomjs.override (oldAttrs: {
     buildInputs = oldAttrs.buildInputs ++ [ pkgs.phantomjs2 ];
   });
-  
+
   webdrvr = nodePackages.webdrvr.override (oldAttrs: {
     buildInputs = oldAttrs.buildInputs ++ [ pkgs.phantomjs ];
-    
+
     preRebuild = ''
       mkdir $TMPDIR/webdrvr
-      
+
       ln -s ${pkgs.fetchurl {
         url = "https://selenium-release.storage.googleapis.com/2.43/selenium-server-standalone-2.43.1.jar";
         sha1 = "ef1b5f8ae9c99332f99ba8794988a1d5b974d27b";
@@ -71,5 +71,12 @@ nodePackages // {
       sed -i -e "s|console.error('Error verifying phantomjs, continuing', err)|console.error('Error verifying phantomjs, continuing', err); return true;|" node_modules/phantomjs-prebuilt/lib/util.js
     '';
     buildInputs = oldAttrs.buildInputs ++ [ pkgs.phantomjs2 ];
+  });
+
+  node2nix =  nodePackages.node2nix.override (oldAttrs: {
+    buildInputs = oldAttrs.buildInputs ++ [ pkgs.makeWrapper ];
+    postInstall = ''
+      wrapProgram "$out/bin/node2nix" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.nix ]}
+    '';
   });
 }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/38946

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

