### PR TITLE
rounded-mgenplus: init at 20150602

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2506,6 +2506,11 @@
     github = "mmlb";
     name = "Manuel Mendez";
   };
+  mnacamura = {
+    email = "m.nacamura@gmail.com";
+    github = "mnacamura";
+    name = "Mitsuhiro Nakamura";
+  };
   moaxcp = {
     email = "moaxcp@gmail.com";
     github = "moaxcp";

--- a/pkgs/data/fonts/rounded-mgenplus/default.nix
+++ b/pkgs/data/fonts/rounded-mgenplus/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage = http://jikasei.me/font/rounded-mgenplus/;
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ mnacamura ];
   };
 }

--- a/pkgs/data/fonts/rounded-mgenplus/default.nix
+++ b/pkgs/data/fonts/rounded-mgenplus/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, p7zip }:
+
+let
+  pname = "rounded-mgenplus";
+  version = "20150602";
+
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://osdn.jp/downloads/users/8/8598/${name}.7z";
+    sha256 = "1k15xvzd3s5ppp151wv31wrfq2ri8v96xh7i71i974rxjxj6gspc";
+  };
+
+  nativeBuildInputs = [ p7zip ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  unpackPhase = ''
+    7z x $src
+  '';
+
+  installPhase = ''
+    install -m 444 -D -t $out/share/fonts/${pname} ${pname}-*.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Japanese font based on Rounded M+ and Noto Sans Japanese";
+    homepage = http://jikasei.me/font/rounded-mgenplus/;
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4712,6 +4712,8 @@ with pkgs;
 
   rnv = callPackage ../tools/text/xml/rnv { };
 
+  rounded-mgenplus = callPackage ../data/fonts/rounded-mgenplus { };
+
   roundup = callPackage ../tools/misc/roundup { };
 
   routino = callPackage ../tools/misc/routino { };


### PR DESCRIPTION
###### Motivation for this change

This is a rounded Japanese font which supports plenty of Kanji characters and has many type face variations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

