### PR TITLE
Cassandra service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -189,6 +189,7 @@
   ./services/continuous-integration/jenkins/slave.nix
   ./services/databases/4store-endpoint.nix
   ./services/databases/4store.nix
+  ./services/databases/cassandra.nix
   ./services/databases/clickhouse.nix
   ./services/databases/couchdb.nix
   ./services/databases/firebird.nix


### PR DESCRIPTION
###### Motivation for this change
Allows for service.cassandra to be used in nixos/configuration.nix as probably intended

###### Things done

Added cassandra to the module-list.nix file

---

