### PR TITLE
octopus: 7.2 -> 7.3

### DIFF
--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "7.2";
+  version = "7.3";
   fftwAll = symlinkJoin { name ="ftw-dev-out"; paths = [ fftw.dev fftw.out ]; };
 
 in stdenv.mkDerivation {
@@ -11,7 +11,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.tddft.org/programs/octopus/down.php?file=${version}/octopus-${version}.tar.gz";
-    sha256 = "03zzmq72zdnjkhifbmlxs7ig7x6sf6mv8zv9mxhakm9hzwa9yn7m";
+    sha256 = "0hnpqjjxdxh2ggf6ckrsy4hs9iglnazscb4siczddvmysi4kv15d";
   };
 
   nativeBuildInputs = [ perl procps fftw.dev ];


### PR DESCRIPTION
###### Motivation for this change
Version bump with minor bug fixes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

