### PR TITLE
coqPackages.contribs.containers: make available for Coq 8.8

### DIFF
--- a/pkgs/development/coq-modules/contribs/default.nix
+++ b/pkgs/development/coq-modules/contribs/default.nix
@@ -189,7 +189,7 @@ let mkContrib = repo: revs: param:
     sha256 = "1ddwzg12pbzpnz3njin4zhpph92kscrbsn3bzds26yj8fp76zc33";
   };
 
-  containers = mkContrib "containers" [ "8.6" "8.7" ] {
+  containers = mkContrib "containers" [ "8.6" "8.7" "8.8" ] {
     "8.6" = {
       version = "8.6.0";
       rev = "fa1fec7";
@@ -199,6 +199,11 @@ let mkContrib = repo: revs: param:
       version = "20180313";
       rev = "77ac16366529c9e558f70ba86f0168a76ca76b8f";
       sha256 = "01gp8injb0knaxgqsdc4x9h8714k7qxg7j5w7y6i45dnpd81ndr4";
+    };
+    "8.8" = {
+      version = "20180330";
+      rev = "52b86bed1671321b25fe4d7495558f9f221b12aa";
+      sha256 = "0hbnrwdgryr52170cfrlbiymr88jsyxilnpr343vnprqq3zk1xz0";
     };
   }."${coq.coq-version}";
 


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

