### PR TITLE
qt5.qtwebkit: Reduce log size to fix hydra build

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -28,10 +28,15 @@ qtModule {
   preConfigure = ''
     QMAKEPATH="$PWD/Tools/qmake''${QMAKEPATH:+:}$QMAKEPATH"
     fixQtBuiltinPaths . '*.pr?'
+    # Fix hydra's "Log limit exceeded"
+    export qmakeFlags="$qmakeFlags CONFIG+=silent"
   '';
 
   NIX_CFLAGS_COMPILE =
-    [ "-Wno-expansion-to-defined" ] # with gcc7 this warning blows the log over Hydra's limit
+    # with gcc7 this warning blows the log over Hydra's limit
+    [ "-Wno-expansion-to-defined" ]
+    # with clang this warning blows the log over Hydra's limit
+    ++ optional stdenv.isDarwin "-Wno-inconsistent-missing-override"
     ++ optionals flashplayerFix
       [
         ''-DNIXPKGS_LIBGTK2="${getLib gtk2}/lib/libgtk-x11-2.0"''


### PR DESCRIPTION
###### Motivation for this change
This reduces the log size and thus should fix the darwin build of qtwebkit.
https://hydra.nixos.org/build/73631258


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

