### PR TITLE
nixos/dnsdist: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -466,6 +466,7 @@
   ./services/networking/dnschain.nix
   ./services/networking/dnscrypt-proxy.nix
   ./services/networking/dnscrypt-wrapper.nix
+  ./services/networking/dnsdist.nix
   ./services/networking/dnsmasq.nix
   ./services/networking/ejabberd.nix
   ./services/networking/fakeroute.nix

--- a/nixos/modules/services/networking/dnsdist.nix
+++ b/nixos/modules/services/networking/dnsdist.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dnsdist;
+  configFile = pkgs.writeText "dnsdist.conf" "${cfg.config}";
+in {
+  options = {
+    services.dnsdist = {
+      enable = mkEnableOption "dnsdist DNS loadbalancer";
+
+      config = mkOption {
+        default = "";
+        example = ''
+          newServer({address="2001:4860:4860::8888", qps=1})
+          newServer({address="2001:4860:4860::8844", qps=1})
+          newServer({address="2620:0:ccc::2", qps=10})
+          newServer({address="2620:0:ccd::2", name="dns1", qps=10})
+          newServer("192.168.1.2")
+          setServerPolicy(firstAvailable) -- first server within its QPS limit
+        '';
+        type = types.lines;
+        description = "Verbatim dnsdist configuration to use";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.config != "";
+      message = "You must provide services.dnsdist.config.";
+    }];
+
+    systemd.services.dnsdist = {
+      description = "DNS Loadbalancer";
+      unitConfig.Documentation = "man:dnsdist(1) http://dnsdist.org";
+      wantedBy = [ "multi-user.target" ];
+      after = ["network.target" ];
+
+      serviceConfig = {
+        Type = "notify";
+        Restart = "on-failure";
+        RestartSec = 2;
+        TimeoutStopSec = 5;
+        StartLimitInterval = 0;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID";
+        NoNewPrivileges = true;
+        ExecStartPre = "${pkgs.dnsdist}/bin/dnsdist --uid=${toString config.ids.uids.nobody} --gid=${toString config.ids.gids.nogroup} --config=${configFile} --check-config";
+        # Note: when editing the ExecStart command, keep --supervised and --disable-syslog
+        ExecStart = "${pkgs.dnsdist}/bin/dnsdist --supervised --disable-syslog --uid=${toString config.ids.uids.nobody} --gid=${toString config.ids.gids.nogroup} --config=${configFile}";
+        ProtectSystem = "full";
+        ProtectHome = true;
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+        LimitNOFILE = 16384;
+        TasksMax = 8192;
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

There is no module for dnsdist

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

