### PR TITLE
nixos/osquery: add test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -307,6 +307,7 @@ in rec {
   tests.influxdb = callTest tests/influxdb.nix {};
   tests.ipv6 = callTest tests/ipv6.nix {};
   tests.jenkins = callTest tests/jenkins.nix {};
+  tests.osquery = callTest tests/osquery.nix {};
   tests.plasma5 = callTest tests/plasma5.nix {};
   tests.plotinus = callTest tests/plotinus.nix {};
   tests.keymap = callSubTests tests/keymap.nix {};

--- a/nixos/tests/osquery.nix
+++ b/nixos/tests/osquery.nix
@@ -1,0 +1,28 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+
+with lib;
+
+{
+  name = "osquery";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ ma27 ];
+  };
+
+  machine = {
+    services.osquery.enable = true;
+    services.osquery.loggerPath = "/var/log/osquery/logs";
+    services.osquery.pidfile = "/var/run/osqueryd.pid";
+  };
+
+  testScript = ''
+    $machine->start;
+    $machine->waitForUnit("osqueryd.service");
+
+    $machine->succeed("echo 'SELECT address FROM etc_hosts LIMIT 1;' | osqueryi | grep '127.0.0.1'");
+    $machine->succeed(
+      "echo 'SELECT value FROM osquery_flags WHERE name = \"logger_path\";' | osqueryi | grep /var/log/osquery/logs"
+    );
+
+    $machine->succeed("echo 'SELECT value FROM osquery_flags WHERE name = \"pidfile\";' | osqueryi | grep /var/run/osqueryd.pid");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

Some time ago I fixed the broken package `osquery` (see #39336).
I had to test the package manually by starting the daemon locally,
however this doesn't ensure that the module is still functional.

In order to cover the package *and* the integration with the NixOS
module I thought that adding a testcase might be the best idea.

The current testcase does the following things:

* Starts an `osqueryd` service in a test machine with customized logger
  path and PID file

* Ensures that the `osqueryd.service` unit is running

* Checks if the customized flags (`pidfile`, `logger_path`) are applied
  to `osquery`.

* Performs a simple test query against the `etc_hosts` database to check
  if the basic funcitonality of `osquery` (storing system information into
  a database) works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

