### PR TITLE
cddlib: 0.94h -> 0.94i, add cdd_both_reps binary

### DIFF
--- a/pkgs/development/libraries/cddlib/default.nix
+++ b/pkgs/development/libraries/cddlib/default.nix
@@ -1,17 +1,49 @@
-{stdenv, fetchurl, gmp}:
+{ stdenv
+, fetchurl
+, fetchpatch
+, gmp
+, autoreconfHook
+}:
+
 stdenv.mkDerivation rec {
   name = "cddlib-${version}";
-  fileVersion = "094h";
-  version = "0.94h";
-  src = fetchurl {
+  version = "0.94i";
+  src = let
+    fileVersion = stdenv.lib.replaceStrings ["."] [""] version;
+  in fetchurl {
+    # Might switch to github in the future, see
+    # https://trac.sagemath.org/ticket/21952#comment:20
     urls = [
       "http://archive.ubuntu.com/ubuntu/pool/universe/c/cddlib/cddlib_${fileVersion}.orig.tar.gz"
       "ftp://ftp.math.ethz.ch/users/fukudak/cdd/cddlib-${fileVersion}.tar.gz"
     ];
-    name = "";
-    sha256 = "1dasasscwfg793q8fwzgwf64xwj7w62yfvszpr8x8g38jka08vgy";
+    sha256 = "00zdgiqb91vx6gd2103h3ijij0llspsxc6zz3iw2bll39fvkl4xq";
   };
   buildInputs = [gmp];
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+  # compute reduced H and V representation of polytope
+  # this patch is included by most distributions (Debian, Conda, ArchLinux, SageMath)
+  # proposed upstream (no answer yet): https://github.com/cddlib/cddlib/pull/3
+  both_reps_c = (fetchurl {
+    name = "cdd_both_reps.c";
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/cddlib/files/cdd_both_reps.c?id=56bd759df1d0c750a065b8c845e93d5dfa6b549d";
+    sha256 = "0r9yc5bgiz8i72c6vsn2y2mjk5581iw94gji9v7lg16kzzgrk9x0";
+  });
+  preAutoreconf = ''
+    # Required by sage.geometry.polyhedron
+    cp ${both_reps_c} src/cdd_both_reps.c
+    cp ${both_reps_c} src-gmp/cdd_both_reps.c
+  '';
+  patches = [
+    # add the cdd_both_reps binary
+    (fetchpatch {
+      name = "add-cdd_both_reps-binary.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/cddlib/files/cddlib-094h-add-cdd_both_reps-binary.patch?id=78e3a61a68c916450aa4e5ceecd20041583af901";
+      sha256 = "162ni2fr7dpbdkz0b5nizxq7qr5k1i1d75g0smiylpzfb0hb761a";
+    })
+  ];
   meta = {
     inherit version;
     description = ''An implementation of the Double Description Method for generating all vertices of a convex polyhedron'';


### PR DESCRIPTION
###### Motivation for this change

- update cddlib to the latest version, 0.94i
- add the `cdd_both_reps` binary. Sage needs the binary, most other big repositories package it and it is proposed upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

