### PR TITLE
chromium: skia patch appears to be still needed with 66 on aarch64

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -160,7 +160,7 @@ let
         sha256 = "0dc4cmd05qjqyihrd4qb34kz0jlapjgah8bzgnvxf9m4791w062z";
       })
     ] ++ optional enableWideVine ./patches/widevine.patch
-      ++ optionals (stdenv.isAarch64 && versionRange "65" "66") [
+      ++ optionals (stdenv.isAarch64 && versionRange "65" "67") [
         ./patches/skia_buildfix.patch
     ];
 

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -162,6 +162,7 @@ let
     ] ++ optional enableWideVine ./patches/widevine.patch
       ++ optionals (stdenv.isAarch64 && versionRange "65" "67") [
         ./patches/skia_buildfix.patch
+        ./patches/neon_buildfix.patch
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/patches/neon_buildfix.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/neon_buildfix.patch
@@ -1,0 +1,21 @@
+diff --git a/skia/ext/convolver_neon.cc b/skia/ext/convolver_neon.cc
+index 26b91b9..cae6bc2 100644
+--- a/skia/ext/convolver_neon.cc
++++ b/skia/ext/convolver_neon.cc
+
+@@ -23,7 +23,7 @@
+     remainder[2] += coeff * pixels_left[i * 4 + 2];
+     remainder[3] += coeff * pixels_left[i * 4 + 3];
+   }
+-  return {remainder[0], remainder[1], remainder[2], remainder[3]};
++  return vld1q_s32(remainder);
+ }
+ 
+ // Convolves horizontally along a single row. The row data is given in
+@@ -336,4 +336,4 @@
+   }
+ }
+ 
+-}  // namespace skia
+\ No newline at end of file
++}  // namespace skia


### PR DESCRIPTION
The build performed in #39628 with removal of the patch appears [to have failed](https://logs.nix.ci/?key=nixos/nixpkgs.39628&attempt_id=6746ec3b-b6c1-449f-8993-b49c30c10c92): before the timeout, these lines appeared:
```
FAILED: obj/skia/skia_core_and_effects/SkJumper_stages.o
g++ -MMD -MF obj/skia/skia_core_and_effects/SkJumper_stages.o.d -DV8_DEPRECATION_WARNINGS -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_NSS_CERTS=1 -DUSE_X11=1 -DNO_TCMALLOC -DFULL_SAFE_BROWSING -DSAFE_BROWSING_CSD -DSAFE_BROWSING_DB_LOCAL -DCHROMIUM_BUILD -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DSK_IGNORE_LINEONLY_AA_CONVEX_PATH_OPTS -DSK_HAS_PNG_LIBRARY -DSK_HAS_WEBP_LIBRARY -DSK_HAS_JPEG_LIBRARY -DSK_SUPPORT_GPU=1 -DSK_FREETYPE_MINIMUM_RUNTIME_VERSION=\(\(\(FREETYPE_MAJOR\)\ \*\ 0x01000000\)\ \|\ \(\(FREETYPE_MINOR\)\ \*\ 0x00010000\)\ \|\ \(\(FREETYPE_PATCH\)\ \*\ 0x00000100\)\) -DSK_GAMMA_EXPONENT=1.2 -DSK_GAMMA_CONTRAST=0.2 -DSK_DEFAULT_FONT_CACHE_LIMIT=20971520 -I../.. -Igen -I../../skia/config -I../../skia/ext -I../../third_party/skia/include/c -I../../third_party/skia/include/config -I../../third_party/skia/include/core -I../../third_party/skia/include/effects -I../../third_party/skia/include/encode -I../../third_party/skia/include/gpu -I../../third_party/skia/include/images -I../../third_party/skia/include/lazy -I../../third_party/skia/include/pathops -I../../third_party/skia/include/pdf -I../../third_party/skia/include/pipe -I../../third_party/skia/include/ports -I../../third_party/skia/include/utils -I../../third_party/skia/src/gpu -I../../third_party/skia/src/sksl -I../../third_party/skia/include/codec -I../../third_party/skia/include/private -I../../third_party/skia/include/client/android -I../../third_party/skia/src/codec -I../../third_party/skia/src/core -I../../third_party/skia/src/image -I../../third_party/skia/src/images -I../../third_party/skia/src/opts -I../../third_party/skia/src/pdf -I../../third_party/skia/src/ports -I../../third_party/skia/src/shaders -I../../third_party/skia/src/shaders/gradients -I../../third_party/skia/src/sfnt -I../../third_party/skia/src/utils -I../../third_party/skia/src/lazy -I../../third_party/skia/third_party/gif -I../../third_party/skia/src/effects/gradients -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -funwind-tables -fPIC -pipe -pthread -fno-omit-frame-pointer -g0 -fno-builtin-abs -fvisibility=hidden -O2 -fno-ident -fdata-sections -ffunction-sections -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -fno-delete-null-pointer-checks -Wno-missing-field-initializers -Wno-unused-parameter -std=gnu++14 -fno-exceptions -fno-rtti -nostdinc++ -isystem../../buildtools/third_party/libc++/trunk/include -isystem../../buildtools/third_party/libc++abi/trunk/include -fvisibility-inlines-hidden -Wno-narrowing -c ../../third_party/skia/src/jumper/SkJumper_stages.cpp -o obj/skia/skia_core_and_effects/SkJumper_stages.o
../../third_party/skia/src/jumper/SkJumper_stages.cpp: In function 'F from_half(U16)':
../../third_party/skia/src/jumper/SkJumper_stages.cpp:670:12: error: 'vcvt_f32_f16' was not declared in this scope
     return vcvt_f32_f16(h);
            ^~~~~~~~~~~~
../../third_party/skia/src/jumper/SkJumper_stages.cpp: In function 'U16 to_half(F)':
../../third_party/skia/src/jumper/SkJumper_stages.cpp:690:12: error: 'vcvt_f16_f32' was not declared in this scope
     return vcvt_f16_f32(f);
            ^~~~~~~~~~~~
```

So I guess the patch is actually still required on 66.*.

Untested as I don't have access to an aarch64 box, unfortunately.

Cc @chaoflow @bendlas
Replaces #39628

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

