### PR TITLE
treewide: platforms.gnu -> gnu ++ linux, allow using musl

### DIFF
--- a/pkgs/applications/audio/mpc123/default.nix
+++ b/pkgs/applications/audio/mpc123/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu; # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux; # arbitrary choice
   };
 }

--- a/pkgs/applications/audio/mpg321/default.nix
+++ b/pkgs/applications/audio/mpg321/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     homepage = http://mpg321.sourceforge.net/;
     license = licenses.gpl2;
     maintainers = [ maintainers.rycee ];
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/applications/editors/emacs-modes/calfw/default.nix
+++ b/pkgs/applications/editors/emacs-modes/calfw/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = with stdenv.lib.maintainers; [ chaoflow ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/editors/emacs-modes/jdee/default.nix
+++ b/pkgs/applications/editors/emacs-modes/jdee/default.nix
@@ -92,7 +92,7 @@ in
       license = stdenv.lib.licenses.gpl2Plus;
 
       maintainers = [ ];
-      platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+      platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
 
       broken = true;
     };

--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation {
 
   meta = common.meta // {
     maintainers = [ stdenv.lib.maintainers.roconnor ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -49,6 +49,6 @@ stdenv.mkDerivation rec {
     homepage = http://geeqie.sourceforge.net;
 
     maintainers = with maintainers; [ jfrankenau pSub ];
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -196,7 +196,7 @@ rec {
 
       license = stdenv.lib.licenses.gpl3Plus;
       maintainers = [ ];
-      platforms = stdenv.lib.platforms.gnu;
+      platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
     };
   };
 

--- a/pkgs/applications/graphics/ocrad/default.nix
+++ b/pkgs/applications/graphics/ocrad/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
 
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ pSub ];
-    platforms = platforms.gnu;  # arbitrary choice
+    platforms = platforms.gnu ++ platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/applications/graphics/panotools/default.nix
+++ b/pkgs/applications/graphics/panotools/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description = "Free software suite for authoring and displaying virtual reality panoramas";
     license = stdenv.lib.licenses.gpl2Plus;
 
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/applications/graphics/qtpfsgui/default.nix
+++ b/pkgs/applications/graphics/qtpfsgui/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/scantailor/advanced.nix
+++ b/pkgs/applications/graphics/scantailor/advanced.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     description = "Interactive post-processing tool for scanned pages";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jfrankenau ];
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/scantailor/default.nix
+++ b/pkgs/applications/graphics/scantailor/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/ufraw/default.nix
+++ b/pkgs/applications/graphics/ufraw/default.nix
@@ -49,6 +49,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;  # needs GTK+
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # needs GTK+
   };
 }

--- a/pkgs/applications/graphics/viewnior/default.nix
+++ b/pkgs/applications/graphics/viewnior/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
 
     maintainers = [ stdenv.lib.maintainers.smironov ];
 
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/xfig/default.nix
+++ b/pkgs/applications/graphics/xfig/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation {
   meta = {
     description = "An interactive drawing tool for X11";
     homepage = http://xfig.org;
-    platforms = stdenv.lib.platforms.gnu;         # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;         # arbitrary choice
   };
 }

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
 
     maintainers = with maintainers; [ wkennington pSub ];
-    platforms = platforms.gnu;  # arbitrary choice
+    platforms = platforms.gnu ++ platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     homepage = https://telepathy.freedesktop.org/components/telepathy-gabble/;
     description = "Jabber/XMPP connection manager for the Telepathy framework";
     license = licenses.lgpl21Plus;
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/telepathy/haze/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/haze/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A Telepathy connection manager based on libpurple";
-    platforms = stdenv.lib.platforms.gnu; # Random choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux; # Random choice
   };
 }

--- a/pkgs/applications/networking/instant-messengers/telepathy/idle/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/idle/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "IRC connection manager for the Telepathy framework";
     license = stdenv.lib.licenses.lgpl21;
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = https://telepathy.freedesktop.org/components/telepathy-logger/;
     license = licenses.lgpl21;
     maintainers = with maintainers; [ jtojnar ];
