### PR TITLE
tox: libtoxcore and assorted tox client updates

### DIFF
--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -1,19 +1,23 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig,
-  libtoxcore,
-  libpthreadstubs, libXdmcp, libXScrnSaver,
-  qtbase, qtsvg, qttools, qttranslations,
-  ffmpeg, filter-audio, libexif, libsodium, libopus,
-  libvpx, openal, pcre, qrencode, sqlcipher }:
+{ stdenv, mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig
+, libtoxcore
+, libpthreadstubs, libXdmcp, libXScrnSaver
+, qtbase, qtsvg, qttools, qttranslations
+, ffmpeg, filter-audio, libexif, libsodium, libopus
+, libvpx, openal, pcre, qrencode, sqlcipher
+, AVFoundation ? null }:
 
-mkDerivation rec {
+let
+  version = "1.15.0";
+  rev = "v${version}";
+
+in mkDerivation rec {
   name = "qtox-${version}";
-  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner  = "qTox";
     repo   = "qTox";
-    rev    = "v${version}";
-    sha256 = "08x71p23d0sp0w11k8z3wf3k56iclmdq9x652n8ggidgyrdi9f6y";
+    sha256 = "1garwnlmg452b0bwx36rsh08s15q3zylb26l01iiwg4l9vcaldh9";
+    inherit rev;
   };
 
   buildInputs = [
@@ -22,17 +26,18 @@ mkDerivation rec {
     qtbase qtsvg qttranslations
     ffmpeg filter-audio libexif libopus libsodium
     libvpx openal pcre qrencode sqlcipher
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [ AVFoundation] ;
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];
 
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DGIT_DESCRIBE=${version}"
+    "-DGIT_DESCRIBE=${rev}"
     "-DENABLE_STATUSNOTIFIER=False"
     "-DENABLE_GTK_SYSTRAY=False"
     "-DENABLE_APPINDICATOR=False"
+    "-DTIMESTAMP=1"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/ratox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ratox/default.nix
@@ -5,22 +5,24 @@ with stdenv.lib;
 
 let
   configFile = optionalString (conf!=null) (builtins.toFile "config.h" conf);
-in
 
-stdenv.mkDerivation rec {
-  name = "ratox-0.4";
+in stdenv.mkDerivation rec {
+  name = "ratox-0.4.20180303";
 
   src = fetchgit {
     url = "git://git.2f30.org/ratox.git";
-    rev = "0db821b7bd566f6cfdc0cc5a7bbcc3e5e92adb4c";
-    sha256 = "0wmf8hydbcq4bkpsld9vnqw4zfzf3f04vhgwy17nd4p5p389fbl5";
+    rev = "269f7f97fb374a8f9c0b82195c21de15b81ddbbb";
+    sha256 = "0bpn37h8jvsqd66fkba8ky42nydc8acawa5x31yxqlxc8mc66k74";
   };
-
-  patches = [ ./ldlibs.patch ];
 
   buildInputs = [ libtoxcore ];
 
-  preConfigure = optionalString (conf!=null) "cp ${configFile} config.def.h";
+  preConfigure = ''
+    substituteInPlace config.mk \
+      --replace '-lsodium -lopus -lvpx ' ""
+
+    ${optionalString (conf!=null) "cp ${configFile} config.def.h"}
+  '';
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/networking/instant-messengers/ratox/ldlibs.patch
+++ b/pkgs/applications/networking/instant-messengers/ratox/ldlibs.patch
@@ -1,5 +1,0 @@
---- a/config.mk
-+++ b/config.mk
-@@ -13 +13 @@ LDFLAGS  = -L/usr/local/lib
--LDLIBS   = -ltoxcore -ltoxav -ltoxencryptsave -lsodium -lopus -lvpx -lm -lpthread
-+LDLIBS   = -ltoxcore -ltoxav -ltoxencryptsave -lm -lpthread

--- a/pkgs/applications/networking/instant-messengers/toxic/default.nix
+++ b/pkgs/applications/networking/instant-messengers/toxic/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "toxic-${version}";
-  version = "0.7.2";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner  = "Tox";
     repo   = "toxic";
     rev    = "v${version}";
-    sha256 = "1kws6bx5va1wc0k6pqihrla91vicxk4zqghvxiylgfbjr1jnkvwc";
+    sha256 = "0fwmk945nip98m3md58y3ibjmzfq25hns3xf0bmbc6fjpww8d5p5";
   };
 
   makeFlags = [ "PREFIX=$(out)"];

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -1,16 +1,18 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, libtoxcore, filter-audio, dbus, libvpx, libX11, openal, freetype, libv4l
-, libXrender, fontconfig, libXext, libXft, utillinux, git, libsodium, libopus, check }:
+{ stdenv, lib, fetchFromGitHub, check, cmake, pkgconfig
+, libtoxcore, filter-audio, dbus, libvpx, libX11, openal, freetype, libv4l
+, libXrender, fontconfig, libXext, libXft, utillinux, libsodium, libopus }:
 
 stdenv.mkDerivation rec {
   name = "utox-${version}";
 
-  version = "0.16.1";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner  = "uTox";
     repo   = "uTox";
     rev    = "v${version}";
-    sha256 = "0ak10925v67yaga2pw9yzp0xkb5j1181srfjdyqpd29v8mi9j828";
+    sha256 = "12wbq883il7ikldayh8hm0cjfrkp45vn05xx9s1jbfz6gmkidyar";
+    fetchSubmodules = true;
   };
 
   buildInputs = [
@@ -20,16 +22,20 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    cmake git pkgconfig check
+    check cmake pkgconfig
   ];
 
   cmakeFlags = [
-    "-DENABLE_UPDATER=OFF"
-  ] ++ stdenv.lib.optional (!doCheck) "-DENABLE_TESTS=OFF";
+    "-DENABLE_AUTOUPDATE=OFF"
+  ] ++ lib.optional (doCheck) "-DENABLE_TESTS=ON";
 
-  doCheck = true;
+  doCheck = stdenv.isLinux;
 
-  checkTarget = "test";
+  checkPhase = ''
+    runHook preCheck
+    ctest -VV
+    runHook postCheck
+  '';
 
   meta = with stdenv.lib; {
     description = "Lightweight Tox client";

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -1,46 +1,51 @@
 { stdenv, fetchFromGitHub, cmake, libsodium, ncurses, libopus, libmsgpack
 , libvpx, check, libconfig, pkgconfig }:
 
-stdenv.mkDerivation rec {
-  name = "libtoxcore-${version}";
-  version = "0.1.11";
+let
+  generic = { version, sha256 }:
+  stdenv.mkDerivation rec {
+    name = "libtoxcore-${version}";
 
-  src = fetchFromGitHub {
-    owner  = "TokTok";
-    repo   = "c-toxcore";
-    rev    = "v${version}";
+    src = fetchFromGitHub {
+      owner  = "TokTok";
+      repo   = "c-toxcore";
+      rev    = "v${version}";
+      inherit sha256;
+    };
+
+    cmakeFlags = [
+      "-DBUILD_NTOX=ON"
+      "-DDHT_BOOTSTRAP=ON"
+      "-DBOOTSTRAP_DAEMON=ON"
+    ];
+
+    buildInputs = [
+      libsodium libmsgpack ncurses libconfig
+    ] ++ stdenv.lib.optionals (!stdenv.isAarch32) [
+      libopus libvpx
+    ];
+
+    nativeBuildInputs = [ cmake pkgconfig ];
+
+    enableParallelBuilding = true;
+
+    meta = with stdenv.lib; {
+      description = "P2P FOSS instant messaging application aimed to replace Skype";
+      homepage = https://tox.chat;
+      license = licenses.gpl3Plus;
+      maintainers = with maintainers; [ peterhoeg ];
+      platforms = platforms.all;
+    };
+  };
+
+in rec {
+  libtoxcore_0_1 = generic {
+    version = "0.1.11";
     sha256 = "1fya5gfiwlpk6fxhalv95n945ymvp2iidiyksrjw1xw95fzsp1ij";
   };
 
-  cmakeFlags = [
-    "-DBUILD_NTOX=ON"
-    "-DDHT_BOOTSTRAP=ON"
-    "-DBOOTSTRAP_DAEMON=ON"
-  ];
-
-  buildInputs = [
-    libsodium libmsgpack ncurses libconfig
-  ] ++ stdenv.lib.optionals (!stdenv.isAarch32) [
-    libopus
-    libvpx
-  ];
-
-  nativeBuildInputs = [ cmake pkgconfig ];
-
-  enableParallelBuilding = true;
-
-  checkInputs = [ check ];
-
-  checkPhase = "ctest";
-
-  # for some reason the tests are not running - it says "No tests found!!"
-  doCheck = true;
-
-  meta = with stdenv.lib; {
-    description = "P2P FOSS instant messaging application aimed to replace Skype";
-    homepage = https://tox.chat;
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ peterhoeg ];
-    platforms = platforms.all;
+  libtoxcore_0_2 = generic {
+    version = "0.2.2";
+    sha256 = "1463grbbv009pj2g6dbnyk4lr871vw41962m63v21mmp6dkrr7r5";
   };
 }

--- a/pkgs/tools/networking/toxvpn/default.nix
+++ b/pkgs/tools/networking/toxvpn/default.nix
@@ -1,25 +1,22 @@
 { stdenv, fetchFromGitHub, cmake, nlohmann_json,
-libtoxcore, libsodium, systemd, libcap, zeromq }:
+  libtoxcore, libsodium, libcap, zeromq,
+  systemd ? null }:
 
 with stdenv.lib;
 
-let
-  systemdOrNull = if stdenv.system == "x86_64-darwin" then null else systemd;
-  if_systemd = optional (systemdOrNull != null);
-in stdenv.mkDerivation rec {
-  name = "toxvpn-${version}";
-  version = "2017-06-25";
+stdenv.mkDerivation rec {
+  name = "toxvpn-2018-04-17";
 
   src = fetchFromGitHub {
     owner  = "cleverca22";
     repo   = "toxvpn";
-    rev    = "7bd6f169d69c511affa8c9672e8f794e4e205a44";
-    sha256 = "1km8hkrxmrnca1b49vbw5kyldayaln5plvz78vhf8325r6c5san0";
+    rev    = "dc766f98888f500ea51f002f59007eac3f3a0a06";
+    sha256 = "19br3fmrdm45fvymj9kvwikkn8m657yd5fkhx6grv35ckrj83mxz";
   };
 
   buildInputs = [ libtoxcore nlohmann_json libsodium zeromq ]
-    ++ if_systemd systemd
-    ++ optional (stdenv.system != "x86_64-darwin") libcap;
+    ++ optionals stdenv.isLinux [ libcap systemd ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = optional stdenv.isLinux [ "-DSYSTEMD=1" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17461,7 +17461,7 @@ with pkgs;
 
   qtbitcointrader = callPackage ../applications/misc/qtbitcointrader { };
 
-  qtox = libsForQt5.callPackage ../applications/networking/instant-messengers/qtox { ffmpeg = ffmpeg_2; };
+  qtox = libsForQt5.callPackage ../applications/networking/instant-messengers/qtox { };
 
   qtpass = libsForQt5.callPackage ../applications/misc/qtpass { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5220,7 +5220,7 @@ with pkgs;
 
   torsocks = callPackage ../tools/security/tor/torsocks.nix { };
 
-  toxvpn = callPackage ../tools/networking/toxvpn { };
+  toxvpn = callPackage ../tools/networking/toxvpn { libtoxcore = libtoxcore_0_1; };
 
   tpmmanager = callPackage ../applications/misc/tpmmanager { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10358,9 +10358,12 @@ with pkgs;
 
   libtorrentRasterbar = callPackage ../development/libraries/libtorrent-rasterbar { };
 
+  # this is still the new version of the old API
   libtoxcore-new = callPackage ../development/libraries/libtoxcore/new-api.nix { };
 
-  libtoxcore = callPackage ../development/libraries/libtoxcore { };
+  inherit (callPackages ../development/libraries/libtoxcore {})
+    libtoxcore_0_1 libtoxcore_0_2;
+  libtoxcore = libtoxcore_0_2;
 
   libtap = callPackage ../development/libraries/libtap { };
 


### PR DESCRIPTION
###### Motivation for this change

libtoxcore made breaking changes in 0.2 so we now carry both 0.1 and 0.2 for use by the various clients.

Cc @ehmry  @viric @jgeerds @akaWolf @domenkozar @cleverca22 @obadz 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

