### PR TITLE
ocsigen: 2.8 → 2.9; eliom: 6.2.0 → 6.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,34 +1,46 @@
-{ stdenv, fetchurl, which, ocsigen_server, ocsigen_deriving, ocaml,
-  js_of_ocaml, react, lwt, calendar, cryptokit, tyxml,
-  ipaddr, ocamlnet, ssl, ocaml_pcre, ocaml_optcomp,
-  reactivedata, opam, ppx_tools, ppx_deriving, findlib
-, ocamlbuild
+{ stdenv, fetchurl, which, ocsigen_server, ocsigen_deriving, ocaml, camlp4,
+  js_of_ocaml, lwt_react, cryptokit,
+  ipaddr, ocamlnet, lwt_ssl, ocaml_pcre,
+  opam, ppx_tools, ppx_deriving, findlib
+, js_of_ocaml-ocamlbuild, js_of_ocaml-ppx, js_of_ocaml-ppx_deriving_json
+, js_of_ocaml-lwt
+, js_of_ocaml-tyxml
 }:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.02";
+assert stdenv.lib.versionAtLeast ocaml.version "4.03";
 
 stdenv.mkDerivation rec
 {
   pname = "eliom";
-  version = "6.2.0";
+  version = "6.3.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/eliom/archive/${version}.tar.gz";
-    sha256 = "01c4l982ld6d1ndhb6f15ldb2li7mv0bs279d5gs99mpiwsapadx";
+    sha256 = "137hgdzv9fwkzf6xdksqy437lrf8xvrycf5jwc3z4cmpsigs6x7v";
   };
 
   patches = [ ./camlp4.patch ];
 
-  buildInputs = [ ocaml which findlib ocamlbuild ocaml_optcomp opam ppx_tools ];
+  buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild js_of_ocaml-ppx_deriving_json opam ppx_tools
+    ocsigen_deriving
+  ];
 
-  propagatedBuildInputs = [ lwt reactivedata tyxml ipaddr ocsigen_server ppx_deriving
-                            ocsigen_deriving js_of_ocaml
-                            calendar cryptokit ocamlnet react ssl ocaml_pcre ];
+  propagatedBuildInputs = [
+    camlp4
+    cryptokit
+    ipaddr
+    js_of_ocaml-lwt
+    js_of_ocaml-ppx
+    js_of_ocaml-tyxml
+    lwt_react
+    lwt_ssl
+    ocamlnet ocaml_pcre
+    ocsigen_server
+    ppx_deriving
+  ];
 
   installPhase = "opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR";
-
-  createFindlibDestdir = true;
 
   setupHook = [ ./setup-hook.sh ];
 

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, ocaml, findlib, which, react, ssl,
-lwt, ocamlnet, ocaml_pcre, cryptokit, tyxml, ipaddr, zlib,
+{ stdenv, fetchurl, ocaml, findlib, which, react, ssl
+, ocamlnet, ocaml_pcre, cryptokit, tyxml, ipaddr, zlib,
 libev, openssl, ocaml_sqlite3, tree, uutf, makeWrapper, camlp4
-, camlzip, pgocaml
+, camlzip, pgocaml, lwt2, lwt_react, lwt_ssl
 }:
 
 let mkpath = p: n:
@@ -9,17 +9,32 @@ let mkpath = p: n:
   "${p}/lib/ocaml/${v}/site-lib/${n}";
 in
 
