### PR TITLE
monetdb: init at 11.29.3

### DIFF
--- a/pkgs/servers/sql/monetdb/default.nix
+++ b/pkgs/servers/sql/monetdb/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pkgconfig, bison, openssl }:
+
+let
+  version = "11.29.3";
+in stdenv.mkDerivation rec {
+
+  name = "monetdb-${version}";
+
+  src = fetchurl {
+    url = "https://dev.monetdb.org/downloads/sources/archive/MonetDB-${version}.tar.bz2";
+    sha256 = "18l4jkkryki5az5n7gnalfdxz6ibnkg3q2z4cwh1010b313wqi8s";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ bison openssl ];
+
+  meta = with stdenv.lib; {
+    description = "An open source database system";
+    homepage = https://www.monetdb.org/;
+    license = licenses.mpl20;
+    maintainers = [ maintainers.StillerHarpo ];
+  };
+}

--- a/pkgs/servers/sql/monetdb/default.nix
+++ b/pkgs/servers/sql/monetdb/default.nix
@@ -18,6 +18,7 @@ in stdenv.mkDerivation rec {
     description = "An open source database system";
     homepage = https://www.monetdb.org/;
     license = licenses.mpl20;
+    platforms = platforms.unix;
     maintainers = [ maintainers.StillerHarpo ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1318,6 +1318,8 @@ with pkgs;
 
   metabase = callPackage ../servers/metabase { };
 
+  monetdb = callPackage ../servers/sql/monetdb { };
+
   mp3blaster = callPackage ../applications/audio/mp3blaster { };
 
   mp3fs = callPackage ../tools/filesystems/mp3fs { };


### PR DESCRIPTION
###### Motivation for this change
New package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

