### PR TITLE
nixpkgs doc: add format Make target

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,11 +1,16 @@
 MD_TARGETS=$(addsuffix .xml, $(basename $(wildcard ./*.md ./**/*.md)))
 
 .PHONY: all
-all: validate out/html/index.html out/epub/manual.epub
+all: validate format out/html/index.html out/epub/manual.epub
 
 .PHONY: debug
 debug:
 	nix-shell --run "xmloscopy --docbook5 ./manual.xml ./manual-full.xml"
+
+.PHONY: format
+format:
+	find . -iname '*.xml' -type f -print0 | xargs -0 -I{} -n1 \
+		xmlformat --config-file "$$XMLFORMAT_CONFIG" -i {}
 
 .PHONY: clean
 clean:

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -7,7 +7,7 @@ in
 pkgs.stdenv.mkDerivation {
   name = "nixpkgs-manual";
 
-  buildInputs = with pkgs; [ pandoc libxml2 libxslt zip jing ];
+  buildInputs = with pkgs; [ pandoc libxml2 libxslt zip jing  xmlformat ];
 
   src = ./.;
 
@@ -18,6 +18,7 @@ pkgs.stdenv.mkDerivation {
   HIGHLIGHTJS = pkgs.documentation-highlighter;
   XSL = "${pkgs.docbook5_xsl}/xml/xsl";
   RNG = "${pkgs.docbook5}/xml/rng/docbook/docbook.rng";
+  XMLFORMAT_CONFIG = ../nixos/doc/xmlformat.conf;
   xsltFlags = lib.concatStringsSep " " [
     "--param section.autolabel 1"
     "--param section.label.includes.component.label 1"

--- a/doc/shell.nix
+++ b/doc/shell.nix
@@ -1,4 +1,5 @@
 { pkgs ? import ../. {} }:
 (import ./default.nix).overrideAttrs (x: {
   buildInputs = x.buildInputs ++ [ pkgs.xmloscopy ];
+
 })

--- a/nixos/doc/manual/Makefile
+++ b/nixos/doc/manual/Makefile
@@ -1,6 +1,22 @@
-debug:
+.PHONY: all
+all: manual-combined.xml format
+
+.PHONY: debug
+debug: generated manual-combined.xml
+
+manual-combined.xml: generated *.xml
+	rm ./manual-combined.xml
 	nix-shell --packages xmloscopy \
-		--run 'xmloscopy --docbook5 ./manual.xml ./manual-combined.xml'
+		--run "xmloscopy --docbook5 ./manual.xml ./manual-combined.xml"
+
+.PHONY: format
+format:
+	find . -iname '*.xml' -type f -print0 | xargs -0 -I{} -n1 \
+		xmlformat --config-file "../xmlformat.conf" -i {}
+
+.PHONY: clean
+clean:
+	rm -f manual-combined.xml generated
 
 generated: ./options-to-docbook.xsl
 	nix-build ../../release.nix \

--- a/nixos/doc/manual/shell.nix
+++ b/nixos/doc/manual/shell.nix
@@ -1,0 +1,8 @@
+let
+  pkgs = import ../../.. { };
+in
+pkgs.mkShell {
+  name = "nixos-manual";
+
+  buildInputs = with pkgs; [ xmlformat jing xmloscopy ];
+}

--- a/nixos/doc/xmlformat.conf
+++ b/nixos/doc/xmlformat.conf
@@ -1,0 +1,72 @@
+#
+# DocBook Configuration file for "xmlformat"
+# see http://www.kitebird.com/software/xmlformat/
+# 10 Sept. 2004
+#
+
+# Only block elements
+ackno address appendix article biblioentry bibliography bibliomixed \
+biblioset blockquote book bridgehead callout calloutlist caption caution \
+chapter chapterinfo classsynopsis cmdsynopsis colophon constraintdef \
+constructorsynopsis dedication destructorsynopsis entry epigraph equation example \
+figure formalpara funcsynopsis glossary glossdef glossdiv glossentry glosslist \
+glosssee glossseealso graphic graphicco highlights imageobjectco important \
+index indexdiv indexentry indexinfo info informalequation informalexample \
+informalfigure informaltable legalnotice literallayout lot lotentry mediaobject \
+mediaobjectco msgmain msgset note orderedlist para part preface primaryie \
+procedure qandadiv qandaentry qandaset refentry refentrytitle reference \
+refnamediv refsect1 refsect2 refsect3 refsection revhistory screenshot sect1 \
+sect2 sect3 sect4 sect5 section seglistitem set setindex sidebar simpara \
+simplesect step substeps synopfragment synopsis table term title \
+toc variablelist varlistentry warning itemizedlist listitem \
+footnote colspec partintro row simplelist subtitle tbody tgroup thead tip
+  format      block
+  normalize   no
+
+
+#appendix bibliography chapter glossary preface reference
+#  element-break   3
+
+sect1 section
+  element-break   2
+
+
+#
+para abstract
+  format       block
+  entry-break  1
+  exit-break   1
+  normalize    yes
+  wrap-length  79
+
+title
+  format       block
+  normalize = yes
+  entry-break = 0
+  exit-break = 0
+
+# Inline elements
+abbrev accel acronym action application citation citebiblioid citerefentry citetitle \
+classname co code command computeroutput constant country database date email emphasis \
+envar errorcode errorname errortext errortype exceptionname fax filename \
+firstname firstterm footnoteref foreignphrase funcdef funcparams function \
+glossterm group guibutton guiicon guilabel guimenu guimenuitem guisubmenu \
+hardware holder honorific indexterm inlineequation inlinegraphic inlinemediaobject \
+interface interfacename \
+keycap keycode keycombo keysym lineage link literal manvolnum markup medialabel \
+menuchoice methodname methodparam modifier mousebutton olink ooclass ooexception \
+oointerface option optional otheraddr othername package paramdef parameter personname \
+phrase pob postcode productname prompt property quote refpurpose replaceable \
+returnvalue revnumber sgmltag state street structfield structname subscript \
+superscript surname symbol systemitem token trademark type ulink userinput \
+uri varargs varname void wordasword xref year mathphrase member tag
+  format       inline
+
+programlisting screen
+  format       verbatim
+  entry-break = 0
+  exit-break = 0
+
+
+#term
+#  format       inline


### PR DESCRIPTION
###### Motivation for this change

Now, running `make` from within the `nix-shell` will auto-format the Nixpkgs docs.

See https://github.com/NixOS/nixpkgs/pull/39700 for the results. When this merges, I'll run the makefile and commit the results. Until then, it isn't worth doing.