### PR TITLE
Add udev rules for Ledger devices

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -252,6 +252,7 @@
   ./services/hardware/interception-tools.nix
   ./services/hardware/irqbalance.nix
   ./services/hardware/lcd.nix
+  ./services/hardware/ledger.nix
   ./services/hardware/nvidia-optimus.nix
   ./services/hardware/pcscd.nix
   ./services/hardware/pommed.nix

--- a/nixos/modules/services/hardware/ledger.nix
+++ b/nixos/modules/services/hardware/ledger.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.hardware.ledger;
+in {
+  options = {
+    hardware.ledger = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable Ledger hardware support.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = [ pkgs.ledger-udev-rules ];
+  };
+}

--- a/pkgs/os-specific/linux/ledger-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/ledger-udev-rules/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, bash }:
+stdenv.mkDerivation rec {
+  name = "ledger-udev-rules";
+
+  src = fetchFromGitHub {
+    owner = "LedgerHQ";
+    repo = "udev-rules";
+    rev = "681cd1346f2dd5bc3ab19a7985caabbc97e1861b";
+    sha256 = "0g9xb98mpv4rimqbcaqs3qcdqalf6v1h1wjcafgbx9vslz9x4a14";
+  };
+
+  installPhase = ''
+    mkdir --parents "$out/lib/udev/rules.d"
+    cat add_udev_rules.sh | grep echo | sed "s_/etc_$out/lib_" | sed "s_hw1_ledger_" | sed 's_MODE=\\"0660\\",__' | sed 's_GROUP=\\"plugdev\\"_TAG+=\\"uaccess\\"_' > install.sh
+    ${bash}/bin/bash install.sh
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "udev rules to support Ledger devices";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ chris-martin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14427,6 +14427,8 @@ with pkgs;
 
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};
 
+  ledger-udev-rules = callPackage ../os-specific/linux/ledger-udev-rules { };
+
   inherit (callPackages ../data/fonts/redhat-liberation-fonts { })
     liberation_ttf_v1_from_source
     liberation_ttf_v1_binary


### PR DESCRIPTION
This adds udev rules for [Ledget wallets](https://www.ledgerwallet.com/), allowing you to use a Ledger device by adding `hardware.ledger.enable = true;` to your NixOS config.

The source file is a bash script at https://github.com/LedgerHQ/udev-rules/blob/master/add_udev_rules.sh and I made the `ledger-udev-rule` package by applying some replacements with `sed`. The rules file ends up looks like this:

**`lib/udev/rules.d/20-ledger.rules`**
```
SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c",  TAG+="uaccess"
SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="2b7c",  TAG+="uaccess"
SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="3b7c",  TAG+="uaccess"
SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="4b7c",  TAG+="uaccess"
SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1807",  TAG+="uaccess"
SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1808",  TAG+="uaccess"
SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000",  TAG+="uaccess"
SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001",  TAG+="uaccess"
```