### PR TITLE
rubiks: fix build

### DIFF
--- a/pkgs/development/libraries/science/math/rubiks/default.nix
+++ b/pkgs/development/libraries/science/math/rubiks/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildPhase = "true";
 
   installFlags = [
-    "PREFIX=$out"
+    "PREFIX=$(out)"
   ];
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

After implementing a suggestion from my rubiks-init PR (#38803), I failed to realize that `nix build rubiks` now actually produces an empty directory. Probably I only checked for build failure when making that change, without sanity-checking the contents of `result`.

This fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

