### PR TITLE
simplenote: 1.0.6 -> 1.1.3

### DIFF
--- a/pkgs/applications/misc/simplenote/default.nix
+++ b/pkgs/applications/misc/simplenote/default.nix
@@ -5,11 +5,11 @@
  stdenv.mkDerivation rec {
 
   name = "simplenote-${pkgver}";
-  pkgver = "1.0.6";
+  pkgver = "1.1.3";
 
   src = fetchurl {
-    url = "https://github.com/Automattic/simplenote-electron/releases/download/v${pkgver}/Simplenote-linux-x64.${pkgver}.tar.gz";
-    sha256 = "18wj880iw92yd57w781dqaj7iv9j3bqhyh2cbikqrl4m5w9xkla8";
+    url = "https://github.com/Automattic/simplenote-electron/releases/download/v${pkgver}/Simplenote-linux-${pkgver}.tar.gz";
+    sha256 = "1z92yyjmg3bgfqfdpnysf98h9hhhnqzdqqigwlmdmn3d7fy49kcf";
   };
 
   buildCommand = let
@@ -20,6 +20,7 @@
       xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
       xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
       xorg.libXcursor libcap systemd libnotify libXScrnSaver gnome3.gconf
+      xorg.libxcb
     ];
 
     libPathNative = lib.makeLibraryPath packages;


### PR DESCRIPTION
###### Motivation for this change

Upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

