### PR TITLE
psstop: init at 1.3

### DIFF
--- a/pkgs/tools/system/psstop/default.nix
+++ b/pkgs/tools/system/psstop/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib }:
+
+stdenv.mkDerivation rec {
+  name = "psstop-${version}";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "clearlinux";
+    repo = "psstop";
+    rev = "v${version}";
+    sha256 = "03ir3jjpzm7q8n1qc5jr99hqarr9r529w1zb6f7q4wak2vfj7w9h";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ glib ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/clearlinux/psstop;
+    description = "Show processes' memory usage by looking into pss"; # upstream summary
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1358,6 +1358,8 @@ with pkgs;
 
   ps_mem = callPackage ../tools/system/ps_mem { };
 
+  psstop = callPackage ../tools/system/psstop { };
+
   parallel-rust = callPackage ../tools/misc/parallel-rust { };
 
   socklog = callPackage ../tools/system/socklog { };


### PR DESCRIPTION
Utility for reporting PSS of processes.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---