### PR TITLE
nixos-enter: Ensures presence of full /sys tree. (for efivarfs)

### DIFF
--- a/nixos/modules/installer/tools/nixos-enter.sh
+++ b/nixos/modules/installer/tools/nixos-enter.sh
@@ -51,8 +51,9 @@ if [[ ! -e $mountPoint/etc/NIXOS ]]; then
     exit 126
 fi
 
-mkdir -m 0755 -p "$mountPoint/dev"
+mkdir -m 0755 -p "$mountPoint/dev" "$mountPoint/sys"
 mount --rbind /dev "$mountPoint/dev"
+mount --rbind /sys "$mountPoint/sys"
 
 # Run the activation script. Set $LOCALE_ARCHIVE to supress some Perl locale warnings.
 LOCALE_ARCHIVE=$system/sw/lib/locale/locale-archive chroot "$mountPoint" "$system/activate" >&2 || true


### PR DESCRIPTION
This partially reverts a change from e88f28965a7d76e83478d3ae6fcddc165b1c94f1 which removed the `mount --rbind /sys`.

While true that the activation scripts will mount `sysfs` at `/sys`, none of the mountpoints lower in the `/sys` tree are handled by the activation script, which includes `efivarfs`.


###### Motivation for this change

This fixes #38477 since it ensures the presence of `efivarfs` in the `/sys` tree, which is why the systemd-boot installation failed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ☑️ Tested execution of all binary files (usually in `./result/bin/`)
- ☑️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested by:

 * Executing in qemu with efi `exec qemu-system-x86_64 --enable-kvm -bios /nix/store/qcc1qxnmzg4phgij3ap7v3yq4yhaxiqc-OVMF-2017-12-05-fd/FV/OVMF.fd -device e1000,netdev=net0 -netdev user,id=net0 -m 4G -cdrom /nix/store/i6a4v4jpn1016iipzsqlw9f83a9vh2f7-nixos-18.03.git.06c576b-x86_64-linux.iso/iso/nixos-18.03.git.06c576b-x86_64-linux.iso -hda hdd.img`; The actual path for the OVMF bios will change.
 * Ensuring both `nixos-install` and `nixos-enter` work, without any warning or weirdness.


###### Things to do

 * [x] **Cherry-pick to 18.03 !**

---

