### PR TITLE
[RDY] Vdirsyncer update

### DIFF
--- a/pkgs/development/python-modules/milksnake/default.nix
+++ b/pkgs/development/python-modules/milksnake/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, cffi }:
+
+buildPythonPackage rec {
+  pname = "milksnake";
+  version = "0.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "120nprd8lqis7x7zy72536gk2j68f7gxm8gffmx8k4ygifvl7kfz";
+  };
+
+  propagatedBuildInputs = [
+   cffi
+  ];
+
+  # tests rely on pip/venv
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A python library that extends setuptools for binary extensions";
+    homepage = https://github.com/getsentry/milksnake;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,18 +1,30 @@
-{ stdenv, fetchurl, python3Packages, glibcLocales }:
+{ stdenv, python3Packages, glibcLocales, rustPlatform }:
 
 # Packaging documentation at:
 # https://github.com/untitaker/vdirsyncer/blob/master/docs/packaging.rst
 let
   pythonPackages = python3Packages;
-in
-pythonPackages.buildPythonApplication rec {
-  version = "0.16.4";
-  name = "vdirsyncer-${version}";
-
-  src = fetchurl {
-    url = "mirror://pypi/v/vdirsyncer/${name}.tar.gz";
-    sha256 = "03wva48bgv1ad3df6plc9b8xxh6k8bcaxrhlzwh81c9mzn5bspzv";
+  version = "0.17.0a2";
+  pname = "vdirsyncer";
+  name = pname + "-" + version;
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "0y464rsx5la6bp94z2g0nnkbl4nwfya08abynvifw4c84vs1gr4q";
   };
+  native = rustPlatform.buildRustPackage {
+    name = name + "-native";
+    inherit src;
+    sourceRoot = name + "/rust";
+    cargoSha256 = "1cr7xs11gbsc3x5slga9qahchwc22qq49amf28g4jgs9lzf57qis";
+    postInstall = ''
+      mkdir $out/include $out/lib
+      cp $out/bin/libvdirsyncer_rustext* $out/lib
+      rm -r $out/bin
+      cp target/vdirsyncer_rustext.h $out/include
+    '';
+  };
+in pythonPackages.buildPythonApplication rec {
+  inherit version pname src;
 
   propagatedBuildInputs = with pythonPackages; [
     click click-log click-threading
@@ -20,14 +32,33 @@ pythonPackages.buildPythonApplication rec {
     requests
     requests_oauthlib # required for google oauth sync
     atomicwrites
+    milksnake
   ];
 
-  buildInputs = with pythonPackages; [hypothesis pytest pytest-localserver pytest-subtesthack setuptools_scm ] ++ [ glibcLocales ];
+  buildInputs = with pythonPackages; [ setuptools_scm ];
+
+  checkInputs = with pythonPackages; [ hypothesis pytest pytest-localserver pytest-subtesthack ] ++ [ glibcLocales ];
+
+  postPatch = ''
+    sed -i "/cargo build/d" Makefile
+  '';
+
+  preBuild = ''
+    mkdir -p rust/target/release
+    ln -s ${native}/lib/libvdirsyncer_rustext* rust/target/release/
+    ln -s ${native}/include/vdirsyncer_rustext.h rust/target/
+  '';
 
   LC_ALL = "en_US.utf8";
 
+  preCheck = ''
+    ln -sf ../dist/tmpbuild/vdirsyncer/vdirsyncer/_native__lib.so vdirsyncer
+  '';
+
   checkPhase = ''
+    runHook preCheck
     make DETERMINISTIC_TESTS=true test
+    runHook postCheck
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9452,6 +9452,8 @@ in {
 
   micawber = callPackage ../development/python-modules/micawber { };
 
+  milksnake = callPackage ../development/python-modules/milksnake { };
+
   minimock = buildPythonPackage rec {
     version = "1.2.8";
     name = "minimock-${version}";


### PR DESCRIPTION
###### Motivation for this change
The new rust dependency kinda complicates things see https://github.com/NixOS/nixpkgs/issues/33050

@matthiasbeyer and @pbogdan  made the patch, I just created the PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

