### PR TITLE
whois: Fix darwin build

### DIFF
--- a/pkgs/tools/networking/whois/default.nix
+++ b/pkgs/tools/networking/whois/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "HAVE_ICONV=1" ];
   buildFlags = [ "whois" ];
+  NIX_LDFLAGS = stdenv.lib.optionals stdenv.isDarwin [ "-L${libiconv}/lib/" "-liconv" ];
 
   installTargets = [ "install-whois" ];
 


### PR DESCRIPTION
###### Motivation for this change
This fixes the darwin build of whois.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

