### PR TITLE
Add nix-prefetch-github

### DIFF
--- a/pkgs/build-support/nix-prefetch-github/default.nix
+++ b/pkgs/build-support/nix-prefetch-github/default.nix
@@ -1,0 +1,30 @@
+{ python3
+, fetchFromGitHub
+, stdenv
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "nix-prefetch-github";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "seppeljordan";
+    repo = "nix-prefetch-github";
+    rev = "${version}";
+    sha256 = "1rinbv1q4q8m27ih6l81w1lsmwn6cz7q3iyjiycklywpi8684dh6";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    attrs
+    click
+    effect
+    jinja2
+    requests
+  ];
+  meta = with stdenv.lib; {
+    description = "Prefetch sources from github";
+    homepage = https://github.com/seppeljordan/nix-prefetch-github;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.seppeljordan ];
+  };
+}

--- a/pkgs/development/python-modules/effect/default.nix
+++ b/pkgs/development/python-modules/effect/default.nix
@@ -1,28 +1,32 @@
 { buildPythonPackage
 , fetchPypi
 , lib
-, attrs
 , six
+, attrs
+, pytest
+, testtools
 }:
-let
+buildPythonPackage rec {
+  version = "0.11.0";
+  pname = "effect";
 
-version = "0.11.0";
-pname = "effect";
-
-in
-buildPythonPackage {
-  inherit version pname;                      
   src = fetchPypi {
     inherit pname version;
     sha256 = "1q75w4magkqd8ggabhhzzxmxakpdnn0vdg7ygj89zdc9yl7561q6";
   };
+  checkInputs = [
+    pytest
+    testtools
+  ];
   propagatedBuildInputs = [
     six
     attrs
   ];
-  doCheck = false;
+  checkPhase = ''
+    pytest .
+  '';
   meta = with lib; {
-    description = "pure effects for Python";
+    description = "Pure effects for Python";
     homepage = https://github.com/python-effect/effect;
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/effect/default.nix
+++ b/pkgs/development/python-modules/effect/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, attrs
+, six
+}:
+let
+
+version = "0.11.0";
+pname = "effect";
+
+in
+buildPythonPackage {
+  inherit version pname;                      
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1q75w4magkqd8ggabhhzzxmxakpdnn0vdg7ygj89zdc9yl7561q6";
+  };
+  propagatedBuildInputs = [
+    six
+    attrs
+  ];
+  doCheck = false;
+  meta = with lib; {
+    description = "pure effects for Python";
+    homepage = https://github.com/python-effect/effect;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20838,6 +20838,8 @@ with pkgs;
 
   nix-pin = callPackage ../tools/package-management/nix-pin { };
 
+  nix-prefetch-github = callPackage ../build-support/nix-prefetch-github {};
+
   inherit (callPackages ../tools/package-management/nix-prefetch-scripts { })
     nix-prefetch-bzr
     nix-prefetch-cvs

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5180,6 +5180,7 @@ in {
     };
   };
 
+  effect = callPackage ../development/python-modules/effect {};
 
   elpy = buildPythonPackage rec {
     name = "elpy-${version}";


### PR DESCRIPTION
###### Motivation for this change
This PR adds an application to nixpkgs to "prefetch" sources from github.  For this purpose I also added a python package called "effect", because it is a dependency of "nix-prefetch-github"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

