### PR TITLE
release-18.03: ELK 5.6.9 & 6.2.4 & fixes for elasticsearch6 and logstash6 not starting up

### DIFF
--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -32,8 +32,11 @@ let
       (if es5 then (pkgs.writeTextDir "log4j2.properties" cfg.logging)
               else (pkgs.writeTextDir "logging.yml" cfg.logging))
     ];
-    # Elasticsearch 5.x won't start when the scripts directory does not exist
-    postBuild = if es5 then "${pkgs.coreutils}/bin/mkdir -p $out/scripts" else "";
+    postBuild = concatStringsSep "\n" (concatLists [
+      # Elasticsearch 5.x won't start when the scripts directory does not exist
+      (optional es5 "${pkgs.coreutils}/bin/mkdir -p $out/scripts")
+      (optional es6 "ln -s ${cfg.package}/config/jvm.options $out/jvm.options")
+    ]);
   };
 
   esPlugins = pkgs.buildEnv {

--- a/pkgs/development/tools/misc/kibana/5.x.nix
+++ b/pkgs/development/tools/misc/kibana/5.x.nix
@@ -11,9 +11,9 @@ let
   elasticArch = archOverrides."${arch}" or arch;
   plat = elemAt info 1;
   shas = {
-    "x86_64-linux"  = "0hhgpi32168kfzqkp0bjpn7k145ii0s3nkxs3v1n3rgykyyid19d";
-    "i686-linux"    = "1s7h0s8jzxl3nyfklhlk9aadg0wb8x5rbnwlmi6lkw4l5kmlrijv";
-    "x86_64-darwin" = "014bcghb4bin4d8p7k1k251riqa7snc3l5zlm6f1k8nvdfh6wkzr";
+    "x86_64-linux"  = "1rg4j5jm8mkscrwlbx5qk3qjnblyr8z9x5npvyi73zm0ism0gv4j";
+    "i686-linux"    = "14swgx9sf23pns2pj30yyhd0p0rnykdimdrnj8rb0r1pqszw57qx";
+    "x86_64-darwin" = "10l13r47nx74xicnjgb56nvgvx2al1zx1p8f09pjldaa2gjlll2k";
   };
 in stdenv.mkDerivation rec {
   name = "kibana-${version}";

--- a/pkgs/development/tools/misc/kibana/5.x.nix
+++ b/pkgs/development/tools/misc/kibana/5.x.nix
@@ -11,9 +11,9 @@ let
   elasticArch = archOverrides."${arch}" or arch;
   plat = elemAt info 1;
   shas = {
-    "x86_64-linux"  = "1a9n7s9r0klqvpyr5d3a410cchbsb0syx6cqwbhhnihqyw8dcx1i";
-    "i686-linux"    = "0snnm5jwynvk6ahgl42yzl2jhld0ykn79rlcq9dsv2gpqnjb2mmv";
-    "x86_64-darwin" = "0qw3xkj3n3aja8s8n9r4hbr65jm9m6dgfjhhnrln434648rx7z4v";
+    "x86_64-linux"  = "0hhgpi32168kfzqkp0bjpn7k145ii0s3nkxs3v1n3rgykyyid19d";
+    "i686-linux"    = "1s7h0s8jzxl3nyfklhlk9aadg0wb8x5rbnwlmi6lkw4l5kmlrijv";
+    "x86_64-darwin" = "014bcghb4bin4d8p7k1k251riqa7snc3l5zlm6f1k8nvdfh6wkzr";
   };
 in stdenv.mkDerivation rec {
   name = "kibana-${version}";

--- a/pkgs/development/tools/misc/kibana/6.x.nix
+++ b/pkgs/development/tools/misc/kibana/6.x.nix
@@ -7,8 +7,8 @@ let
   arch = elemAt info 0;
   plat = elemAt info 1;
   shas = {
-    "x86_64-linux"  = "1gkswrcvqkblazmhybz0pslafacy0fs2lzyrydrfiirkwdr5qnr2";
-    "x86_64-darwin" = "16lyg7xmiprd7ibj37ajpsw7vfn34z4rfxck5x43zd0jvvn8cchd";
+    "x86_64-linux"  = "15iykvbqgqj9lk764rkl52f47b6v59kvfiqfvdp3n3anszyqcc5d";
+    "x86_64-darwin" = "04fgazl5rzb4vw8xn5s46w44f2rdpki81q2rch2jiq9hf8bqm55m";
   };
 in stdenv.mkDerivation rec {
   name = "kibana-${version}";

--- a/pkgs/development/tools/misc/kibana/6.x.nix
+++ b/pkgs/development/tools/misc/kibana/6.x.nix
@@ -7,8 +7,8 @@ let
   arch = elemAt info 0;
   plat = elemAt info 1;
   shas = {
-    "x86_64-linux"  = "0kgsafjn8wzrmiklfc8jg0h3cx25lhlkby8yz35wgpx4wbk3vfjx";
-    "x86_64-darwin" = "0i2kq9vyjv151kk7h3dl3hjrqqgxsg0qqxdqwjwlz9ja5axzlxhd";
+    "x86_64-linux"  = "1gkswrcvqkblazmhybz0pslafacy0fs2lzyrydrfiirkwdr5qnr2";
+    "x86_64-darwin" = "16lyg7xmiprd7ibj37ajpsw7vfn34z4rfxck5x43zd0jvvn8cchd";
   };
 in stdenv.mkDerivation rec {
   name = "kibana-${version}";

--- a/pkgs/development/tools/misc/kibana/6.x.nix
+++ b/pkgs/development/tools/misc/kibana/6.x.nix
@@ -7,8 +7,8 @@ let
   arch = elemAt info 0;
   plat = elemAt info 1;
   shas = {
-    "x86_64-linux"  = "15iykvbqgqj9lk764rkl52f47b6v59kvfiqfvdp3n3anszyqcc5d";
-    "x86_64-darwin" = "04fgazl5rzb4vw8xn5s46w44f2rdpki81q2rch2jiq9hf8bqm55m";
+    "x86_64-linux"  = "1br9nvwa3i5sfcbnrxp2x3dxxnsbs9iavz6zwgw0jlh5ngf5vysk";
+    "x86_64-darwin" = "1w4dck02i0rrl8m18kvy2zz02cb7bb9a2pdhkd1jfy1qz4ssnhii";
   };
 in stdenv.mkDerivation rec {
   name = "kibana-${version}";

--- a/pkgs/misc/logging/beats/5.x.nix
+++ b/pkgs/misc/logging/beats/5.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "0ri2l8pyl1fnx0zypliwprkk1wkaxz8ywkgz8h2f08v7h1zgq1m6";
+        sha256 = "0d1ijhhk7qwsjmjric4z39npj3i3qzdvrg2h45s76aad1847q0xz";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/misc/logging/beats/5.x.nix
+++ b/pkgs/misc/logging/beats/5.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "0d1ijhhk7qwsjmjric4z39npj3i3qzdvrg2h45s76aad1847q0xz";
+        sha256 = "00g90i58c6gnyzszsx7y75vn1350hrkzrsb50xx700jqg9ii8yin";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/misc/logging/beats/6.x.nix
+++ b/pkgs/misc/logging/beats/6.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "05ay6hdc1jgi6b00bd998zc39ca8jhnk7i6m3mw70s0baqv1scik";
+        sha256 = "0qmwg3c3p8nmvnrx55kzka8c3w6h5w8ak5iipc3hv71xl4y4kavx";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/misc/logging/beats/6.x.nix
+++ b/pkgs/misc/logging/beats/6.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "0nx29cv64q44wyf3ph8486rf78sgsamkia8njkwn10gpw8b5wnjs";
+        sha256 = "194z3j9zwlbc6j97iy1m1cl0xqks3ws2bjp2xrgy8cwpi7fclaw2";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/misc/logging/beats/6.x.nix
+++ b/pkgs/misc/logging/beats/6.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "0qmwg3c3p8nmvnrx55kzka8c3w6h5w8ak5iipc3hv71xl4y4kavx";
+        sha256 = "0nx29cv64q44wyf3ph8486rf78sgsamkia8njkwn10gpw8b5wnjs";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/servers/search/elasticsearch/5.x.nix
+++ b/pkgs/servers/search/elasticsearch/5.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
-    sha256 = "036rcdmkgkh7qi8pvlx9jnbsnb27fc2gkdj9vilyg152mvg0k3c9";
+    sha256 = "0sm99m4m4mmigj6ll22kyaw7zkp1s2i0mhzx15fzidnybdnlifb4";
   };
 
   patches = [ ./es-home-5.x.patch ./es-classpath-5.x.patch ];

--- a/pkgs/servers/search/elasticsearch/5.x.nix
+++ b/pkgs/servers/search/elasticsearch/5.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
-    sha256 = "0wjjvzjbdgdv9qznk1b8dx63zgs7s6jnrrbrnd5dn27lhymxiwpl";
+    sha256 = "036rcdmkgkh7qi8pvlx9jnbsnb27fc2gkdj9vilyg152mvg0k3c9";
   };
 
   patches = [ ./es-home-5.x.patch ./es-classpath-5.x.patch ];

--- a/pkgs/servers/search/elasticsearch/6.x.nix
+++ b/pkgs/servers/search/elasticsearch/6.x.nix
@@ -30,8 +30,7 @@ stdenv.mkDerivation rec {
       ${if (!stdenv.isDarwin)
         then ''--prefix PATH : "${utillinux}/bin/"''
         else ''--prefix PATH : "${getopt}/bin"''} \
-      --set JAVA_HOME "${jre_headless}" \
-      --set ES_JVM_OPTIONS "$out/config/jvm.options"
+      --set JAVA_HOME "${jre_headless}"
 
     wrapProgram $out/bin/elasticsearch-plugin --set JAVA_HOME "${jre_headless}"
   '';

--- a/pkgs/servers/search/elasticsearch/6.x.nix
+++ b/pkgs/servers/search/elasticsearch/6.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
-    sha256 = "0xnap88wmdfvvjgjm7xfmjipamh79nzh9r11cwrh9kqabzn8vp81";
+    sha256 = "13hf00khq33yw6zv022vcrsf6vm43isx40x7ww8r1lqx3vmg3rli";
   };
 
   patches = [ ./es-home-6.x.patch ];

--- a/pkgs/servers/search/elasticsearch/6.x.nix
+++ b/pkgs/servers/search/elasticsearch/6.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
-    sha256 = "10vrj354wa5vx5j31nmwcibpqhnsibk12161mhzcwfabg133avmj";
+    sha256 = "0xnap88wmdfvvjgjm7xfmjipamh79nzh9r11cwrh9kqabzn8vp81";
   };
 
   patches = [ ./es-home-6.x.patch ];

--- a/pkgs/servers/search/elasticsearch/6.x.nix
+++ b/pkgs/servers/search/elasticsearch/6.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
-    sha256 = "03xwd8r0l0a29wl6wrp4bh7xr1b79q2rqfmsq3d5k35pv85sw3lw";
+    sha256 = "10vrj354wa5vx5j31nmwcibpqhnsibk12161mhzcwfabg133avmj";
   };
 
   patches = [ ./es-home-6.x.patch ];

--- a/pkgs/tools/misc/logstash/5.x.nix
+++ b/pkgs/tools/misc/logstash/5.x.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
-    sha256 = "1xac5jfgnqfg2sbnh4g7v040ly7kjw0klvp6cpimxcjci5j0sqnr";
+    sha256 = "0qcq4c4nysdscbjrikhw653xwbi4dwscynjzyndsp8l21vl81x7p";
   };
 
   dontBuild         = true;

--- a/pkgs/tools/misc/logstash/5.x.nix
+++ b/pkgs/tools/misc/logstash/5.x.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
-    sha256 = "0cpim121ydxdjr251by9jw6pidh5b52jl5ldcm7gp015q49x1nl7";
+    sha256 = "1xac5jfgnqfg2sbnh4g7v040ly7kjw0klvp6cpimxcjci5j0sqnr";
   };
 
   dontBuild         = true;

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     cp -r {Gemfile*,modules,vendor,lib,bin,config,data,logstash-core,logstash-core-plugin-api} $out
 
