### PR TITLE
procps-ng: Use official release tarballs, fix version.

### DIFF
--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -1,22 +1,17 @@
-{ lib, stdenv, fetchurl, ncurses, libtool, gettext, autoconf, automake, pkgconfig }:
+{ lib, stdenv, fetchurl, ncurses, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "procps-${version}";
   version = "3.3.14";
 
+  # The project's releases are on SF, but git repo on gitlab.
   src = fetchurl {
-    url = "https://gitlab.com/procps-ng/procps/-/archive/v${version}/procps-v${version}.tar.bz2";
-    sha256 = "0igvsl3s7m5ygxgypzksk4cp2wkvv3lk49s7i9m5wbimyakmr0vf";
+    url = "mirror://sourceforge/procps-ng/procps-ng-${version}.tar.xz";
+    sha256 = "0v3j6rkzzscqds37i105cxx3q4dk04rsgpqfd5p7hzcvk59h5njy";
   };
 
   buildInputs = [ ncurses ];
-  nativeBuildInputs = [ libtool gettext autoconf automake pkgconfig ];
-
-  # autoreconfHook doesn't quite get, what procps-ng buildprocss does
-  # with po/Makefile.in.in and stuff.
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  nativeBuildInputs = [ pkgconfig ];
 
   makeFlags = "usrbin_execdir=$(out)/bin";
 


### PR DESCRIPTION
Also no need to re-generate config bits,
which is good since we encountered an error when trying to do so.


Fixes #39538.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---