### PR TITLE
sublime3: 3162(dev), 3143(stable) -> 3170(stable, dev)

### DIFF
--- a/pkgs/applications/editors/sublime/3/packages.nix
+++ b/pkgs/applications/editors/sublime/3/packages.nix
@@ -5,14 +5,14 @@ let
 in
   rec {
     sublime3-dev = common {
-      buildVersion = "3162";
-      x32sha256 = "190il02hqvv64w17w7xc1fz2wkbhk5a5y96jb25dvafmslm46d4i";
-      x64sha256 = "1nsjhjs6zajhx7m3dk7i450krg6pb03zffm1n3m1v0xb9zr37xz3";
+      buildVersion = "3170";
+      x32sha256 = "04ll92mqnpvvaa161il6l02gvd0g0x95sci0yrywr6jzk6am1fzg";
+      x64sha256 = "1snzjr000qrjyvzd876x5j66138glh0bff3c1b2cb2bfc88c3kzx";
     } {};
 
     sublime3 = common {
-      buildVersion = "3143";
-      x32sha256 = "0dgpx4wij2m77f478p746qadavab172166bghxmj7fb61nvw9v5i";
-      x64sha256 = "06b554d2cvpxc976rvh89ix3kqc7klnngvk070xrs8wbyb221qcw";
+      buildVersion = "3170";
+      x32sha256 = "04ll92mqnpvvaa161il6l02gvd0g0x95sci0yrywr6jzk6am1fzg";
+      x64sha256 = "1snzjr000qrjyvzd876x5j66138glh0bff3c1b2cb2bfc88c3kzx";
     } {};
   }


### PR DESCRIPTION
The dev build is technically at 3169, but I think it makes more sense to put them both at 3170. I imagine the dev build will continue to increase (ex: 3171, 3172, etc).

https://www.sublimetext.com/3
https://www.sublimetext.com/3dev