### PR TITLE
solc: 0.4.20 -> 0.4.23

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -1,7 +1,9 @@
-{ stdenv, fetchzip, fetchurl, boost, cmake, z3 }:
+{ stdenv, fetchzip, fetchFromGitHub, boost, cmake, z3 }:
 
 let
-  version = "0.4.20";
+  version = "0.4.23";
+  rev = "124ca40dc525a987a88176c6e5170978e82fa290";
+  sha256 = "07l8rfqh95yrdmbxc4pfb77s06k5v65dk3rgdqscqmwchkndrmm0";
   jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.7.7.tar.gz;
   jsoncpp = fetchzip {
     url = jsoncppURL;
@@ -12,33 +14,45 @@ in
 stdenv.mkDerivation {
   name = "solc-${version}";
 
-  # Cannot use `fetchFromGitHub' because of submodules
-  src = fetchurl {
-    url = "https://github.com/ethereum/solidity/releases/download/v${version}/solidity_${version}.tar.gz";
-    sha256 = "0jyqnykj537ksfsf2m6ww9vganmpa6yd5fmlfpa5qm1076kq7zd6";
+  src = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "solidity";
+    inherit rev sha256;
   };
 
-  patchPhase = ''
+  patches = [
+    ./patches/boost-shared-libs.patch
+    ./patches/shared-libs-install.patch
+  ];
+
+  postPatch = ''
+    touch prerelease.txt
+    echo >commit_hash.txt "${rev}"
     substituteInPlace cmake/jsoncpp.cmake \
-      --replace '${jsoncppURL}' ${jsoncpp}
+      --replace "${jsoncppURL}" ${jsoncpp}
     substituteInPlace cmake/EthCompilerSettings.cmake \
-      --replace 'add_compile_options(-Werror)' ""
+      --replace "add_compile_options(-Werror)" ""
   '';
 
   cmakeFlags = [
     "-DBoost_USE_STATIC_LIBS=OFF"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DINSTALL_LLLC=ON"
+    "-DTESTS=OFF"
   ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost z3 ];
 
-  meta = {
+  outputs = [ "out" "dev" ];
+
+  meta = with stdenv.lib; {
     description = "Compiler for Ethereum smart contract language Solidity";
     longDescription = "This package also includes `lllc', the LLL compiler.";
     homepage = https://github.com/ethereum/solidity;
-    license = stdenv.lib.licenses.gpl3;
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
-    maintainers = [ stdenv.lib.maintainers.dbrock ];
+    license = licenses.gpl3;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ dbrock akru ];
     inherit version;
   };
 }

--- a/pkgs/development/compilers/solc/patches/boost-shared-libs.patch
+++ b/pkgs/development/compilers/solc/patches/boost-shared-libs.patch
@@ -1,0 +1,24 @@
+diff --git a/libsolidity/CMakeLists.txt b/libsolidity/CMakeLists.txt
+index 97b01c83..0bdec4b4 100644
+--- a/libsolidity/CMakeLists.txt
++++ b/libsolidity/CMakeLists.txt
+@@ -28,7 +28,7 @@ else()
+ endif()
+ 
+ add_library(solidity ${sources} ${headers})
+-target_link_libraries(solidity PUBLIC evmasm devcore)
++target_link_libraries(solidity PUBLIC evmasm devcore ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+ 
+ if (${Z3_FOUND})
+   target_link_libraries(solidity PUBLIC ${Z3_LIBRARY})
+diff --git a/lllc/CMakeLists.txt b/lllc/CMakeLists.txt
+index 5c480093..d6538ee2 100644
+--- a/lllc/CMakeLists.txt
++++ b/lllc/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ add_executable(lllc main.cpp)
+-target_link_libraries(lllc PRIVATE lll)
++target_link_libraries(lllc PRIVATE lll ${Boost_SYSTEM_LIBRARY})
+ 
+ if (INSTALL_LLLC)
+ 	include(GNUInstallDirs)

--- a/pkgs/development/compilers/solc/patches/shared-libs-install.patch
+++ b/pkgs/development/compilers/solc/patches/shared-libs-install.patch
@@ -1,0 +1,64 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ac56b43..dacf3853 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,6 +48,19 @@ add_subdirectory(libevmasm)
+ add_subdirectory(libsolidity)
+ add_subdirectory(libsolc)
+ 
++install(DIRECTORY libdevcore/
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libdevcore
++        FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY libevmasm/
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libevmasm
++        FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY libsolidity/
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libsolidity
++        FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY liblll/
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/liblll
++        FILES_MATCHING PATTERN "*.h")
++
+ if (NOT EMSCRIPTEN)
+ 	add_subdirectory(solc)
+ 	add_subdirectory(liblll)
+diff --git a/libdevcore/CMakeLists.txt b/libdevcore/CMakeLists.txt
+index fa7e3f48..1f9f52b4 100644
+--- a/libdevcore/CMakeLists.txt
++++ b/libdevcore/CMakeLists.txt
+@@ -6,3 +6,4 @@ target_link_libraries(devcore PRIVATE jsoncpp ${Boost_FILESYSTEM_LIBRARIES} ${Bo
+ target_include_directories(devcore PUBLIC "${CMAKE_SOURCE_DIR}")
+ target_include_directories(devcore SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+ add_dependencies(devcore solidity_BuildInfo.h)
++install(TARGETS devcore LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/libevmasm/CMakeLists.txt b/libevmasm/CMakeLists.txt
+index 86192c1b..e7f15e93 100644
+--- a/libevmasm/CMakeLists.txt
++++ b/libevmasm/CMakeLists.txt
+@@ -3,3 +3,4 @@ file(GLOB headers "*.h")
+ 
+ add_library(evmasm ${sources} ${headers})
+ target_link_libraries(evmasm PUBLIC jsoncpp devcore)
++install(TARGETS evmasm LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/liblll/CMakeLists.txt b/liblll/CMakeLists.txt
+index 4cdc073a..b61f03c7 100644
+--- a/liblll/CMakeLists.txt
++++ b/liblll/CMakeLists.txt
+@@ -3,3 +3,4 @@ file(GLOB headers "*.h")
+ 
+ add_library(lll ${sources} ${headers})
+ target_link_libraries(lll PUBLIC evmasm devcore)
++install(TARGETS lll LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/libsolidity/CMakeLists.txt b/libsolidity/CMakeLists.txt
+index 97b01c83..e876177e 100644
+--- a/libsolidity/CMakeLists.txt
++++ b/libsolidity/CMakeLists.txt
+@@ -28,7 +28,8 @@ else()
+ endif()
+ 
+ add_library(solidity ${sources} ${headers})
+ target_link_libraries(solidity PUBLIC evmasm devcore ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
++install(TARGETS solidity LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ if (${Z3_FOUND})
+   target_link_libraries(solidity PUBLIC ${Z3_LIBRARY})


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/ethereum/solidity/releases/tag/v0.4.21
* https://github.com/ethereum/solidity/releases/tag/v0.4.22
* https://github.com/ethereum/solidity/releases/tag/v0.4.23
* enabled shared libraries installation for solidity compiler
* added `dev` output for headers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

