### PR TITLE
python-2.7.14: Fix #27177 and #25750

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -58,6 +58,24 @@ let
       # if DETERMINISTIC_BUILD env var is set
       ./deterministic-build.patch
 
+      # Fix python bug #27177 (https://bugs.python.org/issue27177)
+      # The issue is that `match.group` only recognizes python integers
+      # instead of everything that has `__index__`.
+      # This bug was fixed upstream, but not backported to 2.7
+      (fetchpatch {
+        name = "re_match_index.patch";
+        url = "https://bugs.python.org/file43084/re_match_index.patch";
+        sha256 = "0l9rw6r5r90iybdkp3hhl2pf0h0s1izc68h5d3ywrm92pq32wz57";
+      })
+
+      # "`type_getattro()` calls `tp_descr_get(self, obj, type)` without actually owning a reference to "self".
+      # In very rare cases, this can cause a segmentation fault if "self" is deleted by the descriptor."
+      # https://github.com/python/cpython/pull/6118
+      (fetchpatch {
+        name = "type_getattro.patch";
+        url = "https://github.com/python/cpython/pull/6118/commits/8c6da2d7e7e719c40fb539b7f7cb7583cccc5527.patch";
+        sha256 = "11v9yx20hs3jmw0wggzvmw39qs4mxay4kb8iq2qjydwy9ya61nrd";
+      })
     ] ++ optionals (x11Support && stdenv.isDarwin) [
       ./use-correct-tcl-tk-on-darwin.patch
     ] ++ optionals stdenv.isLinux [


### PR DESCRIPTION
###### Motivation for this change

I originally wanted to include this in the sage PR, but since a world-rebuilding python PR (#39517 by @dtzWill) was just merged into staging maybe its better to only rebuild all python2.7 packages on linux once.

[Python Issue 27177](https://bugs.python.org/issue27177): Regex match.group doesn't support __index__, only standard integers. This was fixed, but not backported to 2.7. sage needs that because it uses its own integers by default. I tried to monkey-patch around this, but apparently you can't monkey-patch `re`.

[Python Issue 25750](https://bugs.python.org/issue25750) leads to occasional crashes, especially on python 2.7. There is an [upstream PR in the making](https://github.com/python/cpython/pull/6118).

As requested previously, there is now a [branch with the sage package](https://github.com/timokau/nixpkgs/tree/sage-on-nixos). This is not yet PR-ready though, contains unneeded patches, duplication, TODOs etc. I will rewrite history on that branch.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

