### PR TITLE
arb: 2.8.1 -> 2.13.0

### DIFF
--- a/pkgs/development/libraries/arb/default.nix
+++ b/pkgs/development/libraries/arb/default.nix
@@ -2,15 +2,21 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "arb";
-  version = "2.8.1";
+  version = "2.13.0";
   src = fetchFromGitHub {
     owner = "fredrik-johansson";
     repo = "${pname}";
     rev = "${version}";
-    sha256 = "15phk71ci9rr32aqznpkd2b993wjahsgliilkg4mnxsr86nwdf6x";
+    sha256 = "1fl9gmxf6c1cphk5r8jbys5pywj2rfm705kv0055i0aqc6hrv303";
   };
   buildInputs = [mpir gmp mpfr flint];
-  configureFlags = "--with-gmp=${gmp} --with-mpir=${mpir} --with-mpfr=${mpfr} --with-flint=${flint}";
+  configureFlags = [
+    "--with-gmp=${gmp}"
+    "--with-mpir=${mpir}"
+    "--with-mpfr=${mpfr}"
+    "--with-flint=${flint}"
+  ];
+  doCheck = true;
   meta = {
     inherit version;
     description = ''A library for arbitrary-precision interval arithmetic'';


### PR DESCRIPTION
###### Motivation for this change

Simple version bump. Also enables tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

