### PR TITLE
iputils: enable rarpd

### DIFF
--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -35,20 +35,21 @@ stdenv.mkDerivation rec {
   installPhase =
     ''
       mkdir -p $out/bin
-      cp -p ping tracepath clockdiff arping rdisc $out/bin/
+      cp -p ping tracepath clockdiff arping rdisc rarpd $out/bin/
       if [ -x ninfod/ninfod ]; then
         cp -p ninfod/ninfod $out/bin
       fi
 
       mkdir -p $out/share/man/man8
       cp -p \
-        doc/clockdiff.8 doc/arping.8 doc/ping.8 doc/rdisc.8 doc/tracepath.8 doc/ninfod.8 \
+        doc/clockdiff.8 doc/arping.8 doc/ping.8 doc/rdisc.8 doc/rarpd.8 doc/tracepath.8 doc/ninfod.8 \
         $out/share/man/man8
     '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/iputils/iputils;
     description = "A set of small useful utilities for Linux networking";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lheckemann ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
It's useful for some obscure little use cases…

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

