### PR TITLE
cups-kyodialog3: init at 8.1601

### DIFF
--- a/pkgs/misc/cups/drivers/kyodialog3/default.nix
+++ b/pkgs/misc/cups/drivers/kyodialog3/default.nix
@@ -1,0 +1,65 @@
+{ stdenv, lib, fetchzip, cups
+
+  # Can either be "EU" or "Global"; it's unclear what the difference is
+  , region ? "Global"
+}:
+
+let
+  platform =
+    if stdenv.system == "x86_64-linux" then "64bit"
+    else if stdenv.system == "i686-linux" then "32bit"
+         else throw "Unsupported system: ${stdenv.system}";
+  debPlatform = 
+    if platform == "64bit" then "amd64"
+    else "i386";
+  debRegion = if region == "EU" then "EU." else "";
+
+  # TODO: add Qt4 for kyodialog3 application
+  libPath = lib.makeLibraryPath [ cups ];
+in
+stdenv.mkDerivation rec {
+  name = "cups-kyodialog3-${version}";
+  version = "8.1601";
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  src = fetchzip {
+    url = "https://usa.kyoceradocumentsolutions.com/content/dam/kdc/kdag/downloads/technical/executables/drivers/kyoceradocumentsolutions/us/en/Kyocera_Linux_PPD_Ver_${version}.tar.gz";
+    sha256 = "11znnlkfssakml7w80gxlz1k59f3nvhph91fkzzadnm9i7a8yjal";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    cd $out
+
+    # unpack the debian archive
+    ar p ${src}/KyoceraLinuxPackages/${region}/${platform}/kyodialog3.en${debRegion}_0.5-0_${debPlatform}.deb data.tar.gz | tar -xz
+    rm -Rf KyoceraLinuxPackages
+
+    # strip $out/usr
+    mv usr/* .
+    rmdir usr
+
+    # allow cups to find the ppd files
+    mkdir -p share/cups/model
+    mv share/ppd/kyocera share/cups/model/Kyocera
+    rmdir share/ppd
+
+    # prepend $out to all references in ppd and desktop files
+    find -name "*.ppd" -exec sed -E -i "s:/usr/lib:$out/lib:g" {} \;
+    find -name "*.desktop" -exec sed -E -i "s:/usr/lib:$out/lib:g" {} \;
+
+    # patchELF all executables
+    find -type f -executable -exec patchelf --set-rpath ${libPath} --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) {} \;
+  '';
+
+  meta = with lib; {
+    description = "CUPS drivers for several Kyocera printers";
+    homepage = "https://www.kyoceradocumentsolutions.com";
+    license = licenses.unfree;
+    maintainers = [ maintainers.steveej ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19994,6 +19994,8 @@ with pkgs;
 
   cups-kyocera = callPackage ../misc/cups/drivers/kyocera {};
 
+  cups-kyodialog3 = callPackage ../misc/cups/drivers/kyodialog3 {};
+
   cups-dymo = callPackage ../misc/cups/drivers/dymo {};
 
   cups-toshiba-estudio = callPackage ../misc/cups/drivers/estudio {};


### PR DESCRIPTION
###### Motivation for this change
This driver package supports many Kyocera printers which obviously useful if you want to use one :-)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

