### PR TITLE
Revamp Agda builder, add documentation

### DIFF
--- a/doc/languages-frameworks/agda.section.md
+++ b/doc/languages-frameworks/agda.section.md
@@ -1,0 +1,35 @@
+---
+title: Agda in Nixpkgs
+author: Langston Barrett (@siddharthist)
+date: 2018-04-21
+---
+# Agda
+
+Everything is exposed to the user via the `agda` attribute.
+
+## Installing the compiler (with libraries)
+
+If you just want a shell with Agda available, run
+```
+nix run nixpkgs.haskellPackages.Agda
+```
+If you want to install Agda in your user profile, run
+```
+nix-env -iA nixos.haskellPackages.Agda 
+```
+
+<!-- TODO: does the following work with `nix run`? If so, how? -->
+
+If you need certain libraries, you can use the function `withPackages`:
+```
+nix-shell -p "agda.withPackages [AgdaStdlib]"
+```
+For instance, if you're working on adding a new Agda library `myNewPackage` to
+nixpkgs, you can test it out by running
+```
+nix-shell -I nixpkgs=$PWD -p "agda.withPackages [myNewPackage]"
+```
+
+## Building a binary with GHC
+
+This is not yet implemented.

--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -13,6 +13,7 @@ in Nixpkgs to easily build packages for other programming languages,
 such as Perl or Haskell.  These are described in this chapter.</para>
 
 
+<xi:include href="agda.section.xml" />
 <xi:include href="beam.xml" />
 <xi:include href="bower.xml" />
 <xi:include href="coq.xml" />

--- a/pkgs/build-support/agda/with-packages.nix
+++ b/pkgs/build-support/agda/with-packages.nix
@@ -1,0 +1,24 @@
+# Build a version of Agda with a set of packages visible
+# packages: The packages visible to Agda
+# This file is inspired by idris-modules/with-packages.nix
+{ symlinkJoin, lib, Agda, makeWrapper, packages }:
+
+let paths' = lib.filter (dep: dep ? isAgdaLibrary && dep.isAgdaLibrary)
+                        (lib.closePropagation packages);
+    packagesShareAgda = map (x: x + "/share/agda") paths';
+    buildFlags = builtins.concatStringsSep " " (map (x: "-i " + x) packagesShareAgda);
+
+in symlinkJoin rec {
+
+  inherit (Agda) version meta;
+
+  name = Agda.name + "-with-packages";
+
+  paths = paths' ++ [ Agda ];
+
+  buildInputs = [ makeWrapper ] ++ paths;
+
+  postBuild = ''
+    wrapProgram $out/bin/agda --add-flags '${buildFlags}'
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11971,11 +11971,11 @@ with pkgs;
 
   ### DEVELOPMENT / LIBRARIES / AGDA
 
-  agda = callPackage ../build-support/agda {
+  agda = (callPackage ../build-support/agda {
     glibcLocales = if pkgs.stdenv.isLinux then pkgs.glibcLocales else null;
     extension = self : super : { };
     inherit (haskellPackages) Agda;
-  };
+  });
 
   agdaBase = callPackage ../development/libraries/agda/agda-base { };
 


### PR DESCRIPTION
The build process for Agda packages now mirrors that of Idris packages. There is an `agda.withPackages` attribute that works like `ghcWithPackages`. 

This should make it easier to implement building Agda binaries, since that process can reuse agdaWithPackages.

###### Motivation for this change
Fixes #19434 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

