### PR TITLE
abootimg: init at 0.6

### DIFF
--- a/pkgs/development/mobile/abootimg/default.nix
+++ b/pkgs/development/mobile/abootimg/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, coreutils, cpio, findutils, gzip, makeWrapper, utillinux }:
+
+let
+  version = "0.6";
+in
+stdenv.mkDerivation {
+  name = "abootimg-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ggrandou";
+    repo = "abootimg";
+    rev = "7e127fee6a3981f6b0a50ce9910267cd501e09d4";
+    sha256 = "1qgx9fxwhylgnixzkz2mzv2707f65qq7rar2rsqak536vhig1z9a";
+  };
+
+  nativeBuildInputs = [ makeWrapper utillinux ];
+
+  postPatch = ''
+    cat <<EOF > version.h
+    #define VERSION_STR "${version}"
+    EOF
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D -m 755 abootimg $out/bin
+    install -D -m444 ./debian/abootimg.1 $out/share/man/man1/abootimg.1;
+
+    install -D -m 755 abootimg-pack-initrd $out/bin
+    wrapProgram $out/bin/abootimg-pack-initrd --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils cpio findutils gzip ]}
+
+    install -D -m 755 abootimg-unpack-initrd $out/bin
+    wrapProgram $out/bin/abootimg-unpack-initrd --prefix PATH : ${stdenv.lib.makeBinPath [ cpio gzip ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ggrandou/abootimg;
+    description = "Manipulate Android Boot Images";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.flokli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -688,6 +688,8 @@ with pkgs;
     pkgs_i686 = pkgsi686Linux;
   };
 
+  abootimg = callPackage ../development/mobile/abootimg {};
+
   adbfs-rootless = callPackage ../development/mobile/adbfs-rootless {
     adb = androidenv.platformTools;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

