### PR TITLE
nixos/tests/systemd: fix broken test

### DIFF
--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -46,6 +46,8 @@ import ./make-test.nix {
 
   testScript = ''
     $machine->waitForX;
+    # wait for user services
+    $machine->waitForUnit("default.target","alice");
 
     # Regression test for https://github.com/NixOS/nixpkgs/issues/35415
     subtest "configuration files are recognized by systemd", sub {


### PR DESCRIPTION
###### Motivation for this change

A timing bug resulted in non-deterministic hydra test failures like [this one](https://hydra.nixos.org/build/72403425).

/cc ZHF #36453 - please backport.

###### Things done

Tested on master and 18.03.

---

