### PR TITLE
home-assistant: 0.67.1 -> 0.68.0

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.67.1";
+  version = "0.68.0";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
@@ -86,7 +86,7 @@
     "device_tracker.unifi" = ps: with ps; [ pyunifi ];
     "device_tracker.unifi_direct" = ps: with ps; [ pexpect ];
     "device_tracker.upc_connect" = ps: with ps; [ defusedxml ];
-    "device_tracker.xiaomi_miio" = ps: with ps; [  ];
+    "device_tracker.xiaomi_miio" = ps: with ps; [ construct ];
     "digital_ocean" = ps: with ps; [ digital-ocean ];
     "discovery" = ps: with ps; [ netdisco ];
     "dominos" = ps: with ps; [  ];
@@ -99,10 +99,12 @@
     "emulated_hue" = ps: with ps; [ aiohttp-cors ];
     "enocean" = ps: with ps; [  ];
     "envisalink" = ps: with ps; [  ];
+    "eufy" = ps: with ps; [  ];
     "fan.xiaomi_miio" = ps: with ps; [ construct ];
     "feedreader" = ps: with ps; [ feedparser ];
     "ffmpeg" = ps: with ps; [ ha-ffmpeg ];
     "folder_watcher" = ps: with ps; [ watchdog ];
+    "fritzbox" = ps: with ps; [  ];
     "frontend" = ps: with ps; [  ];
     "gc100" = ps: with ps; [  ];
     "goalfeed" = ps: with ps; [  ];
@@ -110,6 +112,7 @@
     "hdmi_cec" = ps: with ps; [  ];
     "hive" = ps: with ps; [  ];
     "homekit" = ps: with ps; [  ];
+    "homekit_controller" = ps: with ps; [  ];
     "homematic" = ps: with ps; [ pyhomematic ];
     "homematicip_cloud" = ps: with ps; [  ];
     "http" = ps: with ps; [ aiohttp-cors ];
@@ -166,6 +169,7 @@
     "media_extractor" = ps: with ps; [  ];
     "media_player.anthemav" = ps: with ps; [  ];
     "media_player.aquostv" = ps: with ps; [  ];
+    "media_player.blackbird" = ps: with ps; [  ];
     "media_player.bluesound" = ps: with ps; [ xmltodict ];
     "media_player.braviatv" = ps: with ps; [  ];
     "media_player.cast" = ps: with ps; [ PyChromecast ];
@@ -294,7 +298,6 @@
     "sensor.dovado" = ps: with ps; [  ];
     "sensor.dsmr" = ps: with ps; [  ];
     "sensor.dweet" = ps: with ps; [  ];
-    "sensor.ebox" = ps: with ps; [  ];
     "sensor.eddystone_temperature" = ps: with ps; [ construct ];
     "sensor.eliqonline" = ps: with ps; [  ];
     "sensor.envirophat" = ps: with ps; [  ];
@@ -354,6 +357,7 @@
     "sensor.serial" = ps: with ps; [  ];
     "sensor.serial_pm" = ps: with ps; [  ];
     "sensor.shodan" = ps: with ps; [  ];
+    "sensor.sht31" = ps: with ps; [  ];
     "sensor.sma" = ps: with ps; [  ];
     "sensor.snmp" = ps: with ps; [ pysnmp ];
     "sensor.sochain" = ps: with ps; [  ];
@@ -378,6 +382,7 @@
     "sensor.twitch" = ps: with ps; [  ];
     "sensor.uber" = ps: with ps; [  ];
     "sensor.ups" = ps: with ps; [  ];
+    "sensor.uscis" = ps: with ps; [  ];
     "sensor.vasttrafik" = ps: with ps; [  ];
     "sensor.waqi" = ps: with ps; [  ];
     "sensor.waze_travel_time" = ps: with ps; [  ];
@@ -434,7 +439,7 @@
     "twilio" = ps: with ps; [ twilio ];
     "upcloud" = ps: with ps; [  ];
     "updater" = ps: with ps; [ distro ];
-    "upnp" = ps: with ps; [ miniupnpc ];
+    "upnp" = ps: with ps; [  ];
     "usps" = ps: with ps; [  ];
     "vacuum.roomba" = ps: with ps; [  ];
     "vacuum.xiaomi_miio" = ps: with ps; [ construct ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -8,10 +8,10 @@ let
   py = python3.override {
     packageOverrides = self: super: {
       aiohttp = super.aiohttp.overridePythonAttrs (oldAttrs: rec {
-        version = "3.1.1";
+        version = "3.1.3";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "dc5cab081d4b334d0440b019edf24fe1cb138b8114e0e22d2b0661284bc1775f";
+          sha256 = "9fcef0489e3335b200d31a9c1fb6ba80fdafe14cd82b971168c2f9fa1e4508ad";
         };
       });
       pytest = super.pytest.overridePythonAttrs (oldAttrs: rec {
@@ -58,7 +58,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.67.1";
+  hassVersion = "0.68.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -73,7 +73,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "02czbqdsdar8rjkr0r5g6j1x9caazcir2w1hp595z4cn90c0342f";
+    sha256 = "037gc2sghg5n0li087vvjcf6657rd31wv0m5r23b2cdfds8lxk4w";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20180404.0";
+  version = "20180426.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ac36d4f5e30e93b02dadd2ecdc07218fde3d97ffc2f69a6f1acf5e601cd4e5ad";
+    sha256 = "60ff4e0b0c4538fa0be0db9407f95333546940e119a8d3edb9b0d7e1c86b1f3b";
   };
 
   propagatedBuildInputs = [ user-agents ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @peterhoeg 