### PR TITLE
libsmbios: re-enable python utilities

### DIFF
--- a/pkgs/os-specific/linux/libsmbios/default.nix
+++ b/pkgs/os-specific/linux/libsmbios/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, help2man, gettext
-, libxml2, perl, doxygen }:
+, libxml2, perl, python3, doxygen }:
 
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook doxygen gettext libxml2 help2man perl pkgconfig ];
 
-  configureFlags = [ "--disable-python" "--disable-graphviz" ];
+  buildInputs = [ python3 ];
+
+  configureFlags = [ "--disable-graphviz" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Without this the package is missing quite a few useful utilities such as `smbios-thermal-ctl`. With the latest package release they appear to build and work fine without any further changes.

It would be nice to backport to 18.03.

Note that when testing on a NixOS host system running glibc 2.26 they will emit errors reported in https://github.com/NixOS/nixpkgs/issues/38991. This is unrelated to this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

