### PR TITLE
linuxPackages.exfat-nofuse: 2017-06-19 -> 2018-04-16

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -6,13 +6,13 @@ assert lib.versionAtLeast kernel.version  "4.2" || lib.versionOlder kernel.versi
 
 stdenv.mkDerivation rec {
   name = "exfat-nofuse-${version}-${kernel.version}";
-  version = "2017-06-19";
+  version = "2018-04-16";
 
   src = fetchFromGitHub {
     owner = "dorimanx";
     repo = "exfat-nofuse";
-    rev = "de4c760bc9a05ead83bc3ec6eec6cf1fb106f523";
-    sha256 = "0v979d8sbcb70lakm4jal2ck3gspkdgq9108k127f7ph08vf8djm";
+    rev = "01c30ad52625a7261e1b0d874553b6ca7af25966";
+    sha256 = "0n1ibamf1yj8iqapc86lfscnky9p07ngsi4f2kpv3d5r2s6mzsh6";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
###### Motivation for this change

fix for kernel 4.16 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

