### PR TITLE
fcitx-libpinyin: fix data path

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/datapath.patch
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/datapath.patch
@@ -1,0 +1,16 @@
+--- a/src/utils.cpp
++++ b/src/utils.cpp
+@@ -9,12 +9,7 @@ char* FcitxLibPinyinGetSysPath(LIBPINYIN_LANGUAGE_TYPE type)
+ #ifdef LIBPINYIN_TOOLS_FOUND
+     if (type == LPLT_Simplified) {
+ #endif
+-        /* portable detect here */
+-        if (getenv("FCITXDIR")) {
+-            syspath = fcitx_utils_get_fcitx_path_with_filename("datadir", "libpinyin/data");
+-        } else {
+-            syspath = strdup(LIBPINYIN_PKGDATADIR "/data");
+-        }
++        syspath = strdup(LIBPINYIN_PKGDATADIR "/data");
+ #ifdef LIBPINYIN_TOOLS_FOUND
+     }
+     else {

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -12,6 +12,16 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig  ];
   buildInputs = [ fcitx-qt5 qtbase qtwebengine.dev cmake fcitx gettext libpinyin glib pcre dbus ];
 
+  # With a typical installation via NixOS option i18n.inputMethod.fcitx.engines,
+  # the FCITXDIR environment variable is set to $out of fcitx-with-plugins,
+  # which leads to an incorrect path for pinyin data.
+  #
+  # It is impossible or difficult to fix this issue without patching. We want
+  # FCITXDIR to point into libpinyin, which is currently not symlinked within
+  # fcitx-with-plugins (only fcitx-libpinyin is symlinked). Also, FCITXDIR
+  # doesn't accept multiple directories.
+  patches = [ ./datapath.patch ];
+
   preInstall = ''
     substituteInPlace src/cmake_install.cmake \
       --replace ${fcitx} $out


### PR DESCRIPTION
###### Motivation for this change
fcitx-libpinyin is currently unusable, because it can't find the data files. It seems impossible to fix this issue without patching.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

