### PR TITLE
vlc: drop unused onlyLibVLC argument

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -7,7 +7,6 @@
 , libmtp, unzip, taglib, libkate, libtiger, libv4l, samba, liboggz
 , libass, libva, libdvbpsi, libdc1394, libraw1394, libopus
 , libvdpau, libsamplerate, live555, fluidsynth
-, onlyLibVLC ? false
 , qt4 ? null
 , withQt5 ? false, qtbase ? null, qtx11extras ? null
 , jackSupport ? false
@@ -68,8 +67,7 @@ stdenv.mkDerivation rec {
       "--enable-vdpau"
       "--enable-dvdnav"
       "--enable-samplerate"
-    ]
-    ++ optional onlyLibVLC  "--disable-vlc";
+    ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

nothing within nixpkgs uses this and the package doesn't actually build if it's
supplied.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

