### PR TITLE
sunxi-tools: master20151216 -> master20171130

### DIFF
--- a/pkgs/development/tools/sunxi-tools/default.nix
+++ b/pkgs/development/tools/sunxi-tools/default.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libusb }:
+{ stdenv, fetchFromGitHub, pkgconfig, libusb, zlib }:
 
 stdenv.mkDerivation {
-  name = "sunxi-tools-1.3";
+  name = "sunxi-tools-20171130";
 
   src = fetchFromGitHub {
     owner = "linux-sunxi";
     repo = "sunxi-tools";
-    rev = "be1b4c7400161b90437432076360c1f99970f54f";
-    sha256 = "02pqaaahra4wbv325264qh5i17mxwicmjx9nm33nw2dpmfmg9xhr";
+    rev = "5c1971040c6c44caefb98e371bfca9e18d511da9";
+    sha256 = "0qzm515i3dfn82a6sf7372080zb02d365z52bh0b1q711r4dvjgp";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libusb ];
+  buildInputs = [ libusb zlib ];
 
   buildPhase = ''
-    make all misc
+    make tools misc
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp bin2fex fex2bin phoenix_info sunxi-bootinfo sunxi-fel sunxi-fexc sunxi-nand-part sunxi-pio $out/bin
+    cp bin2fex fex2bin phoenix_info sunxi-bootinfo sunxi-fel sunxi-fexc sunxi-nand-image-builder sunxi-nand-part sunxi-pio $out/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update version. The last was between releases, and a lot has happened since the last release, so I've gone as far as current master

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

