### PR TITLE
mendeley: 1.17.3 -> 1.18, touchup update script

### DIFF
--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -44,14 +44,14 @@ let
     then "i386"
     else "amd64";
 
-  shortVersion = "1.17.13-stable";
+  shortVersion = "1.18-stable";
 
   version = "${shortVersion}_${arch}";
 
   url = "http://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_${version}.deb";
   sha256 = if stdenv.system == arch32
-    then "0q4x62k00whmq8lskphpcxc610cvclxzcr5k0v7pxjxs9sx5yx43"
-    else "01ylyily1hip35z0d4qkdpbzp5yn4r015psc5773xsqlgrnlwjm3";
+    then "046v1j4sc6m0bf89f52zsg8riygrhldplyih5p0cjhcsd45q6fx8"
+    else "072fppgxhiryb6m1fb4qvq8nbblx88xpknnklygch1sw0lyks69h";
 
   deps = [
     qtbase

--- a/pkgs/applications/office/mendeley/update.nix
+++ b/pkgs/applications/office/mendeley/update.nix
@@ -15,9 +15,9 @@ writeScript "update-mendeley" ''
   }
 
   amd64URL=$(follow https://www.mendeley.com/repositories/ubuntu/stable/amd64/mendeleydesktop-latest)
-  amd64V=$(basename $amd64URL|grep -m1 -o "[0-9]\+\.[0-9]\+\.[0-9]\+")
+  amd64V=$(basename $amd64URL|grep -m1 -o "[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?")
   i386URL=$(follow https://www.mendeley.com/repositories/ubuntu/stable/i386/mendeleydesktop-latest)
-  i386V=$(basename $i386URL|grep -m1 -o "[0-9]\+\.[0-9]\+\.[0-9]\+")
+  i386V=$(basename $i386URL|grep -m1 -o "[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?")
 
   echo "amd64 version: $amd64V"
   echo "i386 version:  $i386V"


### PR DESCRIPTION
(support "1.18" instead of "1.18.0")




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---