### PR TITLE
Remove overrides for dead emacs packages.

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -104,9 +104,6 @@ self:
       helm-rtags = markBroken super.helm-rtags;
 
       # upstream issue: missing file header
-      helm-words = markBroken super.helm-words;
-
-      # upstream issue: missing file header
       ido-complete-space-or-hyphen = markBroken super.ido-complete-space-or-hyphen;
 
       # upstream issue: missing file header
@@ -149,9 +146,6 @@ self:
       # upstream issue: missing dependency
       org-readme = markBroken super.org-readme;
 
-      # upstream issue: missing file header
-      perl-completion = markBroken super.perl-completion;
-
       # upstream issue: truncated file
       powershell = markBroken super.powershell;
 
@@ -160,9 +154,6 @@ self:
 
       # upstream issue: missing file header
       qiita = markBroken super.qiita;
-
-      # upstream issue: missing file header
-      railgun = markBroken super.railgun;
 
       # upstream issue: missing file footer
       seoul256-theme = markBroken super.seoul256-theme;
@@ -197,9 +188,6 @@ self:
 
       # upstream issue: missing file header
       window-numbering = markBroken super.window-numbering;
-
-      # upstream issue: missing file header
-      zeitgeist = markBroken super.zeitgeist;
 
       w3m = super.w3m.override (args: {
         melpaBuild = drv: args.melpaBuild (drv // {


### PR DESCRIPTION
###### Motivation for this change
```
nix-env -f "<nixpkgs>" -qaP -A emacsPackagesNg.melpaPackages
nix-env -f "<nixpkgs>" -qaP -A emacsPackagesNg.melpaStablePackages
```
fail with `error: attribute 'XXXXX' missing, at /nix/nixpkgs/pkgs/applications/editors/emacs-modes/melpa-packages.nix:XXX:XX` messages as `super` doesn't contain the referenced attributes anymore.

###### Things done
Remove obsolete packages.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s):
  * nixos/tests/emacs-daemon.nix
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

