### PR TITLE
#39225 - added fix for zfs dracut support

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -130,6 +130,11 @@ let
 
         # Remove tests because they add a runtime dependency on gcc
         rm -rf $out/share/zfs/zfs-tests
+
+        # Add modprobe zfs if missing ()
+        if ! grep --quiet 'modprobe zfs' $(out)/lib/dracut/90zfs/mount-zfs.sh; then
+          sed -i '/udevadm settle/s/^/modprobe zfs 2>\/dev\/null&\n/' $(out)/lib/dracut/90zfs/mount-zfs.sh
+        fi
       '';
 
       outputs = [ "out" ] ++ optionals buildUser [ "lib" "dev" ];
@@ -153,7 +158,7 @@ in {
   # to be adapted
   zfsStable = common {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    #incompatibleKernelVersion = "";
 
     # this package should point to the latest release.
     version = "0.7.8";
@@ -172,7 +177,7 @@ in {
 
   zfsUnstable = common rec {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    #incompatibleKernelVersion = "";
 
     # this package should point to a version / git revision compatible with the latest kernel release
     version = "2018-04-10";
@@ -195,7 +200,7 @@ in {
   # also remove boot.zfs.enableLegacyCrypto
   zfsLegacyCrypto = common {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    #incompatibleKernelVersion = "";
 
     # this package should point to a version / git revision compatible with the latest kernel release
     version = "2018-02-01";


### PR DESCRIPTION
###### Motivation for this change
Resolves issue with ZFS not being detected properly by dracut. (#39225)
Issue was created upstream in https://github.com/zfsonlinux/zfs/pull/7287 and resolved later in https://github.com/tonyhutter/zfs/commit/d565bdaaf3a045c753aebb85d19424d01c861932

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

