### PR TITLE
nixos/modules/services/scheduling/fcron: add setuid to fcrontab

### DIFF
--- a/nixos/modules/services/scheduling/fcron.nix
+++ b/nixos/modules/services/scheduling/fcron.nix
@@ -128,6 +128,7 @@ in
         owner = "fcron";
         group = "fcron";
         setgid = true;
+        setuid = true;
       };
       fcrondyn = {
         source = "${pkgs.fcron}/bin/fcrondyn";


### PR DESCRIPTION
###### Motivation for this change

Without fcrontab being setuid, every attempt by an user in the fcron
group to edit their own crontab (via `fcrontab -e`) results in the
following error:

```
2018-05-06 11:29:07 ERROR could not change euid to 273: Operation not permitted
2018-05-06 11:29:07 ERROR fcron child aborted: this does not affect the main fcron daemon, but this may prevent a job from being run or an email from being sent.
```

Adding setuid by hand has resolved this issue and aligns with the way
fcrontab is installed on other distributions.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

