### PR TITLE
SAGA, SAGA LTS release, dependencies and QGIS SAGA plugin

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -1,14 +1,15 @@
 { stdenv, fetchurl, gdal, cmake, qt4, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
 , qwt, fcgi, python2Packages, libspatialindex, libspatialite, qscintilla, postgresql, makeWrapper
 , qjson, qca2, txt2tags, openssl, darwin, pkgconfig
-, withGrass ? true, grass, IOKit, ApplicationServices
+, withGrass ? true, grass, saga, IOKit, ApplicationServices
 }:
 
 stdenv.mkDerivation rec {
   name = "qgis-2.18.22";
 
   buildInputs = [ gdal qt4 flex openssl bison proj geos xlibsWrapper sqlite gsl qwt qscintilla
-    fcgi libspatialindex libspatialite postgresql qjson qca2 txt2tags pkgconfig ]
+    fcgi libspatialindex libspatialite postgresql qjson qca2 txt2tags pkgconfig
+    saga ]
   ++
     (stdenv.lib.optionals stdenv.isDarwin [IOKit ApplicationServices])
   ++
@@ -60,6 +61,8 @@ stdenv.mkDerivation rec {
       # Necessary for QGIS to find the correct default GRASS path
       # Plugins look for gdal tools like deminfo on the PATH
       ${stdenv.lib.optionalString withGrass "ln -sf ${grass} $out/QGIS.app/Contents/MacOS/grass"}
+      # Necessary for QGIS to find the right SAGA installation
+      ln -sf ${saga}/bin/saga_cmd $out/QGIS.app/Contents/MacOS/bin/saga_cmd
       for file in $(find $out -type f -name "QGIS"); do
         wrapProgram "$file" \
           --prefix DYLD_LIBRARY_PATH : "${qwt}/lib" \

--- a/pkgs/applications/gis/saga/clang_patch.patch
+++ b/pkgs/applications/gis/saga/clang_patch.patch
@@ -1,0 +1,19 @@
+commit e92b250968e9656084ab5984689747ca615ff6e7
+Author: Volker Wichmann <wichmann@laserdata.at>
+Date:   Sun Mar 5 13:49:53 2017 +0100
+
+    saga_api, CSG_Table::Del_Records(): bug fix, check record count correctly
+
+diff --git a/src/saga_core/saga_api/table.cpp b/src/saga_core/saga_api/table.cpp
+index 76a1d8d..fa1a66f 100644
+--- a/src/saga_core/saga_api/table.cpp
++++ b/src/saga_core/saga_api/table.cpp
+@@ -901,7 +901,7 @@ bool CSG_Table::Del_Record(int iRecord)
+ //---------------------------------------------------------
+ bool CSG_Table::Del_Records(void)
+ {
+-	if( m_Records > 0 )
++	if( m_nRecords > 0 )
+ 	{
+ 		_Index_Destroy();
+

--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, gdal, wxGTK30, proj, libiodbc, lzma, jasper,
   libharu, opencv, vigra, postgresql, Cocoa,
-  unixODBC , poppler, hdf4, hdf5, netcdf, sqlite }:
+  unixODBC , poppler, hdf4, hdf5, netcdf, sqlite, qhull }:
 
 stdenv.mkDerivation rec {
   name = "saga-6.3.0";
 
   # See https://groups.google.com/forum/#!topic/nix-devel/h_vSzEJAPXs
   # for why the have additional buildInputs on darwin
-  buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma jasper ]
+  buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma jasper qhull ]
                 ++ stdenv.lib.optionals stdenv.isDarwin
                   [ Cocoa unixODBC poppler hdf4.out hdf5 netcdf sqlite ];
 

--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -1,10 +1,15 @@
 { stdenv, fetchurl, gdal, wxGTK30, proj, libiodbc, lzma, jasper,
-  libharu, opencv, vigra, postgresql }:
+  libharu, opencv, vigra, postgresql, Cocoa,
+  unixODBC , poppler, hdf4, hdf5, netcdf, sqlite }:
 
 stdenv.mkDerivation rec {
   name = "saga-6.3.0";
 
-  buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma jasper ];
+  # See https://groups.google.com/forum/#!topic/nix-devel/h_vSzEJAPXs
+  # for why the have additional buildInputs on darwin
+  buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma jasper ]
+                ++ stdenv.lib.optionals stdenv.isDarwin
+                  [ Cocoa unixODBC poppler hdf4.out hdf5 netcdf sqlite ];
 
   enableParallelBuilding = true;
 
