### PR TITLE
nixos/tests/gnome3-gdm: fix broken test

### DIFF
--- a/nixos/tests/gnome3-gdm.nix
+++ b/nixos/tests/gnome3-gdm.nix
@@ -26,15 +26,22 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
+      # wait for gdm to start and bring up X
+      $machine->waitForUnit("display-manager.service");
       $machine->waitForX;
-      $machine->sleep(15);
+
+      # wait for alice to be logged in
+      $machine->waitForUnit("default.target","alice");
 
       # Check that logging in has given the user ownership of devices.
       $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
 
-      $machine->succeed("su - alice -c 'DISPLAY=:0.0 gnome-terminal &'");
-      $machine->succeed("xauth merge ~alice/.Xauthority");
+      # open a terminal and check it's there
+      $machine->succeed("su - alice -c 'DISPLAY=:0.0 XAUTHORITY=/run/user/\$UID/gdm/Xauthority gnome-terminal'");
+      $machine->succeed("xauth merge /run/user/1000/gdm/Xauthority");
       $machine->waitForWindow(qr/Terminal/);
+
+      # wait to get a nice screenshot
       $machine->sleep(20);
       $machine->screenshot("screen");
     '';


### PR DESCRIPTION
###### Motivation for this change

`nixos.tests.gnome3-gdm` failed due to bugs in the test case.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

