### PR TITLE
slstatus: unstable-2018-03-21 -> unstable-2018-04-16

### DIFF
--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -4,12 +4,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "slstatus-${version}";
-  version = "unstable-2018-03-28";
+  version = "unstable-2018-04-16";
 
   src = fetchgit {
     url = https://git.suckless.org/slstatus;
-    rev = "faa52bdcc0221de2d8fae950e409a8ac5e05bfcd";
-    sha256 = "0i8k7gjvx51y0mwxjlqhyk2dpvkb2d3y8x4l6ckdnyiy5632pn76";
+    rev = "97ef7c2a1d67bb2c9c379e657fbc8e35acd6aafb";
+    sha256 = "1777hgl10imk0l2sgnqgbkfchv1mpxrd82ninzwp7f1rgwchz36v";
   };
 
   configFile = optionalString (conf!=null) (writeText "config.def.h" conf);


### PR DESCRIPTION
###### Motivation for this change
Updates `slstatus` to the current version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

