### PR TITLE
[RDY] iproute: copy files in /etc

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -53,7 +53,10 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
 
   <itemizedlist>
    <listitem>
-    <para></para>
+     <para>When enabled the <literal>iproute2</literal> will copy the files
+       expected by ip route (e.g., <filename>rt_tables</filename>) in
+       <filename>/run/iproute2</filename>. This allows to write aliases for
+       routing tables for instance.</para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/modules/config/iproute2.nix
+++ b/nixos/modules/config/iproute2.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.networking.iproute2;
+  confDir = "/run/iproute2";
+in
+{
+  options.networking.iproute2.enable = mkEnableOption "copy IP route configuration files";
+
+  config = mkMerge [
+    ({ nixpkgs.config.iproute2.confDir = confDir; })
+
+    (mkIf cfg.enable {
+      system.activationScripts.iproute2 = ''
+        cp -R ${pkgs.iproute}/etc/iproute2 ${confDir}
+        chmod -R 664 ${confDir}
+        chmod +x ${confDir}
+      '';
+    })
+  ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -9,6 +9,7 @@
   ./config/fonts/ghostscript.nix
   ./config/gnu.nix
   ./config/i18n.nix
+  ./config/iproute2.nix
   ./config/krb5/default.nix
   ./config/ldap.nix
   ./config/networking.nix

--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, lib, flex, bash, bison, db, iptables, pkgconfig }:
+{ fetchurl, stdenv, config, lib, flex, bash, bison, db, iptables, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "iproute2-${version}";
@@ -26,8 +26,9 @@ stdenv.mkDerivation rec {
     "HDRDIR=$(TMPDIR)/include/iproute2" # Don't install headers
   ];
 
+  # enable iproute2 module if you want this folder to be created
   buildFlags = [
-    "CONFDIR=/etc/iproute2"
+    "CONFDIR=${config.iproute2.confDir or "/run/iproute2"}"
   ];
 
   installFlags = [


### PR DESCRIPTION
When doing source routing/multihoming, it's practical to give names to routing
tables. The absence of the rt_table file in /etc make this impossible.
This patch recreates these files on rebuild so that they can be modified
by the user

###### Motivation for this change
 see NixOS#38638.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

