### PR TITLE
netcat-openbsd-1.187-1-1.190-1 - set version from 1.187 to 1.190:

### DIFF
--- a/pkgs/tools/networking/netcat-openbsd/default.nix
+++ b/pkgs/tools/networking/netcat-openbsd/default.nix
@@ -1,18 +1,18 @@
 {stdenv, fetchurl, fetchpatch, pkgconfig, libbsd}:
 
 stdenv.mkDerivation rec {
-  version = "1.187";
+  version = "1.190";
   deb-version = "${version}-1";
   name = "netcat-openbsd-${version}";
 
   srcs = [
     (fetchurl {
       url = "mirror://debian/pool/main/n/netcat-openbsd/netcat-openbsd_${version}.orig.tar.gz";
-      sha256 = "0sxsxl7n7hnxz931jqsp86cdwiq2lm4h3w0i2a67935pki924gxw";
+      sha256 = "0dp571m42zc7wvb9bf4hz5a08rcc5fknf0gdp98yq19c754c9k38";
     })
     (fetchurl {
       url = "mirror://debian/pool/main/n/netcat-openbsd/netcat-openbsd_${deb-version}.debian.tar.xz";
-      sha256 = "0jwbdis6avxdjzg8bcab1bdz296rkzzkdlv50fr3q0277fxjs49q";
+      sha256 = "0plgrri85sghzn499jzd9d3h7w61ksqj0amkwmcah8dmfkp7jrgv";
     })
   ];
 


### PR DESCRIPTION
http://metadata.ftp-master.debian.org/changelogs/main/n/netcat-openbsd/netcat-openbsd_1.190-1_changelog

###### Motivation for this change

[ookhoi@p70:~]$ sudo nixos-rebuild switch --upgrade
[..]
error: cannot download netcat-openbsd_1.187-1.debian.tar.xz from any mirror
builder for '/nix/store/y7a0fcyv9bg87n0m87xxl398f273y7kh-netcat-openbsd_1.187-1.debian.tar.xz.drv' failed with exit code 1
[..]
cannot build derivation '/nix/store/yyzqrrh9mks0m73n6h89b1s5fpb8k61d-netcat-openbsd-1.187.drv': 1 dependencies couldn't be built
[..]
cannot build derivation '/nix/store/cg4l25bwb131bvjj5jbm58g0g7ji83zb-system-path.drv': 1 dependencies couldn't be built
[..]
cannot build derivation '/nix/store/6mw49gzyqadqdhhxkprnfm5mc2ka0dv3-nixos-system-p70-18.09pre138515.ab5dcdddd18.drv': 1 dependencies couldn't be built
error: build of '/nix/store/6mw49gzyqadqdhhxkprnfm5mc2ka0dv3-nixos-system-p70-18.09pre138515.ab5dcdddd18.drv' failed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

