### PR TITLE
ext4magic: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3144,6 +3144,11 @@
     github = "rittelle";
     name = "Lennart Rittel";
   };
+  rkoe = {
+    email = "rk@simple-is-better.org";
+    github = "rkoe";
+    name = "Roland Koebler";
+  };
   rlupton20 = {
     email = "richard.lupton@gmail.com";
     github = "rlupton20";

--- a/pkgs/tools/filesystems/ext4magic/default.nix
+++ b/pkgs/tools/filesystems/ext4magic/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, fetchpatch, file, libuuid, e2fsprogs, zlib, bzip2 }:
+
+stdenv.mkDerivation rec {
+  version = "0.3.2";
+  name = "ext4magic-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/ext4magic/${name}.tar.gz";
+    sha256 = "8d9c6a594f212aecf4eb5410d277caeaea3adc03d35378257dfd017ef20ea115";
+  };
+
+  patches = [
+    (fetchpatch {
+        url = https://sourceforge.net/p/ext4magic/tickets/10/attachment/ext4magic-0.3.2-i_dir_acl.patch;
+        sha256 = "1accydd8kigid68yir2fbihm3r3x8ws3iyznp25snkx41w6y6x8c";
+    })
+  ];
+
+  buildInputs = [ file libuuid e2fsprogs zlib bzip2 ];
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Recover / undelete files from ext3 or ext4 partitions";
+    longDescription = ''
+      ext4magic can recover/undelete files from ext3 or ext4 partitions
+      by retrieving file-information from the filesystem journal.
+
+      If the information in the journal are sufficient, ext4magic can
+      recover the most file types, with original filename, owner and group,
+      file mode bits and also the old atime/mtime stamps. 
+
+      It's much more effective and works much better than extundelete.
+    '';
+    homepage = http://ext4magic.sourceforge.net/ext4magic_en.html;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.rkoe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2209,6 +2209,8 @@ with pkgs;
 
   exiftool = perlPackages.ImageExifTool;
 
+  ext4magic = callPackage ../tools/filesystems/ext4magic { };
+
   extundelete = callPackage ../tools/filesystems/extundelete { };
 
   expect = callPackage ../tools/misc/expect { };


### PR DESCRIPTION
###### Motivation for this change
Add ext4magic-package, which can undelete files on ext3/ext4.

This seems to be the only tool which can undelete files on ext3/ext4, since extundelete often crashes with a segmentation fault; and even if extundelete would work, ext4magic is more powerful.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

