### PR TITLE
dust: init at 0.2.3

### DIFF
--- a/pkgs/tools/misc/dust/default.nix
+++ b/pkgs/tools/misc/dust/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cargo, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "dust-${version}";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "bootandy";
+    repo = "dust";
+    rev = "v${version}";
+    sha256 = "1l8z1daiq2x92449p2ciblcwl0ddgr3vqj2dsd3z8jj3y0z8j51s";
+  };
+
+  cargoSha256 = "0x3ay440vbc64y3pd8zhd119sw8fih0njmkzpr7r8wdw3k48v96m";
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "du + rust = dust. Like du but more intuitive";
+    homepage = https://github.com/bootandy/dust;
+    license = licenses.asl20;
+    maintainers = [ maintainers.infinisil ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15245,6 +15245,8 @@ with pkgs;
 
   dunst = callPackage ../applications/misc/dunst { };
 
+  du-dust = callPackage ../tools/misc/dust { };
+
   devede = callPackage ../applications/video/devede { };
 
   denemo = callPackage ../applications/audio/denemo {


### PR DESCRIPTION
###### Motivation for this change
Recently having been [featured on lobste.rs frontpage](https://lobste.rs/s/dcflfz/like_du_more_intuitive) I was motivated to add dust to nixpkgs. It's a very simple CLI that outputs disk usage for a directory like this:

```bash
djin:git/dust> dust
  65M  .
  65M └─┬ ./target
  49M   ├─┬ ./target/debug
  26M   │ ├─┬ ./target/debug/deps
  21M   │ │ └── ./target/debug/deps/libclap-9e6625ac8ff074ad.rlib
  13M   │ ├── ./target/debug/dust
 8.9M   │ └─┬ ./target/debug/incremental
 6.7M   │   ├─┬ ./target/debug/incremental/dust-2748eiei2tcnp
 6.7M   │   │ └─┬ ./target/debug/incremental/dust-2748eiei2tcnp/s-ezd6jnik5u-163pyem-1aab9ncf5glum
 3.0M   │   │   └── ./target/debug/incremental/dust-2748eiei2tcnp/s-ezd6jnik5u-163pyem-1aab9ncf5glum/dep-graph.bin
 2.2M   │   └─┬ ./target/debug/incremental/dust-1dlon65p8m3vl
 2.2M   │     └── ./target/debug/incremental/dust-1dlon65p8m3vl/s-ezd6jncecv-1xsnfd0-4dw9l1r2th2t
  15M   └─┬ ./target/release
 9.2M     ├─┬ ./target/release/deps
 6.7M     │ └── ./target/release/deps/libclap-87bc2534ea57f044.rlib
 5.9M     └── ./target/release/dust
```

Since like on crates.io, the name `dust` is already taken in nixpkgs, I'm using `du-dust` as the package attribute instead, as is also the case for [dust's 0.2.3 release](https://github.com/bootandy/dust/releases/tag/v0.2.3).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

