### PR TITLE
et: 0.1 -> 0.1.1

### DIFF
--- a/pkgs/applications/misc/et/default.nix
+++ b/pkgs/applications/misc/et/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "et-${version}";
-  version = "0.1";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "geistesk";
     repo = "et";
     rev = "${version}";
-    sha256 = "1d2hq6p1y2ynk0a3l35lwbm1fcl9kg7rpjcin8bx4xcdpbw42y94";
+    sha256 = "167w9qwfpd63rgy0xmkkkh5krmd91q42c3ijy3j099krgdfbb9bc";
   };
 
   buildInputs = [ libnotify gdk_pixbuf ];


### PR DESCRIPTION
###### Motivation for this change
Updates the `et` program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

