### PR TITLE
kalarm: init

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -84,6 +84,7 @@ let
       incidenceeditor = callPackage ./incidenceeditor.nix {};
       k3b = callPackage ./k3b.nix {};
       kaddressbook = callPackage ./kaddressbook.nix {};
+      kalarm = callPackage ./kalarm.nix {};
       kalarmcal = callPackage ./kalarmcal.nix {};
       kate = callPackage ./kate.nix {};
       kcachegrind = callPackage ./kcachegrind.nix {};

--- a/pkgs/applications/kde/kalarm.nix
+++ b/pkgs/applications/kde/kalarm.nix
@@ -1,0 +1,37 @@
+{
+  mkDerivation, lib,
+  extra-cmake-modules,
+
+  kauth, kcodecs, kcompletion, kconfig, kconfigwidgets, kdbusaddons, kdoctools,
+  kguiaddons, ki18n, kiconthemes, kjobwidgets, kcmutils, kdelibs4support, kio,
+  knotifications, kservice, kwidgetsaddons, kwindowsystem, kxmlgui, phonon,
+
+  kimap, akonadi, akonadi-contacts, akonadi-mime, kalarmcal, kcalcore, kcalutils,
+  kholidays, kidentitymanagement, libkdepim, mailcommon, kmailtransport, kmime,
+  pimcommon, kpimtextedit, kdepim-apps-libs, messagelib,
+
+  qtx11extras,
+
+  kdepim-runtime
+}:
+
+mkDerivation {
+  name = "kalarm";
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.rittelle ];
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    kauth kcodecs kcompletion kconfig kconfigwidgets kdbusaddons kdoctools
+    kguiaddons ki18n kiconthemes kjobwidgets kcmutils kdelibs4support kio
+    knotifications kservice kwidgetsaddons kwindowsystem kxmlgui phonon
+
+    kimap akonadi akonadi-contacts akonadi-mime kalarmcal kcalcore kcalutils
+    kholidays kidentitymanagement libkdepim mailcommon kmailtransport kmime
+    pimcommon kpimtextedit kdepim-apps-libs messagelib
+
+    qtx11extras
+  ];
+  propagatedUserEnvPkgs = [ kdepim-runtime ];
+}


### PR DESCRIPTION
###### Motivation for this change

The KAlarm program is not packaged yet although it is a part of the kdepim applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

