### PR TITLE
clementine: each output should hav a wrapped `GST_PLUGIN_SYSTEM_PATH_1_0`

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -70,13 +70,20 @@ let
 
   free = stdenv.mkDerivation {
     name = "clementine-free-${version}";
-    inherit src patches nativeBuildInputs buildInputs postPatch;
+    inherit src patches nativeBuildInputs postPatch;
+
+    buildInputs = buildInputs ++ [ makeWrapper ];
 
     cmakeFlags = [ "-DUSE_SYSTEM_PROJECTM=ON" ];
 
     enableParallelBuilding = true;
 
     passthru.unfree = unfree;
+
+    postInstall = ''
+      wrapProgram $out/bin/clementine \
+        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+    '';
 
     meta = with stdenv.lib; {
       homepage = http://www.clementine-player.org;
@@ -108,8 +115,7 @@ let
       rmdir $out/bin
 
       makeWrapper ${free}/bin/clementine $out/bin/clementine \
-        --set CLEMENTINE_SPOTIFYBLOB $out/libexec/clementine \
-        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+        --set CLEMENTINE_SPOTIFYBLOB $out/libexec/clementine
 
       mkdir -p $out/share
       for dir in applications icons kde4; do


### PR DESCRIPTION
###### Motivation for this change

see https://github.com/NixOS/nixpkgs/commit/ef5e212d20959d4d883df2ff2a54e5ef4b2512a5#r28723596

/cc @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

