### PR TITLE
xmlformat: init at 1.04

### DIFF
--- a/pkgs/tools/text/xml/xmlformat/default.nix
+++ b/pkgs/tools/text/xml/xmlformat/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, perl }:
+stdenv.mkDerivation rec {
+  name = "xmlformat-${version}";
+  version = "1.04";
+
+  src = fetchurl {
+    url = "http://www.kitebird.com/software/xmlformat/xmlformat-${version}.tar.gz";
+    sha256 = "1vwgzn4ha0az7dx0cyc6dx5nywwrx9gxhyh08mvdcq27wjbh79vi";
+  };
+
+  buildInputs = [ perl ];
+  buildPhase = ''
+    patchShebangs ./xmlformat.pl
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./xmlformat.pl $out/bin/xmlformat
+    cp ./LICENSE $out/
+  '';
+
+  meta = {
+    description = "a configurable formatter (or 'pretty-printer') for XML documents";
+    homepage = "http://www.kitebird.com/software/xmlformat/";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5736,6 +5736,8 @@ with pkgs;
 
   xml2 = callPackage ../tools/text/xml/xml2 { };
 
+  xmlformat = callPackage ../tools/text/xml/xmlformat { };
+
   xmlroff = callPackage ../tools/typesetting/xmlroff { };
 
   xmloscopy = callPackage ../tools/text/xml/xmloscopy { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

