### PR TITLE
uftp: 4.9.5 -> 4.9.6 ["backport" to 18.03]

### DIFF
--- a/pkgs/servers/uftp/default.nix
+++ b/pkgs/servers/uftp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "uftp-${version}";
-  version = "4.9.5";
+  version = "4.9.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/uftp-multicast/source-tar/uftp-${version}.tar.gz";
-    sha256 = "1alsha0mhscp0jha2wlb5mqqkx2967s7rpm0x8c2v7jws1d0m1w3";
+    sha256 = "0byg7ff39i32ljzqxn6rhiz3zs1b04y50xpvzmjx5v8pmdajn0sz";
   };
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
Just cherry-picked 9b40680d466677e4fc77c6e8a40f7b4c0a191053.
Working fine for me on top of current release-18.03 branch.

Changelog for 4.9.6: http://uftp-multicast.sourceforge.net/Changes.txt