### PR TITLE
xxHash: 0.6.3.20171018 -> 0.6.4.20171222

### DIFF
--- a/pkgs/development/libraries/xxHash/default.nix
+++ b/pkgs/development/libraries/xxHash/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "xxHash-${version}";
-  version = "0.6.3.20171018";
+  version = "0.6.4.20171222";
 
   src = fetchFromGitHub {
-    sha256 = "0061ivxpx0p24m4vg7kfx9fs9f0jxvv4g76bmyss5gp90p05hc18";
-    rev = "333804ccf0c0339451accac023deeab9e5f7c002";
+    sha256 = "1az5vm14rdc3pa3l0wj180wpii14if16diril3gz8q9ip1215gwj";
+    rev = "7caf8bd76440c75dfe1070d3acfbd7891aea8fca";
     repo = "xxHash";
     owner = "Cyan4973";
   };


### PR DESCRIPTION
###### Motivation for this change
Updated version of xxHash features a library target that may be useful
for some packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

