### PR TITLE
libnfsidmap: add missing include, fix w/musl

### DIFF
--- a/pkgs/development/libraries/libnfsidmap/default.nix
+++ b/pkgs/development/libraries/libnfsidmap/default.nix
@@ -2,11 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "libnfsidmap-0.25";
-  
+
   src = fetchurl {
     url = "http://www.citi.umich.edu/projects/nfsv4/linux/libnfsidmap/${name}.tar.gz";
     sha256 = "1kzgwxzh83qi97rblcm9qj80cdvnv8kml2plz0q103j0hifj8vb5";
   };
+
+  postPatch = ''
+    sed -i '1i#include <sys/types.h>' cfg.h
+  '';
 
   preConfigure =
     ''


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---