### PR TITLE
libu2f-server: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/libu2f-server/default.nix
+++ b/pkgs/development/libraries/libu2f-server/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, fetchurl, pkgconfig, json_c, openssl, check }:
+{ stdenv, fetchurl, pkgconfig, json_c, openssl, check, file, help2man, which, gengetopt }:
 
 stdenv.mkDerivation rec {
-  name = "libu2f-server-1.0.1";
-
+  name = "libu2f-server-1.1.0";
   src = fetchurl {
     url = "https://developers.yubico.com/libu2f-server/Releases/${name}.tar.xz";
-    sha256 = "0vhzixz1s629qv9dpdj6b7fxfyxnr5j2vx2cq9q6v790a68ga656";
+    sha256 = "0xx296nmmqa57w0v5p2kasl5zr1ms2gh6qi4lhv6xvzbmjp3rkcd";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ json_c openssl check ];
+  buildInputs = [ json_c openssl check file help2man which gengetopt ];
 
   meta = with stdenv.lib; {
     homepage = https://developers.yubico.com/libu2f-server/;


### PR DESCRIPTION
###### Motivation for this change
Simple upgrade, also the previous version is broken at least with pam_u2f (see issues [1](https://github.com/Yubico/pam-u2f/issues/80) and [2](https://github.com/Yubico/pam-u2f/issues/93))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @philandstuff 