### PR TITLE
zramSwap: default to 1 device

### DIFF
--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -25,7 +25,7 @@ in
         type = types.bool;
         description = ''
           Enable in-memory compressed swap space provided by the zram kernel
-          module. It is recommended to enable only for kernel 3.14 or higher.
+          module.
           See https://www.kernel.org/doc/Documentation/blockdev/zram.txt
         '';
       };
@@ -34,8 +34,7 @@ in
         default = 1;
         type = types.int;
         description = ''
-          Number of zram swap devices to create. It should be equal to the
-          number of CPU cores your system has for kernel < v3.15.
+          Number of zram swap devices to create.
         '';
       };
 

--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -26,15 +26,16 @@ in
         description = ''
           Enable in-memory compressed swap space provided by the zram kernel
           module. It is recommended to enable only for kernel 3.14 or higher.
+          See https://www.kernel.org/doc/Documentation/blockdev/zram.txt
         '';
       };
 
       numDevices = mkOption {
-        default = 4;
+        default = 1;
         type = types.int;
         description = ''
           Number of zram swap devices to create. It should be equal to the
-          number of CPU cores your system has.
+          number of CPU cores your system has for kernel < v3.15.
         '';
       };
 


### PR DESCRIPTION
One device per cpu is only needed for kernel 3.14
