### PR TITLE
Enable some imake builds on darwin

### DIFF
--- a/pkgs/applications/misc/gv/default.nix
+++ b/pkgs/applications/misc/gv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, Xaw3d, ghostscriptX, perl }:
+{ stdenv, fetchurl, Xaw3d, ghostscriptX, perl, pkgconfig, libiconv }:
 
 let
   name = "gv-3.7.4";
@@ -11,7 +11,18 @@ stdenv.mkDerivation {
     sha256 = "0q8s43z14vxm41pfa8s5h9kyyzk1fkwjhkiwbf2x70alm6rv6qi1";
   };
 
-  buildInputs = [ Xaw3d ghostscriptX perl ];
+  configureFlags = stdenv.lib.optionals stdenv.isDarwin [
+    "--enable-SIGCHLD-fallback"
+  ];
+
+  buildInputs = [
+    Xaw3d
+    ghostscriptX
+    perl
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    pkgconfig
+    libiconv
+  ];
 
   patchPhase = ''
     sed 's|\<gs\>|${ghostscriptX}/bin/gs|g' -i "src/"*.in
@@ -32,6 +43,6 @@ stdenv.mkDerivation {
 
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/misc/oneko/default.nix
+++ b/pkgs/applications/misc/oneko/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.daidouji.com/oneko/";
     license = licenses.publicDomain;
     maintainers = [ maintainers.xaverdh ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }
 

--- a/pkgs/development/libraries/Xaw3d/default.nix
+++ b/pkgs/development/libraries/Xaw3d/default.nix
@@ -14,6 +14,6 @@ stdenv.mkDerivation {
 
   meta = {
     description = "3D widget set based on the Athena Widget set";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/games/xskat/default.nix
+++ b/pkgs/games/xskat/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   meta = {
     inherit (s) version;
     description = ''Famous german card game'';
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.free;
     longDescription = ''Play the german card game Skat against the AI or over IRC.'';
     homepage = http://www.xskat.de/;

--- a/pkgs/games/xsok/default.nix
+++ b/pkgs/games/xsok/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     sed -e '/chown /d' -i src/Imakefile
     sed -e '/chmod /d' -i src/Imakefile
     sed -e '/InstallAppDefaults/d' -i src/Imakefile
+    sed -e 's/CC = gcc/CC = cc/g' -i src/Imakefile
   '';
 
   makeFlags = ["BINDIR=$(out)/bin"];
@@ -41,7 +42,7 @@ stdenv.mkDerivation rec {
     description = "A generic Sokoban game for X11";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     homepage = https://tracker.debian.org/pkg/xsok;
   };
 }

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2570,6 +2570,9 @@ let
       url = mirror://xorg/individual/util/xorg-cf-files-1.0.6.tar.bz2;
       sha256 = "0kckng0zs1viz0nr84rdl6dswgip7ndn4pnh5nfwnviwpsfmmksd";
     };
+    postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+      substituteInPlace $out/lib/X11/config/darwin.cf --replace "/usr/bin/" ""
+    '';
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ ];
     meta.platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
###### Motivation for this change
This enables a few imake based builds on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

