### PR TITLE
macOS closure-size reduction

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
   patches = [ ./absolute-paths.diff ];
 
-  outputs = [ "out" "man" "doc" "info" ];
+  outputs = [ "out" "dev" "man" "doc" "info" ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
@@ -20,5 +20,6 @@ appleDerivation {
 
   postInstall = ''
     mv $out/usr/local/include $out/include
+    rm -rf $out/usr
   '';
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -3,7 +3,8 @@
   removefile, libresolv, Libnotify, libplatform, libpthread, mDNSResponder, launchd, libutil, version }:
 
 appleDerivation rec {
-  phases = [ "unpackPhase" "installPhase" ];
+  dontBuild = true;
+  dontConfigure = true;
 
   nativeBuildInputs = [ cpio ];
 

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -7,6 +7,8 @@ appleDerivation rec {
 
   nativeBuildInputs = [ cpio ];
 
+  outputs = [ "out" "dev" ];
+
   installPhase = ''
     export NIX_ENFORCE_PURITY=
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -225,7 +225,7 @@ in rec {
     allowedRequisites =
       [ bootstrapTools ] ++
       (with pkgs; [ xz.bin xz.out libcxx libcxxabi ]) ++
-      (with pkgs.darwin; [ dyld Libsystem CF ICU locale ]);
+      (with pkgs.darwin; [ dyld Libsystem Libsystem.dev CF ICU locale ]);
 
     overrides = persistent;
   };
@@ -263,7 +263,7 @@ in rec {
     allowedRequisites =
       [ bootstrapTools ] ++
       (with pkgs; [ xz.bin xz.out bash libcxx libcxxabi ]) ++
-      (with pkgs.darwin; [ dyld ICU Libsystem locale ]);
+      (with pkgs.darwin; [ dyld ICU Libsystem Libsystem.dev locale ]);
 
     overrides = persistent;
   };
@@ -383,7 +383,7 @@ in rec {
       binutils.bintools darwin.binutils darwin.binutils.bintools
       cc.expand-response-params
     ]) ++ (with pkgs.darwin; [
-      dyld Libsystem CF cctools ICU libiconv locale
+      dyld Libsystem Libsystem.dev CF cctools ICU libiconv locale
     ]);
 
     overrides = self: super:


### PR DESCRIPTION
These are a couple of changes to reduce closure size. Based on the output of ```nix-store -qR $(nix-build -A nix) | xargs du -sch | sort -h```:

```
68K     /nix/store/3l6nwsgsp4jyii72qmjzg550myc12kkm-bzip2-1.0.6.0.1-bin
80K     /nix/store/brsvr29c2w07qf6yjrq4n5k0fma6461d-bzip2-1.0.6.0.1
88K     /nix/store/7l324p6dmgxvv5dyi89l3hljbk1l6zhz-nix-2.0.1-man
100K    /nix/store/27jk2cnq6x7ls12cdn4awmzgfx281hyg-zlib-1.2.11
144K    /nix/store/ig0dykdy3vhkj7fj5sy0avyc68sj759i-xz-5.2.3-bin
152K    /nix/store/8s3dnrs0nvn7r2x07p6557xvjilm7qz8-xz-5.2.3
152K    /nix/store/bgg5gwlp86lqrcrxybvpw18sbc34i4v1-nghttp2-1.24.0-lib
168K    /nix/store/a2p84va4w4g7cjqqx1icmfdqiqqnfcmp-libssh2-1.8.0
176K    /nix/store/q41xv3gbh3ayfaxjj6hzwkszz7kilyks-gzip-1.9
212K    /nix/store/jhm3ari7cfrznp6knfiqq6873zw760bm-boehm-gc-7.6.4
564K    /nix/store/slsk698k0z9c8gqqdjnmivahqnch9pd4-curl-7.59.0
604K    /nix/store/m8z5wglaz4pdrrjxynq2q50r1bhfxb32-libsodium-1.0.16
644K    /nix/store/60ww1ja7av5lnm584qray3wnckrn1c4p-gmp-6.1.2
688K    /nix/store/l3g88gagk2a2y7grzp9w6jkj4ymzpqdd-libc++abi-5.0.1
808K    /nix/store/877d5gk4mzgw8q22nzwx40g502f5ri5b-libatomic_ops-7.6.2
1.1M    /nix/store/4cq7zlsqbs3l2lf7bb3vr03xxf0v2czz-bash-4.4-p12
1.1M    /nix/store/h90rp179q22r68cwmm7jjl4sphvdh9ym-libiconv-osx-10.11.6
1.5M    /nix/store/nvn4c4g2ydlrr8mgb8b6f79qi26w48w2-sqlite-3.21.0
1.6M    /nix/store/vn99garaqrg51xlb0qq4zzdrnmddsyph-brotli-1.0.3-lib
1.7M    /nix/store/2k9v6cha9r6ikqn9iyp6frqlc8kl1l5k-libkrb5-1.15.2
1.7M    /nix/store/dpi4c08jkfqbpsp2y8fd1wx9pjfciza6-coreutils-8.29
2.5M    /nix/store/5zddplqzjz4cvnirdnnvlv48y2m6kjz4-CF-osx-10.10.5
2.6M    /nix/store/qqp1h7sksdlwz2w4kg5z0k92wxbdx7wm-gnutar-1.30
3.5M    /nix/store/6jgixnd9szvwidp9zbnr61kx0xsm0b5p-openssl-1.0.2o
3.7M    /nix/store/j9vqw6z1g563pr2vj79ff9wqcr77v7q1-aws-sdk-cpp-1.3.22
6.2M    /nix/store/db6vf9amv937fqmmfzayi1sqa5xrhj0f-nix-2.0.1
6.8M    /nix/store/ggbd4h41rnvgsvjyyqd0y73jnmqzvp8r-libc++-5.0.1
9.1M    /nix/store/cmm30wfd981rx7bfm98mnamlgabpdps3-gettext-0.19.8
9.3M    /nix/store/46qj01lcjz48wb4hc7mvn3mhb3syda7h-Libsystem-osx-10.11.6
31M     /nix/store/pbn1p52nckwckwx0320hsj8vk3vnbkrs-ICU-osx-10.10.5
88M     total
```

should reduce:
- ICU
- libSystem
- gettext

(also I wonder if aws-sdk-cpp should be disabled by default? it's huge & not necessary for regular Nix users)

Note - I don't have the time to build this right now. I think they are pretty straightforward changes though & hopefully ofborg will succeed.