### PR TITLE
glogg: init at 1.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1577,6 +1577,11 @@
     email = "t@larkery.com";
     name = "Tom Hinton";
   };
+  hlolli = {
+    email = "hlolli@gmail.com";
+    github = "hlolli";
+    name = "Hlöðver Sigurðsson";
+  };
   hodapp = {
     email = "hodapp87@gmail.com";
     github = "Hodapp87";

--- a/pkgs/applications/misc/glogg/default.nix
+++ b/pkgs/applications/misc/glogg/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, qt5, boost }:
+
+stdenv.mkDerivation rec {
+
+  name = "glogg-1.1.4";
+  
+  src = fetchurl {
+    url = "http://glogg.bonnefon.org/files/${name}.tar.gz";
+    sha256 = "0c1ddc72ebfc255bbb246446fb7be5b0fd1bb1594c70045c3e537cb6d274965b";
+  };
+
+  buildInputs = [ qt5.qmake boost ];
+
+  qmakeFlags = [ "glogg.pro" ];
+
+  installCommand = ''
+    make install INSTALL_ROOT=$out
+  '';
+
+  meta = {
+    description = "The fast, smart log explorer";
+    longDescription = ''
+      A multi-platform GUI application to browse and search through long or complex log files. It is designed with programmers and system administrators in mind. glogg can be seen as a graphical, interactive combination of grep and less.
+    '';
+    homepage = http://glogg.bonnefon.org/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = [ stdenv.lib.maintainers.hlolli ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2525,6 +2525,8 @@ with pkgs;
 
   glmark2 = callPackage ../tools/graphics/glmark2 { };
 
+  glogg = callPackage ../applications/misc/glogg { };
+
   glxinfo = callPackage ../tools/graphics/glxinfo { };
 
   gmvault = callPackage ../tools/networking/gmvault { };


### PR DESCRIPTION
###### Motivation for this change
This is a fine large file explorer / log explorer which is missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Didn't test darwin, but if the test fail, I'll change the platform meta.