### PR TITLE
iconpack-obsidian: restrict platforms to linux

### DIFF
--- a/pkgs/data/icons/iconpack-obsidian/default.nix
+++ b/pkgs/data/icons/iconpack-obsidian/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
     description = "Gnome Icon Pack based upon Faenza";
     homepage = https://github.com/madmaxms/iconpack-obsidian;
     license = licenses.lgpl3;
-    platforms = platforms.all;
+    # darwin cannot deal with file names differing only in case
+    platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/39941#issuecomment-387057547

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).