### PR TITLE
vim_configurable: replace default ftNix patch with sources from vim-nix

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -4,6 +4,7 @@ args@{ source ? "default", callPackage, fetchurl, stdenv, ncurses, pkgconfig, ge
 , composableDerivation, writeText, lib, config, glib, gtk2, gtk3, python, perl, tcl, ruby
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
 , libICE
+, vimPlugins
 
 # apple frameworks
 , CoreServices, CoreData, Cocoa, Foundation, libobjc, cf-private
@@ -80,6 +81,11 @@ composableDerivation {
     flags = {
         ftNix = {
           patches = [ ./ft-nix-support.patch ];
+          preConfigure = ''
+            cp ${vimPlugins.vim-nix.src}/ftplugin/nix.vim runtime/ftplugin/nix.vim
+            cp ${vimPlugins.vim-nix.src}/indent/nix.vim runtime/indent/nix.vim
+            cp ${vimPlugins.vim-nix.src}/syntax/nix.vim runtime/syntax/nix.vim
+          '';
         };
       }
       // edf {

--- a/pkgs/applications/editors/vim/ft-nix-support.patch
+++ b/pkgs/applications/editors/vim/ft-nix-support.patch
@@ -6,7 +6,7 @@ index a8e6261..2b008fc 100644
  " Z80 assembler asz80
  au BufNewFile,BufRead *.z8a			setf z8a
  
-+" NIX
++" Nix
 +au BufNewFile,BufRead *.nix		setf nix
 +
  augroup END
@@ -18,79 +18,3 @@ index a8e6261..2b008fc 100644
  unlet s:cpo_save
 +
 +
-diff --git a/runtime/syntax/nix.vim b/runtime/syntax/nix.vim
-new file mode 100644
-index 0000000..a2f9918
---- /dev/null
-+++ b/runtime/syntax/nix.vim
-@@ -0,0 +1,56 @@
-+" Vim syntax file
-+" Language:	nix
-+" Maintainer:	Marc Weber <marco-oweber@gmx.de>
-+"               Modify and commit if you feel that way
-+" Last Change:	2011 Jun
-+"
-+" this syntax file can be still be enhanced very much..
-+" Don't ask, do it :-)
-+" This file (github.com/MarcWeber/vim-addon-nix) is periodically synced with
-+" the patch found in vim_configurable (nixpkgs)
-+
-+" Quit when a (custom) syntax file was already loaded
-+if exists("b:current_syntax")
-+  finish
-+endif
-+
-+
-+sy cluster nixStrings contains=nixStringParam,nixStringIndented
-+
-+syn keyword	nixKeyword	let throw inherit import true false null with
-+syn keyword	nixConditional	if else then
-+syn keyword     nixBrace        ( ) { } =
-+syn keyword     nixBuiltin         __currentSystem __currentTime __isFunction __getEnv __trace __toPath __pathExists 
-+  \ __readFile __toXML __toFile __filterSource __attrNames __getAttr __hasAttr __isAttrs __listToAttrs __isList 
-+  \ __head __tail __add __sub __lessThan __substring __stringLength
-+
-+syn region nixStringIndented start=+''+ skip=+'''\|''${\|"+ end=+''+ contains=nixStringParam
-+" syn region nixString         start=+"+ skip=+\\"+ end=+"+
-+syn match nixAttr "\w\+\ze\s*="
-+syn match nixFuncArg "\zs\w\+\ze\s*:"
-+syn region nixStringParam start=+\${+ end=+}+ contains=@nixStrings
-+syn region nixMultiLineComment start=+/\*+ skip=+\\"+ end=+\*/+
-+syn match  nixEndOfLineComment "#.*$"
-+
-+hi def link nixKeyword       Keyword
-+hi def link nixConditional   Conditional
-+hi def link nixBrace         Special
-+hi def link nixString        String
-+hi def link nixStringIndented String
-+hi def link nixBuiltin       Special
-+hi def link nixStringParam   Macro
-+hi def link nixMultiLineComment Comment
-+hi def link nixEndOfLineComment Comment
-+hi def link nixAttr        Identifier
-+hi def link nixFuncArg     Identifier
-+
-+syn sync maxlines=20000
-+syn sync minlines=50000
-+
-+let b:current_syntax = "nix"
-+
-+" thanks to domenkozar
-+" scan backwards to find begining of multiline statements
-+syn sync ccomment nixMultiLineComment minlines=10 maxlines=500
-+syn sync ccomment nixStringIndented minlines=10 maxlines=500
-+syn sync ccomment nixString maxlines=10
-diff --git a/runtime/ftplugin/nix.vim b/runtime/ftplugin/nix.vim
-new file mode 100644
---- /dev/null
-+++ b/runtime/ftplugin/nix.vim
-@@ -0,0 +1,2 @@
-+" Only do this when not done yet for this buffer
-+if exists("b:did_ftplugin")
-+  finish
-+endif
-+let b:did_ftplugin = 1
-+
-+" coding conventions
-+setlocal shiftwidth=2 expandtab softtabstop=2
-+let b:undo_ftplugin = "setlocal sw< et< sts<"


### PR DESCRIPTION
###### Motivation for this change

Fixes

```
Error detected while processing /nix/store/hsl0shnwwrim8z7si295yp1dh5rx2sfl-vim_configurable-8.0.1655/share/vim/vim80/ftplugin/nix.vim:
line    3:
E171: Missing :endif
Press ENTER or type command to continue
```

https://github.com/NixOS/nixpkgs/pull/39260#issuecomment-384078342

/cc @Mic92 @chreekat 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