@@ -13,11 +18,11 @@ stdenv.mkDerivation rec {
     sha256 = "0hyjim8fcp3mna1hig22nnn4ki3j6b7096am2amcs99sdr09jjxv";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "System for Automated Geoscientific Analyses";
     homepage = http://www.saga-gis.org;
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [ stdenv.lib.maintainers.michelk ];
-    platforms = ["x86_64-linux" ];
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.michelk ];
+    platforms = with platforms; unix;
   };
 }

--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -1,17 +1,22 @@
 { stdenv, fetchurl, gdal, wxGTK30, proj, libiodbc, lzma, jasper,
   libharu, opencv, vigra, postgresql, Cocoa,
-  unixODBC , poppler, hdf4, hdf5, netcdf, sqlite, qhull }:
+  unixODBC , poppler, hdf4, hdf5, netcdf, sqlite, qhull, giflib }:
 
 stdenv.mkDerivation rec {
   name = "saga-6.3.0";
 
   # See https://groups.google.com/forum/#!topic/nix-devel/h_vSzEJAPXs
   # for why the have additional buildInputs on darwin
-  buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma jasper qhull ]
+  buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma
+                  jasper qhull giflib ]
                 ++ stdenv.lib.optionals stdenv.isDarwin
                   [ Cocoa unixODBC poppler hdf4.out hdf5 netcdf sqlite ];
 
   enableParallelBuilding = true;
+
+  patches = [ ./finite-6.3.0.patch];
+
+  CXXFLAGS = stdenv.lib.optionalString stdenv.cc.isClang "-std=c++11 -Wno-narrowing";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/saga-gis/SAGA%20-%206/SAGA%20-%206.3.0/saga-6.3.0.tar.gz";

