### PR TITLE
kdeApplications.mbox-importer: fix hydra build

### DIFF
--- a/pkgs/applications/kde/mbox-importer.nix
+++ b/pkgs/applications/kde/mbox-importer.nix
@@ -14,7 +14,4 @@ mkDerivation {
   buildInputs = [
     akonadi akonadi-search kconfig kservice kio mailcommon mailimporter messagelib
   ];
-  preHook = ''
-    set -x
-  '';
 }


### PR DESCRIPTION
###### Motivation for this change

Build succeded locally but failed on hydra with "log limit exceeded". Disable verbose logging.

/cc ZHF #36453 - please backport

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

