### PR TITLE
facette: init at 0.4.0

### DIFF
--- a/pkgs/servers/monitoring/facette/default.nix
+++ b/pkgs/servers/monitoring/facette/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub
+, go, pkgconfig, nodejs, nodePackages, pandoc, rrdtool }:
+
+stdenv.mkDerivation rec {
+  name = "facette-${version}";
+  version = "0.4.0";
+  src = fetchFromGitHub {
+    owner = "facette";
+    repo = "facette";
+    rev = "${version}";
+    sha256 = "1m7krq439qlf7b4l4bfjw0xfvjgj67w59mh8rf7c398rky04p257";
+  };
+  nativeBuildInputs = [ go pkgconfig nodejs nodePackages.npm pandoc ];
+  buildInputs = [ rrdtool ];
+  preBuild = ''
+    export HOME="$NIX_BUILD_ROOT" # npm needs a writable home
+  '';
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Time series data visualization software";
+    longDescription = ''
+      Facette is a web application to display time series data from various
+      sources — such as collectd, Graphite, InfluxDB or KairosDB — on graphs.
+    '';
+    homepage = https://facette.io/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12375,6 +12375,8 @@ with pkgs;
 
   exim = callPackage ../servers/mail/exim { };
 
+  facette = callPackage ../servers/monitoring/facette { };
+
   fcgiwrap = callPackage ../servers/fcgiwrap { };
 
   felix = callPackage ../servers/felix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: The makefile downloads the go dependencies at build time, so this package isn't buildable without an internet connection. Is this ok or do I have to make a workaround?

~~meta attribute coming in two minutes~~ done