### PR TITLE
sacrifice: fix runtime on darwin

### DIFF
--- a/pkgs/applications/science/physics/sacrifice/default.nix
+++ b/pkgs/applications/science/physics/sacrifice/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
     "--with-pythia=${pythia}"
   ];
 
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -add_rpath ${pythia}/lib "$out"/bin/run-pythia
+  '';
+
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Fixes following error:
```
dyld: Library not loaded: @rpath/libpythia8.dylib
  Referenced from: /nix/store/xxxxx-sacrifice-1.0.0/bin/run-pythia
  Reason: image not found
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
