### PR TITLE
[WIP] Fix taffybar

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -422,9 +422,6 @@ self: super: {
   # https://github.com/evanrinehart/mikmod/issues/1
   mikmod = addExtraLibrary super.mikmod pkgs.libmikmod;
 
-  # https://github.com/haskell-gi/haskell-gi/pull/163
-  haskell-gi = dontCheck super.haskell-gi;
-
   # https://github.com/basvandijk/threads/issues/10
   threads = dontCheck super.threads;
 

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -145,6 +145,8 @@ self: super: builtins.intersectAttrs super {
   gtksourceview2 = addPkgconfigDepend super.gtksourceview2 pkgs.gtk2;
   gtk-traymanager = addPkgconfigDepend super.gtk-traymanager pkgs.gtk3;
   gi-gdkx11 = addPkgconfigDepend super.gi-gdkx11 pkgs.gtk3;
+  gi-dbusmenu = super.gi-dbusmenu.override { dbusmenu-glib = pkgs.libdbusmenu-glib; };
+  gi-dbusmenugtk3 = super.gi-dbusmenugtk3.override { dbusmenu-gtk3 = pkgs.libdbusmenu-gtk3; };
   taffybar = (addPkgconfigDepend super.taffybar pkgs.gtk3).override { dbus = self.dbus_1_0_1; };
 
   # Need WebkitGTK, not just webkit.

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -144,6 +144,7 @@ self: super: builtins.intersectAttrs super {
   gtk = disableHardening (addPkgconfigDepend (addBuildTool super.gtk self.gtk2hs-buildtools) pkgs.gtk2) ["fortify"];
   gtksourceview2 = addPkgconfigDepend super.gtksourceview2 pkgs.gtk2;
   gtk-traymanager = addPkgconfigDepend super.gtk-traymanager pkgs.gtk3;
+  gi-gdkx11 = addPkgconfigDepend super.gi-gdkx11 pkgs.gtk3;
   taffybar = (addPkgconfigDepend super.taffybar pkgs.gtk3).override { dbus = self.dbus_1_0_1; };
 
   # Need WebkitGTK, not just webkit.

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -214,6 +214,10 @@ stdenv.mkDerivation ({
 
   LANG = "en_US.UTF-8";         # GHC needs the locale configured during the Haddock phase.
 
+  # XXX: workaround for https://ghc.haskell.org/trac/ghc/ticket/11042.
+  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath (stdenv.lib.filter (x: x != null) systemBuildInputs);
+                    # ^^^ Internally uses `getOutput "lib"` (equiv. to getLib)
+
   prePatch = optionalString (editedCabalFile != null) ''
     echo "Replace Cabal file with edited version from ${newCabalFileUrl}."
     cp ${newCabalFile} ${pname}.cabal

--- a/pkgs/development/libraries/libdbusmenu/default.nix
+++ b/pkgs/development/libraries/libdbusmenu/default.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib dbus-glib json-glib
     gobjectIntrospection vala_0_38 gnome-doc-utils
-  ] ++ optional (gtkVersion != null) (if gtkVersion == "2" then gtk2 else gtk3);
+  ];
+
+  propagatedBuildInputs = optional (gtkVersion != null) (if gtkVersion == "2" then gtk2 else gtk3);
 
   postPatch = ''
     for f in {configure,ltmain.sh,m4/libtool.m4}; do


### PR DESCRIPTION
###### Motivation for this change

Fix taffybar.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This makes all the dependencies for taffybar build but taffybar itself fails with:

```
gcc: error trying to exec '/nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/libexec/gcc/x86_64-unknown-linux-gnu/7.3.0/collect2': execv: Argument list too long
```

Not sure how to fix this -- there may be duplicated arguments in `configureFlags` for Cabal, should we filter them somehow? @peti, any ideas?

For testing one can skip https://github.com/NixOS/nixpkgs/pull/40186/commits/76f629ee1def0ba0da8cb4972719ec709d7dd1d0 and https://github.com/NixOS/nixpkgs/pull/40186/commits/7c698dd228c5abb64972fe8a7cbfc94239625668 -- those are mass rebuild changes.