### PR TITLE
treewide: Modular setup hooks

### DIFF
--- a/pkgs/build-support/bintools-wrapper/add-flags.sh
+++ b/pkgs/build-support/bintools-wrapper/add-flags.sh
@@ -11,16 +11,7 @@ var_templates_bool=(
     NIX+DONT_SET_RPATH
 )
 
-declare -a role_infixes=()
-if [ "${NIX_BINTOOLS_WRAPPER_@infixSalt@_TARGET_BUILD:-}" ]; then
-    role_infixes+=(_BUILD_)
-fi
-if [ "${NIX_BINTOOLS_WRAPPER_@infixSalt@_TARGET_HOST:-}" ]; then
-    role_infixes+=(_)
-fi
-if [ "${NIX_BINTOOLS_WRAPPER_@infixSalt@_TARGET_TARGET:-}" ]; then
-    role_infixes+=(_TARGET_)
-fi
+accumulateRoles
 
 for var in "${var_templates_list[@]}"; do
     mangleVarList "$var" "${role_infixes[@]}"

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -190,7 +190,12 @@ stdenv.mkDerivation {
 
   depsTargetTargetPropagated = extraPackages;
 
-  setupHook = ./setup-hook.sh;
+  wrapperName = "BINTOOLS_WRAPPER";
+
+  setupHooks = [
+    ../setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   postFixup =
     ''

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -294,7 +294,7 @@ stdenv.mkDerivation {
       set +u
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
-      substituteAll ${../cc-wrapper/utils.sh} $out/nix-support/utils.sh
+      substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
 
       ##
       ## Extra custom steps
@@ -305,7 +305,7 @@ stdenv.mkDerivation {
 
   inherit dynamicLinker expand-response-params;
 
-  # for substitution in utils.sh
+  # for substitution in utils.bash
   expandResponseParams = "${expand-response-params}/bin/expand-response-params";
 
   meta =

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -14,7 +14,7 @@ if [ -n "@coreutils_bin@" ]; then
     PATH="@coreutils_bin@/bin"
 fi
 
-source @out@/nix-support/utils.sh
+source @out@/nix-support/utils.bash
 
 if [ -z "${NIX_BINTOOLS_WRAPPER_@infixSalt@_FLAGS_SET:-}" ]; then
     source @out@/nix-support/add-flags.sh

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -11,44 +11,22 @@ set -u
 [[ -z ${crossConfig-} ]] || (( "$hostOffset" < 0 )) || return 0
 
 bintoolsWrapper_addLDVars () {
-    case $depHostOffset in
-        -1) local role='BUILD_' ;;
-        0)  local role='' ;;
-        1)  local role='TARGET_' ;;
-        *)  echo "bintools-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
-            return 1 ;;
-    esac
+    # See ../setup-hooks/role.bash
+    local role_post role_pre
+    getTargetRoleEnvHook
 
     if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
-        export NIX_${role}LDFLAGS+=" -L$1/lib64"
+        export NIX_${role_pre}LDFLAGS+=" -L$1/lib64"
     fi
 
     if [[ -d "$1/lib" ]]; then
-        export NIX_${role}LDFLAGS+=" -L$1/lib"
+        export NIX_${role_pre}LDFLAGS+=" -L$1/lib"
     fi
 }
 
-case $targetOffset in
-    -1)
-        export NIX_BINTOOLS_WRAPPER_@infixSalt@_TARGET_BUILD=1
-        role_pre='BUILD_'
-        role_post='_FOR_BUILD'
-        ;;
-    0)
-        export NIX_BINTOOLS_WRAPPER_@infixSalt@_TARGET_HOST=1
-        role_pre=''
-        role_post=''
-        ;;
-    1)
-        export NIX_BINTOOLS_WRAPPER_@infixSalt@_TARGET_TARGET=1
-        role_pre='TARGET_'
-        role_post='_FOR_TARGET'
-        ;;
-    *)
-        echo "cc-wrapper: used as improper sort of dependency" >2;
-        return 1
-        ;;
-esac
+# See ../setup-hooks/role.bash
+getTargetRole
+getTargetRoleWrapper
 
 addEnvHooks "$targetOffset" bintoolsWrapper_addLDVars
 

