### PR TITLE
qmlbox2d and gcompris: do not fix Qt version to 5.9 [WIP]

### DIFF
--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -1,19 +1,23 @@
-{stdenv, qtdeclarative, fetchFromGitHub, qmake }:
+{ stdenv, fetchFromGitHub, qmake, qtdeclarative }:
+
 stdenv.mkDerivation rec {
-  name = "qml-box2d-2018-03-16";
+  name = "qml-box2d-${version}";
+  version = "2018-04-06";
+
   src = fetchFromGitHub {
-    owner = "qml-box2d";
-    repo = "qml-box2d";
-    sha256 = "1fbsvv28b4r0szcv8bk5gxpf8v534jp2axyfp438384sy757wsq2";
-    rev = "21e57f1";
+    owner  = "qml-box2d";
+    repo   = "qml-box2d";
+    rev    = "b7212d5640701f93f0cd88fbd3a32c619030ae62";
+    sha256 = "0gb8limy6ck23z3k0k2j7c4c4s95p40f6lbzk4szq7fjnnw22kb7";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ qmake ];
 
   buildInputs = [ qtdeclarative ];
 
-  patchPhase = ''
+  enableParallelBuilding = true;
+
+  postPatch = ''
     substituteInPlace box2d.pro \
       --replace '$$[QT_INSTALL_QML]' "/$qtQmlPrefix/"
     qmakeFlags="$qmakeFlags PREFIXSHORTCUT=$out"
@@ -22,10 +26,10 @@ stdenv.mkDerivation rec {
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
   meta = with stdenv.lib; {
-    description = "A QML plugin for Box2D engine";
-    homepage = "https://github.com/qml-box2d/qml-box2d";
-    maintainers = [ maintainers.guibou ];
-    platforms = platforms.linux;
+    description = "A QML plugin for the Box2D engine";
+    homepage = https://github.com/qml-box2d/qml-box2d;
     license = licenses.zlib;
+    maintainers = with maintainers; [ guibou ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/games/gcompris/default.nix
+++ b/pkgs/games/gcompris/default.nix
@@ -1,27 +1,27 @@
-{stdenv, cmake, qtbase, fetchurl, qtdeclarative, qtmultimedia, qttools, qtsensors, qmlbox2d, gettext, qtquickcontrols, qtgraphicaleffects, makeWrapper,
-  gst_all_1, ninja
-}:
+{ stdenv, fetchurl, cmake, makeWrapper, ninja
+, qtbase, qtdeclarative, qtmultimedia, qttools, qtsensors, qmlbox2d, gettext, qtquickcontrols, qtgraphicaleffects
+, gst_all_1 }:
+
 stdenv.mkDerivation rec {
-  version = "0.90";
+  version = "0.91";
   name = "gcompris-${version}";
 
   src = fetchurl {
     url = "http://gcompris.net/download/qt/src/gcompris-qt-${version}.tar.xz";
-    sha256 = "1i5adxnhig849qxwi3c4v7r84q6agx1zxkd69fh4y7lcmq2qiaza";
+    sha256 = "09h098w9q79hnzla1pcpqlnnr6dbafm4q6zmdp7wlk11ym8n9kvg";
   };
 
   cmakeFlags = "-DQML_BOX2D_LIBRARY=${qmlbox2d}/${qtbase.qtQmlPrefix}/Box2D.2.0";
 
   nativeBuildInputs = [ cmake ninja makeWrapper ];
-  buildInputs = [ qtbase qtdeclarative qttools qtsensors qmlbox2d gettext qtquickcontrols qtmultimedia qtgraphicaleffects] ++ soundPlugins;
-  soundPlugins = with gst_all_1; [gst-plugins-good gstreamer gst-plugins-base gst-plugins-bad];
+
+  buildInputs = [
+    qtbase qtdeclarative qttools qtsensors qmlbox2d gettext qtquickcontrols qtmultimedia qtgraphicaleffects
+  ] ++ (with gst_all_1; [ gst-plugins-good gstreamer gst-plugins-base gst-plugins-bad ]);
 
   postInstall = ''
-    # install .desktop and icon file
-    mkdir -p $out/share/applications/
-    mkdir -p $out/share/icons/hicolor/256x256/apps/
-    cp ../org.kde.gcompris.desktop $out/share/applications/gcompris.desktop
-    cp -r ../images/256-apps-gcompris-qt.png $out/share/icons/hicolor/256x256/apps/gcompris-qt.png
+    install -Dm644 ../org.kde.gcompris.desktop        $out/share/applications/gcompris.desktop
+    install -Dm644 ../images/256-apps-gcompris-qt.png $out/share/icons/hicolor/256x256/apps/gcompris-qt.png
 
     wrapProgram "$out/bin/gcompris-qt" \
        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
@@ -29,9 +29,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A high quality educational software suite, including a large number of activities for children aged 2 to 10";
-    homepage = "https://gcompris.net/";
-    maintainers = [ maintainers.guibou ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    homepage = https://gcompris.net/;
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ guibou ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11366,7 +11366,8 @@ with pkgs;
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
     qmltermwidget = callPackage ../development/libraries/qmltermwidget { };
-    qmlbox2d = libsForQt59.callPackage ../development/libraries/qmlbox2d { };
+
+    qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
 
     qscintilla = callPackage ../development/libraries/qscintilla {
       withQt5 = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19266,7 +19266,7 @@ with pkgs;
 
   gcs = callPackage ../games/gcs { };
 
-  gcompris = libsForQt59.callPackage ../games/gcompris { };
+  gcompris = libsForQt5.callPackage ../games/gcompris { };
 
   gemrb = callPackage ../games/gemrb { };
 


### PR DESCRIPTION
###### Motivation for this change

They both *do not* work with 5.10.

We wait until gcompris properly supports 5.10. While it launches, a number of graphical artifacts are missing.

Cc @guibou 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

