### PR TITLE
Enable language-puppet again

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6374,7 +6374,7 @@ dont-distribute-packages:
   language-oberon:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-objc:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-pig:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  language-puppet:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  language-puppet:                              [ i686-linux ]
   language-python-colour:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-python-test:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-python:                              [ i686-linux, x86_64-linux, x86_64-darwin ]

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6374,7 +6374,7 @@ dont-distribute-packages:
   language-oberon:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-objc:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-pig:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  language-puppet:                              [ i686-linux ]
+  language-puppet:                              [ i686-linux, x86_64-darwin ]
   language-python-colour:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-python-test:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-python:                              [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
The latest version of `language-puppet` now works with the latest `lts-11`:
https://www.stackage.org/lts-11.5/package/language-puppet-1.3.17

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

