### PR TITLE
draftsight: 2017-SP2 -> 2018-SP2, remove gstreamer

### DIFF
--- a/pkgs/applications/graphics/draftsight/default.nix
+++ b/pkgs/applications/graphics/draftsight/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, requireFile, dpkg, makeWrapper, gcc, libGLU_combined, xdg_utils,
+{ stdenv, fetchurl, dpkg, makeWrapper, gcc, libGLU_combined, xdg_utils,
   dbus_tools, alsaLib, cups, fontconfig, glib, icu, libpng12,
-  xkeyboard_config, gstreamer, zlib, libxslt, libxml2, sqlite, orc,
+  xkeyboard_config, zlib, libxslt, libxml2, sqlite, orc,
   libX11, libXcursor, libXrandr, libxcb, libXi, libSM, libICE,
   libXrender, libXcomposite }:
 
-let version = "2017-SP2"; in
+let version = "2018SP2"; in
 stdenv.mkDerivation {
   name = "draftsight-${version}";
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
           $out/bin/$exe \
           --prefix "QT_XKB_CONFIG_ROOT" ":" "${xkeyboard_config}/share/X11/xkb"
     done
-    for lib in $out/draftsight/opt/dassault-systemes/DraftSight/Libraries/*.so; do
+    for lib in $out/draftsight/opt/dassault-systemes/DraftSight/Libraries/*.so*; do
       # DraftSight ships with broken symlinks for some reason
       if [ -f $(readlink -f $lib) ]
       then
@@ -41,6 +41,19 @@ stdenv.mkDerivation {
         echo "Ignoring broken link $lib"
       fi
     done
+    for lib in $out/draftsight/opt/dassault-systemes/DraftSight/APISDK/lib/cpp/*.so*; do
+      if [ -f $(readlink $lib) ]
+      then
+        echo "Patching $lib..."
+        chmod u+w $lib
+        patchelf --set-rpath $libPath:\$ORIGIN/../Libraries $lib
+      else
+        echo "Ignoring broken link $lib"
+      fi
+    done
+    # These libraries shouldn't really be here anyway:
+    find $out/draftsight/opt/dassault-systemes/DraftSight/APISDK/Samples/C++ \
+         -type d -name _lib | xargs rm -r
   '';
 
   # TODO: Figure out why HelpGuide segfaults at startup.
@@ -51,15 +64,15 @@ stdenv.mkDerivation {
   # that it dlopen()'s libraries in paths removed by shrinking RPATH.
   dontPatchELF = true;
 
-  src = requireFile {
+  src = fetchurl {
     name = "draftSight.deb";
-    url = "https://www.3ds.com/?eID=3ds_brand_download&uid=41&pidDown=13426&L=0";
-    sha256 = "04i3dqza6y4p2059pqg5inp3qzr5jmiqplzzk7h1a6gh380v1rbr";
+    url = "http://dl-ak.solidworks.com/nonsecure/draftsight/${version}/draftSight.deb";
+    sha256 = "05lrvml0zkzqg0sj6sj2h8h66hxdmsw5fg9fwz923r1y8j48qxdx";
   };
 
   libPath = stdenv.lib.makeLibraryPath [ gcc.cc libGLU_combined xdg_utils
     dbus_tools alsaLib cups.lib fontconfig glib icu libpng12
-    xkeyboard_config gstreamer zlib libxslt libxml2 sqlite orc libX11
+    xkeyboard_config zlib libxslt libxml2 sqlite orc libX11
     libXcursor libXrandr libxcb libXi libSM libICE libXrender
     libXcomposite ];
 


### PR DESCRIPTION
###### Motivation for this change

This is addressing https://github.com/NixOS/nixpkgs/issues/39975. In addition, since the same URL is always used for Draftsight while the versions are updated, the hashes were all wrong - so the version required updating anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

