### PR TITLE
idrisPackages.vdom: init at 0.6.0

### DIFF
--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -194,6 +194,8 @@
 
     union_type = callPackage ./union_type.nix {};
 
+    vdom = callPackage ./vdom.nix {};
+
     vecspace = callPackage ./vecspace.nix {};
 
     webgl = callPackage ./webgl.nix {};

--- a/pkgs/development/idris-modules/vdom.nix
+++ b/pkgs/development/idris-modules/vdom.nix
@@ -1,0 +1,28 @@
+{ build-idris-package
+, fetchFromGitHub
+, prelude
+, base
+, lib
+, idris
+}:
+build-idris-package  {
+  name = "vdom";
+  version = "0.6.0";
+
+  idrisDeps = [ prelude base ];
+
+  src = fetchFromGitHub {
+    owner = "brandondyck";
+    repo = "idris-vdom";
+    rev = "ff32c14feeac937f7418830a9a3463cd9582be8a";
+    sha256 = "0aila1qdpmhrp556dzaxk7yn7vgkwcnbp9jhw8f8pl51xs3s2kvf";
+  };
+
+  meta = {
+    description = "Virtual DOM in pure Idris";
+    homepage = https://github.com/brandondyck/idris-vdom;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.brainrape ];
+    inherit (idris.meta) platforms;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Packaged idris virtualdom library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

