### PR TITLE
1password init at version 0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1825,6 +1825,11 @@
     github = "joamaki";
     name = "Jussi Maki";
   };
+  joelburget = {
+    email = "joelburget@gmail.com";
+    github = "joelburget";
+    name = "Joel Burget";
+  };
   joelmo = {
     email = "joel.moberg@gmail.com";
     github = "joelmo";

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip }:
+{ stdenv, lib, fetchzip, makeWrapper }:
 
 let
   src =
@@ -14,14 +14,15 @@ let
 in stdenv.mkDerivation {
   name = "1password-0.4";
   inherit src;
+  nativeBuildInputs = [ makeWrapper ];
   installPhase = ''
     mkdir -p $out/bin
-    cp op $out/bin/op.wrapped
+    install -D op $out/share/1password/op
 
     # https://github.com/NixOS/patchelf/issues/66#issuecomment-267743051
-    echo "#!/bin/sh" > $out/bin/op
-    echo $(< $NIX_CC/nix-support/dynamic-linker) $out/bin/op.wrapped \"\$@\" >> $out/bin/op
-    chmod +x $out/bin/op
+    makeWrapper $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/op \
+      --argv0 op \
+      --add-flags $out/share/1password/op
   '';
   meta = with lib; {
     description = "1Password command-line tool";

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchzip }:
+
+let
+  src =
+    if stdenv.system == "i686-linux" then fetchzip {
+      url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4/op_linux_386_v0.4.zip";
+      sha256 = "0mhlqvd3az50gnfil0xlq10855v3bg7yb05j6ndg4h2c551jrq41";
+      stripRoot = false;
+    } else fetchzip {
+      url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4/op_linux_amd64_v0.4.zip";
+      sha256 = "15cv8xi4slid9jicdmc5xx2r9ag63wcx1mn7hcgzxbxbhyrvwhyf";
+      stripRoot = false;
+    };
+in stdenv.mkDerivation {
+  name = "1password-0.4";
+  inherit src;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp op $out/bin/op.wrapped
+
+    # https://github.com/NixOS/patchelf/issues/66#issuecomment-267743051
+    echo "#!/bin/sh" > $out/bin/op
+    echo $(< $NIX_CC/nix-support/dynamic-linker) $out/bin/op.wrapped \"\$@\" >> $out/bin/op
+    chmod +x $out/bin/op
+  '';
+  meta = with lib; {
+    description = "1Password command-line tool";
+    homepage    = "https://blog.agilebits.com/2017/09/06/announcing-the-1password-command-line-tool-public-beta/";
+    maintainers = with maintainers; [ joelburget ];
+    license     = licenses.unfree;
+    platforms   = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,8 +1,6 @@
-{ stdenv, lib, fetchzip, makeWrapper }:
+{ stdenv, fetchzip, makeWrapper }:
 
-let
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "1password-${version}";
   version = "0.4";
   src = if stdenv.system == "i686-linux" then fetchzip {
@@ -14,6 +12,7 @@ in stdenv.mkDerivation rec {
     sha256 = "15cv8xi4slid9jicdmc5xx2r9ag63wcx1mn7hcgzxbxbhyrvwhyf";
     stripRoot = false;
   };
+
   nativeBuildInputs = [ makeWrapper ];
   installPhase = ''
     mkdir -p $out/bin
@@ -24,7 +23,8 @@ in stdenv.mkDerivation rec {
       --argv0 op \
       --add-flags $out/share/1password/op
   '';
-  meta = with lib; {
+
+  meta = with stdenv.lib; {
     description = "1Password command-line tool";
     homepage    = "https://blog.agilebits.com/2017/09/06/announcing-the-1password-command-line-tool-public-beta/";
     maintainers = with maintainers; [ joelburget ];

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,19 +1,19 @@
 { stdenv, lib, fetchzip, makeWrapper }:
 
 let
-  src =
-    if stdenv.system == "i686-linux" then fetchzip {
-      url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4/op_linux_386_v0.4.zip";
-      sha256 = "0mhlqvd3az50gnfil0xlq10855v3bg7yb05j6ndg4h2c551jrq41";
-      stripRoot = false;
-    } else fetchzip {
-      url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4/op_linux_amd64_v0.4.zip";
-      sha256 = "15cv8xi4slid9jicdmc5xx2r9ag63wcx1mn7hcgzxbxbhyrvwhyf";
-      stripRoot = false;
-    };
-in stdenv.mkDerivation {
-  name = "1password-0.4";
-  inherit src;
+
+in stdenv.mkDerivation rec {
+  name = "1password-${version}";
+  version = "0.4";
+  src = if stdenv.system == "i686-linux" then fetchzip {
+    url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_386_v${version}.zip";
+    sha256 = "0mhlqvd3az50gnfil0xlq10855v3bg7yb05j6ndg4h2c551jrq41";
+    stripRoot = false;
+  } else fetchzip {
+    url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip";
+    sha256 = "15cv8xi4slid9jicdmc5xx2r9ag63wcx1mn7hcgzxbxbhyrvwhyf";
+    stripRoot = false;
+  };
   nativeBuildInputs = [ makeWrapper ];
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -400,6 +400,8 @@ with pkgs;
 
   ### TOOLS
 
+  _1password = callPackage ../applications/misc/1password { };
+
   _9pfs = callPackage ../tools/filesystems/9pfs { };
 
   a2ps = callPackage ../tools/text/a2ps { };


### PR DESCRIPTION
###### Motivation for this change

Add the tool described here https://blog.agilebits.com/2017/09/06/announcing-the-1password-command-line-tool-public-beta/ .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---