### PR TITLE
tixati: 2.55 -> 2.57

### DIFF
--- a/pkgs/applications/networking/p2p/tixati/default.nix
+++ b/pkgs/applications/networking/p2p/tixati/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "tixati-${version}";
-  version = "2.55";
+  version = "2.57";
 
   src = fetchurl {
     url = "https://download2.tixati.com/download/tixati-${version}-1.x86_64.manualinstall.tar.gz";
-    sha256 = "02mha6lfcb0mg0y977bxa6xg8krpbsbzpm4b5xw6y6wign4d8a8w";
+    sha256 = "0z6znh62ry4fmc6c54zq79pk1b5bwkz93bxsfgvxpf6sajpyf9n7";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Minor version bump.

@ryantm For unknown reason repology [does not see](https://repology.org/metapackage/tixati/versions) the presence of this package in nixpkgs; this results in your bot skipping it. There could be more packages like this one

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

