### PR TITLE
memtest86plus: fix, switch to using coreboot's branch

### DIFF
--- a/pkgs/tools/misc/memtest86+/default.nix
+++ b/pkgs/tools/misc/memtest86+/default.nix
@@ -1,35 +1,13 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
-  name = "memtest86+-5.01";
+  name = "memtest86+-5.01+coreboot-20180113";
 
-  src = fetchurl {
-    url = "http://www.memtest.org/download/5.01/${name}.tar.gz";
-    sha256 = "0fch1l55753y6jkk0hj8f6vw4h1kinkn9ysp22dq5g9zjnvjf88l";
+  src = fetchgit {
+    url = "https://review.coreboot.org/memtest86plus";
+    rev = "5ca4eb9544e51254254d09ae6e70f93403469ec3";
+    sha256 = "08m4rjr0chhhb1whgggknz926zv9hm8bisnxqp8lffqiwhb55rgk";
   };
-
-  patches = [
-    (fetchurl {
-      url = "https://sources.debian.net/data/main/m/memtest86+/5.01-3/debian/patches/doc-serialconsole";
-      sha256 = "1qh2byj9bmpchym8iq20n4hqmy10nrl6bi0d9pgdqikkmw9m38jq";
-    })
-    (fetchurl {
-      url = "https://sources.debian.net/data/main/m/memtest86+/5.01-3/debian/patches/multiboot";
-      sha256 = "0nq61307ah5b41ff5nqs99wjzjzlajvfv6k9c9d0gqvhx8r4dvmy";
-    })
-    (fetchurl {
-      url = "https://sources.debian.net/data/main/m/memtest86+/5.01-3/debian/patches/memtest86+-5.01-O0.patch";
-      sha256 = "1xmj3anq1fr0cxwv8lqfp5cr5f58v7glwc6z0v8hx8aib8yj1wl2";
-    })
-    (fetchurl {
-      url = "https://sources.debian.net/data/main/m/memtest86+/5.01-3/debian/patches/memtest86+-5.01-array-size.patch";
-      sha256 = "0yxlzpfs6313s91y984p7rlf5rgybcjhg7i9zqy4wqhm3j90f1kb";
-    })
-    (fetchurl {
-      url = "https://sources.debian.net/data/main/m/memtest86+/5.01-3/debian/patches/gcc-5";
-      sha256 = "13xfy6sn8qbj1hx4vms2cz24dsa3bl8n2iblz185hkn11y7141sc";
-    })
-  ];
 
   preBuild = ''
     # Really dirty hack to get Memtest to build without needing a Glibc

--- a/pkgs/tools/misc/memtest86+/default.nix
+++ b/pkgs/tools/misc/memtest86+/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I. -std=gnu90";
 
-  hardeningDisable = [ "fortify" "stackprotector" "pic" ];
+  hardeningDisable = [ "all" ];
 
   buildFlags = "memtest.bin";
 


### PR DESCRIPTION
###### Motivation for this change

It failed to work on my Thinkpad X230. This fixes it both with Lenovo BIOS and with coreboot. I think the first patch should be backported to 18.03.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] other Linux distributions
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
