### PR TITLE
nixos/keepalived: Implemented vrrp-instance track scripts and track interfaces

### DIFF
--- a/nixos/modules/services/networking/keepalived/vrrp-instance-options.nix
+++ b/nixos/modules/services/networking/keepalived/vrrp-instance-options.nix
@@ -108,6 +108,20 @@ with lib;
       description = "Declarative vhost config";
     };
 
+    trackScripts = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "chk_cmd1" "chk_cmd2" ];
+      description = "List of script names to invoke for health tracking.";
+    };
+
+    trackInterfaces = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "eth0" "eth1" ];
+      description = "List of network interfaces to monitor for health tracking.";
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";

--- a/nixos/modules/services/networking/keepalived/vrrp-script-options.nix
+++ b/nixos/modules/services/networking/keepalived/vrrp-script-options.nix
@@ -1,0 +1,64 @@
+{ lib } :
+
+with lib;
+with lib.types;
+{
+  options = {
+
+    script = mkOption {
+      type = str;
+      example = "\${pkgs.curl} -f http://localhost:80";
+      description = "(Path of) Script command to execute followed by args, i.e. cmd [args]...";
+    };
+
+    interval = mkOption {
+      type = int;
+      default = 1;
+      description = "Seconds between script invocations.";
+    };
+
+    timeout = mkOption {
+      type = int;
+      default = 5;
+      description = "Seconds after which script is considered to have failed.";
+    };
+
+    weight = mkOption {
+      type = int;
+      default = 0;
+      description = "Following a failure, adjust the priority by this weight.";
+    };
+
+    rise = mkOption {
+      type = int;
+      default = 5;
+      description = "Required number of successes for OK transition.";
+    };
+
+    fall = mkOption {
+      type = int;
+      default = 3;
+      description = "Required number of failures for KO transition.";
+    };
+
+    user = mkOption {
+      type = str;
+      default = "keepalived_script";
+      description = "Name of user to run the script under.";
+    };
+
+    group = mkOption {
+      type = nullOr str;
+      default = null;
+      description = "Name of group to run the script under. Defaults to user group.";
+    };
+
+    extraConfig = mkOption {
+      type = lines;
+      default = "";
+      description = "Extra lines to be added verbatim to the vrrp_script section.";
+    };
+
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change
It would be nice to be able to explicitly declare keepalived virtual IP healthcheck scripts and interfaces, in order for failover to make sense.

Furthermore; tracking scripts in particular, cannot be included with `keepalived.extraConfig`, because VRRP scripts must be declared **above** script usage in keepalived.conf , otherwise keepalived will complain with something like:
> Keepalived_vrrp[4265]: check_script no match, ignoring...

See: http://www.askmrisp.com/2017/04/17/solved-keepalived-not-running-track_script/ for details.


###### Things done

- [X] Tested full backward-compatibility in that keepalived.conf is **not** changed if no track scripts or track interfaces are added to the config, and that **all** new top-level options have default values.
- [X] Tested track scripts and track interfaces on NixOS 17.09 + 18.03, both with keepalived v1.3.6
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions - **Ubuntu 17.10**
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