--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -14,18 +14,7 @@ var_templates_bool=(
     NIX+ENFORCE_NO_NATIVE
 )
 
-# Accumulate infixes for taking in the right input parameters. See setup-hook
-# for details.
-declare -a role_infixes=()
-if [ "${NIX_CC_WRAPPER_@infixSalt@_TARGET_BUILD:-}" ]; then
-    role_infixes+=(_BUILD_)
-fi
-if [ "${NIX_CC_WRAPPER_@infixSalt@_TARGET_HOST:-}" ]; then
-    role_infixes+=(_)
-fi
-if [ "${NIX_CC_WRAPPER_@infixSalt@_TARGET_TARGET:-}" ]; then
-    role_infixes+=(_TARGET_)
-fi
+accumulateRoles
 
 # We need to mangle names for hygiene, but also take parameters/overrides
 # from the environment.

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -15,7 +15,7 @@ if [[ -n "@coreutils_bin@" && -n "@gnugrep_bin@" ]]; then
     PATH="@coreutils_bin@/bin:@gnugrep_bin@/bin"
 fi
 
-source @out@/nix-support/utils.sh
+source @out@/nix-support/utils.bash
 
 # Flirting with a layer violation here.
 if [ -z "${NIX_BINTOOLS_WRAPPER_@infixSalt@_FLAGS_SET:-}" ]; then

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -191,7 +191,12 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ bintools ];
   depsTargetTargetPropagated = extraPackages;
 
-  setupHook = ./setup-hook.sh;
+  wrapperName = "CC_WRAPPER";
+
+  setupHooks = [
+    ../setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   postFixup =
     ''

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -282,7 +282,7 @@ stdenv.mkDerivation {
     + ''
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
-      substituteAll ${./utils.sh} $out/nix-support/utils.sh
+      substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
 
       ##
       ## Extra custom steps
@@ -293,7 +293,7 @@ stdenv.mkDerivation {
 
   inherit expand-response-params;
 
-  # for substitution in utils.sh
+  # for substitution in utils.bash
   expandResponseParams = "${expand-response-params}/bin/expand-response-params";
 
   meta =

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -66,55 +66,22 @@ set -u
 # over no state, and there's no @-substitutions within, so any redefined
 # function is guaranteed to be exactly the same.
 ccWrapper_addCVars () {
-    # The `depHostOffset` describes how the host platform of the dependencies
-    # are slid relative to the depending package. It is brought into scope of
-    # the environment hook defined as the role of the dependency being applied.
-    case $depHostOffset in
-        -1) local role='BUILD_' ;;
-        0)  local role='' ;;
-        1)  local role='TARGET_' ;;
-        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
-            return 1 ;;
-    esac
+    # See ../setup-hooks/role.bash
+    local role_post role_pre
+    getTargetRoleEnvHook
 
     if [[ -d "$1/include" ]]; then
-        export NIX_${role}CFLAGS_COMPILE+=" ${ccIncludeFlag:--isystem} $1/include"
+        export NIX_${role_pre}CFLAGS_COMPILE+=" ${ccIncludeFlag:--isystem} $1/include"
     fi
 
     if [[ -d "$1/Library/Frameworks" ]]; then
-        export NIX_${role}CFLAGS_COMPILE+=" -F$1/Library/Frameworks"
+        export NIX_${role_pre}CFLAGS_COMPILE+=" -F$1/Library/Frameworks"
     fi
 }
 
-# Since the same cc-wrapper derivation can be depend on in multiple ways, we
-# need to accumulate *each* role (i.e. target platform relative the depending
-# derivation) in which the cc-wrapper derivation is used.
-# `NIX_CC_WRAPPER_@infixSalt@_TARGET_*` tracks this (needs to be an exported env
-# var so can't use fancier data structures).
-#
-# We also need to worry about what role is being added on *this* invocation of
-# setup-hook, which `role` tracks.
-case $targetOffset in
-    -1)
-        export NIX_CC_WRAPPER_@infixSalt@_TARGET_BUILD=1
-        role_pre='BUILD_'
-        role_post='_FOR_BUILD'
-        ;;
-    0)
-        export NIX_CC_WRAPPER_@infixSalt@_TARGET_HOST=1
-        role_pre=''
-        role_post=''
-        ;;
-    1)
-        export NIX_CC_WRAPPER_@infixSalt@_TARGET_TARGET=1
-        role_pre='TARGET_'
-        role_post='_FOR_TARGET'
-        ;;
-    *)
-        echo "cc-wrapper: used as improper sort of dependency" >2;
-        return 1
-        ;;
-esac
+# See ../setup-hooks/role.bash
+getTargetRole
+getTargetRoleWrapper
 
 # We use the `targetOffset` to choose the right env hook to accumulate the right
 # sort of deps (those with that offset).

