### PR TITLE
fzf: fix vim plugin patch phase

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -23,8 +23,13 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   patchPhase = ''
-    sed -i -e "s|expand('<sfile>:h:h').'/bin/fzf'|'$bin/bin/fzf'|" plugin/fzf.vim
-    sed -i -e "s|expand('<sfile>:h:h').'/bin/fzf-tmux'|'$bin/bin/fzf-tmux'|" plugin/fzf.vim
+    sed -i -e "s|expand('<sfile>:h:h')|'$bin'|" plugin/fzf.vim
+
+    # Original and output files can't be the same
+    if cmp -s $src/plugin/fzf.vim plugin/fzf.vim; then
+      echo "Vim plugin patch not applied properly. Aborting" && \
+      exit 1
+    fi
   '';
 
   preInstall = ''


### PR DESCRIPTION

###### Motivation for this change

During patch phase, the path to the fzf binary is overwritten in the vim plugin source. The sed expression doing this wasn't working because the fzf code changed in this commit: https://github.com/junegunn/fzf/commit/02ceae15a235de6b5cd2aca9de070fb3fff78e5b making the patch useless.


###### Things done

I fixed the sed expression and added a check to verify that the plugin was effectively patched to prevent this to happen in the future.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

