### PR TITLE
zoom-us: update 2.0.106600.0904 -> 2.0.123200.0405, cleanup

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, system, makeWrapper, makeDesktopItem,
-  alsaLib, dbus, glib, gstreamer, fontconfig, freetype, libpulseaudio, libxml2,
-  libxslt, libGLU_combined, nspr, nss, sqlite, utillinux, zlib, xorg, udev, expat, libv4l }:
+  alsaLib, dbus, glib, fontconfig, freetype, libpulseaudio,
+  utillinux, zlib, xorg, udev, sqlite, expat, libv4l, procps }:
 
 let
 
-  version = "2.0.106600.0904";
+  version = "2.0.123200.0405";
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
-      sha256 = "1dcr0rqgjingjqbqv37hqjhhwy8axnjyirrnmjk44b5xnh239w9s";
+      sha256 = "1ifwa2xf5mw1ll2j1f39qd7mpyxpc6xj3650dmlnxf525dsm573z";
     };
   };
 
@@ -17,25 +17,20 @@ in stdenv.mkDerivation {
 
   src = srcs.${system};
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   libPath = stdenv.lib.makeLibraryPath [
     alsaLib
-    dbus
+    expat
     glib
-    gstreamer
-    fontconfig
     freetype
     libpulseaudio
-    libxml2
-    libxslt
-    nspr
-    nss
+    zlib
+    dbus
+    fontconfig
     sqlite
     utillinux
-    zlib
     udev
-    expat
 
     xorg.libX11
     xorg.libSM
@@ -79,6 +74,7 @@ in stdenv.mkDerivation {
     makeWrapper $packagePath/zoom $out/bin/zoom-us \
         --prefix LD_LIBRARY_PATH : "$packagePath:$libPath" \
         --prefix LD_PRELOAD : "${libv4l}/lib/v4l1compat.so" \
+        --prefix PATH : "${procps}/bin" \
         --set QT_PLUGIN_PATH "$packagePath/platforms" \
         --set QT_XKB_CONFIG_ROOT "${xorg.xkeyboardconfig}/share/X11/xkb" \
         --set QTCOMPOSE "${xorg.libX11.out}/share/X11/locale"


### PR DESCRIPTION
Apart from version update:
- remove some packages from `LD_LIBRARY_PATH`. I haven't found any
references for them. Most of them were copypasted from AUR expression
(closure size 347Mb -> 328Mb)
- found an implicit reference to `pidof` (`procps` package), in my case this caused warnings
about mismatched Glibc version. I've found implicit reference to `sh` too,
with Glibc warning too, but I don't know how to fix this, and looks like it's
only a warning

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
