### PR TITLE
python: get rid of pytest-sugar in checkInputs

### DIFF
--- a/pkgs/development/python-modules/cheroot/default.nix
+++ b/pkgs/development/python-modules/cheroot/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchPypi, buildPythonPackage
 , more-itertools, six
-, coverage, codecov, pytest, pytestcov, pytest-sugar, portend
+, pytest, pytestcov, portend
 , backports_unittest-mock, setuptools_scm }:
 
 buildPythonPackage rec {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   buildInputs = [ setuptools_scm ];
 
-  checkInputs = [ coverage codecov pytest pytestcov pytest-sugar portend backports_unittest-mock  ];
+  checkInputs = [ pytest pytestcov portend backports_unittest-mock ];
 
   checkPhase = ''
     py.test cheroot

--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -1,11 +1,10 @@
 { lib, buildPythonPackage, fetchPypi
 , cheroot, portend, routes, six
 , setuptools_scm
-, backports_unittest-mock, codecov, coverage, objgraph, pathpy, pytest, pytest-sugar, pytestcov
+, backports_unittest-mock, objgraph, pathpy, pytest, pytestcov
 }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "CherryPy";
   version = "14.0.1";
 
@@ -18,7 +17,7 @@ buildPythonPackage rec {
 
   buildInputs = [ setuptools_scm ];
 
-  checkInputs = [ backports_unittest-mock codecov coverage objgraph pathpy pytest pytest-sugar pytestcov ];
+  checkInputs = [ backports_unittest-mock objgraph pathpy pytest pytestcov ];
 
   checkPhase = ''
     LANG=en_US.UTF-8 pytest

--- a/pkgs/development/python-modules/portend/default.nix
+++ b/pkgs/development/python-modules/portend/default.nix
@@ -1,19 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest, pytest-sugar, pytest-warnings, setuptools_scm
-, tempora }:
+, pytest, setuptools_scm, tempora }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "portend";
   version = "2.2";
-
-  buildInputs = [ pytest pytest-sugar pytest-warnings setuptools_scm ];
-  propagatedBuildInputs = [ tempora ];
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "bc48d3d99e1eaf2e9406c729f8848bfdaf87876cd3560dc3ec6c16714f529586";
   };
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [ tempora ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
 
   meta = with stdenv.lib; {
     description = "Monitor TCP ports for bound or unbound states";

--- a/pkgs/development/python-modules/pytest-sugar/default.nix
+++ b/pkgs/development/python-modules/pytest-sugar/default.nix
@@ -19,5 +19,9 @@ buildPythonPackage rec {
     description = "A plugin that changes the default look and feel of py.test";
     homepage = https://github.com/Frozenball/pytest-sugar;
     license = licenses.bsd3;
+
+    # incompatible with pytest 3.5
+    # https://github.com/Frozenball/pytest-sugar/issues/134
+    broken = true; # 2018-04-20
   };
 }


### PR DESCRIPTION
###### Motivation for this change
closes #39178 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

