### PR TITLE
aliases: remove broken digit aliases

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -24,10 +24,6 @@ in
   ### Deprecated aliases - for backward compatibility
 
 mapAliases (rec {
-  _2048-in-terminal = "2048-in-terminal"; # added 2017-01-16
-  _2bwm = "2bwm"; # added 2017-01-16
-  _389-ds-base = "389-ds-base"; # added 2017-01-16
-  _90secondportraits = "90secondsportraits"; # added 2017-01-16
   accounts-qt = libsForQt5.accounts-qt; # added 2015-12-19
   adobeReader = adobe-reader; # added 2013-11-04
   aircrackng = aircrack-ng; # added 2016-01-14


### PR DESCRIPTION
###### Motivation for this change

these aliases seem to be broken.
