### PR TITLE
[release-18.03] slurm: 17.11.3 -> 17.11.5 (Fix CVE-2018-7033)

### DIFF
--- a/pkgs/development/python-modules/pyslurm/default.nix
+++ b/pkgs/development/python-modules/pyslurm/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "pyslurm";
-  version = "20170302";
+  version = "20180427";
 
   src = fetchFromGitHub {
     repo = "pyslurm";
     owner = "PySlurm";
-    rev = "f5a756f199da404ec73cb7fcd7f04ec4d21ea3ff";
-    sha256 = "1xn321nc8i8zmngh537j6lnng1rhdp460qx4skvh9daz5h9nxznx";
+    rev = "3900e1afac9ffd13c80c57d8c39933d42eb7bad7";
+    sha256 = "1a183ig4sdbc70rx2yyaslyq61wkbsf8cbim1jj0kzrp65nf0vls";
   };
 
   buildInputs = [ cython slurm ];

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-${version}";
-  version = "17.11.3";
+  version = "17.11.5";
 
   src = fetchurl {
     url = "https://download.schedmd.com/slurm/${name}.tar.bz2";
-    sha256 = "1x3i6z03d9m46fvj1cslrapm1drvgyqch9pn4xf23kvbz4gkhaps";
+    sha256 = "07ghyyz12k4rksm06xf7dshwp1ndm13zphdbqja99401q4xwbx9r";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

Fix CVE-2018-7033

* https://lists.schedmd.com/pipermail/slurm-announce/2018/000006.html
* https://nvd.nist.gov/vuln/detail/CVE-2018-7033

Fixes #39668

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
