### PR TITLE
adr-tools: init at 2.1.0

### DIFF
--- a/pkgs/applications/misc/adr-tools/default.nix
+++ b/pkgs/applications/misc/adr-tools/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "adr-tools-${version}";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "npryce";
+    repo = "adr-tools";
+    rev = "${version}";
+    sha256 = "19hs7fv8j1hw7gj0rr8vqfsxi1axkpg7rli0705nlcnxd9yc7rx6";
+  };
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp src/* "$out/bin"
+  '';
+
+  meta = {
+    homepage = https://github.com/npryce/adr-tools;
+    description = "Command-line tools for working with Architecture Decision Records";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.mbode ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14674,6 +14674,8 @@ with pkgs;
 
   adobe-reader = callPackage_i686 ../applications/misc/adobe-reader { };
 
+  adr-tools = callPackage ../applications/misc/adr-tools { };
+
   masterpdfeditor = libsForQt5.callPackage ../applications/misc/masterpdfeditor { };
 
   aeolus = callPackage ../applications/audio/aeolus { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

