### PR TITLE
open-ecard: init at 1.2.4

### DIFF
--- a/pkgs/tools/security/open-ecard/default.nix
+++ b/pkgs/tools/security/open-ecard/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchurl, jre, pcsclite, makeDesktopItem, makeWrapper }:
+
+let
+  version = "1.2.4";
+
+  srcs = {
+    richclient = fetchurl {
+      url = "https://jnlp.openecard.org/richclient-${version}-20171212-0958.jar";
+      sha256 = "1ckhyhszp4zhfb5mn67lz603b55z814jh0sz0q5hriqzx017j7nr";
+    };
+    cifs = fetchurl {
+      url = "https://jnlp.openecard.org/cifs-${version}-20171212-0958.jar";
+      sha256 = "0rc862lx3y6sw87r1v5xjmqqpysyr1x6yqhycqmcdrwz0j3wykrr";
+    };
+    logo = fetchurl {
+      url = https://raw.githubusercontent.com/ecsec/open-ecard/1.2.3/gui/graphics/src/main/ext/oec_logo_bg-transparent.svg;
+      sha256 = "0rpmyv10vjx2yfpm03mqliygcww8af2wnrnrppmsazdplksaxkhs";
+    };
+  };
+in stdenv.mkDerivation rec {
+  appName = "open-ecard";
+  name = "${appName}-${version}";
+
+  src = srcs.richclient;
+
+  phases = "installPhase";
+
+  buildInputs = [ makeWrapper ];
+
+  desktopItem = makeDesktopItem {
+    name = appName;
+    desktopName = "Open eCard App";
+    genericName = "eCard App";
+    comment = "Client side implementation of the eCard-API-Framework";
+    icon = "oec_logo_bg-transparent.svg";
+    exec = appName;
+    categories = "Utility;Security;";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/java
+    cp ${srcs.richclient} $out/share/java/richclient-${version}.jar
+    cp ${srcs.cifs} $out/share/java/cifs-${version}.jar
+
+    mkdir -p $out/share/applications $out/share/pixmaps
+    cp $desktopItem/share/applications/* $out/share/applications
+    cp ${srcs.logo} $out/share/pixmaps/oec_logo_bg-transparent.svg
+
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/${appName} \
+      --add-flags "-cp $out/share/java/cifs-${version}.jar" \
+      --add-flags "-jar $out/share/java/richclient-${version}.jar" \
+      --suffix LD_LIBRARY_PATH ':' ${pcsclite}/lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Client side implementation of the eCard-API-Framework (BSI
+      TR-03112) and related international standards, such as ISO/IEC 24727";
+    homepage = https://www.openecard.org/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ sephalon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4076,6 +4076,8 @@ with pkgs;
 
   opendylan_bin = callPackage ../development/compilers/opendylan/bin.nix { };
 
+  open-ecard = callPackage ../tools/security/open-ecard { };
+
   openjade = callPackage ../tools/text/sgml/openjade { };
 
   openmvg = callPackage ../applications/science/misc/openmvg { };


### PR DESCRIPTION
###### Things done

I've tested this with the `scm-scl011` PC/SC driver and a German eID card.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

