### PR TITLE
linux-mptcp: enable advanced schedulers

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -33,8 +33,7 @@ buildLinux (rec {
     DEFAULT_MPTCP_PM default
 
     # MPTCP scheduler selection.
-    # Disabled as the only non-default is the useless round-robin.
-    MPTCP_SCHED_ADVANCED n
+    MPTCP_SCHED_ADVANCED y
     DEFAULT_MPTCP_SCHED default
 
     # Smarter TCP congestion controllers


### PR DESCRIPTION
###### Motivation for this change
Most likely if you use MPTCP you want to experiment a bit with schedulers !

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

