### PR TITLE
bonzomatic: init at 2018-03-29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2650,6 +2650,11 @@
     github = "nmattia";
     name = "Nicolas Mattia";
   };
+  nocent = {
+    email = "nocent@protonmail.ch";
+    github = "nocent";
+    name = "nocent";
+  };
   nocoolnametom = {
     email = "nocoolnametom@gmail.com";
     github = "nocoolnametom";

--- a/pkgs/applications/editors/bonzomatic/default.nix
+++ b/pkgs/applications/editors/bonzomatic/default.nix
@@ -1,14 +1,14 @@
 { stdenv, makeWrapper, fetchFromGitHub, cmake, alsaLib, mesa_glu, libXcursor, libXinerama, libXrandr, xorgserver }:
 
-let
-  name = "bonzomatic";
-in stdenv.mkDerivation {
-  inherit name;
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "bonzomatic";
+  version = "2018-03-29";
 
   src = fetchFromGitHub {
-    repo = name;
     owner = "Gargaj";
-    rev = "2018-03-29";
+    repo = pname;
+    rev = version;
     sha256 = "12mdfjvbhdqz1585772rj4cap8m4ijfci6ib62jysxjf747k41fg";
   };
 
@@ -25,7 +25,6 @@ in stdenv.mkDerivation {
       unfreeRedistributable # contains libbass.so in repository
     ];
     maintainers = [ maintainers.nocent ];
-    platforms = platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }
-

--- a/pkgs/applications/editors/bonzomatic/default.nix
+++ b/pkgs/applications/editors/bonzomatic/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, makeWrapper, fetchFromGitHub, cmake, alsaLib, mesa_glu, libXcursor, libXinerama, libXrandr, xorgserver }:
+
+let
+  name = "bonzomatic";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchFromGitHub {
+    repo = name;
+    owner = "Gargaj";
+    rev = "2018-03-29";
+    sha256 = "12mdfjvbhdqz1585772rj4cap8m4ijfci6ib62jysxjf747k41fg";
+  };
+
+  buildInputs = [ cmake makeWrapper alsaLib mesa_glu libXcursor libXinerama libXrandr xorgserver ];
+
+  postFixup = ''
+    wrapProgram $out/bin/Bonzomatic --prefix LD_LIBRARY_PATH : "${alsaLib}/lib"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A live-coding tool for writing 2D fragment/pixel shaders";
+    license = with licenses; [
+      unlicense
+      unfreeRedistributable # contains libbass.so in repository
+    ];
+    maintainers = [ maintainers.nocent ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14943,6 +14943,8 @@ with pkgs;
     ffmpeg = ffmpeg_2;
   };
 
+  bonzomatic = callPackage ../applications/editors/bonzomatic { };
+
   brackets = callPackage ../applications/editors/brackets { gconf = gnome3.gconf; };
 
   notmuch-bower = callPackage ../applications/networking/mailreaders/notmuch-bower { };


### PR DESCRIPTION
###### Motivation for this change
Adds [Bonzomatic](https://github.com/Gargaj/Bonzomatic), a live-coding tool for writing 2D fragment/pixel shaders.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I added the unfreeRedistributable license, as the upstream repo contains [libbass.so](https://www.un4seen.com/bass.html#license) which is only free for non-commercial use.