### PR TITLE
nfs-utils, tcp_wrappers, libnfsidmap: cleanup, fix w/musl

### DIFF
--- a/pkgs/development/libraries/libnfsidmap/default.nix
+++ b/pkgs/development/libraries/libnfsidmap/default.nix
@@ -2,11 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "libnfsidmap-0.25";
-  
+
   src = fetchurl {
     url = "http://www.citi.umich.edu/projects/nfsv4/linux/libnfsidmap/${name}.tar.gz";
     sha256 = "1kzgwxzh83qi97rblcm9qj80cdvnv8kml2plz0q103j0hifj8vb5";
   };
+
+  postPatch = ''
+    sed -i '1i#include <sys/types.h>' cfg.h
+  '';
 
   preConfigure =
     ''

--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, pkgconfig, utillinux, libcap, libtirpc, libevent, libnfsidmap
+{ stdenv, fetchurl, fetchpatch, lib, pkgconfig, utillinux, libcap, libtirpc, libevent, libnfsidmap
 , sqlite, kerberos, kmod, libuuid, keyutils, lvm2, systemd, coreutils, tcp_wrappers
 , buildEnv
 }:
@@ -38,6 +38,18 @@ in stdenv.mkDerivation rec {
       "--enable-libmount-mount"
     ]
     ++ lib.optional (stdenv ? glibc) "--with-rpcgen=${stdenv.glibc.bin}/bin/rpcgen";
+
+  patches = lib.optionals stdenv.hostPlatform.isMusl [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/alpinelinux/aports/cb880042d48d77af412d4688f24b8310ae44f55f/main/nfs-utils/0011-exportfs-only-do-glibc-specific-hackery-on-glibc.patch";
+      sha256 = "0rrddrykz8prk0dcgfvmnz0vxn09dbgq8cb098yjjg19zz6d7vid";
+    })
+    # http://openwall.com/lists/musl/2015/08/18/10
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/alpinelinux/aports/cb880042d48d77af412d4688f24b8310ae44f55f/main/nfs-utils/musl-getservbyport.patch";
+      sha256 = "1fqws9dz8n1d9a418c54r11y3w330qgy2652dpwcy96cm44sqyhf";
+    })
+  ];
 
   postPatch =
     ''

--- a/pkgs/os-specific/linux/tcp-wrappers/cdecls.patch
+++ b/pkgs/os-specific/linux/tcp-wrappers/cdecls.patch
@@ -1,0 +1,31 @@
+__BEGIN_DECLS/__END_DECLS are BSD specific and not defined in musl
+glibc and uclibc had sys/cdefs.h doing it.
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Index: tcp_wrappers_7.6/tcpd.h
+===================================================================
+--- tcp_wrappers_7.6.orig/tcpd.h
++++ tcp_wrappers_7.6/tcpd.h
+@@ -11,7 +11,9 @@
+ #include <netinet/in.h>
+ #include <stdio.h>
+ 
+-__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ /* Structure to describe one communications endpoint. */
+ 
+@@ -252,6 +254,8 @@ extern char *fix_strtok();
+ extern char *my_strtok();
+ #endif
+ 
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif

