### PR TITLE
gnupatch: fix CVE-2018-6951

### DIFF
--- a/pkgs/tools/text/gnupatch/CVE-2018-6951.patch
+++ b/pkgs/tools/text/gnupatch/CVE-2018-6951.patch
@@ -1,0 +1,28 @@
+From f290f48a621867084884bfff87f8093c15195e6a Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruen@gnu.org>
+Date: Mon, 12 Feb 2018 16:48:24 +0100
+Subject: Fix segfault with mangled rename patch
+
+http://savannah.gnu.org/bugs/?53132
+* src/pch.c (intuit_diff_type): Ensure that two filenames are specified
+for renames and copies (fix the existing check).
+---
+ src/pch.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/pch.c b/src/pch.c
+index ff9ed2c..bc6278c 100644
+--- a/src/pch.c
++++ b/src/pch.c
+@@ -974,7 +974,8 @@ intuit_diff_type (bool need_header, mode_t *p_file_type)
+     if ((pch_rename () || pch_copy ())
+ 	&& ! inname
+ 	&& ! ((i == OLD || i == NEW) &&
+-	      p_name[! reverse] &&
++	      p_name[reverse] && p_name[! reverse] &&
++	      name_is_valid (p_name[reverse]) &&
+ 	      name_is_valid (p_name[! reverse])))
+       {
+ 	say ("Cannot %s file without two valid file names\n", pch_rename () ? "rename" : "copy");
+-- 
+cgit v1.0-41-gc330

--- a/pkgs/tools/text/gnupatch/default.nix
+++ b/pkgs/tools/text/gnupatch/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "1zfqy4rdcy279vwn2z1kbv19dcfw25d2aqy9nzvdkq5bjzd0nqdc";
   };
 
+  patches = [
+    # https://git.savannah.gnu.org/cgit/patch.git/patch/?id=f290f48a621867084884bfff87f8093c15195e6a
+    ./CVE-2018-6951.patch
+  ];
+
   buildInputs = stdenv.lib.optional doCheck ed;
 
   configureFlags = stdenv.lib.optionals (hostPlatform != buildPlatform) [


### PR DESCRIPTION
Fix CVE for #38993 

I can't use `fetchpatch` in `gnupatch` so I used fetchurl to fetch the patch. 
Is it an expected behavior? (I wouldn't be surprised we can't use gnupatch to build gnupatch but I didn't look at this in details).

Should I rebase this patch on `staging`?