### PR TITLE
clang: fix install on Darwin

### DIFF
--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -50,10 +50,10 @@ let
 
     outputs = [ "out" "lib" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
-    # Clang expects to find sanitizer libraries in its own prefix
     postInstall = ''
+      # Clang expects to find LLVMgold in its own prefix
       ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+      # Clang expects to find sanitizer libraries in its own prefix
       ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
       ln -sv $out/bin/clang $out/bin/cpp
 

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -52,7 +52,9 @@ let
 
     postInstall = ''
       # Clang expects to find LLVMgold in its own prefix
-      ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+      if [ -e ${llvm}/lib/LLVMgold.so ]; then
+        ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+      fi
       # Clang expects to find sanitizer libraries in its own prefix
       ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
       ln -sv $out/bin/clang $out/bin/cpp


### PR DESCRIPTION
###### Motivation for this change

As of Nix 2.0, building the `user-environment` package on macOS (Darwin) fails because LLVMgold.so is a broken symlink. Fix the issue by not creating the symlink in the first place, since it wouldn't be used on Darwin anyway.

###### Requests for comments

It seems that Nix 2.0's new buildenv implementation breaks with broken symlinks. Where can I find the code for the new buildenv implementation? The buildenv source in this repository (NixOS/nixpkgs) looks like a Perl script, not a compiled binary which I have in `/nix/store/xmi4fylvx4qc79ji9v5q3zfy9vfdy4sv-nix-2.0/libexec/nix/buildenv`.

I think these changes will cause full rebuilds. Should they go on master or staging?

Should I bother with other versions of Clang (e.g. 4.0.1 in `pkgs/development/compilers/llvm/4/default.nix`)? How can I install those with `nix-env -i`?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platforms: `nix-env -i --no-build-output --max-jobs 3 --cores 8 -f . clang`
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)

###### Things to do

- [ ] Test more thoroughly
- [ ] Update other versions of Clang
- [x] Figure out if LLVM's Gold LTO plugin is *supposed* to be built on Darwin
- [ ] Find the change in Nix 2.0 or buildenv which caused the broken symlink to break the build
