### PR TITLE
tempita: 0.5.2 -> 0.5.3-2016-09-28, Python 3 support

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14070,20 +14070,20 @@ in {
   };
 
   tempita = buildPythonPackage rec {
-    version = "0.5.2";
+    version = "0.5.3-2016-09-28";
     name = "tempita-${version}";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/T/Tempita/Tempita-${version}.tar.gz";
-      sha256 = "cacecf0baa674d356641f1d406b8bff1d756d739c46b869a54de515d08e6fc9c";
+    src = pkgs.fetchFromGitHub {
+      owner = "gjhiggins";
+      repo = "tempita";
+      rev = "47414a7c6e46a9a9afe78f0bce2ea299fa84d10";
+      sha256 = "0f33jjjs5rvp7ar2j6ggyfykcrsrn04jaqcq71qfvycf6b7nw3rn";
     };
-
-    disabled = isPy3k;
 
     buildInputs = with self; [ nose ];
 
     meta = {
-      homepage = http://pythonpaste.org/tempita/;
+      homepage = https://github.com/gjhiggins/tempita;
       description = "A very small text templating language";
     };
   };


### PR DESCRIPTION
###### Motivation for this change

Tempita is abandoned upstream (no release since 2013, website redirects to archive.org), but sqlalchemy-migrate depends on it. There is a [fork available](https://github.com/gjhiggins/tempita) that fixes Python 3 compatibility. This fork is used by the official [Arch Linux tempita package](https://www.archlinux.org/packages/community/any/python-tempita/).

###### Things done

This PR updates tempita to use this fork, so that it works with Python 3.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

