### PR TITLE
enlightenment: add dependency on mesa_noglu

### DIFF
--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, efl,
   xcbutilkeysyms, libXrandr, libXdmcp, libxcb, libffi, pam, alsaLib,
-  luajit, bzip2, libpthreadstubs, gdbm, libcap, libGLU,
+  luajit, bzip2, libpthreadstubs, gdbm, libcap, libGLU, mesa_noglu,
   xkeyboard_config, pcre
 }:
 
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     libpthreadstubs
     gdbm
     pcre
+    mesa_noglu
   ] ++
     stdenv.lib.optionals stdenv.isLinux [ libcap ];
 


### PR DESCRIPTION
###### Motivation for this change

Without the dependence on `mesa_noglu` compilation fails with the error

```
meson.build:258:0: ERROR: Could not generate cargs for ecore-evas:
```

It seems that `gbm` (provided by `mesa_noglu`) is needed.

Adding `mesa_noglu` fixes a similar error with `terminology`, where the error message was more verbose (building with auto tools), mentioning that `gbm` was not found.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).