### PR TITLE
mathematica: add mesa, fix `libGL.so.1 not found` messages

### DIFF
--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -19,6 +19,8 @@
 , libxml2
 , libuuid
 , lang ? "en"
+, libGL
+, libGLU
 }:
 
 let
@@ -56,6 +58,8 @@ stdenv.mkDerivation rec {
     libxml2
     libuuid
     zlib
+    libGL
+    libGLU
   ] ++ (with xorg; [
     libX11
     libXext


### PR DESCRIPTION
###### Motivation for this change
mathematica failed after an update a few weeks ago. this seems to fix it. i didn't add the other stuff, missing from `ldd` output, as i don't know about those. Maybe we should provide the nix-version of those libraries as well?

still missing, :
```
ldd /nix/store/y91mmrbkl376hbibncfxihcvd5hiqazy-mathematica-11.2.0/libexec/Mathematica/SystemFiles/FrontEnd/Binaries/Linux-x86-64/Mathematica
        linux-vdso.so.1 (0x00007ffdb8bbe000)
        libML64i4.so => not found
        libOSMesa32.so.8 => not found
        libGLU.so.1 => /nix/store/bdhs7n1df5rrq9x4vwlv13csajw8jlhk-glu-9.0.0/lib/libGLU.so.1 (0x00007f441d32b000)
        libfontconfig.so.1 => /nix/store/8k0av2bnifc32apzb6wjk8ghv52b5b2x-fontconfig-2.12.6-lib/lib/libfontconfig.so.1 (0x00007f441d0e5000)
        libportaudio.so.2 => not found
        libpangocairo-1.0.so.0 => not found
        libpangoft2-1.0.so.0 => not found
        libpango-1.0.so.0 => not found
        libharfbuzz.so.0 => not found
        libcairo.so.2 => not found
        libgobject-2.0.so.0 => /nix/store/azxcljz7prb2qm36andkfc7zqzccb4ks-glib-2.56.0/lib/libgobject-2.0.so.0 (0x00007f441ce91000)
        libglib-2.0.so.0 => /nix/store/azxcljz7prb2qm36andkfc7zqzccb4ks-glib-2.56.0/lib/libglib-2.0.so.0 (0x00007f441cb79000)
        libfreetype.so.6 => /nix/store/3192bm9pzlzj1f4nqf16zvaqr73k2fhc-freetype-2.9/lib/libfreetype.so.6 (0x00007f441c8c0000)
        libffi.so.6 => not found
        libpixman-1.so.0 => not found
        librt.so.1 => /nix/store/27x7pinqdsl9f3rpbm8bsszd9fhwq266-glibc-2.27/lib/librt.so.1 (0x00007f441c6b8000)
        libz.so.1 => /nix/store/vj9716h62y21a2hv18al8zvhlqpl30sx-zlib-1.2.11/lib/libz.so.1 (0x00007f441c4a1000)
        libdl.so.2 => /nix/store/27x7pinqdsl9f3rpbm8bsszd9fhwq266-glibc-2.27/lib/libdl.so.2 (0x00007f441c29d000)
        libGL.so.1 => /nix/store/p5j2c7ldxpj9dibz9psm3kswagrpzpd8-libGL-1.0.0/lib/libGL.so.1 (0x00007f441c00c000)
        libQt5PrintSupportWRI.so.5 => not found
        libQt5WidgetsWRI.so.5 => not found
        libQt5GuiWRI.so.5 => not found
        libQt5NetworkWRI.so.5 => not found
        libQt5XmlWRI.so.5 => not found
        libQt5CoreWRI.so.5 => not found
        libpthread.so.0 => /nix/store/27x7pinqdsl9f3rpbm8bsszd9fhwq266-glibc-2.27/lib/libpthread.so.0 (0x00007f441bded000)
        libXext.so.6 => /nix/store/lrf55lrjk8mpyxzqyp7s5sk1ks8lfjm9-libXext-1.3.3/lib/libXext.so.6 (0x00007f441bbda000)
        libX11.so.6 => /nix/store/m6y2ffn4s45xg5ajq0b703alppyib9xq-libX11-1.6.5/lib/libX11.so.6 (0x00007f441b899000)
        libm.so.6 => /nix/store/27x7pinqdsl9f3rpbm8bsszd9fhwq266-glibc-2.27/lib/libm.so.6 (0x00007f441b504000)
        libstdc++.so.6 => /nix/store/vz5q4hi1rdc91llnrrd5dfvqw3xn4sgw-gcc-7.3.0-lib/lib/libstdc++.so.6 (0x00007f441b17d000)
        libc.so.6 => /nix/store/27x7pinqdsl9f3rpbm8bsszd9fhwq266-glibc-2.27/lib/libc.so.6 (0x00007f441adc9000)
        /nix/store/27x7pinqdsl9f3rpbm8bsszd9fhwq266-glibc-2.27/lib/ld-linux-x86-64.so.2 => /nix/store/27x7pinqdsl9f3rpbm8bsszd9fhwq266-glibc-2.27/lib64/ld-linux-x86-64.so.2 (0x00007f441d5a9000)
        libgcc_s.so.1 => /nix/store/vz5q4hi1rdc91llnrrd5dfvqw3xn4sgw-gcc-7.3.0-lib/lib/libgcc_s.so.1 (0x00007f441abb1000)
        libGLX.so.0 => /nix/store/z1awd0gkjajkvc4n2wpdld90hn89llg4-libglvnd-1.0.0/lib/libGLX.so.0 (0x00007f441a97f000)
        libxcb.so.1 => /nix/store/wingc2n1b4plkbzvkcw4mqkyb4k2slyq-libxcb-1.12/lib/libxcb.so.1 (0x00007f441a756000)
        libXau.so.6 => /nix/store/w6q0mp40267561qv2pqy1j8rniwcwi0a-libXau-1.0.8/lib/libXau.so.6 (0x00007f441a552000)
        libXdmcp.so.6 => /nix/store/qli3rm0b0hpj53qk8spy1c3hdxbyj97w-libXdmcp-1.1.2/lib/libXdmcp.so.6 (0x00007f441a34c000)
        libGLdispatch.so.0 => /nix/store/z1awd0gkjajkvc4n2wpdld90hn89llg4-libglvnd-1.0.0/lib/libGLdispatch.so.0 (0x00007f441a096000)
        libbz2.so.1 => /nix/store/7rzhsff1x0a01yk4x6v157c2vf1jil8r-bzip2-1.0.6.0.1/lib/libbz2.so.1 (0x00007f4419e86000)
        libpng16.so.16 => /nix/store/1n47iy8z04x07ahq8phzdp1bvmqwfmmc-libpng-apng-1.6.34/lib/libpng16.so.16 (0x00007f4419c4f000)
        libexpat.so.1 => /nix/store/d8iybpqmqj8zksbk8hh3lq6iwfg71vwy-expat-2.2.5/lib/libexpat.so.1 (0x00007f4419a1d000)
        libpcre.so.1 => /nix/store/8904vd5gg478fdn5l6i853l9x07cv78z-pcre-8.41/lib/libpcre.so.1 (0x00007f44197aa000)
        libffi.so.6 => /nix/store/4y40yrzqaaxnckx8zwhidhaffqgnfpqg-libffi-3.2.1/lib/../lib64/libffi.so.6 (0x00007f44195a1000)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

