### PR TITLE
add pythonPackages.outcome, pythonPackages.trio

### DIFF
--- a/pkgs/development/python-modules/outcome/default.nix
+++ b/pkgs/development/python-modules/outcome/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, attrs
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "outcome";
+  version = "0.1.0a0";
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0cqwakzigw0602dxlb7c1882jwr8hn5nrxk1l8iwlmzc9whh48wn";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ attrs ];
+  # Has a test dependency on trio, which depends on outcome.
+  doCheck = false;
+
+  meta = {
+    description = "Capture the outcome of Python function calls.";
+    homepage = https://github.com/python-trio/outcome;
+    license = with lib.licenses; [ mit asl20 ];
+    maintainers = with lib.maintainers; [ catern ];
+  };
+}

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -1,0 +1,42 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, attrs
+, sortedcontainers
+, async_generator
+, idna
+, outcome
+, contextvars
+, pytest
+, pyopenssl
+, trustme
+}:
+
+buildPythonPackage rec {
+  pname = "trio";
+  version = "0.4.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ib1x47knlad9pljb64ywfiv6m3dfrqqjwka6j1b73hixmszb5h4";
+  };
+
+  checkInputs = [ pytest pyopenssl trustme ];
+  # It appears that the build sandbox doesn't include /etc/services, and these tests try to use it.
+  checkPhase = ''
+    py.test -k 'not test_getnameinfo and not test_SocketType_resolve and not test_getprotobyname'
+  '';
+  propagatedBuildInputs = [
+    attrs
+    sortedcontainers
+    async_generator
+    idna
+    outcome
+  ] ++ lib.optionals (pythonOlder "3.7") [ contextvars ];
+
+  meta = {
+    description = "An async/await-native I/O library for humans and snake people";
+    homepage = https://github.com/python-trio/trio;
+    license = with lib.licenses; [ mit asl20 ];
+    maintainers = with lib.maintainers; [ catern ];
+  };
+}

--- a/pkgs/development/python-modules/trustme/default.nix
+++ b/pkgs/development/python-modules/trustme/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, cryptography, pytest, pyopenssl, service-identity }:
+
+buildPythonPackage rec {
+  pname = "trustme";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1215vr6l6c0fzsv5gyay82fxd4fidvq2rd94wvjrljs6h2wajazk";
+  };
+
+  checkInputs = [ pytest pyopenssl service-identity ];
+  checkPhase = ''
+    py.test
+  '';
+  propagatedBuildInputs = [
+    cryptography
+  ];
+
+  meta = {
+    description = "#1 quality TLS certs while you wait, for the discerning tester";
+    homepage = https://github.com/python-trio/trustme;
+    license = with lib.licenses; [ mit asl20 ];
+    maintainers = with lib.maintainers; [ catern ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -440,6 +440,8 @@ in {
 
   trustme = callPackage ../development/python-modules/trustme {};
 
+  trio = callPackage ../development/python-modules/trio {};
+
   tokenserver = callPackage ../development/python-modules/tokenserver {};
 
   toml = callPackage ../development/python-modules/toml { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -303,6 +303,8 @@ in {
 
   oauthenticator = callPackage ../development/python-modules/oauthenticator { };
 
+  outcome = callPackage ../development/python-modules/outcome {};
+
   plantuml = callPackage ../tools/misc/plantuml { };
 
   Pmw = callPackage ../development/python-modules/Pmw { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -438,6 +438,8 @@ in {
     hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; };
   };
 
+  trustme = callPackage ../development/python-modules/trustme {};
+
   tokenserver = callPackage ../development/python-modules/tokenserver {};
 
   toml = callPackage ../development/python-modules/toml { };


### PR DESCRIPTION
This pull request doesn't yet build. I have a separate pull request
for the first two packages in this series, since they build fine.

The problem starts at the "outcome" package. It fails with:

    installing
    /build/outcome-0.1.0a0/dist /build/outcome-0.1.0a0
    Processing ./outcome-0.1.0a0-py2.py3-none-any.whl
    Collecting attrs (from outcome==0.1.0a0)
      Could not find a version that satisfies the requirement attrs (from outcome==0.1.0a0) (from versions: )
    No matching distribution found for attrs (from outcome==0.1.0a0)
    builder for '/nix/store/2k15pq05a7iv97fy6p2yxzqd5hzlk5h8-python3.6-outcome-0.1.0a0.drv' failed with exit code 1

Even though attrs is in its propagatedBuildInputs... any ideas?