### PR TITLE
bspwm: 0.9.4 -> 0.9.5

### DIFF
--- a/pkgs/applications/window-managers/bspwm/default.nix
+++ b/pkgs/applications/window-managers/bspwm/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "bspwm-${version}";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner  = "baskerville";
     repo   = "bspwm";
     rev    = version;
-    sha256 = "1srgsszp184zg123wdij0zp57c16m7lmal51rhflyx2c9fiiqm9l";
+    sha256 = "09h3g1rxxjyw861mk32lj774nmwkx8cwxq4wfgmf4dpbizymvhhr";
   };
 
   buildInputs = [ libxcb libXinerama xcbutil xcbutilkeysyms xcbutilwm ];

--- a/pkgs/applications/window-managers/bspwm/default.nix
+++ b/pkgs/applications/window-managers/bspwm/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A tiling window manager based on binary space partitioning";
     homepage = https://github.com/baskerville/bspwm;
-    maintainers = with maintainers; [ meisternu epitrochoid ];
+    maintainers = with maintainers; [ meisternu epitrochoid rvolosatovs ];
     license = licenses.bsd2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

