### PR TITLE
ocaml: default to 4.06 on aarch64 (since 4.05 is broken there)

### DIFF
--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1046,5 +1046,10 @@ in rec
 
   ocamlPackages_latest = ocamlPackages_4_06;
 
-  ocamlPackages = ocamlPackages_4_05;
+  ocamlPackages =
+    # OCaml 4.05 is broken on aarch64
+    if system == "aarch64-linux" then
+      ocamlPackages_4_06
+    else
+      ocamlPackages_4_05;
 }


### PR DESCRIPTION
OCaml 4.05 (the current default in `nixpkgs`) is broken on aarch64. I don’t know how to fix it. Also, `nixpkgs` is not ready to have OCaml 4.06 as a default. Hence this workaround.
