### PR TITLE
shutter: wrap `XDG_DATA_DIRS` with `hicolor-icon-theme`

### DIFF
--- a/pkgs/applications/graphics/shutter/default.nix
+++ b/pkgs/applications/graphics/shutter/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, fetchpatch, perl, perlPackages, makeWrapper, imagemagick, gdk_pixbuf, librsvg }:
+{ stdenv, fetchurl, fetchpatch, perl, perlPackages, makeWrapper, imagemagick, gdk_pixbuf, librsvg
+, hicolor-icon-theme
+}:
 
 let
   perlModules = with perlPackages;
@@ -29,6 +31,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/shutter \
       --set PERL5LIB "${stdenv.lib.makePerlPath perlModules}" \
       --prefix PATH : "${imagemagick.out}/bin" \
+      --suffix XDG_DATA_DIRS : "${hicolor-icon-theme}/share" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

When opening `shutter` it adds an indicator icon to the status bar.
However this doesn't happen (and an ugly default icon will be used) if
`shutter` can't find the `hicolor-icon-theme`. In such a case a warning
like this can be found in `stderr`:

```
Gtk-WARNING **: Could not find the icon 'image-png'. The 'hicolor' theme
was not found either, perhaps you need to install it.
```

As I don't think that we should force users to install this theme
globally and several other packages including `tor-browser`, `gparted`
or `clawsmail` add `hicolor-icon-theme` to their closure this seems to
be a fair measure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

