### PR TITLE
virtualbox: fix pci_get_bus_and_slot removed in kernel 4.17

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -94,9 +94,7 @@ in stdenv.mkDerivation {
 
   patches =
      optional enableHardening ./hardened.patch
-  ++ [ ./qtx11extras.patch ];
-
-
+  ++ [ ./qtx11extras.patch ./kernpcidev.patch ];
 
   postPatch = ''
     sed -i -e 's|/sbin/ifconfig|${nettools}/bin/ifconfig|' \

--- a/pkgs/applications/virtualization/virtualbox/kernpcidev.patch
+++ b/pkgs/applications/virtualization/virtualbox/kernpcidev.patch
@@ -1,0 +1,18 @@
+diff --git a/src/VBox/HostDrivers/VBoxPci/linux/VBoxPci-linux.c b/src/VBox/HostDrivers/VBoxPci/linux/VBoxPci-linux.c
+index b8019f7..b7d2e39 100644
+--- a/src/VBox/HostDrivers/VBoxPci/linux/VBoxPci-linux.c
++++ b/src/VBox/HostDrivers/VBoxPci/linux/VBoxPci-linux.c
+@@ -73,8 +73,11 @@ MODULE_LICENSE("GPL");
+ MODULE_VERSION(VBOX_VERSION_STRING);
+ #endif
+ 
+-
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
++# define PCI_DEV_GET(v,d,p)            pci_get_device(v,d,p)
++# define PCI_DEV_PUT(x)                pci_dev_put(x)
++# define PCI_DEV_GET_SLOT(bus, devfn)  pci_get_domain_bus_and_slot(0, bus, devfn)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)
+ # define PCI_DEV_GET(v,d,p)            pci_get_device(v,d,p)
+ # define PCI_DEV_PUT(x)                pci_dev_put(x)
+ # define PCI_DEV_GET_SLOT(bus, devfn)  pci_get_bus_and_slot(bus, devfn)


### PR DESCRIPTION
###### Motivation for this change
`pci_get_bus_and_slot` function has been [removed](https://github.com/torvalds/linux/commit/db7a726ea8a26ae1e418f9e08845d64cbc079480) in kernel 4.17 and `virtualbox` doesn't build with that kernel.
Patched virtualbox to use `pci_get_domain_bus_and_slot` if kernel >=4.17.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

