### PR TITLE
matrix-synapse: 0.27.2 -> 0.27.4

### DIFF
--- a/pkgs/development/python-modules/canonicaljson/default.nix
+++ b/pkgs/development/python-modules/canonicaljson/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, frozendict, simplejson, six
+}:
+
+buildPythonPackage rec {
+  pname = "canonicaljson";
+  version = "1.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1q50zk9a0r7kd56rdf9cgyxxj7vy54j96sgh8vc8jhmsvdv8dzh6";
+  };
+
+  propagatedBuildInputs = [
+    frozendict simplejson six
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/matrix-org/python-canonicaljson;
+    description = "Encodes objects and arrays as RFC 7159 JSON.";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "frozendict";
+  version = "1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ibf1wipidz57giy53dh7mh68f2hz38x8f4wdq88mvxj5pr7jhbp";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/slezica/python-frozendict;
+    description = "An immutable dictionary";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -9,6 +9,9 @@ buildPythonPackage rec {
     sha256 = "0ibf1wipidz57giy53dh7mh68f2hz38x8f4wdq88mvxj5pr7jhbp";
   };
 
+  # frozendict does not come with tests
+  doCheck = false;
+
   meta = with stdenv.lib; {
     homepage = https://github.com/slezica/python-frozendict;
     description = "An immutable dictionary";

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -26,13 +26,13 @@ let
   };
 in pythonPackages.buildPythonApplication rec {
   name = "matrix-synapse-${version}";
-  version = "0.27.2";
+  version = "0.27.4";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse";
     rev = "v${version}";
-    sha256 = "00hcjs5hbayamckcsfd92s7f3da9jv5nm5ygvwinyc7ml7gn66i3";
+    sha256 = "051bwr4vz8mwglh1m9rqlljbn8g3alvd52f09ff887nsi6z3jc17";
   };
 
   patches = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2558,11 +2558,11 @@ in {
   fritzconnection = callPackage ../development/python-modules/fritzconnection { };
 
   frozendict = buildPythonPackage rec {
-    name = "frozendict-0.5";
+    name = "frozendict-1.2";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/f/frozendict/${name}.tar.gz";
-      sha256 = "0m4kg6hbadvf99if78nx01q7qnbyhdw3x4znl5dasgciyi54432n";
+      sha256 = "0ibf1wipidz57giy53dh7mh68f2hz38x8f4wdq88mvxj5pr7jhbp";
     };
 
     meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16638,20 +16638,7 @@ EOF
     };
   };
 
-  canonicaljson = buildPythonPackage rec {
-    name = "canonicaljson-${version}";
-    version = "1.1.3";
-
-    src = pkgs.fetchgit {
-      url = "https://github.com/matrix-org/python-canonicaljson.git";
-      rev = "refs/tags/v${version}";
-      sha256 = "11j0xmbw2hbl789pyfga02w8aa3s8rkc8pk6501r1sfy8xljd8zy";
-    };
-
-    propagatedBuildInputs = with self; [
-      frozendict simplejson six
-    ];
-  };
+  canonicaljson = callPackage ../development/python-modules/canonicaljson { };
 
   daemonize = buildPythonPackage rec {
     name = "daemonize-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16640,16 +16640,16 @@ EOF
 
   canonicaljson = buildPythonPackage rec {
     name = "canonicaljson-${version}";
-    version = "1.0.0";
+    version = "1.1.3";
 
     src = pkgs.fetchgit {
       url = "https://github.com/matrix-org/python-canonicaljson.git";
       rev = "refs/tags/v${version}";
-      sha256 = "0r82zlip93y169ijkn8xpbp0yr22mf92pni6dw420vb53l27sprq";
+      sha256 = "11j0xmbw2hbl789pyfga02w8aa3s8rkc8pk6501r1sfy8xljd8zy";
     };
 
     propagatedBuildInputs = with self; [
-      frozendict simplejson
+      frozendict simplejson six
     ];
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2557,20 +2557,7 @@ in {
 
   fritzconnection = callPackage ../development/python-modules/fritzconnection { };
 
-  frozendict = buildPythonPackage rec {
-    name = "frozendict-1.2";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/f/frozendict/${name}.tar.gz";
-      sha256 = "0ibf1wipidz57giy53dh7mh68f2hz38x8f4wdq88mvxj5pr7jhbp";
-    };
-
-    meta = {
-      homepage = https://github.com/slezica/python-frozendict;
-      description = "An immutable dictionary";
-      license = stdenv.lib.licenses.mit;
-    };
-  };
+  frozendict = callPackage ../development/python-modules/frozendict { };
 
   ftputil = callPackage ../development/python-modules/ftputil { };
 


### PR DESCRIPTION
###### Motivation for this change
together with required dependency version bumps.

Mainly brings performance improvements and some bugfixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

