### PR TITLE
cloud-init: reduce closure size

### DIFF
--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -1,4 +1,4 @@
-{ lib, pythonPackages, fetchurl, kmod, systemd, cloud-utils }:
+{ lib, pythonPackages, fetchurl, kmod, systemd, e2fsprogs }:
 
 let version = "0.7.9";
 
@@ -22,7 +22,7 @@ in pythonPackages.buildPythonApplication rec {
       --replace 'self.init_system = ""' 'self.init_system = "systemd"'
 
     substituteInPlace cloudinit/config/cc_growpart.py \
-      --replace 'util.subp(["growpart"' 'util.subp(["${cloud-utils}/bin/growpart"'
+      --replace 'util.subp(["growpart"' 'util.subp(["${e2fsprogs}/bin/growpart"'
 
     # Argparse is part of python stdlib
     sed -i s/argparse// requirements.txt


### PR DESCRIPTION
We replace cloud-utils by e2fsprog since we only use growpart while
cloud-utils brings also qemu (and more).

###### Motivation for this change
Just to reduce the closure size. See #39076 

###### Things done
`nix-build nixos/tests/cloud-init.nix` passed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

