### PR TITLE
i3lock-pixeled: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/misc/screensavers/i3lock-pixeled/default.nix
+++ b/pkgs/misc/screensavers/i3lock-pixeled/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "i3lock-pixeled-${version}";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "https://github.com/Ma27/i3lock-pixeled/archive/${version}.tar.gz";
-    sha256 = "046qbx4qvcc66h53h4mm9pyjj9gjc6dzy38a0f0jc5a84xbivh7k";
+    sha256 = "0vlynm833fk1mmdnkcgh4hwqmfypn22zskhysm110k39zvikif0h";
   };
 
   propagatedBuildInputs = with pkgs; [


### PR DESCRIPTION
###### Motivation for this change

Simple feature release with some improvements.
See https://github.com/Ma27/i3lock-pixeled/releases/tag/1.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

