### PR TITLE
atlassian-cli: init at 7.8.0

### DIFF
--- a/pkgs/applications/office/atlassian-cli/default.nix
+++ b/pkgs/applications/office/atlassian-cli/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchzip, jre }:
+stdenv.mkDerivation {
+  name = "atlassian-cli";
+  version = "7.8.0";
+  src = fetchzip {
+    url            = https://bobswift.atlassian.net/wiki/download/attachments/16285777/atlassian-cli-7.8.0-distribution.zip;
+    sha256         = "111s4d9m6vxq8jwh1d6ar1f4n5zmyjg7gi2vl3aq63kxbfld9vw7";
+    extraPostFetch = "chmod go-w $out";
+  };
+  tools = [ "agile" "bamboo" "bitbucket" "confluence" "csv"
+    "hipchat" "jira" "servicedesk" "structure" "tempo" "trello" "upm" ];
+  installPhase = ''
+    mkdir -p $out/{bin,share/doc/atlassian-cli}
+    cp -r lib $out/share/java
+    cp -r README.txt license $out/share/doc/atlassian-cli
+    for tool in $tools
+    do
+      substitute ${./wrapper.sh} $out/bin/$tool \
+        --subst-var out \
+        --subst-var-by jre ${jre} \
+        --subst-var-by tool $tool
+      chmod +x $out/bin/$tool
+    done
+  '';
+  meta = with stdenv.lib; {
+    description = "An integrated family of CLI’s for various Atlassian applications";
+    homepage    = https://bobswift.atlassian.net/wiki/spaces/ACLI/overview;
+    maintainers = [ maintainers.twey ];
+    license     = [ licenses.unfreeRedistributable ];
+  };
+}

--- a/pkgs/applications/office/atlassian-cli/wrapper.sh
+++ b/pkgs/applications/office/atlassian-cli/wrapper.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+tool=@tool@
+user=ATLASSIAN_${tool^^}_USER
+host=ATLASSIAN_${tool^^}_HOST
+pass=ATLASSIAN_${tool^^}_PASS
+
+[ -f ~/.atlassian-cli ] && source ~/.atlassian-cli
+if [ x = ${!user-x} ] || [ x = ${!host-x} ] || [ x = ${!pass-x} ]
+then
+    >&2 echo please define $user, $host, and $pass in '~/.atlassian-cli'
+    exit 1
+fi
+
+@jre@/bin/java \
+    -jar @out@/share/java/@tool@-cli-* \
+    --server "${!host}" \
+    --user "${!user}" \
+    --password "${!pass}" \
+    "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14766,6 +14766,8 @@ with pkgs;
 
   artha = callPackage ../applications/misc/artha { };
 
+  atlassian-cli = callPackage ../applications/office/atlassian-cli { };
+
   atomEnv = callPackage ../applications/editors/atom/env.nix {
     gconf = gnome2.GConf;
   };


### PR DESCRIPTION
###### Motivation for this change
Packages up Bob Swift's Atlassian CLI (non-free, redistributable) for automation of Atlassian services.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

