### PR TITLE
nixos/release-small.nix: disable predictable-interface-names test

### DIFF
--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -41,9 +41,14 @@ in rec {
         nfs3
         openssh
         php-pcre
-        predictable-interface-names
+        #predictable-interface-names  # disabled because of #39069
         proxy
         simple;
+      # add the 3 sub-tests of predictable-interface-names not affected by #39069
+      inherit (nixos'.tests.predictable-interface-names)
+        vm-test-run-predictableInterfaceNames
+        vm-test-run-unpredictableInterfaceNames
+        vm-test-run-unpredictableInterfaceNames-with-networkd;
       installer = {
         inherit (nixos'.tests.installer)
           lvm


### PR DESCRIPTION
###### Motivation for this change

Remove `vm-test-run-predictableInterface-names-with-networkd` from `tested` job, as it failed non-deterministically due to a race condition (#39069), which kept the "small" nixos channels from updating.

This is a temporary fix and should be reverted after #39069 is fixed.

The failing test is also part of the `nixos:release-combined` hydra jobset (but not a constituent of `tested` there) so it will still be run and allow us to track the issue.

---

