### PR TITLE
buildbot: 1.1.0 -> 1.1.1, fix build

### DIFF
--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -14,11 +14,11 @@ let
   package = pythonPackages.buildPythonApplication rec {
     name = "${pname}-${version}";
     pname = "buildbot";
-    version = "1.1.0";
+    version = "1.1.1";
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "1rhmlcvw0dsr4f37sb3xmb9xcn76lsrsw2g1z611g339nmxzi0sc";
+      sha256 = "1vcmanx3ma3cfyiddjcmsnx6qmxd3m5blqax04rcsiq2zq4dmzir";
     };
 
     buildInputs = with pythonPackages; [

--- a/pkgs/development/tools/build-managers/buildbot/plugins.nix
+++ b/pkgs/development/tools/build-managers/buildbot/plugins.nix
@@ -11,7 +11,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version format;
-      sha256 = "0nmrq50c5ib185rpb8ai1mm7gjq2mjvxik1kqrjfa62i1ia9ikyj";
+      sha256 = "01v9w8iy9q6fwrmz6db7fanjixax7whn74k67bj0czrbjjkpfzvb";
     };
 
     meta = with stdenv.lib; {
@@ -29,7 +29,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "1laz7l7cbbz0czb6skxw314bd2qk2f63qw3n2rs7m7v11gd9cdll";
+      sha256 = "1cwxkzpgwzk9b361rj980bbnmhzzsr46pgf94zqpg3na8xm6hpwj";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -49,7 +49,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "0mmri8c4n1zwxc1dx2a11yllrmnwqqxjvvil9224lbs98mpchppi";
+      sha256 = "0ival58f50128315d0nck63pzya2zm7q6hvgmxfbjl0my8il9p2l";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -69,7 +69,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "0nwlw2m3qfifia6gy3d4lrnycra50k98ax071p2zjqknanh563vr";
+      sha256 = "0jiwfb699nqbmpcm88y187ig4ha6p7d4v98mjwa9blhm54dk8kh1";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];
@@ -89,7 +89,7 @@
 
     src = pythonPackages.fetchPypi {
       inherit pname version;
-      sha256 = "1zml9bd910zwcby4vr3lmzap2grinha2w5zgb2cmixmz7hfrqswp";
+      sha256 = "00mfn24gbwr2p3n7nsijzv949l7hiksiafhma18nnh40r8f4l5f2";
     };
 
     propagatedBuildInputs = with pythonPackages; [ buildbot-pkg ];

--- a/pkgs/development/tools/build-managers/buildbot/worker.nix
+++ b/pkgs/development/tools/build-managers/buildbot/worker.nix
@@ -3,11 +3,11 @@
 pythonPackages.buildPythonApplication (rec {
   name = "${pname}-${version}";
   pname = "buildbot-worker";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "0hpiawf0dq8phsvihlcx9bpl70n7s3rhcgbgma36bark6sgr4y8y";
+    sha256 = "02xfzlcy3cnvc3cmpl9gs6209a3qm71yz5pahbws9jcyhv6fbrrm";
   };
 
   buildInputs = with pythonPackages; [ setuptoolsTrial mock ];


### PR DESCRIPTION
Buildbot is currently broken as the result of two incomplete semi-automated/bulk updates. #36964 updated buildbot without updating its plugins (or buildbot-worker, but it was updated later in #37168), I don't think this caused any problems, but we should try to avoid this in the future. More importantly, #38483 updated buildbot-pkg, which implicitly updates the plugins, so they now fail to build due to hash mismatches.

###### Things done

This PR updates all of buildbot to 1.1.1, and fixes the hashes of the plugins.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

