### PR TITLE
kcgi: init -> 0.10.5

### DIFF
--- a/pkgs/development/web/kcgi/default.nix
+++ b/pkgs/development/web/kcgi/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, pkgconfig, fetchFromGitHub, libbsd }:
+
+stdenv.mkDerivation rec {
+  pname = "kcgi";
+  version = "0.10.5";
+  underscoreVersion = stdenv.lib.replaceChars ["."] ["_"] version;
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "kristapsdz";
+    repo = pname;
+    rev = "VERSION_${underscoreVersion}";
+    sha256 = "0ksdjqibkj7h1a99i84i6y0949c0vwx789q0sslzdkkgqvjnw3xw";
+  };
+  patchPhase = ''substituteInPlace configure \
+    --replace /usr/local /
+  '';
+  
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ ] ++ stdenv.lib.optionals stdenv.isLinux [ libbsd ] ;
+
+  dontAddPrefix = true;
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://kristaps.bsd.lv/kcgi;
+    description = "Minimal CGI and FastCGI library for C/C++";
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = [ maintainers.leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8030,6 +8030,8 @@ with pkgs;
     gperf = gperf_3_0;
   };
 
+  kcgi = callPackage ../development/web/kcgi { };
+
   kcov = callPackage ../development/tools/analysis/kcov { };
 
   kube-aws = callPackage ../development/tools/kube-aws { };


### PR DESCRIPTION
###### Motivation for this change

New fcgi library, also dependency for https://kristaps.bsd.lv/kcaldav/

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

