### PR TITLE
 nixos docs: Update installation partitioner instructions

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -92,12 +92,12 @@
 <screen>
 # fdisk /dev/sda # <lineannotation>(or whatever device you want to install on)</lineannotation>
 -- for UEFI systems only
+> g      # <lineannotation>(create an empty GPT table)</lineannotation>
 > n      # <lineannotation>(create a new partition for /boot)</lineannotation>
 > 3      # <lineannotation>(make it a partition number 3)</lineannotation>
 >        # <lineannotation>(press enter to accept the default)</lineannotation>
 > +512M  # <lineannotation>(the size of the UEFI boot partition)</lineannotation>
 > t      # <lineannotation>(change the partition type ...)</lineannotation>
-> 3      # <lineannotation>(... of the boot partition ...)</lineannotation>
 > 1      # <lineannotation>(... to 'UEFI System')</lineannotation>
 -- for BIOS or UEFI systems
 > n      # <lineannotation>(create a new partition for /swap)</lineannotation>
@@ -108,8 +108,9 @@
 > 1      # <lineannotation>(make it a partition number 1)</lineannotation>
 >        # <lineannotation>(press enter to accept the default)</lineannotation>
 >        # <lineannotation>(press enter to accept the default and use the rest of the remaining space)</lineannotation>
-> a      # <lineannotation>(make the partition bootable)</lineannotation>
 > x      # <lineannotation>(enter expert mode)</lineannotation>
+> A      # <lineannotation>(make the partition bootable)</lineannotation>
+> 1      # <lineannotation>(...partition one, the boot partition)</lineannotation>
 > f      # <lineannotation>(fix up the partition ordering)</lineannotation>
 > r      # <lineannotation>(exit expert mode)</lineannotation>
 > w      # <lineannotation>(write the partition table to disk and exit)</lineannotation></screen>


### PR DESCRIPTION
Updating the instructions to match experience 

- added:

```
> g      # <lineannotation>(create an empty GPT table)</lineannotation>
```

- Remove this line, because there's only one partition (so you aren't prompted for the partition number)

```
> 3      # <lineannotation>(... of the boot partition ...)</lineannotation>
```

- for GPT partitions, the bootable option is under `x` (expert mode). I updated the commands to x-A-1 for bootable.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

