### PR TITLE
i3lock-color: fix manpage-name and manpage

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   installFlags = "PREFIX=\${out} SYSCONFDIR=\${out}/etc MANDIR=\${out}/share/man";
   postInstall = ''
     mv $out/bin/i3lock $out/bin/i3lock-color
+    mv $out/share/man/man1/i3lock.1 $out/share/man/man1/i3lock-color.1
+    sed -i 's/^\.B i3lock$/.B i3lock-color/' $out/share/man/man1/i3lock-color.1
   '';
   meta = with stdenv.lib; {
     description = "A simple screen locker like slock";

--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -25,8 +25,9 @@ stdenv.mkDerivation rec {
   installFlags = "PREFIX=\${out} SYSCONFDIR=\${out}/etc MANDIR=\${out}/share/man";
   postInstall = ''
     mv $out/bin/i3lock $out/bin/i3lock-color
+    mv $out/etc/pam.d/i3lock $out/etc/pam.d/i3lock-color
     mv $out/share/man/man1/i3lock.1 $out/share/man/man1/i3lock-color.1
-    sed -i 's/^\.B i3lock$/.B i3lock-color/' $out/share/man/man1/i3lock-color.1
+    sed -i 's/\(^\|\s\|"\)i3lock\(\s\|$\)/\1i3lock-color\2/g' $out/share/man/man1/i3lock-color.1
   '';
   meta = with stdenv.lib; {
     description = "A simple screen locker like slock";

--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
   installFlags = "PREFIX=\${out} SYSCONFDIR=\${out}/etc MANDIR=\${out}/share/man";
   postInstall = ''
     mv $out/bin/i3lock $out/bin/i3lock-color
-    mv $out/etc/pam.d/i3lock $out/etc/pam.d/i3lock-color
     mv $out/share/man/man1/i3lock.1 $out/share/man/man1/i3lock-color.1
     sed -i 's/\(^\|\s\|"\)i3lock\(\s\|$\)/\1i3lock-color\2/g' $out/share/man/man1/i3lock-color.1
   '';


### PR DESCRIPTION
###### Motivation for this change
The manpage of i3lock-color should also be named i3lock-color (and not i3lock), and talk about i3lock-color (and not i3lock), so:

- rename manpage from i3lock.1 to i3lock-color.1
- change "i3lock" to "i3lock-color" in manpage-synopsis

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @garbas @malyn 