### PR TITLE
freetds: 1.00.80 -> 1.00.91

### DIFF
--- a/pkgs/development/libraries/freetds/default.nix
+++ b/pkgs/development/libraries/freetds/default.nix
@@ -4,18 +4,16 @@
 
 assert odbcSupport -> unixODBC != null;
 
+# Work is in progress to move to cmake so revisit that later
+
 stdenv.mkDerivation rec {
   name = "freetds-${version}";
-  version = "1.00.80";
+  version = "1.00.91";
 
   src = fetchurl {
     url    = "http://www.freetds.org/files/stable/${name}.tar.bz2";
-    sha256 = "17s15avxcyhfk0zsj8rggizhpd2j2sa41w5xlnshzd2r3piqyl6k";
+    sha256 = "04c344xdvh2j36r01ph7yhy5rb1668il0z9vyphwdy6qqwywh622";
   };
-
-  configureFlags = [
-    "--with-tdsver=7.3"
-  ];
 
   buildInputs = [
     openssl


### PR DESCRIPTION
###### Motivation for this change

Regular update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

