### PR TITLE
pythonPackages.cysignals: 1.6.9 -> 1.7.1

### DIFF
--- a/pkgs/development/python-modules/cysignals/default.nix
+++ b/pkgs/development/python-modules/cysignals/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "cysignals";
-  version = "1.6.9";
+  version = "1.7.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "003invnixqy1h4lb358vwrxykxzp15csaddkgq3pqqmswnva5908";
+    sha256 = "15nky8siwlc7s8v23vv4m0mnxa1z6jcs2qfr26m2mkw9j9g2na2j";
   };
 
   hardeningDisable = [


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

