### PR TITLE
nixos manual: add missing space after "copytoram"

### DIFF
--- a/nixos/doc/manual/installation/installing-usb.xml
+++ b/nixos/doc/manual/installation/installing-usb.xml
@@ -51,7 +51,7 @@ ISO, copy its contents verbatim to your drive, then either:
   <listitem>
     <para>If you want to load the contents of the ISO to ram after bootin
     (So you can remove the stick after bootup) you can append the parameter
-    <literal>copytoram</literal>to the <literal>options</literal> field.</para>
+    <literal>copytoram</literal> to the <literal>options</literal> field.</para>
   </listitem>
 </itemizedlist>
 </para>


### PR DESCRIPTION
###### Motivation for this change

The English language requires whitespace between words.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

