### PR TITLE
pythonPackages.django: 1.11.9 -> 1.11.12

### DIFF
--- a/pkgs/development/python-modules/django/1_11.nix
+++ b/pkgs/development/python-modules/django/1_11.nix
@@ -6,14 +6,13 @@
 
 buildPythonPackage rec {
   pname = "Django";
-  name = "${pname}-${version}";
-  version = "1.11.9";
+  version = "1.11.12";
 
   disabled = pythonOlder "2.7";
 
   src = fetchurl {
-    url = "http://www.djangoproject.com/m/releases/1.11/${name}.tar.gz";
-    sha256 = "0d0hh9sh2rwazi7z2lnqvz1424bq6ps6c5h6ss04klp14agi4g9m";
+    url = "http://www.djangoproject.com/m/releases/1.11/${pname}-${version}.tar.gz";
+    sha256 = "1szjha338grhf9dq0wpbrqwvak597shsx474pm5j67kn09xqqfad";
   };
 
   patches = stdenv.lib.optionals withGdal [


### PR DESCRIPTION
Once merged, I’ll backport this to `release-18.03`.

Some  derivations that needs django failes to build before and after this update.

###### Motivation for this change

Release notes and associated fixed CVEs:
- https://docs.djangoproject.com/en/2.0/releases/1.11.10/
  - CVE-2018-6188
- https://docs.djangoproject.com/en/2.0/releases/1.11.11/
  - CVE-2018-7536
  - CVE-2018-7537
- https://docs.djangoproject.com/en/2.0/releases/1.11.12/




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

