### PR TITLE
vmTools: update Debian 9 names and hashes

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -997,22 +997,22 @@ rec {
     };
 
     debian9i386 = {
-      name = "debian-9.3-stretch-i386";
-      fullName = "Debian 9.3 Stretch (i386)";
+      name = "debian-9.4-stretch-i386";
+      fullName = "Debian 9.4 Stretch (i386)";
       packagesList = fetchurl {
         url = mirror://debian/dists/stretch/main/binary-i386/Packages.xz;
-        sha256 = "1rpv0r92pkr9dmjvpffvgmq3an1s83npfmq870h67jqag3qpwj9l";
+        sha256 = "05z5ccg4ysbrgallhai53sh83i0364w7a3fdq84dpv1li059jf10";
       };
       urlPrefix = mirror://debian;
       packages = commonDebianPackages;
     };
 
     debian9x86_64 = {
-      name = "debian-9.3-stretch-amd64";
-      fullName = "Debian 9.3 Stretch (amd64)";
+      name = "debian-9.4-stretch-amd64";
+      fullName = "Debian 9.4 Stretch (amd64)";
       packagesList = fetchurl {
         url = mirror://debian/dists/stretch/main/binary-amd64/Packages.xz;
-        sha256 = "1gnkvh7wc5yp0rw8kq8p8rlskvl0lc4cv3gdylw8qpqzy75xqlig";
+        sha256 = "19j0c54b1b9lbk9fv2c2aswdh0s2c3klf97zrlmsz4hs8wm9jylq";
       };
       urlPrefix = mirror://debian;
       packages = commonDebianPackages;


### PR DESCRIPTION
###### Motivation for this change

Since the release of Debian 9.4, the package archives in `vmTools` have been out of date.  This PR fixes their hashes and updates their names.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

