### PR TITLE
buildkite-agent3: init at 3.0.1

### DIFF
--- a/pkgs/development/tools/continuous-integration/buildkite-agent/2.x.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/2.x.nix
@@ -1,0 +1,12 @@
+{ callPackage, fetchFromGitHub, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  src = fetchFromGitHub {
+    owner = "buildkite";
+    repo = "agent";
+    rev = "v${version}";
+    sha256 = "07065hhhb418w5qlqnyiap45r59paysysbwz1l7dmaw3j4q8m8rg";
+  };
+  version = "2.6.10";
+  hasBootstrapScript = true;
+})

--- a/pkgs/development/tools/continuous-integration/buildkite-agent/3.x.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/3.x.nix
@@ -1,0 +1,12 @@
+{ callPackage, fetchFromGitHub, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  src = fetchFromGitHub {
+    owner = "buildkite";
+    repo = "agent";
+    rev = "v${version}";
+    sha256 = "09smyrzp1xkczlmh8vqb7bmjb2b5d6yf9birjgaw36c6m44bpfvs";
+  };
+  version = "3.0.1";
+  hasBootstrapScript = false;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7564,7 +7564,9 @@ with pkgs;
   buildbot-ui = buildbot.withPlugins (with self.buildbot-plugins; [ www ]);
   buildbot-full = buildbot.withPlugins (with self.buildbot-plugins; [ www console-view waterfall-view grid-view wsgi-dashboards ]);
 
-  buildkite-agent = callPackage ../development/tools/continuous-integration/buildkite-agent { };
+  buildkite-agent = buildkite-agent2;
+  buildkite-agent2 = callPackage ../development/tools/continuous-integration/buildkite-agent/2.x.nix { };
+  buildkite-agent3 = callPackage ../development/tools/continuous-integration/buildkite-agent/3.x.nix { };
 
   byacc = callPackage ../development/tools/parsing/byacc { };
 


### PR DESCRIPTION
###### Motivation for this change

New stable release. Version 2.6 is kept for backwards compatibility.

https://github.com/buildkite/agent/releases/tag/v3.0.0
https://github.com/buildkite/agent/releases/tag/v3.0.1


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The v3.0.1 agent seems to connect to buildkite and run builds. I have tested on Darwin.

/cc @zimbatm @pawelpacana 