### PR TITLE
binutils: fix R_AARCH64_ABS32 on aarch64

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -64,6 +64,12 @@ stdenv.mkDerivation rec {
 
     # https://sourceware.org/bugzilla/show_bug.cgi?id=22868
     ./gold-symbol-visibility.patch
+
+  ] ++ stdenv.lib.optionals targetPlatform.isAarch64 [
+    # Version 2.30 introduced strict requirements on ELF relocations which cannot
+    # be satisfied on aarch64 platform. Add backported fix from bugzilla.
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=22764
+    ./relax-R_AARCH64_ABS32-R_AARCH64_ABS16-absolute.patch
   ];
 
   outputs = [ "out" "info" "man" ];

--- a/pkgs/development/tools/misc/binutils/relax-R_AARCH64_ABS32-R_AARCH64_ABS16-absolute.patch
+++ b/pkgs/development/tools/misc/binutils/relax-R_AARCH64_ABS32-R_AARCH64_ABS16-absolute.patch
@@ -1,0 +1,130 @@
+diff --git a/bfd/ChangeLog b/bfd/ChangeLog
+index c310da6ed3..d31f46171f 100644
+--- a/bfd/ChangeLog
++++ b/bfd/ChangeLog
+@@ -1,3 +1,10 @@
++2018-02-05  Renlin Li  <renlin.li@arm.com>
++
++       PR ld/22764
++       * elfnn-aarch64.c (elfNN_aarch64_check_relocs): Relax the
++       R_AARCH64_ABS32 and R_AARCH64_ABS16 for absolute symbol. Apply the
++       check for writeable section as well.
++
+ 2018-01-27  Nick Clifton  <nickc@redhat.com>
+ 
+ 	This is the 2.30 release:
+diff --git a/bfd/elfnn-aarch64.c b/bfd/elfnn-aarch64.c
+index d5711e0eb1..973188220b 100644
+--- a/bfd/elfnn-aarch64.c
++++ b/bfd/elfnn-aarch64.c
+@@ -7074,10 +7074,19 @@ elfNN_aarch64_check_relocs (bfd *abfd, struct bfd_link_info *info,
+ #if ARCH_SIZE == 64
+ 	case BFD_RELOC_AARCH64_32:
+ #endif
+-	  if (bfd_link_pic (info)
+-	      && (sec->flags & SEC_ALLOC) != 0
+-	      && (sec->flags & SEC_READONLY) != 0)
++	  if (bfd_link_pic (info) && (sec->flags & SEC_ALLOC) != 0)
+ 	    {
++	      if (h != NULL
++		  /* This is an absolute symbol.  It represents a value instead
++		     of an address.  */
++		  && ((h->root.type == bfd_link_hash_defined
++		       && bfd_is_abs_section (h->root.u.def.section))
++		      /* This is an undefined symbol.  */
++		      || h->root.type == bfd_link_hash_undefined))
++		break;
++
++	      /* For local symbols, defined global symbols in a non-ABS section,
++		 it is assumed that the value is an address.  */
+ 	      int howto_index = bfd_r_type - BFD_RELOC_AARCH64_RELOC_START;
+ 	      _bfd_error_handler
+ 		/* xgettext:c-format */
+diff --git a/ld/ChangeLog b/ld/ChangeLog
+index 6337cd0cb6..1aaa6da3b5 100644
+--- a/ld/ChangeLog
++++ b/ld/ChangeLog
+@@ -1,3 +1,11 @@
++2018-02-05  Renlin Li  <renlin.li@arm.com>
++
++       PR ld/22764
++       * testsuite/ld-aarch64/emit-relocs-258.s: Define symbol as an address.
++       * testsuite/ld-aarch64/emit-relocs-259.s: Likewise.
++       * testsuite/ld-aarch64/pr22764.s: New.
++       * testsuite/ld-aarch64/pr22764.d: New.
++
+ 2018-01-27  Nick Clifton  <nickc@redhat.com>
+ 
+ 	This is the 2.30 release:
+diff --git a/ld/testsuite/ld-aarch64/aarch64-elf.exp b/ld/testsuite/ld-aarch64/aarch64-elf.exp
+index f31089361b..d766f3736b 100644
+--- a/ld/testsuite/ld-aarch64/aarch64-elf.exp
++++ b/ld/testsuite/ld-aarch64/aarch64-elf.exp
+@@ -275,6 +275,7 @@ run_dump_test "pr17415"
+ run_dump_test_lp64 "tprel_g2_overflow"
+ run_dump_test "tprel_add_lo12_overflow"
+ run_dump_test "protected-data"
++run_dump_test_lp64 "pr22764"
+ 
+ # ifunc tests
+ run_dump_test "ifunc-1"
+diff --git a/ld/testsuite/ld-aarch64/emit-relocs-258.s b/ld/testsuite/ld-aarch64/emit-relocs-258.s
+index f724776243..87bb657c5d 100644
+--- a/ld/testsuite/ld-aarch64/emit-relocs-258.s
++++ b/ld/testsuite/ld-aarch64/emit-relocs-258.s
+@@ -1,5 +1,6 @@
++.global dummy
+ .text
+-
++dummy:
+   ldr x0, .L1
+ 
+ .L1:
+diff --git a/ld/testsuite/ld-aarch64/emit-relocs-259.s b/ld/testsuite/ld-aarch64/emit-relocs-259.s
+index 7e1ba3ceb4..0977c9d869 100644
+--- a/ld/testsuite/ld-aarch64/emit-relocs-259.s
++++ b/ld/testsuite/ld-aarch64/emit-relocs-259.s
+@@ -1,5 +1,6 @@
++.global dummy
+ .text
+-
++dummy:
+   ldr x0, .L1
+ 
+ .L1:
+diff --git a/ld/testsuite/ld-aarch64/pr22764.d b/ld/testsuite/ld-aarch64/pr22764.d
+new file mode 100644
+index 0000000000..997519f469
+--- /dev/null
++++ b/ld/testsuite/ld-aarch64/pr22764.d
+@@ -0,0 +1,18 @@
++#source: pr22764.s
++#ld: -shared -T relocs.ld -defsym sym_abs1=0x1 -defsym sym_abs2=0x2 -defsym sym_abs3=0x3 -e0 --emit-relocs
++#notarget: aarch64_be-*-*
++#objdump: -dr
++#...
++
++Disassembly of section \.text:
++
++0000000000010000 \<\.text\>:
++   10000:	d503201f 	nop
++	...
++			10004: R_AARCH64_ABS64	sym_abs1
++   1000c:	00000002 	\.word	0x00000002
++			1000c: R_AARCH64_ABS32	sym_abs2
++   10010:	0003      	\.short	0x0003
++			10010: R_AARCH64_ABS16	sym_abs3
++   10012:	0000      	\.short	0x0000
++   10014:	d503201f 	nop
+diff --git a/ld/testsuite/ld-aarch64/pr22764.s b/ld/testsuite/ld-aarch64/pr22764.s
+new file mode 100644
+index 0000000000..25e36b4a12
+--- /dev/null
++++ b/ld/testsuite/ld-aarch64/pr22764.s
+@@ -0,0 +1,6 @@
++  .text
++  nop
++  .xword sym_abs1
++  .word sym_abs2
++  .short sym_abs3
++  nop


### PR DESCRIPTION
###### Motivation for this change
currently aarch64 builds of various packages (kernel, boot, qemu) fail on nixos-unstable-small due to https://sourceware.org/bugzilla/show_bug.cgi?id=22764

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

