### PR TITLE
RFC: haskell: allow overriding all package sets at once

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -666,6 +666,56 @@ prefer one built with GHC 7.8.x in the first place. However, for users who
 cannot use GHC 7.10.x at all for some reason, the approach of downgrading to an
 older version might be useful.
 
+### How to override packages in all compiler-specific package sets
+
+In the previous section we learned how to override a package in a single
+compiler-specific package set. You may have some overrides defined that you want
+to use across multiple package sets. To accomplish this you could use the
+technique that we learned in the previous section by repeating the overrides for
+all the compiler-specific package sets. For example:
+
+```nix
+{
+  packageOverrides = super: let self = super.pkgs; in
+  {
+    haskell = super.haskell // {
+      packages = super.haskell.packages // {
+        ghc784 = super.haskell.packages.ghc784.override {
+          overrides = self: super: {
+            my-package = ...;
+            my-other-package = ...;
+          };
+        };
+        ghc822 = super.haskell.packages.ghc784.override {
+          overrides = self: super: {
+            my-package = ...;
+            my-other-package = ...;
+          };
+        };
+        ...
+      };
+    };
+  };
+}
+```
+
+However there's a more convenient way to override all compiler-specific package
+sets at once:
+
+```nix
+{
+  packageOverrides = super: let self = super.pkgs; in
+  {
+    haskell = super.haskell // {
+      packageOverrides = self: super: {
+        my-package = ...;
+        my-other-package = ...;
+      };
+    };
+  };
+}
+```
+
 ### How to recover from GHC's infamous non-deterministic library ID bug
 
 GHC and distributed build farms don't get along well:

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -19,7 +19,10 @@ let
     inherit pkgs;
   };
 
-  callPackage = newScope { inherit haskellLib; };
+  callPackage = newScope {
+    inherit haskellLib;
+    overrides = pkgs.haskell.packageOverrides;
+  };
 
   bootstrapPackageSet = self: super: {
     mkDerivation = drv: super.mkDerivation (drv // {
@@ -98,6 +101,9 @@ in rec {
       integerSimpleGhcNames
       (name: compiler."${name}".override { enableIntegerSimple = true; }));
   };
+
+  # Default overrides that are applied to all package sets.
+  packageOverrides = self : super : {};
 
   # Always get compilers from `buildPackages`
   packages = let bh = buildPackages.haskell; in {


### PR DESCRIPTION
CC @peti

###### Motivation for this change

I often have a bunch of overrides for local Haskell packages that I want to apply to all, or at least a bunch of, package sets at once. For example today I worked on `inline-c` and had to write the following `default.nix` in the `inline-c` repo:

```nix
{ nixpkgs ? import <nixpkgs> }:
let
  overlay = final : previous :
    let
      haskellOverrides = {
        overrides = self : super : with final.haskell.lib;
          let
            localHsPkg = name :
              let
                src = ./. + "/${name}";
                spec = super.haskellSrc2nix {
                  inherit name;
                  src = src + "/${name}.cabal";
                };
                drv = super.callPackage spec {};
              in overrideCabal drv (_drv: { inherit src; });
          in {
            inline-c     = localHsPkg "inline-c";
            inline-c-cpp = localHsPkg "inline-c-cpp";
          };
      };
    in {
      haskellPackages = previous.haskellPackages.override haskellOverrides;
      haskell = previous.haskell // {
        packages = previous.haskell.packages // {
          ghc822 = previous.haskell.packages.ghc822.override haskellOverrides;
          ghc841 = previous.haskell.packages.ghc841.override haskellOverrides;
          ghc842 = previous.haskell.packages.ghc842.override haskellOverrides;
        };
      };
    };
in nixpkgs { overlays = [ overlay ]; }
```

With the proposed change the last part can be simplified to:

```nix
{
  haskell = previous.haskell // {
    overrides = haskellOverrides;
  };
}
```

which will override all compiler-specific package sets using `haskellOverrides`.

An alternative design could be to make `overrides` an argument of `<nixpkgs/pkgs/top-level/haskell-packages.nix>` so that we can override `haskell` as follows:

```nix
{
  haskell = previous.haskell.override {
    overrides = haskellOverrides;
  };
}
```

I choose the former because it looks a bit simpler.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


