### PR TITLE
bluemix-cli: init at 0.6.6

### DIFF
--- a/pkgs/tools/admin/bluemix-cli/default.nix
+++ b/pkgs/tools/admin/bluemix-cli/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "bluemix-cli-${version}";
+  version = "0.6.6";
+
+  src = fetchzip {
+    url    = "https://clis.ng.bluemix.net/download/bluemix-cli/${version}/linux64";
+    sha256 = "1h3zh8x9681y2ag1wqp003kxlkf1qjnihh3h98wrbmr7f35rmp1x";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/bluemix $out/bin
+    cp bin/bluemix-analytics $out/bin
+    cp bin/cfcli/cf $out/bin
+    chmod 0755 $out/bin/*
+  '';
+
+  meta = with lib; {
+    description  = "Administration CLI for IBM BlueMix";
+    homepage     = "https://console.bluemix.net/docs/cli/index.html";
+    downloadPage = "https://console.bluemix.net/docs/cli/reference/bluemix_cli/download_cli.html#download_install";
+    license      = licenses.unfree;
+    maintainers  = maintainers.tazjin;
+    platforms    = platforms.linux;
+  };
+}

--- a/pkgs/tools/admin/bluemix-cli/default.nix
+++ b/pkgs/tools/admin/bluemix-cli/default.nix
@@ -1,20 +1,17 @@
-{ lib, stdenv, fetchzip }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "bluemix-cli-${version}";
   version = "0.6.6";
 
-  src = fetchzip {
-    url    = "https://clis.ng.bluemix.net/download/bluemix-cli/${version}/linux64";
-    sha256 = "1h3zh8x9681y2ag1wqp003kxlkf1qjnihh3h98wrbmr7f35rmp1x";
+  src = fetchurl {
+    name = "linux64.tar.gz";
+    url = "https://clis.ng.bluemix.net/download/bluemix-cli/${version}/linux64";
+    sha256 = "1swjawc4szqrl0wgjcb4na1hbxylaqp2mp53lxsbfbk1db0c3y85";
   };
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp bin/bluemix $out/bin
-    cp bin/bluemix-analytics $out/bin
-    cp bin/cfcli/cf $out/bin
-    chmod 0755 $out/bin/*
+    install -m755 -D --target $out/bin bin/bluemix bin/bluemix-analytics bin/cfcli/cf
   '';
 
   meta = with lib; {

--- a/pkgs/tools/admin/bluemix-cli/default.nix
+++ b/pkgs/tools/admin/bluemix-cli/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     downloadPage = "https://console.bluemix.net/docs/cli/reference/bluemix_cli/download_cli.html#download_install";
     license      = licenses.unfree;
     maintainers  = maintainers.tazjin;
-    platforms    = platforms.linux;
+    platforms    = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -831,6 +831,8 @@ with pkgs;
 
   blink = callPackage ../applications/networking/instant-messengers/blink { };
 
+  bluemix-cli = callPackage ../tools/admin/bluemix-cli { };
+
   libqmatrixclient = libsForQt5.callPackage ../development/libraries/libqmatrixclient { };
 
   quaternion = libsForQt5.callPackage ../applications/networking/instant-messengers/quaternion { };


### PR DESCRIPTION
Adds the (non-free, binary) IBM Bluemix CLI which is required to
administrate IBM Bluemix services.

###### Motivation for this change

A friend needed access to this tool on NixOS and I used it as an example for walking him through how to package upstream binaries in Nix.

Submitting because it may be useful to other people, too, though i don't intend to personally maintain version updates for this package (which I hope is fine).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

