### PR TITLE
 nix-pin: 0.1.2 -> 0.2.2

### DIFF
--- a/pkgs/tools/package-management/nix-pin/default.nix
+++ b/pkgs/tools/package-management/nix-pin/default.nix
@@ -20,6 +20,19 @@ let self = stdenv.mkDerivation rec {
     let api = import "${self}/share/nix/api.nix" { inherit pkgs; }; in
     {
       inherit (api) augmentedPkgs pins callPackage;
+      updateScript = ''
+        set -e
+        echo
+        cd ${toString ./.}
+        ${pkgs.nix-update-source}/bin/nix-update-source \
+          --prompt version \
+          --replace-attr version \
+          --set owner timbertson \
+          --set repo nix-pin \
+          --set type fetchFromGitHub \
+          --set rev 'version-{version}' \
+          --modify-nix default.nix
+      '';
     };
   meta = with stdenv.lib; {
     homepage = "https://github.com/timbertson/nix-pin";

--- a/pkgs/tools/package-management/nix-pin/default.nix
+++ b/pkgs/tools/package-management/nix-pin/default.nix
@@ -1,12 +1,12 @@
 { pkgs, stdenv, fetchFromGitHub, mypy, python3 }:
 let self = stdenv.mkDerivation rec {
   name = "nix-pin-${version}";
-  version = "0.1.2";
+  version = "0.2.2";
   src = fetchFromGitHub {
     owner = "timbertson";
     repo = "nix-pin";
-    rev = "version-0.1.2";
-    sha256 = "1zwfb5198qzbjwivgiaxbwva9frgrrqaj92nw8vz95yi08pijssh";
+    rev = "version-0.2.2";
+    sha256 = "1kw43kzy4m6lnnif51r2a8i4vcgr7d4vqb1c75p7pk2b9y3jwxsz";
   };
   buildInputs = [ python3 mypy ];
   buildPhase = ''
@@ -16,12 +16,11 @@ let self = stdenv.mkDerivation rec {
     mkdir "$out"
     cp -r bin share "$out"
   '';
-  passthru = {
-    callWithPins = path: args:
-      import "${self}/share/nix/call.nix" {
-        inherit pkgs path args;
-      };
-  };
+  passthru =
+    let api = import "${self}/share/nix/api.nix" { inherit pkgs; }; in
+    {
+      inherit (api) augmentedPkgs pins callPackage;
+    };
   meta = with stdenv.lib; {
     homepage = "https://github.com/timbertson/nix-pin";
     description = "nixpkgs development utility";


### PR DESCRIPTION
Also added an updateScript for automating updates

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

