### PR TITLE
WIP fwupd: 1.0.5 -> 1.1.0

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -71,6 +71,13 @@ in {
           BlacklistPlugins=${lib.concatStringsSep ";" cfg.blacklistPlugins}
         '';
       };
+      "fwupd/uefi.conf" = {
+        source = pkgs.writeText "uefi.conf" ''
+          [uefi]
+          OverrideESPMountPoint=${config.boot.loader.efi.efiSysMountPoint}
+        '';
+      };
+
     } // originalEtc // extraTrustedKeys;
 
     services.dbus.packages = [ pkgs.fwupd ];

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, meson, ninja, gettext, gnome3, wrapGAppsHook, packagekit, ostree
-, glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobjectIntrospection, flatpak
+, glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobjectIntrospection, flatpak, fwupd
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, gtk-doc, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
@@ -27,12 +27,11 @@ stdenv.mkDerivation rec {
     gnome3.gtk glib packagekit appstream-glib libsoup
     gnome3.gsettings-desktop-schemas gnome3.gnome-desktop
     gspell json-glib libsecret ostree
-    polkit flatpak
+    polkit flatpak fwupd
   ];
 
   mesonFlags = [
     "-Denable-rpm=false"
-    "-Denable-fwupd=false"
     "-Denable-oauth=false"
     "-Denable-ubuntu-reviews=false"
     "-Denable-gudev=false"

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -1,40 +1,48 @@
 { stdenv, fetchurl, fetchpatch, gtk-doc, pkgconfig, gobjectIntrospection, intltool
 , libgudev, polkit, appstream-glib, gusb, sqlite, libarchive, glib-networking
 , libsoup, help2man, gpgme, libxslt, elfutils, libsmbios, efivar, glibcLocales
-, fwupdate, libyaml, valgrind, meson, libuuid, colord, docbook_xml_dtd_43, docbook_xsl
-, ninja, gcab, gnutls, python3, wrapGAppsHook, json-glib
-, shared-mime-info, umockdev
+, gnu-efi, libyaml, valgrind, meson, libuuid, colord, docbook_xml_dtd_43, docbook_xsl
+, ninja, gcab, gnutls, python3, wrapGAppsHook, json-glib, bash-completion
+, shared-mime-info, umockdev, vala, makeFontsConf, freefont_ttf
 }:
 let
   # Updating? Keep $out/etc synchronized with passthru.filesInstalledToEtc
-  version = "1.0.5";
+  version = "1.1.0";
   python = python3.withPackages (p: with p; [ pygobject3 pycairo pillow ]);
   installedTestsPython = python3.withPackages (p: with p; [ pygobject3 requests ]);
+
+  fontsConf = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
 in stdenv.mkDerivation {
   name = "fwupd-${version}";
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-    sha256 = "0wm195vkf6x1kg1dz0sbfwpdcn9f6638l7vyzplcfrb3v07pqxpq";
+    sha256 = "0flfpzb0fxgixxddpwak4s63i35kr915pdfq5mfrnxq4bwcj24yd";
   };
 
-  outputs = [ "out" "devdoc" "man" "installedTests" ];
+  outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];
 
   nativeBuildInputs = [
     meson ninja gtk-doc pkgconfig gobjectIntrospection intltool glibcLocales shared-mime-info
-    valgrind gcab docbook_xml_dtd_43 docbook_xsl help2man libxslt python wrapGAppsHook
+    valgrind gcab docbook_xml_dtd_43 docbook_xsl help2man libxslt python wrapGAppsHook vala
   ];
   buildInputs = [
-    polkit appstream-glib gusb sqlite libarchive libsoup elfutils libsmbios fwupdate libyaml
+    polkit appstream-glib gusb sqlite libarchive libsoup elfutils libsmbios gnu-efi libyaml
     libgudev colord gpgme libuuid gnutls glib-networking efivar json-glib umockdev
+    bash-completion
   ];
 
   LC_ALL = "en_US.UTF-8"; # For po/make-images
 
   patches = [
-    ./fix-missing-deps.patch
+    ./fix-paths.patch
+
+    # Allow localedir in lib output
+    # https://github.com/hughsie/fwupd/pull/626
     (fetchpatch {
-      url = https://github.com/hughsie/fwupd/commit/767210e4b1401d5d5bb7ac1e7c052a60b6529d88.patch;
-      sha256 = "00adfabxpgdg74jx7i6jihhh8njjk2r7v3fxqs4scj3vn06k5fmw";
+      url = https://github.com/hughsie/fwupd/commit/9822c387ea13419a0eb2624fcd13d50735cb89f8.patch;
+      sha256 = "12bk6ga2hvsswpc4gal95l2z5a6gp3vdjq16zm2npligcvf37b6i";
     })
   ];
 
