### PR TITLE
latte-dock: 0.7.4 -> 0.7.5

### DIFF
--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, cmake, xorg, plasma-framework, fetchFromGitHub
 , extra-cmake-modules, karchive, kwindowsystem, qtx11extras, kcrash }:
 
-let version = "0.7.4"; in
+let version = "0.7.5"; in
 
 mkDerivation {
   name = "latte-dock-${version}";
@@ -10,7 +10,7 @@ mkDerivation {
     owner = "psifidotos";
     repo = "Latte-Dock";
     rev = "v${version}";
-    sha256 = "0w4fphgpdvql31wrypxyfahmr4cv5ap96wjc4270yyawnrqrx0y6";
+    sha256 = "0fblbx6qk4miag1mhiyns7idsw03p9pj3xc3xxxnb5rpj1fy0ifv";
   };
 
   buildInputs = [ plasma-framework xorg.libpthreadstubs xorg.libXdmcp xorg.libSM ];


### PR DESCRIPTION
###### Motivation for this change
Wanted newest latte-dock.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

