### PR TITLE
way-cooler: renaming commands is not needed anymore

### DIFF
--- a/pkgs/applications/window-managers/way-cooler/default.nix
+++ b/pkgs/applications/window-managers/way-cooler/default.nix
@@ -20,24 +20,16 @@ let
       mkdir -p $out/etc
       cp -r config $out/etc/way-cooler
     '';
-    postFixup = ''
-      cd $out/bin
-      mv way_cooler way-cooler
-    '';
   });
   wc-bg = ((callPackage ./wc-bg.nix {}).wc_bg {}).overrideAttrs (oldAttrs: rec {
     nativeBuildInputs = [ makeWrapper ];
 
     postFixup = ''
-      makeWrapper $out/bin/wc_bg $out/bin/wc-bg \
+      makeWrapper $out/bin/wc-bg $out/bin/wc-bg \
         --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ wayland ]}"
     '';
   });
   wc-grab = ((callPackage ./wc-grab.nix {}).wc_grab {}).overrideAttrs (oldAttrs: rec {
-    postFixup = ''
-      cd $out/bin
-      mv wc_grab wc-grab
-    '';
   });
   wc-lock = (((callPackage ./wc-lock.nix {}).wc_lock {}).override {
     crateOverrides = defaultCrateOverrides // {
@@ -47,7 +39,7 @@ let
     nativeBuildInputs = [ makeWrapper ];
 
     postFixup = ''
-      makeWrapper $out/bin/wc_lock $out/bin/wc-lock \
+      makeWrapper $out/bin/wc-lock $out/bin/wc-lock \
         --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ libxkbcommon wayland ]}"
     '';
   });


### PR DESCRIPTION
… '_' with '-' to fix multiple way-cooler compile failures

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

