### PR TITLE
spdk: init at 18.04-pre

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -488,6 +488,11 @@
     github = "auntie";
     name = "Jonathan Glines";
   };
+  avalent = {
+    email = "ashley.valent@gmail.com";
+    github = "avalent";
+    name = "Ashley Valent";
+  };
   avnik = {
     email = "avn@avnik.info";
     github = "avnik";

--- a/pkgs/misc/drivers/spdk/default.nix
+++ b/pkgs/misc/drivers/spdk/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, numactl
+, libaio
+, cunit
+, libuuid
+, fetchFromGitHub
+, gcc
+, openssl
+, python
+}:
+
+stdenv.mkDerivation rec {
+  name = "spdk-${version}";
+  version = "v18.04-pre";
+
+  src = fetchFromGitHub {
+    repo = "spdk";
+    owner = "spdk";
+    rev = "a3f8876777762f9b99544b78ee0b24ff66266c5c";
+    sha256 = "1hb22h8c8b3q91ypfj084ic8gw1fibhfckivfgl334hbbxvay0j0";
+    fetchSubmodules = true;
+  };
+
+  CFLAGS = "-msha -msse4.1 -mssse3";
+
+  buildInputs = [
+    cunit
+    gcc
+    libaio
+    libuuid
+    numactl
+    python
+    openssl
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.spdk.io";
+    description = "The Storage Performance Development Kit (SPDK)";
+    longDescription = ''
+      The Storage Performance Development Kit (SPDK) provides a set of tools and
+      libraries for writing high performance, scalable, user-mode storage
+      applications.
+    '';
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ avalent ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20860,6 +20860,8 @@ with pkgs;
     hasktags = haskellPackages.hasktags;
   };
 
+  spdk = callPackage ../misc/drivers/spdk { };
+
   splix = callPackage ../misc/cups/drivers/splix { };
 
   steamcontroller = callPackage ../misc/drivers/steamcontroller { };


### PR DESCRIPTION
The Storage Performance Development Kit (SPDK) provides a set of tools
and libraries for writing high performance, scalable, user-mode storage
applications.

###### Motivation for this change

To support the development of user-space storage drivers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

