### PR TITLE
sit: fix tests on aarch64

### DIFF
--- a/pkgs/applications/version-management/sit/aarch64-eexist.patch
+++ b/pkgs/applications/version-management/sit/aarch64-eexist.patch
@@ -1,0 +1,17 @@
+diff --git a/sit-core/src/repository.rs b/sit-core/src/repository.rs
+index ebd357d..074dcc9 100644
+--- a/sit-core/src/repository.rs
++++ b/sit-core/src/repository.rs
+@@ -305,6 +305,12 @@ impl Repository {
+         let id: String = name.into();
+         let mut path = self.items_path.clone();
+         path.push(&id);
++        #[cfg(all(debug_assertions, target_arch = "aarch64"))] {
++          use std::io;
++          if path.is_dir() {
++             return Err(io::Error::from_raw_os_error(17).into()); // 17 is EEXIST
++          }
++        }
+         fs::create_dir(path)?;
+         let id = OsString::from(id);
+         Ok(Item {

--- a/pkgs/applications/version-management/sit/default.nix
+++ b/pkgs/applications/version-management/sit/default.nix
@@ -15,6 +15,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "102haqix13nwcncng1s8qkw68spn6fhh3vysk2nbahw6f78zczqg";
 
+  patches = [ ./aarch64-eexist.patch ];
+
   meta = with stdenv.lib; {
     description = "Serverless Information Tracker";
     homepage = https://sit.sh/;


### PR DESCRIPTION
As we found out in #40032, sit tests won't pass on
aarch64. The problem seems to be related to
`create_dir` not returning an error if the directory
already exists, happening specifically on aarch64+debug
(not aarch64+release)

This update injects a patch for tests that will also
be included in subsequent versions of SIT.

###### Motivation for this change

Making SIT available for aarch64 users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

