### PR TITLE
unixtools: refactor for less redundancy

### DIFF
--- a/pkgs/top-level/unix-tools.nix
+++ b/pkgs/top-level/unix-tools.nix
@@ -11,7 +11,6 @@
 # input, not "procps" which requires Linux.
 
 let
-
   singleBinary = cmd: providers: let
       provider = "${lib.getBin providers.${hostPlatform.parsed.kernel.name}}/bin/${cmd}";
     in runCommand cmd {
@@ -27,8 +26,6 @@ let
       ln -s "${provider}" "$out/bin/${cmd}"
     '';
 
-in rec {
-
   # more is unavailable in darwin
   # just use less
   more_compat = runCommand "more" {} ''
@@ -36,117 +33,114 @@ in rec {
     ln -s ${pkgs.less}/bin/less $out/bin/more
   '';
 
-  # singular binaries
-  arp = singleBinary "arp" {
-    linux = pkgs.nettools;
-    darwin = pkgs.darwin.network_cmds;
+  bins = lib.mapAttrs singleBinary {
+    # singular binaries
+    arp = {
+      linux = pkgs.nettools;
+      darwin = pkgs.darwin.network_cmds;
+    };
+    col = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.text_cmds;
+    };
+    eject = {
+      linux = pkgs.utillinux;
+    };
+    getopt = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.getopt;
+    };
+    fdisk = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.diskdev_cmds;
+    };
+    fsck = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.diskdev_cmds;
+    };
+    hexdump = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.shell_cmds;
+    };
+    hostname = {
+      linux = pkgs.nettools;
+      darwin = pkgs.darwin.shell_cmds;
+    };
+    ifconfig = {
+      linux = pkgs.nettools;
+      darwin = pkgs.darwin.network_cmds;
+    };
+    logger = {
+      linux = pkgs.utillinux;
+    };
+    more = {
+      linux = pkgs.utillinux;
+      darwin = more_compat;
+    };
+    mount = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.diskdev_cmds;
+    };
+    netstat = {
+      linux = pkgs.nettools;
+      darwin = pkgs.darwin.network_cmds;
+    };
+    ping = {
+      linux = pkgs.iputils;
+      darwin = pkgs.darwin.network_cmds;
+    };
+    ps = {
+      linux = pkgs.procps;
+      darwin = pkgs.darwin.ps;
+    };
+    quota = {
+      linux = pkgs.linuxquota;
+      darwin = pkgs.darwin.diskdev_cmds;
+    };
+    route = {
+      linux = pkgs.nettools;
+      darwin = pkgs.darwin.network_cmds;
+    };
+    script = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.shell_cmds;
+    };
+    sysctl = {
+      linux = pkgs.procps;
+      darwin = pkgs.darwin.system_cmds;
+    };
+    top = {
+      linux = pkgs.procps;
+      darwin = pkgs.darwin.top;
+    };
+    umount = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.diskdev_cmds;
+    };
+    whereis = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.shell_cmds;
+    };
+    wall = {
+      linux = pkgs.utillinux;
+    };
+    write = {
+      linux = pkgs.utillinux;
+      darwin = pkgs.darwin.basic_cmds;
+    };
   };
-  col = singleBinary "col" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.text_cmds;
-  };
-  eject = singleBinary "eject" {
-    linux = pkgs.utillinux;
-  };
-  getopt = singleBinary "getopt" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.getopt;
-  };
-  fdisk = singleBinary "fdisk" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.diskdev_cmds;
-  };
-  fsck = singleBinary "fsck" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.diskdev_cmds;
-  };
-  hexdump = singleBinary "hexdump" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.shell_cmds;
-  };
-  hostname = singleBinary "hostname" {
-    linux = pkgs.nettools;
-    darwin = pkgs.darwin.shell_cmds;
-  };
-  ifconfig = singleBinary "ifconfig" {
-    linux = pkgs.nettools;
-    darwin = pkgs.darwin.network_cmds;
-  };
-  logger = singleBinary "logger" {
-    linux = pkgs.utillinux;
-  };
-  more = singleBinary "more" {
-    linux = pkgs.utillinux;
-    darwin = more_compat;
-  };
-  mount = singleBinary "mount" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.diskdev_cmds;
-  };
-  netstat = singleBinary "netstat" {
-    linux = pkgs.nettools;
-    darwin = pkgs.darwin.network_cmds;
-  };
-  ping = singleBinary "ping" {
-    linux = pkgs.iputils;
-    darwin = pkgs.darwin.network_cmds;
-  };
-  ps = singleBinary "ps" {
-    linux = pkgs.procps;
-    darwin = pkgs.darwin.ps;
-  };
-  quota = singleBinary "quota" {
-    linux = pkgs.linuxquota;
-    darwin = pkgs.darwin.diskdev_cmds;
-  };
-  route = singleBinary "route" {
-    linux = pkgs.nettools;
-    darwin = pkgs.darwin.network_cmds;
-  };
-  script = singleBinary "script" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.shell_cmds;
-  };
-  sysctl = singleBinary "sysctl" {
-    linux = pkgs.procps;
-    darwin = pkgs.darwin.system_cmds;
-  };
-  top = singleBinary "top" {
-    linux = pkgs.procps;
-    darwin = pkgs.darwin.top;
-  };
-  umount = singleBinary "umount" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.diskdev_cmds;
-  };
-  whereis = singleBinary "whereis" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.shell_cmds;
-  };
-  wall = singleBinary "wall" {
-    linux = pkgs.utillinux;
-  };
-  write = singleBinary "write" {
-    linux = pkgs.utillinux;
-    darwin = pkgs.darwin.basic_cmds;
+
+  makeCompat = name': value: buildEnv {
+      name = name' + "-compat";
+      paths = value;
   };
 
   # Compatibility derivations
   # Provided for old usage of these commands.
-
-  procps = buildEnv {
-    name = "procps-compat";
-    paths = [ ps sysctl top ];
+  compat = with bins; lib.mapAttrs makeCompat {
+    procps = [ ps sysctl top ];
+    utillinux = [ fsck fdisk getopt hexdump mount
+                  script umount whereis write col ];
+    nettools = [ arp hostname ifconfig netstat route ];
   };
-
-  utillinux = buildEnv {
-    name = "utillinux-compat";
-    paths = [ fsck fdisk getopt hexdump mount
-              script umount whereis write col ];
-  };
-
-  nettools = buildEnv {
-    name = "nettools-compat";
-    paths = [ arp hostname ifconfig netstat route ];
-  };
-}
+in bins // compat

--- a/pkgs/top-level/unix-tools.nix
+++ b/pkgs/top-level/unix-tools.nix
@@ -131,8 +131,8 @@ let
   };
 
   makeCompat = name': value: buildEnv {
-      name = name' + "-compat";
-      paths = value;
+    name = name' + "-compat";
+    paths = value;
   };
 
   # Compatibility derivations


### PR DESCRIPTION
###### Motivation for this change

`unix-tools` didn't quite follow the DRY principle, refactored it to follow this principle better. 

This shouldn't actually change the output of any derivation, just the way we get there, so @GrahamcOfBorg shouldn't give any rebuilds. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

