### PR TITLE
gede: 2.0.4 -> 2.6.1, fix ctags dependency

### DIFF
--- a/pkgs/development/tools/misc/gede/default.nix
+++ b/pkgs/development/tools/misc/gede/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "gede-${version}";
-  version = "2.0.4";
+  version = "2.6.1";
 
   src = fetchurl {
     url = "http://gede.acidron.com/uploads/source/${name}.tar.xz";
-    sha256 = "0ip86ss35sc330p4aykv5qj74jbdwh38i928w1bxb6g3w0xmfqba";
+    sha256 = "0jallpchl3c3i90hwic4n7n0ggk5wra0fki4by9ag26ln0k42c4r";
   };
 
   nativeBuildInputs = [ makeWrapper python ];
 
-  buildInputs = [ qt4 ];
+  buildInputs = [ qt4 ctags ];
 
   postPatch = ''
     sed -i build.py -e 's,qmake-qt4,qmake,'
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildPhase = ":";
 
   installPhase = ''
-    python build.py install --prefix="$out"
+    python build.py install --verbose --prefix="$out"
     wrapProgram $out/bin/gede \
       --prefix PATH : ${stdenv.lib.makeBinPath [ ctags gdb ]}
   '';


### PR DESCRIPTION
###### Motivation for this change

Closes #39162 .

/cc @dtzWill  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

