### PR TITLE
Updating dependencies of neovim

### DIFF
--- a/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
+++ b/pkgs/applications/editors/neovim/ruby_provider/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    msgpack (1.2.2)
+    msgpack (1.2.4)
     multi_json (1.13.1)
-    neovim (0.6.2)
+    neovim (0.7.0)
       msgpack (~> 1.0)
       multi_json (~> 1.0)
 

--- a/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
+++ b/pkgs/applications/editors/neovim/ruby_provider/gemset.nix
@@ -2,10 +2,10 @@
   msgpack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ai0sfdv9jnr333fsvkn7a8vqvn0iwiw83yj603a3i68ds1x6di1";
+      sha256 = "09xy1wc4wfbd1jdrzgxwmqjzfdfxbz0cqdszq2gv6rmc3gv1c864";
       type = "gem";
     };
-    version = "1.2.2";
+    version = "1.2.4";
   };
   multi_json = {
     source = {
@@ -19,9 +19,9 @@
     dependencies = ["msgpack" "multi_json"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "15r3j9bwlpm1ry7cp6059xb0irvsvvlmw53i28z6sf2khwfj5j53";
+      sha256 = "0b487dzz41im8cwzvfjqgf8kkrp6mpkvcbzhazrmqqw8gxyvfbq4";
       type = "gem";
     };
-    version = "0.6.2";
+    version = "0.7.0";
   };
 }

--- a/pkgs/development/python-modules/neovim/default.nix
+++ b/pkgs/development/python-modules/neovim/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "neovim";
-  version = "0.2.4";
+  version = "0.2.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0accfgyvihs08bwapgakx6w93p4vbrq2448n2z6gw88m2hja9jm3";
+    sha256 = "0xlj54w9bnmq4vidk6r08hwa6az7drahi08w1qf4j9q45rs8mrbc";
   };
 
   checkInputs = [ nose ];


### PR DESCRIPTION
pythonPackages.neovim: 0.2.4 -> ~~0.2.5~~ 0.2.6
gem-neovim: 0.6.2 -> 0.7.0
gem-msgpack: 1.2.2 -> 1.2.4

###### Motivation for this change
In neovim, `:CheckHealth`:
```
WARNING: Latest nvim-python-neovim is NOT installed: 0.2.6
WARNING: Gem "neovim" is out-of-date. Installed: 0.6.2, latest: 0.7.0
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

