### PR TITLE
pysensors: init at 2017-07-13

### DIFF
--- a/pkgs/development/python-modules/pysensors/default.nix
+++ b/pkgs/development/python-modules/pysensors/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, python, fetchFromGitHub, lm_sensors }:
+buildPythonPackage rec {
+  version = "2017-07-13";
+  pname = "pysensors";
+
+  # note that https://pypi.org/project/PySensors/ is a different project
+  src = fetchFromGitHub {
+    owner = "bastienleonard";
+    repo = "pysensors";
+    rev = "ef46fc8eb181ecb8ad09b3d80bc002d23d9e26b3";
+    sha256 = "1xvbxnkz55fk5fpr514263c7s7s9r8hgrw4ybfaj5a0mligmmrfm";
+  };
+
+  buildInputs = [ lm_sensors ];
+
+  # Tests are disable because they fail on `aarch64-linux`, probably
+  # due to sandboxing
+  doCheck = false;
+
+  checkPhase = ''
+    cd tests
+    ${python.interpreter} -m unittest discover
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ guibou ];
+    description = "Easy hardware health monitoring in Python for Linux systems";
+    homepage = http://pysensors.readthedocs.org;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18271,6 +18271,8 @@ EOF
 
   pyspark = callPackage ../development/python-modules/pyspark { };
 
+  pysensors = callPackage ../development/python-modules/pysensors { };
+
   sseclient = callPackage ../development/python-modules/sseclient { };
 
   textacy = callPackage ../development/python-modules/textacy { };


### PR DESCRIPTION
###### Motivation for this change

Pysensors is a python package to read hardware sensors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

