### PR TITLE
GDM wayland improvements

### DIFF
--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -135,6 +135,9 @@ in
 
     systemd.services.display-manager.path = [ pkgs.gnome3.gnome-session ];
 
+    # Allow choosing an user account
+    services.accounts-daemon.enable = true;
+
     services.dbus.packages = [ gdm ];
 
     systemd.user.services.dbus.wantedBy = [ "default.target" ];

--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, itstool, libxml2, xorg, dbus
+{ stdenv, fetchurl, substituteAll, pkgconfig, glib, itstool, libxml2, xorg, dbus
 , intltool, accountsservice, libX11, gnome3, systemd, autoreconfHook
 , gtk, libcanberra-gtk3, pam, libtool, gobjectIntrospection, plymouth
 , librsvg, coreutils }:
@@ -12,50 +12,56 @@ stdenv.mkDerivation rec {
     sha256 = "1yxjjyrp0ywrc25cp81bsdhp79zn0c0jag48hlp00b5wfnkqy1kp";
   };
 
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "gdm"; attrPath = "gnome3.gdm"; };
-  };
-
   # Only needed to make it build
   preConfigure = ''
     substituteInPlace ./configure --replace "/usr/bin/X" "${xorg.xorgserver.out}/bin/X"
   '';
 
-  postPatch = ''
-    substituteInPlace daemon/gdm-manager.c --replace "/bin/plymouth" "${plymouth}/bin/plymouth"
-    substituteInPlace data/gdm.service.in  --replace "/bin/kill" "${coreutils}/bin/kill"
-  '';
-
-  configureFlags = [ "--sysconfdir=/etc"
-                     "--localstatedir=/var"
-                     "--with-plymouth=yes"
-                     "--with-initial-vt=7"
-                     "--with-systemdsystemunitdir=$(out)/etc/systemd/system" ];
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-plymouth=yes"
+    "--with-initial-vt=7"
+    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+  ];
 
   nativeBuildInputs = [ pkgconfig libxml2 itstool intltool autoreconfHook libtool gnome3.dconf ];
-  buildInputs = [ glib accountsservice systemd
-                  gobjectIntrospection libX11 gtk
-                  libcanberra-gtk3 pam plymouth librsvg ];
+  buildInputs = [
+    glib accountsservice systemd
+    gobjectIntrospection libX11 gtk
+    libcanberra-gtk3 pam plymouth librsvg
+  ];
 
   enableParallelBuilding = true;
 
   # Disable Access Control because our X does not support FamilyServerInterpreted yet
-  patches = [ ./sessions_dir.patch
-              ./gdm-x-session_extra_args.patch
-              ./gdm-session-worker_xserver-path.patch
-             ];
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit coreutils plymouth;
+    })
+    ./sessions_dir.patch
+    ./gdm-x-session_extra_args.patch
+    ./gdm-session-worker_xserver-path.patch
+  ];
 
-  postInstall = ''
-    # Prevent “Could not parse desktop file orca-autostart.desktop or it references a not found TryExec binary”
-    rm $out/share/gdm/greeter/autostart/orca-autostart.desktop
-  '';
+  installFlags = [
+    "sysconfdir=$(out)/etc"
+    "dbusconfdir=$(out)/etc/dbus-1/system.d"
+  ];
 
-  installFlags = [ "sysconfdir=$(out)/etc" "dbusconfdir=$(out)/etc/dbus-1/system.d" ];
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "gdm";
+      attrPath = "gnome3.gdm";
+    };
+  };
 
   meta = with stdenv.lib; {
-    homepage = https://wiki.gnome.org/Projects/GDM;
     description = "A program that manages graphical display servers and handles graphical user logins";
-    platforms = platforms.linux;
+    homepage = https://wiki.gnome.org/Projects/GDM;
+    license = licenses.gpl2Plus;
     maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, glib, itstool, libxml2, xorg, dbus
 , intltool, accountsservice, libX11, gnome3, systemd, autoreconfHook
 , gtk, libcanberra-gtk3, pam, libtool, gobjectIntrospection, plymouth
-, librsvg, coreutils }:
+, librsvg, coreutils, xwayland }:
 
 stdenv.mkDerivation rec {
   name = "gdm-${version}";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit coreutils plymouth;
+      inherit coreutils plymouth xwayland;
     })
     ./sessions_dir.patch
     ./gdm-x-session_extra_args.patch

