### PR TITLE
webmetro: init => unstable-20180426

### DIFF
--- a/pkgs/servers/webmetro/default.nix
+++ b/pkgs/servers/webmetro/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "webmetro";
+  name = "${pname}-${version}";
+  version = "unstable-20180426";
+
+  src = fetchFromGitHub {
+    owner = "Tangent128";
+    repo = pname;
+    rev = "4f6cc00fe647bd311d00a8a4cb53ab08f20a04f9";
+    sha256 = "1n2c7ygs8qsd5zgii6fqqcwg427bsij082bg4ijnzkq5630dx651";
+  };
+
+  cargoSha256 = "0drf331qic1gf58j7izwp0q2l4w0dyrhr19rd2y5k43cw4m1nq59";
+
+  meta = with stdenv.lib; {
+    description = "Simple relay server for broadcasting a WebM stream";
+    longDescription = ''
+    Webmetro is a simple relay server for broadcasting a WebM stream
+    from one uploader to many downloaders, via HTTP.
+    The initialization segment is remembered, so that viewers can join
+    mid-stream.  Cluster timestamps are rewritten to be monotonic, so multiple
+    (compatibly-encoded) webm files can be chained together without
+    clients needing to reconnect.
+    '';
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12925,6 +12925,8 @@ with pkgs;
 
   wallabag = callPackage ../servers/web-apps/wallabag { };
 
+  webmetro = callPackage ../servers/webmetro { };
+
   winstone = callPackage ../servers/http/winstone { };
 
   xinetd = callPackage ../servers/xinetd { };


### PR DESCRIPTION
###### Motivation for this change

Interesting new server for streaming webm video.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

