### PR TITLE
Revert "libretro.mame: 2017-06-04 -> 2017-03-02"

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -232,11 +232,10 @@ in with stdenv.lib.licenses;
 
   mame = (mkLibRetroCore {
     core = "mame";
-    version = "2018-03-02";
     src = fetchRetro {
       repo = "mame";
-      rev = "893f1ac2231b348b63209fd5b2545f770458ae8f";
-      sha256 = "1j9p82q9jhf5lf4w392zd09bq0j4iw1afhznymg0v60jv592h3gz";
+      rev = "9f8a36adeb4dc54ec2ecac992ce91bcdb377519e";
+      sha256 = "0blfvq28hgv9kkpijd8c9d9sa5g2qr448clwi7wrj8kqfdnrr8m1";
     };
     description = "Port of MAME to libretro";
     license = gpl2Plus;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#37640

See https://hydra.nixos.org/job/nixpkgs/trunk/libretro.mame.x86_64-linux/

Needs to be investigated further.