### PR TITLE
tt-rss: fix directory permissions

### DIFF
--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -6,9 +6,9 @@ let
 
   configVersion = 26;
 
-  cacheDir = "cache";
-  lockDir = "lock";
-  feedIconsDir = "feed-icons";
+  cacheDir = "${cfg.root}/cache";
+  lockDir = "${cfg.root}/lock";
+  feedIconsDir = "${cfg.root}/feed-icons";
 
   dbPort = if cfg.database.port == null
     then (if cfg.database.type == "pgsql" then 5432 else 3306)
@@ -520,6 +520,22 @@ let
           ln -sf "${tt-rss-config}" "${cfg.root}/config.php"
           chown -R "${cfg.user}" "${cfg.root}"
           chmod -R 755 "${cfg.root}"
+
+          chown -R ${cfg.user}:nginx \
+            "${cacheDir}/export" \
+            "${cacheDir}/images" \
+            "${cacheDir}/js" \
+            "${cacheDir}/upload" \
+            "${feedIconsDir}" \
+            "${lockDir}"
+
+          chmod -R g+w \
+            "${cacheDir}/export" \
+            "${cacheDir}/images" \
+            "${cacheDir}/js" \
+            "${cacheDir}/upload" \
+            "${feedIconsDir}" \
+            "${lockDir}"
         ''
 
         + (optionalString (cfg.database.type == "pgsql") ''


### PR DESCRIPTION
###### Motivation for this change
tt-rss expects several directories to be writable by the application user, which
was not the case. This caused the application to crash at startup.

###### Things done
 I fixed this by adjusting the permissions in the preStart
script. In addition, I explicitly configured the directories to be in the state directory.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

