### PR TITLE
unifi: introduce unifiTesting and upgrade unifiLTS and unifiStable

### DIFF
--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -1,53 +1,61 @@
-{ stdenv
-, dpkg
-, fetchurl
-, unzip
-, useLTS ? false
-}:
-
+{ stdenv, dpkg, fetchurl }:
 
 let
-  versions = {
-    stable = {
-      version = "5.7.20";
-      sha256 = "1ylj4i5mcv6z9n32275ccdf1rqk74zilqsih3r6xzhm30pxrd8dd";
+  generic = { version, sha256, suffix ? "" }:
+  stdenv.mkDerivation rec {
+    name = "unifi-controller-${version}";
+
+    src = fetchurl {
+      url = "https://dl.ubnt.com/unifi/${version}${suffix}/unifi_sysvinit_all.deb";
+      inherit sha256;
     };
-    lts = {
-      version = "5.6.36";
-      sha256 = "075q7vm56fdsjwh72y2cb1pirl2pxdkvqnhvd3bf1c2n64mvp6bi";
+
+    nativeBuildInputs = [ dpkg ];
+
+    unpackPhase = ''
+      runHook preUnpack
+      dpkg-deb -x $src ./
+      runHook postUnpack
+    '';
+
+    doConfigure = false;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cd ./usr/lib/unifi
+      cp -ar dl lib webapps $out
+
+      runHook postInstall
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = http://www.ubnt.com/;
+      description = "Controller for Ubiquiti UniFi access points";
+      license = licenses.unfree;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ wkennington ];
     };
   };
-  selectedVersion =
-    let attr = if useLTS then "lts" else "stable";
-    in versions."${attr}";
-in
 
-stdenv.mkDerivation {
-  name = "unifi-controller-${selectedVersion.version}";
-  src = with selectedVersion; fetchurl {
-    url = "https://dl.ubnt.com/unifi/${version}/unifi_sysvinit_all.deb";
-    inherit sha256;
+in rec {
+
+  # https://help.ubnt.com/hc/en-us/articles/115000441548-UniFi-Current-Controller-Versions
+
+  unifiLTS = generic {
+    version = "5.6.36";
+    sha256  = "075q7vm56fdsjwh72y2cb1pirl2pxdkvqnhvd3bf1c2n64mvp6bi";
   };
 
-  buildInputs = [ dpkg ];
+  unifiStable = generic {
+    version = "5.7.20";
+    sha256  = "1ylj4i5mcv6z9n32275ccdf1rqk74zilqsih3r6xzhm30pxrd8dd";
+  };
 
-  unpackPhase = ''
-    dpkg-deb -x $src ./
-  '';
-
-  doConfigure = false;
-
-  installPhase = ''
-    mkdir -p $out
-    cd ./usr/lib/unifi
-    cp -ar dl lib webapps $out
-  '';
-
-  meta = with stdenv.lib; {
-    homepage = http://www.ubnt.com/;
-    description = "Controller for Ubiquiti UniFi accesspoints";
-    license = licenses.unfree;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
+  unifiTesting = generic {
+    version = "5.8.14";
+    suffix  = "-7ef9535d1b";
+    sha256  = "09gr7zkck6npjhhmd27c9ymyna6anwj3w9v9zjicz9skbrddkccq";
   };
 }

--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -44,8 +44,8 @@ in rec {
   # https://help.ubnt.com/hc/en-us/articles/115000441548-UniFi-Current-Controller-Versions
 
   unifiLTS = generic {
-    version = "5.6.36";
-    sha256  = "075q7vm56fdsjwh72y2cb1pirl2pxdkvqnhvd3bf1c2n64mvp6bi";
+    version = "5.6.37";
+    sha256  = "0kiksqsbmmfva1blbpg2wl4c3w7j6dzzqmwp6028g7bh303c47qa";
   };
 
   unifiStable = generic {

--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -49,8 +49,8 @@ in rec {
   };
 
   unifiStable = generic {
-    version = "5.7.20";
-    sha256  = "1ylj4i5mcv6z9n32275ccdf1rqk74zilqsih3r6xzhm30pxrd8dd";
+    version = "5.7.23";
+    sha256  = "14jkhp9jl341zsyk5adh3g98mhqwfbd42c7wahzc31bxq8a0idp7";
   };
 
   unifiTesting = generic {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12912,8 +12912,11 @@ with pkgs;
 
   axis2 = callPackage ../servers/http/tomcat/axis2 { };
 
-  unifi = callPackage ../servers/unifi { };
-  unifiLTS = callPackage ../servers/unifi { useLTS=true; };
+  inherit (callPackages ../servers/unifi { })
+    unifiLTS
+    unifiStable
+    unifiTesting;
+  unifi = unifiStable;
 
   virtuoso6 = callPackage ../servers/sql/virtuoso/6.x.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Regular package updates as well as making the test version available.

The suffix for the testing download can be obtained after signing up for their beta program. I haven't tried this package admittedly.

Cc: @badi @wkennington 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

