### PR TITLE
remove deprecated 2bwm alias

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -25,7 +25,6 @@ in
 
 mapAliases (rec {
   _2048-in-terminal = "2048-in-terminal"; # added 2017-01-16
-  _2bwm = "2bwm"; # added 2017-01-16
   _389-ds-base = "389-ds-base"; # added 2017-01-16
   _90secondportraits = "90secondsportraits"; # added 2017-01-16
   accounts-qt = libsForQt5.accounts-qt; # added 2015-12-19


### PR DESCRIPTION
###### Motivation for this change

Get 2bwm to run again.