### PR TITLE
quassel: 0.12.4 -> 0.12.5 (fixes RCE & remote crash)

### DIFF
--- a/pkgs/applications/networking/irc/quassel/source.nix
+++ b/pkgs/applications/networking/irc/quassel/source.nix
@@ -1,9 +1,9 @@
 { fetchurl }:
 
 rec {
-  version = "0.12.4";
+  version = "0.12.5";
   src = fetchurl {
     url = "https://github.com/quassel/quassel/archive/${version}.tar.gz";
-    sha256 = "0q2qlhy1d6glw9pwxgcgwvspd1mkk3yi6m21dx9gnj86bxas2qs2";
+    sha256 = "04f42x87a4wkj3va3wnmj2jl7ikqqa7d7nmypqpqwalzpzk7kxwv";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

It was found that Quassel could be remotely crashed and had an
unauthenticated RCE vulnerability. The public annoucement can be found
on the oss-sec archive [1]. The bump to 0.12.5 is supposed fix both issues.

[1] http://seclists.org/oss-sec/2018/q2/77


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

