### PR TITLE
yarn2nix error handling improvements

### DIFF
--- a/pkgs/development/tools/yarn2nix/bin/yarn2nix.js
+++ b/pkgs/development/tools/yarn2nix/bin/yarn2nix.js
@@ -141,4 +141,7 @@ Promise.all(pkgs.map(updateResolvedSha1)).then(() => {
   if (!options['--no-nix']) {
     generateNix(json.object);
   }
-})
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/pkgs/development/tools/yarn2nix/bin/yarn2nix.js
+++ b/pkgs/development/tools/yarn2nix/bin/yarn2nix.js
@@ -37,8 +37,11 @@ function generateNix(lockedDependencies) {
 
   for (var depRange in lockedDependencies) {
     let dep = lockedDependencies[depRange];
-
     let depRangeParts = depRange.split('@');
+    if (depRangeParts[1].startsWith('file:')) {
+      throw new Error(`${depRange} is a local dependency`)
+    }
+
     let [url, sha1] = dep["resolved"].split("#");
     let file_name = path.basename(url)
 

--- a/pkgs/development/tools/yarn2nix/default.nix
+++ b/pkgs/development/tools/yarn2nix/default.nix
@@ -28,6 +28,17 @@ let
     };
   };
 
+  reformatPackageName = pname:
+    let
+      # regex adapted from `validate-npm-package-name`
+      # will produce 3 parts e.g.
+      # "@someorg/somepackage" -> [ "@someorg/" "someorg" "somepackage" ]
+      # "somepackage" -> [ null null "somepackage" ]
+      parts = builtins.tail (builtins.match "(@([^/]*)/)?([^/]*)" pname);
+      # if there is no organisation we need to filter out null values.
+      non-null = builtins.filter (x: x != null) parts;
+    in builtins.concatStringsSep "-" non-null;
+
   # Generates the yarn.nix from the yarn.lock file
   mkYarnNix = yarnLock:
     runCommand "yarn.nix" {}
@@ -131,10 +142,11 @@ let
   }@attrs:
     let
       package = lib.importJSON packageJSON;
-      pname = package.name;
+      pname = package.name
+      safeName = reformatPackageName pname;
       version = package.version;
       deps = mkYarnModules {
-        name = "${pname}-modules-${version}";
+        name = "${safeName}-modules-${version}";
         preBuild = yarnPreBuild;
         inherit packageJSON yarnLock yarnNix yarnFlags pkgConfig;
       };
@@ -142,7 +154,7 @@ let
     in stdenv.mkDerivation (builtins.removeAttrs attrs ["pkgConfig"] // {
       inherit src;
 
-      name = unlessNull name "${pname}-${version}";
+      name = unlessNull name "${safeName}-${version}";
 
       buildInputs = [ yarn nodejs ] ++ extraBuildInputs;
 

--- a/pkgs/development/tools/yarn2nix/package.json
+++ b/pkgs/development/tools/yarn2nix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarn2nix",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Convert packages.json and yarn.lock into a Nix expression that downloads all the dependencies",
   "main": "index.js",
   "repository": ".",


### PR DESCRIPTION
###### Motivation for this change

[`package.json` files can specify local paths as dependencies](https://docs.npmjs.com/files/package.json#local-paths), and yarn creates corresponding entries in the yarn.lock file for them.  Currently yarn2nix errors when processing those entries, but still exits with a zero status.  This means that `yarn2nix.mkYarnPackage` writes an incomplete and unparseable nix file to the store and then tries to read it, with an error like `error: syntax error, unexpected $end, at /nix/store/76ml5lgvrc41b5c4y8jsy1iw8z50cw8s-yarn.nix:3081:6`.

One way to reproduce:

```
$ git clone git@github.com:yarnpkg/yarn.git
# ...
$ cd yarn 
$ nix run -f channel:nixos-unstable yarn2nix -c yarn2nix
# ...
    {
      name = "eslint-plugin-relay-0.0.21.tgz";
      path = fetchurl {
        name = "eslint-plugin-relay-0.0.21.tgz";
        url  = "https://registry.yarnpkg.com/eslint-plugin-relay/-/eslint-plugin-relay-0.0.21.tgz";
        sha1 = "fbda01bd783aa7ed9eb0effe410049911e1449ef";
      };
    }
(node:62298) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'split' of undefined
$ echo $?
0
```

I don't know what the policy around the yarn2nix version number is; sorry if I was wrong to bump it.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).