### PR TITLE
i3lock/i3lock-color: meta: improve description

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -27,8 +27,29 @@ stdenv.mkDerivation rec {
     mv $out/bin/i3lock $out/bin/i3lock-color
   '';
   meta = with stdenv.lib; {
-    description = "A simple screen locker like slock";
-    homepage = https://i3wm.org/i3lock/;
+    description = "A simple screen locker like slock, enhanced version with extra configuration options";
+    longDescription = ''
+      Simple screen locker. After locking, a colored background (default: white) or
+      a configurable image is shown, and a ring-shaped unlock-indicator gives feedback
+      for every keystroke. After entering your password, the screen is unlocked again.
+
+      i3lock-color is forked from i3lock (https://i3wm.org/i3lock/) with the following
+      enhancements / additional configuration options:
+
+      - indicator:
+        - shape: ring or bar
+        - size: configurable
+        - all colors: configurable
+        - all texts: configurable
+        - visibility: can be always visible, can be restricted to some screens
+
+      - background: optionally show a blurred screen instead of a single color
+
+      - more information: show text at configurable positions:
+        - clock: time/date with configurable format
+        - keyboard-layout
+    '';
+    homepage = http://github.com/PandorasFox/i3lock-color;
     maintainers = with maintainers; [ garbas malyn ];
     license = licenses.bsd3;
 

--- a/pkgs/applications/window-managers/i3/lock.nix
+++ b/pkgs/applications/window-managers/i3/lock.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A simple screen locker like slock";
+    longDescription = ''
+      Simple screen locker. After locking, a colored background (default: white) or
+      a configurable image is shown, and a ring-shaped unlock-indicator gives feedback
+      for every keystroke. After entering your password, the screen is unlocked again.
+    '';
     homepage = https://i3wm.org/i3lock/;
     maintainers = with maintainers; [ garbas malyn domenkozar ];
     license = licenses.bsd3;


### PR DESCRIPTION
###### Motivation for this change

i3lock-color currently has the exactly same description as i3lock; and both do not have a long description, so:

- i3lock-color: extend description to differ from i3lock
- i3lock/i3lock-color: add long description (so you know what it does before installing it)
- i3lock-color: fix homepage to point to the i3lock-color-github-page

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @garbas @malyn