### PR TITLE
lib/systems: Fix eval for iphone32* examples

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -96,7 +96,7 @@ rec {
   };
 
   iphone32 = {
-    config = "armv7-apple-ios";
+    config = "armv7a-apple-ios";
     # config = "arm-apple-darwin10";
     sdkVer = "10.2";
     useiOSPrebuilt = true;

--- a/pkgs/os-specific/darwin/ios-sdk-pkgs/default.nix
+++ b/pkgs/os-specific/darwin/ios-sdk-pkgs/default.nix
@@ -13,7 +13,7 @@ let
 minSdkVersion = "9.0";
 
 iosPlatformArch = { parsed, ... }: {
-  "arm"     = "armv7";
+  "armv7a"  = "armv7";
   "aarch64" = "arm64";
   "x86_64"  = "x86_64";
 }.${parsed.cpu.name};


### PR DESCRIPTION
###### Motivation for this change

Whoops messed up 9a845de873dfcc31f360a08f1b1f786c6f649c7d slightly.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @ElvishJerricco