### PR TITLE
terraform-provider-ibm: 0.8.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-provider-ibm/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-provider-ibm/default.nix
@@ -12,7 +12,7 @@
 
 buildGoPackage rec {
   name = "terraform-provider-ibm-${version}";
-  version = "0.8.0";
+  version = "0.9.1";
 
   goPackagePath = "github.com/terraform-providers/terraform-provider-ibm";
   subPackages = [ "./" ];
@@ -20,7 +20,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "IBM-Cloud";
     repo = "terraform-provider-ibm";
-    sha256 = "1jc1g2jadh02z4lfqnvgqk5cqrzk8pnn3cj3cwsm3ksa8pccf6w4";
+    sha256 = "1j8v7r5lsvrg1afdbwxi8vq665qr47a9pddqgmpkirh99pzixgr6";
     rev = "v${version}";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Version update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

