### PR TITLE
grass: Compile with libLAS

### DIFF
--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, flex, bison, pkgconfig, zlib, libtiff, libpng, fftw
 , cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
-, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages
+, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages, libLAS
 }:
 
 stdenv.mkDerivation {
@@ -12,7 +12,8 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo
-  readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql mysql.connector-c blas ]
+  readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql mysql.connector-c blas
+  libLAS ]
     ++ (with python2Packages; [ python dateutil wxPython30 numpy ]);
 
   # On Darwin the installer tries to symlink the help files into a system
@@ -33,6 +34,7 @@ stdenv.mkDerivation {
     "--with-mysql-includes=${mysql.connector-c}/include/mysql"
     "--with-mysql-libs=${mysql.connector-c}/lib/mysql"
     "--with-blas"
+    "--with-liblas=${libLAS}/bin/liblas-config"
   ];
 
   # Otherwise a very confusing "Can't load GDAL library" error

--- a/pkgs/development/libraries/LASzip/default.nix
+++ b/pkgs/development/libraries/LASzip/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.laszip.org;
     license = stdenv.lib.licenses.lgpl2;
     maintainers = [ stdenv.lib.maintainers.michelk ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libLAS/default.nix
+++ b/pkgs/development/libraries/libLAS/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, boost, cmake, gdal, libgeotiff, libtiff, LASzip }:
+{ stdenv, fetchurl, boost, cmake, gdal, libgeotiff, libtiff, LASzip, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   name = "libLAS-1.8.1";
@@ -9,14 +9,22 @@ stdenv.mkDerivation rec {
     sha256 = "0xjfxb3ydvr2258ji3spzyf81g9caap19ql2pk91wiivqsc4mnws";
   };
 
-  buildInputs = [ boost cmake gdal libgeotiff libtiff LASzip ];
+  buildInputs = [ boost cmake gdal libgeotiff libtiff LASzip ]
+                ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
+  cmakeFlags = [
+    "-DGDAL_CONFIG=${gdal}/bin/gdal-config"
+  ];
+
+  postFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change "@rpath/liblas.3.dylib" "$out/lib/liblas.3.dylib" $out/lib/liblas_c.dylib
+  '';
 
   meta = {
     description = "LAS 1.0/1.1/1.2 ASPRS LiDAR data translation toolset";
     homepage = http://www.liblas.org;
     license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.michelk ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This enables the grass commands `r.in.lidar` and so on for working with lidar data. 

Thanks to @LnL7 for all his help with these changes. 

Subsumes #29082

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

