### PR TITLE
cargo-fuzz: init at 0.5.3

### DIFF
--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, fetchurl, runCommand, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "cargo-fuzz-${version}";
+  version = "0.5.3"; # Note to self: on 0.5.4, remove the hand-added Cargo.lock
+
+  src =
+    let
+      source = fetchFromGitHub {
+        owner = "rust-fuzz";
+        repo = "cargo-fuzz";
+        rev = version;
+        sha256 = "1l452fnjw7i10nrd4y4rssi5d457vgjp6rhdr9cnq32bjhdkprrs";
+      };
+      cargo-lock = fetchurl {
+        url = "https://gist.githubusercontent.com/Ekleog/7d5b62d13b7207aafa4c37d1bbdf2de7/raw/c6027fc1c531947f4d6836a3c4cba1b3e24df24c/Cargo.lock";
+        sha256 = "0d7b6kxfbfvwksybzrihylamg2zv5fmsk9m6xshryhwipskzzvmd";
+      };
+    in
+    runCommand "cargo-fuzz-src" {} ''
+      cp -R ${source} $out
+      chmod +w $out
+      cp ${cargo-lock} $out/Cargo.lock
+    '';
+
+  cargoSha256 = "0ajm8qp8hi7kn7199ywv26cmjv13phxv72lz8kcq97hxg17x0dkk";
+
+  meta = with stdenv.lib; {
+    description = "Command line helpers for fuzzing";
+    homepage = https://github.com/rust-fuzz/cargo-fuzz;
+    license = with licenses; [ mit asl20 ];
+    maintainers = [ maintainers.ekleog ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6848,7 +6848,7 @@ with pkgs;
 
   buildRustCrate = callPackage ../build-support/rust/build-rust-crate.nix { };
 
-  cargo-vendor = callPackage ../build-support/rust/cargo-vendor {};
+  cargo-vendor = callPackage ../build-support/rust/cargo-vendor { };
 
   carnix = (callPackage ../build-support/rust/carnix.nix { }).carnix { };
 
@@ -6872,6 +6872,8 @@ with pkgs;
     });
 
   cargo-edit = callPackage ../tools/package-management/cargo-edit { };
+
+  cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
 
   rainicorn = callPackage ../development/tools/rust/rainicorn { };
   rustfmt = callPackage ../development/tools/rust/rustfmt { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