-    platforms = platforms.gnu; # Arbitrary choice
+    platforms = platforms.gnu ++ platforms.linux; # Arbitrary choice
   };
 }

--- a/pkgs/applications/networking/instant-messengers/telepathy/salut/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/salut/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Link-local XMPP connection manager for Telepathy";
-    platforms = platforms.gnu; # Random choice
+    platforms = platforms.gnu ++ platforms.linux; # Random choice
     maintainers = [ maintainers.lethalman ];
   };
 }

--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -73,6 +73,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
 
     maintainers = with maintainers; [ viric vrthra ];
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/applications/networking/p2p/gnunet/git.nix
+++ b/pkgs/applications/networking/p2p/gnunet/git.nix
@@ -87,6 +87,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
 
     maintainers = with stdenv.lib.maintainers; [ viric ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/networking/p2p/gnunet/svn.nix
+++ b/pkgs/applications/networking/p2p/gnunet/svn.nix
@@ -88,6 +88,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
 
     maintainers = with stdenv.lib.maintainers; [ viric ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -113,6 +113,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnucash.org/;
 
     maintainers = [ stdenv.lib.maintainers.peti stdenv.lib.maintainers.domenkozar ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -80,6 +80,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnucash.org/;
 
     maintainers = [ stdenv.lib.maintainers.peti stdenv.lib.maintainers.domenkozar ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/science/machine-learning/torch/torch-distro.nix
+++ b/pkgs/applications/science/machine-learning/torch/torch-distro.nix
@@ -9,7 +9,7 @@ let
     homepage = http://torch.ch;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ smironov ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 
   distro_src = src;

--- a/pkgs/applications/science/misc/megam/default.nix
+++ b/pkgs/applications/science/misc/megam/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     license = "non-commercial";
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/applications/science/misc/tulip/default.nix
+++ b/pkgs/applications/science/misc/tulip/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/applications/video/qstopmotion/default.nix
+++ b/pkgs/applications/video/qstopmotion/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ maintainers.leenaars ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome-3/core/folks/default.nix
+++ b/pkgs/desktops/gnome-3/core/folks/default.nix
@@ -45,6 +45,6 @@ in stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.lgpl2Plus;
 
     maintainers = gnome3.maintainers;
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/development/compilers/gprolog/default.nix
+++ b/pkgs/development/compilers/gprolog/default.nix
@@ -63,6 +63,6 @@ stdenv.mkDerivation rec {
     '';
 
     maintainers = [ stdenv.lib.maintainers.peti ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -87,6 +87,6 @@ stdenv.mkDerivation {
 
     # Build fails on Cygwin and Darwin:
     # <http://article.gmane.org/gmane.lisp.scheme.mit-scheme.devel/489>.
-    platforms = platforms.gnu ++ platforms.freebsd;
+    platforms = platforms.gnu ++ platforms.linux ++ platforms.freebsd;
   };
 }

--- a/pkgs/development/guile-modules/guile-lib/default.nix
+++ b/pkgs/development/guile-modules/guile-lib/default.nix
@@ -40,6 +40,6 @@ in stdenv.mkDerivation {
     homepage = "http://www.nongnu.org/guile-lib/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ vyp ];
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/development/guile-modules/guile-ncurses/default.nix
+++ b/pkgs/development/guile-modules/guile-ncurses/default.nix
@@ -39,6 +39,6 @@ in stdenv.mkDerivation {
     homepage = "https://www.gnu.org/software/guile-ncurses/";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ vyp ];
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/development/libraries/clutter-gst/default.nix
+++ b/pkgs/development/libraries/clutter-gst/default.nix
@@ -30,6 +30,6 @@ in stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.lgpl2Plus;
 
     maintainers = with stdenv.lib.maintainers; [ lethalman ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/development/libraries/clutter-gtk/default.nix
+++ b/pkgs/development/libraries/clutter-gtk/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.clutter-project.org/;
     license = stdenv.lib.licenses.lgpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ lethalman ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/development/libraries/libcanberra/default.nix
+++ b/pkgs/development/libraries/libcanberra/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.lgpl2Plus;
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/development/libraries/libchamplain/default.nix
+++ b/pkgs/development/libraries/libchamplain/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     '';
 
      maintainers = gnome3.maintainers;
-     platforms = platforms.gnu;  # arbitrary choice
+     platforms = platforms.gnu ++ platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/development/libraries/libchop/default.nix
+++ b/pkgs/development/libraries/libchop/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = http://nongnu.org/libchop/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ viric ];
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
     homepage = http://gtkpod.sourceforge.net/;
     description = "Library used by gtkpod to access the contents of an ipod";
     license = "LGPL";
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libxmi/default.nix
+++ b/pkgs/development/libraries/libxmi/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     description = "Library for rasterizing 2-D vector graphics";
     homepage = http://www.gnu.org/software/libxmi/;
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
     maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/tokyo-tyrant/default.nix
+++ b/pkgs/development/libraries/tokyo-tyrant/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.lgpl21Plus;
 
-    platforms = stdenv.lib.platforms.gnu;         # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;         # arbitrary choice
     maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/vcdimager/default.nix
+++ b/pkgs/development/libraries/vcdimager/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = http://www.gnu.org/software/vcdimager/;
     description = "Full-featured mastering suite for authoring, disassembling and analyzing Video CDs and Super Video CDs";
-    platforms = platforms.gnu; # random choice
+    platforms = platforms.gnu ++ platforms.linux; # random choice
     license = licenses.gpl2;
   };
 }

--- a/pkgs/development/tools/misc/complexity/default.nix
+++ b/pkgs/development/tools/misc/complexity/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
     homepage = http://www.gnu.org/software/complexity/;
 
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
     maintainers = [ ];
   };
 }

--- a/pkgs/os-specific/gnu/mig/default.nix
+++ b/pkgs/os-specific/gnu/mig/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
 
     homepage = http://www.gnu.org/software/hurd/microkernel/mach/mig/gnu_mig.html;
 
-    # platforms = stdenv.lib.platforms.gnu;  # really GNU/Hurd
+    # platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # really GNU/Hurd
     maintainers = [ stdenv.lib.maintainers.ludo ];
   };
 }

--- a/pkgs/servers/http/myserver/default.nix
+++ b/pkgs/servers/http/myserver/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
 
     # libevent fails to build on Cygwin and Guile has troubles on Darwin.
-    platforms = lib.platforms.gnu;
+    platforms = lib.platforms.gnu ++ lib.platforms.linux;
 
     broken = true; # needs patch for gets()
   };

