### PR TITLE
nixos-container: support restarts

### DIFF
--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -242,9 +242,19 @@ sub terminateContainer {
     while ( kill 0, $leader ) { Time::HiRes::sleep(0.1) }
 }
 
+sub startContainer {
+    system("systemctl", "start", "container\@$containerName") == 0
+        or die "$0: failed to start container\n";
+}
+
 sub stopContainer {
     system("systemctl", "stop", "container\@$containerName") == 0
         or die "$0: failed to stop container\n";
+}
+
+sub restartContainer {
+    stopContainer;
+    startContainer;
 }
 
 # Run a command in the container.
@@ -285,9 +295,12 @@ if ($action eq "destroy") {
     unlink($confFile) or die;
 }
 
+elsif ($action eq "restart") {
+    restartContainer;
+}
+
 elsif ($action eq "start") {
-    system("systemctl", "start", "container\@$containerName") == 0
-        or die "$0: failed to start container\n";
+    startContainer;
 }
 
 elsif ($action eq "stop") {


### PR DESCRIPTION
###### Motivation for this change

I wanted to be able to restart a container.

Running the nixos/tests/container* tests doesn't complete as containers-restart_networking.nix fails but it also fails without this change.

Cc @globin @nh2 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

