### PR TITLE
fflas-ffpack: Drop liblapack dependency

### DIFF
--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, givaro, pkgconfig, openblas, liblapack
+{ stdenv, fetchFromGitHub, autoreconfHook, givaro, pkgconfig, openblas
 , gmpxx
 , optimize ? false # impure
 }:
@@ -19,10 +19,10 @@ stdenv.mkDerivation rec {
     autoreconfHook
     pkgconfig
   ] ++ stdenv.lib.optionals doCheck checkInputs;
-  buildInputs = [ givaro (liblapack.override {shared = true;}) openblas];
+  buildInputs = [ givaro openblas];
   configureFlags = [
     "--with-blas-libs=-lopenblas"
-    "--with-lapack-libs=-llapack"
+    "--with-lapack-libs=-lopenblas"
   ] ++ stdenv.lib.optionals (!optimize) [
     # disable SIMD instructions (which are enabled *when available* by default)
     "--disable-sse"


### PR DESCRIPTION
###### Motivation for this change

`lapack` doesn't build on aarch64 and is not needed for fflas-ffpack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

