### PR TITLE
bwsyncandshare: init at 11.6.703

### DIFF
--- a/pkgs/applications/networking/bwsyncandshare/default.nix
+++ b/pkgs/applications/networking/bwsyncandshare/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, oraclejre8, ... }:
+
+stdenv.mkDerivation rec {
+  name = "bwSyncAndShare-${version}";
+  version = "11.6.703";
+
+  src = fetchurl {
+    # No version-numbered tarball available, only a "Latest" version.
+    # This will break whenever a new version is published.
+    url = https://download.bwsyncandshare.kit.edu/clients/bwSyncAndShare_Latest_Linux.tar.gz;
+    sha256 = "1yw81l9pv5qkl5l12i7lgma4bvn5jfnj1w1s68pfwzc145zzh8cc";
+  };
+
+  # Upstream package includes a bundled Oracle jre8. We replace this with a dependency
+  # to support multiple platforms. Current version refuses to run with openjdk.
+  buildInputs = [ oraclejre8 ];
+
+  patchPhase = ''
+    substituteInPlace install-files/bwSyncAndShare.desktop --replace "/usr/share/" "$out/share/"
+    substituteInPlace bwSyncAndShare-Client.sh \
+       --replace '$CLIENT_INSTALL/jre/bin/java' "${oraclejre8}/bin/java" \
+       --replace "CLIENT_INSTALL=." "CLIENT_INSTALL=$out/share/bwSyncAndShare"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D -m 644 -t $out/share/bwSyncAndShare/ bwSyncAndShare.jar
+    install -D -m 755 -t $out/share/bwSyncAndShare/ bwSyncAndShare-Client.sh
+    ln -s $out/share/bwSyncAndShare/bwSyncAndShare-Client.sh $out/bin/bwSyncAndShare
+    install -D -m 644 -t $out/share/icons/hicolor/128x128/apps/ install-files/bwSyncAndShare.png
+    install -D -m 644 -t $out/share/applications/ install-files/bwSyncAndShare.desktop
+    install -D -m 644 -t $out/ LICENSE README VERSION
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Client for a file sync/share service run by some German state universities.";
+    homepage = https://bwsyncandshare.kit.edu;
+    license = licenses.unfree;
+    platforms = oraclejre8.meta.platforms;
+    maintainers = with maintainers; [ xeji ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14963,6 +14963,8 @@ with pkgs;
 
   bviplus = callPackage ../applications/editors/bviplus { };
 
+  bwsyncandshare = callPackage ../applications/networking/bwsyncandshare { };
+
   calf = callPackage ../applications/audio/calf {
       inherit (gnome2) libglade;
       stdenv = overrideCC stdenv gcc5;


### PR DESCRIPTION
###### Motivation for this change

Client for a [file sync and share service](https://bwsyncandshare.kit.edu) run by public universities in the German state of Baden-Württemberg for students and staff.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

