### PR TITLE
setup: get enableParallelBuilding compatible with bmake

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -977,7 +977,7 @@ buildPhase() {
         # Old bash empty array hack
         # shellcheck disable=SC2086
         local flagsArray=(
-            ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
+            ${enableParallelBuilding:+-j ${NIX_BUILD_CORES}}
             $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
             $buildFlags ${buildFlagsArray+"${buildFlagsArray[@]}"}
         )
@@ -997,7 +997,7 @@ checkPhase() {
     # Old bash empty array hack
     # shellcheck disable=SC2086
     local flagsArray=(
-        ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
+        ${enableParallelBuilding:+-j ${NIX_BUILD_CORES}}
         $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
         ${checkFlags:-VERBOSE=y} ${checkFlagsArray+"${checkFlagsArray[@]}"}
         ${checkTarget:-check}
@@ -1109,7 +1109,7 @@ installCheckPhase() {
     # Old bash empty array hack
     # shellcheck disable=SC2086
     local flagsArray=(
-        ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
+        ${enableParallelBuilding:+-j ${NIX_BUILD_CORES}}
         $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
         $installCheckFlags ${installCheckFlagsArray+"${installCheckFlagsArray[@]}"}
         ${installCheckTarget:-installcheck}


### PR DESCRIPTION
The BSD version of make requires a space after "-j". In addition BSD make does not recognize the "--load-avg" option. From what I can tell this should be okay because load average already should default to the value set by "-j". Need more research on whether this is correct.

This is more of a proof of concept. Right now we can just set these args manually with BSD make.