### PR TITLE
input-utils: init at 1.3

### DIFF
--- a/pkgs/os-specific/linux/input-utils/default.nix
+++ b/pkgs/os-specific/linux/input-utils/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, linuxHeaders }:
+
+stdenv.mkDerivation rec {
+  name = "input-utils-${version}";
+  version = "1.3";
+  
+  src = fetchurl {
+    url = "https://www.kraxel.org/releases/input/input-${version}.tar.gz";
+    sha256 = "11w0pp20knx6qpgzmawdbk1nj2z3fzp8yd6nag6s8bcga16w6hli";
+  };
+
+  prePatch = ''
+    # Use proper include path for kernel include files.
+    substituteInPlace ./name.sh --replace "/usr/include/linux/" "${linuxHeaders}/include/linux/"
+    substituteInPlace ./lirc.sh --replace "/usr/include/linux/" "${linuxHeaders}/include/linux/"
+  '';
+
+  makeFlags = [
+    "prefix=$(out)"
+    "STRIP=-s"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Input layer utilities, includes lsinput";
+    homepage    = https://www.kraxel.org/blog/linux/input/;
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ samueldr ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3047,6 +3047,8 @@ with pkgs;
 
   innoextract = callPackage ../tools/archivers/innoextract { };
 
+  input-utils = callPackage ../os-specific/linux/input-utils { };
+
   intecture-agent = callPackage ../tools/admin/intecture/agent.nix { };
 
   intecture-auth = callPackage ../tools/admin/intecture/auth.nix { };


### PR DESCRIPTION
###### Motivation for this change

Adds @kraxel's [input](https://www.kraxel.org/blog/linux/input/), as input-utils, the name commonly used in other distributions.

This includes the `lsinput` utility (among others), which can be used to list information the different input devices found under `/dev/input/`. This is useful e.g. when wanting to find the input device file for a joypad or for actkbd.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - ❌ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
