### PR TITLE
quakespasm, vkquake: enable userdirs support

### DIFF
--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -10,10 +10,12 @@ stdenv.mkDerivation rec {
   };
 
   sourceRoot = "${name}/Quake";
-  
+
   buildInputs = [
     gzip SDL libvorbis libmad
   ];
+
+  buildFlags = [ "DO_USERDIRS=1" ];
 
   preInstall = ''
     mkdir -p "$out/bin"
@@ -21,19 +23,19 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
-  
+
   meta = {
     description = "An engine for iD software's Quake";
     homepage = http://quakespasm.sourceforge.net/;
     longDescription = ''
       QuakeSpasm is a modern, cross-platform Quake 1 engine based on FitzQuake.
-      It includes support for 64 bit CPUs and custom music playback, a new sound driver, 
+      It includes support for 64 bit CPUs and custom music playback, a new sound driver,
       some graphical niceities, and numerous bug-fixes and other improvements.
-      Quakespasm utilizes either the SDL or SDL2 frameworks, so choose which one 
-      works best for you. SDL is probably less buggy, but SDL2 has nicer features 
+      Quakespasm utilizes either the SDL or SDL2 frameworks, so choose which one
+      works best for you. SDL is probably less buggy, but SDL2 has nicer features
       and smoother mouse input - though no CD support.
     '';
-  
+
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.m3tti ];
   };

--- a/pkgs/games/quakespasm/vulkan.nix
+++ b/pkgs/games/quakespasm/vulkan.nix
@@ -12,10 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   sourceRoot = "source/Quake";
-  
+
   buildInputs = [
     makeWrapper gzip SDL2 libvorbis libmad vulkan-loader.dev
   ];
+
+  buildFlags = [ "DO_USERDIRS=1" ];
 
   preInstall = ''
     mkdir -p "$out/bin"
@@ -28,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
-  
+
   meta = {
     description = "Vulkan Quake port based on QuakeSpasm";
     homepage = src.meta.homepage;
@@ -40,7 +42,7 @@ stdenv.mkDerivation rec {
       passes & sub passes, pipeline barriers & synchronization, compute shaders, push &
       specialization constants, CPU/GPU parallelism and memory pooling.
     '';
-  
+
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.gnidorah ];
   };


### PR DESCRIPTION
###### Motivation for this change

QuakeSpasm and vkQuake support loading game content from the `~/.quakespasm` and `~/.vkquake` directories, respectively. Enable the build flag to support this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

