### PR TITLE
python: python-digitalocean: fix build

### DIFF
--- a/pkgs/development/python-modules/digitalocean/default.nix
+++ b/pkgs/development/python-modules/digitalocean/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, requests }:
+{ stdenv, buildPythonPackage, fetchPypi, requests, jsonpickle }:
 
 buildPythonPackage rec {
   pname = "python-digitalocean";
@@ -6,10 +6,10 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06391cf0b253c8b4a5a10b3a4b7b7808b890a1d1e3b43d5ce3b5293a9c77af6b";
+    sha256 = "0h4drpdsmk0b3rlvg6q6cz11k23w0swj1iddk7xdcw4m7r7c52kw";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [ requests jsonpickle ];
 
   # Package doesn't distribute tests.
   doCheck = false;


### PR DESCRIPTION
fix hash and add missing dependency "jsonpickle"

see https://github.com/NixOS/nixpkgs/commit/886048fdff39963ec6ba89a650954c4c641a93e6#diff-714655688532fd4a33aab2085f266252

###### Motivation for this change

fix build

###### Things done

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