--- a/pkgs/desktops/gnome-3/core/gdm/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gdm/fix-paths.patch
@@ -1,3 +1,14 @@
+--- a/daemon/gdm-local-display-factory.c
++++ b/daemon/gdm-local-display-factory.c
+@@ -450,7 +450,7 @@
+ #ifdef ENABLE_WAYLAND_SUPPORT
+                         gboolean wayland_enabled = FALSE;
+                         if (gdm_settings_direct_get_boolean (GDM_KEY_WAYLAND_ENABLE, &wayland_enabled)) {
+-                                if (wayland_enabled && g_file_test ("/usr/bin/Xwayland", G_FILE_TEST_IS_EXECUTABLE) ) {
++                                if (wayland_enabled && g_file_test ("@xwayland@/bin/Xwayland", G_FILE_TEST_IS_EXECUTABLE) ) {
+                                         session_type = "wayland";
+                                 }
+                         }
 --- a/daemon/gdm-manager.c
 +++ b/daemon/gdm-manager.c
 @@ -147,7 +147,7 @@

--- a/pkgs/desktops/gnome-3/core/gdm/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gdm/fix-paths.patch
@@ -1,0 +1,49 @@
+--- a/daemon/gdm-manager.c
++++ b/daemon/gdm-manager.c
+@@ -147,7 +147,7 @@
+         GError  *error;
+ 
+         error = NULL;
+-        res = g_spawn_command_line_sync ("/bin/plymouth --ping",
++        res = g_spawn_command_line_sync ("@plymouth@/bin/plymouth --ping",
+                                          NULL, NULL, &status, &error);
+         if (! res) {
+                 g_debug ("Could not ping plymouth: %s", error->message);
+@@ -165,7 +165,7 @@
+         GError  *error;
+ 
+         error = NULL;
+-        res = g_spawn_command_line_sync ("/bin/plymouth deactivate",
++        res = g_spawn_command_line_sync ("@plymouth@/bin/plymouth deactivate",
+                                          NULL, NULL, NULL, &error);
+         if (! res) {
+                 g_warning ("Could not deactivate plymouth: %s", error->message);
+@@ -180,7 +180,7 @@
+         GError  *error;
+ 
+         error = NULL;
+-        res = g_spawn_command_line_async ("/bin/plymouth quit --retain-splash", &error);
++        res = g_spawn_command_line_async ("@plymouth@/bin/plymouth quit --retain-splash", &error);
+         if (! res) {
+                 g_warning ("Could not quit plymouth: %s", error->message);
+                 g_error_free (error);
+@@ -196,7 +196,7 @@
+         GError  *error;
+ 
+         error = NULL;
+-        res = g_spawn_command_line_async ("/bin/plymouth quit", &error);
++        res = g_spawn_command_line_async ("@plymouth@/bin/plymouth quit", &error);
+         if (! res) {
+                 g_warning ("Could not quit plymouth: %s", error->message);
+                 g_error_free (error);
+--- a/data/gdm.service.in
++++ b/data/gdm.service.in
+@@ -28,7 +28,7 @@
+ StandardOutput=syslog
+ StandardError=inherit
+ EnvironmentFile=-@LANG_CONFIG_FILE@
+-ExecReload=/bin/kill -SIGHUP $MAINPID
++ExecReload=@coreutils@/bin/kill -SIGHUP $MAINPID
+ 
+ [Install]
+ Alias=display-manager.service


### PR DESCRIPTION
###### Motivation for this change
Apparently, Wayland session was not used at all until now by GDM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

