### PR TITLE
jumanpp: init at 1.02

### DIFF
--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     homepage = http://nlp.ist.i.kyoto-u.ac.jp/index.php?JUMAN++;
     license = licenses.asl20;
     maintainers = with maintainers; [ mt-caret ];
-    platforms = platforms.all;
+    platforms = platforms.x86_64;
   };
 }

--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     homepage = http://nlp.ist.i.kyoto-u.ac.jp/index.php?JUMAN++;
     license = licenses.asl20;
     maintainers = with maintainers; [ mt-caret ];
-    platforms = platforms.x86_64;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, boost, libunwind, gperftools }:
+stdenv.mkDerivation rec {
+  name = "jumanpp";
+  version = "1.02";
+  src = fetchurl {
+    url = "http://lotus.kuee.kyoto-u.ac.jp/nl-resource/jumanpp/jumanpp-${version}.tar.xz";
+    sha256 = "14768b419bak8h2px8chw4cbfscb0jj012bpr769qv5nn6f53yh1";
+  };
+  buildInputs = [ boost libunwind gperftools ];
+  meta = with stdenv.lib; {
+    description = "A Japanese morphological analyser using a recurrent neural network language model (RNNLM)";
+    longDescription = ''
+      JUMAN++ is a new morphological analyser that considers semantic
+      plausibility of word sequences by using a recurrent neural network
+      language model (RNNLM).
+    '';
+    homepage = http://nlp.ist.i.kyoto-u.ac.jp/index.php?JUMAN++;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mt-caret ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, boost, libunwind, gperftools }:
+{ stdenv, fetchurl, cmake, protobuf }:
 stdenv.mkDerivation rec {
   name = "jumanpp";
-  version = "1.02";
+  version = "2.0.0-rc2";
+
   src = fetchurl {
-    url = "http://lotus.kuee.kyoto-u.ac.jp/nl-resource/jumanpp/jumanpp-${version}.tar.xz";
-    sha256 = "14768b419bak8h2px8chw4cbfscb0jj012bpr769qv5nn6f53yh1";
+    url = "https://github.com/ku-nlp/${name}/releases/download/v${version}/${name}-${version}.tar.xz";
+    sha256 = "17fzmd0f5m9ayfhsr0mg7hjp3pg1mhbgknhgyd8v87x46g8bg6qp";
   };
-  buildInputs = [ boost libunwind gperftools ];
+  buildInputs = [ cmake protobuf ];
+
   meta = with stdenv.lib; {
     description = "A Japanese morphological analyser using a recurrent neural network language model (RNNLM)";
     longDescription = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3395,6 +3395,8 @@ with pkgs;
 
   ispell = callPackage ../tools/text/ispell {};
 
+  jumanpp = callPackage ../tools/text/jumanpp {};
+
   kindlegen = callPackage ../tools/typesetting/kindlegen { };
 
   latex2html = callPackage ../tools/misc/latex2html { };


### PR DESCRIPTION
###### Motivation for this change

Adds JUMAN++, a morphological analyzer for Japanese.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

