### PR TITLE
lsof: 4.90 -> 4.91

### DIFF
--- a/pkgs/development/tools/misc/lsof/default.nix
+++ b/pkgs/development/tools/misc/lsof/default.nix
@@ -4,13 +4,13 @@ let dialect = with stdenv.lib; last (splitString "-" stdenv.system); in
 
 stdenv.mkDerivation rec {
   name = "lsof-${version}";
-  version = "4.90";
+  version = "4.91";
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   buildInputs = [ ncurses ];
 
   src = fetchurl {
-    urls = ["https://fossies.org/linux/misc/lsof_4.90.tar.bz2"] ++ # Mirrors seem to be down...
+    urls = ["https://fossies.org/linux/misc/lsof_${version}.tar.bz2"] ++ # Mirrors seem to be down...
       ["ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_${version}.tar.bz2"]
       ++ map (
         # the tarball is moved after new version is released
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
         + "${stdenv.lib.optionalString isOld "OLD/"}lsof_${version}.tar.bz2"
       ) [ false true ]
       ;
-    sha256 = "1xhn3amvl5mmwji5g90nkw7lfmh2494v18qbv1f729hrg468853g";
+    sha256 = "18sh4hbl9jw2szkf0gvgan8g13f3g4c6s2q9h3zq5gsza9m99nn9";
   };
 
   unpackPhase = "tar xvjf $src; cd lsof_*; tar xvf lsof_*.tar; sourceRoot=$( echo lsof_*/); ";


### PR DESCRIPTION
Issue mentioned bump may help, untested.

https://github.com/NixOS/nixpkgs/issues/39496

FWIW, snippet from `00DIST` (4.90 -> 4.91):

                A bug has been reported in the PTY endpoint processing of
                Linux lsof 4.90 by Peter Wu <peter@lekensteyn.nl>, making it
                necessary for me to release another revision of lsof.

                This revision applies two fixes that correct the Linux PTY
                endpoint processing bug. Masatake YAMATO <yamato@redhat.com>
                supplied the fixes.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---