### PR TITLE
nixos/acme: Fix broken post-stop script

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -257,7 +257,7 @@ in
 
                     if [ -e /tmp/lastExitCode ] && [ "$(cat /tmp/lastExitCode)" = "0" ]; then
                       ${if data.activationDelay != null then ''
-                      
+
                       ${data.preDelay}
 
                       if [ -d '${lpath}' ]; then
@@ -266,6 +266,10 @@ in
                         systemctl --wait start acme-setlive-${cert}.service
                       fi
                       '' else data.postRun}
+
+                      # noop ensuring that the "if" block is non-empty even if
+                      # activationDelay == null and postRun == ""
+                      true
                     fi
                   '';
 
@@ -294,7 +298,7 @@ in
                         chown '${data.user}:${data.group}' '${cpath}'
                       fi
                   '';
-                  script = 
+                  script =
                     ''
                       workdir="$(mktemp -d)"
 


### PR DESCRIPTION
###### Motivation for this change

Previously the script would contain an empty `if` block (which is invalid
syntax) if both `data.activationDelay == null` and `data.postRun == ""`. Fix
this by adding a no-op `true`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

