### PR TITLE
awscli: 1.14.50 -> 1.15.10; fix build

### DIFF
--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -19,11 +19,11 @@ let
 
 in py.pkgs.buildPythonApplication rec {
   pname = "awscli";
-  version = "1.14.50";
+  version = "1.15.10";
 
   src = py.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "1yiwj7cl9r1k9226mdq6pcmrs044k7p3d133lzgv9rb1dgp4053c";
+    sha256 = "0nwpanbfx5h0bad8wwvvbhpjf9r6n885bbv2w8mw7vijdgclkq8x";
   };
 
   # No tests included
@@ -41,6 +41,12 @@ in py.pkgs.buildPythonApplication rec {
     groff
     less
   ];
+
+  postPatch = ''
+    for i in {py,cfg}; do
+      substituteInPlace setup.$i --replace "botocore==1.10.10" "botocore>=1.10.9,<=1.11"
+    done
+  '';
 
   postInstall = ''
     mkdir -p $out/etc/bash_completion.d


### PR DESCRIPTION
###### Motivation for this change

As reported in #39676 the build broke because of ca52152 as the bump of
`pythonPackages.botocore` to 1.10.9 clashed with the wanted dependencies
in `awscli`.

In order to reduce the risk of accidental bugs because of loosened
version constraints I bumped the AWS CLI to `1.15.10` which depends on
`botocore@1.10` as well.

Fixes #39676

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

