### PR TITLE
tuxpaint: init at 0.9.22 

### DIFF
--- a/pkgs/games/tuxpaint/default.nix
+++ b/pkgs/games/tuxpaint/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, SDL, SDL_image, SDL_ttf, SDL_mixer, libpng,
+  cairo, librsvg, gettext, libpaper, fribidi, pkgconfig, gperf }:
+
+stdenv.mkDerivation rec {
+  version = "0.9.22";
+  name = "tuxpaint-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/tuxpaint/${version}/${name}.tar.gz";
+    sha256 = "1qrbrdck9yxpcg3si6jb9i11w8lw9h4hqad0pfaxgyiniqpr7gca";
+  };
+
+  nativeBuildInputs = [ SDL SDL_image SDL_ttf SDL_mixer libpng cairo
+    librsvg gettext libpaper fribidi pkgconfig gperf ];
+  hardeningDisable = [ "format" ];
+  makeFlags = [ "GPERF=${gperf}/bin/gperf"
+                "PREFIX=$$out"
+                "COMPLETIONDIR=$$out/share/bash-completion/completions"
+              ];
+
+  patches = [ ./tuxpaint-completion.diff ];
+  postPatch = ''
+    grep -Zlr include.*SDL . | xargs -0 sed -i -e 's,"SDL,"SDL/SDL,'
+  '';
+
+  # stamps
+  stamps = fetchurl {
+    url = "mirror://sourceforge/project/tuxpaint/tuxpaint-stamps/2014-08-23/tuxpaint-stamps-2014.08.23.tar.gz";
+    sha256 = "0rhlwrjz44wp269v3rid4p8pi0i615pzifm1ym6va64gn1bms06q";
+  };
+
+  postInstall = ''
+    tar xzf $stamps
+    cd tuxpaint-stamps-2014.08.23
+    make install-all PREFIX=$out
+    rm -rf $out/share/tuxpaint/stamps/military
+  '';
+
+  meta = {
+    description = "Open Source Drawing Software for Children";
+    homepage = http://www.tuxpaint.org/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ woffs ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/games/tuxpaint/tuxpaint-completion.diff
+++ b/pkgs/games/tuxpaint/tuxpaint-completion.diff
@@ -1,0 +1,16 @@
+--- tuxpaint-0.9.22/src/tuxpaint-completion.bash~	1970-01-01 01:00:01.000000000 +0100
++++ tuxpaint-0.9.22/src/tuxpaint-completion.bash	2018-03-06 10:54:03.437560921 +0100
+@@ -8,7 +8,6 @@
+ # FIXME: See http://www.debian-administration.org/articles/316 for an intro
+ # to how we should be doing this... -bjk 2009.09.09
+ 
+-have tuxpaint &&
+ _tuxpaint()
+ {
+         local cur
+@@ -96,4 +95,4 @@
+         fi
+ 
+ }
+-[ "${have:-}" ] && complete -F _tuxpaint $filenames tuxpaint
++complete -F _tuxpaint $filenames tuxpaint

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19442,6 +19442,8 @@ with pkgs;
 
   tremulous = callPackage ../games/tremulous { };
 
+  tuxpaint = callPackage ../games/tuxpaint { };
+
   speed_dreams = callPackage ../games/speed-dreams {
     # Torcs wants to make shared libraries linked with plib libraries (it provides static).
     # i686 is the only platform I know than can do that linking without plib built with -fPIC


### PR DESCRIPTION
###### Motivation for this change
Nice drawing software for children.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

