### PR TITLE
nixos/powerManagement: add "med_power_with_dipm" scsiLinkPolicy

### DIFF
--- a/nixos/modules/tasks/scsi-link-power-management.nix
+++ b/nixos/modules/tasks/scsi-link-power-management.nix
@@ -2,7 +2,20 @@
 
 with lib;
 
-let cfg = config.powerManagement.scsiLinkPolicy; in
+let
+
+  cfg = config.powerManagement.scsiLinkPolicy;
+
+  kernel = config.boot.kernelPackages.kernel;
+
+  allowedValues = [
+    "min_power"
+    "max_performance"
+    "medium_power"
+    "med_power_with_dipm"
+  ];
+
+in
 
 {
   ###### interface
@@ -11,10 +24,13 @@ let cfg = config.powerManagement.scsiLinkPolicy; in
 
     powerManagement.scsiLinkPolicy = mkOption {
       default = null;
-      type = types.nullOr (types.enum [ "min_power" "max_performance" "medium_power" ]);
+      type = types.nullOr (types.enum allowedValues);
       description = ''
         SCSI link power management policy. The kernel default is
         "max_performance".
+        </para><para>
+        "med_power_with_dipm" is supported by kernel versions
+        4.15 and newer.
       '';
     };
 
@@ -24,6 +40,12 @@ let cfg = config.powerManagement.scsiLinkPolicy; in
   ###### implementation
 
   config = mkIf (cfg != null) {
+
+    assertions = singleton {
+      assertion = (cfg == "med_power_with_dipm") -> versionAtLeast kernel.version "4.15";
+      message = "med_power_with_dipm is not supported for kernels older than 4.15";
+    };
+
     services.udev.extraRules = ''
       SUBSYSTEM=="scsi_host", ACTION=="add", KERNEL=="host*", ATTR{link_power_management_policy}="${cfg}"
     '';


### PR DESCRIPTION
###### Motivation for this change

Linux kernels 4.15-rc1 and newer added a "med_power_with_dipm" option for SATA link policy management. This is intended for devices which are not stable under "min_power" but need certain LPM features enabled to save power.

Some background:

- https://hansdegoede.livejournal.com/18412.html
- https://patchwork.kernel.org/patch/9952739/

This change adds this new option to `config.powerManagement.scsiLinkPolicy`, and asserts the system is configured to boot with 4.15 or later if this option is set.

It might be desirable to set this as default for kernels 4.15 and newer, as in the newer Fedora kernels. Power savings is nearly as good as "min_power" with much better stability, as seen here: https://fedoraproject.org/wiki/Changes/ImprovedLaptopBatteryLife#User_Experience. In the past, "min_power" was the NixOS default but this was reverted due to stability issues for users; see https://github.com/NixOS/nixpkgs/issues/11276.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

