### PR TITLE
musl: provide 'iconv' utility like other libc's

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -17,11 +17,14 @@ let
     sha256 = "14igk6k00bnpfw660qhswagyhvr0gfqg4q55dxvaaq7ikfkrir71";
   };
 
-  # iconv tool, implemented by musl author:
+  # iconv tool, implemented by musl author.
+  # Original: http://git.etalabs.net/cgit/noxcuse/plain/src/iconv.c?id=02d288d89683e99fd18fe9f54d4e731a6c474a4f
+  # We use copy from Alpine which fixes error messages, see:
+  # https://git.alpinelinux.org/cgit/aports/commit/main/musl/iconv.c?id=a3d97e95f766c9c378194ee49361b375f093b26f
   iconv_c = fetchurl {
     name = "iconv.c";
-    url = "http://git.etalabs.net/cgit/noxcuse/plain/src/iconv.c?id=02d288d89683e99fd18fe9f54d4e731a6c474a4f";
-    sha256 = "1yafz6y509zxpa1i830p5463p91g0y70q60z8q054078qrpln8hp";
+    url = "https://git.alpinelinux.org/cgit/aports/plain/main/musl/iconv.c?id=a3d97e95f766c9c378194ee49361b375f093b26f";
+    sha256 = "1mzxnc2ncq8lw9x6n7p00fvfklc9p3wfv28m68j0dfz5l8q2k6pp";
   };
 
 in

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -17,6 +17,13 @@ let
     sha256 = "14igk6k00bnpfw660qhswagyhvr0gfqg4q55dxvaaq7ikfkrir71";
   };
 
+  # iconv tool, implemented by musl author:
+  iconv_c = fetchurl {
+    name = "iconv.c";
+    url = "http://git.etalabs.net/cgit/noxcuse/plain/src/iconv.c?id=02d288d89683e99fd18fe9f54d4e731a6c474a4f";
+    sha256 = "1yafz6y509zxpa1i830p5463p91g0y70q60z8q054078qrpln8hp";
+  };
+
 in
 stdenv.mkDerivation rec {
   name    = "musl-${version}";
@@ -77,6 +84,9 @@ stdenv.mkDerivation rec {
     moveToOutput lib/musl-gcc.specs $dev
     substituteInPlace $dev/bin/musl-gcc \
       --replace $out/lib/musl-gcc.specs $dev/lib/musl-gcc.specs
+
+    # provide 'iconv' utility
+    $CC ${iconv_c} -o $out/bin/iconv
   '' + lib.optionalString useBSDCompatHeaders ''
     install -D ${queue_h} $dev/include/sys/queue.h
     install -D ${cdefs_h} $dev/include/sys/cdefs.h

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -51,6 +51,13 @@ stdenv.mkDerivation rec {
       --replace -fno-asynchronous-unwind-tables ""
   '';
 
+  patches = [
+    # Minor touchup to build system making dynamic linker symlink relative
+    (fetchurl {
+      url = https://raw.githubusercontent.com/openwrt/openwrt/87606e25afac6776d1bbc67ed284434ec5a832b4/toolchain/musl/patches/300-relative.patch;
+      sha256 = "0hfadrycb60sm6hb6by4ycgaqc9sgrhh42k39v8xpmcvdzxrsq2n";
+    })
+  ];
   preConfigure = ''
     configureFlagsArray+=("--syslibdir=$out/lib")
   '';
@@ -80,7 +87,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
 
     # Create 'ldd' symlink, builtin
-    ln -s $out/lib/libc.so $out/bin/ldd
+    ln -rs $out/lib/libc.so $out/bin/ldd
 
     # (impure) cc wrapper around musl for interactive usuage
     for i in musl-gcc musl-clang ld.musl-clang; do

--- a/pkgs/stdenv/linux/bootstrap-tools-musl/scripts/unpack-bootstrap-tools.sh
+++ b/pkgs/stdenv/linux/bootstrap-tools-musl/scripts/unpack-bootstrap-tools.sh
@@ -26,7 +26,7 @@ for i in $out/bin/* $out/libexec/gcc/*/*/*; do
         ./patchelf --set-interpreter $LD_BINARY --set-rpath $out/lib --force-rpath "$i"
 done
 
-for i in $out/lib/libiconv*.so $out/lib/libpcre* $out/lib/libc.so; do
+for i in $out/lib/libpcre* $out/lib/libc.so; do
     if [ -L "$i" ]; then continue; fi
     echo patching "$i"
     $out/bin/patchelf --set-rpath $out/lib --force-rpath "$i"

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -362,7 +362,6 @@ in
         ++  [ /*propagated from .dev*/ linuxHeaders
             binutils gcc gcc.cc gcc.cc.lib gcc.expand-response-params
           ]
-          ++ lib.optional (localSystem.libc == "musl") libiconv
           ++ lib.optionals localSystem.isAarch64
             [ prevStage.updateAutotoolsGnuConfigScriptsHook prevStage.gnu-config ];
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -136,8 +136,6 @@ in with pkgs; rec {
         cp -d ${libmpc.out}/lib/libmpc*.so* $out/lib
         cp -d ${zlib.out}/lib/libz.so* $out/lib
         cp -d ${libelf}/lib/libelf.so* $out/lib
-      '' + lib.optionalString (hostPlatform.libc == "musl") ''
-        cp -d ${libiconv.out}/lib/libiconv*.so* $out/lib
 
       '' + lib.optionalString (hostPlatform != buildPlatform) ''
         # These needed for cross but not native tools because the stdenv


### PR DESCRIPTION
This is expected of our libc's.

Implementation is from musl author, FWIW.

It's not actively maintained AFAICT
but I don't know of any problems with it either.

If we run into problems with this we can
look elsewhere, but let's make sure we
have a reason before pulling in something
more complicated.

Fixes building through `git` on: x86_64-musl, cross-musl (since iconv util is needed by docbook2x on the way)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---