### PR TITLE
cockroachdb: refactor and 1.1.5->2.0.0

### DIFF
--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -1,35 +1,40 @@
-{ stdenv, buildGoPackage, fetchurl, cmake, xz, which, autoconf }:
+{ stdenv, buildGoPackage, fetchurl, go, cmake, which, autoconf, libedit }:
 
-buildGoPackage rec {
+stdenv.mkDerivation rec {
   name = "cockroach-${version}";
-  version = "1.1.5";
-
-  goPackagePath = "github.com/cockroachdb/cockroach";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "https://binaries.cockroachdb.com/cockroach-v${version}.src.tgz";
-    sha256 = "0i2lg60424i1yg9dhapfsy3majnlbad2wlf93d9l161jf5lp9a2d";
+    sha256 = "0x8hf5qwvgb2w6dcnvy20v77nf19f0l1pb40jf31rm72xhk3bwvy";
   };
 
-  nativeBuildInputs = [ cmake xz which autoconf ];
+  # https://github.com/knz/go-libedit tries to be clever about its
+  # dependencies. It bundles its own copy of libedit to avoid an extra
+  # dependency on linux, but it uses an external libedit on darwin.
+  # For simplicity's sake, just depend on libedit everywhere.
+  # Note that if the libedit dependency is changed to be darwin-only,
+  # a linux-only dependency on ncurses would need to be added.
+  nativeBuildInputs = [ go cmake which autoconf libedit ];
+
+  # Even though we depend on cmake for some bundled dependencies, the
+  # top-level build is not cmake and we don't want the cmake
+  # configurePhase hooks.
+  dontUseCmakeConfigure = true;
 
   buildPhase = ''
     runHook preBuild
-    cd $NIX_BUILD_TOP/go/src/${goPackagePath}
     patchShebangs .
     make buildoss
-    cd src/${goPackagePath}
-    for asset in man autocomplete; do
-      ./cockroach gen $asset
-    done
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    install -D cockroach $bin/bin/cockroach
-    install -D cockroach.bash $bin/share/bash-completion/completions/cockroach.bash
-    cp -r man $bin/share/man
+    install -D src/github.com/cockroachdb/cockroach/cockroach $out/bin/cockroach
+    $out/bin/cockroach gen man --path=$out/share/man/man1
+    install -d $out/share/bash-completion/completions
+    $out/bin/cockroach gen autocomplete --out=$out/share/bash-completion/completions/cockroach.bash
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Building CockroachDB from a tarball has little in common with other go
packages, so buildGoPackage wasn't doing anything useful. Refactor to
a plain derivation with go as a dependency. Build from top-level
instead of in the go package path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

