### PR TITLE
babelstone-han: 11.0.0 -> 11.0.2

### DIFF
--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,19 +1,19 @@
 {stdenv, fetchzip}:
 
 let
-  version = "11.0.0";
+  version = "11.0.2";
 in fetchzip {
   name = "babelstone-han-${version}";
 
-  url = http://www.babelstone.co.uk/Fonts/3902/BabelStoneHan.zip;
+  url = http://www.babelstone.co.uk/Fonts/Download/BabelStoneHan.zip;
   postFetch = ''
     mkdir -p $out/share/fonts/truetype
     unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
   '';
-  sha256 = "1w3v69lacsy0nha20rkbs6f0dskf5xm6p250qx4a1m69d4a1gx7v";
+  sha256 = "003cz520riskjp729y3piqhmnzfw3jyrmb94im7jyvlc7hp14cdh";
 
   meta = with stdenv.lib; {
-    description = "Unicode CJK font with over 32600 Han characters";
+    description = "Unicode CJK font with over 36000 Han characters";
     homepage = http://www.babelstone.co.uk/Fonts/Han.html;
 
     license = licenses.free;


### PR DESCRIPTION
###### Motivation for this change

new font version; old link answers with 404
