### PR TITLE
pdf-quench: init at 1.0.5

### DIFF
--- a/pkgs/applications/misc/pdf-quench/default.nix
+++ b/pkgs/applications/misc/pdf-quench/default.nix
@@ -16,7 +16,7 @@ pythonPackages.buildPythonApplication rec {
     gtk3
     gobjectIntrospection
     goocanvas2
-    (poppler.override { introspectionSupport = true; })
+    poppler_gi
   ];
   propagatedBuildInputs = with pythonPackages; [ pygobject3 pypdf2 ];
 

--- a/pkgs/applications/misc/pdf-quench/default.nix
+++ b/pkgs/applications/misc/pdf-quench/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pkgs, pythonPackages, wrapGAppsHook}:
+
+pythonPackages.buildPythonApplication rec {
+  name = "pdf-quench-${version}";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "linuxerwang";
+    repo = "pdf-quench";
+    rev = "b72b3970b371026f9a7ebe6003581e8a63af98f6";
+    sha256 = "1rp9rlwr6rarcsxygv5x2c5psgwl6r69k0lsgribgyyla9cf2m7n";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+  buildInputs = with pkgs; [ gtk3 gobjectIntrospection goocanvas2 (poppler.override { introspectionSupport = true; }) ];
+  propagatedBuildInputs = with pythonPackages; [ pygobject3 pypdf2 ];
+
+  dontBuild = true;
+  doCheck = false;
+
+  postPatch = ''
+    substituteInPlace src/pdf_quench.py \
+      --replace /usr/bin/python "${pythonPackages.python}/bin/python"
+    '';
+
+  installPhase = ''
+    install -D -T -m 755 src/pdf_quench.py $out/bin/pdf-quench
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/linuxerwang/pdf-quench;
+    description = "A visual tool for cropping pdf files";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/applications/misc/pdf-quench/default.nix
+++ b/pkgs/applications/misc/pdf-quench/default.nix
@@ -12,16 +12,16 @@ pythonPackages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
-  buildInputs = with pkgs; [ gtk3 gobjectIntrospection goocanvas2 (poppler.override { introspectionSupport = true; }) ];
+  buildInputs = with pkgs; [
+    gtk3
+    gobjectIntrospection
+    goocanvas2
+    (poppler.override { introspectionSupport = true; })
+  ];
   propagatedBuildInputs = with pythonPackages; [ pygobject3 pypdf2 ];
 
-  dontBuild = true;
+  format = "other";
   doCheck = false;
-
-  postPatch = ''
-    substituteInPlace src/pdf_quench.py \
-      --replace /usr/bin/python "${pythonPackages.python}/bin/python"
-    '';
 
   installPhase = ''
     install -D -T -m 755 src/pdf_quench.py $out/bin/pdf-quench

--- a/pkgs/development/libraries/goocanvas/2.x.nix
+++ b/pkgs/development/libraries/goocanvas/2.x.nix
@@ -13,11 +13,13 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig gettext gtk-doc python2 ];
-  buildInputs = [ gtk3 cairo glib ];
+  buildInputs = [ gtk3 cairo glib gobjectIntrospection ];
 
   configureFlags = [
     "--disable-python"
   ];
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "$(dev)/share/gir-1.0";
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "$(out)/lib/girepository-1.0";
 
   meta = with stdenv.lib; {
     description = "Canvas widget for GTK+ based on the the Cairo 2D library";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4276,6 +4276,8 @@ with pkgs;
 
   pdfmod = callPackage ../applications/misc/pdfmod { };
 
+  pdf-quench = callPackage ../applications/misc/pdf-quench { };
+
   jbig2enc = callPackage ../tools/graphics/jbig2enc { };
 
   pdfread = callPackage ../tools/graphics/pdfread {


### PR DESCRIPTION
###### Motivation for this change
This adds [pdf-quench](https://github.com/linuxerwang/pdf-quench), a visual tool for cropping pdf files.
On that way, I added gobject introspection support to `goocanvas_2`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

