### PR TITLE
tracker-miners: switch to meson, some tweaks

### DIFF
--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -115,6 +115,7 @@ stdenv.mkDerivation rec {
     ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
   '';
   
+  # https://bugzilla.gnome.org/show_bug.cgi?id=796145
   postFixup = ''
     rm $out/share/tracker/miners/org.freedesktop.Tracker1.Miner.RSS.service
   '';

--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -114,6 +114,10 @@ stdenv.mkDerivation rec {
   postInstall = ''
     ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
   '';
+  
+  postFixup = ''
+    rm $out/share/tracker/miners/org.freedesktop.Tracker1.Miner.RSS.service
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/Tracker;

--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -1,46 +1,100 @@
-{ stdenv, intltool, fetchurl, libxml2, upower
-, substituteAll, pkgconfig, gtk3, glib, gexiv2
-, bash, wrapGAppsHook, itstool, vala, sqlite, libxslt
-, gnome3, librsvg, gdk_pixbuf, libnotify
-, evolution-data-server, gst_all_1, poppler
-, icu, taglib, libjpeg, libtiff, giflib, libcue
-, libvorbis, flac, exempi, networkmanager
-, libpng, libexif, libgsf, libuuid, bzip2
-, libsoup, json-glib, libseccomp
-, libiptcdata }:
+{ stdenv, fetchurl, substituteAll, intltool, itstool, libxslt, makeWrapper
+, meson, ninja, pkgconfig, vala, wrapGAppsHook, bzip2, dbus, evolution-data-server
+, exempi, flac, giflib, glib, gnome3, gst_all_1, icu, json-glib, libcue, libexif
+, libgsf, libiptcdata, libjpeg, libpng, libseccomp, libsoup, libtiff, libuuid
+, libvorbis, libxml2, poppler, taglib, upower }:
 
-let
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
   pname = "tracker-miners";
   version = "2.0.4";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
     sha256 = "0mp9m2waii583sjgr61m1ni6py6dry11r0rzidgvw1g4cxhn89j6";
   };
 
-  NIX_CFLAGS_COMPILE = "-I${poppler.dev}/include/poppler";
+  # https://github.com/NixOS/nixpkgs/issues/39547
+  LIBRARY_PATH = stdenv.lib.makeLibraryPath [ giflib ];
 
-  enableParallelBuilding = true;
-
-  nativeBuildInputs = [ vala pkgconfig intltool itstool libxslt wrapGAppsHook ];
-  # TODO: add libgrss, libenca, libosinfo
-  buildInputs = [
-    bzip2 evolution-data-server exempi flac giflib glib gnome3.totem-pl-parser
-    gnome3.tracker gst_all_1.gst-plugins-base gst_all_1.gstreamer icu
-    json-glib libcue libexif libgsf libiptcdata libjpeg libpng libseccomp libsoup
-    libtiff libuuid libvorbis libxml2 poppler taglib upower gexiv2
+  nativeBuildInputs = [
+    intltool
+    itstool
+    libxslt
+    makeWrapper
+    meson
+    ninja
+    pkgconfig
+    vala
+    wrapGAppsHook
   ];
 
-  LANG = "en_US.UTF-8"; # for running tests
+  # TODO: add libgrss, libenca, libosinfo
+  buildInputs = [
+    bzip2
+    dbus
+    evolution-data-server
+    exempi
+    flac
+    giflib
+    glib
+    gnome3.gexiv2
+    gnome3.totem-pl-parser
+    gnome3.tracker
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    icu
+    json-glib
+    libcue
+    libexif
+    libgsf
+    libiptcdata
+    libjpeg
+    libpng
+    libseccomp
+    libsoup
+    libtiff
+    libuuid
+    libvorbis
+    libxml2
+    poppler
+    taglib
+    upower
+  ];
 
-  doCheck = true;
+  mesonFlags = [
+    "-Dminer_rss=false" # needs libgrss
+  ];
 
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
       inherit (gnome3) tracker;
+    })
+    # https://bugzilla.gnome.org/show_bug.cgi?id=795573
+    (fetchurl {
+      url = https://bugzilla.gnome.org/attachment.cgi?id=371422;
+      sha256 = "1rzwzrc7q73k42s1j1iw52chy10w6y3xksfrzg2l42nn9wk7n281";
+    })
+    # https://bugzilla.gnome.org/show_bug.cgi?id=795574
+    (fetchurl {
+      url = https://bugzilla.gnome.org/attachment.cgi?id=371423;
+      sha256 = "0b2ck8z4b2yrgwg4v9jsac5n8h3a91qkp90vv17wxcvr4v50fg48";
+    })
+    # https://bugzilla.gnome.org/show_bug.cgi?id=795575
+    (fetchurl {
+      url = https://bugzilla.gnome.org/attachment.cgi?id=371424;
+      sha256 = "03i29fabxrpraydh7712vdrc571qmiq0l4axj24gbi6h77xn7mxc";
+    })
+    # https://bugzilla.gnome.org/show_bug.cgi?id=795576
+    (fetchurl {
+      url = https://bugzilla.gnome.org/attachment.cgi?id=371427;
+      sha256 = "187flswvzymjfxwfrrhizb1cvs780zm39aa3i2vwa5fbllr7kcpf";
+    })
+    # https://bugzilla.gnome.org/show_bug.cgi?id=795577
+    (fetchurl {
+      url = https://bugzilla.gnome.org/attachment.cgi?id=371425;
+      sha256 = "05m629469jr2lm2cjs54n7xwyim2d5rwwvdjxzcwh5qpfjds5phm";
     })
   ];
 
@@ -51,11 +105,21 @@ in stdenv.mkDerivation rec {
     };
   };
 
+  # https://github.com/NixOS/nixpkgs/pull/39534#discussion_r184339131
+  # https://github.com/NixOS/nixpkgs/pull/37693
+  preConfigure = ''
+    mesonFlagsArray+=("-Ddbus_services=$out/share/dbus-1/services")
+  '';
+
+  postInstall = ''
+    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/Tracker;
     description = "Desktop-neutral user information store, search tool and indexer";
     maintainers = gnome3.maintainers;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

After this commit, GNOME Music will properly display FLAC tracks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

