### PR TITLE
mariadb: Fix mariadb_config include path.

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -34,7 +34,7 @@ common = rec { # attributes common to both builds
     sed -i 's,[^"]*/var/log,/var/log,g' storage/mroonga/vendor/groonga/CMakeLists.txt
   '';
 
-  patches = [ ./cmake-includedir.patch ]
+  patches = [ ./cmake-includedir.patch ./include-dirs-path.patch ]
     ++ stdenv.lib.optional stdenv.cc.isClang ./clang-isfinite.patch;
 
   cmakeFlags = [

--- a/pkgs/servers/sql/mariadb/include-dirs-path.patch
+++ b/pkgs/servers/sql/mariadb/include-dirs-path.patch
@@ -1,0 +1,13 @@
+diff --git a/libmariadb/mariadb_config/mariadb_config.c.in b/libmariadb/mariadb_config/mariadb_config.c.in
+index 45d2f4e..e5666db 100644
+--- a/libmariadb/mariadb_config/mariadb_config.c.in
++++ b/libmariadb/mariadb_config/mariadb_config.c.in
+@@ -5,7 +5,7 @@
+ 
+ static char *mariadb_progname;
+ 
+-#define INCLUDE "-I@CMAKE_INSTALL_PREFIX@/@INSTALL_INCLUDEDIR@ -I@CMAKE_INSTALL_PREFIX@/@INSTALL_INCLUDEDIR@/mysql"
++#define INCLUDE "-I@INSTALL_INCLUDEDIR@ -I@INSTALL_INCLUDEDIR@/mysql"
+ #define LIBS    "-L@CMAKE_INSTALL_PREFIX@/@INSTALL_LIBDIR@/ -lmariadb @extra_dynamic_LDFLAGS@"
+ #define LIBS_SYS "@extra_dynamic_LDFLAGS@"
+ #define CFLAGS  INCLUDE


### PR DESCRIPTION
Fixes #39984.

###### Motivation for this change

This PR fixes the include paths exposed by mysql_config.

###### From

```
mysql_config 
Usage: /nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/bin/mysql_config [OPTIONS]
Options:
        --cflags         [-I/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13//nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/include/mysql -I/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13//nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/include/mysql/mysql]
        --include        [-I/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13//nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/include/mysql -I/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13//nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/include/mysql/mysql]
        --libs           [-L/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/lib/ -lmariadb -lz -ldl -lm -lpthread -lssl -lcrypto]
        --libs_r         [-L/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/lib/ -lmariadb -lz -ldl -lm -lpthread -lssl -lcrypto]
        --plugindir      [/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/lib/mysql/plugin]
        --socket         [/run/mysqld/mysqld.sock]
        --port           [3306]
        --version        [10.2.13]
        --libmysqld-libs [-L/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/lib  -lmysqld -lpthread -lz -lm -ldl -lssl -lcrypto -lpcre -lcrypt -llz4 -llzo2 -llzma -lbz2 -laio -lnuma -lsystemd]
        --variable=VAR   VAR is one of:
                pkgincludedir [/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/include/mysql]
                pkglibdir     [/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/lib]
                plugindir     [/nix/store/49z7dlzj4ylbvzf5gbi1zm9vh1c9iygi-mariadb-10.2.13/lib/mysql/plugin]
```

###### To

```
 ./result/bin/mysql_config                                                                                         ninjatrappeur@thinkpad-nix
Usage: ./result/bin/mysql_config [OPTIONS]
Options:
        --cflags         [-I/nix/store/xmgdzlkd3c53q1fnyafkcfpay9q27zh5-mariadb-10.2.12/include/mysql -I/nix/store/xmgdzlkd3c53q1fnyafkcfpay9q27zh5-mariadb-10.2.12/include/mysql/mysql]
        --include        [-I/nix/store/xmgdzlkd3c53q1fnyafkcfpay9q27zh5-mariadb-10.2.12/include/mysql -I/nix/store/xmgdzlkd3c53q1fnyafkcfpay9q27zh5-mariadb-10.2.12/include/mysql/mysql]
        --libs           [-L/nix/store/xmgdzlkd3c53q1fnyafkcfpay9q27zh5-mariadb-10.2.12/lib/ -lmariadb -lz -ldl -lm -lpthread -lssl -lcrypto]
        --libs_r         [-L/nix/store/xmgdzlkd3c53q1fnyafkcfpay9q27zh5-mariadb-10.2.12/lib/ -lmariadb -lz -ldl -lm -lpthread -lssl -lcrypto]
        --plugindir      [/nix/store/xmgdzlkd3c53q1fnyafkcfpay9q27zh5-mariadb-10.2.12/lib/mysql/plugin]
        --socket         [/run/mysqld/mysqld.sock]
        --port           [3306]
        --version        [10.2.12]
        --libmysqld-libs [-L/home/ninjatrappeur/Code/nixpkgs/result/lib/mysql  -lmysqld -lpthread -lz -lm -ldl -lssl -lcrypto -lpcre -lcrypt -llz4 -llzo2 -llzma -lbz2 -laio -lnuma -lsystemd]
        --variable=VAR   VAR is one of:
                pkgincludedir [/home/ninjatrappeur/Code/nixpkgs/result/include/mysql]
                pkglibdir     [/home/ninjatrappeur/Code/nixpkgs/result/lib/mysql]
                plugindir     [/nix/store/xmgdzlkd3c53q1fnyafkcfpay9q27zh5-mariadb-10.2.12/lib/mysql/plugin]

```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @vcunat @globin @ekaitz-zarraga
