### PR TITLE
soapysdr+plugins: init at 0.6.1

### DIFF
--- a/pkgs/applications/misc/limesuite/default.nix
+++ b/pkgs/applications/misc/limesuite/default.nix
@@ -30,8 +30,6 @@ in stdenv.mkDerivation {
     libX11
   ];
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   postInstall = ''
     mkdir -p $out/lib/udev/rules.d
     cp ../udev-rules/64-limesuite.rules $out/lib/udev/rules.d

--- a/pkgs/applications/misc/limesuite/default.nix
+++ b/pkgs/applications/misc/limesuite/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchFromGitHub, cmake
+, sqlite, wxGTK30, libusb1, soapysdr
+, mesa_glu, libX11, gnuplot, fltk
+} :
+
+let
+  version = "18.04.1";
+
+in stdenv.mkDerivation {
+  name = "limesuite-${version}";
+
+  src = fetchFromGitHub {
+    owner = "myriadrf";
+    repo = "LimeSuite";
+    rev = "v${version}";
+    sha256 = "1aaqnwif1j045hvj011k5dyqxgxx72h33r4al74h5f8al81zvzj9";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    libusb1
+    sqlite
+    wxGTK30
+    fltk
+    gnuplot
+    libusb1
+    soapysdr
+    mesa_glu
+    libX11
+  ];
+
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d
+    cp ../udev-rules/64-limesuite.rules $out/lib/udev/rules.d
+
+    mkdir -p $out/share/limesuite
+    cp bin/Release/lms7suite_mcu/* $out/share/limesuite
+
+    cp bin/dualRXTX $out/bin
+    cp bin/basicRX $out/bin
+    cp bin/singleRX $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Driver and GUI for LMS7002M-based SDR platforms";
+    homepage = https://github.com/myriadrf/LimeSuite;
+    license = licenses.apache2;
+    maintainers = with maintainers; [ markuskowa ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/applications/misc/limesuite/default.nix
+++ b/pkgs/applications/misc/limesuite/default.nix
@@ -47,7 +47,7 @@ in stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "Driver and GUI for LMS7002M-based SDR platforms";
     homepage = https://github.com/myriadrf/LimeSuite;
-    license = licenses.apache2;
+    license = licenses.asl20;
     maintainers = with maintainers; [ markuskowa ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/soapyairspy/default.nix
+++ b/pkgs/applications/misc/soapyairspy/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake
+, airspy, soapysdr
+} :
+
+let
+  version = "0.1.1";
+
+in stdenv.mkDerivation {
+  name = "soapyairspy-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapyAirspy";
+    rev = "soapy-airspy-${version}";
+    sha256 = "072vc9619s9f22k7639krr1p2418cmhgm44yhzy7x9dzapc43wvk";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ airspy soapysdr ];
+
+  cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pothosware/SoapyAirspy;
+    description = "SoapySDR plugin for Airspy devices";
+    license = licenses.mit;
+    maintainers = with maintainers; [ markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/soapybladerf/default.nix
+++ b/pkgs/applications/misc/soapybladerf/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, libbladeRF, soapysdr
+} :
+
+let
+  version = "0.3.5";
+
+in stdenv.mkDerivation {
+  name = "soapybladerf-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapyBladeRF";
+    rev = "soapy-bladerf-${version}";
+    sha256 = "1n7vy6y8k1smq3l729npxbhxbnrc79gz06dxkibsihz4k8sddkrg";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ libbladeRF soapysdr ];
+
+  cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
+
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pothosware/SoapyBladeRF;
+    description = "SoapySDR plugin for BladeRF devices";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/soapyhackrf/default.nix
+++ b/pkgs/applications/misc/soapyhackrf/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, hackrf, soapysdr
+} :
+
+let
+  version = "0.3.2";
+
+in stdenv.mkDerivation {
+  name = "soapyhackrf-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapyHackRF";
+    rev = "soapy-hackrf-${version}";
+    sha256 = "1sgx2nk8yrzfwisjfs9mw0xwc47bckzi17p42s2pbv7zcxzpb66p";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ hackrf soapysdr ];
+
+  cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pothosware/SoapyHackRF;
+    description = "SoapySDR plugin for HackRF devices";
+    license = licenses.mit;
+    maintainers = with maintainers; [ markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/soapyremote/default.nix
+++ b/pkgs/applications/misc/soapyremote/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, soapysdr }:
+
+let
+  version = "0.4.3";
+
+in stdenv.mkDerivation {
+  name = "soapyremote-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapyRemote";
+    rev = "d07f43863b1ef79252f8029cfb5947220f21311d";
+    sha256 = "0i101dfqq0aawybv0qyjgsnhk39dc4q6z6ys2gsvwjhpf3d48aw0";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ soapysdr ];
+
+  cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pothosware/SoapyRemote;
+    description = "SoapySDR plugin for remote access to SDRs";
+    license = licenses.boost;
+    maintainers = with maintainers; [ markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/soapysdr/default.nix
+++ b/pkgs/applications/misc/soapysdr/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, lndir, makeWrapper
+, fetchFromGitHub, cmake
+, libusb, pkgconfig
+, python, swig2, numpy, ncurses
+, extraPackages ? []
+} :
+
+let
+  version = "0.6.1";
+
+in stdenv.mkDerivation {
+  name = "soapysdr-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapySDR";
+    rev = "soapy-sdr-${version}";
+    sha256 = "1azbb2j6dv0b2dd5ks6yqd31j17sdhi9p82czwc8zy2isymax0l9";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ libusb ncurses numpy swig2 python ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DUSE_PYTHON_CONFIG=ON"
+  ];
+
+  postFixup = lib.optionalString (lib.length extraPackages != 0) ''
+    # Join all plugins via symlinking
+    for i in ${toString extraPackages}; do
+      ${lndir}/bin/lndir -silent $i $out
+    done
+
+    # Needed for at least the remote plugin server
+    for file in out/bin/*; do
+        ${makeWrapper}/bin/wrapProgram "$file" \
+            --prefix SOAPY_SDR_PLUGIN_PATH : ${lib.makeSearchPath "lib/SoapySDR/modules0.6" extraPackages}
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pothosware/SoapySDR;
+    description = "Vendor and platform neutral SDR support library";
+    license = licenses.boost;
+    maintainers = with maintainers; [ markuskowa ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/applications/misc/soapyuhd/default.nix
+++ b/pkgs/applications/misc/soapyuhd/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, uhd, boost, soapysdr
+} :
+
+let
+  version = "0.3.4";
+
+in stdenv.mkDerivation {
+  name = "soapyuhd-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapyUHD";
+    rev = "soapy-uhd-${version}";
+    sha256 = "1da7cjcvfdqhgznm7x14s1h7lwz5lan1b48akw445ah1vxwvh4hl";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ uhd boost soapysdr ];
+
+  cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
+
+  postPatch = ''
+    sed -i "s:DESTINATION .*uhd/modules:DESTINATION $out/lib/uhd/modules:" CMakeLists.txt
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pothosware/SoapyAirspy;
+    description = "SoapySDR plugin for UHD devices";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/welle-io/default.nix
+++ b/pkgs/applications/misc/welle-io/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildEnv, fetchFromGitHub, cmake, pkgconfig
 , qtbase, qtcharts, qtmultimedia, qtquickcontrols, qtquickcontrols2
-, faad2, rtl-sdr, libusb, fftwSinglePrec }:
+, faad2, rtl-sdr, soapysdr-with-plugins, libusb, fftwSinglePrec }:
 let
 
   version = "1.0-rc2";
@@ -28,10 +28,11 @@ in stdenv.mkDerivation {
     qtquickcontrols
     qtquickcontrols2
     rtl-sdr
+    soapysdr-with-plugins
   ];
 
   cmakeFlags = [
-    "-DRTLSDR=true"
+    "-DRTLSDR=true" "-DSOAPYSDR=true"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/misc/welle-io/default.nix
+++ b/pkgs/applications/misc/welle-io/default.nix
@@ -42,7 +42,6 @@ in stdenv.mkDerivation {
     homepage = http://www.welle.io/;
     maintainers = with maintainers; [ ck3d ];
     license = licenses.gpl2;
-    platforms = with platforms; linux ++ darwin;
+    platforms = with platforms; [ "x86_64-linux" "i686-linux" ] ++ darwin;
   };
-
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3513,6 +3513,8 @@ with pkgs;
 
   libwebsockets = callPackage ../development/libraries/libwebsockets { };
 
+  limesuite = callPackage ../applications/misc/limesuite { };
+
   limesurvey = callPackage ../servers/limesurvey { };
 
   linuxquota = callPackage ../tools/misc/linuxquota { };
@@ -11477,6 +11479,7 @@ with pkgs;
   soapysdr-with-plugins = callPackage ../applications/misc/soapysdr {
     inherit (python3Packages) python numpy;
     extraPackages = [
+      limesuite
       soapyairspy
       soapybladerf
       soapyhackrf

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11464,6 +11464,29 @@ with pkgs;
 
   snappy = callPackage ../development/libraries/snappy { };
 
+  soapyairspy = callPackage ../applications/misc/soapyairspy { };
+
+  soapybladerf = callPackage ../applications/misc/soapybladerf { };
+
+  soapyhackrf = callPackage ../applications/misc/soapyhackrf { };
+
+  soapysdr = callPackage ../applications/misc/soapysdr { inherit (python3Packages) python numpy; };
+
+  soapyremote = callPackage ../applications/misc/soapyremote { };
+
+  soapysdr-with-plugins = callPackage ../applications/misc/soapysdr {
+    inherit (python3Packages) python numpy;
+    extraPackages = [
+      soapyairspy
+      soapybladerf
+      soapyhackrf
+      soapyremote
+      soapyuhd
+    ];
+  };
+
+  soapyuhd = callPackage ../applications/misc/soapyuhd { };
+
   socket_wrapper = callPackage ../development/libraries/socket_wrapper { };
 
   sofia_sip = callPackage ../development/libraries/sofia-sip { };


### PR DESCRIPTION
###### Motivation for this change
This the first step to integrate the soapysdr driver, which provides a unified SDR driver library.
Includes the following components:
- soapysdr library
- SDR plugins for: airspy, hackrf, bladerf, uhd, limesdr
- Remote plugin
- Integration with welle-io

See also: https://github.com/NixOS/nixpkgs/pull/37020
@roosemberth Does this implementation work for you?

Thanks to @ck3d for some valuable feedback on integrating the plugin system

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

