### PR TITLE
prometheus-snmp-exporter: 0.3.0 -> 0.9.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/snmp-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/snmp-exporter.nix
@@ -2,16 +2,15 @@
 
 buildGoPackage rec {
   name = "snmp_exporter-${version}";
-  version = "0.3.0";
-  rev = "v${version}";
+  version = "0.9.0";
 
   goPackagePath = "github.com/prometheus/snmp_exporter";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "prometheus";
     repo = "snmp_exporter";
-    sha256 = "1cklsi3cpalmnp0qjkgb7xbgbkr014hk2z54gfynzvzqjmsbxk6a";
+    rev = "v${version}";
+    sha256 = "081ah4zyy53plhm6znwrx55phm2ysxzyx7d4hm8zzrv5r967rgl1";
   };
 
   buildInputs = [ net_snmp ];
@@ -22,7 +21,7 @@ buildGoPackage rec {
     description = "SNMP Exporter for Prometheus";
     homepage = https://github.com/prometheus/snmp_exporter;
     license = licenses.asl20;
-    maintainers = with maintainers; [ oida ];
+    maintainers = with maintainers; [ oida willibutz ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Things done
added myself as maintainer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
/cc @oida 