### PR TITLE
matterbridge module: add configPath option as a workaround, waiting for nix encryption

### DIFF
--- a/nixos/modules/services/networking/matterbridge.nix
+++ b/nixos/modules/services/networking/matterbridge.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ options, config, pkgs, lib, ... }:
 
 with lib;
 
@@ -6,7 +6,11 @@ let
 
   cfg = config.services.matterbridge;
 
-  matterbridgeConfToml = pkgs.writeText "matterbridge.toml" (cfg.configFile);
+  matterbridgeConfToml =
+    if cfg.configPath == null then
+      pkgs.writeText "matterbridge.toml" (cfg.configFile)
+    else
+      cfg.configPath;
 
 in
 
@@ -15,17 +19,32 @@ in
     services.matterbridge = {
       enable = mkEnableOption "Matterbridge chat platform bridge";
 
+      configPath = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        example = "/etc/nixos/matterbridge.toml";
+        description = ''
+          The path to the matterbridge configuration file.
+        '';
+      };
+
       configFile = mkOption {
         type = types.str;
         example = ''
-          #WARNING: as this file contains credentials, be sure to set correct file permissions          [irc]
+          # WARNING: as this file contains credentials, do not use this option!
+          # It is kept only for backwards compatibility, and would cause your
+          # credentials to be in the nix-store, thus with the world-readable
+          # permission bits.
+          # Use services.matterbridge.configPath instead.
+
+          [irc]
               [irc.freenode]
               Server="irc.freenode.net:6667"
               Nick="matterbot"
 
           [mattermost]
               [mattermost.work]
-               #do not prefix it wit http:// or https://
+               # Do not prefix it with http:// or https://
                Server="yourmattermostserver.domain"
                Team="yourteam"
                Login="yourlogin"
@@ -44,6 +63,10 @@ in
               channel="off-topic"
         '';
         description = ''
+          WARNING: THIS IS INSECURE, as your password will end up in
+          <filename>/nix/store</filename>, thus publicly readable. Use
+          <literal>services.matterbridge.configPath</literal> instead.
+
           The matterbridge configuration file in the TOML file format.
         '';
       };
@@ -65,32 +88,31 @@ in
     };
   };
 
-  config = mkMerge [
-    (mkIf cfg.enable {
+  config = mkIf cfg.enable {
+    warnings = optional options.services.matterbridge.configFile.isDefined
+      "The option services.matterbridge.configFile is insecure and should be replaced with services.matterbridge.configPath";
 
-      users.extraUsers = mkIf (cfg.user == "matterbridge") [
-        { name = "matterbridge";
-          group = "matterbridge";
-        } ];
-
-      users.extraGroups = mkIf (cfg.group == "matterbridge") [
-        { name = "matterbridge";
-        } ];
-
-      systemd.services.matterbridge = {
-        description = "Matterbridge chat platform bridge";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" ];
-
-        serviceConfig = {
-          User = cfg.user;
-          Group = cfg.group;
-          ExecStart = "${pkgs.matterbridge.bin}/bin/matterbridge -conf ${matterbridgeConfToml}";
-          Restart = "always";
-          RestartSec = "10";
-        };
+    users.extraUsers = optional (cfg.user == "matterbridge")
+      { name = "matterbridge";
+        group = "matterbridge";
       };
-    })
-  ];
-}
 
+    users.extraGroups = optional (cfg.group == "matterbridge")
+      { name = "matterbridge";
+      };
+
+    systemd.services.matterbridge = {
+      description = "Matterbridge chat platform bridge";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${pkgs.matterbridge.bin}/bin/matterbridge -conf ${matterbridgeConfToml}";
+        Restart = "always";
+        RestartSec = "10";
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Waiting for NixOS/rfcs/pull/5 , files including secrets should not be set in the nix store, so adding a configPath option as workaround.

I've tested this PR with `nixos-rebuild` and `nix-diff`: with the same configuration, absolutely no change happens (apart from the nixos-version hash change). With `configPath` set, the parameter appears to be properly set.

I think that, as a security fix, this deserves backport to 18.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

