### PR TITLE
mongodb-compass: init at 1.13.1

### DIFF
--- a/pkgs/tools/misc/mongodb-compass/default.nix
+++ b/pkgs/tools/misc/mongodb-compass/default.nix
@@ -1,0 +1,86 @@
+{ stdenv, fetchurl, dpkg
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
+, gnome2, libnotify, libxcb, nspr, nss, systemd, xorg }:
+
+let
+
+  version = "1.13.1";
+
+  rpath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gnome2.GConf
+    gnome2.gdk_pixbuf
+    gnome2.gtk
+    gnome2.pango
+    libnotify
+    libxcb
+    nspr
+    nss
+    stdenv.cc.cc
+    systemd
+
+    xorg.libxkbfile
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libXScrnSaver
+  ] + ":${stdenv.cc.cc.lib}/lib64";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://downloads.mongodb.com/compass/mongodb-compass_${version}_amd64.deb";
+        sha256 = "0x23jshnr0rafm5sn2vhq2y2gryg8mksahzyv5fszblgaxay234p";
+      }
+    else
+      throw "MongoDB compass is not supported on ${stdenv.system}";
+
+in stdenv.mkDerivation {
+  name = "mongodb-compass-${version}";
+
+  inherit src;
+
+  buildInputs = [ dpkg ];
+  unpackPhase = "true";
+
+  buildCommand = ''
+    IFS=$'\n'
+    dpkg -x $src $out
+    cp -av $out/usr/* $out
+    rm -rf $out/share/lintian
+    #The node_modules are bringing in non-linux files/dependencies
+    find $out -name "*.app" -exec rm -rf {} \; || true
+    find $out -name "*.dll" -delete
+    find $out -name "*.exe" -delete
+    # Otherwise it looks "suspicious"
+    chmod -R g-w $out
+    for file in `find $out -type f -perm /0111 -o -name \*.so\*`; do
+      echo "Manipulating file: $file"
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/share/mongodb-compass "$file" || true
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The GUI for MongoDB";
+    homepage = https://www.mongodb.com/products/compass;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1420,6 +1420,8 @@ with pkgs;
 
   mcrypt = callPackage ../tools/misc/mcrypt { };
 
+  mongodb-compass = callPackage ../tools/misc/mongodb-compass { };
+  
   mongodb-tools = callPackage ../tools/misc/mongodb-tools { };
 
   mozlz4a = callPackage ../tools/compression/mozlz4a {


### PR DESCRIPTION
###### Motivation for this change

Just wanted a nicer way to manipulate and access MongoDB databases. I've played around with it, and everything seems to work.

###### Questions

This technically doesn't fit the **CONTRIBUTING.md** since I haven't put myself as a maintainer, do I add myself to the maintainer-list.nix in this PR?

The package derivation was liberally from the package declaration for **slack**, is there a more general package environment for electron based apps and if not, is it worth making one?

###### Things done

Only added the bare-necessary components to get this running on Linux. There is technically a MacOS version which we could also include in here, but I don't have a mac which I can test on.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

