### PR TITLE
singularity: 2.4.6 -> 2.5.1

### DIFF
--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -13,11 +13,12 @@
 , gnused
 , curl
 , utillinux
+, libarchive
  }:
 
 stdenv.mkDerivation rec {
   name = "singularity-${version}";
-  version = "2.4.6";
+  version = "2.5.1";
 
   enableParallelBuilding = true;
 
@@ -45,11 +46,11 @@ stdenv.mkDerivation rec {
     owner = "singularityware";
     repo = "singularity";
     rev = version;
-    sha256 = "0bs1jqm7v7wv1kdxq8kyqn3gl5m76j0wwwgjyjnndrhczlsh5m1d";
+    sha256 = "1i029qs6dfpyirhbdz0nrx2sh5fddysk4wqkjqj5m60kxs4x8a3d";
   };
 
   nativeBuildInputs = [ autoreconfHook makeWrapper ];
-  buildInputs = [ coreutils gnugrep python e2fsprogs which gnutar squashfsTools gzip gnused curl utillinux ];
+  buildInputs = [ coreutils gnugrep python e2fsprogs which gnutar squashfsTools gzip gnused curl utillinux libarchive ];
 
   meta = with stdenv.lib; {
     homepage = http://singularity.lbl.gov/;


### PR DESCRIPTION
###### Motivation for this change

There is a severe security issue in the 2.4 version of Singularity. This version fixes the issue. I am totally new to Nix and Nixos, but I built it locally and it seems to work. I have no idea how to continue further than creating this PR. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

