### PR TITLE
pytaglib: init at 1.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2511,6 +2511,11 @@
     github = "fstamour";
     name = "Francis St-Amour";
   };
+  mrkkrp = {
+    email = "markkarpov92@gmail.com";
+    github = "mrkkrp";
+    name = "Mark Karpov";
+  };
   mrVanDalo = {
     email = "contact@ingolf-wagner.de";
     github = "mrVanDalo";

--- a/pkgs/development/python-modules/pytaglib/default.nix
+++ b/pkgs/development/python-modules/pytaglib/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, taglib
+, cython
+}:
+
+buildPythonPackage rec {
+  pname   = "pytaglib";
+  version = "1.4.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "44ab26dc4b33962b8db0bb8856e7b166539c0c555bc933a6bbbc96f4ec51c7a2";
+  };
+
+  buildInputs = [ taglib cython ];
+
+  meta = {
+    homepage = https://github.com/supermihi/pytaglib;
+    description = "Python 2.x/3.x bindings for the Taglib audio metadata library";
+    license = lib.licenses.gpl3;
+  };
+}

--- a/pkgs/development/python-modules/pytaglib/default.nix
+++ b/pkgs/development/python-modules/pytaglib/default.nix
@@ -3,6 +3,8 @@
 , fetchPypi
 , taglib
 , cython
+, pytest
+, glibcLocales
 }:
 
 buildPythonPackage rec {
@@ -15,6 +17,12 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ taglib cython ];
+
+  checkInputs = [ pytest glibcLocales ];
+
+  checkPhase = ''
+    LC_ALL=en_US.utf-8 pytest .
+  '';
 
   meta = {
     homepage = https://github.com/supermihi/pytaglib;

--- a/pkgs/development/python-modules/pytaglib/default.nix
+++ b/pkgs/development/python-modules/pytaglib/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     homepage = https://github.com/supermihi/pytaglib;
     description = "Python 2.x/3.x bindings for the Taglib audio metadata library";
     license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.mrkkrp ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8227,6 +8227,8 @@ in {
     };
   };
 
+  pytaglib = callPackage ../development/python-modules/pytaglib { };
+
   pyte = callPackage ../development/python-modules/pyte { };
 
   graphviz = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

I need the binding.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Problems:

* Doesn't pass the tests because of some encoding issue:

```
======================================================================
ERROR: test_unicode_filename (tests.test_bytes_unicode.TestBytesUnicode)
Ensure file can be opened if filename is provided as bytes object.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/nix-build-python2.7-pytaglib-1.4.3.drv-0/pytaglib-1.4.3/tests/test_bytes_unicode.py", line 25, in test_unicode_filename
    with copyTestFile('testöü.flac') as f:
  File "/nix/store/l9j2jsc9flrbmpf799nw9wdq59gpwms8-python-2.7.14/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/tmp/nix-build-python2.7-pytaglib-1.4.3.drv-0/pytaglib-1.4.3/tests/__init__.py", line 39, in copyTestFile
    shutil.copyfile(orig_file, copy_file)
  File "/nix/store/l9j2jsc9flrbmpf799nw9wdq59gpwms8-python-2.7.14/lib/python2.7/shutil.py", line 82, in copyfile
    if _samefile(src, dst):
  File "/nix/store/l9j2jsc9flrbmpf799nw9wdq59gpwms8-python-2.7.14/lib/python2.7/shutil.py", line 72, in _samefile
    return os.path.samefile(src, dst)
  File "/nix/store/l9j2jsc9flrbmpf799nw9wdq59gpwms8-python-2.7.14/lib/python2.7/posixpath.py", line 155, in samefile
    s1 = os.stat(f1)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 76-77: ordinal not in range(128)

----------------------------------------------------------------------
Ran 18 tests in 0.009s

FAILED (errors=7)
Test failed: <unittest.runner.TextTestResult run=18 errors=7 failures=0>
error: Test failed: <unittest.runner.TextTestResult run=18 errors=7 failures=0>
builder for '/nix/store/9m38142507d4d0p38cxx1kznfzdbjl1x-python2.7-pytaglib-1.4.3.drv' failed with exit code 1
error: build of '/nix/store/9m38142507d4d0p38cxx1kznfzdbjl1x-python2.7-pytaglib-1.4.3.drv' failed
```

I'm sure this must be solvable I just don't know how.

* I'm not sure about "tested using sandboxing". Should I rebuild my NixOS with `nix.useSandbox = true` and then test it? This means that I should modify my system in order to test a package? Not nice, probably I'm missing something.
* `nix-shell -p nox --run "nox-review wip"` says "No uncommit changes. Did you mean to use the "--against" option?". So I tried it like this: `nix-shell -p nox --run "nox-review wip --against master"`, it failed because of the same encoding issue.
* "`meta.maintainers` should be set", should I add myself there?
