### PR TITLE
Add epeg

### DIFF
--- a/pkgs/applications/graphics/epeg/default.nix
+++ b/pkgs/applications/graphics/epeg/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, pkgconfig, libtool, autoconf, automake
+, libjpeg, libexif
+}:
+
+stdenv.mkDerivation rec {
+  name = "epeg-0.9.1.042"; # version taken from configure.ac
+
+  src = fetchFromGitHub {
+    owner = "mattes";
+    repo = "epeg";
+    rev = "248ae9fc3f1d6d06e6062a1f7bf5df77d4f7de9b";
+    sha256 = "14ad33w3pxrg2yfc2xzyvwyvjirwy2d00889dswisq8b84cmxfia";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkgconfig libtool autoconf automake ];
+
+  propagatedBuildInputs = [ libjpeg libexif ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mattes/epeg;
+    description = "Insanely fast JPEG/ JPG thumbnail scaling";
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ nh2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15571,6 +15571,8 @@ with pkgs;
 
   epdfview = callPackage ../applications/misc/epdfview { };
 
+  epeg = callPackage ../applications/graphics/epeg/default.nix { };
+
   inherit (gnome3) epiphany;
 
   epic5 = callPackage ../applications/networking/irc/epic5 { };


### PR DESCRIPTION
###### Motivation for this change

epeg (library and application) allows for very fast jpeg downscaling.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

