### PR TITLE
gnushogi: init at 1.4.2

### DIFF
--- a/pkgs/games/gnushogi/default.nix
+++ b/pkgs/games/gnushogi/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "gnushogi-${version}";
+  version = "1.4.2";
+  buildInputs = [ zlib ];
+
+  src = fetchurl {
+    url = "mirror://gnu/gnushogi/${name}.tar.gz";
+    sha256 = "0a9bsl2nbnb138lq0h14jfc5xvz7hpb2bcsj4mjn6g1hcsl4ik0y";
+  };
+
+  meta = with stdenv.lib; {
+    description = "GNU implementation of Shogi, also known as Japanese Chess";
+    homepage = https://www.gnu.org/software/gnushogi/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.ciil ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19077,6 +19077,8 @@ with pkgs;
 
   gnujump = callPackage ../games/gnujump { };
 
+  gnushogi = callPackage ../games/gnushogi { };
+
   gogui = callPackage ../games/gogui {};
 
   gtetrinet = callPackage ../games/gtetrinet {


### PR DESCRIPTION
###### Motivation for this change
add cli gnushogi game to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

