### PR TITLE
notmuch: 0.26 -> 0.26.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -12,7 +12,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "0.26";
+  version = "0.26.1";
   name = "notmuch-${version}";
 
   passthru = {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://notmuchmail.org/releases/${name}.tar.gz";
-    sha256 = "1pvn1n7giv8n3xlazi3wpscdqhd2yak0fgv68aj23myr5bnr9s6k";
+    sha256 = "0dx8nhdmkaqabxcgxfa757m99fi395y76h9ynx8539yh9m7y9xyk";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nixpkgs-update tools.

This update was made based on information from https://repology.org/metapackage/notmuch/versions.

These checks were done:

- built on NixOS
- ran ‘/nix/store/05v4k89ni4phwyxvqskr0hji49b5fmck-notmuch-0.26.1/bin/notmuch --help’ got 0 exit code
- ran ‘/nix/store/05v4k89ni4phwyxvqskr0hji49b5fmck-notmuch-0.26.1/bin/notmuch help’ got 0 exit code
- ran ‘/nix/store/05v4k89ni4phwyxvqskr0hji49b5fmck-notmuch-0.26.1/bin/notmuch --version’ and found version 0.26.1
- found 0.26.1 with grep in /nix/store/05v4k89ni4phwyxvqskr0hji49b5fmck-notmuch-0.26.1
- directory tree listing: https://gist.github.com/adeae189f9ac416571a7c0e3beca712f

###### Motivation for this change

While fixing notmuch, minor version bump. 
Checked building on staging-18.03 and rebuilding muchsync and neomutt against it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

