### PR TITLE
kcov: 34 -> 35

### DIFF
--- a/pkgs/development/tools/analysis/kcov/aarch64_nt_prstatus.patch
+++ b/pkgs/development/tools/analysis/kcov/aarch64_nt_prstatus.patch
@@ -1,0 +1,12 @@
+diff --git a/src/engines/ptrace.cc b/src/engines/ptrace.cc
+index 59b615f..e02cddf 100644
+--- a/src/engines/ptrace.cc
++++ b/src/engines/ptrace.cc
+@@ -21,6 +21,7 @@
+ 
+ #if defined(__aarch64__)
+ #  include <sys/uio.h>
++#  include <elf.h>
+ #endif
+ 
+ #include <map>

--- a/pkgs/development/tools/analysis/kcov/default.nix
+++ b/pkgs/development/tools/analysis/kcov/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib curl elfutils python libiberty libopcodes ];
 
+  patches = [ ./aarch64_nt_prstatus.patch ];
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/analysis/kcov/default.nix
+++ b/pkgs/development/tools/analysis/kcov/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "kcov-${version}";
-  version = "34";
+  version = "35";
 
   src = fetchFromGitHub {
     owner = "SimonKagstrom";
     repo = "kcov";
     rev = "v${version}";
-    sha256 = "1i4pn5na8m308pssk8585nmqi8kwd63a9h2rkjrn4w78ibmxvj01";
+    sha256 = "1da9vm87pi5m9ika0q1f1ai85w3vwlap8yln147yr9sc37jp5jcw";
   };
 
   preConfigure = "patchShebangs src/bin-to-c-source.py";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     homepage = http://simonkagstrom.github.io/kcov/index.html;
     license = licenses.gpl2;
 
-    maintainers = [ maintainers.gal_bolle ];
+    maintainers = with maintainers; [ gal_bolle ekleog ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
As the maintainer currently in `meta.maintainers` appears to not have
touched the package since 2015, I've also added myself there.

cc @FlorentBecker 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