--- a/pkgs/servers/pies/default.nix
+++ b/pkgs/servers/pies/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
     homepage = http://www.gnu.org/software/pies/;
 
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
     maintainers = [ ];
   };
 }

--- a/pkgs/tools/X11/xnee/default.nix
+++ b/pkgs/tools/X11/xnee/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnu.org/software/xnee/;
 
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/tools/filesystems/mtools/default.nix
+++ b/pkgs/tools/filesystems/mtools/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.gnu.org/software/mtools/;
     description = "Utilities to access MS-DOS disks";
-    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.darwin;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ ];
   };
 }

--- a/pkgs/tools/graphics/logstalgia/default.nix
+++ b/pkgs/tools/graphics/logstalgia/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       a Miscellaneous section.
     '';
 
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
     maintainers = with maintainers; [ pSub ];
   };
 }

--- a/pkgs/tools/misc/grub/pvgrub_image/default.nix
+++ b/pkgs/tools/misc/grub/pvgrub_image/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
          Xen guests
       '';
 
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 })

--- a/pkgs/tools/misc/grub/trusted.nix
+++ b/pkgs/tools/misc/grub/trusted.nix
@@ -98,6 +98,6 @@ stdenv.mkDerivation rec {
     description = "GRUB 2.0 extended with TCG (TPM) support for integrity measured boot process (trusted boot)";
     homepage = https://github.com/Sirrix-AG/TrustedGRUB2;
     license = licenses.gpl3Plus;
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/tools/misc/picocom/default.nix
+++ b/pkgs/tools/misc/picocom/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     description = "Minimal dumb-terminal emulation program";
     homepage = https://github.com/npat-efault/picocom/;
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/tools/misc/urjtag/default.nix
+++ b/pkgs/tools/misc/urjtag/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Enhanced, modern tool for communicating over JTAG with flash chips, CPUs,and many more";
     homepage = http://urjtag.org/;
     license = with stdenv.lib.licenses; [ gpl2Plus lgpl21Plus ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
     maintainers = with stdenv.lib.maintainers; [ lowfatcomputing ];
   };
 }

