### PR TITLE
nixos/release-combined.nix: make test set consistent with release-small.nix

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -58,6 +58,8 @@ in rec {
         nixos.ova.x86_64-linux or []
 
         #(all nixos.tests.containers)
+        (all nixos.tests.containers-imperative)
+        (all nixos.tests.containers-ipv4)
         nixos.tests.chromium.x86_64-linux or []
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
@@ -98,6 +100,7 @@ in rec {
         (all nixos.tests.misc)
         (all nixos.tests.mutableUsers)
         (all nixos.tests.nat.firewall)
+        (all nixos.tests.nat.firewall-conntrack)
         (all nixos.tests.nat.standalone)
         (all nixos.tests.networking.scripted.loopback)
         (all nixos.tests.networking.scripted.static)
@@ -112,6 +115,7 @@ in rec {
         (all nixos.tests.nfs4)
         (all nixos.tests.openssh)
         (all nixos.tests.php-pcre)
+        (all nixos.tests.predictable-interface-names)
         (all nixos.tests.printing)
         (all nixos.tests.proxy)
         (all nixos.tests.sddm.default)


### PR DESCRIPTION
###### Motivation for this change

Tests for the "small" NixOS channel should be a subset of tests for the full "release" channel so these channels advance consistently. Currently, the small channel can be blocked while the full channel advances, which does not make much sense.

Fix this by adding some tests to `release-combined.nix` that previously were only in `release-small.nix`.

(Eventually the common "small" subset of tests should be factored out to force consistency but I'll save that for another time.)

cc @srhb @vcunat 

---

