### PR TITLE
lib, openssl: 2 misc bits towards iOS support 

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -88,16 +88,36 @@ rec {
   #
 
   iphone64 = {
-    config = "aarch64-apple-darwin14";
-    arch = "arm64";
-    libc = "libSystem";
+    config = "aarch64-apple-ios";
+    # config = "aarch64-apple-darwin14";
+    sdkVer = "10.2";
+    useiOSPrebuilt = true;
     platform = {};
   };
 
   iphone32 = {
-    config = "arm-apple-darwin10";
-    arch = "armv7-a";
-    libc = "libSystem";
+    config = "armv7-apple-ios";
+    # config = "arm-apple-darwin10";
+    sdkVer = "10.2";
+    useiOSPrebuilt = true;
+    platform = {};
+  };
+
+  iphone64-simulator = {
+    config = "x86_64-apple-ios";
+    # config = "x86_64-apple-darwin14";
+    sdkVer = "10.2";
+    useiOSPrebuilt = true;
+    isiPhoneSimulator = true;
+    platform = {};
+  };
+
+  iphone32-simulator = {
+    config = "i686-apple-ios";
+    # config = "i386-apple-darwin11";
+    sdkVer = "10.2";
+    useiOSPrebuilt = true;
+    isiPhoneSimulator = true;
     platform = {};
   };
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -48,6 +48,8 @@ let
           then "./Configure mingw${toString hostPlatform.parsed.cpu.bits}"
         else if hostPlatform.isLinux
           then "./Configure linux-generic${toString hostPlatform.parsed.cpu.bits}"
+        else if hostPlatform.isiOS
+          then "./Configure ios${toString hostPlatform.parsed.cpu.bits}-cross"
         else
           throw "Not sure what configuration to use for ${hostPlatform.config}"
       );


### PR DESCRIPTION
###### Motivation for this change

CC @ElvishJerricco

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

