### PR TITLE
nixos: sign kernel modules; add security.enforceModuleSignature option

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -319,6 +319,7 @@ in rec {
   tests.kernel-copperhead = callTest tests/kernel-copperhead.nix {};
   tests.kernel-latest = callTest tests/kernel-latest.nix {};
   tests.kernel-lts = callTest tests/kernel-lts.nix {};
+  tests.kernel-signed-modules = callTest tests/kernel-signed-modules.nix {};
   tests.kubernetes.dns = callSubTestsOnMatchingSystems ["x86_64-linux"] tests/kubernetes/dns.nix {};
   ## kubernetes.e2e should eventually replace kubernetes.rbac when it works
   #tests.kubernetes.e2e = callSubTestsOnMatchingSystems ["x86_64-linux"] tests/kubernetes/e2e.nix {};

--- a/nixos/tests/kernel-signed-modules.nix
+++ b/nixos/tests/kernel-signed-modules.nix
@@ -1,0 +1,23 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "kernel-signed-modules";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ symphorien ];
+  };
+
+  machine = { config, pkgs, ... }: {
+    boot.initrd.kernelModules = ["zram"];
+    security.enforceModuleSignature = true;
+    environment.systemPackages = [ pkgs.kmod pkgs.tree pkgs.xz pkgs.binutils ];
+  };
+
+  testScript = ''
+    # check that modules copied to the initrd work
+    print $machine->succeed("lsmod");
+    print $machine->succeed("lsmod | grep zram");
+    # check we can load modules now
+    print $machine->succeed("modprobe bonding");
+    # check we cannot load an unsigned module
+    print $machine->succeed("cp /run/current-system/kernel-modules/lib/modules/*/kernel/block/bfq.ko.xz /tmp && unxz /tmp/bfq.ko.xz && strip --strip-debug /tmp/bfq.ko");
+    print $machine->fail("insmod /tmp/bfq.ko");
+  '';
+})

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -345,6 +345,8 @@ with stdenv.lib;
   NLS_ISO8859_1 m    # VFAT default for the iocharset= mount option
 
   # Runtime security tests
+  MODULE_SIG y
+  MODULE_SIG_ALL y # sign modules automatically
   ${optionalString (versionOlder version "4.11") ''
     DEBUG_SET_MODULE_RONX? y # Detect writes to read-only module pages
   ''}

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -158,6 +158,9 @@ let
                           if platform.kernelTarget == "zImage" || platform.kernelTarget == "Image.gz" then "zinstall" else
                           "install") ];
 
+      # don't strip signatures off modules; anyway strip is a noop when compression is enabled.
+      dontStrip = true;
+
       postInstall = (optionalString installsFirmware ''
         mkdir -p $out/lib/firmware
       '') + (if (platform ? kernelDTB && platform.kernelDTB) then ''


### PR DESCRIPTION
This enables the following kernel options:

MODULE_SIG: when a module is loaded, a signature is checked. If it is
not present or invalid, then:
* if the kernel booted with module.sig_enforce (which is the consequence
of setting `security.enforceModuleSignature=true`) then the module is
rejected
* otherwise the kernel is just tainted.

MODULE_SIG_ALL: when building the kernel, a key is created and modules
are automatically signed with it. When the build is finished, we cannot
persist the key since this would put it world readable in the store so
it is just dropped. As a consequence, *only upstream kernel modules are
signed*. Third party modules like zfs cannot be signed and cannot be
loaded with `security.enforceModuleSignature=true`.

A nixos test is provided to test that everything works as intended.

Reference:
https://www.kernel.org/doc/html/v4.10/admin-guide/module-signing.html

###### Motivation for this change
Enabling module signature

###### Alternative designs
require the users to create themselves a key and point us to it in their configuration so that out of tree
modules can be signed
This would be way more complicated, just for the sake of out-of-tree modules users.

Note that tainting the kernel just for having loaded an unsigned module even for users who don't care about this feature is not a drawback since loading an out-of-tree module already entails tainting the kernel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Only tested with 4.14 because building a full kernel is quite long, but the feature exists since 4.3 in this
form, so this should be fine. Anyway, there is a test.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---

