### PR TITLE
bash-supergenpass: 2012-11-02 -> 2018-04-18

### DIFF
--- a/pkgs/tools/security/bash-supergenpass/default.nix
+++ b/pkgs/tools/security/bash-supergenpass/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "bash-supergenpass-unstable-${version}";
-  version = "2012-11-02";
+  version = "2018-04-18";
 
   nativeBuildInputs = [ makeWrapper ];
 
   src = fetchFromGitHub {
     owner = "lanzz";
     repo = "bash-supergenpass";
-    rev = "c84eaa22fb59ab6c390e7f2de7984513347e3a9a";
-    sha256 = "0d3l55kdrf6arb98vwwz9ww55ing5w323fg7546v56hlq3hs5qc9";
+    rev = "ece772b9ec095946ac4ea985cda5561b211e56f0";
+    sha256 = "1gkbrycyyl7y3klbfx7xjvvfw5df1h4fj6x1f73gglfy6nk8ffnd";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

