### PR TITLE
nodejs: init at v10.0.0

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -2,14 +2,14 @@
 , ApplicationServices, CoreServices }:
 
 stdenv.mkDerivation rec {
-  version = "1.20.0";
+  version = "1.20.2";
   name = "libuv-${version}";
 
   src = fetchFromGitHub {
     owner = "libuv";
     repo = "libuv";
     rev = "v${version}";
-    sha256 = "0bjxny5bjl0qy978i9n2b96vd72h9dd7ghylvhfsi1aqfwc0s1qz";
+    sha256 = "14zlf59fr03v684ryapc57r9nfrznyk5xvcd59q04rb435ibib48";
   };
 
   postPatch = let

--- a/pkgs/development/web/nodejs/v10.nix
+++ b/pkgs/development/web/nodejs/v10.nix
@@ -1,0 +1,11 @@
+{ stdenv, callPackage, lib, openssl, enableNpm ? true }:
+
+let
+  buildNodejs = callPackage ./nodejs.nix { inherit openssl; };
+in
+  buildNodejs {
+    inherit enableNpm;
+    version = "10.0.0";
+    sha256 = "0l5bx2j4f2ij19kx14my7g7k37j3fn9qpjvbisjvhpbm42810fg2";
+    patches = lib.optionals stdenv.isDarwin [ ./no-xcode-v7.patch ];
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3390,6 +3390,14 @@ with pkgs;
   nodejs-9_x = callPackage ../development/web/nodejs/v9.nix {};
   nodejs-slim-9_x = callPackage ../development/web/nodejs/v9.nix { enableNpm = false; };
 
+  nodejs-10_x = callPackage ../development/web/nodejs/v10.nix {
+    openssl = openssl_1_1_0;
+  };
+  nodejs-slim-10_x = callPackage ../development/web/nodejs/v10.nix {
+    enableNpm = false;
+    openssl = openssl_1_1_0;
+  };
+
   nodePackages_8_x = callPackage ../development/node-packages/default-v8.nix {
     nodejs = pkgs.nodejs-8_x;
   };


### PR DESCRIPTION
###### Motivation for this change

[release notes](https://nodejs.org/en/blog/release/v10.0.0/)

As node 10 requires libuv 1.20.2 this PR goes against staging.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've just started builds locally on darwin and nixOS but this probably takes few hours.

I'll update the checkboxes above, when the builds are done.
