### PR TITLE
particl-core: init at 0.16.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -998,6 +998,11 @@
     github = "demin-dmitriy";
     name = "Dmitriy Demin";
   };
+  demyanrogozhin = {
+    email = "demyan.rogozhin@gmail.com";
+    github = "demyanrogozhin";
+    name = "Demyan Rogozhin";
+  };
   derchris = {
     email = "derchris@me.com";
     github = "derchrisuk";

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -87,4 +87,6 @@ rec {
   parity = callPackage ./parity { };
   parity-beta = callPackage ./parity/beta.nix { };
   parity-ui = callPackage ./parity-ui { };
+
+  particl-core = callPackage ./particl/particl-core.nix { boost = boost165; miniupnpc = miniupnpc_2; withGui = false; };
 }

--- a/pkgs/applications/altcoins/particl/particl-core.nix
+++ b/pkgs/applications/altcoins/particl/particl-core.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, autoconf
+, automake
+, autoreconfHook
+, boost
+, db48
+, fetchurl
+, libevent
+, libtool
+, miniupnpc
+, openssl
+, pkgconfig
+, utillinux
+, zeromq
+, zlib
+, withGui
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "particl-core-${version}";
+  version     = "0.16.0.4";
+
+  src = fetchurl {
+    url = "https://github.com/particl/particl-core/archive/v${version}.tar.gz";
+    sha256 = "1yy8pw13rn821jpi1zvzwi3ipxi1bgfxv8g6jz49qlbjzjmjcr68";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl db48 boost zlib
+                  miniupnpc libevent zeromq ]
+                  ++ optionals stdenv.isLinux [ utillinux ];
+
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ];
+
+  meta = {
+    description = "Privacy-Focused Marketplace & Decentralized Application Platform";
+    longDescription= ''
+      An open source, decentralized privacy platform built for global person to person eCommerce.
+    '';
+    homepage = https://particl.io/;
+    maintainers = with maintainers; [ demyanrogozhin ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/particl/particl-core.nix
+++ b/pkgs/applications/altcoins/particl/particl-core.nix
@@ -1,6 +1,4 @@
 { stdenv
-, autoconf
-, automake
 , autoreconfHook
 , boost
 , db48
@@ -14,6 +12,7 @@
 , zeromq
 , zlib
 , withGui
+, unixtools
 }:
 
 with stdenv.lib;
@@ -28,9 +27,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs = [ openssl db48 boost zlib
-                  miniupnpc libevent zeromq ]
-                  ++ optionals stdenv.isLinux [ utillinux ];
+  buildInputs = [
+    openssl db48 boost zlib miniupnpc libevent zeromq
+    unixtools.hexdump
+  ];
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14896,6 +14896,8 @@ with pkgs;
 
   stellar-core = self.altcoins.stellar-core;
 
+  particl-core = self.altcoins.particl-core;
+
   aumix = callPackage ../applications/audio/aumix {
     gtkGUI = false;
   };


### PR DESCRIPTION
###### Motivation for this change
As nix user I want to have particld and particl-cli available at nixpkgs.

Particl is privacy-focused altcoin build for p2p eCommerce.
Added Particl Core - daemon used to run staking node.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` - not applied
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

