### PR TITLE
prometheus-postfix-exporter: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/servers/monitoring/prometheus/postfix-exporter-deps.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter-deps.nix
@@ -10,30 +10,12 @@
     };
   }
   {
-    goPackagePath = "github.com/coreos/go-systemd";
-    fetch = {
-      type = "git";
-      url = "https://github.com/coreos/go-systemd";
-      rev = "d1b7d058aa2adfc795ad17ff4aaa2bc64ec11c78";
-      sha256 = "1nz3v1b90hnmj2vjjwq96pr6psxlndqjyd30v9sgiwygzb7db9mv";
-    };
-  }
-  {
-    goPackagePath = "github.com/coreos/pkg";
-    fetch = {
-      type = "git";
-      url = "https://github.com/coreos/pkg";
-      rev = "97fdf19511ea361ae1c100dd393cc47f8dcfa1e1";
-      sha256 = "1srn87wih25l09f75483hnxsr8fc6rq3bk7w1x8125ym39p6mg21";
-    };
-  }
-  {
     goPackagePath = "github.com/golang/protobuf";
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev = "e09c5db296004fbe3f74490e84dcd62c3c5ddb1b";
-      sha256 = "1acnmalkqwrq6k3l71c4pyws0zn18r2609kqaq55lhbdcjgzid31";
+      rev = "b4deda0973fb4c70b50d226b1af49f3da59f5265";
+      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
     };
   }
   {
@@ -68,8 +50,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/common";
-      rev = "d0f7cd64bda49e08b22ae8a730aa57aa0db125d6";
-      sha256 = "1d4hfbb66xsf0wq317fwhgrwakqzhvryw4d7ip851lwrpql5fqcx";
+      rev = "d811d2e9bf898806ecfb6ef6296774b13ffc314c";
+      sha256 = "0r4067r4ysmljksqw3awcxx5qplqhykahc5igdzgkky7i4bvaik1";
     };
   }
   {

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
@@ -1,8 +1,11 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, systemd, makeWrapper }:
+{ stdenv, buildGoPackage, fetchFromGitHub, systemd, makeWrapper
+, withSystemdSupport ? true }:
+
+with stdenv.lib;
 
 buildGoPackage rec {
   name = "postfix_exporter-${version}";
-  version = "0.1.1";
+  version = "0.1.2";
 
   goPackagePath = "github.com/kumina/postfix_exporter";
 
@@ -10,20 +13,41 @@ buildGoPackage rec {
     owner = "kumina";
     repo = "postfix_exporter";
     rev = version;
-    sha256 = "1p2j66jzzgyv2w832pw57g02vrac6ldrblqllgwyy0i8krb3ibyz";
+    sha256 = "1b9ib3scxni6hlw55wv6f0z1xfn27l0p29as24f71rs70pyzy4hm";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ systemd ];
+  nativeBuildInputs = optional withSystemdSupport makeWrapper;
+  buildInputs = optional withSystemdSupport systemd;
+  buildFlags = optional (!withSystemdSupport) "-tags nosystemd";
 
   goDeps = ./postfix-exporter-deps.nix;
+  extraSrcs = optionals withSystemdSupport [
+    {
+      goPackagePath = "github.com/coreos/go-systemd";
+      src = fetchFromGitHub {
+        owner = "coreos";
+        repo = "go-systemd";
+        rev = "d1b7d058aa2adfc795ad17ff4aaa2bc64ec11c78";
+        sha256 = "1nz3v1b90hnmj2vjjwq96pr6psxlndqjyd30v9sgiwygzb7db9mv";
+      };
+    }
+    {
+      goPackagePath = "github.com/coreos/pkg";
+      src = fetchFromGitHub {
+        owner = "coreos";
+        repo = "pkg";
+        rev = "97fdf19511ea361ae1c100dd393cc47f8dcfa1e1";
+        sha256 = "1srn87wih25l09f75483hnxsr8fc6rq3bk7w1x8125ym39p6mg21";
+      };
+    }
+  ];
 
-  postInstall = ''
+  postInstall = optionalString withSystemdSupport ''
     wrapProgram $bin/bin/postfix_exporter \
       --prefix LD_LIBRARY_PATH : "${systemd.lib}/lib"
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     inherit (src.meta) homepage;
     description = "A Prometheus exporter for Postfix";
     license = licenses.asl20;


### PR DESCRIPTION
With this release systemd support became optional.
It can now be disabled by passing `withSystemdSupport = false` to `callPackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---