### PR TITLE
rdf4store: mark as broken

### DIFF
--- a/pkgs/servers/http/4store/default.nix
+++ b/pkgs/servers/http/4store/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     sed -e 's@#! */bin/bash@#! ${stdenv.shell}@' -i configure
     find . -name Makefile -exec sed -e "s@/usr/local@$out@g" -i '{}' ';'
 
-    rm src/utilities/4s-backend 
+    rm src/utilities/4s-backend
     sed -e 's@/var/lib/4store@${db_dir}@g' -i configure.ac src/utilities/*
     sed -e '/FS_STORE_ROOT/d' -i src/utilities/Makefile*
   '';
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     homepage = https://4store.danielknoell.de/;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
+    broken = true; # since 2018-04-11
   };
 }


### PR DESCRIPTION
###### Motivation for this change

cc @7c6f434c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

