### PR TITLE
nixos: warn on missing `stateVersion`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -310,6 +310,7 @@ rec {
 
     in opt //
       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
+        inherit (res.defsFinal') highestPrio;
         definitions = map (def: def.value) res.defsFinal;
         files = map (def: def.file) res.defsFinal;
         inherit (res) isDefined;
@@ -317,7 +318,7 @@ rec {
 
   # Merge definitions of a value of a given type.
   mergeDefinitions = loc: type: defs: rec {
-    defsFinal =
+    defsFinal' =
       let
         # Process mkMerge and mkIf properties.
         defs' = concatMap (m:
@@ -325,15 +326,20 @@ rec {
         ) defs;
 
         # Process mkOverride properties.
-        defs'' = filterOverrides defs';
+        defs'' = filterOverrides' defs';
 
         # Sort mkOrder properties.
         defs''' =
           # Avoid sorting if we don't have to.
-          if any (def: def.value._type or "" == "order") defs''
-          then sortProperties defs''
-          else defs'';
-      in defs''';
+          if any (def: def.value._type or "" == "order") defs''.values
+          then sortProperties defs''.values
+          else defs''.values;
+      in {
+        values = defs''';
+        inherit (defs'') highestPrio;
+      };
+
+    defsFinal = defsFinal'.values;
 
     # Type-check the remaining definitions, and merge them.
     mergedValue = foldl' (res: def:
@@ -416,13 +422,18 @@ rec {
 
      Note that "z" has the default priority 100.
   */
-  filterOverrides = defs:
+  filterOverrides = defs: (filterOverrides' defs).values;
+
+  filterOverrides' = defs:
     let
       defaultPrio = 100;
       getPrio = def: if def.value._type or "" == "override" then def.value.priority else defaultPrio;
       highestPrio = foldl' (prio: def: min (getPrio def) prio) 9999 defs;
       strip = def: if def.value._type or "" == "override" then def // { value = def.value.content; } else def;
-    in concatMap (def: if getPrio def == highestPrio then [(strip def)] else []) defs;
+    in {
+      values = concatMap (def: if getPrio def == highestPrio then [(strip def)] else []) defs;
+      inherit highestPrio;
+    };
 
   /* Sort a list of properties.  The sort priority of a property is
      1000 by default, but can be overridden by wrapping the property

--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -70,7 +70,7 @@
     <listitem>
      <para>
       <link xlink:href="https://github.com/NixOS/nixpkgs/compare/bdf161ed8d21...6b63c4616790">
-      Bump the <literal>system.defaultChannel</literal> attribute in
+      Bump the <literal>system.nixos.defaultChannel</literal> attribute in
       <literal>nixos/modules/misc/version.nix</literal> </link>
      </para>
     </listitem>

--- a/nixos/doc/manual/release-notes/rl-1509.xml
+++ b/nixos/doc/manual/release-notes/rl-1509.xml
@@ -433,9 +433,9 @@ system.autoUpgrade.enable = true;
      default. If you have existing systems with such host keys and want to
      continue to use them, please set
 <programlisting>
-system.stateVersion = "14.12";
+system.nixos.stateVersion = "14.12";
 </programlisting>
-     The new option <option>system.stateVersion</option> ensures that certain
+     The new option <option>system.nixos.stateVersion</option> ensures that certain
      configuration changes that could break existing systems (such as the
      <command>sshd</command> host key setting) will maintain compatibility with
      the specified NixOS release. NixOps sets the state version of existing

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -628,7 +628,7 @@ $bootLoaderConfig
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you
   # should.
-  system.stateVersion = "${\(qw(@release@))}"; # Did you read the comment?
+  system.nixos.stateVersion = "${\(qw(@release@))}"; # Did you read the comment?
 
 }
 EOF

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -12,29 +12,29 @@ in
 
 {
 
-  options.system = {
+  options.system.nixos = {
 
-    nixos.version = mkOption {
+    version = mkOption {
       internal = true;
       type = types.str;
       description = "The full NixOS version (e.g. <literal>16.03.1160.f2d4ee1</literal>).";
     };
 
-    nixos.release = mkOption {
+    release = mkOption {
       readOnly = true;
       type = types.str;
       default = trivial.release;
       description = "The NixOS release (e.g. <literal>16.03</literal>).";
     };
 
-    nixos.versionSuffix = mkOption {
+    versionSuffix = mkOption {
       internal = true;
       type = types.str;
       default = trivial.versionSuffix;
       description = "The NixOS version suffix (e.g. <literal>1160.f2d4ee1</literal>).";
     };
 
-    nixos.revision = mkOption {
+    revision = mkOption {
       internal = true;
       type = types.str;
       default = if pathIsDirectory gitRepo then commitIdFromGitRepo gitRepo
@@ -43,7 +43,7 @@ in
       description = "The Git revision from which this NixOS configuration was built.";
     };
 
-    nixos.codeName = mkOption {
+    codeName = mkOption {
       readOnly = true;
       type = types.str;
       description = "The NixOS release code name (e.g. <literal>Emu</literal>).";

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ options, config, lib, pkgs, ... }:
 
 with lib;
 
@@ -75,6 +75,9 @@ in
   };
 
   config = {
+
+    warnings = lib.optional (options.system.nixos.stateVersion.highestPrio > 1000)
+      "You don't have `system.nixos.stateVersion` explicitly set. Expect things to break.";
 
     system.nixos = {
       # These defaults are set here rather than up there so that

--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -40,7 +40,7 @@ in
 
           # Subscribe the root user to the NixOS channel by default.
           if [ "$USER" = root -a ! -e $HOME/.nix-channels ]; then
-              echo "${config.system.defaultChannel} nixos" > $HOME/.nix-channels
+              echo "${config.system.nixos.defaultChannel} nixos" > $HOME/.nix-channels
           fi
 
           # Create the per-user garbage collector roots directory.

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -204,6 +204,8 @@ with lib;
     (mkRenamedOptionModule [ "system" "nixosVersionSuffix" ] [ "system" "nixos" "versionSuffix" ])
     (mkRenamedOptionModule [ "system" "nixosRevision" ] [ "system" "nixos" "revision" ])
     (mkRenamedOptionModule [ "system" "nixosLabel" ] [ "system" "nixos" "label" ])
+    (mkRenamedOptionModule [ "system" "stateVersion" ] [ "system" "nixos" "stateVersion" ])
+    (mkRenamedOptionModule [ "system" "defaultChannel" ] [ "system" "nixos" "defaultChannel" ])
 
     # Users
     (mkAliasOptionModule [ "users" "extraUsers" ] [ "users" "users" ])

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -218,7 +218,7 @@ in
   config = mkIf config.services.mysql.enable {
 
     services.mysql.dataDir =
-      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then "/var/lib/mysql"
+      mkDefault (if versionAtLeast config.system.nixos.stateVersion "17.09" then "/var/lib/mysql"
                  else "/var/mysql");
 
     users.extraUsers.mysql = {

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -147,7 +147,7 @@ in
       };
       superUser = mkOption {
         type = types.str;
-        default= if versionAtLeast config.system.stateVersion "17.09" then "postgres" else "root";
+        default= if versionAtLeast config.system.nixos.stateVersion "17.09" then "postgres" else "root";
         internal = true;
         description = ''
           NixOS traditionally used 'root' as superuser, most other distros use 'postgres'.
@@ -166,14 +166,14 @@ in
 
     services.postgresql.package =
       # Note: when changing the default, make it conditional on
-      # ‘system.stateVersion’ to maintain compatibility with existing
+      # ‘system.nixos.stateVersion’ to maintain compatibility with existing
       # systems!
-      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then pkgs.postgresql96
-            else if versionAtLeast config.system.stateVersion "16.03" then pkgs.postgresql95
+      mkDefault (if versionAtLeast config.system.nixos.stateVersion "17.09" then pkgs.postgresql96
+            else if versionAtLeast config.system.nixos.stateVersion "16.03" then pkgs.postgresql95
             else pkgs.postgresql94);
 
     services.postgresql.dataDir =
-      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}"
+      mkDefault (if versionAtLeast config.system.nixos.stateVersion "17.09" then "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}"
                  else "/var/db/postgresql");
 
     services.postgresql.authentication = mkAfter

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -342,7 +342,7 @@ in {
       };
       database_type = mkOption {
         type = types.enum [ "sqlite3" "psycopg2" ];
-        default = if versionAtLeast config.system.stateVersion "18.03"
+        default = if versionAtLeast config.system.nixos.stateVersion "18.03"
           then "psycopg2"
           else "sqlite3";
         description = ''

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -14,7 +14,7 @@ let
     (optionalString (cfg.defaultMode == "norouting") "--routing=none")
   ] ++ cfg.extraFlags);
 
-  defaultDataDir = if versionAtLeast config.system.stateVersion "17.09" then
+  defaultDataDir = if versionAtLeast config.system.nixos.stateVersion "17.09" then
     "/var/lib/ipfs" else
     "/var/lib/ipfs/.ipfs";
 

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -9,7 +9,7 @@ let
   confFile = pkgs.writeText "radicale.conf" cfg.config;
 
   # This enables us to default to version 2 while still not breaking configurations of people with version 1
-  defaultPackage = if versionAtLeast config.system.stateVersion "17.09" then {
+  defaultPackage = if versionAtLeast config.system.nixos.stateVersion "17.09" then {
     pkg = pkgs.radicale2;
     text = "pkgs.radicale2";
   } else {
@@ -35,7 +35,7 @@ in
       defaultText = defaultPackage.text;
       description = ''
         Radicale package to use. This defaults to version 1.x if
-        <literal>system.stateVersion &lt; 17.09</literal> and version 2.x
+        <literal>system.nixos.stateVersion &lt; 17.09</literal> and version 2.x
         otherwise.
       '';
     };

--- a/nixos/modules/services/web-servers/caddy.nix
+++ b/nixos/modules/services/web-servers/caddy.nix
@@ -66,7 +66,7 @@ in {
       description = "Caddy web server";
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = mkIf (versionAtLeast config.system.stateVersion "17.09")
+      environment = mkIf (versionAtLeast config.system.nixos.stateVersion "17.09")
         { CADDYPATH = cfg.dataDir; };
       serviceConfig = {
         ExecStart = ''

--- a/nixos/modules/virtualisation/amazon-options.nix
+++ b/nixos/modules/virtualisation/amazon-options.nix
@@ -3,7 +3,7 @@
   options = {
     ec2 = {
       hvm = lib.mkOption {
-        default = lib.versionAtLeast config.system.stateVersion "17.03";
+        default = lib.versionAtLeast config.system.nixos.stateVersion "17.03";
         internal = true;
         description = ''
           Whether the EC2 instance is a HVM instance.

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -606,8 +606,8 @@ in
                   { config, pkgs, ... }:
                   { services.postgresql.enable = true;
                     services.postgresql.package = pkgs.postgresql96;
-                    
-                    system.stateVersion = "17.03";
+
+                    system.nixos.stateVersion = "17.03";
                   };
               };
           }

--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -43,7 +43,7 @@ in
             });
           })
         ];
-        system.stateVersion = "17.03";
+        system.nixos.stateVersion = "17.03";
       };
       radicale1_export = lib.recursiveUpdate radicale1 {
         services.radicale.extraArgs = [
@@ -54,7 +54,7 @@ in
         services.radicale.extraArgs = [ "--verify-storage" ];
       };
       radicale2 = lib.recursiveUpdate (common args) {
-        system.stateVersion = "17.09";
+        system.nixos.stateVersion = "17.09";
       };
     };
 


### PR DESCRIPTION
###### Motivation for this change

The first patch is OCD. The last patch is the part of #35366 everyone agreed upon. The middle one is plumbing.

###### Things done

- [X] It works.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

