### PR TITLE
monero: fix daemon crash

### DIFF
--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, git
+{ stdenv, fetchFromGitHub, fetchpatch
+, cmake, pkgconfig, git
 , boost, miniupnpc, openssl, unbound, cppzmq
 , zeromq, pcsclite, readline
 , CoreData, IOKit, PCSC
@@ -20,6 +21,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig git ];
+
+  patches = [
+    # fix daemon crash, remove with 0.12.1.0 update
+    (fetchpatch {
+      url    = "https://github.com/monero-project/monero/commit/08343ab.diff";
+      sha256 = "0f1snrl2mk2czwk1ysympzr8ismjx39fcqgy13276vcmw0cfqi83";
+    })
+  ];
 
   buildInputs = [
     boost miniupnpc openssl unbound


### PR DESCRIPTION
###### Motivation for this change
A recent transaction in the mempool is causing the monero daemon to crash

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

