### PR TITLE
vim: idiomatic nix filetype plugin

### DIFF
--- a/pkgs/applications/editors/vim/ft-nix-support.patch
+++ b/pkgs/applications/editors/vim/ft-nix-support.patch
@@ -92,5 +92,5 @@ new file mode 100644
 +let b:did_ftplugin = 1
 +
 +" coding conventions
-+setlocal shiftwidth=2 expandtab
-+let b:undo_ftplugin = "setlocal sw< et<"
++setlocal shiftwidth=2 expandtab softtabstop=2
++let b:undo_ftplugin = "setlocal sw< et< sts<"

--- a/pkgs/applications/editors/vim/ft-nix-support.patch
+++ b/pkgs/applications/editors/vim/ft-nix-support.patch
@@ -85,5 +85,12 @@ new file mode 100644
 --- /dev/null
 +++ b/runtime/ftplugin/nix.vim
 @@ -0,0 +1,2 @@
++" Only do this when not done yet for this buffer
++if exists("b:did_ftplugin")
++  finish
++endif
++let b:did_ftplugin = 1
++
 +" coding conventions
-+setlocal sw=2 ts=2 expandtab
++setlocal shiftwidth=2 expandtab
++let b:undo_ftplugin = "setlocal sw< et<"


### PR DESCRIPTION
* Never modify tabstop. This causes incompatibilities with other utilities (including other editors) that expect tabs to always be 8 spaces.
* Add standard boilerplate for system-level filetype plugins.

###### Motivation for this change

Existing plugin causing unexpected behavior

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

