### PR TITLE
goxel: don't save imgui.ini to working directory

### DIFF
--- a/pkgs/applications/graphics/goxel/default.nix
+++ b/pkgs/applications/graphics/goxel/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "01022c43pmwiqb18rx9fz08xr99h6p03gw6bp0lay5z61g3xkz17";
   };
 
+  patches = [ ./disable-imgui_ini.patch ];
+
   nativeBuildInputs = [ scons pkgconfig wrapGAppsHook ];
   buildInputs = [ glfw3 gtk3 libpng12 ];
 

--- a/pkgs/applications/graphics/goxel/disable-imgui_ini.patch
+++ b/pkgs/applications/graphics/goxel/disable-imgui_ini.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gui.cpp b/src/gui.cpp
+index 9b7236c..a8a11b2 100644
+--- a/src/gui.cpp
++++ b/src/gui.cpp
+@@ -314,6 +314,8 @@ static void init_ImGui(const inputs_t *inputs)
+     ImGuiIO& io = ImGui::GetIO();
+     io.DeltaTime = 1.0f/60.0f;
+
++    io.IniFilename = NULL;
++
+     io.KeyMap[ImGuiKey_Tab]         = KEY_TAB;
+     io.KeyMap[ImGuiKey_LeftArrow]   = KEY_LEFT;
+     io.KeyMap[ImGuiKey_RightArrow]  = KEY_RIGHT;


### PR DESCRIPTION
###### Motivation for this change

Before, goxel would save a file `imgui.ini` to the current working directory.

##### imgui.ini
```
[Window][Debug##Default]
Pos=60,60
Size=400,400
Collapsed=0

[Window][Goxel]
Pos=0,0
Size=959,353
Collapsed=0
```

[This is to save window configuration, presumably to restore them on next execution.](https://www.reddit.com/r/imgui/comments/4xstmx/no_imguiini/d6jjtlh/)

Is this behaviour worth littering CWD?
An alternative would be to change upstream to honor XDG conventions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

