### PR TITLE
appdaemon: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -33,11 +33,11 @@ let
 
 in python.pkgs.buildPythonApplication rec {
   pname = "appdaemon";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = python.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "ed925d3cb25db2c3f57304a0bca8fd0d9072d7ffe347ac5fcf68c4a30b7f1721";
+    sha256 = "ad16773da21e34e258970bf5740d1634a36c8202ac72c6925d960308ef1c58cf";
   };
 
   propagatedBuildInputs = with python.pkgs; [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @peterhoeg 