### PR TITLE
rocksdb: use jemalloc 4.5.0

### DIFF
--- a/pkgs/development/libraries/jemalloc/common.nix
+++ b/pkgs/development/libraries/jemalloc/common.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, fetchpatch, version, sha256 }:
+
+stdenv.mkDerivation rec {
+  name = "jemalloc-${version}";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/jemalloc/jemalloc/releases/download/${version}/${name}.tar.bz2";
+    inherit sha256;
+  };
+
+  # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
+  # then stops downstream builds (mariadb in particular) from detecting it. This
+  # option should remove the prefix and give us a working jemalloc.
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--with-jemalloc-prefix="
+                   # jemalloc is unable to correctly detect transparent hugepage support on
+                   # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
+                   # kernel ARMv6/7 kernel does not enable it, so we explicitly disable support
+                   ++ stdenv.lib.optional stdenv.isArm "--disable-thp";
+  doCheck = true;
+
+  patches = stdenv.lib.optional stdenv.isAarch64 (fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/jemalloc/jemalloc/pull/1035.patch";
+    sha256 = "02y0q3dp253bipxv4r954nqipbjbj92p6ww9bx5bk3d8pa81wkqq";
+  });
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://jemalloc.net;
+    description = "General purpose malloc(3) implementation";
+    longDescription = ''
+      malloc(3)-compatible memory allocator that emphasizes fragmentation
+      avoidance and scalable concurrency support.
+    '';
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ wkennington ];
+  };
+}

--- a/pkgs/development/libraries/jemalloc/common.nix
+++ b/pkgs/development/libraries/jemalloc/common.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, fetchpatch, version, sha256 }:
+{ stdenv, fetchurl, version, sha256, ... }@args:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   name = "jemalloc-${version}";
   inherit version;
 
@@ -19,11 +19,6 @@ stdenv.mkDerivation rec {
                    ++ stdenv.lib.optional stdenv.isArm "--disable-thp";
   doCheck = true;
 
-  patches = stdenv.lib.optional stdenv.isAarch64 (fetchpatch {
-    url = "https://patch-diff.githubusercontent.com/raw/jemalloc/jemalloc/pull/1035.patch";
-    sha256 = "02y0q3dp253bipxv4r954nqipbjbj92p6ww9bx5bk3d8pa81wkqq";
-  });
-
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
@@ -37,4 +32,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ wkennington ];
   };
-}
+} // (builtins.removeAttrs args [ "stdenv" "fetchurl" "version" "sha256" ]))

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -1,40 +1,6 @@
 { stdenv, fetchurl, fetchpatch }:
-
-stdenv.mkDerivation rec {
-  name = "jemalloc-${version}";
+import ./common.nix {
+  inherit stdenv fetchurl fetchpatch;
   version = "5.0.1";
-
-  src = fetchurl {
-    url = "https://github.com/jemalloc/jemalloc/releases/download/${version}/${name}.tar.bz2";
-    sha256 = "4814781d395b0ef093b21a08e8e6e0bd3dab8762f9935bbfb71679b0dea7c3e9";
-  };
-
-  # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
-  # then stops downstream builds (mariadb in particular) from detecting it. This
-  # option should remove the prefix and give us a working jemalloc.
-  configureFlags = stdenv.lib.optional stdenv.isDarwin "--with-jemalloc-prefix="
-                   # jemalloc is unable to correctly detect transparent hugepage support on
-                   # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
-                   # kernel ARMv6/7 kernel does not enable it, so we explicitly disable support
-                   ++ stdenv.lib.optional stdenv.isArm "--disable-thp";
-  doCheck = true;
-
-  patches = stdenv.lib.optional stdenv.isAarch64 (fetchpatch {
-    url = "https://patch-diff.githubusercontent.com/raw/jemalloc/jemalloc/pull/1035.patch";
-    sha256 = "02y0q3dp253bipxv4r954nqipbjbj92p6ww9bx5bk3d8pa81wkqq";
-  });
-
-  enableParallelBuilding = true;
-
-  meta = with stdenv.lib; {
-    homepage = http://jemalloc.net;
-    description = "General purpose malloc(3) implementation";
-    longDescription = ''
-      malloc(3)-compatible memory allocator that emphasizes fragmentation
-      avoidance and scalable concurrency support.
-    '';
-    license = licenses.bsd2;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
-  };
+  sha256 = "4814781d395b0ef093b21a08e8e6e0bd3dab8762f9935bbfb71679b0dea7c3e9";
 }

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -1,6 +1,10 @@
 { stdenv, fetchurl, fetchpatch }:
 import ./common.nix {
-  inherit stdenv fetchurl fetchpatch;
+  inherit stdenv fetchurl;
   version = "5.0.1";
   sha256 = "4814781d395b0ef093b21a08e8e6e0bd3dab8762f9935bbfb71679b0dea7c3e9";
+  patches = stdenv.lib.optional stdenv.isAarch64 (fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/jemalloc/jemalloc/pull/1035.patch";
+    sha256 = "02y0q3dp253bipxv4r954nqipbjbj92p6ww9bx5bk3d8pa81wkqq";
+  });
 }

--- a/pkgs/development/libraries/jemalloc/jemalloc450.nix
+++ b/pkgs/development/libraries/jemalloc/jemalloc450.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, fetchpatch }:
+{ stdenv, fetchurl }:
 import ./common.nix {
-  inherit stdenv fetchurl fetchpatch;
+  inherit stdenv fetchurl;
   version = "4.5.0";
   sha256 = "10373xhpc10pgmai9fkc1z0rs029qlcb3c0qfnvkbwdlcibdh2cl";
 }

--- a/pkgs/development/libraries/jemalloc/jemalloc450.nix
+++ b/pkgs/development/libraries/jemalloc/jemalloc450.nix
@@ -1,0 +1,6 @@
+{ stdenv, fetchurl, fetchpatch }:
+import ./common.nix {
+  inherit stdenv fetchurl fetchpatch;
+  version = "4.5.0";
+  sha256 = "10373xhpc10pgmai9fkc1z0rs029qlcb3c0qfnvkbwdlcibdh2cl";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11304,7 +11304,7 @@ with pkgs;
 
   rlog = callPackage ../development/libraries/rlog { };
 
-  rocksdb = callPackage ../development/libraries/rocksdb { };
+  rocksdb = callPackage ../development/libraries/rocksdb { jemalloc = jemalloc450; };
 
   rocksdb_lite = rocksdb.override { enableLite = true; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9445,6 +9445,8 @@ with pkgs;
 
   jemalloc = callPackage ../development/libraries/jemalloc { };
 
+  jemalloc450 = callPackage ../development/libraries/jemalloc/jemalloc450.nix { };
+
   jshon = callPackage ../development/tools/parsing/jshon { };
 
   json2hcl = callPackage ../development/tools/json2hcl { };


### PR DESCRIPTION
###### Motivation for this change

Using rocksdb with jemalloc 5 is giving us [some problems](https://github.com/jemalloc/jemalloc/issues/937).
We currently tell everyone to override it, but it's not ideal. This shouldn't be needed once 5.1 comes out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

