### PR TITLE
libjpeg: 1.5.2 -> 1.5.3

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "libjpeg-turbo-${version}";
-  version = "1.5.2";
+  version = "1.5.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/libjpeg-turbo/${name}.tar.gz";
-    sha256 = "0a5m0psfp5952y5vrcs0nbdz1y9wqzg2ms0xwrx752034wxr964h";
+    sha256 = "08r5b5mywwrxv4axvq80dm31cklz81grczlzlxr2xqa6pgi90j5j";
   }; # github releases still need autotools, surprisingly
 
   patches =


### PR DESCRIPTION
###### Motivation for this change

Update is supposed to fix CVE-2017-15232.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS (n/a)
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

