### PR TITLE
souffle: 1.0.0 -> 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3979,6 +3979,11 @@
     github = "vyp";
     name = "vyp";
   };
+  wchresta = {
+    email = "wchresta.nix@chrummibei.ch";
+    github = "wchresta";
+    name = "wchresta";
+  };
   wedens = {
     email = "kirill.wedens@gmail.com";
     name = "wedens";

--- a/pkgs/development/compilers/souffle/default.nix
+++ b/pkgs/development/compilers/souffle/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, boost, bison, flex, openjdk, doxygen, perl, graphviz }:
+{ stdenv, fetchFromGitHub, autoconf, automake, boost, bison, flex, openjdk, doxygen, perl, graphviz, libtool, lsb-release, ncurses, zlib, sqlite }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.0";
+  version = "1.2.0";
   name    = "souffle-${version}";
 
   src = fetchFromGitHub {
     owner  = "souffle-lang";
     repo   = "souffle";
     rev    = version;
-    sha256 = "13j14227dgxcm25z9iizcav563wg2ak9338pb03aqqz8yqxbmz4n";
+    sha256 = "1g8yvm40h102mab8lacpl1cwgqsw1js0s1yn4l84l9fjdvlh2ygd";
   };
 
   buildInputs = [
     autoconf automake boost bison flex openjdk
+    # Used for 1.2.0
+    libtool lsb-release ncurses zlib sqlite
     # Used for docs
     doxygen perl graphviz
   ];
 
   patchPhase = ''
     substituteInPlace configure.ac \
-      --replace "m4_esyscmd([git describe --tags --abbrev=0 | tr -d '\n'])" "${version}"
+      --replace "m4_esyscmd([git describe --tags --abbrev=0 --always | tr -d '\n'])" "${version}"
   '';
 
   # Without this, we get an obscure error about not being able to find a library version
@@ -29,17 +31,11 @@ stdenv.mkDerivation rec {
 
   preConfigure = "./bootstrap";
 
-  # in 1.0.0: parser.hh:40:0: error: unterminated #ifndef
-  enableParallelBuilding = false;
-
-  # See https://github.com/souffle-lang/souffle/issues/176
-  hardeningDisable = [ "fortify" ];
-
   meta = with stdenv.lib; {
     description = "A translator of declarative Datalog programs into the C++ language";
     homepage    = "http://souffle-lang.github.io/";
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = with maintainers; [ copumpkin wchresta ];
     license     = licenses.upl;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Souffle has had two major releases since 1.0.0. We push to the newest release.

We also remove two fixed that were previously needed but not seem to cause issues anymore:
* enable parallel building - parallel building doesn't seem to cause issues anymore (testes with -j 4)
* enable hardening through Fortify, since the bug seems to be fixed, See https://github.com/souffle-lang/souffle/issues/176

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

