### PR TITLE
pass: refactor extension packaging

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -1,10 +1,12 @@
-{ stdenv, lib, fetchurl, fetchFromGitHub
+{ stdenv, lib, pkgs, fetchurl, fetchFromGitHub, buildEnv
 , coreutils, gnused, getopt, git, tree, gnupg, which, procps, qrencode
 , makeWrapper
 
 , xclip ? null, xdotool ? null, dmenu ? null
 , x11Support ? !stdenv.isDarwin
-, tombPluginSupport ? false, tomb
+
+# For backwards-compatibility
+, tombPluginSupport ? false
 }:
 
 with lib;
@@ -14,98 +16,100 @@ assert x11Support -> xclip != null
                   && dmenu != null;
 
 let
-  plugins = map (p: (fetchFromGitHub {
-    owner  = "roddhjav";
-    repo   = "pass-${p.name}";
-    inherit (p) rev sha256;
-  }))
-  ([
-    { name = "import";
-      rev = "491935bd275f29ceac2b876b3a288011d1ce31e7";
-      sha256 = "02mbh05ab8h7kc30hz718d1d1vkjz43b96c7p0xnd92610d2q66q"; }
-    { name = "update";
-      rev = "cf576c9036fd18efb9ed29e0e9f811207b556fde";
-      sha256 = "1hhbrg6a2walrvla6q4cd3pgrqbcrf9brzjkb748735shxfn52hd"; }
-    ] ++ stdenv.lib.optional tombPluginSupport {
-      name = "tomb";
-      rev = "3368134898a42c1b758fabac625ec240e125c6be";
-      sha256 = "0qqmxfg4w3r088qhlkhs44036mya82vjflsjjhw2hk8y0wd2i6ds"; }
-  );
+  passExtensions = import ./extensions { inherit pkgs; };
 
-in stdenv.mkDerivation rec {
-  version = "1.7.1";
-  name    = "password-store-${version}";
+  env = extensions:
+    let
+      selected = extensions passExtensions
+        ++ stdenv.lib.optional tombPluginSupport passExtensions.tomb;
+    in buildEnv {
+      name = "pass-extensions-env";
+      paths = selected;
+      buildInputs = concatMap (x: x.buildInputs) selected;
+    };
 
-  src = fetchurl {
-    url    = "http://git.zx2c4.com/password-store/snapshot/${name}.tar.xz";
-    sha256 = "0scqkpll2q8jhzcgcsh9kqz0gwdpvynivqjmmbzax2irjfaiklpn";
-  };
+  generic = extensionsEnv: extraPassthru: stdenv.mkDerivation rec {
+    version = "1.7.1";
+    name    = "password-store-${version}";
 
-  patches = [ ./set-correct-program-name-for-sleep.patch
-            ] ++ stdenv.lib.optional stdenv.isDarwin ./no-darwin-getopt.patch;
+    src = fetchurl {
+      url    = "http://git.zx2c4.com/password-store/snapshot/${name}.tar.xz";
+      sha256 = "0scqkpll2q8jhzcgcsh9kqz0gwdpvynivqjmmbzax2irjfaiklpn";
+    };
 
-  nativeBuildInputs = [ makeWrapper ];
+    patches = [ ./set-correct-program-name-for-sleep.patch
+              ] ++ stdenv.lib.optional stdenv.isDarwin ./no-darwin-getopt.patch;
 
-  installFlags = [ "PREFIX=$(out)" "WITH_ALLCOMP=yes" ];
+    nativeBuildInputs = [ makeWrapper ];
 
-  postInstall = ''
-    # plugins
-    ${stdenv.lib.concatStringsSep "\n" (map (plugin: ''
-      pushd ${plugin}
-      PREFIX=$out make install
-      popd
-    '') plugins)}
+    buildInputs = [ extensionsEnv ];
 
-    # Install Emacs Mode. NOTE: We can't install the necessary
-    # dependencies (s.el and f.el) here. The user has to do this
-    # himself.
-    mkdir -p "$out/share/emacs/site-lisp"
-    cp "contrib/emacs/password-store.el" "$out/share/emacs/site-lisp/"
-  '' + optionalString x11Support ''
-    cp "contrib/dmenu/passmenu" "$out/bin/"
-  '';
+    installFlags = [ "PREFIX=$(out)" "WITH_ALLCOMP=yes" ];
 
-  wrapperPath = with stdenv.lib; makeBinPath ([
-    coreutils
-    getopt
-    git
-    gnupg
-    gnused
-    tree
-    which
-    qrencode
-    procps
-  ] ++ optional tombPluginSupport tomb
-    ++ ifEnable x11Support [ dmenu xclip xdotool ]);
-
-  postFixup = ''
-    # Fix program name in --help
-    substituteInPlace $out/bin/pass \
-      --replace 'PROGRAM="''${0##*/}"' "PROGRAM=pass"
-
-    # Ensure all dependencies are in PATH
-    wrapProgram $out/bin/pass \
-      --prefix PATH : "${wrapperPath}"
-  '' + stdenv.lib.optionalString x11Support ''
-    # We just wrap passmenu with the same PATH as pass. It doesn't
-    # need all the tools in there but it doesn't hurt either.
-    wrapProgram $out/bin/passmenu \
-      --prefix PATH : "$out/bin:${wrapperPath}"
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Stores, retrieves, generates, and synchronizes passwords securely";
-    homepage    = https://www.passwordstore.org/;
-    license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ lovek323 the-kenny fpletz ];
-    platforms   = platforms.unix;
-
-    longDescription = ''
-      pass is a very simple password store that keeps passwords inside gpg2
-      encrypted files inside a simple directory tree residing at
-      ~/.password-store. The pass utility provides a series of commands for
-      manipulating the password store, allowing the user to add, remove, edit,
-      synchronize, generate, and manipulate passwords.
+    postInstall = ''
+      # Install Emacs Mode. NOTE: We can't install the necessary
+      # dependencies (s.el and f.el) here. The user has to do this
+      # himself.
+      mkdir -p "$out/share/emacs/site-lisp"
+      cp "contrib/emacs/password-store.el" "$out/share/emacs/site-lisp/"
+    '' + optionalString x11Support ''
+      cp "contrib/dmenu/passmenu" "$out/bin/"
     '';
+
+    wrapperPath = with stdenv.lib; makeBinPath ([
+      coreutils
+      getopt
+      git
+      gnupg
+      gnused
+      tree
+      which
+      qrencode
+      procps
+    ] ++ ifEnable x11Support [ dmenu xclip xdotool ]);
+
+    postFixup = ''
+      # Link extensions env
+      rmdir $out/lib/password-store/extensions
+      ln -s ${extensionsEnv}/lib/password-store/extensions $out/lib/password-store/.
+
+      # Fix program name in --help
+      substituteInPlace $out/bin/pass \
+        --replace 'PROGRAM="''${0##*/}"' "PROGRAM=pass"
+
+      # Ensure all dependencies are in PATH
+      wrapProgram $out/bin/pass \
+        --prefix PATH : "${wrapperPath}"
+    '' + stdenv.lib.optionalString x11Support ''
+      # We just wrap passmenu with the same PATH as pass. It doesn't
+      # need all the tools in there but it doesn't hurt either.
+      wrapProgram $out/bin/passmenu \
+        --prefix PATH : "$out/bin:${wrapperPath}"
+    '';
+
+    passthru = {
+      extensions = passExtensions;
+    } // extraPassthru;
+
+    meta = with stdenv.lib; {
+      description = "Stores, retrieves, generates, and synchronizes passwords securely";
+      homepage    = https://www.passwordstore.org/;
+      license     = licenses.gpl2Plus;
+      maintainers = with maintainers; [ lovek323 the-kenny fpletz tadfisher ];
+      platforms   = platforms.unix;
+
+      longDescription = ''
+        pass is a very simple password store that keeps passwords inside gpg2
+        encrypted files inside a simple directory tree residing at
+        ~/.password-store. The pass utility provides a series of commands for
+        manipulating the password store, allowing the user to add, remove, edit,
+        synchronize, generate, and manipulate passwords.
+      '';
+    };
   };
+
+in
+
+generic (env (_: [])) {
+  withExtensions = extensions: generic (env extensions) {};
 }

--- a/pkgs/tools/security/pass/extensions/default.nix
+++ b/pkgs/tools/security/pass/extensions/default.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+
+with pkgs;
+
+{
+  pass-import = callPackage ./import.nix {
+    pythonPackages = python3Packages;
+  };
+  pass-otp = callPackage ./otp.nix {};
+  pass-tomb = callPackage ./tomb.nix {};
+  pass-update = callPackage ./update.nix {};
+}

--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -1,0 +1,37 @@
+{ stdenv, pass, fetchFromGitHub, pythonPackages, makeWrapper }:
+
+let
+  pythonEnv = pythonPackages.python.withPackages (p: [ p.defusedxml ]);
+
+in stdenv.mkDerivation rec {
+  name = "pass-import-${version}";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "roddhjav";
+    repo = "pass-import";
+    rev = "v${version}";
+    sha256 = "189wf2jz2j43k27930cnl53sm2drh1s0nq1nmh4is3rzn8cna6wq";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ pythonEnv ];
+
+  dontBuild = true;
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postFixup = ''
+    wrapProgram $out/lib/password-store/extensions/import.bash \
+      --prefix PATH : "${pythonEnv}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pass extension for importing data from existing password managers";
+    homepage = https://github.com/roddhjav/pass-import;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lovek323 the-kenny fpletz tadfisher ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/pass/extensions/otp.nix
+++ b/pkgs/tools/security/pass/extensions/otp.nix
@@ -1,4 +1,5 @@
-{ stdenv, pass, fetchFromGitHub, oathToolkit }:
+{ stdenv, fetchFromGitHub, oathToolkit }:
+
 stdenv.mkDerivation rec {
   name = "pass-otp-${version}";
   version = "1.1.0";
@@ -10,15 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "1cgj4zc8fq88n3h6c0vkv9i5al785mdprpgpbv5m22dz9p1wqvbb";
   };
 
-  buildInputs = [ pass oathToolkit ];
+  buildInputs = [ oathToolkit ];
+
+  dontBuild = true;
 
   patchPhase = ''
     sed -i -e 's|OATH=\$(which oathtool)|OATH=${oathToolkit}/bin/oathtool|' otp.bash
   '';
 
-  installPhase = ''
-    make PREFIX=$out install
-  '';
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "A pass extension for managing one-time-password (OTP) tokens";

--- a/pkgs/tools/security/pass/extensions/tomb.nix
+++ b/pkgs/tools/security/pass/extensions/tomb.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, tomb }:
+
+stdenv.mkDerivation rec {
+  name = "pass-tomb-${version}";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "roddhjav";
+    repo = "pass-tomb";
+    rev = "v${version}";
+    sha256 = "0wxa673yyzasjlkpd5f3yl5zf7bhsw7h1jbhf6sdjz65bypr2596";
+  };
+
+  buildInputs = [ tomb ];
+
+  dontBuild = true;
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postFixup = ''
+    substituteInPlace $out/lib/password-store/extensions/tomb.bash \
+      --replace 'TOMB="''${PASSWORD_STORE_TOMB:-tomb}"' 'TOMB="''${PASSWORD_STORE_TOMB:-${tomb}/bin/tomb}"'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pass extension that keeps the password store encrypted inside a tomb";
+    homepage = https://github.com/roddhjav/pass-tomb;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lovek323 the-kenny fpletz tadfisher ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/pass/extensions/update.nix
+++ b/pkgs/tools/security/pass/extensions/update.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "pass-update-${version}";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    owner = "roddhjav";
+    repo = "pass-update";
+    rev = "v${version}";
+    sha256 = "0a81q0jfni185zmbislzbcv0qr1rdp0cgr9wf9riygis2xv6rs6k";
+  };
+
+  dontBuild = true;
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Pass extension that provides an easy flow for updating passwords";
+    homepage = https://github.com/roddhjav/pass-update;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lovek323 the-kenny fpletz tadfisher ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -151,6 +151,7 @@ mapAliases (rec {
   openssh_with_kerberos = openssh; # added 2018-01-28
   owncloudclient = owncloud-client;  # added 2016-08
   p11_kit = p11-kit; # added 2018-02-25
