### PR TITLE
ecl: Use boehmgc

### DIFF
--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -4,7 +4,11 @@
 , noUnicode ? false
 , gcc
 , threadSupport ? false
+, useBoehmgc ? true, boehmgc
 }:
+
+assert useBoehmgc -> boehmgc != null;
+
 let
   s = # Generated upstream information
   rec {
@@ -19,6 +23,9 @@ let
   ];
   propagatedBuildInputs = [
     libffi gmp mpfr gcc
+  ] ++ stdenv.lib.optionals useBoehmgc [
+    # replaces ecl's own gc which other packages can depend on, thus propagated
+    boehmgc
   ];
 in
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -4,6 +4,7 @@
 , noUnicode ? false
 , gcc
 , threadSupport ? true
+, useBoehmgc ? false, boehmgc
 }:
 let
   s = # Generated upstream information
@@ -20,6 +21,10 @@ let
   ];
   propagatedBuildInputs = [
     libffi gmp mpfr gcc
+    # replaces ecl's own gc which other packages can depend on, thus propagated
+  ] ++ stdenv.lib.optionals useBoehmgc [
+    # replaces ecl's own gc which other packages can depend on, thus propagated
+    boehmgc
   ];
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
###### Motivation for this change

`ecl` has its own gc and can use either that or `boehmgc`. sage needs `boehmgc`. I'm not entirely sure if its better in all cases, the best I could find on the topic is https://common-lisp.net/project/ecl/static/manual/pr01s06.html which mentions that it is needed on OpenBSD (so apperently more portable).

I'd guess that a dedicated gc is probably better than one maintained by the `ecl` developers.

I should've included that in my last ecl PR, but I just now realized that I need it.

@7c6f434c (why doesn't github allow the PR creator to request a review? :/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

