### PR TITLE
uget-integrator: init at 1.0.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -8,7 +8,7 @@
 , google_talk_plugin, fribid, gnome3/*.gnome-shell*/
 , esteidfirefoxplugin
 , vlc_npapi
-, browserpass, chrome-gnome-shell
+, browserpass, chrome-gnome-shell, uget-integrator
 , libudev
 , kerberos
 }:
@@ -64,6 +64,7 @@ let
         ([ ]
           ++ lib.optional (cfg.enableBrowserpass or false) browserpass
           ++ lib.optional (cfg.enableGnomeExtensions or false) chrome-gnome-shell
+          ++ lib.optional (cfg.enableUgetIntegrator or false) uget-integrator
           ++ extraNativeMessagingHosts
         );
       libs = (if ffmpegSupport then [ ffmpeg ] else with gst_all; [ gstreamer gst-plugins-base ])

--- a/pkgs/tools/networking/uget-integrator/default.nix
+++ b/pkgs/tools/networking/uget-integrator/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, uget, python3Packages }:
+
+stdenv.mkDerivation rec {
+  name = "uget-integrator-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "ugetdm";
+    repo = "uget-integrator";
+    rev = "v${version}";
+    sha256 = "0bfqwbpprxp5sy49p2hqcjdfj7zamnp2hhcnnyccffkn7pghx8pp";
+  };
+
+  nativeBuildInputs = [ python3Packages.wrapPython ];
+
+  buildInputs = [ uget python3Packages.python ];
+
+  installPhase = ''
+    for f in conf/com.ugetdm.{chrome,firefox}.json; do
+      substituteInPlace $f --replace "/usr" "$out"
+    done
+
+	  install -D -t $out/bin                                   bin/uget-integrator
+	  install -D -t $out/etc/opt/chrome/native-messaging-hosts conf/com.ugetdm.chrome.json
+	  install -D -t $out/etc/chromium/native-messaging-hosts   conf/com.ugetdm.chrome.json
+	  install -D -t $out/etc/opera/native-messaging-hosts      conf/com.ugetdm.chrome.json
+	  install -D -t $out/lib/mozilla/native-messaging-hosts    conf/com.ugetdm.firefox.json
+
+    wrapPythonPrograms
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Native messaging host to integrate uGet Download Manager with web browsers";
+    homepage = https://github.com/ugetdm/uget-integrator;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5306,6 +5306,8 @@ with pkgs;
 
   uget = callPackage ../tools/networking/uget { };
 
+  uget-integrator = callPackage ../tools/networking/uget-integrator { };
+
   uif2iso = callPackage ../tools/cd-dvd/uif2iso { };
 
   umlet = callPackage ../tools/misc/umlet { };


### PR DESCRIPTION
###### Motivation for this change

Add the [`uget-integrator`](https://github.com/ugetdm/uget-integrator) package, a native messaging host to integrate [uGet Download Manager](http://ugetdm.com/) with web browsers.

In order to use it with Firefox, the [uGet Integration add-on](https://addons.mozilla.org/en-US/firefox/addon/ugetintegration/) should be installed by the user.

Screenshot:
![199705](https://user-images.githubusercontent.com/1217934/39413958-132454d6-4c08-11e8-9cd5-601006df9250.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).