### PR TITLE
nano-wallet: init at 12.1

### DIFF
--- a/pkgs/applications/altcoins/nano-wallet/CMakeLists.txt.patch
+++ b/pkgs/applications/altcoins/nano-wallet/CMakeLists.txt.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b43f02f6..4470abbf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,7 +119,7 @@ endif (RAIBLOCKS_SECURE_RPC)
+ 
+ include_directories (${CMAKE_SOURCE_DIR})
+ 
+-set(Boost_USE_STATIC_LIBS        ON)
++add_definitions(-DBOOST_LOG_DYN_LINK)
+ set(Boost_USE_MULTITHREADED      ON)
+ 
+ if (BOOST_CUSTOM)

--- a/pkgs/applications/altcoins/nano-wallet/default.nix
+++ b/pkgs/applications/altcoins/nano-wallet/default.nix
@@ -1,0 +1,57 @@
+{lib, pkgs, stdenv, fetchFromGitHub, cmake, pkgconfig, boost, libGL, qtbase}:
+
+stdenv.mkDerivation rec {
+
+  name = "nano-wallet-${version}";
+  version = "12.1";
+
+  src = fetchFromGitHub {
+    owner = "nanocurrency";
+    repo = "raiblocks";
+    rev = "V${version}";
+    sha256 = "10ng7qn6y31s2bjahmpivw2plx90ljjjzb87j3l7zmppsjd2iq03";
+    fetchSubmodules = true;
+  };
+
+  # Use a patch to force dynamic linking
+  patches = [
+    ./CMakeLists.txt.patch
+  ];
+
+  cmakeFlags = let
+    options = {
+      BOOST_ROOT = "${boost}";
+      Boost_USE_STATIC_LIBS = "OFF";
+      RAIBLOCKS_GUI = "ON";
+      RAIBLOCKS_TEST = "ON";
+      Qt5_DIR = "${qtbase.dev}/lib/cmake/Qt5";
+      Qt5Core_DIR = "${qtbase.dev}/lib/cmake/Qt5Core";
+      Qt5Gui_INCLUDE_DIRS = "${qtbase.dev}/include/QtGui";
+      Qt5Widgets_INCLUDE_DIRS = "${qtbase.dev}/include/QtWidgets";
+    };
+    optionToFlag = name: value: "-D${name}=${value}";
+  in lib.mapAttrsToList optionToFlag options;
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ boost libGL qtbase ];
+
+  buildPhase = ''
+    make nano_wallet
+  '';
+
+  checkPhase = ''
+    ./core_test
+  '';
+
+  meta = {
+    inherit version;
+    description = "Wallet for Nano cryptocurrency";
+    homepage = https://nano.org/en/wallet/;
+    license = lib.licenses.bsd2;
+    # Fails on Darwin. See:
+    # https://github.com/NixOS/nixpkgs/pull/39295#issuecomment-386800962
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jluttine ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3846,6 +3846,8 @@ with pkgs;
 
   namazu = callPackage ../tools/text/namazu { };
 
+  nano-wallet = libsForQt5.callPackage ../applications/altcoins/nano-wallet { };
+
   nasty = callPackage ../tools/security/nasty { };
 
   nat-traverse = callPackage ../tools/networking/nat-traverse { };


### PR DESCRIPTION
###### Motivation for this change

~~**NOTE: This is work in progress. Hope to get some help and feedback here.**~~

**Ready to merge now**

This is a wallet for the Nano cryptocurrency (previously known as Raiblocks).
- https://nano.org/en/wallet/
- https://github.com/nanocurrency/raiblocks


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

