### PR TITLE
gnucash: 2.4.15 -> 3.1-1

### DIFF
--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -1,63 +1,81 @@
-{ fetchurl, stdenv, pkgconfig, libxml2, gconf, glib, gtk2, libgnomeui, libofx
-, libgtkhtml, gtkhtml, libgnomeprint, goffice, enchant, gettext, libbonoboui
-, intltool, perl, guile, slibGuile, swig, isocodes, bzip2, makeWrapper, libglade
-, libgsf, libart_lgpl, perlPackages, aqbanking, gwenhywfar
+{ fetchurl, stdenv, pkgconfig, makeWrapper, cmake, gtest
+, boost, icu, libxml2, libxslt, gettext, swig, isocodes, gtk3, glibcLocales
+, webkit, dconf, hicolor-icon-theme, libofx, aqbanking, gwenhywfar, libdbi
+, libdbiDrivers, guile, perl, perlPackages
 }:
 
-/* If you experience GConf errors when running GnuCash on NixOS, see
- * http://wiki.nixos.org/wiki/Solve_GConf_errors_when_running_GNOME_applications
- * for a possible solution.
- */
+let
+
+  # Enable gnc-fq-* to run in command line.
+  perlWrapper = stdenv.mkDerivation {
+    name = perl.name + "-wrapper-for-gnucash";
+    nativeBuildInputs = [ makeWrapper ];
+    buildInputs = [ perl ] ++ (with perlPackages; [ FinanceQuote DateManip ]);
+    phases = [ "installPhase" ];
+    installPhase = ''
+      mkdir -p $out/bin
+      for script in ${perl}/bin/*; do
+        makeWrapper $script $out''${script#${perl}} \
+          --prefix "PERL5LIB" ":" "$PERL5LIB"
+      done
+    '';
+  };
+
+in
 
 stdenv.mkDerivation rec {
-  name = "gnucash-2.4.15";
+  name = "gnucash-${version}";
+  version = "3.1-1";
 
   src = fetchurl {
     url = "mirror://sourceforge/gnucash/${name}.tar.bz2";
-    sha256 = "058mgfwic6a2g7jq6iip5hv45md1qaxy25dj4lvlzjjr141wm4gx";
+    sha256 = "0qfjpmr6hnr0v7l2fi00rilnlyan4kqiyygyidxlpdxqqg76dvx1";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    libxml2 gconf glib gtk2 libgnomeui libgtkhtml gtkhtml
-    libgnomeprint goffice enchant gettext intltool perl guile slibGuile
-    swig isocodes bzip2 makeWrapper libofx libglade libgsf libart_lgpl
-    perlPackages.DateManip perlPackages.FinanceQuote aqbanking gwenhywfar
-  ];
-  propagatedUserEnvPkgs = [ gconf ];
+  nativeBuildInputs = [ pkgconfig makeWrapper cmake gtest ];
 
-  configureFlags = "CFLAGS=-O3 CXXFLAGS=-O3 --disable-dbi --enable-ofx --enable-aqbanking";
+  buildInputs = [
+    boost icu libxml2 libxslt gettext swig isocodes gtk3 glibcLocales
+    webkit dconf hicolor-icon-theme libofx aqbanking gwenhywfar libdbi
+    libdbiDrivers guile perlWrapper
+  ];
+
+  propagatedUserEnvPkgs = [ dconf ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
 
   postInstall = ''
     # Auto-updaters don't make sense in Nix.
     rm $out/bin/gnc-fq-update
 
-    sed -i $out/bin/update-gnucash-gconf \
-       -e 's|--config-source=[^ ]* --install-schema-file|--makefile-install-rule|'
+    # Unnecessary in the release build.
+    rm $out/bin/gnucash-valgrind
 
-    for prog in $(echo "$out/bin/"*)
-    do
-      # Don't wrap the gnc-fq-* scripts, since gnucash calls them as
-      # "perl <script>', i.e. they must be Perl scripts.
-      if [[ $prog =~ gnc-fq ]]; then continue; fi
-      wrapProgram "$prog"                                               \
-        --set SCHEME_LIBRARY_PATH "$SCHEME_LIBRARY_PATH"                \
-        --prefix GUILE_LOAD_PATH ":" "$GUILE_LOAD_PATH"                 \
-        --prefix LD_LIBRARY_PATH ":" "${libgnomeui}/lib/libglade/2.0"   \
-        --prefix LD_LIBRARY_PATH ":" "${libbonoboui}/lib/libglade/2.0"  \
-        --prefix PERL5LIB ":" "$PERL5LIB"                               \
-        --set GCONF_CONFIG_SOURCE 'xml::~/.gconf'                       \
-        --prefix PATH ":" "$out/bin:${stdenv.lib.makeBinPath [ perl gconf ]}"
-    done
-
-    rm $out/share/icons/hicolor/icon-theme.cache
+    wrapProgram "$out/bin/gnucash" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${name}" \
+      --prefix XDG_DATA_DIRS : "${hicolor-icon-theme}/share" \
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules"
   '';
 
-  # The following settings fix failures in the test suite. It's not required otherwise.
-  NIX_LDFLAGS = "-rpath=${guile}/lib -rpath=${glib.out}/lib";
-  preCheck = "export GNC_DOT_DIR=$PWD/dot-gnucash";
-
-  doCheck = false;      # https://github.com/NixOS/nixpkgs/issues/11084
+  # TODO: The following tests FAILED:
+  #   61 - test-gnc-timezone (Failed)
+  #   70 - test-load-c (Failed)
+  #   71 - test-modsysver (Failed)
+  #   72 - test-incompatdep (Failed)
+  #   73 - test-agedver (Failed)
+  #   77 - test-gnc-module-swigged-c (Failed)
+  #   78 - test-gnc-module-load-deps (Failed)
+  #   80 - test-gnc-module-scm-module (Failed)
+  #   81 - test-gnc-module-scm-multi (Failed)
+  preCheck = ''
+    export LD_LIBRARY_PATH=$PWD/lib:$PWD/lib/gnucash:$PWD/lib/gnucash/test:$LD_LIBRARY_PATH
+    export NIX_CFLAGS_LINK="-lgtest -lgtest_main"
+  '';
+  doCheck = false;
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15965,11 +15965,7 @@ with pkgs;
   gmrun = callPackage ../applications/misc/gmrun {};
 
   gnucash = callPackage ../applications/office/gnucash {
-    inherit (gnome2) libgnomeui libgtkhtml gtkhtml libbonoboui libgnomeprint libglade libart_lgpl;
-    gconf = gnome2.GConf;
-    guile = guile_1_8;
-    slibGuile = slibGuile.override { scheme = guile_1_8; };
-    goffice = goffice_0_8;
+    inherit (gnome3) dconf;
   };
 
   gnucash26 = lowPrio (callPackage ../applications/office/gnucash/2.6.nix {


### PR DESCRIPTION
###### Motivation for this change

I would like to use GNU Cash with GTK3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
## Things to be fixed
- [x] Google test fails with the following error messages:
```
/nix/store/05ckbdakp3jmrfymv44wzq1g0awdsdmw-gtest-1.8.0/lib/libgtest_main.a(gtest_main.cc.o): In function `main':
(.text.startup+0x21): undefined reference to `testing::InitGoogleTest(int*, char**)'
(.text.startup+0x26): undefined reference to `testing::UnitTest::GetInstance()'
(.text.startup+0x2e): undefined reference to `testing::UnitTest::Run()'
collect2: error: ld returned 1 exit status
```
This is fixed by adding `export NIX_CFLAGS_LINK="-lgtest -lgtest_main"` before checkPhase.
- [ ] Pass all tests. For the moment 9/108 fail.
- [x] Cannot change settings in `Edit > Preferences`; fixed by adding `dconf` to `propagatedUserEnvPkgs`

## Things that could be done in other PRs
- Install python binding 
- Install documents/helps
- Build with Ninja
