### PR TITLE
gnucash: restore version 2.4

### DIFF
--- a/pkgs/applications/office/gnucash/2.4.nix
+++ b/pkgs/applications/office/gnucash/2.4.nix
@@ -1,0 +1,85 @@
+{ fetchurl, stdenv, pkgconfig, libxml2, gconf, glib, gtk2, libgnomeui, libofx
+, libgtkhtml, gtkhtml, libgnomeprint, goffice, enchant, gettext, libbonoboui
+, intltool, perl, guile, slibGuile, swig, isocodes, bzip2, makeWrapper, libglade
+, libgsf, libart_lgpl, perlPackages, aqbanking, gwenhywfar
+}:
+
+/* If you experience GConf errors when running GnuCash on NixOS, see
+ * http://wiki.nixos.org/wiki/Solve_GConf_errors_when_running_GNOME_applications
+ * for a possible solution.
+ */
+
+stdenv.mkDerivation rec {
+  name = "gnucash-2.4.15";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/gnucash/${name}.tar.bz2";
+    sha256 = "058mgfwic6a2g7jq6iip5hv45md1qaxy25dj4lvlzjjr141wm4gx";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    libxml2 gconf glib gtk2 libgnomeui libgtkhtml gtkhtml
+    libgnomeprint goffice enchant gettext intltool perl guile slibGuile
+    swig isocodes bzip2 makeWrapper libofx libglade libgsf libart_lgpl
+    perlPackages.DateManip perlPackages.FinanceQuote aqbanking gwenhywfar
+  ];
+  propagatedUserEnvPkgs = [ gconf ];
+
+  configureFlags = "CFLAGS=-O3 CXXFLAGS=-O3 --disable-dbi --enable-ofx --enable-aqbanking";
+
+  postInstall = ''
+    # Auto-updaters don't make sense in Nix.
+    rm $out/bin/gnc-fq-update
+
+    sed -i $out/bin/update-gnucash-gconf \
+       -e 's|--config-source=[^ ]* --install-schema-file|--makefile-install-rule|'
+
+    for prog in $(echo "$out/bin/"*)
+    do
+      # Don't wrap the gnc-fq-* scripts, since gnucash calls them as
+      # "perl <script>', i.e. they must be Perl scripts.
+      if [[ $prog =~ gnc-fq ]]; then continue; fi
+      wrapProgram "$prog"                                               \
+        --set SCHEME_LIBRARY_PATH "$SCHEME_LIBRARY_PATH"                \
+        --prefix GUILE_LOAD_PATH ":" "$GUILE_LOAD_PATH"                 \
+        --prefix LD_LIBRARY_PATH ":" "${libgnomeui}/lib/libglade/2.0"   \
+        --prefix LD_LIBRARY_PATH ":" "${libbonoboui}/lib/libglade/2.0"  \
+        --prefix PERL5LIB ":" "$PERL5LIB"                               \
+        --set GCONF_CONFIG_SOURCE 'xml::~/.gconf'                       \
+        --prefix PATH ":" "$out/bin:${stdenv.lib.makeBinPath [ perl gconf ]}"
+    done
+
+    rm $out/share/icons/hicolor/icon-theme.cache
+  '';
+
+  # The following settings fix failures in the test suite. It's not required otherwise.
+  NIX_LDFLAGS = "-rpath=${guile}/lib -rpath=${glib.out}/lib";
+  preCheck = "export GNC_DOT_DIR=$PWD/dot-gnucash";
+
+  doCheck = false;      # https://github.com/NixOS/nixpkgs/issues/11084
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Personal and small-business financial-accounting application";
+
+    longDescription = ''
+      GnuCash is personal and small-business financial-accounting software,
+      freely licensed under the GNU GPL and available for GNU/Linux, BSD,
+      Solaris, macOS and Microsoft Windows.
+
+      Designed to be easy to use, yet powerful and flexible, GnuCash allows
+      you to track bank accounts, stocks, income and expenses.  As quick and
+      intuitive to use as a checkbook register, it is based on professional
+      accounting principles to ensure balanced books and accurate reports.
+    '';
+
+    license = stdenv.lib.licenses.gpl2Plus;
+
+    homepage = http://www.gnucash.org/;
+
+    maintainers = [ stdenv.lib.maintainers.peti stdenv.lib.maintainers.domenkozar ];
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16056,6 +16056,14 @@ with pkgs;
     inherit (gnome3) dconf;
   };
 
+  gnucash24 = callPackage ../applications/office/gnucash/2.4.nix {
+    inherit (gnome2) libgnomeui libgtkhtml gtkhtml libbonoboui libgnomeprint libglade libart_lgpl;
+    gconf = gnome2.GConf;
+    guile = guile_1_8;
+    slibGuile = slibGuile.override { scheme = guile_1_8; };
+    goffice = goffice_0_8;
+  };
+
   gnucash26 = lowPrio (callPackage ../applications/office/gnucash/2.6.nix {
     inherit (gnome2) libgnomecanvas;
     inherit (gnome3) dconf;


### PR DESCRIPTION
###### Motivation for this change

Pull request #39616 upgrades the default gnucash version from 2.4 to 3.1. Skipping major releases (in this case 2.6) is a problem for gnucash. See [here](https://github.com/NixOS/nixpkgs/pull/39616#issuecomment-387423257).

This change restores gnucash 2.4 as the attribute `gnucash24`, leaving 3.1 as the default. It doesn't solve the upgrade path problem, since getting gnucash 2.6 working is necessary to upgrade from 2.4 to 3.1. But users need to be given the chance to upgrade their data files before removing gnucash 2.4.

Note: `2.4.nix` is just a copy of the original `default.nix`; Prior to 3.1 being added and becoming the default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

