### PR TITLE
parity-ui: init at 0.1.1

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -86,4 +86,5 @@ rec {
 
   parity = callPackage ./parity { };
   parity-beta = callPackage ./parity/beta.nix { };
+  parity-ui = callPackage ./parity-ui { };
 }

--- a/pkgs/applications/altcoins/parity-ui/default.nix
+++ b/pkgs/applications/altcoins/parity-ui/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, pkgs, fetchurl, lib, makeWrapper, nodePackages }:
+
+let
+
+uiEnv = pkgs.callPackage ./env.nix { };
+
+in stdenv.mkDerivation rec {
+  name = "parity-ui-${version}";
+  version = "0.1.1";
+
+  src = fetchurl {
+    url = "https://github.com/parity-js/shell/releases/download/v${version}/parity-ui_${version}_amd64.deb";
+    sha256 = "1jym6q63m5f4xm06dxiiabhbqnr0hysf2d3swysncs5hg6w00lh3";
+    name = "${name}.deb";
+  };
+
+  nativeBuildInputs = [ makeWrapper nodePackages.asar ];
+
+  buildCommand = ''
+    mkdir -p $out/usr/
+    ar p $src data.tar.xz | tar -C $out -xJ .
+    substituteInPlace $out/usr/share/applications/parity-ui.desktop \
+      --replace "/opt/Parity UI" $out/bin
+    mv $out/usr/* $out/
+    mv "$out/opt/Parity UI" $out/share/parity-ui
+    rm -r $out/usr/
+    rm -r $out/opt/
+
+    fixupPhase
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${uiEnv.libPath}:$out/share/parity-ui" \
+      $out/share/parity-ui/parity-ui
+
+    find $out/share/parity-ui -name "*.node" -exec patchelf --set-rpath "${uiEnv.libPath}:$out/share/parity-ui" {} \;
+
+    paxmark m $out/share/parity-ui/parity-ui
+
+    mkdir -p $out/bin
+    ln -s $out/share/parity-ui/parity-ui $out/bin/parity-ui
+  '';
+
+  meta = with stdenv.lib; {
+    description = "UI for Parity. Fast, light, robust Ethereum implementation";
+    homepage = http://parity.io;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.sorpaas ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/altcoins/parity-ui/env.nix
+++ b/pkgs/applications/altcoins/parity-ui/env.nix
@@ -1,0 +1,19 @@
+{ stdenv, lib, zlib, glib, alsaLib, dbus, gtk2, atk, pango, freetype, fontconfig
+, libgnome-keyring3, gdk_pixbuf, gvfs, cairo, cups, expat, libgpgerror, nspr
+, nss, xorg, libcap, systemd, libnotify, libsecret, gnome3 }:
+
+let
+  packages = [
+    stdenv.cc.cc zlib glib dbus gtk2 atk pango freetype libgnome-keyring3
+    fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr nss
+    xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
+    xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
+    xorg.libXcursor xorg.libxkbfile xorg.libXScrnSaver libcap systemd libnotify
+    xorg.libxcb libsecret gnome3.gconf
+  ];
+
+  libPathNative = lib.makeLibraryPath packages;
+  libPath64 = lib.makeSearchPathOutput "lib" "lib64" packages;
+  libPath = "${libPathNative}:${libPath64}";
+
+in { inherit packages libPath; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14883,6 +14883,7 @@ with pkgs;
 
   parity = self.altcoins.parity;
   parity-beta = self.altcoins.parity-beta;
+  parity-ui = self.altcoins.parity-ui;
 
   stellar-core = self.altcoins.stellar-core;
 


### PR DESCRIPTION
###### Motivation for this change

Parity will [split](https://paritytech.io/creating-a-lighter-experience/) its UI with the core client. So we have a new package `parity-ui`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

