### PR TITLE
 plank: init at 0.11.4

### DIFF
--- a/pkgs/applications/misc/plank/default.nix
+++ b/pkgs/applications/misc/plank/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, vala, atk, cairo, glib, gnome3, gtk3, libwnck3
 , libX11, libXfixes, libXi, pango, intltool, pkgconfig, libxml2
 , bamf, gdk_pixbuf, libdbusmenu-gtk3, file
-, wrapGAppsHook, gobjectIntrospection }:
+, wrapGAppsHook, autoreconfHook, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   pname = "plank";
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     libxml2 # xmllint
     wrapGAppsHook
     gobjectIntrospection
+    autoreconfHook
   ];
 
   buildInputs = [ vala atk cairo glib gnome3.gnome-menus

--- a/pkgs/applications/misc/plank/default.nix
+++ b/pkgs/applications/misc/plank/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, vala, atk, cairo, glib, gnome3, gtk3, libwnck3
+, libX11, libXfixes, libXi, pango, intltool, pkgconfig, libxml2
+, bamf, gdk_pixbuf, libdbusmenu-gtk3, file
+, wrapGAppsHook, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  pname = "plank";
+  version = "0.11.4";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://launchpad.net/${pname}/1.0/${version}/+download/${name}.tar.xz";
+    sha256 = "1f41i45xpqhjxql9nl4a1sz30s0j46aqdhbwbvgrawz6himcvdc8";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    libxml2 # xmllint
+    wrapGAppsHook
+    gobjectIntrospection
+  ];
+
+  buildInputs = [ vala atk cairo glib gnome3.gnome-menus
+                  gtk3 gnome3.libgee libwnck3 libX11 libXfixes
+                  libXi pango gnome3.gnome-common bamf gdk_pixbuf
+                  libdbusmenu-gtk3 gnome3.dconf ];
+
+  # fix paths
+  makeFlags = [
+    "INTROSPECTION_GIRDIR=$(out)/share/gir-1.0/"
+    "INTROSPECTION_TYPELIBDIR=$(out)/lib/girepository-1.0"
+  ];
+
+  postPatch = ''
+    substituteInPlace ./configure \
+      --replace "/usr/bin/file" "${file}/bin/file"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Elegant, simple, clean dock";
+    homepage = https://launchpad.net/plank;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ davidak ];
+  };
+}

--- a/pkgs/development/libraries/bamf/default.nix
+++ b/pkgs/development/libraries/bamf/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, libgtop, libwnck3, glib, vala, pkgconfig
+, libstartup_notification, gobjectIntrospection, gtk-doc
+, python27, pythonPackages, libxml2 }:
+
+stdenv.mkDerivation rec {
+  pname = "bamf";
+  version = "0.5.3";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://launchpad.net/${pname}/0.5/${version}/+download/${name}.tar.gz";
+    sha256 = "051vib8ndp09ph5bfwkgmzda94varzjafwxf6lqx7z1s8rd7n39l";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    gtk-doc
+    gobjectIntrospection
+  ];
+
+  buildInputs = [ libgtop libwnck3 vala libstartup_notification
+                  python27 pythonPackages.libxslt libxml2 glib ];
+
+  postPatch = ''
+    substituteInPlace data/Makefile.in \
+      --replace '/usr/lib/systemd/user' '@datarootdir@/systemd/user'
+  '';
+
+  # fix paths
+  makeFlags = [
+    "INTROSPECTION_GIRDIR=$(out)/share/gir-1.0/"
+    "INTROSPECTION_TYPELIBDIR=$(out)/lib/girepository-1.0"
+  ];
+
+  # ignore deprecation errors
+  NIX_CFLAGS_COMPILE = "-Wno-deprecated-declarations";
+
+  meta = with stdenv.lib; {
+    description = "Application matching framework";
+    longDescription = ''
+      Removes the headache of applications matching
+      into a simple DBus daemon and c wrapper library.
+    '';
+    homepage = https://launchpad.net/bamf;
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ davidak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8527,6 +8527,8 @@ with pkgs;
 
   backward-cpp = callPackage ../development/libraries/backward-cpp { };
 
+  bamf = callPackage ../development/libraries/bamf { };
+
   bctoolbox = callPackage ../development/libraries/bctoolbox {
     mbedtls = mbedtls_1_3;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17088,6 +17088,8 @@ with pkgs;
 
   pijul = callPackage ../applications/version-management/pijul {};
 
+  plank = callPackage ../applications/misc/plank { };
+
   planner = callPackage ../applications/office/planner { };
 
   playonlinux = callPackage ../applications/misc/playonlinux {


### PR DESCRIPTION
###### Motivation for this change

I want a nice dock.

![screenshot_2018-05-08_01-41-33](https://user-images.githubusercontent.com/91113/39730304-1e24b5a6-5261-11e8-9840-e37b98b00ba2.png)

Also part of the pantheon desktop, that hopefully will be complete some day.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

