### PR TITLE
ltrace: fix warnings and bugs using patches from debian

### DIFF
--- a/pkgs/development/tools/misc/ltrace/default.nix
+++ b/pkgs/development/tools/misc/ltrace/default.nix
@@ -10,10 +10,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ elfutils libunwind ];
 
-  preConfigure =
-    ''
-      configureFlags="--disable-werror"
-      makeFlagsArray=(INSTALL="install -c")
+  prePatch = let
+      debian = fetchurl {
+        url = mirror://debian/pool/main/l/ltrace/ltrace_0.7.3-6.debian.tar.xz;
+        sha256 = "0xc4pfd8qw53crvdxr29iwl8na53zmknca082kziwpvlzsick4kp";
+      };
+    in ''
+      tar xf '${debian}'
+      patches="$patches $(cat debian/patches/series | sed 's|^|debian/patches/|')"
     '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
For details on the patches applied, see:

https://sources.debian.org/patches/ltrace/0.7.3-6/

Disabling '-Werror' may be a problem in the future again,
but for now keep things simple now that they're fixed.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---