### PR TITLE
iml: use openblas instead of atlas

### DIFF
--- a/pkgs/development/libraries/iml/default.nix
+++ b/pkgs/development/libraries/iml/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gmp, atlas}:
+{stdenv, autoreconfHook, fetchurl, gmp, openblas}:
 stdenv.mkDerivation rec {
   name = "iml-${version}";
   version = "1.0.5";
@@ -6,8 +6,18 @@ stdenv.mkDerivation rec {
     url = "http://www.cs.uwaterloo.ca/~astorjoh/iml-${version}.tar.bz2";
     sha256 = "0akwhhz9b40bz6lrfxpamp7r7wkk48p455qbn04mfnl9a1l6db8x";
   };
-  buildInputs = [gmp atlas];
-  configureFlags = "--with-gmp-include=${gmp.dev}/include --with-gmp-lib=${gmp}/lib";
+  buildInputs = [
+    gmp
+    openblas
+  ];
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+  configureFlags = [
+    "--with-gmp-include=${gmp.dev}/include"
+    "--with-gmp-lib=${gmp}/lib"
+    "--with-cblas=-lopenblas"
+  ];
   meta = {
     inherit version;
     description = ''Algorithms for computing exact solutions to dense systems of linear equations over the integers'';


### PR DESCRIPTION
###### Motivation for this change

- atlas takes *forever* to build
- atlas is impure, optimizes for the build machine
- openblas seems to be generally preferred (https://fedoraproject.org/wiki/Changes/OpenBLAS_as_default_BLAS)
- atlas currently doesn't build on aarch

CC @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

