### PR TITLE
xen_4_10: fix qemu-xen build error (memfd)

### DIFF
--- a/pkgs/applications/virtualization/xen/4.10.nix
+++ b/pkgs/applications/virtualization/xen/4.10.nix
@@ -29,6 +29,12 @@ let
 
   xsa = import ./xsa-patches.nix { inherit fetchpatch; };
 
+  qemuMemfdBuildFix = fetchpatch {
+    name = "xen-4.8-memfd-build-fix.patch";
+    url = https://github.com/qemu/qemu/commit/75e5b70e6b5dcc4f2219992d7cffa462aa406af0.patch;
+    sha256 = "0gaz93kb33qc0jx6iphvny0yrd17i8zhcl3a9ky5ylc2idz0wiwa";
+  };
+
   qemuDeps = [
     udev pciutils xorg.libX11 SDL pixman acl glusterfs spice-protocol usbredir
     alsaLib glib python2
@@ -53,6 +59,9 @@ callPackage (import ./generic.nix (rec {
         rev = "b79708a8ed1b3d18bee67baeaf33b3fa529493e2";
         sha256 = "1yxxad6nvlfmrbgyc8ix19qmrsn1rx4zpyiqnfi4x4kg94acwa5w";
       };
+      patches = [
+        qemuMemfdBuildFix
+      ];
       buildInputs = qemuDeps;
       postPatch = ''
         # needed in build but /usr/bin/env is not available in sandbox


### PR DESCRIPTION
###### Motivation for this change

Fix build of xen 4.10 qemu-xen with qemu upstream patch copied from  #38917 (thanks @bendlas).

cc maintainers @eelco @oxij @tstrobel 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

