### PR TITLE
cassandra: 3.11.1 -> 3.11.2

### DIFF
--- a/pkgs/servers/nosql/cassandra/3.11.nix
+++ b/pkgs/servers/nosql/cassandra/3.11.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "3.11.1";
-  sha256 = "1vgh4ysnl4xg8g5v6zm78h3sq308r7s17ppbw0ck4bwyfnbddvkg";
+  version = "3.11.2";
+  sha256 = "0867i3irsji3qkjpp2s171xmjf2r8yhwzhs24ka8hljxv457f8p9";
 })


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

Execution was tested using the new module and tests from #31410. 

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

