### PR TITLE
nix-pin: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/tools/package-management/nix-pin/default.nix
+++ b/pkgs/tools/package-management/nix-pin/default.nix
@@ -1,20 +1,22 @@
-{ pkgs, stdenv, fetchFromGitHub, mypy, python3 }:
+{ lib, pkgs, stdenv, fetchFromGitHub, mypy, python3, nix, git, makeWrapper }:
 let self = stdenv.mkDerivation rec {
   name = "nix-pin-${version}";
-  version = "0.2.2";
+  version = "0.3.0";
   src = fetchFromGitHub {
     owner = "timbertson";
     repo = "nix-pin";
-    rev = "version-0.2.2";
-    sha256 = "1kw43kzy4m6lnnif51r2a8i4vcgr7d4vqb1c75p7pk2b9y3jwxsz";
+    rev = "version-0.3.0";
+    sha256 = "1kq50v8m8y1wji63b7y3wh6nv3ahvdxvvbsb07day2zzf5ysy8kj";
   };
-  buildInputs = [ python3 mypy ];
+  buildInputs = [ python3 mypy makeWrapper ];
   buildPhase = ''
     mypy bin/*
   '';
   installPhase = ''
     mkdir "$out"
     cp -r bin share "$out"
+    wrapProgram $out/bin/nix-pin \
+      --prefix PATH : "${lib.makeBinPath [ nix git ]}"
   '';
   passthru =
     let


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

