### PR TITLE
Fix clblas and libgpuarray on darwin

### DIFF
--- a/pkgs/development/libraries/science/math/clblas/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/default.nix
@@ -7,6 +7,7 @@
 , python
 , ocl-icd
 , opencl-headers
+, Accelerate, CoreGraphics, CoreVideo, OpenCL
 , gtest
 }:
 
@@ -40,11 +41,19 @@ stdenv.mkDerivation rec {
     gfortran
     blas
     python
-    ocl-icd
-    opencl-headers
     boost
     gtest
-  ]; 
+  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
+    ocl-icd
+    opencl-headers
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    Accelerate
+    CoreGraphics
+    CoreVideo
+  ];
+  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [
+    OpenCL
+  ];
 
   enableParallelBuilding = true;
 
@@ -56,7 +65,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ artuuge ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 
 }

--- a/pkgs/development/python-modules/libgpuarray/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   libraryPath = lib.makeLibraryPath (
     []
     ++ lib.optionals cudaSupport [ cudatoolkit.lib cudatoolkit.out ]
-    ++ lib.optionals openclSupport [ ocl-icd clblas ]
+    ++ lib.optionals openclSupport ([ clblas ] ++ lib.optional (!stdenv.isDarwin) ocl-icd)
   );
 
   preBuild = ''
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   postFixup = ''
     rm $out/lib/libgpuarray-static.a
-
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     function fixRunPath {
       p=$(patchelf --print-rpath $1)
       patchelf --set-rpath "$p:$libraryPath" $1
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     description = "Library to manipulate tensors on GPU.";
     license = licenses.free;
     maintainers = with maintainers; [ artuuge ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19673,7 +19673,9 @@ with pkgs;
 
   blas = callPackage ../development/libraries/science/math/blas { };
 
-  clblas = callPackage ../development/libraries/science/math/clblas { };
+  clblas = callPackage ../development/libraries/science/math/clblas {
+    inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo OpenCL;
+  };
 
   jags = callPackage ../applications/science/math/jags { };
 


### PR DESCRIPTION
###### Motivation for this change
This enables the builds for `clblas` and `libgpuarray`, which consequently should also lead to 
 working `python2Packages.Theano`/`python3Packages.Theano`.
This fixes the issue #33073.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

