### PR TITLE
Polybar: make call to i3 pure

### DIFF
--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -1,6 +1,6 @@
 { cairo, cmake, fetchgit, libXdmcp, libpthreadstubs, libxcb, pcre, pkgconfig
 , python2 , stdenv, xcbproto, xcbutil, xcbutilimage, xcbutilrenderutil
-, xcbutilwm, xcbutilxrm, fetchpatch
+, xcbutilwm, xcbutilxrm, fetchpatch, makeWrapper
 
 # optional packages-- override the variables ending in 'Support' to enable or
 # disable modules
@@ -52,7 +52,14 @@ stdenv.mkDerivation rec {
       (if i3Support || i3GapsSupport then jsoncpp else null)
       (if i3Support then i3 else null)
       (if i3GapsSupport then i3-gaps else null)
+
+      (if i3Support || i3GapsSupport then makeWrapper else null)
     ];
+
+    fixupPhase = if (i3Support || i3GapsSupport) then ''
+    wrapProgram $out/bin/polybar \
+      --prefix PATH : "${if i3Support then i3 else i3-gaps}/bin"
+  '' else null;
 
     nativeBuildInputs = [
       cmake pkgconfig


### PR DESCRIPTION
###### Motivation for this change
As noted in https://github.com/rycee/home-manager/issues/206#issuecomment-364432110, "polybar  [uses](https://github.com/jaagr/polybar/blob/d8414c6ec547b58c9ec05db1db46509847f09380/src/modules/i3.cpp#L17) i3ipc to communicate with i3. Error appears since i3ipc::get_socketpath simply [calls](https://github.com/drmgc/i3ipcpp/blob/f4d143a3fa93518f5750dec51180f4af0f25be66/src/ipc.cpp#L256) i3 executable to get the socket path."

This PR makes the call to i3 pure.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

