### PR TITLE
theme-obsidian2: init at 2.5

### DIFF
--- a/pkgs/misc/themes/obsidian2/default.nix
+++ b/pkgs/misc/themes/obsidian2/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "theme-obsidian2-${version}";
+  version = "2.5";
+
+  src = fetchFromGitHub {
+    owner = "madmaxms";
+    repo = "theme-obsidian-2";
+    rev = "v${version}";
+    sha256 = "12jya1gzmhpfh602vbf51vi69fmis7sanvx278h3skm03a7civlv";
+  };
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -a Obsidian-2 $out/share/themes
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gnome theme, based upon Adwaita-Maia dark skin";
+    homepage = https://github.com/madmaxms/theme-obsidian-2;
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19715,6 +19715,8 @@ with pkgs;
 
   numix-sx-gtk-theme = callPackage ../misc/themes/numix-sx { };
 
+  theme-obsidian2 = callPackage ../misc/themes/obsidian2 { };
+
   onestepback = callPackage ../misc/themes/onestepback { };
 
   theme-vertex = callPackage ../misc/themes/vertex { };


### PR DESCRIPTION
###### Motivation for this change

Add [Obsidian-2 theme](https://github.com/madmaxms/theme-obsidian-2), a Gnome theme, based upon Adwaita-Maia dark skin.

![screenshot](https://user-images.githubusercontent.com/1217934/39595382-b6d89d3c-4ee5-11e8-8c00-11eb79d4b80f.jpg)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).