### PR TITLE
jbake: wrap script

### DIFF
--- a/pkgs/development/tools/jbake/default.nix
+++ b/pkgs/development/tools/jbake/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, jre }:
+{ stdenv, fetchzip, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
   version = "2.6.1";
@@ -9,12 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "0zlh2azmv8gj3c4d4ndivar31wd42nmvhxq6xhn09cib9kffxbc7";
   };
 
-  buildInputs = [ jre ];
+  buildInputs = [ makeWrapper jre ];
 
   installPhase = ''
-    substituteInPlace bin/jbake --replace "java" "${jre}/bin/java" 
     mkdir -p $out
     cp -vr * $out
+    wrapProgram $out/bin/jbake --set JAVA_HOME "${jre}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Upstream script now uses JAVA_HOME. This change wraps the script so JAVA_HOME is set.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

