### PR TITLE
vulnix: 1.4.0 -> 1.6.1

### DIFF
--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, pythonPackages, fetchurl, callPackage, nix }:
+{ stdenv, pythonPackages, fetchurl, callPackage, nix, ronn }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "${pname}-${version}";
   pname = "vulnix";
-  version = "1.4.0";
+  version = "1.6.1";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "19kfqxlrigrgwn74x06m70ar2fhyhic5kfmdanjwjcbaxblha3l8";
+    sha256 = "0j6v6phq3naqnpvzxxnynsyv9y7bhig1gzvg594qpknqgyzj16bf";
   };
 
-  buildInputs = with pythonPackages; [ flake8 pytest pytestcov ];
+  buildInputs =
+    [ ronn ] ++
+    (with pythonPackages; [ freezegun pytest pytestcov ]);
 
   propagatedBuildInputs = [
     nix
@@ -20,14 +21,31 @@ pythonPackages.buildPythonApplication rec {
     lxml
     pyyaml
     requests
+    toml
     zodb
   ]);
 
-  postPatch = ''
-    sed -i -e 's/==\([^=]\+\)/>=\1/g' setup.py
+  outputs = [ "out" "doc" ];
+
+  # pytest-flake8 is currently broken
+  # re-enable after it has been fixed
+  # https://github.com/NixOS/nixpkgs/issues/39206
+  patches = [ ./disable-flake8.patch ];
+
+  postBuild = ''
+    make -C doc
   '';
 
-  checkPhase = "py.test";
+  checkPhase = "py.test src/vulnix";
+
+  postInstall = ''
+    install -D -t $out/share/man/man1 doc/vulnix.1
+    install -D -t $out/share/man/man5 doc/vulnix-whitelist.5
+    install -D -t $doc/share/doc/vulnix README.rst CHANGES.rst
+    gzip $doc/share/doc/vulnix/*.rst
+  '';
+
+  dontStrip = true;
 
   meta = with stdenv.lib; {
     description = "NixOS vulnerability scanner";

--- a/pkgs/tools/security/vulnix/disable-flake8.patch
+++ b/pkgs/tools/security/vulnix/disable-flake8.patch
@@ -1,0 +1,23 @@
+diff --git a/setup.cfg b/setup.cfg
+index a9e37ce..41b9886 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -1,5 +1,5 @@
+ [tool:pytest]
+-addopts = --flake8 --tb=native --cov=src --cov-report=html --junitxml=report.xml -m 'not jenkinsonly' src/vulnix
++addopts = --tb=native --cov=src --cov-report=html --junitxml=report.xml -m 'not jenkinsonly' src/vulnix
+ markers = slow: This is a non-unit test and thus is not run by default. Use ``-m slow`` to run these, or ``-m 1`` to run all tests.
+ 
+ [aliases]
+diff --git a/setup.py b/setup.py
+index a9315e5..d14ad59 100644
+--- a/setup.py
++++ b/setup.py
+@@ -35,7 +35,6 @@ setup(
+             'freezegun>0.3',
+             'pytest>=3.2',
+             'pytest-cov>=2.5',
+-            'pytest-flake8',
+             'pytest-runner>=2.11,<3dev',
+             'pytest-timeout>=1.2',
+             'setuptools_scm>=1.15',


### PR DESCRIPTION
###### Motivation for this change

Update to current vulnix which features greatly improved whitelist handling among others.

- Temporarly disable flake8 until #39206 is solved.
- Split docs into own output.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions: Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
