### PR TITLE
bluez: add tools to output that we were building anyway

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -12,24 +12,28 @@ stdenv.mkDerivation rec {
     sha256 = "15ffsaz7l3fgdg03l7g1xx9jw7xgs6pc548zxqsxawsca5x1sc1k";
   };
 
-  pythonPath = with pythonPackages;
-    [ dbus-python pygobject2 pygobject3 recursivePthLoader ];
+  pythonPath = with pythonPackages; [
+    dbus-python pygobject2 pygobject3 recursivePthLoader
+  ];
 
   buildInputs = [
-    pkgconfig dbus glib alsaLib pythonPackages.python pythonPackages.wrapPython
+    dbus glib alsaLib pythonPackages.python pythonPackages.wrapPython
     readline udev libical
   ];
+
+  nativeBuildInputs = [ pkgconfig ];
 
   outputs = [ "out" "dev" "test" ];
 
   patches = [ ./bluez-5.37-obexd_without_systemd-1.patch ];
 
-  preConfigure = ''
-      substituteInPlace tools/hid2hci.rules --replace /sbin/udevadm ${systemd}/bin/udevadm
-      substituteInPlace tools/hid2hci.rules --replace "hid2hci " "$out/lib/udev/hid2hci "
-    '';
+  postConfigure = ''
+    substituteInPlace tools/hid2hci.rules \
+      --replace /sbin/udevadm ${systemd}/bin/udevadm \
+      --replace "hid2hci " "$out/lib/udev/hid2hci "
+  '';
 
-  configureFlags = [
+  configureFlags = (with stdenv.lib; [
     "--localstatedir=/var"
     "--enable-library"
     "--enable-cups"
@@ -40,8 +44,8 @@ stdenv.mkDerivation rec {
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--with-systemduserunitdir=$(out)/etc/systemd/user"
     "--with-udevdir=$(out)/lib/udev"
-    ] ++ stdenv.lib.optional enableWiimote [ "--enable-wiimote" ]
-    ++ stdenv.lib.optional enableMidi [ "--enable-midi" ];
+    ] ++ optional enableWiimote [ "--enable-wiimote" ]
+      ++ optional enableMidi    [ "--enable-midi" ]);
 
   # Work around `make install' trying to create /var/lib/bluetooth.
   installFlags = "statedir=$(TMPDIR)/var/lib/bluetooth";
@@ -73,14 +77,21 @@ stdenv.mkDerivation rec {
     # Add extra configuration
     mkdir $out/etc/bluetooth
     ln -s /etc/bluetooth/main.conf $out/etc/bluetooth/main.conf
+
+    # Add missing tools, ref https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/bluez
+    for files in `find tools/ -type f -perm -755`; do
+      filename=$(basename $files)
+      install -Dm755 tools/$filename $out/bin/$filename
+    done
   '';
 
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.bluez.org/;
-    repositories.git = https://git.kernel.org/pub/scm/bluetooth/bluez.git;
     description = "Bluetooth support for Linux";
+    homepage = http://www.bluez.org/;
+    license = with licenses; [ gpl2 lgpl21 ];
     platforms = platforms.linux;
+    repositories.git = https://git.kernel.org/pub/scm/bluetooth/bluez.git;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

A bunch of the old bluez tools have been deprecated (hciconfig, hcitool) but we weren't distributing their (experimental) replacements making certain bluetooth operations rather difficult.

This PR just adds in what we were building anyway (lifted from Arch Linux) + a few minor style cleanups.

Cc: @globin @fpletz 

I haven't run nox-review as it wants to build the ~~~entire KDE suite~~~ a *ton* of packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

