### PR TITLE
hydra: fix run-time dependencies after latest CPAN update.

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -27,6 +27,7 @@ let
         CatalystViewDownload
         CatalystViewJSON
         CatalystViewTT
+        CatalystXRoleApplicator
         CatalystXScriptServerStarman
         CryptRandPasswd
         DBDPg
@@ -39,6 +40,7 @@ let
         FileSlurp
         IOCompress
         IPCRun
+        JSONAny
         JSONXS
         LWP
         LWPProtocolHttps


### PR DESCRIPTION
###### Motivation for this change

Since the last CPAN update, Hydra gives me the following error:

```
hydra# [   38.522286] hydra-server[1020]: Can't locate CatalystX/RoleApplicator.pm in @INC (you may need to install the CatalystX::RoleApplicator module) (@INC contains: /nix/store/yfhzsc7lpizxb76d9300sy9jawakk5j3-hydra-2017-11-21/libexec/hydra/lib /nix/store/9a33c872rlgda3zqf4x05izyl5jv2hr6-hydra-perl-deps/lib/perl5/site_perl/5.24.3/x86_64-linux-thread-multi /nix/store/9a33c872rlgda3zqf4x05izyl5jv2hr6-hydra-perl-deps/lib/perl5/site_perl/5.24.3 /nix/store/9a33c872rlgda3zqf4x05izyl5jv2hr6-hydra-perl-deps/lib/perl5/site_perl /nix/store/cxdmh98g0lvl1dyq304c1lq7f90dh01f-perl-5.24.3/lib/perl5/site_perl/5.24.3/x86_64-linux-thread-multi /nix/store/cxdmh98g0lvl1dyq304c1lq7f90dh01f-perl-5.24.3/lib/perl5/site_perl/5.24.3 /nix/store/cxdmh98g0lvl1dyq304c1lq7f90dh01f-perl-5.24.3/lib/perl5/site_perl /nix/store/cxdmh98g0lvl1dyq304c1lq7f90dh01f-perl-5.24.3/lib/perl5/5.24.3/x86_64-linux-thread-multi /nix/store/cxdmh98g0lvl1dyq304c1lq7f90dh01f-perl-5.24.3/lib/perl5/5.24.3 .) at /nix/store/yfhzsc7lpizxb76d9300sy9jawakk5j3-hydra-2017-11-21/libexec/hydra/lib/Hydra.pm line 22.
hydra# [   38.542486] hydra-server[1020]: BEGIN failed--compilation aborted at /nix/store/yfhzsc7lpizxb76d9300sy9jawakk5j3-hydra-2017-11-21/libexec/hydra/lib/Hydra.pm line 22.
hydra# [   38.548678] hydra-server[1020]: Compilation failed in require at /nix/store/9a33c872rlgda3zqf4x05izyl5jv2hr6-hydra-perl-deps/lib/perl5/site_perl/5.24.3/Catalyst/Utils.pm line 309.
hydra# [   38.555978] systemd[1]: hydra-server.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
hydra# [   38.558857] systemd[1]: hydra-server.service: Failed with result 'exit-code'.
```

Adding `CatalystXRoleApplicator` to the run-time dependencies fixes that error, but it then complains about `JSON::Any`, so I've fixed that here, as well.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
