### PR TITLE
runInLinuxVM: fix ext4 and crc32c-intel interactions

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -92,7 +92,7 @@ rec {
 
     echo "loading kernel modules..."
     for i in $(cat ${modulesClosure}/insmod-list); do
-      insmod $i
+      insmod $i || echo "warning: unable to load $i"
     done
 
     mount -t devtmpfs devtmpfs /dev


### PR DESCRIPTION
fixes #39946, will also need to be cherry-picked back to master
cc @srhb 