### PR TITLE
awsebcli: 3.12.3 -> 3.12.4

### DIFF
--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -19,6 +19,14 @@ let
         };
       });
 
+      pathspec = super.pathspec.overridePythonAttrs (oldAttrs: rec {
+        version = "0.5.5";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "72c495d1bbe76674219e307f6d1c6062f2e1b0b483a5e4886435127d0df3d0d3";
+        };
+      });
+
       requests = super.requests.overridePythonAttrs (oldAttrs: rec {
         version = "2.9.1";
         src = oldAttrs.src.override {

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -54,11 +54,11 @@ let
   };
 in with localPython.pkgs; buildPythonApplication rec {
   pname = "awsebcli";
-  version = "3.12.3";
+  version = "3.12.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0jj6xhvsrgvc5pm05zbd95zvx36ssywq70j6q1kzcdv1flfzzyp9";
+    sha256 = "128dgxyz2bgl3r4jdkbmjs280004bm0dwzln7p6ly3yjs2x37jl6";
   };
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

Version bump, also fix build after c705acef6e0b5826fdddfa0cc1cbf1b125872a5a updated pathspec dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

