### PR TITLE
vulkan-loader: fix broken symlink in output

### DIFF
--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -48,8 +48,8 @@ stdenv.mkDerivation rec {
     cp -d loader/libvulkan.so* $out/lib
     cp demos/vulkaninfo $out/bin
     mkdir -p $out/lib $out/share/vulkan/explicit_layer.d
-    cp -d layers/*.so $out/lib/
-    cp -d layers/*.json $out/share/vulkan/explicit_layer.d/
+    cp -L layers/*.so $out/lib/
+    cp -L layers/*.json $out/share/vulkan/explicit_layer.d/
     sed -i "s:\\./lib:$out/lib/lib:g" "$out/share/vulkan/"*/*.json
     mkdir -p $dev/include
     cp -rv ../include $dev/


### PR DESCRIPTION
###### Motivation for this change
For some strange reason, non-critical parts of the build output of vulkan-loader are symlinks to the build directory, and this wasn't caught by any automated sanity checks. 1.0.61 (in 18.03) and later are confirmed affected, earlier not tested.

This fixes the install process to conservatively deref the invalid links.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

