### PR TITLE
Fix root volume resizing on EC2 KVM instances (M5, C5, etc) 

### DIFF
--- a/nixos/modules/system/boot/grow-partition.nix
+++ b/nixos/modules/system/boot/grow-partition.nix
@@ -32,8 +32,15 @@ with lib;
       rootDevice="${config.fileSystems."/".device}"
       if [ -e "$rootDevice" ]; then
         rootDevice="$(readlink -f "$rootDevice")"
-        parentDevice="$(lsblk -npo PKNAME "$rootDevice")"
-        TMPDIR=/run sh $(type -P growpart) "$parentDevice" "''${rootDevice#$parentDevice}"
+        parentDevice="$rootDevice"
+        while [ "''${parentDevice%[0-9]}" != "''${parentDevice}" ]; do
+          parentDevice="''${parentDevice%[0-9]}";
+        done
+        partNum="''${rootDevice#''${parentDevice}}"
+        if [ "''${parentDevice%[0-9]p}" != "''${parentDevice}" ] && [ -b "''${parentDevice%p}" ]; then
+          parentDevice="''${parentDevice%p}"
+        fi
+        TMPDIR=/run sh $(type -P growpart) "$parentDevice" "$partNum"
         udevadm settle
       fi
     '';


### PR DESCRIPTION
Fixes:
https://github.com/NixOS/nixpkgs/issues/33417
https://github.com/NixOS/nixpkgs/issues/33092

Root volume resizing was broken on new KVM instances because of the way partition name was computed
```
rootDevice="$(readlink -f "$rootDevice")"
        parentDevice="$(lsblk -npo PKNAME "$rootDevice")"
        TMPDIR=/run sh $(type -P growpart) "$parentDevice" "''${rootDevice#$parentDevice}"
```
`"''${rootDevice#$parentDevice}"` results in `p1` instead of `1` when root device is nvme disk

resulting in small root partition
```
# lsblk
NAME        MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
nvme0n1     259:0    0  32G  0 disk
└─nvme0n1p1 259:2    0  2G  0 part /
```

Suggested solution borrowed from here:
https://git.launchpad.net/cloud-initramfs-tools/tree/growroot/scripts/local-bottom/growroot
(lines 38 - 49)


Performed testing on m4 and m5 instances and confirmed that fix works