### PR TITLE
stdenv: Put back isArm, with deprecation notice.

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -118,6 +118,7 @@ let
       inherit (hostPlatform)
         isDarwin isLinux isSunOS isHurd isCygwin isFreeBSD isOpenBSD
         isi686 isx86_64 is64bit isAarch32 isAarch64 isMips isBigEndian;
+      isArm = builtins.trace "stdenv.isArm is deprecated after 18.03" hostPlatform.isArm;
 
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;


### PR DESCRIPTION
###### Motivation for this change

This was always meant to be deprecated rather than removed.

Back-port of  https://github.com/NixOS/nixpkgs/pull/40154

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