+let param =
+  if stdenv.lib.versionAtLeast ocaml.version "4.03" then {
+    version = "2.9";
+    sha256 = "0na3qa4h89f2wv31li63nfpg4151d0g8fply0bq59j3bhpyc85nd";
+    buildInputs = [ lwt_react lwt_ssl ];
+    ldpath = "";
+  } else {
+    version = "2.8";
+    sha256 = "1v44qv2ixd7i1qinyhlzzqiffawsdl7xhhh6ysd7lf93kh46d5sy";
+    buildInputs = [ lwt2 ];
+    ldpath = "${mkpath lwt2 "lwt"}";
+  }
+; in
+
 stdenv.mkDerivation {
-  name = "ocsigenserver-2.8";
+  name = "ocsigenserver-${param.version}";
 
   src = fetchurl {
-    url = https://github.com/ocsigen/ocsigenserver/archive/2.8.tar.gz;
-    sha256 = "1v44qv2ixd7i1qinyhlzzqiffawsdl7xhhh6ysd7lf93kh46d5sy";
+    url = "https://github.com/ocsigen/ocsigenserver/archive/${param.version}.tar.gz";
+    inherit (param) sha256;
   };
 
-  buildInputs = [ocaml which findlib react ssl lwt
+  buildInputs = [ocaml which findlib react ssl
   ocamlnet ocaml_pcre cryptokit tyxml ipaddr zlib libev openssl
-  ocaml_sqlite3 tree uutf makeWrapper camlp4 pgocaml camlzip ];
+  ocaml_sqlite3 tree uutf makeWrapper camlp4 pgocaml camlzip ]
+  ++ (param.buildInputs or []);
 
   configureFlags = "--root $(out) --prefix /";
 
@@ -31,7 +46,7 @@ stdenv.mkDerivation {
   ''
   rm -rf $out/var/run
   wrapProgram $out/bin/ocsigenserver \
-    --prefix CAML_LD_LIBRARY_PATH : "${mkpath ssl "ssl"}:${mkpath lwt "lwt"}:${mkpath ocamlnet "netsys"}:${mkpath ocamlnet "netstring"}:${mkpath ocaml_pcre "pcre"}:${mkpath cryptokit "cryptokit"}:${mkpath ocaml_sqlite3 "sqlite3"}"
+    --prefix CAML_LD_LIBRARY_PATH : "${mkpath ssl "ssl"}:${param.ldpath}:${mkpath ocamlnet "netsys"}:${mkpath ocamlnet "netstring"}:${mkpath ocaml_pcre "pcre"}:${mkpath cryptokit "cryptokit"}:${mkpath ocaml_sqlite3 "sqlite3"}"
   '';
 
   dontPatchShebangs = true;

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, buildOcaml, ocsigen-toolkit, eliom, ocaml_pcre, pgocaml, macaque, safepass, yojson, ojquery, magick, ocsigen_deriving, ocsigen_server }:
+{ stdenv, fetchurl, buildOcaml, ocsigen-toolkit, eliom, ocaml_pcre, pgocaml, macaque, safepass, yojson, ocsigen_deriving, ocsigen_server
+, js_of_ocaml-camlp4
+}:
 
 buildOcaml rec
 {
   name = "ocsigen-start";
-  version = "1.0.0";
+  version = "1.1.0";
 
-  buildInputs = [ eliom ];
-  propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ojquery ocsigen_deriving ocsigen_server magick ];
+  buildInputs = [ eliom js_of_ocaml-camlp4 ];
+  propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ocsigen_deriving ocsigen_server ];
 
   patches = [ ./templates-dir.patch ];
 
@@ -16,7 +18,7 @@ buildOcaml rec
   
   src = fetchurl {
     url = "https://github.com/ocsigen/${name}/archive/${version}.tar.gz";
-    sha256 = "0npc2iq39ixci6ly0fssklv07zqi5cfa1adad4hm8dbzjawkqqll";
+    sha256 = "09cw6qzcld0m1qm66mbjg9gw8l6dynpw3fzhm3kfx5ldh0afgvjq";
   };
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, buildOcaml, ocaml, eliom, opam }:
+{ stdenv, fetchurl, buildOcaml, ocaml, opam
+, calendar, eliom, js_of_ocaml-ppx_deriving_json
+}:
 
 buildOcaml rec
 {
  name = "ocsigen-toolkit";
- version = "1.0.0";
+ version = "1.1.0";
 
- propagatedBuildInputs = [ eliom ];
+ propagatedBuildInputs = [ calendar eliom js_of_ocaml-ppx_deriving_json ];
  buildInputs = [ opam ];
-
- createFindlibDestdir = true;
 
  installPhase =
   ''
@@ -18,7 +18,7 @@ buildOcaml rec
   '';
 
   src = fetchurl {
-    sha256 = "0wm4fnss7vlkd03ybgfrk63kpip6m6p6kdqjn3f64n11256mwzj2";
+    sha256 = "1i5806gaqqllgsgjz3lf9fwlffqg3vfl49msmhy7xvq2sncbxp8a";
     url = "https://github.com/ocsigen/${name}/archive/${version}.tar.gz";
   };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -504,7 +504,7 @@ let
 
     ocplib-simplex = callPackage ../development/ocaml-modules/ocplib-simplex { };
 
-    ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { lwt = lwt2; };
+    ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };
 
     ocsigen-start = callPackage ../development/ocaml-modules/ocsigen-start { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -217,10 +217,7 @@ let
 
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
-    eliom = callPackage ../development/ocaml-modules/eliom {
-      lwt = lwt2;
-      js_of_ocaml = js_of_ocaml_2;
-    };
+    eliom = callPackage ../development/ocaml-modules/eliom { };
 
     enumerate = callPackage ../development/ocaml-modules/enumerate { };
 


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml ≥ 4.05

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

