### PR TITLE
fstl: init at 0.9.3

### DIFF
--- a/pkgs/applications/graphics/fstl/default.nix
+++ b/pkgs/applications/graphics/fstl/default.nix
@@ -1,0 +1,35 @@
+{stdenv, fetchFromGitHub, qtbase, mesa_glu, qmake}:
+stdenv.mkDerivation rec {
+  name = "fstl-${version}";
+  version = "0.9.3";
+
+  buildInputs = [qtbase mesa_glu];
+
+  prePatch = ''
+    sed -i "s|/usr/bin|$out/bin|g" qt/fstl.pro
+  '';
+
+  preBuild = ''
+    qmake qt/fstl.pro
+  '';
+  
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv fstl.app $out/Applications
+  '';
+
+  src = fetchFromGitHub {
+    owner = "mkeeter";
+    repo = "fstl";
+    rev = "v" + version;
+    sha256 = "1j0y9xbf0ybrrnsmfzgpyyz6bi98xgzn9ivani424j01vffns892";
+  };
+
+  meta = with stdenv.lib; {
+    description = "The fastest STL file viewer";
+    homepage = "https://github.com/mkeeter/fstl";
+    license = licenses.mit;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ tweber ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2391,6 +2391,8 @@ with pkgs;
 
   fsfs = callPackage ../tools/filesystems/fsfs { };
 
+  fstl = qt5.callPackage ../applications/graphics/fstl { };
+
   fswebcam = callPackage ../os-specific/linux/fswebcam { };
 
   fuseiso = callPackage ../tools/filesystems/fuseiso { };


### PR DESCRIPTION
###### Motivation for this change
fstl is a  fast little viewer for .stl files

###### Things done

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