--- a/pkgs/applications/gis/saga/finite-6.3.0.patch
+++ b/pkgs/applications/gis/saga/finite-6.3.0.patch
@@ -1,0 +1,55 @@
+diff --git a/src/tools/imagery/imagery_maxent/me.cpp b/src/tools/imagery/imagery_maxent/me.cpp
+index c5da854..d3e9cff 100755
+--- a/src/tools/imagery/imagery_maxent/me.cpp
++++ b/src/tools/imagery/imagery_maxent/me.cpp
+@@ -21,7 +21,7 @@
+ #ifdef _SAGA_MSW
+ #define isinf(x) (!_finite(x))
+ #else
+-#define isinf(x) (!finite(x))
++#define isinf(x) (!isfinite(x))
+ #endif
+ 
+ /** The input array contains a set of log probabilities lp1, lp2, lp3
+@@ -47,7 +47,7 @@ double sumLogProb(vector<double>& logprobs)
+ /** returns log (e^logprob1 + e^logprob2). */
+ double sumLogProb(double logprob1, double logprob2)
+ {
+-  if (isinf(logprob1) && isinf(logprob2)) 
++  if (isinf(logprob1) && isinf(logprob2))
+     return logprob1; // both prob1 and prob2 are 0, return log 0.
+   if (logprob1>logprob2)
+     return logprob1+log(1+exp(logprob2-logprob1));
+@@ -70,8 +70,8 @@ void MaxEntModel::print(ostream& ostrm, MaxEntTrainer& trainer)
+   for (FtMap::iterator it = _index.begin(); it!=_index.end(); it++) {
+     unsigned long i = it->second;
+     for (unsigned long c = 0; c<_classes; c++) {
+-      ostrm << "lambda(" << trainer.className(c) << ", " 
+-	    << trainer.getStr(it->first) << ")=" 
++      ostrm << "lambda(" << trainer.className(c) << ", "
++	    << trainer.getStr(it->first) << ")="
+ 	    << _lambda[i+c] << endl;
+     }
+   }
+@@ -86,7 +86,7 @@ int MaxEntModel::getProbs(MaxEntEvent& event, vector<double>& probs)
+     double s = 0;
+     for (unsigned int f = 0; f<event.size(); f++) {
+       FtMap::iterator it = _index.find(event[f]);
+-      if (it!=_index.end()) 
++      if (it!=_index.end())
+ 	s += _lambda[it->second+c];
+     }
+     probs[c] = s;
+@@ -142,10 +142,10 @@ double MaxEntModel::getObsCounts(EventSet& events, vector<double>& obsCounts)
+     double ftSum = 0;
+     for (unsigned long j=0; j<e.size(); j++) {
+       FtMap::iterator it = _index.find(e[j]);
+-      if (it!=_index.end()) 
++      if (it!=_index.end())
+ 	obsCounts[it->second+c] += count;
+       else { // new feature, need to expand obsCounts and _lambda
+-	for (unsigned int k = 0; k<_classes; k++) 
++	for (unsigned int k = 0; k<_classes; k++)
+ 	  obsCounts.push_back(0);
+ 	obsCounts[_lambda.size()+c] += count;
+ 	addFeature(e[j]);

--- a/pkgs/applications/gis/saga/finite.patch
+++ b/pkgs/applications/gis/saga/finite.patch
@@ -1,0 +1,13 @@
+diff --git a/saga-gis/src/modules/imagery/imagery_maxent/me.cpp b/saga-gis/src/modules/imagery/imagery_maxent/me.cpp
+index c5da854..d3e9cff 100755
+--- a/src/modules/imagery/imagery_maxent/me.cpp
++++ b/src/modules/imagery/imagery_maxent/me.cpp
+@@ -21,7 +21,7 @@
+ #ifdef _SAGA_MSW
+ #define isinf(x) (!_finite(x))
+ #else
+-#define isinf(x) (!finite(x))
++#define isinf(x) (!isfinite(x))
+ #endif
+
+ /** The input array contains a set of log probabilities lp1, lp2, lp3

--- a/pkgs/applications/gis/saga/lts.nix
+++ b/pkgs/applications/gis/saga/lts.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, gdal, wxGTK30, proj, libiodbc, lzma, jasper,
+  libharu, opencv, vigra, postgresql, autoreconfHook, Cocoa
+  , unixODBC , poppler, hdf4, hdf5, netcdf, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "saga-2.3.2";
+
+  # See https://groups.google.com/forum/#!topic/nix-devel/h_vSzEJAPXs
+  # for why the have additional buildInputs on darwin
+  buildInputs = [ autoreconfHook gdal wxGTK30 proj libharu opencv vigra
+                  postgresql libiodbc lzma jasper
+                  Cocoa unixODBC poppler hdf4.out hdf5 netcdf sqlite ];
+
+  enableParallelBuilding = true;
+
+  sourceRoot = "code-b6f474f/saga-gis";
+
+  patches = [ ./clang_patch.patch ];
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/saga-gis/code.git";
+    rev = "b6f474f8af4af7f0ff82548cc6f88c53547d91f5";
+    sha256 = "0iakynai8mhcwj6wxvafkqhd7b417ss7hyhbcp9wf6092l6vc2zd";
+  };
+
+  meta = with stdenv.lib; {
+    description = "System for Automated Geoscientific Analyses";
+    homepage = http://www.saga-gis.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.mpickering ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/applications/gis/saga/lts.nix
+++ b/pkgs/applications/gis/saga/lts.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
   # for why the have additional buildInputs on darwin
   buildInputs = [ autoreconfHook gdal wxGTK30 proj libharu opencv vigra
                   postgresql libiodbc lzma jasper
-                  Cocoa unixODBC poppler hdf4.out hdf5 netcdf sqlite ];
+                  unixODBC poppler hdf4.out hdf5 netcdf sqlite ]
+                ++ stdenv.lib.optional stdenv.isDarwin Cocoa ;
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/gis/saga/lts.nix
+++ b/pkgs/applications/gis/saga/lts.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  GDAL_CFLAGS = "-std=c++11";
-
   CXXFLAGS = stdenv.lib.optionalString stdenv.cc.isClang "-std=c++11 -Wno-narrowing";
 
   sourceRoot = "code-b6f474f/saga-gis";

--- a/pkgs/applications/gis/saga/lts.nix
+++ b/pkgs/applications/gis/saga/lts.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, gdal, wxGTK30, proj, libiodbc, lzma, jasper,
   libharu, opencv, vigra, postgresql, autoreconfHook, Cocoa
-  , unixODBC , poppler, hdf4, hdf5, netcdf, sqlite }:
+  , unixODBC , poppler, hdf4, hdf5, netcdf, sqlite, qhull, giflib }:
 
 stdenv.mkDerivation rec {
   name = "saga-2.3.2";
@@ -9,14 +9,18 @@ stdenv.mkDerivation rec {
   # for why the have additional buildInputs on darwin
   buildInputs = [ autoreconfHook gdal wxGTK30 proj libharu opencv vigra
                   postgresql libiodbc lzma jasper
-                  unixODBC poppler hdf4.out hdf5 netcdf sqlite ]
+                  unixODBC poppler hdf4.out hdf5 netcdf sqlite qhull giflib ]
                 ++ stdenv.lib.optional stdenv.isDarwin Cocoa ;
 
   enableParallelBuilding = true;
 
+  GDAL_CFLAGS = "-std=c++11";
+
+  CXXFLAGS = stdenv.lib.optionalString stdenv.cc.isClang "-std=c++11 -Wno-narrowing";
+
   sourceRoot = "code-b6f474f/saga-gis";
 
-  patches = [ ./clang_patch.patch ];
+  patches = [ ./clang_patch.patch ./finite.patch];
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/saga-gis/code.git";

--- a/pkgs/desktops/gnome-2/platform/GConf/default.nix
+++ b/pkgs/desktops/gnome-2/platform/GConf/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://projects.gnome.org/gconf/;
     description = "Deprecated system for storing application preferences";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libharu/default.nix
+++ b/pkgs/development/libraries/libharu/default.nix
@@ -15,6 +15,6 @@ stdenv.mkDerivation {
     homepage = http://libharu.org/;
     license = stdenv.lib.licenses.zlib;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libiodbc/default.nix
+++ b/pkgs/development/libraries/libiodbc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk2, useGTK ? false }:
+{ stdenv, fetchurl, pkgconfig, gtk2, Carbon, useGTK ? false }:
 
 stdenv.mkDerivation rec {
   name = "libiodbc-3.52.12";
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = stdenv.lib.optionals useGTK [ gtk2 ];
+  buildInputs = stdenv.lib.optionals useGTK [ gtk2 ]
+                ++ stdenv.lib.optional stdenv.isDarwin Carbon;
 
   preBuild =
     ''
@@ -19,6 +20,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "iODBC driver manager";
     homepage = http://www.iodbc.org;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -15,6 +15,12 @@ in stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR";
 
+  # Fixes compilation with clang (on darwin) see https://github.com/ukoethe/vigra/issues/414
+  patches =
+    let clangPatch = fetchurl { url = "https://github.com/ukoethe/vigra/commit/81958d302494e137f98a8b1d7869841532f90388.patch";
+                                sha256 = "1i1w6smijgb5z8bg9jaq84ccy00k2sxm87s37lgjpyix901gjlgi"; };
+    in [ clangPatch ];
+
   buildInputs = [ boost cmake fftw fftwSinglePrec hdf5 ilmbase libjpeg libpng
                   libtiff numpy openexr python ];
 
@@ -31,6 +37,6 @@ in stdenv.mkDerivation rec {
     homepage = https://hci.iwr.uni-heidelberg.de/vigra;
     license = licenses.mit;
     maintainers = [ maintainers.viric ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19878,6 +19878,10 @@ with pkgs;
 
   saga = callPackage ../applications/gis/saga { };
 
+  saga = callPackage ../applications/gis/saga {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+
   samplv1 = callPackage ../applications/audio/samplv1 { };
 
   sauerbraten = callPackage ../games/sauerbraten {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19877,8 +19877,6 @@ with pkgs;
 
   rrootage = callPackage ../games/rrootage { };
 
-  saga = callPackage ../applications/gis/saga { };
-
   saga = callPackage ../applications/gis/saga {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17950,6 +17950,7 @@ with pkgs;
 
   qgis = callPackage ../applications/gis/qgis {
     inherit (darwin.apple_sdk.frameworks) IOKit ApplicationServices;
+    saga = saga_2_3_2;
   };
 
   qgroundcontrol = libsForQt5.callPackage ../applications/science/robotics/qgroundcontrol { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10373,6 +10373,7 @@ with pkgs;
 
   libiodbc = callPackage ../development/libraries/libiodbc {
     useGTK = config.libiodbc.gtk or false;
+    inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
   libivykis = callPackage ../development/libraries/libivykis { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19882,6 +19882,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  saga_2_3_2 = callPackage ../applications/gis/saga/lts.nix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+
   samplv1 = callPackage ../applications/audio/samplv1 { };
 
   sauerbraten = callPackage ../games/sauerbraten {};


### PR DESCRIPTION
###### Motivation for this change

I wanted to use SAGA plugins with QGIS. In order to do so I had to make SAGA and its dependencies build on darwin. I also had to package an older SAGA release as QGIS requires this specific version. In the end I copied the derivation rather than overriding as it was not too complicated and easier to understand this way. 

Attributes to check: `saga_2_3_2` and `saga`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

