### PR TITLE
ldb: 1.1.27 → 1.1.31

### DIFF
--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, python, pkgconfig, readline, tdb, talloc, tevent
-, popt, libxslt, docbook_xsl, docbook_xml_dtd_42
+, popt, libxslt, docbook_xsl, docbook_xml_dtd_42, cmocka
 }:
 
 stdenv.mkDerivation rec {
-  name = "ldb-1.1.27";
+  name = "ldb-1.1.31";
 
   src = fetchurl {
     url = "mirror://samba/ldb/${name}.tar.gz";
-    sha256 = "1b1mkl5p8swb67s9aswavhzswlib34hpgsv66zgns009paf2df6d";
+    sha256 = "04d53e2ab5b35688f5ed7a4471f5b273da121016e1af0630b36a36506afaeb46"                                                                                                                                                             ;
   };
 
   outputs = [ "out" "dev" ];
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     python readline tdb talloc tevent popt
     libxslt docbook_xsl docbook_xml_dtd_42
+    cmocka
   ];
 
   preConfigure = ''


### PR DESCRIPTION


###### Motivation for this change

To fix #39572. To use sssd with the "ad" module for Active Directory and get rid of the `Unable to load module [ad] with path [/nix/store/i6zipl5jip4g8aisiihmac64h87ahq35-sssd-1.16.0/lib/sssd/libsss_ad.so]: /nix/store/dpp213nfxlnk2mrdw9965rji6y7rv4hz-ldb-1.1.27/lib/libldb.so.1: version `LDB_1.1.30' not found (required by /nix/store/b55k15898pk07pww1cnvq5awn04k3ddc-samba-4.7.6/lib/samba/libldbsamba-samba4.so)` error.

I thought I could write a test with a minimal sssd config file using the ad module but I was having some `Failed to read keytab [default]: No such file or directory` error while running the test. I'm wondering if it's because the vm didn't join a domain with "net ads join".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