+  pass-otp = pass.withExtensions (ext: [ext.pass-otp]); # added 2018-05-04
   pgp-tools = signing-party; # added 2017-03-26
   pidgin-with-plugins = pidgin; # added 2016-06
   pidginlatexSF = pidgin-latex; # added 2014-11-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -656,7 +656,8 @@ with pkgs;
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };
 
   pass = callPackage ../tools/security/pass { };
-  pass-otp = callPackage ../tools/security/pass-otp { };
+
+  passExtensions = recurseIntoAttrs pass.extensions;
 
   gopass = callPackage ../tools/security/gopass { };
 


### PR DESCRIPTION
###### Motivation for this change

It was pointed out in a [`pass-otp` PR](https://github.com/NixOS/nixpkgs/pull/36308#issuecomment-380070642) that the `pass-otp` derivation doesn't actually work, because it's not included in the `pass` environment. For context, `pass` requires extension scripts to live in `${pass}/lib/password-store/extensions`, and those scripts can have external dependencies of their own.

I looked at adding `pass-otp` to the existing `pass` derivation but it was looking a bit nasty to hack in there, as the derivation built a set of extensions unconditionally and included them in the `pass` output.

So I refactored the derivation to clean up some things:

- Build a `pass-extensions-env` environment and link that output to `${pass}/lib/password-store/extensions/`.
- Split extension derivations into `extensions/*.nix`, which can include their own dependencies independently of the generic `pass` derivation.
- Add a `pass.withExtensions` passthru function which builds `pass` with a configurable extensions environment, as in

```nix
pass.withExtensions (ext: with ext; [ pass-otp pass-tomb pass-import pass-update ])
```

- Add a top-level `passExtensions` attribute to facilitate discovering extensions.
- Support the `pass-otp` attribute and the `tombPluginSupport ? false` argument for backwards-compatibility.
- Fix `pass-import`, as it doesn't work currently without a `python.withPackages` python environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

