### PR TITLE
matrix-synapse: 0.27.4 -> 0.28.1

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -26,13 +26,13 @@ let
   };
 in pythonPackages.buildPythonApplication rec {
   name = "matrix-synapse-${version}";
-  version = "0.27.4";
+  version = "0.28.1";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse";
     rev = "v${version}";
-    sha256 = "051bwr4vz8mwglh1m9rqlljbn8g3alvd52f09ff887nsi6z3jc17";
+    sha256 = "1xgiprnhp893zc0g3i7wpwzgjy6q5nb858p0s6kcsca60vr9j6h0";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
0.28.1 is an urgent security update: It contains a mitigation for a major denial of service attack that already has been exploited in the wild. For more details, see https://matrix.org/blog/2018/05/01/security-update-synapse-0-28-1/

In my opinion it would make much sense to backport 0.28.1 to stable. Continuing to run vulnerable 0.27.2 out of stable doesn't make much sense anymore, I see no breaking changes from 0.27.2 to 0.28.1, and at least I don't have the time and internal synapse knowledge to backport the temporary workaround to 0.27.2.

For general changelog, see
https://github.com/matrix-org/synapse/blob/master/CHANGES.rst

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

