### PR TITLE
sshguard: service creates /var/lib/sshguard

### DIFF
--- a/nixos/modules/services/security/sshguard.nix
+++ b/nixos/modules/services/security/sshguard.nix
@@ -133,6 +133,7 @@ in {
             ReadOnlyDirectories = "/";
             ReadWriteDirectories = "/run/sshguard /var/lib/sshguard";
             RuntimeDirectory = "sshguard";
+            StateDirectory = "sshguard";
             CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_RAW";
          };
       };


### PR DESCRIPTION
###### Motivation for this change
fix #30701

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

