### PR TITLE
cryptsetup-generator: add postFixup

### DIFF
--- a/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
+++ b/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
@@ -13,6 +13,17 @@ stdenv.lib.overrideDerivation systemd (p: {
     ninja systemd-cryptsetup systemd-cryptsetup-generator
   '';
 
+  # As ninja install is not used here, the rpath needs to be manually fixed.
+  # Otherwise the resulting binary doesn't properly link against systemd-shared.so
+  postFixup = ''
+    sharedLib=libsystemd-shared-${p.version}.so
+    for prog in `find $out -type f -executable`; do
+      (patchelf --print-needed $prog | grep $sharedLib > /dev/null) && (
+        patchelf --set-rpath `patchelf --print-rpath $prog`:"$out/lib/systemd" $prog
+      ) || true
+    done
+  '';
+
   installPhase = ''
     mkdir -p $out/lib/systemd/
     cp systemd-cryptsetup $out/lib/systemd/systemd-cryptsetup


### PR DESCRIPTION
This makes cryptsetup-generator link correctly
to the shared systemd library.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/35513 removed the fixup from systemd but the cryptsetup-generator still needs it in order to correctly link to the shared library. So add the fixupt there until a better solution is found.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

