### PR TITLE
nixos-install manual: remove --chroot option

### DIFF
--- a/nixos/doc/manual/man-nixos-install.xml
+++ b/nixos/doc/manual/man-nixos-install.xml
@@ -58,9 +58,6 @@
       <arg choice='plain'><option>--show-trace</option></arg>
     </arg>
     <arg>
-      <arg choice='plain'><option>--chroot</option></arg>
-    </arg>
-    <arg>
       <arg choice='plain'><option>--help</option></arg>
     </arg>
   </cmdsynopsis>
@@ -174,14 +171,6 @@ it.</para>
     <term><option>--show-trace</option></term>
     <listitem>
       <para>Causes Nix to print out a stack trace in case of Nix expression evaluation errors.</para>
-    </listitem>
-  </varlistentry>
-
-  <varlistentry>
-    <term><option>--chroot</option></term>
-    <listitem>
-      <para>Chroot into given installation. Any additional arguments passed are going to be executed inside the chroot.
-      </para>
     </listitem>
   </varlistentry>
 


### PR DESCRIPTION
###### Motivation for this change
This option has been removed from the tool in favour of nixos-enter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

