### PR TITLE
python3Packages.yowsup: 2.5.2 -> 2.5.7

### DIFF
--- a/pkgs/development/python-modules/yowsup/argparse-dependency.patch
+++ b/pkgs/development/python-modules/yowsup/argparse-dependency.patch
@@ -1,13 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 053ed07..60f0d9a 100755
+index 991e89c..7a96ccf 100755
 --- a/setup.py
 +++ b/setup.py
 @@ -5,7 +5,7 @@ import yowsup
  import platform
  import sys
  
--deps = ['python-dateutil', 'argparse', 'python-axolotl>=0.1.39', 'six']
+-deps = ['python-dateutil', 'argparse', 'python-axolotl>=0.1.39', 'six==1.10']
 +deps = ['python-dateutil', 'python-axolotl>=0.1.39', 'six']
  
  if sys.version_info < (2,7):
-     deps += ['importlib']
+     deps += ['importlib', "protobuf==3.4.0"]

--- a/pkgs/development/python-modules/yowsup/default.nix
+++ b/pkgs/development/python-modules/yowsup/default.nix
@@ -3,19 +3,18 @@
 }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "yowsup";
-  version = "2.5.2";
+  version = "2.5.7";
 
-  # python2 is currently incompatible with yowsup:
-  # https://github.com/tgalal/yowsup/issues/2325#issuecomment-343516519
+  # The Python 2.x support of this package is incompatible with `six==1.11`:
+  # https://github.com/tgalal/yowsup/issues/2416#issuecomment-365113486
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "tgalal";
     repo = "yowsup";
     rev = "v${version}";
-    sha256 = "16l8jmr32wwvl11m0a4r4id3dkfqj2n7dn6gky1077xwmj2da4fl";
+    sha256 = "1p0hdj5x38v2cxjnhdnqcnp5g7la57mbi365m0z83wa01x2n73w6";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change

The latest update of `yowsup` (https://github.com/tgalal/yowsup/releases/tag/v2.5.7)
contains the following fixes:

* Updated tokens
* Fixed tgalal/yowsup#1842: Bug in protocol_groups RemoveGroupsNotificationProtocolEntity
* Other minor bug fixes

The `argparse-dependency.patch` required a rebase onto the latest
version of `setup.py` and ensures that `argparse` won't be needed as
extra dependency as our `python3` package ships `argparse` by default.

A short note to Python 2 support:

the actual issue related to Python 2.x support has been resolved
(https://github.com/tgalal/yowsup/issues/2325#issuecomment-354533727),
however this relies on `six==1.10` which isn't support by `nixpkgs` as
`six` has been bumped to `1.11`. When trying to inject a patched version
of our `six` package based on `six==1.10` you'll run into issues with
duplicated libraries in your closure as further build dependencies
(`pytest` in this case) use the latest `six` version. As Python 2.7 will
die in 2020 (https://pythonclock.org/) and patching around in the
dependencies of `pytest` to get `yowsup` running isn't worth the effort
in my opinion I decided to keep the Python 2.x build disabled for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

