### PR TITLE
restic-rest-server module: init

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -306,6 +306,7 @@
       ceph = 288;
       duplicati = 289;
       monetdb = 290;
+      restic = 291;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -580,6 +581,7 @@
       ceph = 288;
       duplicati = 289;
       monetdb = 290;
+      restic = 291;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -167,6 +167,7 @@
   ./services/backup/mysql-backup.nix
   ./services/backup/postgresql-backup.nix
   ./services/backup/restic.nix
+  ./services/backup/restic-rest-server.nix
   ./services/backup/rsnapshot.nix
   ./services/backup/tarsnap.nix
   ./services/backup/znapzend.nix

--- a/nixos/modules/services/backup/restic-rest-server.nix
+++ b/nixos/modules/services/backup/restic-rest-server.nix
@@ -1,0 +1,107 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.restic.server;
+in
+{
+  meta.maintainers = [ maintainers.bachp ];
+
+  options.services.restic.server = {
+    enable = mkEnableOption "Restic REST Server";
+
+    listenAddress = mkOption {
+      default = ":8000";
+      example = "127.0.0.1:8080";
+      type = types.str;
+      description = "Listen on a specific IP address and port.";
+    };
+
+    dataDir = mkOption {
+      default = "/var/lib/restic";
+      type = types.path;
+      description = "The directory for storing the restic repository.";
+    };
+
+    appendOnly = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Enable append only mode.
+        This mode allows creation of new backups but prevents deletion and modification of existing backups.
+        This can be useful when backing up systems that have a potential of being hacked.
+      '';
+    };
+
+    privateRepos = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Enable private repos.
+        Grants access only when a subdirectory with the same name as the user is specified in the repository URL.
+      '';
+    };
+
+    prometheus = mkOption {
+      default = false;
+      type = types.bool;
+      description = "Enable Prometheus metrics at /metrics.";
+    };
+
+    extraFlags = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        Extra commandline options to pass to Restic REST server.
+      '';
+    };
+
+    package = mkOption {
+      default = pkgs.restic-rest-server;
+      defaultText = "pkgs.restic-rest-server";
+      type = types.package;
+      description = "Restic REST server package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.restic-rest-server = {
+      description = "Restic REST Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = ''
+          ${cfg.package}/bin/rest-server \
+          --listen ${cfg.listenAddress} \
+          --path ${cfg.dataDir} \
+          ${optionalString cfg.appendOnly "--append-only"} \
+          ${optionalString cfg.privateRepos "--private-repos"} \
+          ${optionalString cfg.prometheus "--prometheus"} \
+          ${escapeShellArgs cfg.extraFlags} \
+        '';
+        Type = "simple";
+        User = "restic";
+        Group = "restic";
+
+        # Security hardening
+        ReadWritePaths = [ cfg.dataDir ];
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        PrivateDevices = true;
+      };
+    };
+
+    users.extraUsers.restic = {
+      group = "restic";
+      home = cfg.dataDir;
+      createHome = true;
+      uid = config.ids.uids.restic;
+    };
+
+    users.extraGroups.restic.gid = config.ids.uids.restic;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Allow running the restic REST server as module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @dotlambda as you added the binary