### PR TITLE
[release-17.09] slurm: Fix CVE-2018-7033

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libtool, curl, python, munge, perl, pam, openssl
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libtool, curl, python, munge, perl, pam, openssl
 , ncurses, mysql, gtk2, lua, hwloc, numactl
 }:
 
@@ -10,6 +10,15 @@ stdenv.mkDerivation rec {
     url = "https://download.schedmd.com/slurm/${name}.tar.bz2";
     sha256 = "0w8v7fzbn7b3f9kg6lcj2jpkzln3vcv9s2cz37xbdifz0m2p1x7s";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/SchedMD/slurm/commit/db468895240ad6817628d07054fe54e71273b2fe.patch";
+      sha256 = "06l3qcqs9isjz3kyv2x3nfjpvfnw720aw4qspbx0fs4jr3if6waa";
+      name = "CVE-2018-7033.patch";
+      excludes = [ "NEWS" ];
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Motivation for this change

* https://lists.schedmd.com/pipermail/slurm-announce/2018/000006.html
* https://nvd.nist.gov/vuln/detail/CVE-2018-7033

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

