### PR TITLE
webkitgtk: add missing libXdamage dependency

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.4.nix
+++ b/pkgs/development/libraries/webkitgtk/2.4.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk2 libwebp enchant
     libxml2 libxslt
-    gst-plugins-base sqlite xorg.libXt
+    gst-plugins-base sqlite xorg.libXt xorg.libXdamage
   ] ++ optionals enableCredentialStorage [
     libsecret
   ] ++ (if stdenv.isDarwin then [


### PR DESCRIPTION
###### Motivation for this change

webkitgtk-2.4.11 fails to build due to a missing dependency on libXdamage. This change is needed so that gnucash-2.6 builds, which in turn is needed to provide an upgrade path from gnucash-2.4 (previous default) to gnucash-3.1 (new default). See #39616 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ~[ ] Tested execution of all binary files (usually in `./result/bin/`)~
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: I successfully ran gnucash-2.6 with this change.

