### PR TITLE
cctools, apple libiconv: Apple clean up for iOS cross

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, appleDerivation }:
+{ stdenv, appleDerivation, autoreconfHook }:
 
 appleDerivation {
-  preConfigure = "cd libiconv";
+  postUnpack = "sourceRoot=$sourceRoot/libiconv";
 
   postInstall = ''
     mv $out/lib/libiconv.dylib $out/lib/libiconv-nocharset.dylib
-    install_name_tool -id $out/lib/libiconv-nocharset.dylib $out/lib/libiconv-nocharset.dylib
+    ${stdenv.cc.bintools.targetPrefix}install_name_tool -id $out/lib/libiconv-nocharset.dylib $out/lib/libiconv-nocharset.dylib
 
     # re-export one useless symbol; ld will reject a dylib that only reexports other dylibs
-    echo 'void dont_use_this(){}' | clang -dynamiclib -x c - -current_version 2.4.0 \
+    echo 'void dont_use_this(){}' | ${stdenv.cc.bintools.targetPrefix}clang -dynamiclib -x c - -current_version 2.4.0 \
       -compatibility_version 7.0.0 -current_version 7.0.0 -o $out/lib/libiconv.dylib \
       -Wl,-reexport_library -Wl,$out/lib/libiconv-nocharset.dylib \
       -Wl,-reexport_library -Wl,$out/lib/libcharset.dylib

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -108,17 +108,15 @@ let
       #  include_next "unistd.h"
       #endif
       EOF
-    '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-      sed -i -e 's|clang++|& -I${libcxx}/include/c++/v1|' cctools/autogen.sh
-    '' + stdenv.lib.optionalString useOld ''
+
       cd cctools
+    '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+      sed -i -e 's|clang++|& -I${libcxx}/include/c++/v1|' autogen.sh
     '';
 
     # TODO: this builds an ld without support for LLVM's LTO. We need to teach it, but that's rather
     # hairy to handle during bootstrap. Perhaps it could be optional?
-    preConfigure = stdenv.lib.optionalString (!useOld) ''
-      cd cctools
-    '' + ''
+    preConfigure = ''
       sh autogen.sh
     '';
 


### PR DESCRIPTION
###### Motivation for this change

One one hand, this is an "incomplete" mass-rebuild as more changes are needed. OTOH it's nice to upstream things as soon as possible before I forget. LMK what you all think.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @ElvishJerricco 
