### PR TITLE
quazip: 0.7.3 -> 0.7.4

### DIFF
--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -1,11 +1,14 @@
-{ fetchurl, stdenv, zip, zlib, qtbase, qmake }:
+{ fetchFromGitHub, stdenv, zip, zlib, qtbase, qmake }:
 
 stdenv.mkDerivation rec {
-  name = "quazip-0.7.3";
+  name = "quazip-${version}";
+  version = "0.7.4";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/quazip/${name}.tar.gz";
-    sha256 = "1db9w8ax1ki0p67a47h4cnbwfgi2di4y3k9nc3a610kffiag7m1a";
+  src = fetchFromGitHub {
+    owner = "stachenov";
+    repo = "quazip";
+    rev = version;
+    sha256 = "0chajfaf59js9yg743hd3pnah7r71mwj6jg695m164lxwzgyg602";
   };
 
   preConfigure = "cd quazip";


### PR DESCRIPTION
Bump, only build-tested.

rebuild script says only handful of users, let's see.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---