### PR TITLE
python35, python36: fix reading large files on darwin

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -67,6 +67,12 @@ in stdenv.mkDerivation {
   patches = [
     ./no-ldconfig.patch
     ./ld_library_path.patch
+  ] ++ optionals stdenv.isDarwin [
+    # Fix for https://bugs.python.org/issue24658
+    (fetchpatch {
+      url = "https://bugs.python.org/file45178/issue24658-3-3.6.diff";
+      sha256 = "1x060hs80nl34mcl2ji2i7l4shxkmxwgq8h8lcmav8rjqqz1nb4a";
+    })
   ] ++ optionals (x11Support && stdenv.isDarwin) [
     ./use-correct-tcl-tk-on-darwin.patch
   ];

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -69,6 +69,12 @@ in stdenv.mkDerivation {
 
   patches = [
     ./no-ldconfig.patch
+  ] ++ optionals stdenv.isDarwin [
+    # Fix for https://bugs.python.org/issue24658
+    (fetchpatch {
+      url = "https://bugs.python.org/file45178/issue24658-3-3.6.diff";
+      sha256 = "1x060hs80nl34mcl2ji2i7l4shxkmxwgq8h8lcmav8rjqqz1nb4a";
+    })
   ] ++ optionals (x11Support && stdenv.isDarwin) [
     ./use-correct-tcl-tk-on-darwin.patch
   ];


### PR DESCRIPTION
###### Motivation for this change

python3 can't read(and write?) big files on darwin:
```
# dd if=/dev/zero of=/tmp/test bs=1048576 count=1024 && python3 -c "open('/tmp/test', 'rb').read()"
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 1.00833 s, 1.1 GB/s

# dd if=/dev/zero of=/tmp/test bs=1048576 count=2048 && python3 -c "open('/tmp/test', 'rb').read()"
2048+0 records in
2048+0 records out
2147483648 bytes (2.1 GB, 2.0 GiB) copied, 2.03879 s, 1.1 GB/s
Traceback (most recent call last):
  File "<string>", line 1, in <module>
OSError: [Errno 22] Invalid argument
```
The bug reproduces on High Sierra and Yosemite. This is also known as macos fread bug # 6434977.

The upstream PR https://github.com/python/cpython/pull/1705 is stalled on fixing tests for Travis. There is no patch for python 3.4, so I don't provide one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