+    patchShebangs $out/bin/logstash
+    patchShebangs $out/bin/logstash-plugin
+
     wrapProgram $out/bin/logstash \
        --set JAVA_HOME "${jre}"
 

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
-    sha256 = "18680qpdvhr16dx66jfia1zrg52005sgdy9yhl7vdhm4gcr7pxwc";
+    sha256 = "17ab1hgmz8w0yr5k6da2pc5dicckkl6l2pv299kf9p8l9v8k1v20";
   };
 
   dontBuild         = true;

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
-    sha256 = "17ab1hgmz8w0yr5k6da2pc5dicckkl6l2pv299kf9p8l9v8k1v20";
+    sha256 = "1rybcjwkdckmwbdi9x8rj5dhzy76s9151sa283j46m83rqbnjchc";
   };
 
   dontBuild         = true;

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
-    sha256 = "1rybcjwkdckmwbdi9x8rj5dhzy76s9151sa283j46m83rqbnjchc";
+    sha256 = "07j3jjg5ik4gjgvcx15qqqas9p1m3815jml82a5r1ip9l6vc4h20";
   };
 
   dontBuild         = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2089,7 +2089,7 @@ with pkgs;
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
   elk5Version = "5.6.8";
-  elk6Version = "6.2.2";
+  elk6Version = "6.2.3";
 
   elasticsearch = callPackage ../servers/search/elasticsearch { };
   elasticsearch2 = callPackage ../servers/search/elasticsearch/2.x.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2088,7 +2088,7 @@ with pkgs;
   evemu = callPackage ../tools/system/evemu { };
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
-  elk5Version = "5.6.6";
+  elk5Version = "5.6.8";
   elk6Version = "6.1.2";
 
   elasticsearch = callPackage ../servers/search/elasticsearch { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2089,7 +2089,7 @@ with pkgs;
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
   elk5Version = "5.6.9";
-  elk6Version = "6.2.3";
+  elk6Version = "6.2.4";
 
   elasticsearch = callPackage ../servers/search/elasticsearch { };
   elasticsearch2 = callPackage ../servers/search/elasticsearch/2.x.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2088,7 +2088,7 @@ with pkgs;
   evemu = callPackage ../tools/system/evemu { };
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
-  elk5Version = "5.6.8";
+  elk5Version = "5.6.9";
   elk6Version = "6.2.3";
 
   elasticsearch = callPackage ../servers/search/elasticsearch { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2089,7 +2089,7 @@ with pkgs;
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
   elk5Version = "5.6.8";
-  elk6Version = "6.1.2";
+  elk6Version = "6.2.2";
 
   elasticsearch = callPackage ../servers/search/elasticsearch { };
   elasticsearch2 = callPackage ../servers/search/elasticsearch/2.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

Cherry-pick of https://github.com/NixOS/nixpkgs/pull/36456 on `release-18.03`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

