### PR TITLE
multibootusb: init at 9.2.0

### DIFF
--- a/pkgs/applications/misc/multibootusb/default.nix
+++ b/pkgs/applications/misc/multibootusb/default.nix
@@ -1,0 +1,59 @@
+{ lib, python36Packages, fetchFromGitHub, libxcb, mtools, p7zip, parted, procps, utillinux, qt5 }:
+python36Packages.buildPythonApplication rec {
+  pname = "multibootusb";
+  name = "${pname}-${version}";
+  version = "9.2.0";
+
+  buildInputs = [
+    python36Packages.dbus-python
+    python36Packages.pyqt5
+    python36Packages.pytest-shutil
+    python36Packages.python
+    python36Packages.pyudev
+    python36Packages.six
+    libxcb
+    mtools
+    p7zip
+    parted
+    procps
+    qt5.full
+    utillinux
+  ];
+
+  src = fetchFromGitHub {
+    owner = "mbusb";
+    repo = pname;
+    rev = "v${version}";
+
+    sha256 = "0wlan0cp6c2i0nahixgpmkm0h4n518gj8rc515d579pqqp91p2h3";
+  };
+
+  # Skip the fixup stage where stuff is shrinked (can't shrink text files)
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    share="$out/share/${pname}"
+    mkdir -p "$share"
+    cp -r data "$share/data"
+    cp -r scripts "$share/scripts"
+    cp "${pname}" "$share/${pname}"
+
+    mkdir "$out/bin"
+    cat > "$out/bin/${pname}" <<EOF
+      #!/bin/sh
+      cd "$share"
+      export PYTHONPATH="$PYTHONPATH:$share"
+      export PATH="$PATH:${parted}/bin:${procps}/bin"
+
+      "${python36Packages.python}/bin/python" "${pname}"
+    EOF
+    chmod +x "$out/bin/${pname}"
+  '';
+
+  meta = with lib; {
+    description = "Multiboot USB creator for Linux live disks";
+    homepage = http://multibootusb.org/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ jD91mZM2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16094,6 +16094,8 @@ with pkgs;
 
   moe =  callPackage ../applications/editors/moe { };
 
+  multibootusb = callPackage ../applications/misc/multibootusb {};
+
   praat = callPackage ../applications/audio/praat { };
 
   quvi = callPackage ../applications/video/quvi/tool.nix {


### PR DESCRIPTION
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

![image](https://user-images.githubusercontent.com/12830969/39814367-41e67c34-5394-11e8-9e22-406815a16777.png)