### PR TITLE
pythia: 8.226 -> 8.235, enable lhapdf6 plugin

### DIFF
--- a/pkgs/applications/science/physics/sacrifice/default.nix
+++ b/pkgs/applications/science/physics/sacrifice/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, boost, hepmc, lhapdf, pythia }:
+{ stdenv, fetchurl, boost, hepmc, lhapdf, pythia, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "sacrifice-${version}";
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ boost hepmc lhapdf pythia ];
+  nativeBuildInputs = [ makeWrapper ];
 
   patches = [
     ./compat.patch
@@ -27,8 +28,11 @@ stdenv.mkDerivation rec {
     "--with-pythia=${pythia}"
   ];
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = if stdenv.isDarwin then ''
     install_name_tool -add_rpath ${pythia}/lib "$out"/bin/run-pythia
+  '' else ''
+    wrapProgram $out/bin/run-pythia \
+      --prefix LD_LIBRARY_PATH : "${pythia}/lib"
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/physics/pythia/default.nix
+++ b/pkgs/development/libraries/physics/pythia/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pythia-${version}";
-  version = "8.226";
+  version = "8.235";
 
   src = fetchurl {
     url = "http://home.thep.lu.se/~torbjorn/pythia8/pythia${builtins.replaceStrings ["."] [""] version}.tgz";
-    sha256 = "1jfjkq78d1llrrm2k5pgsl92a5z8af9rx3n83rzv28lxrqdjix4g";
+    sha256 = "17cfgs7v469pdnnzvlmdagcdhi0h419znqmaws90l9d8cmhhsbz8";
   };
 
   buildInputs = [ boost fastjet hepmc zlib rsync lhapdf ];
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-shared"
     "--with-hepmc2=${hepmc}"
+    "--with-lhapdf6=${lhapdf}"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

