### PR TITLE
rabbitmq: 3.6.15 -> 3.7.4

### DIFF
--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, runCommand
-, erlang, python, libxml2, libxslt, xmlto
+, erlang, elixir, python, libxml2, libxslt, xmlto
 , docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync
 
 , AppKit, Carbon, Cocoa
@@ -13,15 +13,15 @@ let
 
 in stdenv.mkDerivation rec {
   name = "rabbitmq-server-${version}";
-  version = "3.6.15";
+  version = "3.7.4";
 
   src = fetchurl {
-    url = "https://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
-    sha256 = "1zdmil657mhjmd20jv47s5dfpj2liqwvyg0zv2ky3akanfpgj98y";
+    url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${version}/rabbitmq-server-${version}.tar.xz";
+    sha256 = "0y3c3kmj2jnfic4rzfn5x0raigkgscxv94fn3ijnnk535b209iw8";
   };
 
   buildInputs =
-    [ erlang python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip rsync ]
+    [ erlang elixir python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip rsync ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit Carbon Cocoa ];
 
   outputs = [ "out" "man" "doc" ];


### PR DESCRIPTION
###### Motivation for this change

The 3.6 release branch will soon be deprecated / not receive any updates
anymore.

The changelog of the initial 3.7.0 release can be found on GitHub [1].

[1] https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.0

cc @Profpatsch 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

