### PR TITLE
pcsc-scm-scl011: clean up unpack phase

### DIFF
--- a/pkgs/tools/security/pcsc-scm-scl011/default.nix
+++ b/pkgs/tools/security/pcsc-scm-scl011/default.nix
@@ -17,10 +17,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ unzip ];
 
   unpackPhase = ''
-    echo ${stdenv.system}
     unzip $src
     tar xf "Linux Driver Ver${version}/sclgeneric_${version}_linux_${arch}bit.tar.gz"
-    cd sclgeneric_${version}_linux_${arch}bit; export sourceRoot=`pwd`
+    export sourceRoot=$(readlink -e sclgeneric_${version}_linux_${arch}bit)
   '';
 
   # Add support for SCL011 nPA (subsidized model for German eID)


### PR DESCRIPTION
###### Motivation for this change

Just some minor fixes in the unpack phase I've only seen after the pull request has already been accepted…

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

