### PR TITLE
yubikey-personalization-gui: port to qt5

### DIFF
--- a/pkgs/tools/misc/yubikey-personalization-gui/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization-gui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, yubikey-personalization, qt4, qmake4Hook, libyubikey }:
+{ stdenv, fetchurl, pkgconfig, yubikey-personalization, qtbase, qmake, libyubikey }:
 
 stdenv.mkDerivation rec {
   name = "yubikey-personalization-gui-3.1.25";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1knyv5yss8lhzaff6jpfqv12fjf1b8b21mfxzx3qi0hw4nl8n2v8";
   };
 
-  nativeBuildInputs = [ pkgconfig qmake4Hook ];
-  buildInputs = [ yubikey-personalization qt4 libyubikey ];
+  nativeBuildInputs = [ pkgconfig qmake ];
+  buildInputs = [ yubikey-personalization qtbase libyubikey ];
   
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11994,7 +11994,7 @@ with pkgs;
     libusb = libusb1;
   };
 
-  yubikey-personalization-gui = callPackage ../tools/misc/yubikey-personalization-gui { };
+  yubikey-personalization-gui = libsForQt5.callPackage ../tools/misc/yubikey-personalization-gui { };
 
   zeitgeist = callPackage ../development/libraries/zeitgeist { };
 


### PR DESCRIPTION
###### Motivation for this change

Uses QT5's `qmake` hook (http://doc.qt.io/qt-5/qmake-manual.html) to
build `yubikey-personalization-gui` with a non-90s interface.

See #33248

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

