### PR TITLE
nixos/networkd: wait for udev to settle before starting networkd

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -712,6 +712,9 @@ in
     systemd.services.systemd-networkd = {
       wantedBy = [ "multi-user.target" ];
       restartTriggers = map (f: f.source) (unitFiles);
+      # prevent race condition with interface renaming (#39069)
+      requires = [ "systemd-udev-settle.service" ];
+      after = [ "systemd-udev-settle.service" ];
     };
 
     systemd.services.systemd-networkd-wait-online = {


### PR DESCRIPTION
###### Motivation for this change

Fix #39069:  Avoid a race condition between `udevd` renaming and `networkd` configuring interfaces when using `networkd` with predictable interface names.

Please backport to 18.03 because a resulting non-deterministic test failure has frequently delayed the `nixos-18.03-small` channel.

This is an interim fix to get rid of the race condition and resulting test failures. It does not break existing configs that use the old `ethX` interface names for stage 1 (initrd) networking, so it should be safe to backport to 18.03.

(#39329 proposes a better long-term solution: rename interfaces in stage 1 already, so interface names are consistently the same in initrd and fully booted system. But that change will break initrd networking in some existing configs, so we should make it carefully.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

