### PR TITLE
bitwigstudio2: 2.3.1 -> 2.3.2

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio2.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio2.nix
@@ -3,11 +3,11 @@
 
 bitwig-studio1.overrideAttrs (oldAttrs: rec {
   name = "bitwig-studio-${version}";
-  version = "2.3.1";
+  version = "2.3.2";
 
   src = fetchurl {
     url    = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
-    sha256 = "18gghx0ygwh01cidj8mkf82l9qhq2dy1b3yc4ajksvj762yg6cf2";
+    sha256 = "10ji4jqnnlhv4bgvhqwysprax6jcjk4759jskr9imwj6qjnj3vzn";
   };
 
   buildInputs = bitwig-studio1.buildInputs ++ [ ffmpeg ];


### PR DESCRIPTION
###### Motivation for this change
Wanted the latest Bitwig

###### Things done
Incremented the version and the hash.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

