### PR TITLE
yrd: init at 0.5.3

### DIFF
--- a/pkgs/tools/networking/yrd/default.nix
+++ b/pkgs/tools/networking/yrd/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+let
+  pname = "yrd";
+  version = "0.5.3";
+  sha256 = "1yx1hr8z4cvlb3yi24dwafs0nxq41k4q477jc9q24w61a0g662ps";
+
+in pythonPackages.buildPythonApplication {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "kpcyrd";
+    repo = "${pname}";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ argh ];
+
+  meta = with stdenv.lib; {
+    description = "Cjdns swiss army knife";
+    maintainers = with maintainers; [ akru ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    homepage = https://github.com/kpcyrd/yrd;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21502,4 +21502,7 @@ with pkgs;
 
   inherit (recurseIntoAttrs (callPackages ../os-specific/bsd { }))
           netbsd;
+
+  yrd = callPackage ../tools/networking/yrd { };
+
 }


### PR DESCRIPTION
###### Motivation for this change

Added `cjdns` diagnostic tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

