### PR TITLE
[RDY] wireshark: run binary from nix-shell

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -82,6 +82,11 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  shellHook = ''
+    # to be able to run the resulting binary
+    export WIRESHARK_RUN_FROM_BUILD_DIRECTORY=1
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://www.wireshark.org/;
     description = "Powerful network protocol analyzer";


### PR DESCRIPTION
when in a shell, export variable WIRESHARK_RUN_FROM_BUILD_DIRECTORY to be able to run the newly built wireshark
else one get:
./build/run/wireshark: error while loading shared libraries: libwscodecs.so.0: cannot open shared object file: No such file or directory

see https://github.com/NixOS/nixpkgs/issues/29638

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

