### PR TITLE
prometheus-dovecot-exporter: 2018-01-18 -> 0.1.1, add module 

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -20,6 +20,7 @@ let
   exporterOpts = {
     blackbox = import ./exporters/blackbox.nix { inherit config lib pkgs; };
     collectd = import ./exporters/collectd.nix { inherit config lib pkgs; };
+    dovecot  = import ./exporters/dovecot.nix  { inherit config lib pkgs; };
     fritzbox = import ./exporters/fritzbox.nix { inherit config lib pkgs; };
     json     = import ./exporters/json.nix     { inherit config lib pkgs; };
     minio    = import ./exporters/minio.nix    { inherit config lib pkgs; };

--- a/nixos/modules/services/monitoring/prometheus/exporters/dovecot.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dovecot.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.dovecot;
+in
+{
+  port = 9166;
+  extraOpts = {
+    telemetryPath = mkOption {
+      type = types.str;
+      default = "/metrics";
+      description = ''
+        Path under which to expose metrics.
+      '';
+    };
+    socketPath = mkOption {
+      type = types.path;
+      default = "/var/run/dovecot/stats";
+      example = "/var/run/dovecot2/stats";
+      description = ''
+        Path under which the stats socket is placed.
+        The user/group under which the exporter runs,
+        should be able to access the socket in order
+        to scrape the metrics successfully.
+      '';
+    };
+    scopes = mkOption {
+      type = types.listOf types.str;
+      default = [ "user" ];
+      example = [ "user" "global" ];
+      description = ''
+        Stats scopes to query.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-dovecot-exporter}/bin/dovecot_exporter \
+          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+          --web.telemetry-path ${cfg.telemetryPath} \
+          --dovecot.socket-path ${cfg.socketPath} \
+          --dovecot.scopes ${concatStringsSep "," cfg.scopes} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/servers/monitoring/prometheus/dovecot-exporter-deps.nix
+++ b/pkgs/servers/monitoring/prometheus/dovecot-exporter-deps.nix
@@ -32,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev = "c65a0412e71e8b9b3bfd22925720d23c0f054237";
-      sha256 = "1ch3czyzq5abl6zm1l0dfsi09xj43ql9jcbmbhfhxz954pw03v3v";
+      rev = "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175";
+      sha256 = "1pyli3dcagi7jzpiazph4fhkz7a3z4bhd25nwbb7g0iy69b8z1g4";
     };
   }
   {
@@ -50,8 +50,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/client_golang";
-      rev = "06bc6e01f4baf4ee783ffcd23abfcb0b0f9dfada";
-      sha256 = "0dvv21214sn702kc25y5l0gd9d11358976d3w31fgwx7456mjx26";
+      rev = "c3324c1198cf3374996e9d3098edd46a6b55afc9";
+      sha256 = "19qcz5bpzj5kqyhmbq5kxr8nrqqlszazzq6w0wldis1yk1wwww00";
     };
   }
   {
@@ -68,8 +68,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/common";
-      rev = "89604d197083d4781071d3c65855d24ecfb0a563";
-      sha256 = "169rdlaf2mk9z4fydz7ajmngyhmf3q1lk96yhvx46bn986x5xkyn";
+      rev = "e4aa40a9169a88835b849a6efb71e05dc04b88f0";
+      sha256 = "0m1n616d694jca0qjwjn5ci7scfgm2jpi94dhi356arm9lhda4jc";
     };
   }
   {
@@ -77,8 +77,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/procfs";
-      rev = "cb4147076ac75738c9a7d279075a253c0cc5acbd";
-      sha256 = "0zhlrik0f9q1lj6cisgnxgbz4darbcix52hm5abi24l2ahchf5ca";
+      rev = "54d17b57dd7d4a3aa092476596b3f8a933bde349";
+      sha256 = "1b5218hi6k9i637k6xc7ynpll577zbnrhjm9jr2iczy3j0rr4rvr";
     };
   }
   {

--- a/pkgs/servers/monitoring/prometheus/dovecot-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/dovecot-exporter.nix
@@ -1,17 +1,16 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "dovecot_exporter-unstable-${version}";
-  version = "2018-01-18";
-  rev = "4e831356533e2321031df73ebd25dd55dbd8d385";
+  name = "dovecot_exporter-${version}";
+  version = "0.1.1";
 
   goPackagePath = "github.com/kumina/dovecot_exporter";
 
   src = fetchFromGitHub {
     owner = "kumina";
     repo = "dovecot_exporter";
-    inherit rev;
-    sha256 = "0iky1i7m5mlknkhlpsxpjgigssg5m02nx5y7i4biddkqilfic74n";
+    rev = version;
+    sha256 = "0i7nfgkb5jqdbgr16i29jdsvh69dx9qgn6nazpw78k0lgy7mpidn";
   };
 
   goDeps = ./dovecot-exporter-deps.nix;


### PR DESCRIPTION
This updates the `dovecot-exporter` package to the latest release and add a nixos module for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

