### PR TITLE
Add package: git-secrets

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -89,6 +89,8 @@ rec {
 
   git-secret = callPackage ./git-secret { };
 
+  git-secrets = callPackage ./git-secrets { };
+
   git-stree = callPackage ./git-stree { };
 
   git2cl = callPackage ./git2cl { };

--- a/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
@@ -10,20 +10,25 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     inherit repo;
     owner = "awslabs";
-    rev = "v${version}";
+    rev = "${version}";
     sha256 = "14jsm4ks3k5d9iq3jr23829izw040pqpmv7dz8fhmvx6qz8fybzg";
   };
 
-  buildInputs = [ makeWrapper ];
+  buildInputs = [ makeWrapper git];
 
+  # buildPhase = ''
+  #  make man # TODO: need rst2man.py
+  # '';
+  
   installPhase = ''
     install -D git-secrets $out/bin/git-secrets
 
     wrapProgram $out/bin/git-secrets \
       --prefix PATH : "${lib.makeBinPath [ git ]}"
 
-    mkdir $out/share
-    cp -r man $out/share
+    # TODO: see above note on rst2man.py
+    # mkdir $out/share
+    # cp -r man $out/share
   '';
 
   meta = {

--- a/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, git }:
+
+let
+  version = "1.2.1";
+  repo = "git-secrets";
+
+in stdenv.mkDerivation {
+  name = "${repo}-${version}";
+
+  src = fetchFromGitHub {
+    inherit repo;
+    owner = "awslabs";
+    rev = "v${version}";
+    sha256 = "14jsm4ks3k5d9iq3jr23829izw040pqpmv7dz8fhmvx6qz8fybzg";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -D git-secrets $out/bin/git-secrets
+
+    wrapProgram $out/bin/git-secrets \
+      --prefix PATH : "${lib.makeBinPath [ git ]}"
+
+    mkdir $out/share
+    cp -r man $out/share
+  '';
+
+  meta = {
+    description = "Prevents you from committing passwords and other sensitive information to a git repository";
+    homepage = https://github.com/awslabs/git-secretshttps://github.com/awslabs/git-secrets;
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15969,7 +15969,7 @@ with pkgs;
 
   gitAndTools = recurseIntoAttrs (callPackage ../applications/version-management/git-and-tools {});
 
-  inherit (gitAndTools) git gitFull gitSVN git-cola svn2git git-radar git-secret transcrypt git-crypt;
+  inherit (gitAndTools) git gitFull gitSVN git-cola svn2git git-radar git-secret git-secrets transcrypt git-crypt;
 
   gitMinimal = git.override {
     withManual = false;


### PR DESCRIPTION
###### Motivation for this change

This is a new package: `git-secrets`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

