### PR TITLE
simplescreenrecorder: port to qt5

### DIFF
--- a/pkgs/applications/video/simplescreenrecorder/default.nix
+++ b/pkgs/applications/video/simplescreenrecorder/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, alsaLib, ffmpeg, libjack2, libX11, libXext
-, libXfixes, libGLU_combined, pkgconfig, libpulseaudio, qt4, cmake, ninja
+{ stdenv, fetchurl, alsaLib, ffmpeg, libjack2, libX11, libXext, qtx11extras
+, libXfixes, libGLU_combined, pkgconfig, libpulseaudio, qtbase, cmake, ninja
 }:
 
 stdenv.mkDerivation rec {
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     url = "https://github.com/MaartenBaert/ssr/archive/${version}.tar.gz";
     sha256 = "02rl9yyx3hlz9fqvgzv7ipmvx2qahj7ws5wx2m7zs3lssq3qag3g";
   };
+
+  cmakeFlags = [ "-DWITH_QT5=TRUE" ];
 
   patches = [ ./fix-paths.patch ];
 
@@ -24,14 +26,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig cmake ninja ];
   buildInputs = [
     alsaLib ffmpeg libjack2 libX11 libXext libXfixes libGLU_combined
-    libpulseaudio qt4
+    libpulseaudio qtbase qtx11extras
   ];
 
   meta = with stdenv.lib; {
     description = "A screen recorder for Linux";
     homepage = http://www.maartenbaert.be/simplescreenrecorder;
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.goibhniu ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4878,7 +4878,7 @@ with pkgs;
 
   simpleproxy = callPackage ../tools/networking/simpleproxy { };
 
-  simplescreenrecorder = callPackage ../applications/video/simplescreenrecorder { };
+  simplescreenrecorder = libsForQt5.callPackage ../applications/video/simplescreenrecorder { };
 
   sipsak = callPackage ../tools/networking/sipsak { };
 


### PR DESCRIPTION
###### Motivation for this change

See #33248

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

