### PR TITLE
notary: fix build

### DIFF
--- a/pkgs/tools/security/notary/no-git-usage.patch
+++ b/pkgs/tools/security/notary/no-git-usage.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index ab794165..0cbd047f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,8 +5,8 @@ PREFIX?=$(shell pwd)
+ # Add to compile time flags
+ NOTARY_PKG := github.com/theupdateframework/notary
+ NOTARY_VERSION := $(shell cat NOTARY_VERSION)
+-GITCOMMIT := $(shell git rev-parse --short HEAD)
+-GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)
++GITCOMMIT ?= $(shell git rev-parse --short HEAD)
++GITUNTRACKEDCHANGES :=
+ ifneq ($(GITUNTRACKEDCHANGES),)
+ GITCOMMIT := $(GITCOMMIT)-dirty
+ endif


### PR DESCRIPTION
###### Motivation for this change

The package is broken on master for some time now:
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.notary.x86_64-linux/all

The main reason for the breackage is that the `Makefile` script attempts
to retrieve the latest git commit by using `git rev-parse` which breaks
as `git` is not in the build environment. This could be fixed by using
`?=` rather than `:=` for the `GITCOMMIT` variable in the `make` script
to easily override `GITCOMMIT` in the `buildPhase`.

See the Hydra logs for reference:
https://nix-cache.s3.amazonaws.com/log/ib4qp8h4r8d830ra4fah38l7ybb82gp7-notary-0.6.0.drv

Furthermore some refactoring was applied:

* Activated the test suite for `cmd/notary` to confirm the basic
  functionality when building for NixOS.

* Added {pre,post} hooks for `{build,install}Phase`

* Added myself as maintainer to have more people available in case of
  further breakage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