--- a/pkgs/os-specific/linux/tcp-wrappers/default.nix
+++ b/pkgs/os-specific/linux/tcp-wrappers/default.nix
@@ -20,11 +20,14 @@ in stdenv.mkDerivation rec {
   prePatch = ''
     tar -xaf $debian
     patches="$(cat debian/patches/series | sed 's,^,debian/patches/,') $patches"
+
+    substituteInPlace Makefile --replace STRINGS STRINGDEFS
+    substituteInPlace debian/patches/13_shlib_weaksym --replace STRINGS STRINGDEFS
   '';
 
   buildInputs = [ libnsl ];
 
-  makeFlags = [ "STRINGS=" "REAL_DAEMON_DIR=$(out)/bin" "linux" ];
+  makeFlags = [ "REAL_DAEMON_DIR=$(out)/bin" "linux" ];
 
   installPhase = ''
     mkdir -p "$out/bin"

--- a/pkgs/os-specific/linux/tcp-wrappers/default.nix
+++ b/pkgs/os-specific/linux/tcp-wrappers/default.nix
@@ -25,6 +25,14 @@ in stdenv.mkDerivation rec {
     substituteInPlace debian/patches/13_shlib_weaksym --replace STRINGS STRINGDEFS
   '';
 
+  # Fix __BEGIN_DECLS usage (even if it wasn't non-standard, this doesn't include sys/cdefs.h)
+  patches = [ ./cdecls.patch ];
+
+  postPatch = stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    substituteInPlace Makefile \
+      --replace '-DNETGROUP' '-DUSE_GETDOMAIN'
+  '';
+
   buildInputs = [ libnsl ];
 
   makeFlags = [ "REAL_DAEMON_DIR=$(out)/bin" "linux" ];

--- a/pkgs/os-specific/linux/tcp-wrappers/tcp-wrappers-7.6-headers.patch
+++ b/pkgs/os-specific/linux/tcp-wrappers/tcp-wrappers-7.6-headers.patch
@@ -1,0 +1,295 @@
+--- a/options.c
++++ b/options.c
+@@ -34,6 +34,8 @@
+ 
+ /* System libraries. */
+ 
++#include <unistd.h>
++#include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/param.h>
+ #include <sys/socket.h>
+--- a/safe_finger.c
++++ b/safe_finger.c
+@@ -20,6 +20,11 @@
+ 
+ /* System libraries */
+ 
++#include <unistd.h>
++#include <fcntl.h>
++#include <stdlib.h>
++#include <sys/wait.h>
++#include <grp.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <signal.h>
+@@ -27,7 +31,7 @@
+ #include <ctype.h>
+ #include <pwd.h>
+ 
+-extern void exit();
++int pipe_stdin(char **argv);
+ 
+ /* Local stuff */
+ 
+--- a/scaffold.c
++++ b/scaffold.c
+@@ -10,6 +10,7 @@
+ 
+ /* System libraries. */
+ 
++#include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+@@ -27,7 +27,4 @@
+ #endif
+ 
+-#ifndef INET6
+-extern char *malloc();
+-#endif
+ 
+ /* Application-specific. */
+--- a/shell_cmd.c
++++ b/shell_cmd.c
+@@ -14,6 +14,10 @@
+ 
+ /* System libraries. */
+ 
++#include <unistd.h>
++#include <stdlib.h>
++#include <fcntl.h>
++#include <sys/wait.h>
+ #include <sys/types.h>
+ #include <sys/param.h>
+ #include <signal.h>
+@@ -25,8 +25,6 @@
+ #include <syslog.h>
+ #include <string.h>
+ 
+-extern void exit();
+-
+ /* Local stuff. */
+ 
+ #include "tcpd.h"
+--- a/tcpdchk.c
++++ b/tcpdchk.c
+@@ -20,6 +20,8 @@
+ 
+ /* System libraries. */
+ 
++#include <unistd.h>
++#include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #ifdef INET6
+@@ -35,10 +36,7 @@
+ #include <netdb.h>
+ #include <string.h>
+ 
+-extern int errno;
+-extern void exit();
+-extern int optind;
+-extern char *optarg;
++int cidr_mask_addr(char *str);
+ 
+ #ifndef INADDR_NONE
+ #define INADDR_NONE     (-1)		/* XXX should be 0xffffffff */
+--- a/clean_exit.c
++++ b/clean_exit.c
+@@ -13,8 +13,8 @@
+ #endif
+ 
+ #include <stdio.h>
+-
+-extern void exit();
++#include <unistd.h>
++#include <stdlib.h>
+ 
+ #include "tcpd.h"
+ 
+--- a/hosts_access.c
++++ b/hosts_access.c
+@@ -23,6 +23,7 @@
+ 
+ /* System libraries. */
+ 
++#include <stdlib.h>
+ #include <sys/types.h>
+ #ifdef INT32_T
+     typedef uint32_t u_int32_t;
+@@ -43,8 +44,8 @@
+ #include <netdb.h>
+ #endif
+ 
+-extern char *fgets();
+-extern int errno;
++static int match_pattern_ylo(const char *s, const char *pattern);
++int cidr_mask_addr(char *str);
+ 
+ #ifndef	INADDR_NONE
+ #define	INADDR_NONE	(-1)		/* XXX should be 0xffffffff */
+--- a/inetcf.c
++++ b/inetcf.c
+@@ -9,15 +9,14 @@
+ static char sccsid[] = "@(#) inetcf.c 1.7 97/02/12 02:13:23";
+ #endif
+ 
++#include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <stdio.h>
+ #include <errno.h>
+ #include <string.h>
+ 
+-extern int errno;
+-extern void exit();
+-
++#include "scaffold.h"
+ #include "tcpd.h"
+ #include "inetcf.h"
+ 
+--- a/percent_x.c
++++ b/percent_x.c
+@@ -16,12 +16,12 @@
+ 
+ /* System libraries. */
+ 
++#include <unistd.h>
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
+ 
+-extern void exit();
+-
+ /* Local stuff. */
+ 
+ #include "tcpd.h"
+--- a/rfc931.c
++++ b/rfc931.c
+@@ -15,6 +15,7 @@
+ 
+ /* System libraries. */
+ 
++#include <unistd.h>
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <sys/types.h>
+--- a/tcpd.c
++++ b/tcpd.c
+@@ -16,6 +16,7 @@
+ 
+ /* System libraries. */
+ 
++#include <unistd.h>
+ #include <sys/types.h>
+ #include <sys/param.h>
+ #include <sys/stat.h>
+@@ -39,6 +39,8 @@
+ #include "patchlevel.h"
+ #include "tcpd.h"
+ 
++void fix_options(struct request_info *request);
++
+ int     allow_severity = SEVERITY;	/* run-time adjustable */
+ int     deny_severity = LOG_WARNING;	/* ditto */
+ 
+--- a/tcpdmatch.c
++++ b/tcpdmatch.c
+@@ -19,6 +19,8 @@
+ 
+ /* System libraries. */
+ 
++#include <unistd.h>
++#include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+@@ -30,9 +32,6 @@
+ #include <setjmp.h>
+ #include <string.h>
+ 
+-extern void exit();
+-extern int optind;
+-extern char *optarg;
+ 
+ #ifndef	INADDR_NONE
+ #define	INADDR_NONE	(-1)		/* XXX should be 0xffffffff */
+--- a/update.c
++++ b/update.c
+@@ -19,6 +19,7 @@
+ 
+ /* System libraries */
+ 
++#include <unistd.h>
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
+--- a/misc.c
++++ b/misc.c
+@@ -14,11 +14,10 @@
+ #include <arpa/inet.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <stdlib.h>
+ 
+ #include "tcpd.h"
+ 
+-extern char *fgets();
+-
+ #ifndef	INADDR_NONE
+ #define	INADDR_NONE	(-1)		/* XXX should be 0xffffffff */
+ #endif
+--- a/fix_options.c
++++ b/fix_options.c
+@@ -32,6 +32,7 @@
+ 
+ /* fix_options - get rid of IP-level socket options */
+ 
++void
+ fix_options(request)
+ struct request_info *request;
+ {
+@@ -38,11 +38,8 @@
+ #ifdef IP_OPTIONS
+     unsigned char optbuf[BUFFER_SIZE / 3], *cp;
+     char    lbuf[BUFFER_SIZE], *lp;
+-#ifdef __GLIBC__
+-    size_t  optsize = sizeof(optbuf), ipproto;
+-#else
+-    int     optsize = sizeof(optbuf), ipproto;
+-#endif
++    socklen_t optsize = sizeof(optbuf);
++    int ipproto;
+     struct protoent *ip;
+     int     fd = request->fd;
+     unsigned int opt;
+--- a/socket.c
++++ b/socket.c
+@@ -95,11 +95,7 @@
+     static struct sockaddr_in client;
+     static struct sockaddr_in server;
+ #endif
+-#ifdef __GLIBC__
+-    size_t  len;
+-#else
+-    int     len;
+-#endif
++    socklen_t len;
+     char    buf[BUFSIZ];
+     int     fd = request->fd;
+ 
+@@ -430,11 +426,7 @@
+ #else
+     struct sockaddr_in sin;
+ #endif
+-#ifdef __GLIBC__
+-    size_t  size = sizeof(sin);
+-#else
+-    int     size = sizeof(sin);
+-#endif
++    socklen_t size;
+ 
+     /*
+      * Eat up the not-yet received datagram. Some systems insist on a


### PR DESCRIPTION
Replaces previous PR's for these on master.



Can't build nfs-utils on this branch just yet
until systemd bits are upstreamed.

Testing done on branch with those fixes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---