### PR TITLE
rustc: fix aarch64 by disabling two doc tests

### DIFF
--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -24,7 +24,11 @@ in rec {
       ./patches/0001-Disable-fragile-tests-libstd-net-tcp-on-Darwin-Linux.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch
       # https://github.com/rust-lang/rust/issues/45410
-      ++ stdenv.lib.optional stdenv.isAarch64 ./patches/aarch64-disable-test_loading_cosine.patch;
+      ++ stdenv.lib.optionals stdenv.isAarch64 [
+        ./patches/aarch64-disable-test_loading_cosine.patch
+        # should be revisited for next rust version
+        ./patches/aarch64-disable-llvm-compilation-tests.patch
+      ];
 
   };
 

--- a/pkgs/development/compilers/rust/patches/aarch64-disable-llvm-compilation-tests.patch
+++ b/pkgs/development/compilers/rust/patches/aarch64-disable-llvm-compilation-tests.patch
@@ -1,0 +1,20 @@
+--- rustc-1.25.0-src.org/src/libcore/num/mod.rs	2018-03-25 15:26:14.000000000 +0100
++++ rustc-1.25.0-src/src/libcore/num/mod.rs	2018-04-16 12:13:51.391605020 +0100
+@@ -2210,7 +2210,7 @@
+         ///
+         /// Basic usage:
+         ///
+-        /// ```
++        /// ``` ignore
+         /// assert_eq!(2u8.next_power_of_two(), 2);
+         /// assert_eq!(3u8.next_power_of_two(), 4);
+         /// ```
+@@ -2620,7 +2620,7 @@
+     ///
+     /// # Examples
+     ///
+-    /// ```
++    /// ``` ignore
+     /// #![feature(ascii_ctype)]
+     ///
+     /// let uppercase_a = b'A';


### PR DESCRIPTION
The patch is based on hydra's output and untested: https://hydra.nixos.org/build/72883318/nixlog/1

Those did not compile for some reason:

failures:

---- num/mod.rs - num::u32::next_power_of_two (line 2213) stdout ----
        error: Error during translation/LLVM phase.

thread 'rustc' panicked at 'couldn't compile the test', librustdoc/test.rs:298:13

---- num/mod.rs - num::u8::is_ascii_punctuation (line 2623) stdout ----
        error: Error during translation/LLVM phase.

thread 'rustc' panicked at 'couldn't compile the test', librustdoc/test.rs:298:13

failures:
    num/mod.rs - num::u32::next_power_of_two (line 2213)
    num/mod.rs - num::u8::is_ascii_punctuation (line 2623)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