--- a/pkgs/build-support/setup-hooks/role.bash
+++ b/pkgs/build-support/setup-hooks/role.bash
@@ -1,0 +1,75 @@
+# Since the same derivation can be depend on in multiple ways, we need to
+# accumulate *each* role (i.e. host and target platforms relative the depending
+# derivation) in which the derivation is used.
+#
+# The role is intened to be use as part of other variables names like
+#  - $NIX_${role_pre}_SOMETHING
+#  - $NIX_SOMETHING_${role_post}
+
+function getRole() {
+    case $1 in
+        -1)
+            role_pre='BUILD_'
+            role_post='_FOR_BUILD'
+            ;;
+        0)
+            role_pre=''
+            role_post=''
+            ;;
+        1)
+            role_pre='TARGET_'
+            role_post='_FOR_TARGET'
+            ;;
+        *)
+            echo "@name@: used as improper sort of dependency" >2
+            return 1
+            ;;
+    esac
+}
+
+# `hostOffset` describes how the host platform of the package is slid relative
+# to the depending package. `targetOffset` likewise describes the target
+# platform of the package. Both are brought into scope of the setup hook defined
+# for dependency whose setup hook is being processed relative to the package
+# being built.
+
+function getHostRole()   {
+    getRole "$hostOffset"
+}
+function getTargetRole() {
+    getRole "$targetOffset"
+}
+
+# `depHostOffset` describes how the host platform of the dependencies are slid
+# relative to the depending package. `depTargetOffset` likewise describes the
+# target platform of dependenices. Both are brought into scope of the
+# environment hook defined for the dependency being applied relative to the
+# package being built.
+
+function getHostRoleEnvHook()   {
+    getRole "$depHostOffset"
+}
+function getTargetRoleEnvHook() {
+    getRole "$depTargetOffset"
+}
+
+# This variant is inteneded specifically for code-prodocing tool wrapper scripts
+# `NIX_@wrapperName@_@infixSalt@_TARGET_*` tracks this (needs to be an exported
+# env var so can't use fancier data structures).
+function getTargetRoleWrapper() {
+    case $targetOffset in
+        -1)
+            export NIX_@wrapperName@_@infixSalt@_TARGET_BUILD=1
+            ;;
+        0)
+            export NIX_@wrapperName@_@infixSalt@_TARGET_HOST=1
+            ;;
+        1)
+            export NIX_@wrapperName@_@infixSalt@_TARGET_TARGET=1
+            ;;
+        *)
+            echo "@name@: used as improper sort of dependency" >2
+            return 1
+            ;;
+    esac
+}

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -1,3 +1,18 @@
+# Accumulate infixes for taking in the right input parameters with the `mangle*`
+# functions below. See setup-hook for details.
+accumulateRoles() {
+    declare -ga role_infixes=()
+    if [ "${NIX_@wrapperName@_@infixSalt@_TARGET_BUILD:-}" ]; then
+        role_infixes+=(_BUILD_)
+    fi
+    if [ "${NIX_@wrapperName@_@infixSalt@_TARGET_HOST:-}" ]; then
+        role_infixes+=(_)
+    fi
+    if [ "${NIX_@wrapperName@_@infixSalt@_TARGET_TARGET:-}" ]; then
+        role_infixes+=(_TARGET_)
+    fi
+}
+
 mangleVarList() {
     local var="$1"
     shift

--- a/pkgs/development/compilers/gcc/libstdc++-hook.sh
+++ b/pkgs/development/compilers/gcc/libstdc++-hook.sh
@@ -1,13 +1,5 @@
-# The `hostOffset` describes how the host platform of the dependencies are slid
-# relative to the depending package. It is brought into scope of the setup hook
-# defined as the role of the dependency whose hooks is being run.
-case $hostOffset in
-    -1) local role='BUILD_' ;;
-    0)  local role='' ;;
-    1)  local role='TARGET_' ;;
-    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
-        return 1 ;;
-esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
-export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/$(@gcc@/bin/gcc -dumpmachine)"
-export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libstdc++"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/$(@gcc@/bin/gcc -dumpmachine)"
+export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libstdc++"

