### PR TITLE
rocketchat-2.10.5: initial commit

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1577,6 +1577,11 @@
     email = "t@larkery.com";
     name = "Tom Hinton";
   };
+  hlolli = {
+    email = "hlolli@gmail.com";
+    github = "hlolli";
+    name = "Hlöðver Sigurðsson";
+  };
   hodapp = {
     email = "hodapp87@gmail.com";
     github = "Hodapp87";

--- a/pkgs/applications/networking/instant-messengers/rocketchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rocketchat/default.nix
@@ -70,6 +70,11 @@ in stdenv.mkDerivation {
     # Fix the desktop link
     substituteInPlace $out/share/applications/rocketchat.desktop \
       --replace /opt/Rocket.Chat+/rocketchat $out/bin/rocketchat
+
+    # Fix electron-updater warnings, must take exact same amount of
+    # characters, otherwise the aspar archive breaks
+    sed -i 's/    checkForUpdates();/\/\/  checkForUpdates();/' \
+        $out/lib/rocketchat/resources/app.asar
     
   '';
    
@@ -78,6 +83,7 @@ in stdenv.mkDerivation {
     homepage = https://rocket.chat;
     license = licenses.mit;
     platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.hlolli ];
   };
 
 }

--- a/pkgs/applications/networking/instant-messengers/rocketchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rocketchat/default.nix
@@ -1,0 +1,83 @@
+{ stdenv, fetchurl, dpkg, alsaLib, atk, cairo, 
+  cups, curl, dbus, expat, fontconfig, freetype, glib,
+  gnome2, libnotify, libxcb, nspr, nss, systemd, xorg 
+}:
+
+let version = "2.10.5";
+    rpath = stdenv.lib.makeLibraryPath  [ 
+      alsaLib
+      atk
+      cairo
+      cups
+      curl
+      dbus
+      expat
+      fontconfig
+      freetype
+      glib
+      gnome2.GConf
+      gnome2.gdk_pixbuf
+      gnome2.gtk
+      gnome2.pango
+      libnotify
+      libxcb
+      nspr
+      nss
+      stdenv.cc.cc
+      systemd
+      
+      xorg.libxkbfile
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libXScrnSaver ] + ":${stdenv.cc.cc.lib}/lib64";
+
+    src = fetchurl {
+                     url = "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/${version}/rocketchat_${version}_amd64.deb";
+                     sha256 = "907de38c44a1663223bd43cc63b2a1347d9e08c72e248c736f9c88b995ddf583";
+                   };
+
+in stdenv.mkDerivation {
+   name = "rocketchat-${version}";
+   inherit src;
+   buildInputs = [ dpkg ];
+   unpackPhase = true;
+
+   buildCommand = ''
+    mkdir -p $out $out/bin $out/lib
+    dpkg -x $src $out
+    mv $out/usr/share $out/share
+    mv $out/opt/Rocket.Chat+ $out/lib/rocketchat
+    rm -rf $out/usr $out/opt
+
+    # Otherwise it looks "suspicious"
+    chmod -R g-w $out
+
+    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/lib/rocketchat $file || true
+    done
+
+    ln -s $out/lib/rocketchat/rocketchat $out/bin/rocketchat
+
+    # Fix the desktop link
+    substituteInPlace $out/share/applications/rocketchat.desktop \
+      --replace /opt/Rocket.Chat+/rocketchat $out/bin/rocketchat
+    
+  '';
+   
+  meta = with stdenv.lib; {
+    description = "Desktop client for Rocket.Chat";
+    homepage = https://rocket.chat;
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16958,6 +16958,8 @@ with pkgs;
 
   ptex = callPackage ../development/libraries/ptex {};
 
+  rocketchat = callPackage ../applications/networking/instant-messengers/rocketchat {};
+
   rssguard = libsForQt5.callPackage ../applications/networking/feedreaders/rssguard { };
 
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };


### PR DESCRIPTION
###### Motivation for this change
It's basically an Electron desktop app like Slack. I tested it as nix-overlay. There are some warnings printed about Rocket Chat not being able to auto update via electron-updater, but that's ok as we wouldn't want this feature to work. Otherwise no problem. Need to get myself comfortable with the sandbox, slowly learning nixos, so I decided to PR this derivation.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

