### PR TITLE
gede: switch to qt5

### DIFF
--- a/pkgs/development/tools/misc/gede/default.nix
+++ b/pkgs/development/tools/misc/gede/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, python, qt4, ctags, gdb }:
+{ stdenv, fetchurl, makeWrapper, python, qmake, ctags, gdb }:
 
 stdenv.mkDerivation rec {
   name = "gede-${version}";
@@ -9,12 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "0jallpchl3c3i90hwic4n7n0ggk5wra0fki4by9ag26ln0k42c4r";
   };
 
-  nativeBuildInputs = [ makeWrapper python ];
+  nativeBuildInputs = [ qmake makeWrapper python ];
 
-  buildInputs = [ qt4 ctags ];
+  buildInputs = [ ctags ];
+
+  dontUseQmakeConfigure = true;
 
   postPatch = ''
-    sed -i build.py -e 's,qmake-qt4,qmake,'
+    sed -i build.py -e 's,qmake-qt5,qmake,'
   '';
 
   buildPhase = ":";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7823,7 +7823,7 @@ with pkgs;
 
   funnelweb = callPackage ../development/tools/literate-programming/funnelweb { };
 
-  gede = callPackage ../development/tools/misc/gede { };
+  gede = libsForQt5.callPackage ../development/tools/misc/gede { };
 
   gdbgui = callPackage ../development/tools/misc/gdbgui { };
 


### PR DESCRIPTION
###### Motivation for this change

Get rid of qt4.

/cc @dtzWill @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

