### PR TITLE
vamp-sdk: 2.5 -> 2.7.1

### DIFF
--- a/pkgs/development/libraries/audio/vamp/default.nix
+++ b/pkgs/development/libraries/audio/vamp/default.nix
@@ -1,16 +1,19 @@
 # set VAMP_PATH ?
 # plugins availible on sourceforge and http://www.vamp-plugins.org/download.html (various licenses)
 
-{ stdenv, fetchurl, pkgconfig, libsndfile }:
+{ stdenv, fetchFromGitHub, pkgconfig, libsndfile }:
 
 rec {
 
   vampSDK = stdenv.mkDerivation {
-    name = "vamp-sdk-2.5";
+    name = "vamp-sdk-2.7.1";
+    # version = "2.7.1";
 
-    src = fetchurl {
-      url = http://code.soundsoftware.ac.uk/attachments/download/690/vamp-plugin-sdk-2.5.tar.gz;
-      sha256 = "178kfgq08cmgdzv7g8dwyjp4adwx8q04riimncq4nqkm8ng9ywbv";
+    src = fetchFromGitHub {
+      owner = "c4dm";
+      repo = "vamp-plugin-sdk";
+      rev = "vamp-plugin-sdk-v2.7.1";
+      sha256 = "1ifd6l6b89pg83ss4gld5i72fr0cczjnl2by44z5jnndsg3sklw4";
     };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

