### PR TITLE
sweep-visualizer: ffmpeg library clash fix

### DIFF
--- a/pkgs/tools/misc/sweep-visualizer/default.nix
+++ b/pkgs/tools/misc/sweep-visualizer/default.nix
@@ -24,10 +24,9 @@
     buildPhase = ":";
 
     installPhase = ''
-      mkdir -p $out/lib $out/bin $out/share/sweep-visualizer
+      mkdir -p $out/bin $out/share/sweep-visualizer
       mv usr/share/* $out/share
       mv opt/Sweep\ Visualizer\ BETA/* $out/share/sweep-visualizer/
-      mv $out/share/sweep-visualizer/*.so $out/lib/
       ln -s $out/share/sweep-visualizer/sweep_visualizer $out/bin/sweep_visualizer
     '';
 
@@ -40,12 +39,12 @@
       ];
       runtimeLibs = lib.makeLibraryPath [ libudev0-shim ];
     in ''
-      for lib in $out/lib/*.so; do
-        patchelf --set-rpath "$out/lib:${libPath}" $lib
+      for lib in $out/share/sweep-visualizer/*.so; do
+        patchelf --set-rpath "$out/share/sweep-visualizer:${libPath}" $lib
       done
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "$out/lib:${libPath}" \
+        --set-rpath "$out/share/sweep-visualizer:${libPath}" \
         $out/share/sweep-visualizer/sweep_visualizer
       wrapProgram "$out/bin/sweep_visualizer" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
     '';


### PR DESCRIPTION
###### Motivation for this change

sweep-visualizer exposed libffmpeg.so and libnode.so in $out/lib, conflicting with ffmpeg proper.
This PR fixes the problem. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

