### PR TITLE
ecl_16_1_2: Adopt upstream error handling patch

### DIFF
--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -1,9 +1,9 @@
-{stdenv, fetchurl
+{ stdenv, fetchurl, fetchpatch
 , libtool, autoconf, automake
 , gmp, mpfr, libffi, makeWrapper
 , noUnicode ? false
 , gcc
-, threadSupport ? true
+, threadSupport ? false
 }:
 let
   s = # Generated upstream information
@@ -38,6 +38,15 @@ stdenv.mkDerivation {
     (stdenv.lib.optional (! noUnicode)
       "--enable-unicode")
     ;
+
+  patches = [
+    (fetchpatch {
+      # Avoid infinite loop, see https://gitlab.com/embeddable-common-lisp/ecl/issues/43 (fixed upstream)
+      name = "avoid-infinite-loop.patch";
+      url = "https://gitlab.com/embeddable-common-lisp/ecl/commit/caba1989f40ef917e7486f41b9cd5c7e3c5c2d79.patch";
+      sha256 = "07vw91psbc9gdn8grql46ra8lq3bgkzg5v480chnbryna4sv6lbb";
+    })
+  ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation {
   meta = {
     inherit (s) version;
     description = "Lisp implementation aiming to be small, fast and easy to embed";
+    homepage = https://common-lisp.net/project/ecl/;
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

Adopt an upstream fix for a infinite loop bug. This also disables `threadSupport` by default, since the package is only used by `maxima-ecl` anyways and that seems to work better (or at least the only package that depends on *that*, sage) without threading.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

