### PR TITLE
pythonPackages.pymc3: init at 3.2

### DIFF
--- a/pkgs/development/python-modules/patsy/default.nix
+++ b/pkgs/development/python-modules/patsy/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, nose
+, six
+, numpy
+, scipy # optional, allows spline-related features (see patsy's docs)
+, parameterized
+}:
+
+buildPythonPackage rec {
+  pname = "patsy";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fw888zd2s7f5zxm9f98ss93qhwv0sqnbdy21ipj33ccqgakhpz0";
+  };
+
+  checkInputs = [ nose parameterized ];
+  checkPhase = "nosetests -v";
+
+  propagatedBuildInputs = [
+    six
+    numpy
+    scipy
+  ];
+
+  meta = {
+    description = "A Python package for describing statistical models";
+    homepage = https://github.com/pydata/patsy;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ ilya-kolpakov ];
+  };
+}
+

--- a/pkgs/development/python-modules/pymc3/default.nix
+++ b/pkgs/development/python-modules/pymc3/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, Theano
+, pandas
+, patsy
+, joblib
+, tqdm
+, six
+, h5py
+, pytest
+, nose
+, parameterized
+, matplotlib
+}:
+
+buildPythonPackage rec {
+  pname = "pymc3";
+  version = "3.2";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hpzhkpv7sbwkcva7x914yvzcf1d1a952ynbcx6mvlgv5lqghc39";
+  };
+
+  # No need for coverage stats in Nix builds
+  postPatch = ''
+    substituteInPlace setup.py --replace ", 'pytest-cov'" ""
+  '';
+
+  propagatedBuildInputs = [
+    Theano
+    pandas
+    patsy
+    joblib
+    tqdm
+    six
+    h5py
+  ];
+
+  checkInputs = [
+    pytest
+    nose
+    parameterized
+  ];
+
+  # The test suite is computationally intensive and test failures are not
+  # indicative for package usability hence tests are disabled by default.
+  doCheck = false;
+
+  # For some reason tests are run as a part of the *install* phase if enabled.
+  # Theano writes compiled code to ~/.theano hence we set $HOME.
+  preInstall = "export HOME=$(mktemp -d)";
+  postInstall = "rm -rf $HOME";
+
+  meta = {
+    description = "Bayesian estimation, particularly using Markov chain Monte Carlo (MCMC)";
+    homepage = http://github.com/pymc-devs/pymc3;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ilya-kolpakov ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9673,24 +9673,7 @@ in {
     };
   };
 
-  patsy = buildPythonPackage rec {
-    name = "patsy-${version}";
-    version = "0.3.0";
-
-    src = pkgs.fetchurl{
-      url = "mirror://pypi/p/patsy/${name}.zip";
-      sha256 = "a55dd4ca09af4b9608b81f30322beb450510964c022708ab50e83a065ccf15f0";
-    };
-
-    buildInputs = with self; [ nose ];
-    propagatedBuildInputs = with self; [six numpy];
-
-    meta = {
-      description = "A Python package for describing statistical models";
-      homepage = "https://github.com/pydata/patsy";
-      license = licenses.bsd2;
-    };
-  };
+  patsy = callPackage ../development/python-modules/patsy { };
 
   paste = buildPythonPackage rec {
     name = "paste-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8244,6 +8244,8 @@ in {
 
   pygraphviz = callPackage ../development/python-modules/pygraphviz { };
 
+  pymc3 = callPackage ../development/python-modules/pymc3 { };
+
   pympler = buildPythonPackage rec {
     pname = "Pympler";
     version = "0.4.3";


### PR DESCRIPTION
Rebase of https://github.com/NixOS/nixpkgs/pull/39660 on master

###### Motivation for this change
`pymc3` is a Bayesian inference library based on Theano

- Adds the latest stable version of `pymc3`
- Updates `patsy` (required by `pymc3`) from `0.3.0` to `0.5.0`.

###### Things done

- [ ] Tested using sandboxing 
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested the library
- [x] Fits [CONTRIBUTING.md]