### PR TITLE
[17.09] quassel: 0.12.4 fix RCE & DOS

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -4,7 +4,7 @@
 , tag ? "" # tag added to the package name
 , static ? false # link statically
 
-, stdenv, fetchurl, cmake, makeWrapper, dconf
+, stdenv, fetchurl, fetchpatch, cmake, makeWrapper, dconf
 , qtbase, qtscript
 , phonon, libdbusmenu, qca-qt5
 
@@ -32,10 +32,10 @@ assert !buildClient -> !withKDE; # KDE is used by the client only
 
 let
   edf = flag: feature: [("-D" + feature + (if flag then "=ON" else "=OFF"))];
-  source = import ./source.nix { inherit fetchurl; };
+  source = import ./source.nix { inherit fetchurl fetchpatch; };
 
 in with stdenv; mkDerivation rec {
-  inherit (source) src version;
+  inherit (source) src version patches;
 
   name = "quassel${tag}-${version}";
 

--- a/pkgs/applications/networking/irc/quassel/source.nix
+++ b/pkgs/applications/networking/irc/quassel/source.nix
@@ -1,4 +1,4 @@
-{ fetchurl }:
+{ fetchurl, fetchpatch }:
 
 rec {
   version = "0.12.4";
@@ -6,4 +6,16 @@ rec {
     url = "https://github.com/quassel/quassel/archive/${version}.tar.gz";
     sha256 = "0q2qlhy1d6glw9pwxgcgwvspd1mkk3yi6m21dx9gnj86bxas2qs2";
   };
+  patches = [
+    (fetchpatch {
+      name = "CVE-XXX-RCE.patch";
+      url = "https://quassel-irc.org/pub/misc/0001-Implement-custom-deserializer-to-add-our-own-sanity-.patch";
+      sha256 = "0w7gx0xhqfb2h1rxlh9q96bdd23szbxdjs3ydmrzzvyxj5sk8dzd";
+    })
+    (fetchpatch {
+      name = "CVE-XXX-DOS.patch";
+      url = "https://quassel-irc.org/pub/misc/0002-Reject-clients-that-attempt-to-login-before-the-core.patch";
+      sha256 = "0is2jf7qppsx2y10f0zazm27lnkam83wpm8wmnfmdxdxj656ifd1";
+    })
+  ];
 }


### PR DESCRIPTION
###### Motivation for this change

It was found that Quassel could be remotely crashed and had an
unauthenticated RCE vulnerability. The public annoucement can be found
on the oss-sec archive [1]. The added patches are supposed fix both issues.

[1] http://seclists.org/oss-sec/2018/q2/77

(cherry picked from commit 8ae91ea6a3d01afd49025cfd12f5e9ea53f2fdfb)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

