### PR TITLE
glpk: Add gmp support

### DIFF
--- a/pkgs/development/libraries/glpk/default.nix
+++ b/pkgs/development/libraries/glpk/default.nix
@@ -1,12 +1,32 @@
-{ fetchurl, stdenv }:
+{ stdenv
+, fetchurl
+# Excerpt from glpk's INSTALL file:
+# This feature allows the exact simplex solver to use the GNU MP
+# bignum library. If it is disabled, the exact simplex solver uses the
+# GLPK bignum module, which provides the same functionality as GNU MP,
+# however, it is much less efficient.
+, withGmp ? true
+, gmp
+}:
+
+assert withGmp -> gmp != null;
 
 stdenv.mkDerivation rec {
-  name = "glpk-4.65";
+  version = "4.65";
+  name = "glpk-${version}";
 
   src = fetchurl {
     url = "mirror://gnu/glpk/${name}.tar.gz";
     sha256 = "040sfaa9jclg2nqdh83w71sv9rc1sznpnfiripjdyr48cady50a2";
   };
+
+  buildInputs = stdenv.lib.optionals withGmp [
+    gmp
+  ];
+
+  configureFlags = stdenv.lib.optionals withGmp [
+    "--with-gmp"
+  ];
 
   doCheck = true;
 
@@ -23,7 +43,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnu.org/software/glpk/;
     license = stdenv.lib.licenses.gpl3Plus;
 
-    maintainers = [ stdenv.lib.maintainers.bjg ];
+    maintainers = with stdenv.lib.maintainers; [ bjg ];
     platforms = stdenv.lib.platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Excerpt from glpk's INSTALL file:

> This feature allows the exact simplex solver to use the GNU MP
> bignum library. If it is disabled, the exact simplex solver uses the
> GLPK bignum module, which provides the same functionality as GNU MP,
> however, it is much less efficient.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

