### PR TITLE
source-and-tags: fix default.nix

### DIFF
--- a/pkgs/misc/source-and-tags/default.nix
+++ b/pkgs/misc/source-and-tags/default.nix
@@ -1,4 +1,4 @@
-args: with args; {
+{ stdenv, lib, glibcLocales, unzip, hasktags, ctags } : {
   # optional srcDir
   annotatedWithSourceAndTagInfo = x : (x ? passthru && x.passthru ? sourceWithTags 
                                       || x ? meta && x.meta ? sourceWithTags );
@@ -59,8 +59,8 @@ args: with args; {
                     # without this creating tag files for lifted-base fails
                     export LC_ALL=en_US.UTF-8
                     export LANG=en_US.UTF-8
-                    ${if args.stdenv.isLinux then "export LOCALE_ARCHIVE=${args.pkgs.glibcLocales}/lib/locale/locale-archive;" else ""}
- 
+                    ${if stdenv.isLinux then "export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive;" else ""}
+
                     ${toString hasktags}/bin/hasktags --ignore-close-implementation --ctags .
                     mv tags \$TAG_FILE
                    }";


### PR DESCRIPTION
###### Motivation for this change

Inspired by @MarcWeber's recent [mailinglist post about Haskell & tags](https://groups.google.com/d/msgid/nix-devel/8d53871d-4a07-4ce7-add0-be0a33b9d600%40googlegroups.com?utm_medium=email&utm_source=footer) I started experimenting with `sourceAndTags` and discovered it causes Nix evaluation errors. 

###### Things done

I fixed the errors and tested it by observing that the following command produces a correctly looking TAGS file:

```
$ nix-shell -E 'let pkgs = import ./. {}; in pkgs.myEnvFun {name = "myEnvFun-htags-test"; buildInputs = [(pkgs.sourceAndTags.sourceWithTagsDerivation (pkgs.sourceAndTags.addHasktagsTaggingInfo pkgs.haskellPackages.scientific).passthru.sourceWithTags)];}' --run 'cat $TAG_FILES'
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This should also be cherry-picked on `release-18.03` once merged.