### PR TITLE
gnome-boxes: fix USB redirection (#39129)

### DIFF
--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -24,6 +24,7 @@ in stdenv.mkDerivation rec {
     meson ninja vala pkgconfig gettext itstool wrapGAppsHook gobjectIntrospection desktop-file-utils
   ];
 
+  # Required for USB redirection PolicyKit rules file
   propagatedUserEnvPkgs = [ spice-gtk ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -24,6 +24,8 @@ in stdenv.mkDerivation rec {
     meson ninja vala pkgconfig gettext itstool wrapGAppsHook gobjectIntrospection desktop-file-utils
   ];
 
+  propagatedUserEnvPkgs = [ spice-gtk ];
+
   buildInputs = [
     libvirt-glib glib gtk3 gtkvnc libxml2
     libvirt spice-gtk spice-protocol libsoup json-glib webkitgtk libosinfo systemd

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext libsoup autoreconfHook vala gobjectIntrospection ];
 
-  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "share/polkit-1/actions";
+  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "$(out)/share/polkit-1/actions";
 
   configureFlags = [
     "--with-gtk3"


### PR DESCRIPTION
This fixes USB redirection in gnome-boxes by ensuring that the
required PolicyKit action policy file is installed in the spice-gtk
package and adding that package to gnome-boxes propagatedUserEnvPkgs.

###### Motivation for this change
USB redirection stopped working for me and I needed it.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'm running with these modifications on my x86_64 NixOS laptop.
---

