### PR TITLE
pythonPackages.uproot: init at 2.8.23.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2001,6 +2001,11 @@
     github = "kristoff3r";
     name = "Kristoffer Søholm";
   };
+  ktf = {
+    email = "giulio.eulisse@cern.ch";
+    github = "ktf";
+    name = "Giuluo Eulisse";
+ };
   ktosiek = {
     email = "tomasz.kontusz@gmail.com";
     github = "ktosiek";

--- a/pkgs/development/python-modules/uproot/default.nix
+++ b/pkgs/development/python-modules/uproot/default.nix
@@ -1,0 +1,22 @@
+{lib, fetchPypi, buildPythonPackage, numpy}:
+
+buildPythonPackage rec {
+  pname = "uproot";
+  version = "2.8.23";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "121ggyl5s0q66yrbdfznvzrc793zq1w2xnr3baadlzfvqdlkhgj7";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/scikit-hep/uproot;
+    description = "ROOT I/O in pure Python and Numpy";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ktf ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14744,6 +14744,8 @@ in {
 
   uritemplate = callPackage ../development/python-modules/uritemplate { };
 
+  uproot = callPackage ../development/python-modules/uproot {};
+
   uptime = buildPythonPackage rec {
     name = "uptime-${version}";
     version = "3.0.1";


### PR DESCRIPTION
###### Motivation for this change

Package uproot is missing from the distribution.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---