### PR TITLE
partclone: add support for various filesystems

### DIFF
--- a/pkgs/tools/backup/partclone/default.nix
+++ b/pkgs/tools/backup/partclone/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook
-, pkgconfig, libuuid, e2fsprogs
+, pkgconfig, libuuid, e2fsprogs, nilfs-utils, ntfs3g
 }:
 
 stdenv.mkDerivation rec {
@@ -15,8 +15,21 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [
-    e2fsprogs libuuid stdenv.cc.libc
+    e2fsprogs libuuid stdenv.cc.libc nilfs-utils ntfs3g 
     (stdenv.lib.getOutput "static" stdenv.cc.libc)
+  ];
+
+  configureFlags = [
+    "--enable-xfs"
+    "--enable-extfs"
+    "--enable-hfsp"
+    "--enable-fat"
+    "--enable-exfat"
+    "--enable-ntfs"
+    "--enable-btrfs"
+    "--enable-minix"
+    "--enable-f2fs"
+    "--enable-nilfs2"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Adds support for ext2/3/4, fat, hfs+, minix, nilfs, ntfs, and xfs

Closes #39079

###### Motivation for this change

As it stands, the partclone package does not provide support for efficient cloning of filesystems; The partclone.[fs_type] symbolic links are missing. This means that cloning is limited to `partclone.dd`, a bit-identical copy. 

In contrast, this change adds support for *some* of the supported filesystems, allowing `partclone` to perform efficient cloning of said filesystems.

###### Missing filesystems

The following filesystems are not in this change because I was unable to get the configure script to detect the dependencies.

- reiserfs
- ufs
- vmsf
- jsf

In addition, I did not add FUSE support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - ~[ ] macOS~
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

