### PR TITLE
Implement graphicsmagick-imagemagick-compat

### DIFF
--- a/pkgs/applications/graphics/graphicsmagick/compat.nix
+++ b/pkgs/applications/graphics/graphicsmagick/compat.nix
@@ -1,0 +1,37 @@
+{ stdenv, graphicsmagick }:
+
+stdenv.mkDerivation rec {
+  name = "graphicsmagick-imagemagick-compat-${version}";
+  inherit (graphicsmagick) version;
+
+  unpackPhase = "true";
+  buildPhase = "true";
+
+  utils = [
+    "composite"
+    "conjure"
+    "convert"
+    "identify"
+    "mogrify"
+    "montage"
+    "animate"
+    "display"
+    "import"
+  ];
+
+  # TODO: symlink libraries?
+  installPhase = ''
+    mkdir -p "$out"/bin
+    mkdir -p "$out"/share/man/man1
+    for util in ''${utils[@]}; do
+      ln -s ${graphicsmagick}/bin/gm "$out/bin/$util"
+      ln -s ${graphicsmagick}/share/man/man1/gm.1.gz "$out/share/man/man1/$util.1.gz"
+    done
+  '';
+
+  meta = {
+    description = "ImageMagick interface for GraphicsMagick";
+    license = stdenv.lib.licenses.free;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/graphics/graphicsmagick/default.nix
+++ b/pkgs/applications/graphics/graphicsmagick/default.nix
@@ -2,10 +2,9 @@
 , libjpeg, libpng, libtiff, libxml2, zlib, libtool, xz, libX11
 , libwebp, quantumdepth ? 8, fixDarwinDylibNames }:
 
-let version = "1.3.29"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "graphicsmagick-${version}";
+  version = "1.3.29";
 
   src = fetchurl {
     url = "mirror://sourceforge/graphicsmagick/GraphicsMagick-${version}.tar.xz";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16142,6 +16142,8 @@ with pkgs;
   graphicsmagick = callPackage ../applications/graphics/graphicsmagick { };
   graphicsmagick_q16 = callPackage ../applications/graphics/graphicsmagick { quantumdepth = 16; };
 
+  graphicsmagick-imagemagick-compat = callPackage ../applications/graphics/graphicsmagick/compat.nix { };
+
   grisbi = callPackage ../applications/office/grisbi { gtk = gtk2; };
 
   gtkpod = callPackage ../applications/audio/gtkpod { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20540,7 +20540,9 @@ with pkgs;
 
   pythia = callPackage ../development/libraries/physics/pythia { };
 
-  rivet = callPackage ../development/libraries/physics/rivet { };
+  rivet = callPackage ../development/libraries/physics/rivet {
+    imagemagick = graphicsmagick-imagemagick-compat;
+  };
 
   thepeg = callPackage ../development/libraries/physics/thepeg { };
 


### PR DESCRIPTION
###### Motivation for this change

ImageMagick build closure now depends on librsvg and rust. This is a bit bloated and rust is often not available from Hydra. GraphicsMagick claims to be faster and seems to be compatible for various purposes.

This is inspired by:
* https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=graphicsmagick-imagemagick-compat
* https://packages.debian.org/sid/graphicsmagick-imagemagick-compat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
