### PR TITLE
nixos/dhparams: Introduce a 'stateful' option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -77,7 +77,57 @@ following incompatible changes:</para>
 <itemizedlist>
   <listitem>
     <para>
+      The module for <option>security.dhparams</option> has two new options
+      now:
     </para>
+
+    <variablelist>
+      <varlistentry>
+        <term><option>security.dhparams.stateless</option></term>
+        <listitem><para>
+          Puts the generated Diffie-Hellman parameters into the Nix store
+          instead of managing them in a stateful manner in
+          <filename class="directory">/var/lib/dhparams</filename>.
+        </para></listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>security.dhparams.defaultBitSize</option></term>
+        <listitem><para>
+          The default bit size to use for the generated Diffie-Hellman
+          parameters.
+        </para></listitem>
+      </varlistentry>
+    </variablelist>
+
+    <note><para>
+      The path to the actual generated parameter files should now be queried
+      using
+      <literal>config.security.dhparams.params.<replaceable>name</replaceable>.path</literal>
+      because it might be either in the Nix store or in a directory configured
+      by <option>security.dhparams.path</option>.
+    </para></note>
+
+    <note>
+      <title>For developers:</title>
+      <para>
+        Module implementers should not set a specific bit size in order to let
+        users configure it by themselves if they want to have a different bit
+        size than the default (2048).
+      </para>
+      <para>
+        An example usage of this would be:
+<programlisting>
+{ config, ... }:
+
+{
+  security.dhparams.params.myservice = {};
+  environment.etc."myservice.conf".text = ''
+    dhparams = ${config.security.dhparams.params.myservice.path}
+  '';
+}
+</programlisting>
+      </para>
+    </note>
   </listitem>
 </itemizedlist>
 

--- a/nixos/modules/security/dhparams.nix
+++ b/nixos/modules/security/dhparams.nix
@@ -10,7 +10,7 @@ let
         name = "bits";
         description = "integer of at least 16 bits";
       };
-      default = 4096;
+      default = 2048;
       description = ''
         The bit size for the prime that is used during a Diffie-Hellman
         key exchange.

--- a/nixos/modules/security/dhparams.nix
+++ b/nixos/modules/security/dhparams.nix
@@ -4,13 +4,15 @@ let
   inherit (lib) mkOption types;
   cfg = config.security.dhparams;
 
+  bitType = types.addCheck types.int (b: b >= 16) // {
+    name = "bits";
+    description = "integer of at least 16 bits";
+  };
+
   paramsSubmodule = { name, config, ... }: {
     options.bits = mkOption {
-      type = types.addCheck types.int (b: b >= 16) // {
-        name = "bits";
-        description = "integer of at least 16 bits";
-      };
-      default = 2048;
+      type = bitType;
+      default = cfg.defaultBitSize;
       description = ''
         The bit size for the prime that is used during a Diffie-Hellman
         key exchange.
@@ -70,6 +72,11 @@ in {
           existing ones won't be cleaned up. Of course this only applies if
           <option>security.dhparams.stateful</option> is
           <literal>true</literal>.</para></warning>
+
+          <note><title>For module implementers:</title><para>It's recommended
+          to not set a specific bit size here, so that users can easily
+          override this by setting
+          <option>security.dhparams.defaultBitSize</option>.</para></note>
         '';
       };
 
@@ -86,6 +93,16 @@ in {
           <note><para>If this is <literal>false</literal> the resulting store
           path will be non-deterministic and will be rebuilt every time the
           <package>openssl</package> package changes.</para></note>
+        '';
+      };
+
+      defaultBitSize = mkOption {
+        type = bitType;
+        default = 2048;
+        description = ''
+          This allows to override the default bit size for all of the
+          Diffie-Hellman parameters set in
+          <option>security.dhparams.params</option>.
         '';
       };
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -269,6 +269,7 @@ in rec {
   tests.containers-macvlans = callTest tests/containers-macvlans.nix {};
   tests.couchdb = callTest tests/couchdb.nix {};
   tests.deluge = callTest tests/deluge.nix {};
+  tests.dhparams = callTest tests/dhparams.nix {};
   tests.docker = callTestOnMatchingSystems ["x86_64-linux"] tests/docker.nix {};
   tests.docker-tools = callTestOnMatchingSystems ["x86_64-linux"] tests/docker-tools.nix {};
   tests.docker-tools-overlay = callTestOnMatchingSystems ["x86_64-linux"] tests/docker-tools-overlay.nix {};

--- a/nixos/tests/dhparams.nix
+++ b/nixos/tests/dhparams.nix
@@ -54,6 +54,13 @@ in import ./make-test.nix {
     security.dhparams.params.bar2.bits = 19;
   };
 
+  nodes.generation5 = {
+    imports = [ common ];
+    security.dhparams.defaultBitSize = 30;
+    security.dhparams.params.foo3 = {};
+    security.dhparams.params.bar3 = {};
+  };
+
   testScript = { nodes, ... }: let
     getParamPath = gen: name: let
       node = "generation${toString gen}";
@@ -125,6 +132,13 @@ in import ./make-test.nix {
         'expr match ${getParamPath 4 "foo2"} ${builtins.storeDir}',
         'expr match ${getParamPath 4 "bar2"} ${builtins.storeDir}',
       );
+    };
+
+    ${switchToGeneration 5}
+
+    subtest "check whether defaultBitSize works as intended", sub {
+      ${assertParamBits 5 "foo3" 30}
+      ${assertParamBits 5 "bar3" 30}
     };
   '';
 }

