### PR TITLE
rw: init at 1.0

### DIFF
--- a/pkgs/tools/misc/rw/default.nix
+++ b/pkgs/tools/misc/rw/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "rw-${version}";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "https://sortix.org/rw/release/rw-portable-${version}.tar.gz";
+    # Use hash provided by upstream
+    sha256 = "50009730e36991dfe579716f91f4f616f5ba05ffb7bf69c03d41bf305ed93b6d";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://sortix.org/rw;
+    description = "Block device and byte copying program similar to dd";
+    longDescription = ''
+      rw is a command line program which copies information between files
+      or byte streams. The rw command is designed to be a replacement for
+      dd with standard style command line flags.
+    '';
+    license = licenses.isc;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/tools/misc/rw/default.nix
+++ b/pkgs/tools/misc/rw/default.nix
@@ -22,5 +22,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.isc;
     maintainers = with maintainers; [ dtzWill ];
+
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4699,6 +4699,8 @@ with pkgs;
 
   runzip = callPackage ../tools/archivers/runzip { };
 
+  rw = callPackage ../tools/misc/rw { };
+
   rxp = callPackage ../tools/text/xml/rxp { };
 
   rzip = callPackage ../tools/compression/rzip { };


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---