### PR TITLE
ocamlPackages.findlib: 1.7.3 -> 1.8.0

### DIFF
--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -1,22 +1,33 @@
 { stdenv, fetchurl, fetchpatch, m4, ncurses, ocaml, writeText }:
 
+let param =
+  if stdenv.lib.versionAtLeast ocaml.version "4"
+  then {
+    version = "1.8.0";
+    sha256 = "1b97zqjdriqd2ikgh4rmqajgxwdwn013riji5j53y3xvcmnpsyrb";
+  } else {
+    version = "1.7.3";
+    sha256 = "12xx8si1qv3xz90qsrpazjjk4lc1989fzm97rsmc4diwla7n15ni";
+    patches = [ (fetchpatch {
+      url = "https://raw.githubusercontent.com/ocaml/opam-repository/1f29c5ef8eccd373e5ff2169a30bfd95a9ae6050/packages/ocamlfind/ocamlfind.1.7.3-1/files/threads.patch";
+      sha256 = "0cqgpjqpmfbr0ph3jr25gw8hgckj4qlfwmir6vkgi5hvn2qnjpx3";
+    }) ];
+  };
+in
+
 stdenv.mkDerivation rec {
   name = "ocaml-findlib-${version}";
-  version = "1.7.3";
+  inherit (param) version;
 
   src = fetchurl {
     url = "http://download.camlcity.org/download/findlib-${version}.tar.gz";
-    sha256 = "12xx8si1qv3xz90qsrpazjjk4lc1989fzm97rsmc4diwla7n15ni";
+    inherit (param) sha256;
   };
 
   buildInputs = [m4 ncurses ocaml];
 
-  patches = [ ./ldconf.patch ./install_topfind.patch
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/ocaml/opam-repository/1f29c5ef8eccd373e5ff2169a30bfd95a9ae6050/packages/ocamlfind/ocamlfind.1.7.3-1/files/threads.patch";
-      sha256 = "0cqgpjqpmfbr0ph3jr25gw8hgckj4qlfwmir6vkgi5hvn2qnjpx3";
-    })
-  ];
+  patches = [ ./ldconf.patch ./install_topfind.patch ]
+  ++ (param.patches or []);
 
   dontAddPrefix=true;
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with next release of OCaml (4.07).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

