### PR TITLE
 modules/virtualisation/qemu-vm: always enable serial console

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -23,7 +23,7 @@ let
 
   cfg = config.virtualisation;
 
-  qemuGraphics = if cfg.graphics then "" else "-nographic";
+  qemuGraphics = lib.optionalString (!cfg.graphics) "-nographic";
   kernelConsole = if cfg.graphics then "" else "console=${qemuSerialDevice}";
   ttys = [ "tty1" "tty2" "tty3" "tty4" "tty5" "tty6" ];
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -27,7 +27,7 @@ let
 
   # enable both serial console and tty0. select preferred console (last one) based on cfg.graphics
   kernelConsoles = let
-    consoles = [ "console=${qemuSerialDevice}" "console=tty0" ];
+    consoles = [ "console=${qemuSerialDevice},115200n8" "console=tty0" ];
     in lib.concatStringsSep " " (if cfg.graphics then consoles else reverseList consoles);
 
   # XXX: This is very ugly and in the future we really should use attribute

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -24,7 +24,11 @@ let
   cfg = config.virtualisation;
 
   qemuGraphics = lib.optionalString (!cfg.graphics) "-nographic";
-  kernelConsole = if cfg.graphics then "" else "console=${qemuSerialDevice}";
+
+  # enable both serial console and tty0. select preferred console (last one) based on cfg.graphics
+  kernelConsoles = let
+    consoles = [ "console=${qemuSerialDevice}" "console=tty0" ];
+    in lib.concatStringsSep " " (if cfg.graphics then consoles else reverseList consoles);
 
   # XXX: This is very ugly and in the future we really should use attribute
   # sets to build ALL of the QEMU flags instead of this mixed mess of Nix
@@ -107,7 +111,7 @@ let
             ${mkDiskIfaceDriveFlag "0" "file=$NIX_DISK_IMAGE,cache=writeback,werror=report"} \
             -kernel ${config.system.build.toplevel}/kernel \
             -initrd ${config.system.build.toplevel}/initrd \
-            -append "$(cat ${config.system.build.toplevel}/kernel-params) init=${config.system.build.toplevel}/init regInfo=${regInfo}/registration ${kernelConsole} $QEMU_KERNEL_PARAMS" \
+            -append "$(cat ${config.system.build.toplevel}/kernel-params) init=${config.system.build.toplevel}/init regInfo=${regInfo}/registration ${kernelConsoles} $QEMU_KERNEL_PARAMS" \
           ''} \
           $extraDisks \
           ${qemuGraphics} \
@@ -247,9 +251,10 @@ in
         default = true;
         description =
           ''
-            Whether to run QEMU with a graphics window, or access
-            the guest computer serial port through the host tty.
-          '';
+            Whether to run QEMU with a graphics window, or in nographic mode.
+            Serial console will be enabled on both settings, but this will
+            change the preferred console.
+            '';
       };
 
     virtualisation.cores =

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -25,7 +25,6 @@ let
 
   qemuGraphics = lib.optionalString (!cfg.graphics) "-nographic";
   kernelConsole = if cfg.graphics then "" else "console=${qemuSerialDevice}";
-  ttys = [ "tty1" "tty2" "tty3" "tty4" "tty5" "tty6" ];
 
   # XXX: This is very ugly and in the future we really should use attribute
   # sets to build ALL of the QEMU flags instead of this mixed mess of Nix

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation rec {
   postInstall =
     if stdenv.isx86_64       then ''makeWrapper $out/bin/qemu-system-x86_64  $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
     else if stdenv.isi686    then ''makeWrapper $out/bin/qemu-system-i386    $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
-    else if stdenv.isAarch32     then ''makeWrapper $out/bin/qemu-system-arm     $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
+    else if stdenv.isAarch32 then ''makeWrapper $out/bin/qemu-system-arm     $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
     else if stdenv.isAarch64 then ''makeWrapper $out/bin/qemu-system-aarch64 $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
     else "";
 


### PR DESCRIPTION
###### Motivation for this change

Don't make serial console activation dependent on graphical.
Even in qemu graphical mode, you can switch to the serial console via
Ctrl+Alt+3.

With that being done, you also don't need to specify
`systemd.services."serial-getty@ttyS0".enable = true;` either as described in
https://nixos.wiki/wiki/Cheatsheet#Building_a_service_as_a_VM_.28for_testing.29,
as systemd automatically spawns a getty on consoles passwd via cmdline.

This also means, vms built by `nixos-rebuild build-vm` can simply be run
properly in nographic mode by appending `-nographic` to `result/bin/run-*-vm`,
without the need to explicitly add platform-specific `QEMU_KERNEL_PARAMS.`

/cc @dezgeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

