### PR TITLE
asciidoctor: remove mathematical from wrapper, fixes #39098

### DIFF
--- a/pkgs/tools/typesetting/asciidoctor/default.nix
+++ b/pkgs/tools/typesetting/asciidoctor/default.nix
@@ -15,7 +15,6 @@ bundlerApp {
     "asciidoctor-latex"
     "asciidoctor-pdf"
     "asciidoctor-safe"
-    "asciidoctor-mathematical"
   ];
 
   gemConfig = {


### PR DESCRIPTION
because it does not exist in the original derivation, breaking
installation with `nix-env`. Should asciidoctor-mathematical exist?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

