### PR TITLE
lib{std,}c++: Fix setup hooks for cross

### DIFF
--- a/pkgs/development/compilers/gcc/libstdc++-hook.sh
+++ b/pkgs/development/compilers/gcc/libstdc++-hook.sh
@@ -1,2 +1,13 @@
-export NIX_CXXSTDLIB_COMPILE+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/$(@gcc@/bin/gcc -dumpmachine)"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libstdc++"
+# The `hostOffset` describes how the host platform of the dependencies are slid
+# relative to the depending package. It is brought into scope of the setup hook
+# defined as the role of the dependency whose hooks is being run.
+case $hostOffset in
+    -1) local role='BUILD_' ;;
+    0)  local role='' ;;
+    1)  local role='TARGET_' ;;
+    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
+        return 1 ;;
+esac
+
+export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/$(@gcc@/bin/gcc -dumpmachine)"
+export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libstdc++"

--- a/pkgs/development/compilers/llvm/3.5/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.5/libc++/setup-hook.sh
@@ -1,3 +1,14 @@
+# The `hostOffset` describes how the host platform of the dependencies are slid
+# relative to the depending package. It is brought into scope of the setup hook
+# defined as the role of the dependency whose hooks is being run.
+case $hostOffset in
+    -1) local role='BUILD_' ;;
+    0)  local role='' ;;
+    1)  local role='TARGET_' ;;
+    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
+        return 1 ;;
+esac
+
 linkCxxAbi="@linkCxxAbi@"
-export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/3.7/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.7/libc++/setup-hook.sh
@@ -1,3 +1,14 @@
+# The `hostOffset` describes how the host platform of the dependencies are slid
+# relative to the depending package. It is brought into scope of the setup hook
+# defined as the role of the dependency whose hooks is being run.
+case $hostOffset in
+    -1) local role='BUILD_' ;;
+    0)  local role='' ;;
+    1)  local role='TARGET_' ;;
+    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
+        return 1 ;;
+esac
+
 linkCxxAbi="@linkCxxAbi@"
-export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/3.8/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.8/libc++/setup-hook.sh
@@ -1,3 +1,14 @@
+# The `hostOffset` describes how the host platform of the dependencies
+# relative to the depending package. It is brought into scope of the setup hook
+# defined as the role of the dependency whose hooks is being run.
+case $hostOffset in
+    -1) local role='BUILD_' ;;
+    0)  local role='' ;;
+    1)  local role='TARGET_' ;;
+    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
+        return 1 ;;
+esac
+
 linkCxxAbi="@linkCxxAbi@"
-export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/3.9/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.9/libc++/setup-hook.sh
@@ -1,3 +1,14 @@
+# The `hostOffset` describes how the host platform of the dependencies
+# relative to the depending package. It is brought into scope of the setup hook
+# defined as the role of the dependency whose hooks is being run.
+case $hostOffset in
+    -1) local role='BUILD_' ;;
+    0)  local role='' ;;
+    1)  local role='TARGET_' ;;
+    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
+        return 1 ;;
+esac
+
 linkCxxAbi="@linkCxxAbi@"
-export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/4/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/4/libc++/setup-hook.sh
@@ -1,3 +1,14 @@
+# The `hostOffset` describes how the host platform of the dependencies
+# relative to the depending package. It is brought into scope of the setup hook
+# defined as the role of the dependency whose hooks is being run.
+case $hostOffset in
+    -1) local role='BUILD_' ;;
+    0)  local role='' ;;
+    1)  local role='TARGET_' ;;
+    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
+        return 1 ;;
+esac
+
 linkCxxAbi="@linkCxxAbi@"
-export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
@@ -1,3 +1,14 @@
+# The `hostOffset` describes how the host platform of the dependencies
+# relative to the depending package. It is brought into scope of the setup hook
+# defined as the role of the dependency whose hooks is being run.
+case $hostOffset in
+    -1) local role='BUILD_' ;;
+    0)  local role='' ;;
+    1)  local role='TARGET_' ;;
+    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
+        return 1 ;;
+esac
+
 linkCxxAbi="@linkCxxAbi@"
-export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/6/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/6/libc++/setup-hook.sh
@@ -1,3 +1,14 @@
+# The `hostOffset` describes how the host platform of the dependencies
+# relative to the depending package. It is brought into scope of the setup hook
+# defined as the role of the dependency whose hooks is being run.
+case $hostOffset in
+    -1) local role='BUILD_' ;;
+    0)  local role='' ;;
+    1)  local role='TARGET_' ;;
+    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
+        return 1 ;;
+esac
+
 linkCxxAbi="@linkCxxAbi@"
-export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"


### PR DESCRIPTION
###### Motivation for this change

This was causing trouble with iOS cross compilation and C++. libstdc++ is prebuilt, but `CC_FOR_BUILD` wrapper's libcxx was adding a `-stdlib=libc+`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @kmicklas @ElvishJerricco 