--- a/pkgs/development/compilers/llvm/3.5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/libc++/default.nix
@@ -39,7 +39,10 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ../../../../../build-support/setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   meta = {
     homepage = http://libcxx.llvm.org/;

--- a/pkgs/development/compilers/llvm/3.5/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.5/libc++/setup-hook.sh
@@ -1,14 +1,6 @@
-# The `hostOffset` describes how the host platform of the dependencies are slid
-# relative to the depending package. It is brought into scope of the setup hook
-# defined as the role of the dependency whose hooks is being run.
-case $hostOffset in
-    -1) local role='BUILD_' ;;
-    0)  local role='' ;;
-    1)  local role='TARGET_' ;;
-    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
-        return 1 ;;
-esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/3.7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/libc++/default.nix
@@ -33,7 +33,10 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ../../../../../build-support/setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   meta = {
     homepage = http://libcxx.llvm.org/;

--- a/pkgs/development/compilers/llvm/3.7/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.7/libc++/setup-hook.sh
@@ -1,14 +1,6 @@
-# The `hostOffset` describes how the host platform of the dependencies are slid
-# relative to the depending package. It is brought into scope of the setup hook
-# defined as the role of the dependency whose hooks is being run.
-case $hostOffset in
-    -1) local role='BUILD_' ;;
-    0)  local role='' ;;
-    1)  local role='TARGET_' ;;
-    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
-        return 1 ;;
-esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/3.8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++/default.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ../../../../../build-support/setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   meta = {
     homepage = http://libcxx.llvm.org/;

--- a/pkgs/development/compilers/llvm/3.8/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.8/libc++/setup-hook.sh
@@ -1,14 +1,6 @@
-# The `hostOffset` describes how the host platform of the dependencies
-# relative to the depending package. It is brought into scope of the setup hook
-# defined as the role of the dependency whose hooks is being run.
-case $hostOffset in
-    -1) local role='BUILD_' ;;
-    0)  local role='' ;;
-    1)  local role='TARGET_' ;;
-    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
-        return 1 ;;
-esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/3.9/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/libc++/default.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ../../../../../build-support/setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   meta = {
     homepage = http://libcxx.llvm.org/;

--- a/pkgs/development/compilers/llvm/3.9/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.9/libc++/setup-hook.sh
@@ -1,14 +1,6 @@
-# The `hostOffset` describes how the host platform of the dependencies
-# relative to the depending package. It is brought into scope of the setup hook
-# defined as the role of the dependency whose hooks is being run.
-case $hostOffset in
-    -1) local role='BUILD_' ;;
-    0)  local role='' ;;
-    1)  local role='TARGET_' ;;
-    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
-        return 1 ;;
-esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/4/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/4/libc++/default.nix
@@ -44,7 +44,10 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ../../../../../build-support/setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   meta = {
     homepage = http://libcxx.llvm.org/;

--- a/pkgs/development/compilers/llvm/4/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/4/libc++/setup-hook.sh
@@ -1,14 +1,6 @@
-# The `hostOffset` describes how the host platform of the dependencies
-# relative to the depending package. It is brought into scope of the setup hook
-# defined as the role of the dependency whose hooks is being run.
-case $hostOffset in
-    -1) local role='BUILD_' ;;
-    0)  local role='' ;;
-    1)  local role='TARGET_' ;;
-    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
-        return 1 ;;
-esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -40,7 +40,10 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ../../../../../build-support/setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   meta = {
     homepage = http://libcxx.llvm.org/;

--- a/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
@@ -1,14 +1,6 @@
-# The `hostOffset` describes how the host platform of the dependencies
-# relative to the depending package. It is brought into scope of the setup hook
-# defined as the role of the dependency whose hooks is being run.
-case $hostOffset in
-    -1) local role='BUILD_' ;;
-    0)  local role='' ;;
-    1)  local role='TARGET_' ;;
-    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
-        return 1 ;;
-esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -40,7 +40,10 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ../../../../../build-support/setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   meta = {
     homepage = http://libcxx.llvm.org/;

--- a/pkgs/development/compilers/llvm/6/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/6/libc++/setup-hook.sh
@@ -1,14 +1,6 @@
-# The `hostOffset` describes how the host platform of the dependencies
-# relative to the depending package. It is brought into scope of the setup hook
-# defined as the role of the dependency whose hooks is being run.
-case $hostOffset in
-    -1) local role='BUILD_' ;;
-    0)  local role='' ;;
-    1)  local role='TARGET_' ;;
-    *)  echo "cc-wrapper: Error: Cannot be used with $hostOffset-offset deps" >2;
-        return 1 ;;
-esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -48,7 +48,10 @@ stdenv.mkDerivation rec {
   # HACK, see #10874 (and 14664)
   buildInputs = stdenv.lib.optional (!stdenv.isLinux && !hostPlatform.isCygwin) libiconv;
 
-  setupHook = ./gettext-setup-hook.sh;
+  setupHooks = [
+    ../../../build-support/setup-hooks/role.bash
+    ./gettext-setup-hook.sh
+  ];
   gettextNeedsLdflags = hostPlatform.libc != "glibc" && !hostPlatform.isMusl;
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -1,6 +1,8 @@
 gettextDataDirsHook() {
+    # See pkgs/build-support/setup-hooks/role.bash
+    getHostRoleEnvHook
     if [ -d "$1/share/gettext" ]; then
-        addToSearchPath GETTEXTDATADIRS "$1/share/gettext"
+        addToSearchPath "GETTEXTDATADIRS${role_post}" "$1/share/gettext"
     fi
 }
 
@@ -8,21 +10,8 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 
 # libintl must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
-gettextLdflags() {
-    # The `depHostOffset` describes how the host platform of the dependencies
-    # are slid relative to the depending package. It is brought into scope of
-    # the environment hook defined as the role of the dependency being applied.
-    case $depHostOffset in
-        -1) local role='BUILD_' ;;
-        0)  local role='' ;;
-        1)  local role='TARGET_' ;;
-        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
-            return 1 ;;
-    esac
-
-    export NIX_${role}LDFLAGS+=" -lintl"
-}
-
 if [ ! -z "@gettextNeedsLdflags@" ]; then