--- a/pkgs/tools/networking/connect/default.nix
+++ b/pkgs/tools/networking/connect/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       '';
     homepage = https://bitbucket.org/gotoh/connect/wiki/Home;
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ jcumming ];
   };
 }

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -116,6 +116,6 @@ in stdenv.mkDerivation rec {
     homepage = http://www.gnu.org/software/mailutils/;
 
     # Some of the dependencies fail to build on {cyg,dar}win.
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/tools/networking/p2p/amule/default.nix
+++ b/pkgs/tools/networking/p2p/amule/default.nix
@@ -65,7 +65,7 @@ mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl2Plus;
 
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
     maintainers = [ stdenv.lib.maintainers.phreedom ];
   };
 }

--- a/pkgs/tools/networking/p2p/seeks/default.nix
+++ b/pkgs/tools/networking/p2p/seeks/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
     maintainers = [
       stdenv.lib.maintainers.matejc
     ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
     broken = true; # 2018-04-11
   };
 }

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -89,6 +89,6 @@ pythonPackages.buildPythonApplication rec {
     homepage = http://tahoe-lafs.org/;
     license = [ lib.licenses.gpl2Plus /* or */ "TGPPLv1+" ];
     maintainers = with lib.maintainers; [ MostAwesomeDude ];
-    platforms = lib.platforms.gnu;  # arbitrary choice
+    platforms = lib.platforms.gnu ++ lib.platforms.linux;
   };
 }

--- a/pkgs/tools/networking/telnet/default.nix
+++ b/pkgs/tools/networking/telnet/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation {
     description = "A client and daemon for the Telnet protocol";
     homepage = ftp://ftp.suse.com/pub/people/kukuk/ipv6/;
     license = "BSD";
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/security/gnupg/1.nix
+++ b/pkgs/tools/security/gnupg/1.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
       other applications.  A wealth of frontend applications and libraries are
       available.
     '';
-    platforms = platforms.gnu; # arbitrary choice
+    platforms = platforms.gnu ++ platforms.linux; # arbitrary choice
   };
 }

--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -32,7 +32,7 @@ pythonPackages.buildPythonApplication {
 
     license = stdenv.lib.licenses.gpl2;
 
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu kierdavis ];
   };
 }

--- a/pkgs/tools/system/freeipmi/default.nix
+++ b/pkgs/tools/system/freeipmi/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = with stdenv.lib.maintainers; [ raskin ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
 
     updateWalker = true;
     inherit version;

--- a/pkgs/tools/text/namazu/default.nix
+++ b/pkgs/tools/text/namazu/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
     homepage = http://namazu.org/;
 
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
     maintainers = [ ];
     broken = true; # File-MMagic is not compatible with our Perl version
   };

--- a/pkgs/tools/text/numdiff/default.nix
+++ b/pkgs/tools/text/numdiff/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.nongnu.org/numdiff/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ndowens ];
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }

--- a/pkgs/tools/video/dvgrab/default.nix
+++ b/pkgs/tools/video/dvgrab/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     homepage = http://kinodv.org/;
 
     license = licenses.gpl2Plus;
-    platforms = platforms.gnu;
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }


### PR DESCRIPTION
Many packages have use `platforms.gnu` as an "arbitrary choice",
others perhaps because at some point this indicated more
than building w/Linux.

Whatever the reason, for most (nearly all) packages
`platforms.gnu` is overly pessimistic and in particular
effectively means "all Linux triples that don't use musl".

This PR extends these to include all linux platforms,
while keeping `platforms.gnu` in case we ever support
non-Linux gnu platforms again.

No rebuilds should be required.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---