--- a/nixos/tests/dhparams.nix
+++ b/nixos/tests/dhparams.nix
@@ -1,0 +1,105 @@
+let
+  common = { pkgs, ... }: {
+    security.dhparams.enable = true;
+    environment.systemPackages = [ pkgs.openssl ];
+  };
+
+in import ./make-test.nix {
+  name = "dhparams";
+
+  nodes.generation1 = { pkgs, config, ... }: {
+    imports = [ common ];
+    security.dhparams.params.foo = 16;
+    security.dhparams.params.bar = 17;
+
+    systemd.services.foo = {
+      description = "Check systemd Ordering";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig = {
+        # This is to make sure that the dhparams generation of foo occurs
+        # before this service so we need this service to start as early as
+        # possible to provoke a race condition.
+        DefaultDependencies = false;
+
+        # We check later whether the service has been started or not.
+        ConditionPathExists = "${config.security.dhparams.path}/foo.pem";
+      };
+      serviceConfig.Type = "oneshot";
+      serviceConfig.RemainAfterExit = true;
+      # The reason we only provide an ExecStop here is to ensure that we don't
+      # accidentally trigger an error because a file system is not yet ready
+      # during very early startup (we might not even have the Nix store
+      # available, for example if future changes in NixOS use systemd mount
+      # units to do early file system initialisation).
+      serviceConfig.ExecStop = "${pkgs.coreutils}/bin/true";
+    };
+  };
+
+  nodes.generation2 = {
+    imports = [ common ];
+    security.dhparams.params.foo = 18;
+  };
+
+  nodes.generation3 = common;
+
+  testScript = { nodes, ... }: let
+    getParamPath = gen: name: let
+      node = "generation${toString gen}";
+      inherit (nodes.${node}.config.security.dhparams) path;
+    in "${path}/${name}.pem";
+
+    assertParamBits = gen: name: bits: let
+      path = getParamPath gen name;
+    in ''
+      $machine->nest('check bit size of ${path}', sub {
+        my $out = $machine->succeed('openssl dhparam -in ${path} -text');
+        $out =~ /^\s*DH Parameters:\s+\((\d+)\s+bit\)\s*$/m;
+        die "bit size should be ${toString bits} but it is $1 instead."
+          if $1 != ${toString bits};
+      });
+    '';
+
+    switchToGeneration = gen: let
+      node = "generation${toString gen}";
+      inherit (nodes.${node}.config.system.build) toplevel;
+      switchCmd = "${toplevel}/bin/switch-to-configuration test";
+    in ''
+      $machine->nest('switch to generation ${toString gen}', sub {
+        $machine->succeed('${switchCmd}');
+        $main::machine = ''$${node};
+      });
+    '';
+
+  in ''
+    my $machine = $generation1;
+
+    $machine->waitForUnit('multi-user.target');
+
+    subtest "verify startup order", sub {
+      $machine->succeed('systemctl is-active foo.service');
+    };
+
+    subtest "check bit sizes of dhparam files", sub {
+      ${assertParamBits 1 "foo" 16}
+      ${assertParamBits 1 "bar" 17}
+    };
+
+    ${switchToGeneration 2}
+
+    subtest "check whether bit size has changed", sub {
+      ${assertParamBits 2 "foo" 18}
+    };
+
+    subtest "ensure that dhparams file for 'bar' was deleted", sub {
+      $machine->fail('test -e ${getParamPath 1 "bar"}');
+    };
+
+    ${switchToGeneration 3}
+
+    subtest "ensure that 'security.dhparams.path' has been deleted", sub {
+      $machine->fail(
+        'test -e ${nodes.generation3.config.security.dhparams.path}'
+      );
+    };
+  '';
+}


### PR DESCRIPTION
This option allows us to turn off stateful generation of Diffie-Hellman parameters, which in some way is still "stateful" as the generated DH params file is non-deterministic.

However what we can avoid with this is to have an increased surface for failures during system startup, because generation of the parameters is done during build-time.

Another advantage of this is that we no longer need to take care of cleaning up the files that are no longer used and in my humble opinion I would have preferred that #11505 (which puts the DH params in the Nix store) would have been merged instead of #22634 (which we have now).

Nevertheless, this now gives the user the choice to either get non-determinism in some store paths or an increased failure vector introduced during bootup.

Besides of the more obvious advantages pointed out, this also effects test runtime if more services are starting to use this (for example see #39507 and #39288), because generating DH params could take a long time depending on the bit size which adds up to test runtime.

If we generate the DH params in a separate derivation, subsequent test runs won't need to wait for DH params generation during bootup.

Apart from just adding the option I added a NixOS VM test to make sure I don't break the existing implementation plus I've cleaned up the module expression a bit.

Cc: @Ekleog