### PR TITLE
dejavu-fonts: fix missing Perl IOString dependency

### DIFF
--- a/pkgs/data/fonts/dejavu-fonts/default.nix
+++ b/pkgs/data/fonts/dejavu-fonts/default.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, stdenv, fontforge, perl, FontTTF}:
+{ fetchFromGitHub, stdenv, fontforge, perl, perlPackages }:
 
 let
   version = "2.37";
@@ -25,7 +25,7 @@ let
 
   full-ttf = stdenv.mkDerivation {
     name = "dejavu-fonts-full-${version}";
-    nativeBuildInputs = [fontforge perl FontTTF];
+    nativeBuildInputs = [fontforge perl perlPackages.IOString perlPackages.FontTTF];
 
     src = fetchFromGitHub {
       owner = "dejavu-fonts";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14243,9 +14243,7 @@ with pkgs;
 
   crimson = callPackage ../data/fonts/crimson {};
 
-  dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts {
-    inherit (perlPackages);
-  });
+  dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts {});
 
   # solve collision for nix-env before https://github.com/NixOS/nix/pull/815
   dejavu_fontsEnv = buildEnv {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14244,7 +14244,7 @@ with pkgs;
   crimson = callPackage ../data/fonts/crimson {};
 
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts {
-    inherit (perlPackages) FontTTF;
+    inherit (perlPackages);
   });
 
   # solve collision for nix-env before https://github.com/NixOS/nix/pull/815


### PR DESCRIPTION
Per the docs, IOString was recently added as a dependency:
https://github.com/dejavu-fonts/dejavu-fonts/blob/master/BUILDING.md

As-is, attempting to rebulid from source errors out with this missing perl module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

