### PR TITLE
[wip] telnetd: init module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -307,6 +307,7 @@
       duplicati = 289;
       monetdb = 290;
       restic = 291;
+      telnetd = 292;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -582,6 +583,7 @@
       duplicati = 289;
       monetdb = 290;
       restic = 291;
+      telnetd = 292;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -307,7 +307,6 @@
       duplicati = 289;
       monetdb = 290;
       restic = 291;
-      telnetd = 292;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -583,7 +582,6 @@
       duplicati = 289;
       monetdb = 290;
       restic = 291;
-      telnetd = 292;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -665,6 +665,7 @@
   ./services/web-servers/nginx/gitweb.nix
   ./services/web-servers/phpfpm/default.nix
   ./services/web-servers/shellinabox.nix
+  ./services/web-servers/telnet.nix
   ./services/web-servers/tomcat.nix
   ./services/web-servers/traefik.nix
   ./services/web-servers/uwsgi.nix

--- a/nixos/modules/services/web-servers/telnet.nix
+++ b/nixos/modules/services/web-servers/telnet.nix
@@ -43,32 +43,34 @@ in
 
     users.extraUsers = singleton {
       name = user;
+      group = "telnetd";
       description = "Telnet daemon";
     };
 
-      users.extraGroups = singleton {
-        name = "telnetd";
-      };
-
+    # users.extraGroups = singleton {
+    #   name = "telnetd";
+    # };
 
     systemd.services.telnetd = {
       description = "Telnet server";
       wantedBy = [ "multi-user.target" ];
 
-      script = "${pkgs.busybox}/bin/telnetd -p ${toString cfg.port}";
+      # binds by default to ipv6 ?
+      # script = "${pkgs.busybox}/bin/telnetd -p ${toString cfg.port} -b 127.0.0.1";
 
       serviceConfig = {
+        # defaults to ipv6 otherwise ?
+        ExecStart="${pkgs.busybox}/bin/telnetd -p ${toString cfg.port} -b 127.0.0.1";
         User = user;
         Group = "telnetd";
-        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE=+ep";
-        RuntimeDirectory = [ "telnetd" ];
+        AmbientCapabilities="CAP_NET_BIND_SERVICE";
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE=+eip";
+        # RuntimeDirectory = [ "telnetd" ];
         Restart = "always";
+        RestartSec = "500ms";
+        # StartLimitInterval = 86400;
+        StartLimitBurst = 5;
       };
     };
   };
-
-
-  meta.maintainers = with maintainers; [ teto ];
-
 }
-

--- a/nixos/modules/services/web-servers/telnet.nix
+++ b/nixos/modules/services/web-servers/telnet.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.telnet;
+
+in
+{
+
+  options.services.telnet = {
+
+    enable = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Enable telnetd.
+      '';
+    };
+
+    port = mkOption {
+      default = 12345;
+      type = types.int;
+      description = ''
+        Port on which to listen.
+      '';
+    };
+
+  };
+
+  config = mkIf config.services.telnet.enable {
+
+    networking.firewall.allowedUDPPorts =  [ cfg.port ];
+
+    users.extraUsers.telnetd.uid = config.ids.uids.telnetd;
+    users.extraGroups.telnetd.gid = config.ids.gids.telnetd;
+
+
+    systemd.services.telnetd = {
+      description = "Telnet server";
+
+      script = "${pkgs.busybox}/bin/telnetd -p ${toString cfg.port}";
+      serviceConfig = {
+        User = "telnetd";
+        Group = "telnetd";
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+        # RuntimeDirectory = [ "telnetd" ];
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+
+
+  meta.maintainers = with maintainers; [ teto ];
+
+}
+

--- a/nixos/modules/services/web-servers/telnet.nix
+++ b/nixos/modules/services/web-servers/telnet.nix
@@ -4,11 +4,7 @@ with lib;
 
 let
   cfg = config.services.telnet;
-
-  user = "telnetd";
-in
-{
-
+in {
   options.services.telnet = {
 
     enable = mkOption {
@@ -42,34 +38,24 @@ in
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
 
     users.extraUsers = singleton {
-      name = user;
+      name = "telnetd";
       group = "telnetd";
       description = "Telnet daemon";
     };
 
-    # users.extraGroups = singleton {
-    #   name = "telnetd";
-    # };
+    users.extraGroups = singleton {
+      name = "telnetd";
+    };
 
     systemd.services.telnetd = {
       description = "Telnet server";
       wantedBy = [ "multi-user.target" ];
 
-      # binds by default to ipv6 ?
-      # script = "${pkgs.busybox}/bin/telnetd -p ${toString cfg.port} -b 127.0.0.1";
-
       serviceConfig = {
-        # defaults to ipv6 otherwise ?
-        ExecStart="${pkgs.busybox}/bin/telnetd -p ${toString cfg.port} -b 127.0.0.1";
-        User = user;
+        ExecStart="${pkgs.busybox}/bin/telnetd -p ${toString cfg.port} -F";
+        User = "telnetd";
         Group = "telnetd";
-        AmbientCapabilities="CAP_NET_BIND_SERVICE";
-        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE=+eip";
-        # RuntimeDirectory = [ "telnetd" ];
-        Restart = "always";
-        RestartSec = "500ms";
-        # StartLimitInterval = 86400;
-        StartLimitBurst = 5;
+        AmbientCapabilities = "cap_net_bind_service";
       };
     };
   };

--- a/nixos/modules/services/web-servers/telnet.nix
+++ b/nixos/modules/services/web-servers/telnet.nix
@@ -52,7 +52,8 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
-        ExecStart="${pkgs.busybox}/bin/telnetd -p ${toString cfg.port} -F";
+        ExecStart="${pkgs.busybox}/bin/telnetd -p ${toString cfg.port}";
+        Type="forking";
         User = "telnetd";
         Group = "telnetd";
         AmbientCapabilities = "cap_net_bind_service";


### PR DESCRIPTION
###### Motivation for this change
I am trying to package mininet, which I believe rely on mininet.
Eitherway it doesn't hurt to have a telnet module.

It doesn't seem to work though, I can't connect to it via `telnet 127.0.0.1`. `journalctl -b ` doesn't show any error. I wonder if that's firewall related

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

