### PR TITLE
dunst: add wrapper to find librsvg

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, makeWrapper
 , pkgconfig, which, perl, libXrandr
 , cairo, dbus, systemd, gdk_pixbuf, glib, libX11, libXScrnSaver
 , libXinerama, libnotify, libxdg_basedir, pango, xproto, librsvg
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "0i518v2z9fklzl5w60gkwwmg30yz3bd0k4rxjrxjabx73pvxm1mz";
   };
 
-  nativeBuildInputs = [ perl pkgconfig which systemd ];
+  nativeBuildInputs = [ perl pkgconfig which systemd makeWrapper ];
 
   buildInputs = [
     cairo dbus gdk_pixbuf glib libX11 libXScrnSaver
@@ -30,6 +30,11 @@ stdenv.mkDerivation rec {
     "SERVICEDIR_DBUS=$(out)/share/dbus-1/services"
     "SERVICEDIR_SYSTEMD=$(out)/lib/systemd/user"
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/dunst \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+  '';
 
   meta = with stdenv.lib; {
     description = "Lightweight and customizable notification daemon";


### PR DESCRIPTION
###### Motivation for this change

To make dunst work better with SVG icons. Resolves https://github.com/rycee/home-manager/issues/256.

This should probably also be backported to 18.03.

Maintainer CC: @domenkozar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).