### PR TITLE
labelImg: init at 1.6.0

### DIFF
--- a/pkgs/applications/science/machine-learning/labelimg/default.nix
+++ b/pkgs/applications/science/machine-learning/labelimg/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, python2Packages, fetchurl }:
+  python2Packages.buildPythonApplication rec {
+    name = "labelImg-${version}";
+    version = "1.6.0";
+    src = fetchurl {
+      url = "https://github.com/tzutalin/labelImg/archive/v${version}.tar.gz";
+      sha256 = "126kc4r7xm9170kh7snqsfkkc868m5bcnswrv7b4cq9ivlrdwbm4";
+    };
+    propagatedBuildInputs = with python2Packages; [
+      pyqt4
+      lxml
+    ];
+    preBuild = ''
+      make qt4py2
+    '';
+    meta = with stdenv.lib; {
+      description = "LabelImg is a graphical image annotation tool and label object bounding boxes in images";
+      homepage = https://github.com/tzutalin/labelImg;
+      license = licenses.mit;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.cmcdragonkai ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12428,6 +12428,8 @@ with pkgs;
 
   lwan = callPackage ../servers/http/lwan { };
 
+  labelImg = callPackage ../applications/science/machine-learning/labelimg { };
+
   mailman = callPackage ../servers/mail/mailman { };
 
   mattermost = callPackage ../servers/mattermost { };


### PR DESCRIPTION
###### Motivation for this change

Added labelImg.

One issue is that when I run it, I get a message about:

```
/nix/store/xn5gv3lpfy91yvfy9b0i7klfcxh9xskz-bash-4.4-p19/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/home/cmcdragonkai/.includes_sh/shell_environment_common.conf: line 31: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```

But the rest works.

https://github.com/NixOS/nixpkgs/issues/38716

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

