### PR TITLE
nixos/boot: rename network interfaces already in stage 1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -200,6 +200,21 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
       from your config without any issues.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The following changes apply if <literal>system.stateVersion</literal> is
+     changed to 18.09 or higher. For <literal>system.stateVersion = "18.03"</literal> or lower
+     the old behavior is preserved.
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+        If predictable interface names are enabled (<literal>networking.usePredictableInterfaceNames = true </literal>), interfaces are already renamed in Stage 1 (initrd).
+        <emphasis role="strong">This may break existing configurations that require networking in Stage 1 (initrd) to boot. In the worst case, your system may become unbootable.</emphasis> Before updating <literal>stateVersion</literal> to 18.09 or higher, make sure your configuration is not affected.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -209,8 +209,9 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
     <itemizedlist>
      <listitem>
       <para>
-        If predictable interface names are enabled (<literal>networking.usePredictableInterfaceNames = true </literal>), interfaces are already renamed in Stage 1 (initrd).
-        <emphasis role="strong">This may break existing configurations that require networking in Stage 1 (initrd) to boot. In the worst case, your system may become unbootable.</emphasis> Before updating <literal>stateVersion</literal> to 18.09 or higher, make sure your configuration is not affected.
+        If predictable interface names are enabled (<literal>networking.usePredictableInterfaceNames = true </literal>),
+        interfaces are already renamed in Stage 1 (initrd). <emphasis role="strong">This may break existing configurations
+        that require networking in Stage 1 (initrd) to boot. In the worst case, your system may become unbootable.</emphasis>
       </para>
      </listitem>
     </itemizedlist>

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -266,6 +266,9 @@ in
         change randomly across reboots; for instance, you may find
         <literal>eth0</literal> and <literal>eth1</literal> flipping
         unpredictably.
+        For newer configurations with <literal>system.stateVersion >= 18.09</literal>,
+        interfaces are renamed to predictable names in Stage 1 (initrd), and
+        changing this option's value requires a reboot to take effect.
       '';
     };
 

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -266,9 +266,9 @@ in
         change randomly across reboots; for instance, you may find
         <literal>eth0</literal> and <literal>eth1</literal> flipping
         unpredictably.
-        For newer configurations with <literal>system.stateVersion >= 18.09</literal>,
-        interfaces are renamed to predictable names in Stage 1 (initrd), and
-        changing this option's value requires a reboot to take effect.
+        For configurations with <literal>system.stateVersion >= 18.09</literal>,
+        interfaces are renamed to predictable names in Stage 1 (initrd).
+        Changing this option's value may require a reboot to take effect.
       '';
     };
 

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -844,7 +844,10 @@ in
     systemd.services.systemd-networkd = {
       wantedBy = [ "multi-user.target" ];
       restartTriggers = map (f: f.source) (unitFiles);
+    } // optionalAttrs (versionOlder config.system.stateVersion "18.09") {
       # prevent race condition with interface renaming (#39069)
