### PR TITLE
fetchs3: allow to name the derivation output

### DIFF
--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -11,11 +11,13 @@
 }:
 
 let
-  credentialAttrs = stdenvNoCC.lib.optionalAttrs (credentials != null) {
-    AWS_ACCESS_KEY_ID = credentials.access_key_id;
-    AWS_SECRET_ACCESS_KEY = credentials.secret_access_key;
-    AWS_SESSION_TOKEN = credentials.session_token ? null;
+  mkCredentials = { access_key_id, secret_access_key, session_token ? null }: {
+    AWS_ACCESS_KEY_ID = access_key_id;
+    AWS_SECRET_ACCESS_KEY = secret_access_key;
+    AWS_SESSION_TOKEN = session_token;
   };
+
+  credentialAttrs = stdenvNoCC.lib.optionalAttrs (credentials != null) (mkCredentials credentials);
 in runCommand name ({
   nativeBuildInputs = [ awscli ];
   outputHashAlgo = "sha256";

--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -1,6 +1,7 @@
 { stdenvNoCC, runCommand, awscli }:
 
 { s3url
+, name ? builtins.baseNameOf s3url
 , sha256
 , region ? "us-east-1"
 , credentials ? null # Default to looking at local EC2 metadata service
@@ -15,7 +16,7 @@ let
     AWS_SECRET_ACCESS_KEY = credentials.secret_access_key;
     AWS_SESSION_TOKEN = credentials.session_token ? null;
   };
-in runCommand "foo" ({
+in runCommand name ({
   nativeBuildInputs = [ awscli ];
   outputHashAlgo = "sha256";
   outputHash = sha256;

--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -23,6 +23,7 @@ in runCommand name ({
   outputHashAlgo = "sha256";
   outputHash = sha256;
   outputHashMode = if recursiveHash then "recursive" else "flat";
+  AWS_DEFAULT_REGION = region;
 } // credentialAttrs) (if postFetch != null then ''
   downloadedFile="$(mktemp)"
   aws s3 cp ${s3url} $downloadedFile

--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -20,9 +20,13 @@ let
   credentialAttrs = stdenvNoCC.lib.optionalAttrs (credentials != null) (mkCredentials credentials);
 in runCommand name ({
   nativeBuildInputs = [ awscli ];
+
   outputHashAlgo = "sha256";
   outputHash = sha256;
   outputHashMode = if recursiveHash then "recursive" else "flat";
+
+  preferLocalBuild = true;
+
   AWS_DEFAULT_REGION = region;
 } // credentialAttrs) (if postFetch != null then ''
   downloadedFile="$(mktemp)"


### PR DESCRIPTION
###### Motivation for this change

The default output name is "foo" which is not very descriptive. To avoid
rebuilds this is kept as the default but one can now pass an optional
name attribute to change it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

