### PR TITLE
slic3r-prusa3d: fix build

### DIFF
--- a/pkgs/applications/misc/slic3r-prusa3d/default.nix
+++ b/pkgs/applications/misc/slic3r-prusa3d/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
     ClassXSAccessor
     EncodeLocale
     ExtUtilsMakeMaker
+    ExtUtilsTypemapsDefault
     ExtUtilsXSpp
     GrowlGNTP
     ImportInto
@@ -62,7 +63,7 @@ stdenv.mkDerivation rec {
     MathConvexHullMonotoneChain
     MathGeometryVoronoi
     MathPlanePath
-    ModuleBuild
+    ModuleBuildWithXSpp
     Moo
     NetDBus
     OpenGL


### PR DESCRIPTION
before #ffe86fe949199ebe0e5610c74230edf60a05ae8d
perlPackages.ModuleBuildWithXSpp and perlPackages.ExtUtilsTypemapsDefault
seem to have been implicitly provided by perlPackages.MathClipper

###### Motivation for this change
fix build

###### Things done

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

