### PR TITLE
Mixxx: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -1,34 +1,26 @@
-{ stdenv, fetchurl, chromaprint, fetchpatch, fftw, flac, faad2, mp4v2
+{ stdenv, fetchFromGitHub, chromaprint, fetchpatch, fftw, flac, faad2, mp4v2
 , libid3tag, libmad, libopus, libshout, libsndfile, libusb1, libvorbis
 , pkgconfig, portaudio, portmidi, protobuf, qt4, rubberband, scons, sqlite
-, taglib, vampSDK
+, taglib, vampSDK, libebur128, hidapi, opusfile, upower, libjack2, soundtouch, libogg
 }:
 
 stdenv.mkDerivation rec {
   name = "mixxx-${version}";
-  version = "2.0.0";
+  version = "2.1.0";
 
-  src = fetchurl {
-    url = "http://downloads.mixxx.org/${name}/${name}-src.tar.gz";
-    sha256 = "0vb71w1yq0xwwsclrn2jj9bk8w4n14rfv5c0aw46c11mp8xz7f71";
+# The source is not in the usual location, see:
+# https://bugs.launchpad.net/mixxx/+bug/1764840
+  src = fetchFromGitHub {
+      owner = "mixxxdj";
+      repo = "mixxx";
+      rev = "release-${version}";
+      sha256 = "0mh2slj6c28kkzrir752harsmakn0v9h6hi6rj0yy6hygb5lq1wz";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/m/mixxx/2.0.0~dfsg-7.1/debian/patches/0007-fix_gcc6_issue.patch";
-      sha256 = "0kpyv10wcjcvbijk6vpq54gx9sqzrq4kq2qilc1czmisp9qdy5sd";
-    })
-    (fetchpatch {
-      url = "https://622776.bugs.gentoo.org/attachment.cgi?id=487284";
-      name = "sqlite.patch";
-      sha256 = "1qqbd8nrxrjcc1dwvyqfq1k2yz3l071sfcgd2dmpk6j8d4j5kx31";
-    })
- ];
 
   buildInputs = [
     chromaprint fftw flac faad2 mp4v2 libid3tag libmad libopus libshout libsndfile
     libusb1 libvorbis pkgconfig portaudio portmidi protobuf qt4
-    rubberband scons sqlite taglib vampSDK
+    rubberband scons sqlite taglib vampSDK libebur128 hidapi opusfile upower libjack2 soundtouch libogg
   ];
 
   sconsFlags = [

--- a/pkgs/development/libraries/audio/vamp/default.nix
+++ b/pkgs/development/libraries/audio/vamp/default.nix
@@ -1,16 +1,19 @@
 # set VAMP_PATH ?
 # plugins availible on sourceforge and http://www.vamp-plugins.org/download.html (various licenses)
 
-{ stdenv, fetchurl, pkgconfig, libsndfile }:
+{ stdenv, fetchFromGitHub, pkgconfig, libsndfile }:
 
 rec {
 
   vampSDK = stdenv.mkDerivation {
-    name = "vamp-sdk-2.5";
+    name = "vamp-sdk-2.7.1";
+    # version = "2.7.1";
 
-    src = fetchurl {
-      url = http://code.soundsoftware.ac.uk/attachments/download/690/vamp-plugin-sdk-2.5.tar.gz;
-      sha256 = "178kfgq08cmgdzv7g8dwyjp4adwx8q04riimncq4nqkm8ng9ywbv";
+    src = fetchFromGitHub {
+      owner = "c4dm";
+      repo = "vamp-plugin-sdk";
+      rev = "vamp-plugin-sdk-v2.7.1";
+      sha256 = "1ifd6l6b89pg83ss4gld5i72fr0cczjnl2by44z5jnndsg3sklw4";
     };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/audio/vamp/default.nix
+++ b/pkgs/development/libraries/audio/vamp/default.nix
@@ -1,31 +1,30 @@
 # set VAMP_PATH ?
-# plugins availible on sourceforge and http://www.vamp-plugins.org/download.html (various licenses)
+# plugins available on sourceforge and http://www.vamp-plugins.org/download.html (various licenses)
 
 { stdenv, fetchFromGitHub, pkgconfig, libsndfile }:
 
 rec {
 
-  vampSDK = stdenv.mkDerivation {
-    name = "vamp-sdk-2.7.1";
-    # version = "2.7.1";
+  vampSDK = stdenv.mkDerivation rec {
+    name = "vamp-sdk-${version}";
 
     src = fetchFromGitHub {
       owner = "c4dm";
       repo = "vamp-plugin-sdk";
-      rev = "vamp-plugin-sdk-v2.7.1";
+      rev = "vamp-plugin-sdk-v${version}";
       sha256 = "1ifd6l6b89pg83ss4gld5i72fr0cczjnl2by44z5jnndsg3sklw4";
     };
 
-  nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkgconfig ];
+
     buildInputs = [ libsndfile ];
 
     meta = with stdenv.lib; {
       description = "Audio processing plugin system for plugins that extract descriptive information from audio data";
       homepage = https://sourceforge.net/projects/vamp;
       license = licenses.bsd3;
-      maintainers = [ maintainers.goibhniu maintainers.marcweber ];
+      maintainers = with maintainers; [ goibhniu marcweber ];
       platforms = platforms.linux;
     };
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
Version 2.0.0 doesn't build on nixos-unstable, this does.
Needs https://github.com/NixOS/nixpkgs/pull/39105

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

