### PR TITLE
mpfr update

### DIFF
--- a/pkgs/development/libraries/mpfi/default.nix
+++ b/pkgs/development/libraries/mpfi/default.nix
@@ -1,15 +1,20 @@
 {stdenv, fetchurl, mpfr}:
 stdenv.mkDerivation rec {
   name = "mpfi-${version}";
-  version = "1.5.1";
+  version = "1.5.3";
+  file_nr = "37331";
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/30129/mpfi-${version}.tar.bz2";
-    sha256 = "0vk9jfcfiqda0zksg1ffy36pdznpng9b4nl7pfzpz9hps4v6bk1z";
+    # NOTE: the file_nr is whats important here. The actual package name (including the version)
+    # is ignored. To find out the correct file_nr, go to https://gforge.inria.fr/projects/mpfi/
+    # and click on Download in the section "Latest File Releases".
+    url = "https://gforge.inria.fr/frs/download.php/file/${file_nr}/mpfi-${version}.tar.bz2";
+    sha256 = "0bqr8yibl7jbrp0bw7xk1lm7nis7rv26jsz6y8ycvih8n9bx90r3";
   };
   buildInputs = [mpfr];
   meta = {
     inherit version;
     description = ''A multiple precision interval arithmetic library based on MPFR'';
+    homepage = https://gforge.inria.fr/projects/mpfi/;
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -3,11 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "mpfr-3.1.6";
+  version = "4.0.1";
+  name = "mpfr-${version}";
 
   src = fetchurl {
     url = "mirror://gnu/mpfr/${name}.tar.xz";
-    sha256 = "0l598h9klpgkz2bp0rxiqb90mkqh9f2f81n5rpy191j00hdaqqks";
+    sha256 = "0vp1lrc08gcmwdaqck6bpzllkrykvp06vz5gnqpyw0v3h9h4m1v7";
   };
 
   outputs = [ "out" "dev" "doc" "info" ];


### PR DESCRIPTION
###### Motivation for this change

mpfr was outdated, mpfi needs to be updated for compatibility. Also see #36620.
This is a stdenv change and causes a rebuild of everything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

