### PR TITLE
refind: fix runtime errors

### DIFF
--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     install -D -m0644 gptsync/gptsync_${efiPlatform}.efi $out/share/refind/tools_${efiPlatform}/gptsync_${efiPlatform}.efi
 
     # helper scripts
-    install -D -m0755 refind-install $out/share/refind/refind-install
+    install -D -m0755 refind-install $out/bin/refind-install
     install -D -m0755 mkrlconf $out/bin/refind-mkrlconf
     install -D -m0755 mvrefind $out/bin/refind-mvrefind
     install -D -m0755 fonts/mkfont.sh $out/bin/refind-mkfont
@@ -86,21 +86,13 @@ stdenv.mkDerivation rec {
     # keys
     install -D -m0644 keys/* $out/share/refind/keys/
 
-    # The refind-install script assumes that all resource files are
-    # installed under the same directory as the script itself. To avoid
-    # having to patch around this assumption, generate a wrapper that
-    # cds into $out/share/refind and executes the real script from
-    # there.
-    cat >$out/bin/refind-install <<EOF
-#! ${stdenv.shell}
-cd $out/share/refind && exec -a $out/bin/refind-install ./refind-install \$*
-EOF
-    chmod +x $out/bin/refind-install
+    # Fix variable definition of 'RefindDir' which is used to locate ressource files.
+    sed -i "s,\bRefindDir=.*,RefindDir=$out/share/refind,g" $out/bin/refind-install
 
     # Patch uses of `which`.  We could patch in calls to efibootmgr,
     # openssl, convert, and openssl, but that would greatly enlarge
     # refind's closure (from ca 28MB to over 400MB).
-    sed -i 's,`which \(.*\)`,`type -p \1`,g' $out/share/refind/refind-install
+    sed -i 's,`which \(.*\)`,`type -p \1`,g' $out/bin/refind-install
     sed -i 's,`which \(.*\)`,`type -p \1`,g' $out/bin/refind-mvrefind
     sed -i 's,`which \(.*\)`,`type -p \1`,g' $out/bin/refind-mkfont
   '';


### PR DESCRIPTION
In newer versions, instead of using `$PWD` to locate its ressource files,
Refind now refers to the dir containing `$0`.
This causes runtime errors due to missing ressources.

In lieu of a wrapper binary, we now simply patch the variable `RefindDir`
which stores the path to the ressource dir.

Here's a short script (run as root) to help testing this PR.
To see the runtime error that was fixed, replace the call to `refind-install` with the current Nixpkgs version of refind.
```
## Summary: Create temp device, install refind, delete device

# Create temporary loop device
truncate -s 10M /tmp/buf
tmpdev=$(losetup --find --show /tmp/buf)
mkfs.fat $tmpdev

# Run refind 
$(nix-build --no-out-link '<nixpkgs-dev>' -A refind)/bin/refind-install --usedefault $tmpdev --alldrivers
# Show contents of installation
$(nix-build --no-out-link '<nixpkgs>' -A tree)/bin/tree /tmp/refind_install

# Remove device
umount $tmpdev
losetup --detach $tmpdev
rm /tmp/buf
```


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


