### PR TITLE
pythonPackages.entrypoints: Fix buildInputs

### DIFF
--- a/pkgs/development/python-modules/entrypoints/default.nix
+++ b/pkgs/development/python-modules/entrypoints/default.nix
@@ -15,9 +15,9 @@ buildPythonPackage rec {
     sha256 = "d2d587dde06f99545fb13a383d2cd336a8ff1f359c5839ce3a64c917d10c029f";
   };
 
-  checkInputs = [ pytest];
+  checkInputs = [ pytest ];
 
-  propagatedBuildInputs = [] ++ lib.optionals (!isPy3k) [ configparser ];
+  propagatedBuildInputs = lib.optional (!isPy3k) configparser;
 
   checkPhase = ''
     py.test tests

--- a/pkgs/development/python-modules/entrypoints/default.nix
+++ b/pkgs/development/python-modules/entrypoints/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest];
 
-  propagatedBuildInputs = [] ++ lib.optional (!isPy3k) [ configparser ];
+  propagatedBuildInputs = [] ++ lib.optionals (!isPy3k) [ configparser ];
 
   checkPhase = ''
     py.test tests


### PR DESCRIPTION
###### Motivation for this change

Using `lib.optional` implicitly wraps the value in a list, resulting in `propagatedBuildInputs = [[configparser]]`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

