### PR TITLE
cquery: 2018-03-31 -> 2018-05-01

### DIFF
--- a/pkgs/development/tools/misc/cquery/default.nix
+++ b/pkgs/development/tools/misc/cquery/default.nix
@@ -5,8 +5,8 @@ let
   src = fetchFromGitHub {
     owner = "cquery-project";
     repo = "cquery";
-    rev = "e45a9ebbb6d8bfaf8bf1a3135b6faa910afea37e";
-    sha256 = "049gkqbamq4r2nz9yjcwq369zrmwrikzbhfza2x2vndqzaavq5yg";
+    rev = "34b357bc5e873d52d2aa41287c6e138244cea109";
+    sha256 = "0i34v30cl73485bzpbis539x0iq9whpv0403ca5a9h6vqwnvdn7c";
     fetchSubmodules = true;
   };
 
@@ -15,7 +15,7 @@ let
 in
 stdenv.mkDerivation rec {
   name    = "cquery-${version}";
-  version = "2018-03-25";
+  version = "2018-05-01";
 
   inherit src;
 
@@ -46,7 +46,6 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
   installCheckPhase = ''
     pushd ${src}
-    $out/bin/cquery --ci --clang-sanity-check && \
     $out/bin/cquery --ci --test-unit
   '';
 
@@ -56,6 +55,5 @@ stdenv.mkDerivation rec {
     license     = licenses.mit;
     platforms   = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.tobim ];
-    priority    = 3;
   };
 }


### PR DESCRIPTION

###### Motivation for this change
The update should fix the build on osx.


###### Things done
- Updated the ref to the  current HEAD node on the master branch.
- Removed a call from the post installation check, the test was removed upstream.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

