### PR TITLE
colord: fix ColorManager.conf installation path

### DIFF
--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
     "-Denable-docs=false"
   ];
 
+  # Install `ColorManager.conf` under `etc` rather than `share`
+  # See https://github.com/hughsie/colord/issues/61
+  prePatch = ''
+    sed "s/\([[:space:]]*\)install_dir: join_paths(datadir, 'dbus-1', 'system.d') ,/\1install_dir: join_paths(prefix, 'etc', 'dbus-1', 'system.d') ,/" -i data/meson.build
+  '';
+
   nativeBuildInputs = [ meson pkgconfig vala_0_40 ninja gettext libxml2 gobjectIntrospection makeWrapper ];
 
   buildInputs = [ glib polkit gusb lcms2 sqlite systemd dbus bash-completion argyllcms libgudev sane-backends ];


### PR DESCRIPTION
This was fixed for colord-1.4.1 in this PR
https://github.com/NixOS/nixpkgs/commit/fabc930dddcfb6dd3dfc6e3b2536219f559353e0

But the fix was lost in the upgrade to 1.4.2. Without this fix, the
`colord.service` crashes, and features like gnome-3's Night Light no
longer work.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

ping @jtojnar 
