### PR TITLE
tree-wide: disable `doCheck` and `doInstallCheck` where it fails

### DIFF
--- a/pkgs/applications/altcoins/bitcoin.nix
+++ b/pkgs/applications/altcoins/bitcoin.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec{
                                             "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
                                           ];
 
+  # Fails with "This application failed to start because it could not
+  # find or load the Qt platform plugin "minimal""
+  doCheck = false;
+
   meta = {
     description = "Peer-to-peer electronic cash system";
     longDescription= ''

--- a/pkgs/applications/audio/easytag/default.nix
+++ b/pkgs/applications/audio/easytag/default.nix
@@ -22,6 +22,8 @@ in stdenv.mkDerivation rec {
     gsettings-desktop-schemas gnome3.defaultIconTheme
   ];
 
+  doCheck = false; # fails 1 out of 9 tests
+
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -78,6 +78,8 @@ stdenv.mkDerivation rec {
       [ libX11 libXext libXt libwebp ]
     ;
 
+  doCheck = false; # fails 6 out of 76 tests
+
   postInstall = ''
     (cd "$dev/include" && ln -s ImageMagick* ImageMagick)
     moveToOutput "bin/*-config" "$dev"

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -213,6 +213,7 @@ stdenv.mkDerivation (rec {
   ++ extraMakeFlags;
 
   enableParallelBuilding = true;
+  doCheck = false; # "--disable-tests" above
 
   preInstall = ''
     # The following is needed for startup cache creation on grsecurity kernels.

--- a/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
@@ -21,13 +21,16 @@ stdenv.mkDerivation rec {
     pkgconfig intltool autoconf-archive
     appstream-glib
   ];
+
   buildInputs = [ gtk3 json-glib curl glib hicolor-icon-theme ];
 
-  meta = with stdenv.lib;
-    { description = "GTK remote control for the Transmission BitTorrent client";
-      homepage = https://github.com/ajf8/transmission-remote-gtk;
-      license = licenses.gpl2;
-      maintainers = [ maintainers.ehmry ];
-      platforms = platforms.linux;
-    };
+  doCheck = false; # fails with style validation error
+
+  meta = with stdenv.lib; {
+    description = "GTK remote control for the Transmission BitTorrent client";
+    homepage = https://github.com/ajf8/transmission-remote-gtk;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.ehmry ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/applications/version-management/cvs/default.nix
+++ b/pkgs/applications/version-management/cvs/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ nano ];
 
+  doCheck = false; # fails 1 of 1 tests
+
   meta = {
     homepage = http://cvs.nongnu.org;
     description = "Concurrent Versions System - a source control system";

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -88,6 +88,8 @@ let
 
     enableParallelBuilding = true;
 
+    doCheck = false; # fails 10 out of ~2300 tests
+
     meta = {
       description = "A version control system intended to be a compelling replacement for CVS in the open source community";
       homepage = http://subversion.apache.org/;

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -121,6 +121,8 @@ stdenv.mkDerivation rec {
     ++ optional openGLSupport "--enable-opengl"
     ++ optional virglSupport "--enable-virglrenderer";
 
+  doCheck = false; # tries to access /dev
+
   postFixup =
     ''
       for exe in $out/bin/qemu-system-* ; do

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
+  doCheck = false; # needs more tools
+
   installFlags = [ "ZIC=./zic-native" ];
 
   preInstall = ''

--- a/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
@@ -40,4 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
+
+  doCheck = false; # requires X11 daemon
+
 }

--- a/pkgs/desktops/gnome-2/desktop/zenity/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/zenity/default.nix
@@ -13,4 +13,6 @@ stdenv.mkDerivation {
   buildInputs = [ gtk libglade libxml2 libxslt libX11 docbook_xml_dtd_412 ];
 
   nativeBuildInputs = [ pkgconfig intltool gnome-doc-utils which ];
+
+  doCheck = false; # fails, tries to access the net
 }

--- a/pkgs/desktops/gnome-2/platform/gnome-vfs/default.nix
+++ b/pkgs/desktops/gnome-2/platform/gnome-vfs/default.nix
@@ -21,4 +21,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ GConf glib ];
 
   postPatch = "find . -name Makefile.in | xargs sed 's/-DG_DISABLE_DEPRECATED//g' -i ";
+
+  doCheck = false; # needs dbus daemon
 }

--- a/pkgs/desktops/gnome-3/core/dconf/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ meson ninja vala pkgconfig python3 libxslt libxml2 docbook_xsl ];
   buildInputs = [ glib dbus-glib ];
 
+  doCheck = false; # fails 2 out of 9 tests, maybe needs dbus daemon?
+
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;

--- a/pkgs/desktops/xfce/core/xfconf.nix
+++ b/pkgs/desktops/xfce/core/xfconf.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool glib libxfce4util ];
   propagatedBuildInputs = [ dbus-glib ];
 
+  doCheck = false; # requires dbus daemon
+
   meta = with stdenv.lib; {
     homepage = http://docs.xfce.org/xfce/xfconf/start;
     description = "Simple client-server configuration storage and query system for Xfce";
@@ -26,4 +28,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -375,6 +375,8 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap")
     else "";
 
+  doCheck = false; # requires a lot of tools, causes a dependency cycle for stdenv
+
   installTargets =
     if stripped
     then "install-strip"

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -383,6 +383,8 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap")
     else "";
 
+  doCheck = false; # requires a lot of tools, causes a dependency cycle for stdenv
+
   installTargets =
     if stripped
     then "install-strip"

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -400,6 +400,8 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap")
     else "";
 
+  doCheck = false; # requires a lot of tools, causes a dependency cycle for stdenv
+
   installTargets =
     if stripped
     then "install-strip"

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -403,6 +403,8 @@ stdenv.mkDerivation ({
   buildFlags =
     optional bootstrap (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
+  doCheck = false; # requires a lot of tools, causes a dependency cycle for stdenv
+
   installTargets =
     if stripped
     then "install-strip"

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -409,6 +409,8 @@ stdenv.mkDerivation ({
   buildFlags =
     optional bootstrap (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
+  doCheck = false; # requires a lot of tools, causes a dependency cycle for stdenv
+
   installTargets =
     if stripped
     then "install-strip"

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -170,6 +170,7 @@ stdenv.mkDerivation rec {
   stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!targetPlatform.isDarwin) "--keep-file-symbols";
 
   checkTarget = "test";
+  doCheck = false; # fails with "testsuite/tests: No such file or directory.  Stop."
 
   # zsh and other shells are smart about `{ghc}` but bash isn't, and doesn't
   # treat that as a unary `{x,y,z,..}` repetition.

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -133,6 +133,8 @@ let
 
     buildFlags = [ "all" ];
 
+    doCheck = false; # fails with "No rule to make target 'y'."
+
     installPhase = ''
       mkdir -p $out/lib/openjdk $out/share $jre/lib/openjdk
 

--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation rec {
   # This is fixed here:
   # <http://git.savannah.gnu.org/cgit/guile.git/commit/?h=branch_release-1-8&id=a0aa1e5b69d6ef0311aeea8e4b9a94eae18a1aaf>.
   doCheck = false;
+  doInstallCheck = doCheck;
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -89,6 +89,7 @@
   # make check doesn't work on darwin
   # On Linuxes+Hydra the tests are flaky; feel free to investigate deeper.
   doCheck = false;
+  doInstallCheck = doCheck;
 
   setupHook = ./setup-hook-2.0.sh;
 

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -85,6 +85,7 @@
   # make check doesn't work on darwin
   # On Linuxes+Hydra the tests are flaky; feel free to investigate deeper.
   doCheck = false;
+  doInstallCheck = doCheck;
 
   setupHook = ./setup-hook-2.2.sh;
 

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -105,6 +105,8 @@ let
 
     passthru.libPrefix = "lib/perl5/site_perl";
 
+    doCheck = false; # some tests fail, expensive
+
     # TODO: it seems like absolute paths to some coreutils is required.
     postInstall =
       ''

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -241,6 +241,8 @@ in stdenv.mkDerivation {
 
     enableParallelBuilding = true;
 
+    doCheck = false; # expensive, and fails
+
     meta = {
       homepage = http://python.org;
       description = "A high-level dynamically-typed programming language";

--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -176,6 +176,8 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # expensive, and fails
+
   meta = {
     homepage = http://python.org;
     description = "A high-level dynamically-typed programming language";

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -169,6 +169,8 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # expensive, and fails
+
   meta = {
     homepage = http://python.org;
     description = "A high-level dynamically-typed programming language";

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -193,6 +193,8 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # expensive, and fails
+
   meta = {
     homepage = http://python.org;
     description = "A high-level dynamically-typed programming language";

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -136,6 +136,8 @@ let
           ++ op (stdenv.hostPlatform != stdenv.buildPlatform)
              "--with-baseruby=${buildRuby}";
 
+        doCheck = false; # expensive, fails
+
         preInstall = ''
           # Ruby installs gems here itself now.
           mkdir -pv "$out/${passthru.gemPath}"

--- a/pkgs/development/libraries/appstream-glib/default.nix
+++ b/pkgs/development/libraries/appstream-glib/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     "-Ddep11=false"
   ];
 
+  doCheck = false; # fails at least 1 test
+
   postInstall = ''
     moveToOutput "share/installed-tests" "$installedTests"
   '';

--- a/pkgs/development/libraries/at-spi2-atk/default.nix
+++ b/pkgs/development/libraries/at-spi2-atk/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ python popt atk libX11 libICE xorg.libXtst libXi
                   dbus-glib at-spi2-core libSM ];
 
+  doCheck = false; # needs dbus daemon
+
   meta = with stdenv.lib; {
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
   # ToDo: on non-NixOS we create a symlink from there?
   configureFlags = "--with-dbus-daemondir=/run/current-system/sw/bin/";
 
+  doCheck = false; # needs dbus daemon
+
   meta = with stdenv.lib; {
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -72,6 +72,8 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # fails
+
   postInstall = stdenv.lib.optionalString stdenv.isDarwin glib.flattenInclude;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/celt/generic.nix
+++ b/pkgs/development/libraries/celt/generic.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   buildInputs = []
     ++ stdenv.lib.optional liboggSupport libogg;
 
+  doCheck = false; # fails
+
   meta = with stdenv.lib; {
     description = "Ultra-low delay audio codec";
     homepage    = http://www.celt-codec.org/;

--- a/pkgs/development/libraries/ctpp2/default.nix
+++ b/pkgs/development/libraries/ctpp2/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sed -ie 's/<stdlib.h>/<stdlib.h>\n#include <unistd.h>/' src/CTPP2FileSourceLoader.cpp
   '';
 
+  doCheck = false; # fails
+
   meta = {
     description = "A high performance templating engine";
     homepage = http://ctpp.havoc.ru;

--- a/pkgs/development/libraries/eigen/default.nix
+++ b/pkgs/development/libraries/eigen/default.nix
@@ -5,19 +5,21 @@ let
 in
 stdenv.mkDerivation {
   name = "eigen-${version}";
-  
+
   src = fetchurl {
     url = "http://bitbucket.org/eigen/eigen/get/${version}.tar.gz";
     name = "eigen-${version}.tar.gz";
     sha256 = "00l52y7m276gh8wjkqqcxz6x687azrm7a70s3iraxnpy9bxa9y04";
   };
-  
+
   nativeBuildInputs = [ cmake ];
+
+  doCheck = false; # a couple of tests fail with "Child aborted"
 
   postInstall = ''
     sed -e '/Cflags:/s@''${prefix}/@@' -i "$out"/share/pkgconfig/eigen3.pc
   '';
-  
+
   meta = with stdenv.lib; {
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
     license = licenses.lgpl3Plus;

--- a/pkgs/development/libraries/enchant/2.x.nix
+++ b/pkgs/development/libraries/enchant/2.x.nix
@@ -17,6 +17,8 @@ in stdenv.mkDerivation rec {
   buildInputs = [ glib hunspell ];
   propagatedBuildInputs = [ hspell aspell ]; # libtool puts it to la file
 
+  doCheck = false; # fails to compile with with "UnitTest++.h: No such file or directory"
+
   meta = with stdenv.lib; {
     description = "Generic spell checking library";
     homepage = https://abiword.github.io/enchant/;

--- a/pkgs/development/libraries/epoxy/default.nix
+++ b/pkgs/development/libraries/epoxy/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = ''-DLIBGL_PATH="${getLib libGL}/lib"'';
 
+  doCheck = false; # needs X11
+
   meta = {
     description = "A library for handling OpenGL function pointer management";
     homepage = https://github.com/anholt/libepoxy;

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -160,8 +160,9 @@ stdenv.mkDerivation rec {
     ++ optional vdpauSupport libvdpau
     ++ optional sdlSupport (if reqMin "3.2" then SDL2 else SDL);
 
-
   enableParallelBuilding = true;
+
+  doCheck = false; # fails
 
   postFixup = ''
     moveToOutput bin "$bin"

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     '';
 
   # The tests take an excessive amount of time (> 1.5 hours) and memory (> 6 GB).
-  inherit (doCheck);
+  inherit doCheck;
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/gegl/default.nix
+++ b/pkgs/development/libraries/gegl/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
+  doCheck = false; # fails 3 out of 19 tests
+
   meta = {
     description = "Graph-based image processing framework";
     homepage = http://www.gegl.org;

--- a/pkgs/development/libraries/git2/0.25.nix
+++ b/pkgs/development/libraries/git2/0.25.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # hangs. or very expensive?
+
   meta = {
     description = "The Git linkable library";
     homepage = https://libgit2.github.com/;

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (rec {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # hangs. or very expensive?
+
   meta = with stdenv.lib; {
     description = "The Git linkable library";
     homepage = https://libgit2.github.com/;

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -191,6 +191,8 @@ stdenv.mkDerivation ({
 
   preBuild = lib.optionalString withGd "unset NIX_DONT_SET_RPATH";
 
+  doCheck = false; # fails
+
   meta = {
     homepage = http://www.gnu.org/software/libc/;
     description = "The GNU C Library";

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation rec {
       cairoLib = "${getLib cairo}/lib";
     });
 
+  doCheck = false; # fails
+
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/grantlee/5/default.nix
+++ b/pkgs/development/libraries/grantlee/5/default.nix
@@ -31,6 +31,8 @@ mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
+  doCheck = false; # fails all the tests (ctest)
+
   meta = with lib; {
     description = "Qt5 port of Django template system";
     longDescription = ''

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -77,4 +77,7 @@ stdenv.mkDerivation rec {
     ++ optional (!stdenv.isDarwin) mjpegtools;
 
   enableParallelBuilding = true;
+
+  doCheck = false; # fails 20 out of 58 tests, expensive
+
 }

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation rec {
     "--disable-visibility"
   ];
 
+  doCheck = false; # needs X11
+
   postInstall = ''
     moveToOutput share/gtk-2.0/demo "$devdoc"
     # The updater is needed for nixos env and it's tiny.

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation rec {
     "--enable-wayland-backend"
   ];
 
+  doCheck = false; # needs X11
+
   postInstall = optionalString (!stdenv.isDarwin) ''
     substituteInPlace "$out/lib/gtk-3.0/3.0.0/printbackends/libprintbackend-cups.la" \
       --replace '-L${gmp.dev}/lib' '-L${gmp.out}/lib'

--- a/pkgs/development/libraries/gts/default.nix
+++ b/pkgs/development/libraries/gts/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib gettext ];
 
+  doCheck = false; # fails with "permission denied"
+
   meta = {
     homepage = http://gts.sourceforge.net/;
     license = stdenv.lib.licenses.lgpl2Plus;

--- a/pkgs/development/libraries/id3lib/default.nix
+++ b/pkgs/development/libraries/id3lib/default.nix
@@ -9,11 +9,13 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [ zlib ];
-  
+
   src = fetchurl {
     url = mirror://sourceforge/id3lib/id3lib-3.8.3.tar.gz;
     sha256 = "0yfhqwk0w8q2hyv1jib1008jvzmwlpsxvc8qjllhna6p1hycqj97";
   };
+
+  doCheck = false; # fails to compile
 
   meta = {
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/jasper/default.nix
+++ b/pkgs/development/libraries/jasper/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # fails
+
   postInstall = ''
     moveToOutput bin "$bin"
   '';

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+  doCheck = false; # fails with "No suitable file for testing purposes"
 
   meta = {
     description = "MIT Kerberos 5";

--- a/pkgs/development/libraries/lcms/default.nix
+++ b/pkgs/development/libraries/lcms/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation {
 
   outputs = [ "bin" "dev" "out" "man" ];
 
+  doCheck = false; # fails with "Error in Linear interpolation (2p): Must be i=8000, But is n=8001"
+
   meta = {
     description = "Color management engine";
     homepage = http://www.littlecms.com/;

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
     echo "#include <windows.h>" >> config.h
   '' else null;
 
+  doCheck = false; # fails
+
   preFixup = ''
     sed -i $lib/lib/libarchive.la \
       -e 's|-lcrypto|-L${openssl.out}/lib -lcrypto|' \

--- a/pkgs/development/libraries/libcddb/default.nix
+++ b/pkgs/development/libraries/libcddb/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin libiconv;
 
+  doCheck = false; # fails 3 of 5 tests with locale errors
+
   meta = with stdenv.lib; {
     description = "C library to access data on a CDDB server (freedb.org)";
     homepage = http://libcddb.sourceforge.net/;

--- a/pkgs/development/libraries/libcue/default.nix
+++ b/pkgs/development/libraries/libcue/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake bison flex ];
 
+  doCheck = false; # fails all the tests (ctest)
+
   meta = with stdenv.lib; {
     description = "CUE Sheet Parser Library";
     longDescription = ''

--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames
     ;
 
+  doCheck = false; # needs the net
+
   postInstall = stdenv.lib.optionalString sslSupport ''
     moveToOutput "lib/libevent_openssl*" "$openssl"
     substituteInPlace "$dev/lib/pkgconfig/libevent_openssl.pc" \

--- a/pkgs/development/libraries/libical/default.nix
+++ b/pkgs/development/libraries/libical/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     ./respect-env-tzdir.patch
   ];
 
+  doCheck = false; # fails all the tests (ctest)
+
   meta = with stdenv.lib; {
     homepage = https://github.com/libical/libical;
     description = "An Open Source implementation of the iCalendar protocols";

--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin libiconv;
 
+  doCheck = false; # fails
+
   meta = {
     homepage = http://www.gnu.org/software/libidn/;
     description = "Library for internationalized domain names";

--- a/pkgs/development/libraries/libindicator/default.nix
+++ b/pkgs/development/libraries/libindicator/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     "localstatedir=\${TMPDIR}"
   ];
 
+  doCheck = false; # fails 8 out of 8 tests
+
   meta = {
     description = "A set of symbols and convenience functions for Ayatana indicators";
     homepage = https://launchpad.net/libindicator;

--- a/pkgs/development/libraries/liblo/default.nix
+++ b/pkgs/development/libraries/liblo/default.nix
@@ -8,7 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "0sn0ckc1d0845mhsaa62wf7f9v0c0ykiq796a30ja5096kib9qdc";
   };
 
-  meta = { 
+  doCheck = false; # fails 1 out of 3 tests
+
+  meta = {
     description = "Lightweight library to handle the sending and receiving of messages according to the Open Sound Control (OSC) protocol";
     homepage = https://sourceforge.net/projects/liblo;
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/development/libraries/libnih/default.nix
+++ b/pkgs/development/libraries/libnih/default.nix
@@ -4,7 +4,7 @@ let version = "1.0.3"; in
 
 stdenv.mkDerivation rec {
   name = "libnih-${version}";
-  
+
   src = fetchurl {
     url = "http://code.launchpad.net/libnih/1.0/${version}/+download/libnih-${version}.tar.gz";
     sha256 = "01glc6y7z1g726zwpvp2zm79pyb37ki729jkh45akh35fpgp4xc9";
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ dbus expat ];
+
+  doCheck = false; # fails 1 of 17 test
 
   meta = {
     description = "A small library for C application development";

--- a/pkgs/development/libraries/libomxil-bellagio/default.nix
+++ b/pkgs/development/libraries/libomxil-bellagio/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fedora-fixes.patch ];
 
+  doCheck = false; # fails
+
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/omxil/;
     description = "An opensource implementation of the Khronos OpenMAX Integration Layer API to access multimedia components";

--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     )
   '';
 
+  doCheck = false; # fails 1 out of 10 tests
+
   meta = with stdenv.lib; {
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.lgpl21;

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation rec {
         -i gdk-pixbuf-loader/librsvg.thumbnailer.in
   '';
 
+  doCheck = false; # fails 20 of 145 tests, very likely to be buggy
+
   # Merge gdkpixbuf and librsvg loaders
   postInstall = ''
     mv $GDK_PIXBUF/loaders.cache $GDK_PIXBUF/loaders.cache.tmp

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
     "--with-gnome=${if gnomeSupport then "yes" else "no"}"
   ];
 
+  doCheck = false; # fails with "no: command not found"
+
   passthru = {
     propagatedUserEnvPackages = [ glib-networking.out ];
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/libtorrent-rasterbar/generic.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/generic.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # fails to link
+
   meta = with stdenv.lib; {
     homepage = http://www.rasterbar.com/products/libtorrent/;
     description = "A C++ BitTorrent implementation focusing on efficiency and scalability";

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -29,12 +29,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  checkInputs = [ check ];
-
-  checkPhase = "ctest";
+  doCheck = false; # hangs, tries to access the net?
 
   # for some reason the tests are not running - it says "No tests found!!"
-  doCheck = true;
+  checkInputs = [ check ];
+  checkPhase = "ctest";
 
   meta = with stdenv.lib; {
     description = "P2P FOSS instant messaging application aimed to replace Skype";

--- a/pkgs/development/libraries/libuchardet/default.nix
+++ b/pkgs/development/libraries/libuchardet/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake ];
 
+  doCheck = false; # fails all the tests (ctest)
+
   meta = with stdenv.lib; {
     description = "Mozilla's Universal Charset Detector C/C++ API";
     homepage    = https://www.byvoid.com/zht/project/uchardet;

--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  doCheck = false; # fails
+
   meta = with stdenv.lib; {
     homepage = http://www.nongnu.org/libunwind;
     description = "A portable and efficient API to determine the call-chain of a program";

--- a/pkgs/development/libraries/libvdpau-va-gl/default.nix
+++ b/pkgs/development/libraries/libvdpau-va-gl/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ libX11 libpthreadstubs libXau libXdmcp libXext libvdpau glib libva ffmpeg libGLU ];
 
+  doCheck = false; # fails. needs DRI access
+
   meta = with stdenv.lib; {
     homepage = https://github.com/i-rinat/libvdpau-va-gl;
     description = "VDPAU driver with OpenGL/VAAPI backend";

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     "-Dx-locale-root=${libX11.out}/share/X11/locale"
   ];
 
+  doCheck = false; # fails, needs unicode locale
+
   meta = with stdenv.lib; {
     description = "A library to handle keyboard descriptions";
     homepage = https://xkbcommon.org;

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ ilmbase zlib ];
 
   enableParallelBuilding = true;
+  doCheck = false; # fails 1 of 1 tests
 
   meta = with stdenv.lib; {
     homepage = http://www.openexr.com/;

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
       ++ stdenv.lib.optional (cyrus_sasl == null) "--without-cyrus-sasl"
       ++ stdenv.lib.optional stdenv.isFreeBSD "--with-pic";
 
+  doCheck = false; # needs a running LDAP server
+
   installFlags = [ "sysconfdir=$(out)/etc" "localstatedir=$(out)/var" ];
 
   # 1. Fixup broken libtool

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "exampledir=\${out}/etc/pkcs11" ];
 
+  doInstallCheck = false; # probably a bug in this derivation
+
   meta = with stdenv.lib; {
     homepage = https://p11-glue.freedesktop.org/;
     platforms = platforms.all;

--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "doc" "man" "devdoc" ];
 
+  doCheck = false; # fails 1 of 3 tests
+
   postFixup = ''
     moveToOutput bin/pcre2-config "$dev"
   '';

--- a/pkgs/development/libraries/popt/default.nix
+++ b/pkgs/development/libraries/popt/default.nix
@@ -8,10 +8,12 @@ stdenv.mkDerivation rec {
     sha256 = "1j2c61nn2n351nhj4d25mnf3vpiddcykq005w2h6kw79dwlysa77";
   };
 
-  patches = if stdenv.isCygwin then [
+  patches = stdenv.lib.optionals stdenv.isCygwin [
     ./1.16-cygwin.patch
     ./1.16-vpath.patch
-  ] else null;
+  ];
+
+  doCheck = false; # fails
 
   meta = {
     description = "Command line option parsing library";

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -192,6 +192,8 @@ stdenv.mkDerivation rec {
     sed -i 's/^\(LIBS[[:space:]]*=.*$\)/\1 -lobjc/' ./src/corelib/Makefile.Release
   '';
 
+  doCheck = false; # qwebframe test fails with fontconfig errors
+
   postInstall = ''
     rm -rf $out/tests
   '';

--- a/pkgs/development/libraries/sqlcipher/default.nix
+++ b/pkgs/development/libraries/sqlcipher/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   CFLAGS = [ "-DSQLITE_ENABLE_COLUMN_METADATA=1" "-DSQLITE_SECURE_DELETE=1" "-DSQLITE_ENABLE_UNLOCK_NOTIFY=1" "-DSQLITE_HAS_CODEC" ];
   LDFLAGS = lib.optional (readline != null) "-lncurses";
 
+  doCheck = false; # fails. requires tcl?
+
   meta = with stdenv.lib; {
     homepage = http://sqlcipher.net/;
     description = "Full Database Encryption for SQLite";

--- a/pkgs/development/libraries/tk/8.5.nix
+++ b/pkgs/development/libraries/tk/8.5.nix
@@ -8,4 +8,3 @@ callPackage ./generic.nix (args // rec {
   };
 
 })
-

--- a/pkgs/development/libraries/tk/8.6.nix
+++ b/pkgs/development/libraries/tk/8.6.nix
@@ -10,4 +10,3 @@ callPackage ./generic.nix (args // rec {
   patches = [ ./different-prefix-with-tcl.patch ] ++ stdenv.lib.optionals stdenv.isDarwin [ ./Fix-bad-install_name-for-libtk8.6.dylib.patch ];
 
 })
-

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation {
 
   NIX_CFLAGS_LINK = if stdenv.isDarwin then "-lfontconfig" else null;
 
+  doCheck = false; # fails. can't find itself
+
   inherit tcl;
 
   passthru = rec {

--- a/pkgs/development/libraries/zeromq/3.x.nix
+++ b/pkgs/development/libraries/zeromq/3.x.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libuuid ];
 
+  doCheck = false; # fails all the tests (ctest)
+
   meta = with stdenv.lib; {
     branch = "3";
     homepage = http://www.zeromq.org;

--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     sed -i 's,''${PACKAGE_PREFIX_DIR}/,,g' ZeroMQConfig.cmake.in
   '';
 
+  doCheck = false; # fails all the tests (ctest)
+
   meta = with stdenv.lib; {
     branch = "4";
     homepage = http://www.zeromq.org;

--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation rec {
   configureFlags =
     stdenv.lib.optional (stdenv.system == "x86_64-linux" || stdenv.system == "x86_64-darwin") "--enable-only64bit";
 
+  doCheck = false; # fails
+
   postInstall = ''
     for i in $out/lib/valgrind/*.supp; do
       substituteInPlace $i \

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation rec {
   # CMAKE_SYSTEM_NAME, etc.
   configurePlatforms = [ ];
 
+  doCheck = false; # fails
 
   meta = with stdenv.lib; {
     homepage = http://www.cmake.org/;

--- a/pkgs/development/tools/dcadec/default.nix
+++ b/pkgs/development/tools/dcadec/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   installPhase = "make PREFIX=/ DESTDIR=$out install";
 
+  doCheck = false; # fails with "ERROR: Run 'git submodule update --init test/samples' first."
+
   meta = with stdenv.lib; {
     description = "DTS Coherent Acoustics decoder with support for HD extensions";
     maintainers = with maintainers; [ edwtjo ];

--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional stdenv.isDarwin "-mmacosx-version-min=10.9";
 
   enableParallelBuilding = true;
+  doCheck = false; # fails
 
   meta = {
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--disable-scrollkeeper";
 
+  doCheck = false; # requires a lot of stuff
+  doInstallCheck = false; # fails
+
   passthru = {
     # Consumers are expected to copy the m4 files to their source tree, let them reuse the patch
     respect_xml_catalog_files_var_patch = ./respect-xml-catalog-files-var.patch;

--- a/pkgs/development/tools/go2nix/default.nix
+++ b/pkgs/development/tools/go2nix/default.nix
@@ -33,6 +33,8 @@ buildGoPackage rec {
 
   allowGoReference = true;
 
+  doCheck = false; # tries to access the net
+
   meta = with stdenv.lib; {
     description = "Go apps packaging for Nix";
     homepage = https://github.com/kamilchm/go2nix;

--- a/pkgs/development/tools/govers/default.nix
+++ b/pkgs/development/tools/govers/default.nix
@@ -4,7 +4,7 @@ buildGoPackage rec {
   name = "govers-${version}";
   version = "20150109-${stdenv.lib.strings.substring 0 7 rev}";
   rev = "3b5f175f65d601d06f48d78fcbdb0add633565b9";
-  
+
   goPackagePath = "github.com/rogpeppe/govers";
 
   src = fetchgit {
@@ -14,4 +14,7 @@ buildGoPackage rec {
   };
 
   dontRenameImports = true;
+
+  doCheck = false; # fails, silently
+
 }

--- a/pkgs/development/tools/misc/autoconf/2.64.nix
+++ b/pkgs/development/tools/misc/autoconf/2.64.nix
@@ -23,10 +23,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  preCheck =
-    # Make the Autotest test suite run in parallel.
-    '' export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
-    '';
+  # Make the Autotest test suite run in parallel.
+  preCheck =''
+    export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
+  '';
+
+  doInstallCheck = false; # fails
 
   meta = {
     homepage = http://www.gnu.org/software/autoconf/;

--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -24,10 +24,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  preCheck =
-    # Make the Autotest test suite run in parallel.
-    '' export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
-    '';
+  # Make the Autotest test suite run in parallel.
+  preCheck =''
+    export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
+  '';
+
+  doInstallCheck = false; # fails
 
   meta = {
     homepage = http://www.gnu.org/software/autoconf/;

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -121,6 +121,8 @@ stdenv.mkDerivation rec {
     "--enable-fix-loongson2f-nop"
   ] ++ optionals gold [ "--enable-gold" "--enable-plugins" ];
 
+  doCheck = false; # fails
+
   enableParallelBuilding = true;
 
   passthru = {

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   # XXX: The GNU ld wrapper does all sorts of nasty things wrt. RPATH, which
   # leads to the failure of a number of tests.
   doCheck = false;
+  doInstallCheck = false;
 
   # Don't run the native `strip' when cross-compiling.  This breaks at least
   # with `.a' files for MinGW.

--- a/pkgs/development/tools/misc/pkgconfig/default.nix
+++ b/pkgs/development/tools/misc/pkgconfig/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
          "ac_cv_func_posix_getgrgid_r=yes"
        ];
 
+  doCheck = false; # fails
 
   postInstall = ''rm -f "$out"/bin/*-pkg-config''; # clean the duplicate file
 
@@ -42,4 +43,3 @@ stdenv.mkDerivation rec {
   };
 
 }
-

--- a/pkgs/development/tools/parsing/bison/3.x.nix
+++ b/pkgs/development/tools/parsing/bison/3.x.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ m4 perl ] ++ stdenv.lib.optional stdenv.isSunOS help2man;
   propagatedBuildInputs = [ m4 ];
 
+  doCheck = false; # fails
+  doInstallCheck = false; # fails
+
   meta = {
     homepage = http://www.gnu.org/software/bison/;
     description = "Yacc-compatible parser generator";

--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -56,6 +56,7 @@ in stdenv.mkDerivation rec {
     '';
 
   enableParallelBuilding = true;
+  doCheck = false; # fails 4 out of 6 tests
 
   meta = {
     homepage = http://www.linuxfoundation.org/collaborate/workgroups/openprinting/cups-filters;

--- a/pkgs/misc/emulators/wine/winetricks.nix
+++ b/pkgs/misc/emulators/wine/winetricks.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
+  doCheck = false; # requires "bashate"
+
   postInstall = ''
     sed -i \
       -e '2i PATH="${pathAdd}:$PATH"' \

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -36,9 +36,7 @@ let
     substituteInPlace ./common/Make.rules --replace "/usr/share/man" "share/man"
   '';
 
-  # use 'if c then x else null' to avoid rebuilding
-  # patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
-  patches = if stdenv.hostPlatform.isMusl then [
+  patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {
       url = "https://git.alpinelinux.org/cgit/aports/plain/testing/apparmor/0002-Provide-missing-secure_getenv-and-scandirat-function.patch?id=74b8427cc21f04e32030d047ae92caa618105b53";
       name = "0002-Provide-missing-secure_getenv-and-scandirat-function.patch";
@@ -55,7 +53,11 @@ let
       sha256 = "1m4dx901biqgnr4w4wz8a2z9r9dxyw7wv6m6mqglqwf2lxinqmp4";
     })
     # (alpine patches {1,4,5,6,8} are needed for apparmor 2.11, but not 2.12)
-  ] else null;
+  ];
+
+  # Set to `true` after the next FIXME gets fixed or this gets some
+  # common derivation infra. Too much copy-paste to fix one by one.
+  doCheck = false;
 
   # FIXME: convert these to a single multiple-outputs package?
 
@@ -99,6 +101,8 @@ let
       mv $out/lib/python* $python/lib/
     '';
 
+    inherit doCheck;
+
     meta = apparmor-meta "library";
   };
 
@@ -131,6 +135,8 @@ let
       done
     '';
 
+    inherit doCheck;
+
     meta = apparmor-meta "user-land utilities";
   };
 
@@ -153,6 +159,8 @@ let
     postPatch = "cd ./binutils";
     makeFlags = ''LANGS= USE_SYSTEM=1'';
     installFlags = ''DESTDIR=$(out) BINDIR=$(out)/bin'';
+
+    inherit doCheck;
 
     meta = apparmor-meta "binary user-land utilities";
   };
@@ -177,6 +185,8 @@ let
     makeFlags = ''LANGS= USE_SYSTEM=1 INCLUDEDIR=${libapparmor}/include'';
     installFlags = ''DESTDIR=$(out) DISTRO=unknown'';
 
+    inherit doCheck;
+
     meta = apparmor-meta "rule parser";
   };
 
@@ -192,6 +202,8 @@ let
     makeFlags = ''USE_SYSTEM=1'';
     installFlags = ''DESTDIR=$(out)'';
 
+    inherit doCheck;
+
     meta = apparmor-meta "PAM service";
   };
 
@@ -203,6 +215,8 @@ let
 
     postPatch = "cd ./profiles";
     installFlags = ''DESTDIR=$(out) EXTRAS_DEST=$(out)/share/apparmor/extra-profiles'';
+
+    inherit doCheck;
 
     meta = apparmor-meta "profiles";
   };
@@ -217,6 +231,8 @@ let
       mkdir "$out"
       cp -R ./kernel-patches/* "$out"
     '';
+
+    inherit doCheck;
 
     meta = apparmor-meta "kernel patches";
   };

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -98,6 +98,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # tries to access the net
+
   meta = with stdenv.lib; {
     description = "Tiny versions of common UNIX utilities in a single small executable";
     homepage = https://busybox.net/;

--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--datadir=$(prefix)/data";
 
+  doCheck = false; # this does build machine-specific checks (e.g. enumerates PCI bus)
+
   meta = {
     homepage = https://github.com/vcrhonek/hwdata;
     description = "Hardware Database, including Monitors, pci.ids, usb.ids, and video cards";

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -53,6 +53,9 @@ stdenv.mkDerivation {
       "-Wno-error=unused-const-variable" "-Wno-error=misleading-indentation"
     ];
 
+  doCheck = false; # requires "sparse"
+  doInstallCheck = false; # same
+
   separateDebugInfo = true;
   installFlags = "install install-man ASCIIDOC8=1 prefix=$(out)";
 

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation {
     })
   ];
 
+  doCheck = false; # requires root
+
   # To prevent make install from failing.
   preInstall = "installFlags=\"OWNER= GROUP= confdir=$out/etc\"";
 

--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -70,6 +70,8 @@ stdenv.mkDerivation rec {
       sed -e 's/pam_rhosts//g' -i modules/Makefile.in
   '';
 
+  doCheck = false; # fails
+
   meta = {
     homepage = http://ftp.kernel.org/pub/linux/libs/pam/;
     description = "Pluggable Authentication Modules, a flexible mechanism for authenticating user";

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -170,6 +170,8 @@ in stdenv.mkDerivation rec {
       "-USYSTEMD_BINARY_PATH" "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
     ];
 
+  doCheck = false; # fails a bunch of tests
+
   postInstall = ''
     # sysinit.target: Don't depend on
     # systemd-tmpfiles-setup.service. This interferes with NixOps's

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
     "INTROSPECTION_TYPELIBDIR=$(out)/lib/girepository-1.0"
   ];
 
+  doCheck = false; # fails
+
   meta = {
     homepage = http://www.freedesktop.org/wiki/Software/udisks;
     description = "A daemon and command-line utility for querying and manipulating storage devices";

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_LINK = "-lgcc_s";
 
+  doCheck = false; # fails with "env: './linux/integration-test': No such file or directory"
+
   installFlags = "historydir=$(TMPDIR)/foo";
 
   meta = {

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  doCheck = false; # requires root and the net
+
   meta = {
     homepage = http://www.isc.org/software/bind;
     description = "Domain name server";

--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ file perl unzip openssl ];
 
   enableParallelBuilding = true;
+  doCheck = false; # fails
 
   postInstall = ''
     for f in "$out/lib/"*.la $out/bin/net-snmp-config $out/bin/net-snmp-create-v3-user; do

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -75,6 +75,8 @@ let
         wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
       '';
 
+    doInstallCheck = false; # needs a running daemon?
+
     disallowedReferences = [ stdenv.cc ];
 
     passthru = {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -582,6 +582,10 @@ in
     nativeBuildInputs = attrs.nativeBuildInputs ++ [args.bison args.flex];
   };
 
+  xauth = attrs: attrs // {
+    doCheck = false; # fails
+  };
+
   xcursorthemes = attrs: attrs // {
     buildInputs = attrs.buildInputs ++ [xorg.xcursorgen];
     configureFlags = "--with-cursordir=$(out)/share/icons";

--- a/pkgs/tools/archivers/gnutar/default.nix
+++ b/pkgs/tools/archivers/gnutar/default.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
     sed -i gnu/fpending.h -e 's,include <stdio_ext.h>,,'
   '' else null;
 
+  doCheck = false; # fails
+  doInstallCheck = false; # fails
+
   meta = {
     homepage = http://www.gnu.org/software/tar/;
     description = "GNU implementation of the `tar' archiver";

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
   # In stdenv-linux, prevent a dependency on bootstrap-tools.
   makeFlags = "SHELL=/bin/sh GREP=grep";
 
+  doCheck = false; # fails
+
   meta = {
     homepage = https://www.gnu.org/software/gzip/;
     description = "GNU zip compression program";

--- a/pkgs/tools/filesystems/curlftpfs/default.nix
+++ b/pkgs/tools/filesystems/curlftpfs/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [fuse curl glib zlib];
 
+  doCheck = false; # fails, doesn't work well too, btw
+
   meta = {
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/tools/graphics/graphviz/base.nix
+++ b/pkgs/tools/graphics/graphviz/base.nix
@@ -43,6 +43,13 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  # ''
+  #   substituteInPlace rtest/rtest.sh \
+  #     --replace "/bin/ksh" "${mksh}/bin/mksh"
+  # '';
+
+  doCheck = false; # fails with "Graphviz test suite requires ksh93" which is not in nixpkgs
+
   preAutoreconf = "./autogen.sh";
 
   postFixup = optionalString (xorg != null) ''

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -125,6 +125,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # requires X11 daemon
   doInstallCheck = true;
   installCheckPhase = "$out/bin/ibus version";
 

--- a/pkgs/tools/misc/bogofilter/default.nix
+++ b/pkgs/tools/misc/bogofilter/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flex db ];
 
+  doCheck = false; # needs "y" tool
+
   meta = {
     homepage = http://bogofilter.sourceforge.net/;
     longDescription = ''

--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -57,6 +57,9 @@ stdenv.mkDerivation rec {
     ./bootstrap --skip-git --gnulib-srcdir=./gnulib
   '';
 
+  doCheck = false; # tries to wget some fonts
+  doInstallCheck = doCheck;
+
   postInstall =
     # get rid of the runtime dependency on python
     lib.optionalString (!withPython) ''
@@ -72,4 +75,3 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.bsd3;
   };
 }
-

--- a/pkgs/tools/networking/atftp/default.nix
+++ b/pkgs/tools/networking/atftp/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   # Expects pre-GCC5 inline semantics
   NIX_CFLAGS_COMPILE = "-std=gnu89";
 
+  doCheck = false; # fails
+
   meta = {
     description = "Advanced tftp tools";
     maintainers = [ lib.maintainers.raskin ];

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -79,6 +79,8 @@ stdenv.mkDerivation rec {
   CXX = "c++";
   CXXCPP = "c++ -E";
 
+  doCheck = false; # expensive, fails
+
   postInstall = ''
     moveToOutput bin/curl-config "$dev"
     sed '/^dependency_libs/s|${libssh2.dev}|${libssh2.out}|' -i "$out"/lib/*.la

--- a/pkgs/tools/networking/maildrop/default.nix
+++ b/pkgs/tools/networking/maildrop/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./maildrop.configure.hack.patch ]; # for building in chroot
 
+  doCheck = false; # fails with "setlocale: LC_ALL: cannot change locale (en_US.UTF-8)"
+
   meta = with stdenv.lib; {
     homepage = http://www.courier-mta.org/maildrop/;
     description = "Mail filter/mail delivery agent that is used by the Courier Mail Server";

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -85,6 +85,8 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook intltool pkgconfig libxslt docbook_xsl ];
 
+  doCheck = false; # requires /sys, the net
+
   preInstall = ''
     installFlagsArray=( "sysconfdir=$out/etc" "localstatedir=$out/var" "runstatedir=$out/var/run" )
   '';

--- a/pkgs/tools/networking/telnet/default.nix
+++ b/pkgs/tools/networking/telnet/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ncurses];
 
+  doInstallCheck = false; # fails
+
   meta = {
     description = "A client and daemon for the Telnet protocol";
     homepage = ftp://ftp.suse.com/pub/people/kukuk/ipv6/;

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -53,6 +53,8 @@ in stdenv.mkDerivation rec {
       libX11 gtk2 pygtk pysqlite pygobject2 pycairo
     ];
 
+  doCheck = false; # fails 3 tests, probably needs the net
+
   meta = {
     description = "A free and open source utility for network discovery and security auditing";
     homepage    = http://www.nmap.org;

--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   # configure script is not autotools-based, doesn't support these options
   configurePlatforms = [ ];
 
+  doCheck = false; # fails
+
   installTargets = [ "install" "install-lib-shared" "install-lib-so-link" ];
   postInstall = "make -C librhash install-headers";
 

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = false; # needs root
+
   postInstall =
     ''
     rm -f $out/share/doc/sudo/ChangeLog

--- a/pkgs/tools/system/at/default.nix
+++ b/pkgs/tools/system/at/default.nix
@@ -33,12 +33,15 @@ stdenv.mkDerivation rec {
       substituteInPlace ./configure --replace "test -d /var/run" "true"
     '';
 
-  configureFlags =
-    ''
-       --with-etcdir=/etc/at
-       --with-jobdir=/var/spool/atjobs --with-atspool=/var/spool/atspool
-       --with-daemon_username=atd --with-daemon_groupname=atd
-    '';
+  configureFlags = [
+    "--with-etcdir=/etc/at"
+    "--with-jobdir=/var/spool/atjobs"
+    "--with-atspool=/var/spool/atspool"
+    "--with-daemon_username=atd"
+    "--with-daemon_groupname=atd"
+  ];
+
+  doCheck = false; # need "prove" tool
 
   # Ensure that "batch" can invoke the setuid "at" wrapper, if it exists, or
   # else we get permission errors (on NixOS). "batch" is a shell script, so

--- a/pkgs/tools/text/patchutils/default.nix
+++ b/pkgs/tools/text/patchutils/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  doCheck = false; # fails
+
   meta = with stdenv.lib; {
     description = "Tools to manipulate patch files";
     homepage = http://cyberelk.net/tim/software/patchutils;

--- a/pkgs/tools/text/sgml/opensp/default.nix
+++ b/pkgs/tools/text/sgml/opensp/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation {
   buildInputs = stdenv.lib.optionals stdenv.isCygwin [ autoconf automake gettext libiconv libtool ]
     ++ [ xmlto docbook_xml_dtd_412 libxslt docbook_xsl ];
 
+  doCheck = false; # fails
+
   meta = {
     description = "A suite of SGML/XML processing tools";
     license = stdenv.lib.licenses.mit;

--- a/pkgs/tools/typesetting/docbook2x/default.nix
+++ b/pkgs/tools/typesetting/docbook2x/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   name = "docbook2X-0.8.8";
-  
+
   src = fetchurl {
     url = "mirror://sourceforge/docbook2x/${name}.tar.gz";
     sha256 = "0ifwzk99rzjws0ixzimbvs83x6cxqk1xzmg84wa1p7bs6rypaxs0";
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
       --replace '${"\$" + "{prefix}"}' "$out"
   '';
 
+  doCheck = false; # fails a lot of tests
+
   postInstall = ''
     perlPrograms="db2x_manxml db2x_texixml db2x_xsltproc
                   docbook2man docbook2texi";
@@ -34,12 +36,12 @@ stdenv.mkDerivation rec {
     do
       # XXX: We work around the fact that `wrapProgram' doesn't support
       # spaces below by inserting escaped backslashes.
-      wrapProgram $out/bin/$i --prefix PERL5LIB :			\
+      wrapProgram $out/bin/$i --prefix PERL5LIB : \
         "${XMLSAX}/lib/perl5/site_perl:${XMLSAXBase}/lib/perl5/site_perl:${XMLParser}/lib/perl5/site_perl" \
-	--prefix PERL5LIB :						\
-	"${XMLNamespaceSupport}/lib/perl5/site_perl"			\
-	--prefix XML_CATALOG_FILES "\ "					\
-	"$out/share/docbook2X/dtd/catalog.xml\ $out/share/docbook2X/xslt/catalog.xml\ ${docbook_xml_dtd_43}/xml/dtd/docbook/catalog.xml"
+        --prefix PERL5LIB : \
+        "${XMLNamespaceSupport}/lib/perl5/site_perl" \
+        --prefix XML_CATALOG_FILES "\ " \
+        "$out/share/docbook2X/dtd/catalog.xml\ $out/share/docbook2X/xslt/catalog.xml\ ${docbook_xml_dtd_43}/xml/dtd/docbook/catalog.xml"
     done
 
     wrapProgram $out/bin/sgml2xml-isoent --prefix PATH : \

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -204,6 +204,8 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
   CXXFLAGS = "-std=c++11 -Wno-reserved-user-defined-literal"; # TODO: remove once texlive 2018 is out?
   enableParallelBuilding = true;
 
+  doCheck = false; # fails
+
   # now distribute stuff into outputs, roughly as upstream TL
   # (uninteresting stuff remains in $out, typically duplicates from `core`)
   outputs = [ "out" "metafont" "metapost" "luatex" "xetex" ];

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -438,6 +438,8 @@ let
       );
     '';
 
+    doCheck = false; # fails to find itself
+
     installTargets = [ "install" "install-unix" ];
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
(the trivial part)

###### Motivation for this change

#33599. I implemented that issue for fun and giggles and now run a system that is "fully-tested". Turns out, not unexpectedly, an enormous number of packages fail to check. This is the first patch from that patchset. This patch disables many things that fail, but I couldn't (even partially) fix them. I.e. this patch contains only trivial `doCheck = false` changes and a couple of cleanups. The rest is coming later.

Note that I started documenting error messages too late, hence many changes here just disable tests without comments. I'm too lazy to repeat the effort to document the "doCheck = false; # fails" lines as rebuilding and fixing everything multiple times with 33599-patchset took almost two weeks.

Note: For most packages you won't be able to check why they actually fail with just `doCheck = true;` without some more patches from the patchset because the patchset adds `checkTraget` autodetection to stdenv.

###### Things done

- [X] When combined with other patches in the series the system builds.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

