### PR TITLE
qscintilla: revert bump to fix the build

### DIFF
--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     ++ (if withQt5 then [ qmake ] else [ qmake4Hook ]);
 
 
-  patches = [] ++ lib.optional withQt5 [ xcodePatch ];
+  patches = lib.optional (stdenv.isDarwin && withQt5) [ xcodePatch ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -10,13 +10,13 @@ let xcodePatch =
 in
 stdenv.mkDerivation rec {
   pname = "qscintilla";
-  version = "2.10.3";
+  version = "2.9.4";
 
   name = "${pname}-${if withQt5 then "qt5" else "qt4"}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/QScintilla2/QScintilla-${version}/QScintilla_gpl-${version}.zip";
-    sha256 = "0rsx0b0iz5yf3x594kzhi0c2wpbmknv9b0a3rmx5w37bvmpd6qav";
+    sha256 = "04678skipydx68zf52vznsfmll2v9aahr66g50lcqbr6xsmgr1yi";
   };
 
   buildInputs = [ (if withQt5 then qtbase else qt4) ]


### PR DESCRIPTION
###### Motivation for this change

This reverts the bump of `qscintilla` performed in #37330 as it actively breaks the qt5-darwin support added in 734323872a7271625e4948d9732f8ad0d59e9332.

Furthermore #37330 (namely 8ee6a03a3e75c6aaf4d7cf53bd6ffc6892d89950) **never** worked when building the `qt4` variant `nix-build -A qscintilla`.

The original bump broke the following packages transitively:

* *pkgs.tora*
* *pkgs.sqlitebrowser*
* *pkgs.sonic-pi*
* and many more...

As I don't have the required resources to actively test/maintain the darwin compatibility of `qscintilla` and the `qt4` variant **never** worked since the bump, I'd vote to revert the change for now and perform a bump with tested `qt4` and `darwin` derivations.

/cc @ryantm @mpickering @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

