### PR TITLE
home-assistant: add a few knobs and make config YAML

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -5,7 +5,9 @@ with lib;
 let
   cfg = config.services.home-assistant;
 
-  configFile = pkgs.writeText "configuration.yaml" (builtins.toJSON cfg.config);
+  configFile = pkgs.writeText "configuration.json" (builtins.toJSON (if cfg.applyDefaultConfig
+    then (lib.recursiveUpdate defaultConfig (if (isNull cfg.config) then {} else cfg.config))
+    else cfg.config));
 
   availableComponents = pkgs.home-assistant.availableComponents;
 
@@ -38,6 +40,12 @@ let
     then (cfg.package.override { inherit extraComponents; })
     else cfg.package;
 
+  # If you are changing this, please update the description in applyDefaultConfig
+  defaultConfig = {
+    homeassistant.time_zone = config.time.timeZone;
+    http.server_port = (toString cfg.port);
+  };
+
 in {
   meta.maintainers = with maintainers; [ dotlambda ];
 
@@ -48,6 +56,26 @@ in {
       default = "/var/lib/hass";
       type = types.path;
       description = "The config directory, where your <filename>configuration.yaml</filename> is located.";
+    };
+
+    port = mkOption {
+      default = 8123;
+      type = types.int;
+      description = "The port on which to listen.";
+    };
+
+    applyDefaultConfig = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Setting this option enables a few configuration options for HA based on NixOS configuration (such as time zone) to avoid having to manually specify configuration we already have.
+        </para>
+        <para>
+        Currently one side effect of enabling this is that the <literal>http</literal> component will be enabled.
+        </para>
+        <para>
+        This only takes effect if <literal>config != null</literal> in order to ensure that a manually managed <filename>configuration.yaml</filename> is not overwritten.
+      '';
     };
 
     config = mkOption {
@@ -110,15 +138,14 @@ in {
         ln -s ${configFile} ${cfg.configDir}/configuration.yaml
       '';
       serviceConfig = {
-        ExecStart = ''
-          ${package}/bin/hass --config "${cfg.configDir}"
-        '';
+        ExecStart = "${package}/bin/hass --config '${cfg.configDir}'";
         User = "hass";
         Group = "hass";
         Restart = "on-failure";
         ProtectSystem = "strict";
         ReadWritePaths = "${cfg.configDir}";
         PrivateTmp = true;
+        RemoveIPC = true;
       };
       path = [
         "/run/wrappers" # needed for ping

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -5,9 +5,10 @@ with lib;
 let
   cfg = config.services.home-assistant;
 
-  configFile = pkgs.writeText "configuration.json" (builtins.toJSON (if cfg.applyDefaultConfig
-    then (lib.recursiveUpdate defaultConfig (if (isNull cfg.config) then {} else cfg.config))
-    else cfg.config));
+  # cfg.config != null can be assumed here
+  configFile = pkgs.writeText "configuration.json"
+    (builtins.toJSON (if cfg.applyDefaultConfig then
+    (lib.recursiveUpdate defaultConfig cfg.config) else cfg.config));
 
   availableComponents = pkgs.home-assistant.availableComponents;
 

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -134,8 +134,10 @@ in {
       description = "Home Assistant";
       after = [ "network.target" ];
       preStart = lib.optionalString (cfg.config != null) ''
-        rm -f ${cfg.configDir}/configuration.yaml
-        ln -s ${configFile} ${cfg.configDir}/configuration.yaml
+        config=${cfg.configDir}/configuration.yaml
+        rm -f $config
+        ${pkgs.remarshal}/bin/json2yaml -i ${configFile} -o $config
+        chmod 444 $config
       '';
       serviceConfig = {
         ExecStart = "${package}/bin/hass --config '${cfg.configDir}'";

--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -51,9 +51,9 @@ in {
     startAll;
     $hass->waitForUnit("home-assistant.service");
 
-    # Since config is specified using a Nix attribute set,
-    # configuration.yaml is a link to the Nix store
-    $hass->succeed("test -L ${configDir}/configuration.yaml");
+    # The config is specified using a Nix attribute set,
+    # but then converted from JSON to YAML
+    $hass->succeed("test -f ${configDir}/configuration.yaml");
 
     # Check that Home Assistant's web interface and API can be reached
     $hass->waitForOpenPort(8123);

--- a/pkgs/development/tools/remarshal/default.nix
+++ b/pkgs/development/tools/remarshal/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, python3Packages, fetchFromGitHub }:
 
-pythonPackages.buildPythonApplication rec {
-  name = "remarshal-${version}";
+python3Packages.buildPythonApplication rec {
+  pname = "remarshal";
   version = "0.7.0";
 
   src = fetchFromGitHub {
@@ -11,10 +11,8 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1wsgvzfp40lvly7nyyhv9prip4vi32rfc8kdji587jpw28zc1dfb";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
-    dateutil
-    pytoml
-    pyyaml
+  propagatedBuildInputs = with python3Packages; [
+    dateutil pytoml pyyaml
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

- Make port configurable so we can use it elsewhere (open in the firewall is one example).
- Additionally, some settings based on NixOS configuration is set via defaultConfig which is then merged with the user provided configuration. For now that just means http port and time zone but others can easily be added.
- Use remarshal to convert configuration to YAML. HA doesn't mind the configuration being JSON instead of YAML but since YAML is the official language, use that as it allows users to easily exchange config
data with other parties in the community.

Cc @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http:// nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

