### PR TITLE
teseq: init at 1.1.1

### DIFF
--- a/pkgs/applications/misc/teseq/default.nix
+++ b/pkgs/applications/misc/teseq/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+let
+  version = "1.1.1";
+in
+stdenv.mkDerivation {
+  name = "teseq-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnu/teseq/teseq-${version}.tar.gz";
+    sha256 = "08ln005qciy7f3jhv980kfhhfmh155naq59r5ah9crz1q4mx5yrj";
+  };
+
+  meta = {
+    homepage = https://www.gnu.org/software/teseq/;
+    description = "Escape sequence illuminator";
+    license = stdenv.lib.licenses.gpl3;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.vaibhavsagar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21364,6 +21364,8 @@ with pkgs;
 
   wire-desktop = callPackage ../applications/networking/instant-messengers/wire-desktop { };
 
+  teseq = callPackage ../applications/misc/teseq {  };
+
   # Unix tools
   unixtools = recurseIntoAttrs (callPackages ./unix-tools.nix { });
   inherit (unixtools) hexdump ps logger eject umount


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

