### PR TITLE
Add userdb support to PAM

### DIFF
--- a/pkgs/development/libraries/db/generic.nix
+++ b/pkgs/development/libraries/db/generic.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation (rec {
 
   patches = extraPatches;
 
+  outputs = [ "out" "lib" ];
+
   configureFlags =
     [
       (if cxxSupport then "--enable-cxx" else "--disable-cxx")

--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, fetchpatch, flex, cracklib }:
+{ stdenv, buildPackages, hostPlatform, fetchurl, fetchpatch, flex, cracklib, db4 }:
 
 stdenv.mkDerivation rec {
   name = "linux-pam-${version}";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ flex ];
 
-  buildInputs = [ cracklib ];
+  buildInputs = [ cracklib db4 ];
 
   enableParallelBuilding = true;
 
@@ -72,9 +72,10 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails
 
-  meta = {
-    homepage = http://ftp.kernel.org/pub/linux/libs/pam/;
+  meta = with stdenv.lib; {
+    homepage = http://www.linux-pam.org/;
     description = "Pluggable Authentication Modules, a flexible mechanism for authenticating user";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    license = licenses.bsd3;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Related to https://github.com/NixOS/nixpkgs/pull/39005 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

