### PR TITLE
WIP: qt5.qtwebengine: Fix darwin build

### DIFF
--- a/pkgs/development/libraries/openbsm/default.nix
+++ b/pkgs/development/libraries/openbsm/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0b98359hd8mm585sh145ss828pg2y8vgz38lqrb7nypapiyqdnd1";
   };
 
-  patches = [ ./bsm-add-audit_token_to_pid.patch ];
+  # patches = [ ./bsm-add-audit_token_to_pid.patch ];
 
   meta = {
     homepage = http://www.openbsm.org/;

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -13,6 +13,7 @@
 , systemd
 , enableProprietaryCodecs ? true
 , gn, darwin, openbsm
+, xcbuild
 , lib, stdenv # lib.optional, needsPax
 }:
 
@@ -24,8 +25,9 @@ qtModule {
   name = "qtwebengine";
   qtInputs = [ qtdeclarative qtquickcontrols qtlocation qtwebchannel ];
   nativeBuildInputs = [
-    bison coreutils flex git gperf ninja pkgconfig python2 which gn
+    bison coreutils flex git gperf ninja pkgconfig python2 which gn xcbuild
   ];
+  dontUseXcbuild = true;
   doCheck = true;
   outputs = [ "bin" "dev" "out" ];
 
@@ -64,7 +66,12 @@ qtModule {
     + optionalString stdenv.isDarwin ''
       # Remove annoying xcode check
       substituteInPlace mkspecs/features/platform.prf \
-        --replace "lessThan(QMAKE_XCODE_VERSION, 7.3)" false
+        --replace "lessThan(QMAKE_XCODE_VERSION, 7.3)" false \
+        --replace "/usr/bin/xcodebuild" "xcodebuild"
+
+      substituteInPlace src/3rdparty/chromium/build/mac_toolchain.py \
+        --replace "/usr/bin/xcode-select" "xcode-select"
+
       substituteInPlace src/core/config/mac_osx.pri \
         --replace /usr ${stdenv.cc} \
         --replace "isEmpty(QMAKE_MAC_SDK_VERSION)" false

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -176,6 +176,12 @@ EOF
     Prefix = ..
     EOF
     paxmark m $out/libexec/QtWebEngineProcess
+  '' + ''
+    # Sometimes the darwin build succeeds, even though nothing was actually built
+    if [ ! -f "$out/lib/libQt5WebEngine${stdenv.hostPlatform.extensions.sharedLibrary}" ]; then
+      echo "Build did not produce expected output libQt5WebEngine.{so,dylib,..}"
+      exit 1;
+    fi
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -102,15 +102,15 @@ print('sdk_version="10.10"')
 print('sdk_platform_path=""')
 print('sdk_build="17B41"')
 EOF
-
-    # Apple has some secret stuff they don't share with OpenBSM
-    substituteInPlace src/3rdparty/chromium/base/mac/mach_port_broker.mm \
-      --replace "audit_token_to_pid(msg.trailer.msgh_audit)" "msg.trailer.msgh_audit.val[5]"
-    substituteInPlace src/3rdparty/chromium/sandbox/mac/bootstrap_sandbox.cc \
-      --replace "audit_token_to_pid(msg.trailer.msgh_audit)" "msg.trailer.msgh_audit.val[5]"
     '';
 
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_10 -DMAC_OS_X_VERSION_MIN_REQUIRED=MAC_OS_X_VERSION_10_10";
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.isDarwin [
+    "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_10"
+    "-DMAC_OS_X_VERSION_MIN_REQUIRED=MAC_OS_X_VERSION_10_10"
+
+    # Apple has some secret stuff they don't share with OpenBSM
+    "-Daudit_token_to_pid(a)=(a.val[5])"
+  ];
 
   preConfigure = ''
     export NINJAFLAGS=-j$NIX_BUILD_CORES

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -12,7 +12,7 @@
 , pciutils
 , systemd
 , enableProprietaryCodecs ? true
-, gn, darwin, openbsm
+, gn, darwin, openbsm, cups
 , xcbuild
 , lib, stdenv # lib.optional, needsPax
 }:
@@ -185,6 +185,7 @@ EOF
 
     openbsm
     libunwind
+    cups
   ]);
 
   dontUseNinjaBuild = true;

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -68,9 +68,25 @@ qtModule {
       substituteInPlace mkspecs/features/platform.prf \
         --replace "lessThan(QMAKE_XCODE_VERSION, 7.3)" false \
         --replace "/usr/bin/xcodebuild" "xcodebuild"
-
+      substituteInPlace src/3rdparty/chromium/sandbox/mac/seatbelt.cc \
+        --replace "<sandbox.h>" '"${darwin.apple_sdk.sdk}/include/sandbox.h"'
       substituteInPlace src/3rdparty/chromium/build/mac_toolchain.py \
         --replace "/usr/bin/xcode-select" "xcode-select"
+
+      substituteInPlace src/3rdparty/chromium/sandbox/mac/xpc_message_server.cc \
+        --replace "audit_token_to_pid(token)" "(token.val[5])"
+      substituteInPlace src/3rdparty/chromium/base/mac/mach_port_broker.mm \
+        --replace "audit_token_to_pid(msg.trailer.msgh_audit)" "(msg.trailer.msgh_audit.val[5])"
+      substituteInPlace src/3rdparty/chromium/sandbox/mac/bootstrap_sandbox.cc \
+        --replace "audit_token_to_pid(msg.trailer.msgh_audit)" "(msg.trailer.msgh_audit.val[5])"
+      substituteInPlace src/3rdparty/chromium/sandbox/mac/mach_message_server.cc \
+        --replace "audit_token_to_pid(trailer->msgh_audit)" "(trailer->msgh_audit.val[5])"
+      substituteInPlace src/3rdparty/chromium/sandbox/mac/mach_message_server.cc \
+        --replace "audit_token_to_pid(token)" "(token.val[5])"
+      substituteInPlace src/3rdparty/chromium/third_party/crashpad/crashpad/util/mach/mach_message.cc \
+        --replace "audit_token_to_pid(audit_trailer->msgh_audit)" "(audit_trailer->msgh_audit.val[5])"
+
+
 
       substituteInPlace src/core/config/mac_osx.pri \
         --replace /usr ${stdenv.cc} \
@@ -107,9 +123,6 @@ EOF
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.isDarwin [
     "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_10"
     "-DMAC_OS_X_VERSION_MIN_REQUIRED=MAC_OS_X_VERSION_10_10"
-
-    # Apple has some secret stuff they don't share with OpenBSM
-    "-Daudit_token_to_pid(a)=(a.val[5])"
   ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -25,8 +25,8 @@ qtModule {
   name = "qtwebengine";
   qtInputs = [ qtdeclarative qtquickcontrols qtlocation qtwebchannel ];
   nativeBuildInputs = [
-    bison coreutils flex git gperf ninja pkgconfig python2 which gn xcbuild
-  ];
+    bison coreutils flex git gperf ninja pkgconfig python2 which gn
+  ] ++ optional stdenv.isDarwin xcbuild;
   dontUseXcbuild = true;
   doCheck = true;
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change
This fixes issue: #36932

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

