### PR TITLE
Remove uses of libOnly

### DIFF
--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -1,14 +1,8 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, python2, perl, yacc, flex
 , texinfo, perlPackages
 , openldap, libcap_ng, sqlite, openssl, db, libedit, pam
-
-# Extra Args
-, type ? ""
 }:
 
-let
-  libOnly = type == "lib";
-in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "${type}heimdal-${version}";
@@ -23,12 +17,10 @@ stdenv.mkDerivation rec {
 
   patches = [ ./heimdal-make-missing-headers.patch ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig python2 perl yacc flex ]
-    ++ (with perlPackages; [ JSON ])
-    ++ optional (!libOnly) texinfo;
+  nativeBuildInputs = [ autoreconfHook pkgconfig python2 perl yacc flex texinfo ]
+    ++ (with perlPackages; [ JSON ]);
   buildInputs = optionals (!stdenv.isFreeBSD) [ libcap_ng db ]
-    ++ [ sqlite openssl libedit ]
-    ++ optionals (!libOnly) [ openldap pam ];
+    ++ [ sqlite openssl libedit openldap pam ];
 
   ## ugly, X should be made an option
   configureFlags = [
@@ -40,7 +32,6 @@ stdenv.mkDerivation rec {
     "--with-openssl=${openssl.dev}"
     "--without-x"
     "--with-berkeley-db=${db}"
-  ] ++ optionals (!libOnly) [
     "--with-openldap=${openldap.dev}"
   ] ++ optionals (!stdenv.isFreeBSD) [
     "--with-capng"
@@ -48,24 +39,6 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     sed -i '/^DEFAULT_INCLUDES/ s,$, -I..,' source/cf/Makefile.am.common
-  '';
-
-  buildPhase = optionalString libOnly ''
-    (cd include; make -j $NIX_BUILD_CORES)
-    (cd lib; make -j $NIX_BUILD_CORES)
-    (cd tools; make -j $NIX_BUILD_CORES)
-    (cd include/hcrypto; make -j $NIX_BUILD_CORES)
-    (cd lib/hcrypto; make -j $NIX_BUILD_CORES)
-  '';
-
-  installPhase = optionalString libOnly ''
-    (cd include; make -j $NIX_BUILD_CORES install)
-    (cd lib; make -j $NIX_BUILD_CORES install)
-    (cd tools; make -j $NIX_BUILD_CORES install)
-    (cd include/hcrypto; make -j $NIX_BUILD_CORES install)
-    (cd lib/hcrypto; make -j $NIX_BUILD_CORES install)
-    rm -rf $out/{libexec,sbin,share}
-    find $out/bin -type f | grep -v 'krb5-config' | xargs rm
   '';
 
   # We need to build hcrypt for applications like samba

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -5,7 +5,7 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "${type}heimdal-${version}";
+  name = "heimdal-${version}";
   version = "7.5.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -3,8 +3,7 @@
 , withData ? true, poppler_data
 , qt5Support ? false, qtbase ? null
 , introspectionSupport ? false, gobjectIntrospection ? null
-, utils ? false
-, minimal ? false, suffix ? "glib"
+, minimal ? false
 }:
 
 let # beware: updates often break cups-filters build
@@ -12,14 +11,14 @@ let # beware: updates often break cups-filters build
   mkFlag = optset: flag: "-DENABLE_${flag}=${if optset then "on" else "off"}";
 in
 stdenv.mkDerivation rec {
-  name = "poppler-${suffix}-${version}";
+  name = "poppler-${version}";
 
   src = fetchurl {
     url = "${meta.homepage}/poppler-${version}.tar.xz";
     sha256 = "04d1z1ygyb3llzc6s6c99wxafvljj2sc5b76djif34f7mzfqmk17";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "bin" ];
 
   buildInputs = [ libiconv libintl ] ++ lib.optional withData poppler_data;
 
@@ -40,7 +39,7 @@ stdenv.mkDerivation rec {
     (mkFlag (!minimal) "GLIB")
     (mkFlag (!minimal) "CPP")
     (mkFlag (!minimal) "LIBCURL")
-    (mkFlag utils "UTILS")
+    "-DENABLE_UTILS=on"
     (mkFlag qt5Support "QT5")
   ];
 

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -7,9 +7,6 @@
 , dbus ? null, libffado ? null, alsaLib ? null
 , libopus ? null
 , darwin
-
-# Extra options
-, prefix ? ""
 }:
 
 with stdenv.lib;
@@ -17,16 +14,14 @@ let
   inherit (python2Packages) python dbus-python;
   shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
 
-  libOnly = prefix == "lib";
-
   optDbus = if stdenv.isDarwin then null else shouldUsePkg dbus;
-  optPythonDBus = if libOnly then null else shouldUsePkg dbus-python;
-  optLibffado = if libOnly then null else shouldUsePkg libffado;
-  optAlsaLib = if libOnly then null else shouldUsePkg alsaLib;
+  optPythonDBus = shouldUsePkg dbus-python;
+  optLibffado = shouldUsePkg libffado;
+  optAlsaLib = shouldUsePkg alsaLib;
   optLibopus = shouldUsePkg libopus;
 in
 stdenv.mkDerivation rec {
-  name = "${prefix}jack2-${version}";
+  name = "jack2-${version}";
   version = "1.9.12";
 
   src = fetchFromGitHub {
@@ -75,12 +70,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     python waf install
-  '' + (if libOnly then ''
-    rm -rf $out/{bin,share}
-    rm -rf $out/lib/{jack,libjacknet*,libjackserver*}
-  '' else ''
     wrapProgram $out/bin/jack_control --set PYTHONPATH $PYTHONPATH
-  '');
+  '';
 
   meta = {
     description = "JACK audio connection kit, version 2 with jackdbus";

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -4,16 +4,11 @@
 # Optional dependencies
 , libjack2 ? null, dbus ? null, dbus_cplusplus ? null, alsaLib ? null
 , pyqt4 ? null, dbus-python ? null, xdg_utils ? null
-
-# Other Flags
-, prefix ? ""
 }:
 
 let
 
   shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
-
-  libOnly = prefix == "lib";
 
   optLibjack2 = shouldUsePkg libjack2;
   optDbus = shouldUsePkg dbus;
@@ -24,7 +19,7 @@ let
   optXdg_utils = shouldUsePkg xdg_utils;
 in
 stdenv.mkDerivation rec {
-  name = "${prefix}ffado-${version}";
+  name = "ffado-${version}";
   version = "2.4.0";
 
   src = fetchurl {
@@ -36,7 +31,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     expat libraw1394 libconfig libavc1394 libiec61883
-  ] ++ stdenv.lib.optionals (!libOnly) [
     optLibjack2 optDbus optDbus_cplusplus optAlsaLib optPyqt4
     optXdg_utils libxmlxx glibmm
   ];
@@ -69,10 +63,7 @@ stdenv.mkDerivation rec {
       SERIALIZE_USE_EXPAT=True \
   '';
 
-  installPhase = if libOnly then ''
-    scons PREFIX=$TMPDIR UDEVDIR=$TMPDIR \
-      LIBDIR=$out/lib INCLUDEDIR=$out/include install
-  '' else ''
+  installPhase = ''
     scons PREFIX=$out PYPKGDIR=$PYDIR UDEVDIR=$out/lib/udev/rules.d install
   '' + stdenv.lib.optionalString (optPyqt4 != null && optPythonDBus != null) ''
     wrapProgram $out/bin/ffado-mixer --prefix PYTHONPATH : \

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -10,7 +10,7 @@
 
 , x11Support ? false
 
-, useSystemd ? true
+, useSystemd ? stdenv.isLinux
 
 , # Whether to support the JACK sound system as a backend.
   jackaudioSupport ? false
@@ -59,8 +59,8 @@ stdenv.mkDerivation rec {
     lib.optionals stdenv.isLinux [ libcap ];
 
   buildInputs =
-    [ libtool libsndfile speexdsp fftwFloat libasyncns webrtc-audio-processing ]
-    ++ lib.optionals stdenv.isLinux [ glib dbus ]
+    [ libtool libsndfile speexdsp fftwFloat ]
+    ++ lib.optionals stdenv.isLinux [ glib libasyncns webrtc-audio-processing ]
     ++ lib.optionals stdenv.isDarwin [ CoreServices AudioUnit Cocoa ]
     ++ lib.optional jackaudioSupport libjack2
     ++ lib.optionals x11Support [ xorg.xlibsWrapper xorg.libXtst xorg.libXi ]

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -120,7 +120,6 @@ mapAliases (rec {
   libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || hostPlatform.libc != "glibc") gettext; # added 2018-03-14
   libjack2 = jack2Full; # added 2018-04-25
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
-  libkrb5 = krb5Full; # added 2018-04-25
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
   libpulseaudio-vanilla = pulseaudioLight; # added 2018-04-25
   libtidy = html-tidy;  # added 2014-12-21

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -119,6 +119,7 @@ mapAliases (rec {
   libheimdal = heimdalFull; # added 2018-04-25
   libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || hostPlatform.libc != "glibc") gettext; # added 2018-03-14
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
+  libkrb5 = krb5Full; # added 2018-04-25
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
   libtidy = html-tidy;  # added 2014-12-21
   links = links2; # added 2016-01-31

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -167,6 +167,7 @@ mapAliases (rec {
   pidginwindowmerge = pidgin-window-merge; # added 2018-01-08
   postage = pgmanage; # added 2017-11-03
   poppler_qt5 = libsForQt5.poppler;  # added 2015-12-19
+  poppler_utils = poppler.bin; # added 2018-04-25
   PPSSPP = ppsspp; # added 2017-10-01
   prometheus-statsd-bridge = prometheus-statsd-exporter;  # added 2017-08-27
   qca-qt5 = libsForQt5.qca-qt5;  # added 2015-12-19

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -121,7 +121,6 @@ mapAliases (rec {
   libjack2 = jack2Full; # added 2018-04-25
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
-  libpulseaudio-vanilla = pulseaudioLight; # added 2018-04-25
   libtidy = html-tidy;  # added 2014-12-21
   libv4l = v4l_utils.dev; # added 2018-04-25
   links = links2; # added 2016-01-31

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -118,6 +118,7 @@ mapAliases (rec {
   libgumbo = gumbo; # added 2018-01-21
   libheimdal = heimdalFull; # added 2018-04-25
   libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || hostPlatform.libc != "glibc") gettext; # added 2018-03-14
+  libjack2 = jack2Full; # added 2018-04-25
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   libkrb5 = krb5Full; # added 2018-04-25
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -115,6 +115,7 @@ mapAliases (rec {
   libgnome_keyring = libgnome-keyring; # added 2018-02-25
   libgnome_keyring3 = libgnome-keyring3; # added 2018-02-25
   libgumbo = gumbo; # added 2018-01-21
+  libheimdal = heimdalFull; # added 2018-04-25
   libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || hostPlatform.libc != "glibc") gettext; # added 2018-03-14
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -122,6 +122,7 @@ mapAliases (rec {
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   libkrb5 = krb5Full; # added 2018-04-25
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
+  libpulseaudio-vanilla = pulseaudioLight; # added 2018-04-25
   libtidy = html-tidy;  # added 2014-12-21
   links = links2; # added 2016-01-31
   lttngTools = lttng-tools;  # added 2014-07-31

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -112,6 +112,7 @@ mapAliases (rec {
   libcap_manpages = libcap.doc; # added 2016-04-29
   libcap_pam = if stdenv.isLinux then libcap.pam else null; # added 2016-04-29
   libcap_progs = libcap.out; # added 2016-04-29
+  libffado = ffadoFull; # added 2018-04-25
   libgnome_keyring = libgnome-keyring; # added 2018-02-25
   libgnome_keyring3 = libgnome-keyring3; # added 2018-02-25
   libgumbo = gumbo; # added 2018-01-21

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -123,6 +123,7 @@ mapAliases (rec {
   libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
   libpulseaudio-vanilla = pulseaudioLight; # added 2018-04-25
   libtidy = html-tidy;  # added 2014-12-21
+  libv4l = v4l_utils.dev; # added 2018-04-25
   links = links2; # added 2016-01-31
   lttngTools = lttng-tools;  # added 2014-07-31
   lttngUst = lttng-ust;  # added 2014-07-31

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20628,7 +20628,6 @@ with pkgs;
     libopus = libopus.override { withCustomModes = true; };
     inherit (darwin.apple_sdk.frameworks) AudioToolbox CoreAudio CoreFoundation;
   };
-  libjack2 = jack2Full.override { prefix = "lib"; };
 
   keynav = callPackage ../tools/X11/keynav { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9538,6 +9538,12 @@ with pkgs;
   krb5Full = callPackage ../development/libraries/kerberos/krb5.nix {
     inherit (darwin) bootstrap_cmds;
   };
+  libkrb5 = krb5Full.override {
+    openldap = null;
+    libedit = null;
+    yacc = null;
+    fetchurl = fetchurlBoot;
+  };
 
   languageMachines = recurseIntoAttrs (import ../development/libraries/languagemachines/packages.nix { inherit callPackage; });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13150,7 +13150,6 @@ with pkgs;
   ffadoFull = callPackage ../os-specific/linux/ffado {
     inherit (python2Packages) python pyqt4 dbus-python;
   };
-  libffado = ffadoFull.override { prefix = "lib"; };
 
   fbterm = callPackage ../os-specific/linux/fbterm { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9346,7 +9346,6 @@ with pkgs;
   kerberos = libkrb5;
 
   heimdalFull = callPackage ../development/libraries/kerberos/heimdal.nix { };
-  libheimdal = heimdalFull.override { type = "lib"; };
 
   harfbuzz = callPackage ../development/libraries/harfbuzz { };
   harfbuzz-icu = callPackage ../development/libraries/harfbuzz {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10997,12 +10997,9 @@ with pkgs;
 
   poppler_min = poppler.override { # TODO: maybe reduce even more
     minimal = true;
-    suffix = "min";
   };
 
   poppler_qt4 = callPackage ../development/libraries/poppler/qt4.nix { };
-
-  poppler_utils = poppler.override { suffix = "utils"; utils = true; };
 
   popt = callPackage ../development/libraries/popt { };
 
@@ -11227,7 +11224,6 @@ with pkgs;
     poppler = callPackage ../development/libraries/poppler {
       lcms = lcms2;
       qt5Support = true;
-      suffix = "qt5";
     };
 
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -224,6 +224,10 @@ with pkgs;
   # uses the curl from the previous bootstrap phase (e.g. a statically
   # linked curl in the case of stdenv-linux).
   fetchurlBoot = stdenv.fetchurlBoot;
+  krb5Boot = krb5.override {
+    fetchurl = fetchurlBoot;
+    openldap = null;
+  };
 
   fetchzip = callPackage ../build-support/fetchzip { };
 
@@ -1846,6 +1850,7 @@ with pkgs;
 
   curl = callPackage ../tools/networking/curl rec {
     fetchurl = fetchurlBoot;
+    kerberos = krb5Boot;
     http2Support = true;
     zlibSupport = true;
     sslSupport = zlibSupport;
@@ -8666,7 +8671,7 @@ with pkgs;
   cxxtest = callPackage ../development/libraries/cxxtest { };
 
   cyrus_sasl = callPackage ../development/libraries/cyrus-sasl {
-    kerberos = if stdenv.isFreeBSD then libheimdal else kerberos;
+    kerberos = if stdenv.isFreeBSD then libheimdal else krb5Boot;
   };
 
   # Make bdb5 the default as it is the last release under the custom
@@ -9540,12 +9545,7 @@ with pkgs;
     inherit (darwin) bootstrap_cmds;
   };
   krb5Full = krb5;
-  libkrb5 = krb5.override {
-    openldap = null;
-    libedit = null;
-    yacc = null;
-    fetchurl = fetchurlBoot;
-  };
+  libkrb5 = krb5;
 
   languageMachines = recurseIntoAttrs (import ../development/libraries/languagemachines/packages.nix { inherit callPackage; });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12564,11 +12564,6 @@ with pkgs;
 
   # libpulse implementations
 
-  libpulseaudio-vanilla = callPackage ../servers/pulseaudio {
-    libOnly = true;
-    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
-  };
-
   apulse = callPackage ../misc/apulse { };
 
   libpressureaudio = callPackage ../misc/apulse/pressureaudio.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12544,11 +12544,12 @@ with pkgs;
 
   # Name is changed to prevent use in packages;
   # please use libpulseaudio instead.
-  pulseaudioLight = callPackage ../servers/pulseaudio {
+  pulseaudio = callPackage ../servers/pulseaudio {
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };
+  pulseaudioLight = pulseaudio;
 
-  pulseaudioFull = callPackage ../servers/pulseaudio {
+  pulseaudioFull = pulseaudio.override {
     gconf = gnome3.gconf;
     x11Support = true;
     jackaudioSupport = true;
@@ -12572,6 +12573,7 @@ with pkgs;
     libpulseaudio = libpulseaudio-vanilla; # meta only
   };
 
+  libpulseaudio-vanilla = pulseaudioLight;
   libpulseaudio = libpulseaudio-vanilla;
 
   tomcat_connectors = callPackage ../servers/http/apache-modules/tomcat-connectors { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13138,6 +13138,7 @@ with pkgs;
 
   ffadoFull = callPackage ../os-specific/linux/ffado {
     inherit (python2Packages) python pyqt4 dbus-python;
+    libjack2 = libjack2.override { libffado = null; };
   };
 
   fbterm = callPackage ../os-specific/linux/fbterm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9538,10 +9538,6 @@ with pkgs;
   krb5Full = callPackage ../development/libraries/kerberos/krb5.nix {
     inherit (darwin) bootstrap_cmds;
   };
-  libkrb5 = krb5Full.override {
-    fetchurl = fetchurlBoot;
-    type = "lib";
-  };
 
   languageMachines = recurseIntoAttrs (import ../development/libraries/languagemachines/packages.nix { inherit callPackage; });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10417,10 +10417,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices CoreServices;
   };
 
-  libv4l = lowPrio (v4l_utils.override {
-    withUtils = false;
-  });
-
   libva = callPackage ../development/libraries/libva { };
   libva-minimal = libva.override { minimal = true; };
   libva-utils = callPackage ../development/libraries/libva-utils { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2707,11 +2707,11 @@ with pkgs;
 
   grub2_full = callPackage ../tools/misc/grub/2.0x.nix { };
 
-  grub2_efi = grub2_full.override {
+  grub2_efi = grub2.override {
     efiSupport = true;
   };
 
-  grub2_light = grub2_full.override {
+  grub2_light = grub2.override {
     zfsSupport = false;
   };
 
@@ -3726,10 +3726,12 @@ with pkgs;
 
   mitmproxy = callPackage ../tools/networking/mitmproxy { };
 
-  mjpegtoolsFull = callPackage ../tools/video/mjpegtools { };
-
-  mjpegtools = self.mjpegtoolsFull.override {
+  mjpegtools = callPackage ../tools/video/mjpegtools {
     withMinimal = true;
+  };
+
+  mjpegtoolsFull = mjpegtools.override {
+    withMinimal = false;
   };
 
   mkcue = callPackage ../tools/cd-dvd/mkcue { };
@@ -4315,28 +4317,27 @@ with pkgs;
 
   philter = callPackage ../tools/networking/philter { };
 
-  pinentry = pinentry_ncurses.override {
-    inherit gtk2;
+  pinentry = callPackage ../tools/security/pinentry {
+    libcap = if stdenv.isDarwin then null else libcap;
   };
 
-  pinentry_ncurses = callPackage ../tools/security/pinentry {
-    libcap = if stdenv.isDarwin then null else libcap;
+  pinentry_ncurses = pinentry.override {
     gtk2 = null;
   };
 
-  pinentry_emacs = pinentry_ncurses.override {
+  pinentry_emacs = pinentry.override {
     enableEmacs = true;
   };
 
-  pinentry_gnome = pinentry_ncurses.override {
+  pinentry_gnome = pinentry.override {
     gcr = gnome3.gcr;
   };
 
-  pinentry_qt4 = pinentry_ncurses.override {
+  pinentry_qt4 = pinentry.override {
     qt = qt4;
   };
 
-  pinentry_qt5 = pinentry_ncurses.override {
+  pinentry_qt5 = pinentry.override {
     qt = qt5.qtbase;
   };
 
@@ -4359,7 +4360,7 @@ with pkgs;
   plan9port = callPackage ../tools/system/plan9port { };
 
   platformioPackages = callPackage ../development/arduino/platformio { };
-  platformio = platformioPackages.platformio-chrootenv.override {};
+  platformio = platformioPackages.platformio-chrootenv;
 
   platinum-searcher = callPackage ../tools/text/platinum-searcher { };
 
@@ -9348,7 +9349,7 @@ with pkgs;
   heimdalFull = callPackage ../development/libraries/kerberos/heimdal.nix { };
 
   harfbuzz = callPackage ../development/libraries/harfbuzz { };
-  harfbuzz-icu = callPackage ../development/libraries/harfbuzz {
+  harfbuzz-icu = harfbuzz.override {
     withIcu = true;
     withGraphite2 = true;
   };
@@ -9535,10 +9536,11 @@ with pkgs;
 
   kinetic-cpp-client = callPackage ../development/libraries/kinetic-cpp-client { };
 
-  krb5Full = callPackage ../development/libraries/kerberos/krb5.nix {
+  krb5 = callPackage ../development/libraries/kerberos/krb5.nix {
     inherit (darwin) bootstrap_cmds;
   };
-  libkrb5 = krb5Full.override {
+  krb5Full = krb5;
+  libkrb5 = krb5.override {
     openldap = null;
     libedit = null;
     yacc = null;
@@ -9732,14 +9734,12 @@ with pkgs;
 
   libdbi = callPackage ../development/libraries/libdbi { };
 
-  libdbiDriversBase = callPackage ../development/libraries/libdbi-drivers {
+  libdbiDriversBase = libdbiDrivers.override {
     mysql = null;
     sqlite = null;
   };
 
-  libdbiDrivers = libdbiDriversBase.override {
-    inherit sqlite mysql;
-  };
+  libdbiDrivers = callPackage ../development/libraries/libdbi-drivers { };
 
   libdbusmenu-glib = callPackage ../development/libraries/libdbusmenu { };
   libdbusmenu-gtk2 = callPackage ../development/libraries/libdbusmenu { gtkVersion = "2"; };
@@ -15727,19 +15727,19 @@ with pkgs;
 
   welle-io = libsForQt5.callPackage ../applications/misc/welle-io { };
 
-  wireshark-cli = callPackage ../applications/networking/sniffers/wireshark {
-    withQt = false;
+  wireshark = callPackage ../applications/networking/sniffers/wireshark {
+    withQt = true;
     withGtk = false;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices SystemConfiguration;
   };
+  wireshark-qt = wireshark;
 
   # the cli binary is actually called tshark and often packaged under this name
   tshark = wireshark-cli;
 
   # The GTK UI is deprecated by upstream. You probably want the QT version.
-  wireshark-gtk = wireshark-cli.override { withGtk = true; };
-  wireshark-qt = wireshark-cli.override { withQt = true; };
-  wireshark = wireshark-qt;
+  wireshark-gtk = wireshark.override { withGtk = true; };
+  wireshark-cli = wireshark.override { withGtk = false; withQt = false; };
 
   fbida = callPackage ../applications/graphics/fbida { };
 
@@ -16257,13 +16257,12 @@ with pkgs;
     libwebp = null;
   };
 
-  imagemagick = imagemagickBig.override {
+  imagemagick = callPackage ../applications/graphics/ImageMagick {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices;
     ghostscript = null;
   };
 
-  imagemagickBig = callPackage ../applications/graphics/ImageMagick {
-    inherit (darwin.apple_sdk.frameworks) ApplicationServices;
-  };
+  imagemagickBig = imagemagick.override { inherit ghostscript; };
 
   imagemagick7_light = lowPrio (imagemagick7.override {
     bzip2 = null;
@@ -19856,12 +19855,12 @@ with pkgs;
   # and with or without atlas as a dependency. The default `liblapack` is 3.4.1
   # with atlas. Atlas, when built with liblapack as a dependency, uses 3.5.0
   # without atlas. Etc.
-  liblapackWithAtlas = callPackage ../development/libraries/science/math/liblapack {};
-  liblapackWithoutAtlas = liblapackWithAtlas.override { atlas = null; };
-  liblapack_3_5_0WithAtlas = callPackage ../development/libraries/science/math/liblapack/3.5.0.nix {};
-  liblapack_3_5_0WithoutAtlas = liblapack_3_5_0WithAtlas.override { atlas = null; };
-  liblapack = liblapackWithAtlas;
-  liblapack_3_5_0 = liblapack_3_5_0WithAtlas;
+  liblapack = callPackage ../development/libraries/science/math/liblapack {};
+  liblapackWithAtlas = liblapack;
+  liblapackWithoutAtlas = liblapack.override { atlas = null; };
+  liblapack_3_5_0 = callPackage ../development/libraries/science/math/liblapack/3.5.0.nix {};
+  liblapack_3_5_0WithAtlas = liblapack_3_5_0;
+  liblapack_3_5_0WithoutAtlas = liblapack_3_5_0.override { atlas = null; };
 
   liblbfgs = callPackage ../development/libraries/science/math/liblbfgs { };
 


### PR DESCRIPTION
We failed to get any sort of consensus on #39515 so I am opening this spinoff PR that focuses on the worst overrides offenders. Basically, a few packages rely on this legacy "libOnly" flag that tells them to only build the "library" part of the package.

## What's wrong with libOnly

libOnly is an attempt to be more precise on what a package builds. The goal is to decrease closure size. Unfortunately, it's usage also means that you have to build each package twice - once for the libraries and another for the actual runtime (even though the runtime will still build the library). Since multiple outputs have been released, this is no longer the correct way to decrease closure size. Outputs like "lib" and "dev" should be used instead and mean you only have to build things once.

## Current offenders
- libpulseaudio
- libjack2
- libheimdal
- libkrb5
- libffado

## Backwards compatibility

This PR retains aliases for each of the libOnly overrides so old references to "libpulseaudio", and "libjack", etc. will continue to work.
