### PR TITLE
openssl: enable parallel building

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -71,8 +71,7 @@ let
 
     makeFlags = [ "MANDIR=$(man)/share/man" ];
 
-    # Parallel building is broken in OpenSSL.
-    enableParallelBuilding = false;
+    enableParallelBuilding = true;
 
     postInstall = ''
       # If we're building dynamic libraries, then don't install static


### PR DESCRIPTION
There is no improvement for the build duration of openssl 1.0
but the one of openssl 1.1 is reduced significantly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
/cc @dtzWill @edolstra 
