### PR TITLE
opentimestamps: 0.2.1 -> 0.3.0, opentimestamps-client: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/opentimestamps/default.nix
+++ b/pkgs/development/python-modules/opentimestamps/default.nix
@@ -2,15 +2,17 @@
 , bitcoinlib, GitPython, pysha3 }:
 
 buildPythonPackage rec {
-  name = "opentimestamps-${version}";
-  version = "0.2.1";
+  pname = "opentimestamps";
+  version = "0.3.0";
   disabled = (!isPy3k);
 
+  # We can't use the pypi source because it doesn't include README.md which is
+  # needed in setup.py
   src = fetchFromGitHub {
     owner = "opentimestamps";
     repo = "python-opentimestamps";
-    rev = "python-opentimestamps-v0.2.1";
-    sha256 = "1cilv1ls9mdqk8zriqfkz7xcl8i1ncm0f89n4c8k4s82kf5y56rm";
+    rev = "python-opentimestamps-v${version}";
+    sha256 = "1i843mbz4h9vqc3y2x09ix6bv9wc0gzq36zhbnmf5by08iaiydks";
   };
 
   # Remove a failing test which expects the test source file to reside in the

--- a/pkgs/tools/misc/opentimestamps-client/default.nix
+++ b/pkgs/tools/misc/opentimestamps-client/default.nix
@@ -1,19 +1,21 @@
 { lib, buildPythonApplication, fetchFromGitHub, isPy3k
-, opentimestamps, GitPython, pysocks }:
+, opentimestamps, appdirs, GitPython, pysocks }:
 
 buildPythonApplication rec {
-  name = "opentimestamps-client-${version}";
-  version = "0.5.1";
+  pname = "opentimestamps-client";
+  version = "0.6.0";
   disabled = (!isPy3k);
 
+  # We can't use the pypi source because it doesn't include README.md which is
+  # needed in setup.py
   src = fetchFromGitHub {
     owner = "opentimestamps";
     repo = "opentimestamps-client";
-    rev = "opentimestamps-client-v0.5.1";
-    sha256 = "0s549xkb75r5wyvjlfmac8a1df6w0y55l98f492zsihdns1d6rzq";
+    rev = "opentimestamps-client-v${version}";
+    sha256 = "05m8nllqad3k69mvby5q08y22i0wrj84gqifdgcldimrrn1i00xp";
   };
 
-  propagatedBuildInputs = [ opentimestamps GitPython pysocks ];
+  propagatedBuildInputs = [ opentimestamps appdirs GitPython pysocks ];
 
   meta = {
     description = "Command-line tool to create and verify OpenTimestamps proofs";


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [?] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). ( --> I took the liberty to merge two version bumps into this single commit.)

---

