### PR TITLE
insomnia: 5.15.0 -> 5.16.0

### DIFF
--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -6,7 +6,7 @@
   libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext, libXfixes, libXi, libXrandr,
   libXrender, libXtst, libxcb,
 
-  libudev0-shim, glibc, curl
+  libudev0-shim, glibc, curl, openssl
 }:
 
 let
@@ -15,14 +15,14 @@ let
     gtk2-x11 nspr nss stdenv.cc.cc.lib libX11 libXScrnSaver libXcomposite libXcursor libXdamage libXext libXfixes
     libXi libXrandr libXrender libXtst libxcb
   ];
-  runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl ];
+  runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl ];
 in stdenv.mkDerivation rec {
   name = "insomnia-${version}";
-  version = "5.15.0";
+  version = "5.16.0";
 
   src = fetchurl {
     url = "https://github.com/getinsomnia/insomnia/releases/download/v${version}/insomnia_${version}_amd64.deb";
-    sha256 = "17pxgxpss5jxzpmcim7hkyyj0fgyxwdiyxb2idpsna2hmhaipyxa";
+    sha256 = "1cpw63ibxaa08vms7fbxr5ap2yh4vcl8q3rjfn0ag1zkimz8cg2p";
   };
 
   nativeBuildInputs = [ makeWrapper dpkg ];


### PR DESCRIPTION
###### Motivation for this change
Update insomnia.  Fixes #39542, which does not add the required ssl library and would lead to a broken package.

Unfortunately the binary does not respond to any commandline flags, so I found no good way to quickly check for this regression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

