### PR TITLE
twine: update 1.9.1 -> 1.11.0

### DIFF
--- a/pkgs/development/python-modules/twine/default.nix
+++ b/pkgs/development/python-modules/twine/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "twine";
-  version = "1.9.1";
+  version = "1.11.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "caa45b7987fc96321258cd7668e3be2ff34064f5c66d2d975b641adca659c1ab";
+    sha256 = "09cz9v63f8mrs4znbjapjj2z3wdfryq8q364zm0wzjhbzzcs9n9g";
   };
 
   propagatedBuildInputs = [ pkginfo requests requests_toolbelt tqdm pyblake2 ];


### PR DESCRIPTION
###### Motivation for this change
twine 1.11.0 is the minimum version to upload packages with built in support for markdown long_descriptions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

