### PR TITLE
simp_le: drop upper bound of acme requirement

### DIFF
--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -10,6 +10,8 @@ pythonPackages.buildPythonApplication rec {
   };
 
   postPatch = ''
+    # drop upper bound of acme requirement
+    sed -ri "s/'(acme>=[^,]+),<[^']+'/'\1'/" setup.py
     substituteInPlace simp_le.py \
       --replace "/bin/sh" "${bash}/bin/sh"
   '';


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/38744#issuecomment-383123807

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @gebner @makefu @matthewbauer 