### PR TITLE
lib/generators: print paths without quotes & move function down

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -317,7 +317,8 @@ runTests {
     expr = mapAttrs (const (generators.toPretty {})) rec {
       int = 42;
       bool = true;
-      string = "fnord";
+      string = ''fno"rd'';
+      path = /. + "/foo"; # toPath returns a string
       null_ = null;
       function = x: x;
       functionArgs = { arg ? 4, foo }: arg;
@@ -328,13 +329,14 @@ runTests {
     expected = rec {
       int = "42";
       bool = "true";
-      string = "\"fnord\"";
+      string = ''"fno\"rd"'';
+      path = "/foo";
       null_ = "null";
       function = "<λ>";
       functionArgs = "<λ:{(arg),foo}>";
       list = "[ 3 4 ${function} [ false ] ]";
       attrs = "{ \"foo\" = null; \"foo bar\" = \"baz\"; }";
-      drv = "<δ>";
+      drv = "<δ:test>";
     };
   };
 


### PR DESCRIPTION
- [x] ran lib tests