-    addEnvHooks "$hostOffset" gettextLdflags
+    # See pkgs/build-support/setup-hooks/role.bash
+    getHostRole
+    export NIX_${role_pre}LDFLAGS+=" -lintl"
 fi

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -14,7 +14,10 @@ stdenv.mkDerivation rec {
     sha256 = "0y1ij745r4p48mxq84rax40p10ln7fc7m243p8k8sia519i3dxfc";
   };
 
-  setupHook = ./setup-hook.sh;
+  setupHooks = [
+    ../../../build-support/setup-hooks/role.bash
+    ./setup-hook.sh
+  ];
 
   postPatch =
     lib.optionalString ((hostPlatform != buildPlatform && hostPlatform.libc == "msvcrt") || stdenv.cc.nativeLibc)

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -1,18 +1,6 @@
 # libiconv must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
-iconvLdflags() {
-    # The `depHostOffset` describes how the host platform of the dependencies
-    # are slid relative to the depending package. It is brought into scope of
-    # the environment hook defined as the role of the dependency being applied.
-    case $depHostOffset in
-        -1) local role='BUILD_' ;;
-        0)  local role='' ;;
-        1)  local role='TARGET_' ;;
-        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
-            return 1 ;;
-    esac
 
-    export NIX_${role}LDFLAGS+=" -liconv"
-}
-
-addEnvHooks "$hostOffset" iconvLdflags
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
+export NIX_${role_pre}LDFLAGS+=" -liconv"

