### PR TITLE
Make plymouth work with gdm wayland

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -87,9 +87,10 @@ in
 
     systemd.services.plymouth-kexec.wantedBy = [ "kexec.target" ];
     systemd.services.plymouth-halt.wantedBy = [ "halt.target" ];
+    systemd.services.plymouth-quit-wait.wantedBy = [ "multi-user.target" ];
     systemd.services.plymouth-quit = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "display-manager.service" "multi-user.target" ];
+      after = [ "display-manager.service" ];
     };
     systemd.services.plymouth-poweroff.wantedBy = [ "poweroff.target" ];
     systemd.services.plymouth-reboot.wantedBy = [ "reboot.target" ];


### PR DESCRIPTION
###### Motivation for this change

 @jtojnar is getting gdm to use wayland in #39615. Trying it out I ran into a problem where gdm would fail the first time when using plymouth (on a 3rd gen X1 carbon, but not in a VM for some reason).

According to the service directory in plymouth  "multi-user.target" should want "plymouth-quit-wait.service":
```
├── multi-user.target.wants
│   ├── plymouth-quit.service -> ../plymouth-quit.service
│   └── plymouth-quit-wait.service -> ../plymouth-quit-wait.service
```

This change fixed gdm running wayland, and seems like reasonable change since it's apparently expected by plymouth.

However the change made other display managers not quit plymouth properly, leaving it running in the background consuming cpu. Removing "multi-user.target" from `plymouth-quit.after` makes plymouth quit as expected. Not sure why having it there was a problem though.

cc @abbradar (sorry for bugging you) as he's the author of the code I'm changing.

###### Things done

Tested all the display managers in a VM. All are showing the console on stage 1. as expected (I'm assuming this is needed for LUKS password). Also tested without `xserver` which also worked fine.

Though I haven't tested the configuration with LUKS enabled. If someone knows how to test this easily in eg. a VM that would be great.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

