### PR TITLE
git-review: 1.25.0 -> 1.26.0

### DIFF
--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -2,7 +2,7 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "git-review-${version}";
-  version = "1.25.0";
+  version = "1.26.0";
 
   # Manually set version because prb wants to get it from the git
   # upstream repository (and we are installing from tarball instead)
@@ -14,7 +14,7 @@ pythonPackages.buildPythonApplication rec {
 
   src = fetchurl rec {
     url = "https://github.com/openstack-infra/git-review/archive/${version}.tar.gz";
-    sha256 = "aa594690ed586041a524d6e5ae76152cbd53d4f03a98b20b213d15cecbe128ce";
+    sha256 = "106nk6p7byf5vi68b2fvmwma5nk7qrv39nfj9p1bfxmb1gjdixhc";
   };
 
   propagatedBuildInputs = with pythonPackages; [ pbr requests setuptools ];


### PR DESCRIPTION
Fixes #39012.

Semi-automatic update. These checks were done:

- built on NixOS
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/.git-review-wrapped -h` got 0 exit code
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/.git-review-wrapped --help` got 0 exit code
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/.git-review-wrapped --version` and found version 1.26.0
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/git-review -h` got 0 exit code
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/git-review --help` got 0 exit code
- ran `/nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0/bin/git-review --version` and found version 1.26.0
- found 1.26.0 with grep in /nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0
- found 1.26.0 in filename of file in /nix/store/p5k6zxrdcnl84xjnkicm3wblq20c82l5-git-review-1.26.0

(cherry picked from commit dafc368d72491d2acff1c7df5eccfeb5106faa5d)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

