### PR TITLE
handbrake: refactor (fx, clenup, description, cosmetics, add maintainer)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28,6 +28,11 @@
     github = "AndersonTorres";
     name = "Anderson Torres";
   };
+  Anton-Latukha = {
+    email = "anton.latuka+nixpkgs@gmail.com";
+    github = "Anton-Latukha";
+    name = "Anton Latukha";
+  };
   Baughn = {
     email = "sveina@gmail.com";
     github = "Baughn";

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -37,15 +37,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake python2 pkgconfig yasm autoconf automake libtool m4
-  ] ++ lib.optionals useGtk [
-    intltool wrapGAppsHook
-  ];
+  ] ++ lib.optionals useGtk [ intltool wrapGAppsHook ];
 
   buildInputs = [
     fribidi fontconfig freetype jansson zlib
     libass libiconv libsamplerate libxml2 bzip2
     libogg libopus libtheora libvorbis libdvdcss a52dec libmkv
-    lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264 x265 libvpx
+    lame libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264 x265 libvpx
   ] ++ lib.optionals useGtk [
     glib gtk3 libappindicator-gtk3 libnotify
     gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
@@ -59,8 +57,6 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     patchShebangs scripts
-
-    echo 'TAG=${version}' > version.txt
 
     # `configure` errors out when trying to read the current year which is too low
     substituteInPlace make/configure.py \
@@ -97,13 +93,17 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = http://handbrake.fr/;
-    description = "A tool for ripping DVDs into video files";
+    description = "A tool for converting video files and ripping DVDs";
     longDescription = ''
-      Handbrake is a versatile transcoding DVD ripper. This package
-      provides the cli HandbrakeCLI and the GTK+ version ghb.
+      Tool for converting and remuxing video files
+      into selection of modern and widely supported codecs
+      and containers. Very versatile and customizable.
+      Package provides:
+      CLI - `HandbrakeCLI`
+      GTK+ GUI - `ghb`
     '';
     license = licenses.gpl2;
-    maintainers = with maintainers; [ wmertens ];
+    maintainers = with maintainers; [ Anton-Latukha wmertens ];
     # Not tested on anything else
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

* fx: `ffmpeg` was one of default `buildInputs`
* by request adding myself as a maintainer of the package
* description was outdated. Rewrote to much more precise modernized description.
* `version.txt` patch no longer needed in `1.0.7`. Moreover in the version `1.1.0` this patching should be removed.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---