### PR TITLE
zoom-us: liblgvnd fix for libGL.so in libpath

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, system, makeWrapper, makeDesktopItem,
   alsaLib, dbus, glib, fontconfig, freetype, libpulseaudio,
-  utillinux, zlib, xorg, udev, sqlite, expat, libv4l, procps }:
+  utillinux, zlib, xorg, udev, sqlite, expat, libv4l, procps, libGL }:
 
 let
 
@@ -24,6 +24,7 @@ in stdenv.mkDerivation {
     expat
     glib
     freetype
+    libGL
     libpulseaudio
     zlib
     dbus


### PR DESCRIPTION
###### Motivation for this change
libglvnd change caused libGL.so to not be found.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

