### PR TITLE
coq: fix installation of OCaml libraries

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -123,8 +123,11 @@ self = stdenv.mkDerivation {
 
   buildFlags = "revision coq coqide bin/votour";
 
+  createFindlibDestdir = true;
+
   postInstall = ''
     cp bin/votour $out/bin/
+    ln -s $out/lib/coq $OCAMLFIND_DESTDIR/coq
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -34,11 +34,9 @@ let
 self = stdenv.mkDerivation {
   name = "coq-${version}";
 
-  inherit coq-version;
-  inherit camlp5;
-  inherit (ocamlPackages) ocaml;
   passthru = {
-    inherit (ocamlPackages) findlib num;
+    inherit coq-version camlp5;
+    inherit (ocamlPackages) ocaml findlib num;
     emacsBufferSetup = pkgs: ''
       ; Propagate coq paths to children
       (inherit-local-permanent coq-prog-name "${self}/bin/coqtop")


### PR DESCRIPTION
###### Motivation for this change

Be able to use the OCaml libraries of Coq through `findlib`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

