### PR TITLE
coqPackages.mathcomp: 1.6.4 -> 1.7.0

### DIFF
--- a/pkgs/development/coq-modules/autosubst/default.nix
+++ b/pkgs/development/coq-modules/autosubst/default.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation rec {
     platforms = coq.meta.platforms;
   };
 
-  passthru = { inherit (mathcomp) compatibleCoqVersions; };
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+  };
+
 
 }

--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation {
     inherit (coq.meta) platforms;
   };
 
-  passthru = { inherit (ssreflect) compatibleCoqVersions; };
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+  };
 
 }

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation {
     platforms = coq.meta.platforms;
   };
 
-  passthru = { inherit (mathcomp) compatibleCoqVersions; };
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+  };
+
 
 }

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -1,29 +1,29 @@
 { callPackage, fetchurl, coq }:
 
 let param =
+
+  let param_1_7 = {
+      version = "1.7.0";
+      sha256 = "05zgyi4wmasi1rcyn5jq42w0bi9713q9m8dl1fdgl66nmacixh39";
+  }; in
+
   {
     "8.5" =  {
       version = "1.6.1";
-      url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.1.tar.gz;
       sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
     };
 
-    "8.6" =  {
-      version = "1.6.4";
-      url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.4.tar.gz;
-      sha256 = "0qmjjb6jsxmmf4gpw10r30rmrvwqgzirvvgyy41mz2vhgwis8wn6";
-    };
-
-    "8.7" = {
-      version = "1.6.4";
-      url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.4.tar.gz;
-      sha256 = "0qmjjb6jsxmmf4gpw10r30rmrvwqgzirvvgyy41mz2vhgwis8wn6";
-    };
+    "8.6" = param_1_7;
+    "8.7" = param_1_7;
+    "8.8" = param_1_7;
 
   }."${coq.coq-version}"
 ; in
 
 callPackage ./generic.nix {
   name = "coq${coq.coq-version}-mathcomp-${param.version}";
-  src = fetchurl { inherit (param) url sha256; };
+  src = fetchurl {
+    url = "https://github.com/math-comp/math-comp/archive/mathcomp-${param.version}.tar.gz";
+    inherit (param) sha256;
+  };
 }

--- a/pkgs/development/coq-modules/mathcomp/generic.nix
+++ b/pkgs/development/coq-modules/mathcomp/generic.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   buildFlags = stdenv.lib.optionalString withDoc "doc";
 
   preBuild = ''
-    patchShebangs etc/utils/ssrcoqdep
+    patchShebangs etc/utils/ssrcoqdep || true
     cd mathcomp
     export COQBIN=${coq}/bin/
   '';
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" ];
   };
 
 }

--- a/pkgs/development/coq-modules/ssreflect/default.nix
+++ b/pkgs/development/coq-modules/ssreflect/default.nix
@@ -1,29 +1,29 @@
 { callPackage, fetchurl, coq }:
 
 let param =
+
+  let param_1_7 = {
+    version = "1.7.0";
+    sha256 = "05zgyi4wmasi1rcyn5jq42w0bi9713q9m8dl1fdgl66nmacixh39";
+  }; in
+
   {
     "8.5" =  {
       version = "1.6.1";
-      url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.1.tar.gz;
       sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
     };
 
-    "8.6" =  {
-      version = "1.6.4";
-      url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.4.tar.gz;
-      sha256 = "0qmjjb6jsxmmf4gpw10r30rmrvwqgzirvvgyy41mz2vhgwis8wn6";
-    };
-
-    "8.7" = {
-      version = "1.6.4";
-      url = https://github.com/math-comp/math-comp/archive/mathcomp-1.6.4.tar.gz;
-      sha256 = "0qmjjb6jsxmmf4gpw10r30rmrvwqgzirvvgyy41mz2vhgwis8wn6";
-    };
+    "8.6" = param_1_7;
+    "8.7" = param_1_7;
+    "8.8" = param_1_7;
 
   }."${coq.coq-version}"
 ; in
 
 callPackage ./generic.nix {
   name = "coq${coq.coq-version}-ssreflect-${param.version}";
-  src = fetchurl { inherit (param) url sha256; };
+  src = fetchurl {
+    url = "https://github.com/math-comp/math-comp/archive/mathcomp-${param.version}.tar.gz";
+    inherit (param) sha256;
+  };
 }

--- a/pkgs/development/coq-modules/ssreflect/generic.nix
+++ b/pkgs/development/coq-modules/ssreflect/generic.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   inherit patches;
 
   preBuild = ''
-    patchShebangs etc/utils/ssrcoqdep
+    patchShebangs etc/utils/ssrcoqdep || true
     cd mathcomp/ssreflect
     export COQBIN=${coq}/bin/
   '';
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

New release, compatible with Coq 8.8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

