### PR TITLE
glibc: use local copy of patch to fix w/musl

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -95,12 +95,7 @@ stdenv.mkDerivation ({
       ./allow-kernel-2.6.32.patch
     ]
     ++ lib.optional stdenv.isx86_64 ./fix-x64-abi.patch
-    ++ lib.optional stdenv.hostPlatform.isMusl
-      (fetchpatch {
-        name = "fix-with-musl.patch";
-        url = "https://sourceware.org/bugzilla/attachment.cgi?id=10151&action=diff&collapsed=&headers=1&format=raw";
-        sha256 = "18kk534k6da5bkbsy1ivbi77iin76lsna168mfcbwv4ik5vpziq2";
-      });
+    ++ lib.optional stdenv.hostPlatform.isMusl ./fix-rpc-types-musl-conflicts.patch;
 
   postPatch =
     ''

--- a/pkgs/development/libraries/glibc/fix-rpc-types-musl-conflicts.patch
+++ b/pkgs/development/libraries/glibc/fix-rpc-types-musl-conflicts.patch
@@ -1,0 +1,38 @@
+@@ -, +, @@ 
+---
+ sunrpc/rpc/types.h | 22 ++++++----------------
+ 1 file changed, 6 insertions(+), 16 deletions(-)
+--- a/sunrpc/rpc/types.h	
++++ a/sunrpc/rpc/types.h	
+@@ -69,24 +69,14 @@ typedef unsigned long rpcport_t;
+ #include <sys/types.h>
+ #endif
+ 
+-#if defined __APPLE_CC__ || defined __FreeBSD__
+-# define __u_char_defined
+-# define __daddr_t_defined
+-#endif
+-
+-#ifndef __u_char_defined
+-typedef __u_char u_char;
+-typedef __u_short u_short;
+-typedef __u_int u_int;
+-typedef __u_long u_long;
+-typedef __quad_t quad_t;
+-typedef __u_quad_t u_quad_t;
+-typedef __fsid_t fsid_t;
++/* IMPORTANT NOTE: This has been modified to build against the musl C
++ * library and it probably now ONLY builds with the musl C library.
++ *
++ * See: https://sourceware.org/bugzilla/show_bug.cgi?id=21604
++ */
+ # define __u_char_defined
+-#endif
+ #ifndef __daddr_t_defined
+-typedef __daddr_t daddr_t;
+-typedef __caddr_t caddr_t;
++typedef int daddr_t;
+ # define __daddr_t_defined
+ #endif
+ 
+-- 


### PR DESCRIPTION
fetchpatch doesn't work with bootstrap fetchurl,
so just use local file like we do for other glibc patches.




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---