### PR TITLE
prometheus-postfix-exporter: 2017-06-01 -> 0.1.1, update module

### DIFF
--- a/pkgs/servers/monitoring/prometheus/postfix-exporter-deps.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter-deps.nix
@@ -5,8 +5,26 @@
     fetch = {
       type = "git";
       url = "https://github.com/beorn7/perks";
-      rev = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9";
-      sha256 = "1hrybsql68xw57brzj805xx2mghydpdiysv3gbhr7f5wlxj2514y";
+      rev = "3a771d992973f24aa725d07868b467d1ddfceafb";
+      sha256 = "1l2lns4f5jabp61201sh88zf3b0q793w4zdgp9nll7mmfcxxjif3";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-systemd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-systemd";
+      rev = "d1b7d058aa2adfc795ad17ff4aaa2bc64ec11c78";
+      sha256 = "1nz3v1b90hnmj2vjjwq96pr6psxlndqjyd30v9sgiwygzb7db9mv";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/pkg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/pkg";
+      rev = "97fdf19511ea361ae1c100dd393cc47f8dcfa1e1";
+      sha256 = "1srn87wih25l09f75483hnxsr8fc6rq3bk7w1x8125ym39p6mg21";
     };
   }
   {
@@ -14,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev = "c65a0412e71e8b9b3bfd22925720d23c0f054237";
-      sha256 = "1ch3czyzq5abl6zm1l0dfsi09xj43ql9jcbmbhfhxz954pw03v3v";
+      rev = "e09c5db296004fbe3f74490e84dcd62c3c5ddb1b";
+      sha256 = "1acnmalkqwrq6k3l71c4pyws0zn18r2609kqaq55lhbdcjgzid31";
     };
   }
   {
@@ -32,8 +50,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/client_golang";
-      rev = "06bc6e01f4baf4ee783ffcd23abfcb0b0f9dfada";
-      sha256 = "0dvv21214sn702kc25y5l0gd9d11358976d3w31fgwx7456mjx26";
+      rev = "82f5ff156b29e276022b1a958f7d385870fb9814";
+      sha256 = "111j329yrlgvh73dm80gawwxsh9dgjkw74254kyj5c2rfmra7znz";
     };
   }
   {
@@ -50,8 +68,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/common";
-      rev = "89604d197083d4781071d3c65855d24ecfb0a563";
-      sha256 = "169rdlaf2mk9z4fydz7ajmngyhmf3q1lk96yhvx46bn986x5xkyn";
+      rev = "d0f7cd64bda49e08b22ae8a730aa57aa0db125d6";
+      sha256 = "1d4hfbb66xsf0wq317fwhgrwakqzhvryw4d7ip851lwrpql5fqcx";
     };
   }
   {
@@ -59,8 +77,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/procfs";
-      rev = "cb4147076ac75738c9a7d279075a253c0cc5acbd";
-      sha256 = "0zhlrik0f9q1lj6cisgnxgbz4darbcix52hm5abi24l2ahchf5ca";
+      rev = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e";
+      sha256 = "0x128p15h35mgwqxkigfkk1lfrcz9g697ahl8v6xp9kwvcqvjrrf";
     };
   }
 ]

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
@@ -1,20 +1,26 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, systemd, makeWrapper }:
 
 buildGoPackage rec {
-  name = "postfix_exporter-unstable-${version}";
-  version = "2017-06-01";
-  rev = "a8b4bed735a03f234fcfffba85302f51025e6b1d";
+  name = "postfix_exporter-${version}";
+  version = "0.1.1";
 
   goPackagePath = "github.com/kumina/postfix_exporter";
 
   src = fetchFromGitHub {
     owner = "kumina";
     repo = "postfix_exporter";
-    inherit rev;
-    sha256 = "0rxvjpyjcvr1y8k8skq5f1bnl0mpgvaa04dn8c44v7afqnv78riy";
+    rev = version;
+    sha256 = "1p2j66jzzgyv2w832pw57g02vrac6ldrblqllgwyy0i8krb3ibyz";
   };
 
+  buildInputs = [ systemd makeWrapper ];
+
   goDeps = ./postfix-exporter-deps.nix;
+
+  postInstall = ''
+    wrapProgram $bin/bin/postfix_exporter \
+      --prefix LD_LIBRARY_PATH : "${systemd.lib}/lib"
+  '';
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
###### Motivation for this change
Support for metric collection from systemd-journal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

