### PR TITLE
ruby-modules: Import gemset if it's a path OR a string.

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -29,7 +29,7 @@ with  import ./functions.nix { inherit lib gemConfig; };
 let
   gemFiles = bundlerFiles args;
 
-  importedGemset = if builtins.typeOf gemFiles.gemset == "path"
+  importedGemset = if builtins.typeOf gemFiles.gemset != "set"
     then import gemFiles.gemset
     else gemFiles.gemset;
 


### PR DESCRIPTION
Commit comment:

This fixes the bug introduced by [@aneeshusa's] 8686b98612dc which broke bundlerEnv
exprs when gemdir was a string (thus making gemset a string by
`gemset = gemdir + "/gemset.nix"`) which made it being treated as a
set.

---

`pkgs/development/ruby-modules/bundled-common/functions.nix`:
```
  gemset =
    if gemset == null then assert gemdir != null; gemdir + "/gemset.nix"
    else gemset;
```
`pkgs/development/ruby-modules/bundled-common/default.nix`:
``` 
importedGemset = if builtins.typeOf gemFiles.gemset == "path"
    then import gemFiles.gemset
    else gemFiles.gemset;
```

I stumbled upon this because I set `gemdir` to the value of a filterSource expression, which is a string.

    nix-repl> builtins.typeOf (builtins.filterSource (_: _: true) <nixpkgs/lib>)                   
    "string"

###### Motivation for this change

Try building `pkgs/servers/monitoring/sensu/default.nix` on the latest master(e.g. `92f0d31b949bcf018262` with this change:
```
    diff --git a/pkgs/servers/monitoring/sensu/default.nix b/pkgs/servers/monitoring/sensu/default.nix
    index dba0c32b353..cbbc50b6b1b 100644
    --- a/pkgs/servers/monitoring/sensu/default.nix
    +++ b/pkgs/servers/monitoring/sensu/default.nix
    @@ -5,7 +5,7 @@ bundlerEnv rec {
       version = (import ./gemset.nix).sensu.version;

       inherit ruby;
    -  gemdir = ./.;
    +  gemdir = "${./.}";

       meta = with lib; {
         description = "A monitoring framework that aims to be simple, malleable, and scalable";
```

It ain't gonna build, but it did before.