### PR TITLE
gdk_pixbuf: 2.36.7 → 2.36.12

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -1,40 +1,50 @@
-{ stdenv, fetchurl, pkgconfig, glib, libtiff, libjpeg, libpng, libX11, gnome3
-, jasper, gobjectIntrospection, doCheck ? false }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, python3, libxml2, libxslt, docbook_xsl
+, docbook_xml_dtd_43, gtk-doc, glib, libtiff, libjpeg, libpng, libX11, gnome3
+, jasper, gobjectIntrospection, doCheck ? false, makeWrapper }:
 
 let
   pname = "gdk-pixbuf";
-  version = "2.36.7";
-  # TODO: since 2.36.8 gdk-pixbuf gets configured to use mime-type sniffing,
-  # which apparently requires access to shared-mime-info files during runtime.
+  version = "2.36.12";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "1b6e5eef09d98f05f383014ecd3503e25dfb03d7e5b5f5904e5a65b049a6a4d8";
+    sha256 = "0d534ysa6n9prd17wwzisq7mj6qkhwh8wcf8qgin1ar3hbs5ry7z";
   };
 
-  outputs = [ "out" "dev" "devdoc" ];
+  patches = [
+    # TODO: since 2.36.8 gdk-pixbuf gets configured to use mime-type sniffing,
+    # which requires access to shared-mime-info files during runtime.
+    # For now, we are patching the build script to avoid the dependency.
+    ./no-mime-sniffing.patch
+  ];
+
+  outputs = [ "out" "dev" "man" "devdoc" ];
 
   setupHook = ./setup-hook.sh;
 
-  enableParallelBuilding = true;
-
   # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
-  buildInputs = [ libX11 gobjectIntrospection ];
+  buildInputs = [ libX11 ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    meson ninja pkgconfig gettext python3 libxml2 libxslt docbook_xsl docbook_xml_dtd_43
+    gtk-doc gobjectIntrospection makeWrapper
+  ];
 
   propagatedBuildInputs = [ glib libtiff libjpeg libpng jasper ];
 
-  configureFlags = "--with-libjasper --with-x11"
-    + stdenv.lib.optionalString (gobjectIntrospection != null) " --enable-introspection=yes"
-    ;
+  mesonFlags = [
+    "-Ddocs=true"
+    "-Djasper=true"
+    "-Dx11=true"
+    "-Dgir=${if gobjectIntrospection != null then "true" else "false"}"
+  ];
 
-  # on darwin, tests don't link
-  preBuild = stdenv.lib.optionalString (stdenv.isDarwin && !doCheck) ''
-    substituteInPlace Makefile --replace "docs tests" "docs"
+  postPatch = ''
+    chmod +x build-aux/* # patchShebangs only applies to executables
+    patchShebangs build-aux
   '';
 
   postInstall =
@@ -42,6 +52,9 @@ stdenv.mkDerivation rec {
     ''
       moveToOutput "bin" "$dev"
       moveToOutput "bin/gdk-pixbuf-thumbnailer" "$out"
+
+      # We need to install 'loaders.cache' in lib/gdk-pixbuf-2.0/2.10.0/
+      $dev/bin/gdk-pixbuf-query-loaders --update-cache
     '';
 
   # The tests take an excessive amount of time (> 1.5 hours) and memory (> 6 GB).

--- a/pkgs/development/libraries/gdk-pixbuf/no-mime-sniffing.patch
+++ b/pkgs/development/libraries/gdk-pixbuf/no-mime-sniffing.patch
@@ -1,0 +1,18 @@
+--- a/meson.build
++++ b/meson.build
+@@ -186,13 +186,8 @@
+ gmodule_dep = dependency('gmodule-no-export-2.0')
+ gio_dep = dependency('gio-2.0')
+ 
+-# On non-Windows/macOS systems we always required shared-mime-info and GIO
+-if host_system != 'windows' and host_system != 'darwin'
+-  shared_mime_dep = dependency('shared-mime-info')
+-  gdk_pixbuf_conf.set('GDK_PIXBUF_USE_GIO_MIME', 1)
+-else
+-  shared_mime_dep = []
+-endif
++# No MIME sniffing for now
++shared_mime_dep = []
+ 
+ gdk_pixbuf_deps = [ mathlib_dep, gobject_dep, gmodule_dep, gio_dep, shared_mime_dep ]
+ 


### PR DESCRIPTION
###### Motivation for this change
[Previous attempt](https://github.com/NixOS/nixpkgs/pull/36312) failed due to `gdk-pixbuf` forcing the use of `shared-mime-info`, which did not work on systems that missed it in their `XDG_DATA_DIRS`. Since there is no way to propagate `s-m-i` from `gdk-pixbuf` to `XDG_DATA_DIRS` of all the depending packages, we are patching the build script not to enable type sniffing. Proper solution would be [hardcoding the `s-m-i` path into glib](https://github.com/NixOS/nixpkgs/pull/36312#issuecomment-370270925).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Tested [regression case](https://github.com/NixOS/nixpkgs/pull/36312#issuecomment-381775622)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

