### PR TITLE
nixos/infinoted: Abstract over libinfinity version

### DIFF
--- a/nixos/modules/services/editors/infinoted.nix
+++ b/nixos/modules/services/editors/infinoted.nix
@@ -129,7 +129,7 @@ in {
         serviceConfig = {
           Type = "simple";
           Restart = "always";
-          ExecStart = "${cfg.package}/bin/infinoted-0.6 --config-file=/var/lib/infinoted/infinoted.conf";
+          ExecStart = "${cfg.package}/bin/infinoted-${versions.majorMinor cfg.package.version} --config-file=/var/lib/infinoted/infinoted.conf";
           User = cfg.user;
           Group = cfg.group;
           PermissionsStartOnly = true;

--- a/pkgs/development/libraries/libinfinity/default.nix
+++ b/pkgs/development/libraries/libinfinity/default.nix
@@ -12,7 +12,8 @@ let
 
 in stdenv.mkDerivation rec {
 
-  name = "libinfinity-0.7.1";
+  name = "libinfinity-${version}";
+  version = "0.7.1";
   src = fetchurl {
     url = "http://releases.0x539.de/libinfinity/${name}.tar.gz";
     sha256 = "1jw2fhrcbpyz99bij07iyhy9ffyqdn87vl8cb1qz897y3f2f0vk2";
@@ -35,6 +36,10 @@ in stdenv.mkDerivation rec {
     ${edf daemon "libdaemon"}
     ${edf avahiSupport "avahi"}
   '';
+
+  passthru = {
+    inherit version;
+  };
 
   meta = {
     homepage = http://gobby.0x539.de/;


### PR DESCRIPTION
###### Motivation for this change
The NixOS service referred to `infinoted-0.6` which broke with the bump to `0.7.1`.

###### Things done
Instead of hardcoding `0.6` we now `passthru` the relevant version and use it to generate the name of the executable.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

