### PR TITLE
rocksdb: package binary tools

### DIFF
--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenv, lib
 , fetchFromGitHub
 , fixDarwinDylibNames
 , which, perl
@@ -15,12 +15,13 @@
 
 let
   malloc = if jemalloc != null then jemalloc else gperftools;
+  tools = [ "sst_dump" "ldb" "rocksdb_dump" "rocksdb_undump" "blob_dump" ];
 in
 stdenv.mkDerivation rec {
   name = "rocksdb-${version}";
   version = "5.10.3";
 
-  outputs = [ "dev" "out" "static" ];
+  outputs = [ "dev" "out" "static" "bin" ];
 
   src = fetchFromGitHub {
     owner = "facebook";
@@ -55,7 +56,7 @@ stdenv.mkDerivation rec {
   buildFlags = buildAndInstallFlags ++ [
     "shared_lib"
     "static_lib"
-  ];
+  ] ++ tools ;
 
   installFlags = buildAndInstallFlags ++ [
     "INSTALL_PATH=\${out}"
@@ -69,6 +70,9 @@ stdenv.mkDerivation rec {
     cat make_config.mk
     mkdir -pv $static/lib/
     mv -vi $out/lib/${LIBNAME}.a $static/lib/
+
+    install -d ''${!outputBin}/bin
+    install -D ${lib.concatStringsSep " " tools} ''${!outputBin}/bin
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib
+{ stdenv
 , fetchFromGitHub
 , fixDarwinDylibNames
 , which, perl
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     mv -vi $out/lib/${LIBNAME}.a $static/lib/
 
     install -d ''${!outputBin}/bin
-    install -D ${lib.concatStringsSep " " tools} ''${!outputBin}/bin
+    install -D ${stdenv.lib.concatStringsSep " " tools} ''${!outputBin}/bin
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

rocksdb includes some binaries that can be useful for debugging (sst_dump, ldb, rocksdb_dump, rocksdb_undump, blob_dump).
Add a bin output and install them there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