@@ -47,7 +55,8 @@ in stdenv.mkDerivation {
     substituteInPlace data/installed-tests/fwupdmgr.test.in --subst-var-by installedtestsdir "$installedTests/share/installed-tests/fwupd"
   '';
 
-  doCheck = true;
+  # /etc/os-release not available in sandbox
+  # doCheck = true;
 
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
@@ -55,11 +64,19 @@ in stdenv.mkDerivation {
 
   mesonFlags = [
     "-Dplugin_dummy=true"
-    "-Dbootdir=/boot"
     "-Dudevdir=lib/udev"
     "-Dsystemdunitdir=lib/systemd/system"
+    "-Defi-libdir=${gnu-efi}/lib"
+    "-Defi-ldsdir=${gnu-efi}/lib"
+    "-Defi-includedir=${gnu-efi}/include/efi"
     "--localstatedir=/var"
   ];
+
+  # TODO: We need to be able to override the directory flags from meson setup hook
+  # better – declaring them multiple times might become an error.
+  preConfigure = ''
+    mesonFlagsArray+=("--libexecdir=$out/libexec")
+  '';
 
   postInstall = ''
     moveToOutput share/installed-tests "$installedTests"
@@ -67,6 +84,9 @@ in stdenv.mkDerivation {
       --prefix GI_TYPELIB_PATH : "$out/lib/girepository-1.0:${libsoup}/lib/girepository-1.0"
   '';
 
+  FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
+
+  # /etc/fwupd/uefi.conf is created by the services.hardware.fwupd NixOS module
   passthru = {
     filesInstalledToEtc = [
       "fwupd/remotes.d/fwupd.conf"
@@ -74,8 +94,10 @@ in stdenv.mkDerivation {
       "fwupd/remotes.d/lvfs.conf"
       "fwupd/remotes.d/vendor.conf"
       "pki/fwupd/GPG-KEY-Hughski-Limited"
+      "pki/fwupd/GPG-KEY-Linux-Foundation-Metadata"
       "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
       "pki/fwupd/LVFS-CA.pem"
+      "pki/fwupd-metadata/GPG-KEY-Linux-Foundation-Metadata"
       "pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service"
       "pki/fwupd-metadata/LVFS-CA.pem"
     ];

--- a/pkgs/os-specific/linux/firmware/fwupd/fix-paths.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/fix-paths.patch
@@ -6,7 +6,7 @@
 -)
 --- a/data/meson.build
 +++ b/data/meson.build
-@@ -7,16 +7,12 @@
+@@ -8,16 +8,12 @@
    subdir('installed-tests')
  endif
  
@@ -26,8 +26,8 @@
  install_data(['metadata.xml'],
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
-@@ -3,13 +3,13 @@
-       'GPG-KEY-Hughski-Limited',
+@@ -4,14 +4,14 @@
+       'GPG-KEY-Linux-Foundation-Firmware',
        'GPG-KEY-Linux-Vendor-Firmware-Service',
      ],
 -    install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
@@ -35,6 +35,7 @@
    )
  
    install_data([
+       'GPG-KEY-Linux-Foundation-Metadata',
        'GPG-KEY-Linux-Vendor-Firmware-Service',
      ],
 -    install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
@@ -42,7 +43,7 @@
    )
  endif
  
-@@ -17,12 +17,12 @@
+@@ -19,12 +19,12 @@
    install_data([
        'LVFS-CA.pem',
      ],
@@ -66,9 +67,9 @@
 -    install_dir : join_paths(sysconfdir, 'fwupd', 'remotes.d')
 +    install_dir : join_paths(get_option('prefix'), 'etc', 'fwupd', 'remotes.d')
    )
- endif
- 
-@@ -19,12 +19,12 @@
+   i18n.merge_file(
+     input: 'lvfs.metainfo.xml',
+@@ -37,12 +37,12 @@
    output : 'fwupd.conf',
    configuration : con2,
    install: true,
@@ -92,13 +93,3 @@
 -    echo 'Creating stateful directory'
 -    mkdir -p ${DESTDIR}${LOCALSTATEDIR}/lib/fwupd
  #fi
---- a/po/make-images.sh
-+++ b/po/make-images.sh
-@@ -7,6 +7,7 @@
- #
- install -m 0755 -d ${MESON_INSTALL_DESTDIR_PREFIX}/share/locale/
- ${MESON_SOURCE_ROOT}/po/make-images "Installing firmware update…" ${MESON_INSTALL_DESTDIR_PREFIX}/share/locale/ ${MESON_SOURCE_ROOT}/po/LINGUAS
-+shopt -s nullglob
- for x in ${MESON_INSTALL_DESTDIR_PREFIX}/share/locale/*/LC_IMAGES/*.bmp ; do
-     gzip -f ${x}
- done


### PR DESCRIPTION
We override the ESP mount point in the config file /etc/fwupd/uefi.conf
(available since version 1.0.6), as it is set to a path in the nix store
during build time.

Current issues: See issue #39386 

Also:

Tests are disabled as it needs /etc/os-release, which is not available
when building with sandboxing enabled.

I also get a lot of `bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)` during the build, but am not sure if this is an issue with my system configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

