### PR TITLE
git: disable failing test w/musl for now

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -277,6 +277,9 @@ EOF
     # XXX: I failed to understand why this one fails.
     # Could someone try to re-enable it on the next release ?
     disable_test t1700-split-index "null sha1"
+  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    # Test fails (as of 2.17.0, musl 1.1.19)
+    disable_test t3900-i18n-commit
   '';
 
 


### PR DESCRIPTION
I'm working to resolve this but it will take some time
(patches sent to upstream musl, maybe to git afterwards)
and for now this blocks quite a lot.

If that doesn't work out we can explore options such as
always using GNU libiconv with musl.

For the curious, here's what I sent upstream:
(waiting for response/discussion before applying to our musl)

* http://www.openwall.com/lists/musl/2018/05/02/2
* http://www.openwall.com/lists/musl/2018/05/03/1


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---