### PR TITLE
pspg: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/tools/misc/pspg/default.nix
+++ b/pkgs/tools/misc/pspg/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, gnugrep, ncurses, pkgconfig }:
+{ stdenv, fetchFromGitHub, gnugrep, ncurses, pkgconfig, readline }:
 
 stdenv.mkDerivation rec {
   name = "pspg-${version}";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "okbob";
     repo = "pspg";
     rev = "${version}";
-    sha256 = "1swrg4bg7i4xpdrsg8dsfldbxaffni04x8i1s0g6h691qcin675v";
+    sha256 = "10r6jfcqw4wclp84f07g3bda844csgm4sh7cjsnk2smmal7nhybs";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gnugrep ncurses ];
+  buildInputs = [ gnugrep ncurses readline ];
 
   preBuild = ''
     makeFlags="PREFIX=$out PKG_CONFIG=${pkgconfig}/bin/pkg-config"


### PR DESCRIPTION
###### Motivation for this change
Update pspg, readline is a new dependency for this release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

