### PR TITLE
pythonPackages.yeelight: init at 0.4.0

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -151,7 +151,7 @@
     "light.tikteck" = ps: with ps; [  ];
     "light.tplink" = ps: with ps; [  ];
     "light.xiaomi_miio" = ps: with ps; [ construct ];
-    "light.yeelight" = ps: with ps; [  ];
+    "light.yeelight" = ps: with ps; [ yeelight ];
     "light.yeelightsunflower" = ps: with ps; [  ];
     "light.zengge" = ps: with ps; [  ];
     "linode" = ps: with ps; [ linode-api ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18304,6 +18304,21 @@ EOF
   h11 = callPackage ../development/python-modules/h11 { };
 
   python-docx = callPackage ../development/python-modules/python-docx { };
+
+  yeelight = buildPythonPackage rec {
+    name = "yeelight-${version}";
+    version = "0.4.0";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/y/yeelight/${name}.tar.gz";
+      sha256 = "0v5glz4q52w3p51c2yc3pfjlscbnbjq7lkb6j8cz7kkd5pprpp6f";
+    };
+    propagatedBuildInputs = with self; [ future enum-compat ];
+    meta = {
+      homepage = https://gitlab.com/stavros/python-yeelight;
+      description = "A Python library for controlling YeeLight WiFi RGB bulbs";
+      license = licenses.bsd2;
+    };
+  };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

