### PR TITLE
error message honores nested dots in attribute path elements

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -127,7 +127,18 @@ rec {
 
 
   /* Helper functions. */
-  showOption = concatStringsSep ".";
+  showOption = let
+    contains = c: str:
+      if ((builtins.stringLength str) == 0) then
+        false
+      else (
+        if (hasPrefix c str) then
+          true
+        else
+          contains c (substring 1 (builtins.stringLength str) str)
+      );
+  in x: concatStringsSep "." (map (el: if (contains "." el) then ''"${el}"'' else el) x);
+
   showFiles = files: concatStringsSep " and " (map (f: "`${f}'") files);
   unknownModule = "<unknown-file>";
 


### PR DESCRIPTION
while using submodules we encountered that if the value is used but was not assigned
one would see this incorrect error message:

  error: The option `nixcloud.TLS.certs.example.com.mode' is used but not defined.

this patch fixes it to:

  error: The option `nixcloud.TLS.certs."example.com".mode' is used but not defined.

**please also backport to 18.03**

# note

i've checked this patch locally, see the error message. if wanted i can prepare a minimal example how to reproduce.