### PR TITLE
Fix android prebuilt ghc [Fixes #40194]

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.2.nix
+++ b/pkgs/development/compilers/ghc/8.4.2.nix
@@ -22,7 +22,7 @@
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.
-  enableShared ? true
+  enableShared ? !targetPlatform.useAndroidPrebuilt
 
 , version ? "8.4.2"
 }:

--- a/pkgs/development/compilers/ghc/8.4.2.nix
+++ b/pkgs/development/compilers/ghc/8.4.2.nix
@@ -50,6 +50,8 @@ let
   '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
     GhcLibHcOpts += -fPIC
     GhcRtsHcOpts += -fPIC
+  '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
+    EXTRA_CC_OPTS += -std=gnu99
   '';
 
   # Splicer will pull out correct variations

--- a/pkgs/development/compilers/ghc/8.4.2.nix
+++ b/pkgs/development/compilers/ghc/8.4.2.nix
@@ -3,7 +3,7 @@
 
 # build-tools
 , bootPkgs, alex, happy
-, autoconf, automake, coreutils, fetchurl, perl, python3
+, autoconf, automake, coreutils, fetchurl, fetchpatch, perl, python3
 
 , libffi, libiconv ? null, ncurses
 
@@ -80,6 +80,13 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   outputs = [ "out" "doc" ];
+
+  patches = [(fetchpatch {
+    url = "https://git.haskell.org/hsc2hs.git/patch/738f3666c878ee9e79c3d5e819ef8b3460288edf";
+    sha256 = "0plzsbfaq6vb1023lsarrjglwgr9chld4q3m99rcfzx0yx5mibp3";
+    extraPrefix = "utils/hsc2hs/";
+    stripLen = 1;
+  })];
 
   postPatch = "patchShebangs .";
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -22,7 +22,7 @@
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.
-  enableShared ? true
+  enableShared ? !targetPlatform.useAndroidPrebuilt
 
 , version ? "8.5.20180118"
 }:

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -50,6 +50,8 @@ let
   '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
     GhcLibHcOpts += -fPIC
     GhcRtsHcOpts += -fPIC
+  '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
+    EXTRA_CC_OPTS += -std=gnu99
   '';
 
   # Splicer will pull out correct variations


### PR DESCRIPTION
###### Motivation for this change

In order to build GHC to cross compile to android, we need an extra c flag, and we need a patch from master to fix hsc2hs. There is also an issue with forbidden references in dynamic exes, so for now we just don't `enableShared`:

```
RPATH of binary /nix/store/bbg892bbs7dqjqm9y1jpgwc2s5sw1xxb-aarch64-unknown-linux-android-ghc-8.4.2/lib/aarch64-unknown-linux-android-ghc-8.4.2/bin/ghc-iserv-dyn contains a forbidden reference to /tmp/nix-build-aarch64-unknown-linux-android-ghc-8.4.2.drv
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

