### PR TITLE
nixos doc: mananager -> manager

### DIFF
--- a/nixos/doc/manual/installation/installing-from-other-distro.xml
+++ b/nixos/doc/manual/installation/installing-from-other-distro.xml
@@ -154,7 +154,7 @@ $ sudo useradd -u 30000 -g nixbld -G nixbld nixbld</screen>
 $ sudo userdel nixbld
 $ sudo groupdel nixbld</screen>
 
-            <para>If you do not wish to keep the Nix package mananager
+            <para>If you do not wish to keep the Nix package manager
                 installed either, run something like <literal>sudo rm -rv
                     ~/.nix-* /nix</literal> and remove the line that the Nix
                 installer added to your <literal>~/.profile</literal>.</para>


### PR DESCRIPTION
###### Motivation for this change

I hate fun.

###### Things done

- [x] Tested using a spell checker
- Built on platform(s)
   - [x] NixOS
- [x] Proofread all documentation files (usually in `./result/share/doc`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