--- a/pkgs/os-specific/bsd/netbsd/compat-setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/compat-setup-hook.sh
@@ -1,18 +1,6 @@
-setupCompatFlags() {
-    # The `depHostOffset` describes how the host platform of the dependencies
-    # are slid relative to the depending package. It is brought into scope of
-    # the environment hook defined as the role of the dependency being applied.
-    case $depHostOffset in
-        -1) local role='BUILD_' ;;
-        0)  local role='' ;;
-        1)  local role='TARGET_' ;;
-        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
-            return 1 ;;
-    esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
-    export NIX_${role}LDFLAGS+=" -lnbcompat"
-    export NIX_${role}CFLAGS_COMPILE+=" -DHAVE_NBTOOL_CONFIG_H"
-    export NIX_${role}CFLAGS_COMPILE+=" -include nbtool_config.h"
-}
-
-addEnvHooks "$hostOffset" setupCompatFlags
+export NIX_${role_pre}LDFLAGS+=" -lnbcompat"
+export NIX_${role_pre}CFLAGS_COMPILE+=" -DHAVE_NBTOOL_CONFIG_H"
+export NIX_${role_pre}CFLAGS_COMPILE+=" -include nbtool_config.h"

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -167,7 +167,10 @@ let
     sha256 = "17phkfafybxwhzng44k5bhmag6i55br53ky1nwcmw583kg2fa86z";
     version = "7.1.2";
 
-    setupHook = ./compat-setup-hook.sh;
+    setupHooks = [
+      ../../../build-support/setup-hooks/role.bash
+      ./compat-setup-hook.sh
+    ];
 
     # override defaults to prevent infinite recursion
     nativeBuildInputs = [ makeMinimal ];
@@ -270,7 +273,10 @@ let
 
       runHook postInstall
     '';
-    setupHook = ./fts-setup-hook.sh;
+    setupHooks = [
+      ../../../build-support/setup-hooks/role.bash
+      ./fts-setup-hook.sh
+    ];
   };
 
   stat = netBSDDerivation {

--- a/pkgs/os-specific/bsd/netbsd/fts-setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/fts-setup-hook.sh
@@ -1,16 +1,4 @@
-ftsLdflags() {
-    # The `depHostOffset` describes how the host platform of the dependencies
-    # are slid relative to the depending package. It is brought into scope of
-    # the environment hook defined as the role of the dependency being applied.
-    case $depHostOffset in
-        -1) local role='BUILD_' ;;
-        0)  local role='' ;;
-        1)  local role='TARGET_' ;;
-        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
-            return 1 ;;
-    esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
-    export NIX_${role}LDFLAGS+=" -lfts"
-}
-
-addEnvHooks "$hostOffset" ftsLdflags
+export NIX_${role_pre}LDFLAGS+=" -lfts"

--- a/pkgs/os-specific/linux/musl/fts-setup-hook.sh
+++ b/pkgs/os-specific/linux/musl/fts-setup-hook.sh
@@ -1,17 +1,4 @@
-ftsLdflags() {
-    # The `depHostOffset` describes how the host platform of the dependencies
-    # are slid relative to the depending package. It is brought into scope of
-    # the environment hook defined as the role of the dependency being applied.
-    case $depHostOffset in
-        -1) local role='BUILD_' ;;
-        0)  local role='' ;;
-        1)  local role='TARGET_' ;;
-        *)  echo "cc-wrapper: Error: Cannot be used with $depHostOffset-offset deps" >2;
-            return 1 ;;
-    esac
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
 
-    export NIX_${role}LDFLAGS+=" -lfts"
-}
-
-addEnvHooks "$hostOffset" ftsLdflags
-
+export NIX_${role_pre}LDFLAGS+=" -lfts"

--- a/pkgs/os-specific/linux/musl/fts.nix
+++ b/pkgs/os-specific/linux/musl/fts.nix
@@ -12,5 +12,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  setupHook = ./fts-setup-hook.sh;
+  setupHooks = [
+    ../../../build-support/setup-hooks/role.bash
+    ./fts-setup-hook.sh
+  ];
 }


### PR DESCRIPTION
###### Motivation for this change

It's error prone to copy paste this "role" stuff everywhere. Also, the more similar the `*-wrapper`s are, the easier it will be add a `pkgconfig-wrapper` as @bgamari once mentioned needing. Also some of the env hooks should just be setup hooks (setup hooks directly rather than setup hooks that define env hooks).

I don't really like this `setupHooks` bloat, but after https://github.com/NixOS/nixpkgs/pull/31414 we can just make these helper setup hooks dependencies, which will work fine. I'd have loved to land that PR first, but fixing it requires https://github.com/NixOS/nixpkgs/issues/26004 which would be easier (but still hard) with this, so I do this stop-gap first.

Fixes #40046

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

