### PR TITLE
oraclejdk8: 8.161 -> 8.171

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,11 +1,11 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "161";
+  patchVersion = "171";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256.i686-linux = "1p6p93msn3bsg9775rq171kd4160w4w8z57p0qpjdjycfix62sfg";
-  sha256.x86_64-linux = "07h2wah80qr78y0f821z12lbdmsv90xbckdn3glnj2riwfh5dg3d";
-  sha256.armv7l-linux = "0mngw2lnhx3hzgp444advybhjn5hjk3mi14y72km4kp03gh82a7x";
-  sha256.aarch64-linux = "18l5fny7yxhpj5c935rnlq4pvwadyr5zkid6yh9x87frl401shy7";
+  sha256.i686-linux = "0dh5r02v40pinway952fflw2r0i1xi67hmyb87c278qfp4jn929p";
+  sha256.x86_64-linux = "10jr4z0bw9wcws5xgc4qkw101cadfx5bkyvcnc4l3v5axwvjipdn";
+  sha256.armv7l-linux = "1bqivmp1wfnypgg5bsfzi25yzl7vd2xncfap9mi8jn63aj633dw0";
+  sha256.aarch64-linux = "1016lf3g1syjsl29m58s2s2w9nkj4jkvxhqg4s35vy41cs2v77j7";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change

This was the version shown on the download page.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