+      # This is not necessary for newer configs (stateVersion>=18.09)
+      # since they do interface renaming in stage 1
       requires = [ "systemd-udev-settle.service" ];
       after = [ "systemd-udev-settle.service" ];
     };

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -314,7 +314,7 @@ in rec {
   tests.hydra = callTest tests/hydra {};
   tests.i3wm = callTest tests/i3wm.nix {};
   tests.iftop = callTest tests/iftop.nix {};
-  tests.initrd-network-ssh = callTest tests/initrd-network-ssh {};
+  tests.initrd-network-ssh = callSubTests tests/initrd-network-ssh {};
   tests.installer = callSubTests tests/installer.nix {};
   tests.influxdb = callTest tests/influxdb.nix {};
   tests.ipv6 = callTest tests/ipv6.nix {};

--- a/nixos/tests/initrd-network-ssh/default.nix
+++ b/nixos/tests/initrd-network-ssh/default.nix
@@ -1,59 +1,76 @@
-import ../make-test.nix ({ lib, ... }:
+{ system ? builtins.currentSystem }:
 
-{
-  name = "initrd-network-ssh";
-  meta = with lib.maintainers; {
-    maintainers = [ willibutz ];
-  };
+let
+  inherit (import ../../lib/testing.nix { inherit system; }) makeTest pkgs;
+in
+  with pkgs; lib.listToAttrs ( map (predictable: {
 
-  nodes = with lib; rec {
-    server =
-      { config, ... }:
-      {
-        boot.kernelParams = [
-          "ip=${config.networking.primaryIPAddress}:::255.255.255.0::eth1:none"
-        ];
-        boot.initrd.network = {
-          enable = true;
-          ssh = {
-            enable = true;
-            authorizedKeys = [ "${readFile ./openssh.pub}" ];
-            port = 22;
-            hostRSAKey = ./dropbear.priv;
+    name = if predictable then "predictable" else "unpredictable";
+
+    value = makeTest {
+      name = "initrd-network-ssh"+ lib.optionalString predictable "predictable";
+      meta = with lib.maintainers; {
+        maintainers = [ willibutz xeji ];
+      };
+
+      nodes = with lib;
+        let interface2 = if predictable then "ens4" else "eth1";
+        in rec {
+        server =
+          { config, ... }:
+          {
+            # for stateVersion < 18.09 this doesn't make a difference in initrd
+            system.stateVersion = "18.09";
+            networking.usePredictableInterfaceNames = mkForce predictable;
+            boot.kernelParams = [
+              "ip=${config.networking.primaryIPAddress}:::255.255.255.0::${interface2}:none"
+            ];
+            boot.initrd.network = {
+              enable = true;
+              # for initrd networking with predictable interface names,
+              # udhcpc must be given the name as an argument
+              udhcpc.extraArgs = [ (lib.optionalString predictable "-i ${interface2}")];
+              ssh = {
+                enable = true;
+                authorizedKeys = [ "${readFile ./openssh.pub}" ];
+                port = 22;
+                hostRSAKey = ./dropbear.priv;
+              };
+            };
+            boot.initrd.preLVMCommands = ''
+              while true; do
+                if [ -f fnord ]; then
+                  poweroff
+                fi
+                sleep 1
+              done
+            '';
           };
-        };
-        boot.initrd.preLVMCommands = ''
-          while true; do
-            if [ -f fnord ]; then
-              poweroff
-            fi
-            sleep 1
-          done
-        '';
+
+        client =
+          { config, ... }:
+          {
+            environment.etc.knownHosts = {
+              text = concatStrings [
+                "server,"
+                "${toString (head (splitString " " (
+                  toString (elemAt (splitString "\n" config.networking.extraHosts) 2)
+                )))} "
+                "${readFile ./dropbear.pub}"
+              ];
+            };
+          };
       };
 
-    client =
-      { config, ... }:
-      {
-        environment.etc.knownHosts = {
-          text = concatStrings [
-            "server,"
-            "${toString (head (splitString " " (
-              toString (elemAt (splitString "\n" config.networking.extraHosts) 2)
-            )))} "
-            "${readFile ./dropbear.pub}"
-          ];
-        };
-      };
-  };
-
-  testScript = ''
-    startAll;
-    $client->waitForUnit("network.target");
-    $client->copyFileFromHost("${./openssh.priv}","/etc/sshKey");
-    $client->succeed("chmod 0600 /etc/sshKey");
-    $client->waitUntilSucceeds("ping -c 1 server");
-    $client->succeed("ssh -i /etc/sshKey -o UserKnownHostsFile=/etc/knownHosts server 'touch /fnord'");
-    $client->shutdown;
-  '';
-})
+      testScript = ''
+        $client->waitForUnit("network.target");
+        $client->copyFileFromHost("${./openssh.priv}","/etc/sshKey");
+        $client->succeed("chmod 0600 /etc/sshKey");
+        $server->start;
+        $client->waitUntilSucceeds("ping -c 1 server");
+        $client->succeed("ssh -i /etc/sshKey -o UserKnownHostsFile=/etc/knownHosts server 'touch /fnord'");
+        $client->shutdown;
+      '';
+    };
+  }) [false true] 
+)

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -2,11 +2,12 @@
 
 let
   inherit (import ../lib/testing.nix { inherit system; }) makeTest pkgs;
-in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
+in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: stateV: {
   name = pkgs.lib.optionalString (!predictable) "un" + "predictable"
-       + pkgs.lib.optionalString withNetworkd "Networkd";
+       + pkgs.lib.optionalString withNetworkd "Networkd"
+       + builtins.replaceStrings ["."] [""] stateV;
   value = makeTest {
-    name = "${if predictable then "" else "un"}predictableInterfaceNames${if withNetworkd then "-with-networkd" else ""}";
+    name = "${if predictable then "" else "un"}predictableInterfaceNames${if withNetworkd then "-with-networkd" else ""}-${stateV}";
     meta = {};
 
     machine = { lib, ... }: {
@@ -15,9 +16,8 @@ in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
       networking.dhcpcd.enable = !withNetworkd;
       # So we can see the initrd device names in the log
       # although we don't add an automated test here
-      boot.initrd.network.enable = true;
-      # test new behavior for 18.09
-      system.stateVersion = "18.09";
+      boot.initrd.network.enable = (stateV == "18.09");
+      system.stateVersion = stateV;
     };
 
     testScript = ''
@@ -26,4 +26,4 @@ in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
       $machine->fail("ip link show ${if predictable then "eth0" else "ens3"}");
     '';
   };
-}) [[true false] [true false]])
+}) [[true false] [true false] ["18.03" "18.09"]])

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -13,6 +13,11 @@ in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
       networking.usePredictableInterfaceNames = lib.mkForce predictable;
       networking.useNetworkd = withNetworkd;
       networking.dhcpcd.enable = !withNetworkd;
+      # So we can see the initrd device names in the log
+      # although we don't add an automated test here
+      boot.initrd.network.enable = true;
+      # test new behavior for 18.09
+      system.stateVersion = "18.09";
     };
 
     testScript = ''


### PR DESCRIPTION
###### Motivation for this change

Fix #39069. When `networking.usePredictableInterfaceNames = true`, rename network interfaces already in stage 1 boot  to avoid a race condition between interface renaming and configuration.
This also ensures consistent interface names between stage 1 (initrd) and fully booted system.

~~~Please backport to 18.03 because a resulting non-deterministic test failure has frequently delayed the `nixos-18.03-small` channel.~~~ (better not, see discussion)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

