### PR TITLE
Zabbix-agent 3.4

### DIFF
--- a/pkgs/servers/monitoring/zabbix/3.4.nix
+++ b/pkgs/servers/monitoring/zabbix/3.4.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, pkgconfig, postgresql, curl, openssl, zlib, pcre, libevent, libiconv }:
+
+
+let
+
+  version = "3.4.8";
+  branch = "3.4";
+
+  src = fetchurl {
+    url = "https://netix.dl.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/${version}/zabbix-${version}.tar.gz";
+    sha256 = "cec14993d1ec2c9d8c51f6608c9408620f27174db92edc2347bafa7b841ccc07";
+  };
+
+in
+
+{
+  agent = stdenv.mkDerivation {
+    name = "zabbix-agent-${version}";
+
+    inherit src;
+
+     configureFlags = [
+      "--enable-agent"
+      "--with-libpcre=${pcre.dev}"
+      "--with-iconv=${libiconv}"
+    ];
+    buildInputs = [ pcre libiconv ];
+
+    meta = with stdenv.lib; {
+      inherit branch;
+      description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
+      homepage = http://www.zabbix.com/;
+      license = licenses.gpl2;
+      maintainers = [ maintainers.eelco ];
+      platforms = platforms.linux;
+    };
+  };
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13002,6 +13002,7 @@ with pkgs;
 
   zabbix20 = callPackage ../servers/monitoring/zabbix/2.0.nix { };
   zabbix22 = callPackage ../servers/monitoring/zabbix/2.2.nix { };
+  zabbix34 = callPackage ../servers/monitoring/zabbix/3.4.nix { };
 
   zipkin = callPackage ../servers/monitoring/zipkin { };
 


### PR DESCRIPTION
###### Motivation for this change
The latest Zabbix agent offered by Nixpkgs is currently 2.2 which is pretty old, the default package is even older (1.8) which include the agent and the server. I think it is time to move to a newer version of Zabbix. It would be better to merge this pull request thought ( #31123 ) as it include the version 3.4 of the agent and the server in the default.nix package instead of 1.8. If it is preferable to keep the default.nix the way it is, I think my PR can be usefull for people who want to use the 3.4 version of the agent.

When testing I used the following nix expression to make sure to use the 3.4 version instead of the default one:

```nixpkgs.config.packageOverrides = pkgs: {
     zabbix.agent = pkgs.zabbix34.agent or (lib.overrideDerivation pkgs.zabbix20.agent (a: rec {
       name = "zabbix-${version}";
       version = "3.4.8";
 
       src = pkgs.fetchurl {
         url = "https://netix.dl.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/${version}/zabbix-${version}.tar.gz";
         sha256 = "cec14993d1ec2c9d8c51f6608c9408620f27174db92edc2347bafa7b841ccc07";
       };
     }));
   };
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

