### PR TITLE
lib/strings.nix: fixes & additions

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,7 +80,8 @@ let
     inherit (strings) concatStrings concatMapStrings concatImapStrings
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep makeSearchPath makeSearchPathOutput
-      makeLibraryPath makeBinPath makePerlPath optionalString
+      makeLibraryPath makeBinPath makePerlPath makeManPath makeInfoPath
+      makeXdgPath optionalString
       hasPrefix hasSuffix stringToCharacters stringAsChars escape
       escapeShellArg escapeShellArgs replaceChars lowerChars upperChars
       toLower toUpper addContextFrom splitString removePrefix

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -82,7 +82,7 @@ rec {
        => "//bin"
   */
   makeSearchPath = subDir: packages:
-    concatStringsSep ":" (map (path: path + "/" + subDir) packages);
+    concatStringsSep ":" (map (path: path + "/" + subDir) (builtins.filter (x: x != null) packages));
 
   /* Construct a Unix-style search path, using given package output.
      If no output is found, fallback to `.out` and then to the default.

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -126,6 +126,18 @@ rec {
   */
   makePerlPath = makeSearchPathOutput "lib" "lib/perl5/site_perl";
 
+  /* Construct an XDG path. Suitable to use as XDG_DATA_DIRS.
+  */
+  makeXdgPath = makeSearchPathOutput "xdg" "share";
+
+  /* Construct a manual page path. Suitable to use as MANPATH.
+  */
+  makeManPath = makeSearchPathOutput "man" "share/man";
+  
+  /* Construct an info page path. Suitable to use as INFOPATH.
+  */
+  makeInfoPath = makeSearchPathOutput "info" "share/info";
+
   /* Depending on the boolean `cond', return either the given string
      or the empty string. Useful to concatenate against a bigger string.
 


### PR DESCRIPTION
Adds 3 new functions:

-makeXdgPath
-makeInfoPath
-makeManPath

Also allows you to put null in a search path. So something like this will work:

```
lib.makeSearchPath "lib" [ libxml2 libintl ]
```

(notice that libintl will be null on Glibc systems).