### PR TITLE
farbfeld, sent: wrap PATH for 2ff and sent

### DIFF
--- a/pkgs/applications/misc/sent/default.nix
+++ b/pkgs/applications/misc/sent/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, farbfeld, libX11, libXft
+{ stdenv, fetchurl, farbfeld, libX11, libXft, makeWrapper
 , patches ? [] }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0cxysz5lp25mgww73jl0mgip68x7iyvialyzdbriyaff269xxwvv";
   };
 
-  buildInputs = [ farbfeld libX11 libXft ];
+  buildInputs = [ libX11 libXft ];
+  nativeBuildInputs = [ makeWrapper ];
 
   # unpacking doesn't create a directory
   sourceRoot = ".";
@@ -17,6 +18,9 @@ stdenv.mkDerivation rec {
   inherit patches;
 
   installFlags = [ "PREFIX=$(out)" ];
+  postInstall = ''
+    wrapProgram "$out/bin/sent" --prefix PATH : "${farbfeld}/bin"
+  '';
 
   meta = with stdenv.lib; {
     description = "A simple plaintext presentation tool";

--- a/pkgs/development/libraries/farbfeld/default.nix
+++ b/pkgs/development/libraries/farbfeld/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, libpng, libjpeg }:
+{ stdenv, fetchgit, makeWrapper, file, libpng, libjpeg }:
 
 stdenv.mkDerivation rec {
   name = "farbfeld-${version}";
@@ -11,8 +11,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libpng libjpeg ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installFlags = "PREFIX=/ DESTDIR=$(out)";
+  postInstall = ''
+    wrapProgram "$out/bin/2ff" --prefix PATH : "${file}/bin"
+  '';
 
   meta = with stdenv.lib; {
     description = "Suckless image format with conversion tools";


### PR DESCRIPTION
###### Motivation for this change
Both farbfeld's `2ff` and `sent` depends on `file`/`2ff` to be available in the `PATH`. This PR wraps the programs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

