### PR TITLE
nixos/bind: Allow to set extra options

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -27,6 +27,7 @@ let
         forwarders { ${concatMapStrings (entry: " ${entry}; ") cfg.forwarders} };
         directory "/var/run/named";
         pid-file "/var/run/named/named.pid";
+        ${cfg.extraOptions}
       };
 
       ${cfg.extraConfig}
@@ -139,6 +140,15 @@ in
         description = "
           Extra lines to be added verbatim to the generated named configuration file.
         ";
+      };
+
+      extraOptions = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Extra lines to be added verbatim to the options section of the
+          generated named configuration file.
+        '';
       };
 
       configFile = mkOption {

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -247,6 +247,7 @@ in rec {
   tests.avahi = callTest tests/avahi.nix {};
   tests.beegfs = callTest tests/beegfs.nix {};
   tests.bittorrent = callTest tests/bittorrent.nix {};
+  tests.bind = callTest tests/bind.nix {};
   tests.blivet = callTest tests/blivet.nix {};
   tests.boot = callSubTests tests/boot.nix {};
   tests.boot-stage1 = callTest tests/boot-stage1.nix {};

--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -1,0 +1,27 @@
+import ./make-test.nix {
+  name = "bind";
+
+  machine = { pkgs, lib, ... }: {
+    services.bind.enable = true;
+    services.bind.extraOptions = "empty-zones-enable no;";
+    services.bind.zones = lib.singleton {
+      name = ".";
+      file = pkgs.writeText "root.zone" ''
+        $TTL 3600
+        . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
+        . IN NS ns.example.org.
+
+        ns.example.org. IN A    192.168.0.1
+        ns.example.org. IN AAAA abcd::1
+
+        1.0.168.192.in-addr.arpa IN PTR ns.example.org.
+      '';
+    };
+  };
+
+  testScript = ''
+    $machine->waitForUnit('bind.service');
+    $machine->waitForOpenPort(53);
+    $machine->succeed('host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org');
+  '';
+}


### PR DESCRIPTION
BIND doesn't allow the options section (or any section I'd guess) to be defined more than once, so whenever you want to set an additional option you're stuck using weird hacks like this:

```nix
{ services.bind.forwarders = lib.mkForce [ "}; empty-zones-enable no; #" ]; }
```

This basically exploits the fact that values coming from the module options aren't escaped and thus works in a similar vain to how SQL injection works.

Another option would be to just set `configFile` to a file that includes all the options, including zones. That obviously makes the configuration way less extensible and more awkward to use with the module system.

To make sure this change does work correctly I added a small test just for that. The test could use some improvements, but better to have a test rather than none at all. For a future improvement the test could be merged with the NSD test, because both use the same zone file format.