### PR TITLE
iconpack-obsidian: init at 4.0.1

### DIFF
--- a/pkgs/data/icons/iconpack-obsidian/default.nix
+++ b/pkgs/data/icons/iconpack-obsidian/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, gtk3 }:
+
+stdenv.mkDerivation rec {
+  name = "iconpack-obsidian-${version}";
+  version = "4.0.1";
+
+  src = fetchFromGitHub {
+    owner = "madmaxms";
+    repo = "iconpack-obsidian";
+    rev = "v${version}";
+    sha256 = "1mlaldqjc3am2d2m577fhsidlnfqlhmnf1l8hh50iqr94mc14fab";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  installPhase = ''
+     mkdir -p $out/share/icons
+     mv Obsidian* $out/share/icons
+  '';
+
+  postFixup = ''
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gnome Icon Pack based upon Faenza";
+    homepage = https://github.com/madmaxms/iconpack-obsidian;
+    license = licenses.lgpl3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14396,6 +14396,8 @@ with pkgs;
 
   ibm-plex = callPackage ../data/fonts/ibm-plex { };
 
+  iconpack-obsidian = callPackage ../data/icons/iconpack-obsidian { };
+
   inconsolata = callPackage ../data/fonts/inconsolata {};
   inconsolata-lgc = callPackage ../data/fonts/inconsolata/lgc.nix {};
 


### PR DESCRIPTION
###### Motivation for this change

Add [iconpack-obsidian](https://github.com/madmaxms/iconpack-obsidian), a Gnome Icon Pack based upon Faenza, optimized for dark themes.

![logo](https://user-images.githubusercontent.com/1217934/39596624-55945404-4ee9-11e8-872b-3b7d4f9211f4.jpg)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).