### PR TITLE
chromium: See if Hydra obeys a 24h meta.timeout

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -51,5 +51,6 @@ mkChromiumDerivation (base: rec {
     license = licenses.bsd3;
     platforms = platforms.linux;
     hydraPlatforms = if channel == "stable" then ["aarch64-linux" "x86_64-linux"] else [];
+    timeout = 86400; # 24 hours
   };
 })


### PR DESCRIPTION
###### Motivation for this change
Fixes #39476. Well, works around it at least.

It appears that Hydra has *some* support for setting timeout values. Experiments show that meta.timeout does carry over to timeout in builds column, but it's a bit unclear whether that actually carries through anywhere (yet?)

Discussion on #nixos-dev culminated in "let's try it!"