### PR TITLE
agg: disable building of examples to fix build

### DIFF
--- a/pkgs/development/libraries/agg/default.nix
+++ b/pkgs/development/libraries/agg/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sh autogen.sh
   '';
 
-  configureFlags = "--x-includes=${libX11.dev}/include --x-libraries=${libX11.out}/lib";
+  configureFlags = "--x-includes=${libX11.dev}/include --x-libraries=${libX11.out}/lib --enable-examples=no";
 
   # libtool --tag=CXX --mode=link g++ -g -O2 libexamples.la ../src/platform/X11/libaggplatformX11.la ../src/libagg.la -o alpha_mask2 alpha_mask2.o
   # libtool: error: cannot find the library 'libexamples.la'


### PR DESCRIPTION
###### Motivation for this change

Previously the build was failing with due to not being able to find `libexamples.la.`

```
/nix/store/q1g0rl8zfmz7r371fp5p42p4acmv297d-bash-4.4-p19/bin/bash ../libtool  --tag=CXX   --mode=link g++  -g -O2 libexamples.la  .
./src/platform/X11/libaggplatformX11.la ../src/libagg.la  -o alpha_mask2 alpha_mask2.o
libtool:   error: cannot find the library 'libexamples.la' or unhandled argument 'libexamples.la'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

