### PR TITLE
dbeaver: 5.0.2 -> 5.0.3

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   name = "dbeaver-ce-${version}";
-  version = "5.0.2";
+  version = "5.0.3";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.jkiss.org/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "0jk8z0s14rc1fnmi7pynhybslwm147mqih187zsa33xqmmhlw1lp";
+    sha256 = "0pk40jzmd23cv690a8wslxbb4xp4msq2zwh7xm0hvs64ykm9a581";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

 * [Updates dbeaver 5.0.3](https://dbeaver.jkiss.org/2018/04/15/dbeaver-5-0-3/).

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

> *As a side note, #34182 is still open and I will still gladly accept any help in figuring out how to build this using the source release.*