### PR TITLE
Add xfconf runtime dependency to xfce apps

### DIFF
--- a/pkgs/desktops/xfce/applications/parole.nix
+++ b/pkgs/desktops/xfce/applications/parole.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     gtk dbus-glib libxfce4ui libxfce4util xfconf
     taglib libnotify
   ] ++ (with gst_all_1; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav]);
+  propagatedUserEnvPkgs = [ xfconf ];
 
   configureFlags = [ "--with-gstreamer=1.0" ];
 

--- a/pkgs/desktops/xfce/applications/ristretto.nix
+++ b/pkgs/desktops/xfce/applications/ristretto.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     [ pkgconfig intltool libexif gtk dbus-glib exo libxfce4util
       libxfce4ui xfconf hicolor-icon-theme makeWrapper
     ];
+  propagatedUserEnvPkgs = [ xfconf ];
 
   postInstall = ''
     wrapProgram "$out/bin/ristretto" \

--- a/pkgs/desktops/xfce/applications/xfce4-mixer.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-mixer.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     [ pkgconfig intltool glib gstreamer gtk
       libxfce4util libxfce4ui xfce4-panel xfconf libunique makeWrapper
     ] ++ gst_plugins;
+  propagatedUserEnvPkgs = [ xfconf ];
 
   postInstall =
     ''

--- a/pkgs/desktops/xfce/applications/xfce4-notifyd.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-notifyd.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ intltool libnotify gtk libxfce4util libxfce4ui xfconf ];
+  propagatedUserEnvPkgs = [ xfconf ];
 
   preFixup = ''
     rm $out/share/icons/hicolor/icon-theme.cache

--- a/pkgs/desktops/xfce/applications/xfce4-volumed-pulse.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-volumed-pulse.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     ];
 
   nativeBuildInputs = [ pkgconfig ];
+  propagatedUserEnvPkgs = [ xfconf ];
 
   meta = with stdenv.lib; {
     homepage = https://launchpad.net/xfce4-volumed-pulse;

--- a/pkgs/desktops/xfce/applications/xfce4-volumed.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-volumed.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     [ gstreamer gst_plugins_minimal gtk2
       keybinder xfconf libnotify
     ];
+  propagatedUserEnvPkgs = [ xfconf ];
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 

--- a/pkgs/desktops/xfce/core/thunar-build.nix
+++ b/pkgs/desktops/xfce/core/thunar-build.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     gtk dbus-glib libstartup_notification libnotify libexif pcre udev
     exo libxfce4util xfconf xfce4-panel
   ];
+  propagatedUserEnvPkgs = [ xfconf ];
   # TODO: optionality?
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/xfce/core/xfce4-appfinder.nix
+++ b/pkgs/desktops/xfce/core/xfce4-appfinder.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ pkgconfig intltool glib gtk libxfce4util libxfce4ui garcon xfconf ];
+  propagatedUserEnvPkgs = [ xfconf ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/xfce/core/xfce4-panel.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
       ++ optional withGtk3 gtk3;
 
   propagatedBuildInputs = [ (if withGtk3 then libxfce4ui_gtk3 else libxfce4ui) ];
+  propagatedUserEnvPkgs = [ xfconf ];
 
   configureFlags = optional withGtk3 "--enable-gtk3";
 

--- a/pkgs/desktops/xfce/core/xfce4-power-manager.nix
+++ b/pkgs/desktops/xfce/core/xfce4-power-manager.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     (if withGtk3
     then [ gtk3 libxfce4ui_gtk3 xfce4panel_gtk3 ]
     else [ gtk  libxfce4ui      xfce4-panel      ]);
+  propagatedUserEnvPkgs = [ xfconf ];
 
   postPatch = lib.optionalString withGtk3 ''
     substituteInPlace configure --replace gio-2.0 gio-unix-2.0

--- a/pkgs/desktops/xfce/core/xfce4-settings.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
     xf86inputlibinput
     libxklavier
   ];
+  propagatedUserEnvPkgs = [ xfconf ];
 
   configureFlags = [ "--enable-pluggable-dialogs" "--enable-sound-settings" ];
 


### PR DESCRIPTION
xfce4-panel requires xfconf as a runtime dependency in order to actually load configs.
~~deja-dup requires dconf as a runtime dependency in order to actually save configs.~~