### PR TITLE
bat: init at 0.2.0

### DIFF
--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, pkgs, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  name    = "bat-${version}";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner  = "sharkdp";
+    repo   = "bat";
+    rev    = "v${version}";
+    sha256 = "0qbjkrakcpvnzzljifykw88g0qmmk60id23sjvhp4md54h4xg29p";
+  };
+
+  cargoSha256 = "07r10wwxv8svrw94djl092zj512868izlxldsiljfj34230abl02";
+
+  buildInputs = with pkgs; [ openssl pkgconfig cmake zlib file perl curl ];
+
+  meta = with stdenv.lib; {
+    description = "A cat(1) clone with syntax highlighting and Git integration";
+    homepage    = https://github.com/sharkdp/bat;
+    license     = licenses.mit;
+    maintainers = [];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -785,6 +785,8 @@ with pkgs;
 
   bashmount = callPackage ../tools/filesystems/bashmount {};
 
+  bat = callPackage ../tools/misc/bat { };
+
   bc = callPackage ../tools/misc/bc { };
 
   bdf2psf = callPackage ../tools/misc/bdf2psf { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

