### PR TITLE
tree-wide: fix instance of "meta.maintainer" -> "meta.maintainers"

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -374,7 +374,7 @@ and `CFLAGS`.
       description = "A pythonic wrapper around FFTW, the FFT library, presenting a unified interface for all the supported transforms";
       homepage = http://hgomersall.github.com/pyFFTW/;
       license = with licenses; [ bsd2 bsd3 ];
-      maintainer = with maintainers; [ fridh ];
+      maintainers = with maintainers; [ fridh ];
     };
   };
 }

--- a/pkgs/development/python-modules/yolk/default.nix
+++ b/pkgs/development/python-modules/yolk/default.nix
@@ -17,7 +17,7 @@ buildPythonApplication rec {
   meta = {
     description = "Command-line tool for querying PyPI and Python packages installed on your system";
     homepage = https://github.com/cakebread/yolk;
-    maintainer = with maintainers; [];
+    maintainers = with maintainers; [];
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/zipfile36/default.nix
+++ b/pkgs/development/python-modules/zipfile36/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     description = "Read and write ZIP files - backport of the zipfile module from Python 3.6";
     homepage = https://gitlab.com/takluyver/zipfile36;
     license = lib.licenses.psfl;
-    maintainer = lib.maintainers.fridh;
+    maintainers = lib.maintainers.fridh;
   };
 }

--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -120,7 +120,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
     meta = with stdenv.lib; {
       license = licenses.unfree;
-      maintainer = [ maintainers.jraygauthier ];
+      maintainers = [ maintainers.jraygauthier ];
       # A 32 bit linux would also be possible with some effort (specific download of binaries + 
       # patching of the elf files with 32 bit interpreter).
       platforms = [ "x86_64-linux" ];

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -36,6 +36,6 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
     meta = with lib; {
       license = licenses.mit;
-      maintainer = [ maintainers.jraygauthier ];
+      maintainers = [ maintainers.jraygauthier ];
     };
 }


### PR DESCRIPTION
Encountered one of these when using check-meta, did a quick
search to find other instances.


unbreak eval, fixup incorrect meta attribute names.



(Most of this does not apply!)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---