### PR TITLE
KDE: Add KMyMoney

### DIFF
--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, lib, fetchurl, doxygen, extra-cmake-modules, graphviz, kdoctools
+
+, akonadi, alkimia, aqbanking, gmp, gwenhywfar, kactivities, karchive
+, kcmutils, kcontacts, kdewebkit, kdiagram, kholidays, kidentitymanagement
+, kitemmodels, libical, libofx, qgpgme
+
+# Needed for running tests:
+, qtbase, xvfb_run
+
+# For weboob, which only supports Python 2.x:
+, python2Packages
+}:
+
+stdenv.mkDerivation rec {
+  name = "kmymoney-${version}";
+  version = "5.0.1";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/kmymoney/${version}/src/${name}.tar.xz";
+    sha256 = "1c9apnvc07y17pzy4vygry1dai5ass2z7j354lrcppa85b18yvnx";
+  };
+
+  # Hidden dependency that wasn't included in CMakeLists.txt:
+  NIX_CFLAGS_COMPILE = "-I${kitemmodels.dev}/include/KF5";
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    doxygen extra-cmake-modules graphviz kdoctools python2Packages.wrapPython
+  ];
+
+  buildInputs = [
+    akonadi alkimia aqbanking gmp gwenhywfar kactivities karchive kcmutils
+    kcontacts kdewebkit kdiagram kholidays kidentitymanagement kitemmodels
+    libical libofx qgpgme
+
+    # Put it into buildInputs so that CMake can find it, even though we patch
+    # it into the interface later.
+    python2Packages.weboob
+  ];
+
+  weboobPythonPath = [ python2Packages.weboob ];
+
+  postInstall = ''
+    buildPythonPath "$weboobPythonPath"
+    patchPythonScript "$out/share/kmymoney/weboob/kmymoneyweboob.py"
+
+    # Within the embedded Python interpreter, sys.argv is unavailable, so let's
+    # assign it to a dummy value so that the assignment of sys.argv[0] injected
+    # by patchPythonScript doesn't fail:
+    sed -i -e '1i import sys; sys.argv = [""]' \
+      "$out/share/kmymoney/weboob/kmymoneyweboob.py"
+  '';
+
+  doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  installCheckPhase = let
+    pluginPath = "${qtbase.bin}/${qtbase.qtPluginPrefix}";
+  in lib.optionalString doInstallCheck ''
+    QT_PLUGIN_PATH=${lib.escapeShellArg pluginPath} CTEST_OUTPUT_ON_FAILURE=1 \
+      ${xvfb_run}/bin/xvfb-run -s '-screen 0 1024x768x24' make test \
+      ARGS="-E '(reports-chart-test)'" # Test fails, so exclude it for now.
+  '';
+
+  meta = {
+    description = "Personal finance manager for KDE";
+    homepage = https://kmymoney.org/;
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/development/libraries/alkimia/default.nix
+++ b/pkgs/development/libraries/alkimia/default.nix
@@ -18,6 +18,13 @@ mkDerivation rec {
 
   meta = {
     description = "Library used by KDE finance applications";
+    longDescription = ''
+      Alkimia is the infrastructure for common storage and business
+      logic that will be used by all financial applications in KDE.
+
+      The target is to share financial related information over
+      application bounderies.
+    '';
     license = lib.licenses.lgpl21Plus;
     platforms = qtbase.meta.platforms;
   };

--- a/pkgs/development/libraries/alkimia/default.nix
+++ b/pkgs/development/libraries/alkimia/default.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, fetchurl, lib
+, extra-cmake-modules, doxygen, graphviz, qtbase, mpir
+}:
+
+mkDerivation rec {
+  name = "alkimia-${version}";
+  version = "7.0.1";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/alkimia/${version}/src/${name}.tar.xz";
+    sha256 = "1fri76465058fgsyrmdrc3hj1javz4g10mfzqp5rsj7qncjr1i22";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules doxygen graphviz ];
+
+  buildInputs = [ qtbase ];
+  propagatedBuildInputs = [ mpir ];
+
+  meta = {
+    description = "Library used by KDE finance applications";
+    license = lib.licenses.lgpl21Plus;
+    platforms = qtbase.meta.platforms;
+  };
+}

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -155,6 +155,7 @@ let
       kded = callPackage ./kded.nix {};
       kdesignerplugin = callPackage ./kdesignerplugin.nix {};
       kdesu = callPackage ./kdesu.nix {};
+      kdewebkit = callPackage ./kdewebkit.nix {};
       kemoticons = callPackage ./kemoticons.nix {};
       kglobalaccel = callPackage ./kglobalaccel.nix {};
       kiconthemes = callPackage ./kiconthemes {};

--- a/pkgs/development/libraries/kde-frameworks/kdewebkit.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdewebkit.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, extra-cmake-modules
+, kconfig, kcoreaddons, kio, kparts, qtwebkit
+}:
+
+mkDerivation {
+  name = "kdewebkit";
+  nativeBuildInputs = [ extra-cmake-modules ];
+  buildInputs = [ kconfig kcoreaddons kio kparts ];
+  propagatedBuildInputs = [ qtwebkit ];
+  outputs = [ "out" "dev" ];
+}

--- a/pkgs/development/libraries/mpir/default.nix
+++ b/pkgs/development/libraries/mpir/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1fvmhrqdjs925hzr2i8bszm50h00gwsh17p2kn2pi51zrxck9xjj";
   };
 
+  configureFlags = [ "--enable-cxx" ];
+
   meta = {
     inherit version;
     description = ''A highly optimised library for bignum arithmetic forked from GMP'';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16476,6 +16476,11 @@ with pkgs;
 
   kmplayer = libsForQt5.callPackage ../applications/video/kmplayer { };
 
+  kmymoney = libsForQt5.callPackage ../applications/office/kmymoney {
+    inherit (kdeApplications) kidentitymanagement;
+    inherit (kdeFrameworks) kdewebkit;
+  };
+
   kodestudio = callPackage ../applications/editors/kodestudio { };
 
   konversation = libsForQt5.callPackage ../applications/networking/irc/konversation { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11181,6 +11181,8 @@ with pkgs;
 
     accounts-qt = callPackage ../development/libraries/accounts-qt { };
 
+    alkimia = callPackage ../development/libraries/alkimia { };
+
     fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };
 
     qgpgme = callPackage ../development/libraries/gpgme { };


### PR DESCRIPTION
This adds [KMyMoney](https://kmymoney.org/), a finance manager for KDE plus a few required dependencies.

I ran the upstream test suite as well as the following manual tests:

  * Basic startup
  * Completing the wizard
  * Add some test transactions
  * GPG encryption
  * Generation of charts and reports
  * Rough check whether OFX integration lists supported financial institutions.
  * Small check of AqBanking implementation, whether accounts and users can be configured, but didn't test actual connectivity with a financial institution.
  * Check of Weboob integration with a test PayPal backend, however also just with a dummy account and without actually connecting to PayPal.

I also added @7c6f434c to the reviewers, because he's the maintainer of `mpir` where I had to enable C++ support (see 6134887bef5357ccda4d81aef78182217df4c3ed for details).

Note that I didn't add myself as a maintainer because I'm not personally using KMyMoney but just packaged it for someone else. I hope this is useful for other people, so that maybe someday™ there will be a proper maintainer.