### PR TITLE
[release-18.03] slurm: Fix CVE-2018-7033

### DIFF
--- a/pkgs/servers/computing/slurm/CVE-2018-7033.patch
+++ b/pkgs/servers/computing/slurm/CVE-2018-7033.patch
@@ -1,0 +1,156 @@
+From db468895240ad6817628d07054fe54e71273b2fe Mon Sep 17 00:00:00 2001
+From: Danny Auble <da@schedmd.com>
+Date: Thu, 15 Mar 2018 12:11:08 -0600
+Subject: [PATCH 1/3] Add unpackstr_xmalloc_escaped and
+ unpackstr_xmalloc_chooser.
+
+Use unpackstr_xmalloc_chooser as part of safe_unpackstr_xmalloc macro.
+This ensures that the slurmdbd is always working on escaped strings.
+
+Fixes CVE-2018-7033.
+
+Bug 4792.
+diff --git a/src/common/pack.c b/src/common/pack.c
+index 494d3be217..3861bb68f0 100644
+--- a/src/common/pack.c
++++ b/src/common/pack.c
+@@ -54,6 +54,7 @@
+ #include "src/common/pack.h"
+ #include "src/common/xmalloc.h"
+ #include "src/common/xassert.h"
++#include "src/slurmdbd/read_config.h"
+ 
+ /*
+  * Define slurm-specific aliases for use by plugins, see slurm_xlator.h
+@@ -85,6 +86,8 @@ strong_alias(unpackmem,		slurm_unpackmem);
+ strong_alias(unpackmem_ptr,	slurm_unpackmem_ptr);
+ strong_alias(unpackmem_xmalloc,	slurm_unpackmem_xmalloc);
+ strong_alias(unpackmem_malloc,	slurm_unpackmem_malloc);
++strong_alias(unpackstr_xmalloc_escaped, slurm_unpackstr_xmalloc_escaped);
++strong_alias(unpackstr_xmalloc_chooser, slurm_unpackstr_xmalloc_chooser);
+ strong_alias(packstr_array,	slurm_packstr_array);
+ strong_alias(unpackstr_array,	slurm_unpackstr_array);
+ strong_alias(packmem_array,	slurm_packmem_array);
+@@ -801,6 +804,79 @@ int unpackmem_malloc(char **valp, uint32_t * size_valp, Buf buffer)
+ 	return SLURM_SUCCESS;
+ }
+ 
++/*
++ * Given a buffer containing a network byte order 16-bit integer,
++ * and an arbitrary char string, copy the data string into the location
++ * specified by valp and escape ' and \ to be database safe.
++ * Also return the sizes of 'valp' in bytes.
++ * Adjust buffer counters.
++ * NOTE: valp is set to point into a newly created buffer,
++ *	the caller is responsible for calling xfree() on *valp
++ *	if non-NULL (set to NULL on zero size buffer value)
++ * NOTE: size_valp may not match how much data was processed from buffer, but
++ *       will match the length of the returned 'valp'.
++ * WARNING: These escapes are sufficient to protect MariaDB/MySQL, but
++ *          may not be sufficient if databases are added in the future.
++ */
++int unpackstr_xmalloc_escaped(char **valp, uint32_t *size_valp, Buf buffer)
++{
++	uint32_t ns;
++
++	if (remaining_buf(buffer) < sizeof(ns))
++		return SLURM_ERROR;
++
++	memcpy(&ns, &buffer->head[buffer->processed], sizeof(ns));
++	*size_valp = ntohl(ns);
++	buffer->processed += sizeof(ns);
++
++	if (*size_valp > MAX_PACK_MEM_LEN) {
++		error("%s: Buffer to be unpacked is too large (%u > %u)",
++		      __func__, *size_valp, MAX_PACK_MEM_LEN);
++		return SLURM_ERROR;
++	} else if (*size_valp > 0) {
++		uint32_t cnt = *size_valp;
++
++		if (remaining_buf(buffer) < cnt)
++			return SLURM_ERROR;
++
++		/* make a buffer 2 times the size just to be safe */
++		*valp = xmalloc_nz((cnt * 2) + 1);
++		if (*valp) {
++			char *copy = NULL, *str, tmp;
++			uint32_t i;
++			copy = *valp;
++			str = &buffer->head[buffer->processed];
++
++			for (i = 0; i < cnt && *str; i++) {
++				tmp = *str++;
++				if ((tmp == '\\') || (tmp == '\'')) {
++					*copy++ = '\\';
++					(*size_valp)++;
++				}
++
++				*copy++ = tmp;
++			}
++
++			/* Since we used xmalloc_nz, terminate the string. */
++			*copy++ = '\0';
++		}
++
++		/* add the original value since that is what we processed */
++		buffer->processed += cnt;
++	} else
++		*valp = NULL;
++	return SLURM_SUCCESS;
++}
++
++int unpackstr_xmalloc_chooser(char **valp, uint32_t *size_valp, Buf buf)
++{
++	if (slurmdbd_conf)
++		return unpackstr_xmalloc_escaped(valp, size_valp, buf);
++	else
++		return unpackmem_xmalloc(valp, size_valp, buf);
++}
++
++
+ /*
+  * Given a pointer to array of char * (char ** or char *[] ) and a size
+  * (size_val), convert size_val to network byte order and store in the
+diff --git a/src/common/pack.h b/src/common/pack.h
+index a3d4cd050e..50e3da19d1 100644
+--- a/src/common/pack.h
++++ b/src/common/pack.h
+@@ -125,6 +125,9 @@ int	unpackmem_ptr(char **valp, uint32_t *size_valp, Buf buffer);
+ int	unpackmem_xmalloc(char **valp, uint32_t *size_valp, Buf buffer);
+ int	unpackmem_malloc(char **valp, uint32_t *size_valp, Buf buffer);
+ 
++int	unpackstr_xmalloc_escaped(char **valp, uint32_t *size_valp, Buf buffer);
++int	unpackstr_xmalloc_chooser(char **valp, uint32_t *size_valp, Buf buffer);
++
+ void	packstr_array(char **valp, uint32_t size_val, Buf buffer);
+ int	unpackstr_array(char ***valp, uint32_t* size_val, Buf buffer);
+ 
+@@ -333,8 +336,12 @@ int	unpackmem_array(char *valp, uint32_t size_valp, Buf buffer);
+ #define safe_unpackstr_malloc	                        \
+         safe_unpackmem_malloc
+ 
+-#define safe_unpackstr_xmalloc	                        \
+-        safe_unpackmem_xmalloc
++#define safe_unpackstr_xmalloc(valp, size_valp, buf) do {	\
++	assert(sizeof(*size_valp) == sizeof(uint32_t));        	\
++	assert(buf->magic == BUF_MAGIC);		        \
++	if (unpackstr_xmalloc_chooser(valp, size_valp, buf))    \
++		goto unpack_error;		       		\
++} while (0)
+ 
+ #define safe_unpackstr_array(valp,size_valp,buf) do {	\
+ 	assert(sizeof(*size_valp) == sizeof(uint32_t)); \
+diff --git a/src/common/slurm_xlator.h b/src/common/slurm_xlator.h
+index 7403c01748..c186383c22 100644
+--- a/src/common/slurm_xlator.h
++++ b/src/common/slurm_xlator.h
+@@ -249,6 +249,8 @@
+ #define	unpackmem_ptr		slurm_unpackmem_ptr
+ #define	unpackmem_xmalloc	slurm_unpackmem_xmalloc
+ #define	unpackmem_malloc	slurm_unpackmem_malloc
++#define	unpackstr_xmalloc_escaped slurm_unpackstr_xmalloc_escaped
++#define	unpackstr_xmalloc_chooser slurm_unpackstr_xmalloc_chooser
+ #define	packstr_array		slurm_packstr_array
+ #define	unpackstr_array		slurm_unpackstr_array
+ #define	packmem_array		slurm_packmem_array
+

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libtool, curl, python, munge, perl, pam, openssl
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libtool, curl, python, munge, perl, pam, openssl
 , ncurses, mysql, gtk2, lua, hwloc, numactl
 }:
 
@@ -10,6 +10,10 @@ stdenv.mkDerivation rec {
     url = "https://download.schedmd.com/slurm/${name}.tar.bz2";
     sha256 = "1x3i6z03d9m46fvj1cslrapm1drvgyqch9pn4xf23kvbz4gkhaps";
   };
+
+  patches = [
+    ./CVE-2018-7033.patch
+  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Motivation for this change

* https://lists.schedmd.com/pipermail/slurm-announce/2018/000006.html
* https://nvd.nist.gov/vuln/detail/CVE-2018-7033

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

