### PR TITLE
extundelete: fix build with e2fsprogs 1.44

### DIFF
--- a/pkgs/tools/filesystems/extundelete/default.nix
+++ b/pkgs/tools/filesystems/extundelete/default.nix
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ e2fsprogs ];
 
+  # inode field i_dir_acl was repurposed as i_size_high in e2fsprogs 1.44,
+  # breaking the build
+  patchPhase = ''
+    substituteInPlace src/insertionops.cc \
+      --replace "Directory ACL:" "High 32 bits of size:" \
+      --replace "inode.i_dir_acl" "inode.i_size_high"
+  '';
+
   meta = with stdenv.lib; {
     description = "Utility that can recover deleted files from an ext3 or ext4 partition";
     homepage = http://extundelete.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change

Didn't build  with `e2fsprogs` 1.44 because one of the inode fields was renamed and repurposed.

Please backport to 18.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

