### PR TITLE
feh: remove --theme=feh parameter

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    wrapProgram "$out/bin/feh" --prefix PATH : "${libjpeg.bin}/bin" \
-                               --add-flags '--theme=feh'
+    wrapProgram "$out/bin/feh" --prefix PATH : "${libjpeg.bin}/bin"
     install -D -m 644 man/*.1 $out/share/man/man1
   '';
 


### PR DESCRIPTION
Whatever this is, it keeps adding --theme=feh to my ~/.fehbg every time I call it.
Is this wrapper even needed at all? I can call `./.feh-wrapped` manually on my system without issues.

EDIT: ![Screenshot](https://i.imgur.com/ZMYIThL.png)