### PR TITLE
singular: Fix ntl dependency

### DIFF
--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, gmp, bison, perl, autoconf, ncurses, readline, coreutils, pkgconfig
 , autoreconfHook
+, file
 , flint
 , ntl
 , cddlib
@@ -18,7 +19,9 @@ stdenv.mkDerivation rec {
     sha256 = "0wvgz7l1b7zkpmim0r3mvv4fp8xnhlbz4c7hc90rn30snlansnf1";
   };
 
-  configureFlags = stdenv.lib.optionals enableFactory [
+  configureFlags = [
+    "--with-ntl=${ntl}"
+  ] ++stdenv.lib.optionals enableFactory [
     "--enable-factory"
   ] ++ stdenv.lib.optionals enableGfanlib [
     "--enable-gfanlib"
@@ -42,11 +45,19 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals enableGfanlib [
     cddlib
   ];
-  nativeBuildInputs = [ autoconf bison perl pkgconfig autoreconfHook ];
+  nativeBuildInputs = [
+    bison
+    perl
+    pkgconfig
+    autoreconfHook
+  ];
 
-  preConfigure = ''
-    find . -type f -exec sed -e 's@/bin/rm@${coreutils}&@g' -i '{}' ';'
-    find . -type f -exec sed -e 's@/bin/uname@${coreutils}&@g' -i '{}' ';'
+  preAutoreconf = ''
+    find . -type f -readable -writable -exec sed \
+      -e 's@/bin/rm@${coreutils}&@g' \
+      -e 's@/bin/uname@${coreutils}&@g' \
+      -e 's@/usr/bin/file@${file}/bin/file@g' \
+      -i '{}' ';'
   '';
 
   hardeningDisable = stdenv.lib.optional stdenv.isi686 "stackprotector";


### PR DESCRIPTION
###### Motivation for this change

I added the ntl dependency in my recent PR (#38768). I failed to actually tell singular where to find it though, so its not used.

I'm pretty sure this worked for me before and I can't remember removing the `--with-ntl` line, but it doesn't find it now so I must've removed it some time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

