### PR TITLE
unixODBCDrivers.mariadb: fix library file reference required for ODBC

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -45,7 +45,7 @@
 
     passthru = {
       fancyName = "MariaDB";
-      driver = "lib/libmyodbc3-3.51.12.so";
+      driver = "lib/libmaodbc.so";
     };
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes bug https://github.com/NixOS/nixpkgs/issues/39835

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested ODBC connection with my custom program on NixOS which is used in production.