### PR TITLE
borgbackup: add blake2 library to build inputs

### DIFF
--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python3Packages, acl, lz4, openssl, openssh }:
+{ stdenv, python3Packages, acl, libb2, lz4, openssl, openssh }:
 
 python3Packages.buildPythonApplication rec {
   pname = "borgbackup";
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
     sphinx guzzle_sphinx_theme
   ];
   buildInputs = [
-    lz4 openssl python3Packages.setuptools_scm
+    libb2 lz4 openssl python3Packages.setuptools_scm
   ] ++ stdenv.lib.optionals stdenv.isLinux [ acl ];
   propagatedBuildInputs = with python3Packages; [
     cython msgpack-python
@@ -28,6 +28,7 @@ python3Packages.buildPythonApplication rec {
   preConfigure = ''
     export BORG_OPENSSL_PREFIX="${openssl.dev}"
     export BORG_LZ4_PREFIX="${lz4.dev}"
+    export BORG_LIBB2_PREFIX="${libb2}"
   '';
 
   makeWrapperArgs = [

--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python3Packages, acl, libb2, lz4, openssl, openssh }:
+{ stdenv, python3Packages, acl, libb2, lz4, zstd, openssl, openssh }:
 
 python3Packages.buildPythonApplication rec {
   pname = "borgbackup";
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
     sphinx guzzle_sphinx_theme
   ];
   buildInputs = [
-    libb2 lz4 openssl python3Packages.setuptools_scm
+    libb2 lz4 zstd openssl python3Packages.setuptools_scm
   ] ++ stdenv.lib.optionals stdenv.isLinux [ acl ];
   propagatedBuildInputs = with python3Packages; [
     cython msgpack-python
@@ -29,6 +29,7 @@ python3Packages.buildPythonApplication rec {
     export BORG_OPENSSL_PREFIX="${openssl.dev}"
     export BORG_LZ4_PREFIX="${lz4.dev}"
     export BORG_LIBB2_PREFIX="${libb2}"
+    export BORG_LIBZSTD_PREFIX="${zstd}"
   '';
 
   makeWrapperArgs = [


### PR DESCRIPTION
###### Motivation for this change

Currently a vendored version of libb2 is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

