### PR TITLE
librsvg: 2.42.3 → 2.42.4

### DIFF
--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -5,17 +5,17 @@
 
 let
   pname = "librsvg";
-  version = "2.42.3";
+  version = "2.42.4";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "0mz6rdxpnnjnk15nahlwpa2gba0ws1hs2dnyk1agqw5ip522qkvh";
+    sha256 = "1qsd0j7s97ab5fzy5b5gix5b7hbw57cr46ia8pkcrr4ylsi80li2";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "installedTests" ];
 
   buildInputs = [ libxml2 libgsf bzip2 libcroco pango libintl ];
 
@@ -26,8 +26,17 @@ stdenv.mkDerivation rec {
       ApplicationServices
     ]);
 
-  configureFlags = [ "--enable-introspection" "--enable-vala" ]
-    ++ stdenv.lib.optional stdenv.isDarwin "--disable-Bsymbolic";
+  configureFlags = [
+    "--enable-introspection"
+    "--enable-vala"
+    "--enable-installed-tests"
+    "--enable-always-build-tests"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--disable-Bsymbolic";
+
+  makeFlags = [
+    "installed_test_metadir=$(installedTests)/share/installed-tests/RSVG"
+    "installed_testdir=$(installedTests)/libexec/installed-tests/RSVG"
+  ];
 
   NIX_CFLAGS_COMPILE
     = stdenv.lib.optionalString stdenv.isDarwin "-I${cairo.dev}/include/cairo";


### PR DESCRIPTION
###### Motivation for this change
Changes: https://gitlab.gnome.org/GNOME/librsvg/blob/2.42.4/NEWS

I also enabled [installed tests](https://github.com/NixOS/nixpkgs/issues/34987), which you can run using `env XDG_DATA_DIRS=$(nix-build -A librsvg.installedTests)/share nix-shell -p gnome-desktop-testing --run 'gnome-desktop-testing-runner'` but at the moment it fails because they refer to `/build` directory. ([upstream bug](https://gitlab.gnome.org/GNOME/librsvg/issues/259))

Regular tests are still failing, opened an upstream issue: https://gitlab.gnome.org/GNOME/librsvg/issues/258

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

