### PR TITLE
impure.nix: stringify path from NIX_PATH

### DIFF
--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -41,7 +41,7 @@ in
   # fix-point made by Nixpkgs.
   overlays ? let
       isDir = path: pathExists (path + "/.");
-      pathOverlays = try <nixpkgs-overlays> "";
+      pathOverlays = try (toString <nixpkgs-overlays>) "";
       homeOverlaysFile = homeDir + "/.config/nixpkgs/overlays.nix";
       homeOverlaysDir = homeDir + "/.config/nixpkgs/overlays";
       overlays = path:


### PR DESCRIPTION
If impure.nix gets the path from NIX_PATH, the type is `path`, and `path+"/."` is a no-op. Stringify it first so `isDir` will return false if it's not, in fact, a dir. This way, single files can be specified with nixpkgs-overlays in the NIX_PATH.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

