### PR TITLE
terraform-provider-ibm: init at 0.8.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-provider-ibm/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-provider-ibm/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+#
+# USAGE:
+# install the following package globally or in nix-shell:
+#
+#   (terraform.withPlugins ( plugins: [ terraform-provider-ibm ]))
+#
+# examples:
+# https://github.com/IBM-Cloud/terraform-provider-ibm/tree/master/examples
+#
+
+buildGoPackage rec {
+  name = "terraform-provider-ibm-${version}";
+  version = "0.8.0";
+
+  goPackagePath = "github.com/terraform-providers/terraform-provider-ibm";
+  subPackages = [ "./" ];
+
+  src = fetchFromGitHub {
+    owner = "IBM-Cloud";
+    repo = "terraform-provider-ibm";
+    sha256 = "1jc1g2jadh02z4lfqnvgqk5cqrzk8pnn3cj3cwsm3ksa8pccf6w4";
+    rev = "v${version}";
+  };
+
+  # Terraform allow checking the provider versions, but this breaks
+  # if the versions are not provided via file paths.
+  postBuild = "mv go/bin/terraform-provider-ibm{,_v${version}}";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/IBM-Cloud/terraform-provider-ibm;
+    description = "Terraform provider is used to manage IBM Cloud resources.";
+    platforms = platforms.all;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ jensbin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20944,6 +20944,8 @@ with pkgs;
   terraform = terraform_0_11;
   terraform-full = terraform_0_11-full;
 
+  terraform-provider-ibm = callPackage ../applications/networking/cluster/terraform-provider-ibm {};
+
   terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};
 
   terraform-provider-nixos = callPackage ../applications/networking/cluster/terraform-provider-nixos {};


### PR DESCRIPTION
###### Motivation for this change
IBM is providing a terraform provider to interact with their Bluemix and Softlayer cloud.

Add ```(terraform.withPlugins ( plugins: [ terraform-provider-ibm ]))``` to add the provider to terraform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
