### PR TITLE
oraclejdk: 8u161, 8u162 -> 8u171, 8u172 (backporting to 17.09)

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "161";
+  patchVersion = "171";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1p6p93msn3bsg9775rq171kd4160w4w8z57p0qpjdjycfix62sfg";
-  sha256_x86_64 = "07h2wah80qr78y0f821z12lbdmsv90xbckdn3glnj2riwfh5dg3d";
-  sha256_armv7l = "0mngw2lnhx3hzgp444advybhjn5hjk3mi14y72km4kp03gh82a7x";
+  sha256_i686 = "0dh5r02v40pinway952fflw2r0i1xi67hmyb87c278qfp4jn929p";
+  sha256_x86_64 = "10jr4z0bw9wcws5xgc4qkw101cadfx5bkyvcnc4l3v5axwvjipdn";
+  sha256_armv7l = "1bqivmp1wfnypgg5bsfzi25yzl7vd2xncfap9mi8jn63aj633dw0";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "162";
+  patchVersion = "172";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "097vlvvj1vr7815rgarf5x97lagi4q0kai0x4lvd4y3wrzdqikzf";
-  sha256_x86_64 = "0mq2d0lj53gzn4qqdjdgbwl0h857k2rnsnr2hkmvihnrgza85v38";
-  sha256_armv7l = "0xzsgdmpgs1n1g70hgly0mpxflhjrmq3vxwx8gl0kmqdiv4hqwjp";
+  sha256_i686 = "0csskx8xis0dr1948j76fgrwwsj4gzdbjqfi7if4v4j62b9i0hqa";
+  sha256_x86_64 = "0inkx73rwv7cvn9lqcr3hmnm0sr89h1fh29yamikb4dn02a0p818";
+  sha256_armv7l = "1576cb0rlc42dsnmh388gy1wjas7ac6g135s8h74x8sm4b56qpln";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change

See #39156.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

