### PR TITLE
terminology: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, efl, pcre, makeWrapper }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, efl, pcre, mesa_noglu, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "terminology-${version}";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/terminology/${name}.tar.xz";
-    sha256 = "05ncxvzb9rzkyjvd95hzn8lswqdwr8cix6rd54nqn9559jibh4ns";
+    sha256 = "0kw34l5lahn1qaks3ah6x8k41d6hfywpqfak2p7qq1z87zj506mx";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     (pkgconfig.override { vanilla = true; })
     makeWrapper
   ];
@@ -17,11 +19,12 @@ stdenv.mkDerivation rec {
   buildInputs = [
     efl
     pcre
+    mesa_noglu
   ];
 
   meta = {
-    description = "The best terminal emulator written with the EFL";
-    homepage = http://enlightenment.org/;
+    description = "Powerful terminal emulator based on EFL";
+    homepage = https://www.enlightenment.org/about-terminology;
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];


### PR DESCRIPTION
###### Motivation for this change

- Update to version [1.2.0](https://www.enlightenment.org/news/2018-04-15-terminology-1.2.0)
- Switch build tools from autotools to meson

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).