### PR TITLE
Merge pull request #39062 from vaibhavsagar/bump-all-cabal-hashes

### DIFF
--- a/pkgs/data/misc/hackage/default.nix
+++ b/pkgs/data/misc/hackage/default.nix
@@ -1,6 +1,6 @@
 { fetchurl }:
 
 fetchurl {
-  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/30eca1c57b9358eff984ab93dbfd213d6b08706b.tar.gz";
-  sha256 = "0kd5y2jlydbr1jv2ckdpsn2ialbxk2aj19c8i0brzz0wwzirg7q5";
+  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/61de1110af16fa0645a8cc8bbaf4a9c6fca9d8e8.tar.gz";
+  sha256 = "0vwfm1imwcffyliaama572ksjgqmwxk48py0wgvgpi2vg08w7a12";
 }


### PR DESCRIPTION
all-cabal-hashes: bump to 2018-04-19T00:28:09Z
(cherry picked from commit eb0943feb08078e94b34e377af094fcf3a036330)

This allows us to use newer packages from Hackage.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

