### PR TITLE
nixos/tests/statsd: fix non-deterministic failure

### DIFF
--- a/nixos/tests/statsd.nix
+++ b/nixos/tests/statsd.nix
@@ -35,6 +35,6 @@ with lib;
   testScript = ''
     $statsd1->start();
     $statsd1->waitForUnit("statsd.service");
-    $statsd1->succeed("nc -z 127.0.0.1 8126");
+    $statsd1->waitUntilSucceeds("nc -z 127.0.0.1 8126");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Test failed sometimes on [Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.statsd.x86_64-linux/all) because the service wasn't ready immediately after starting the systemd unit.

Fixed by waiting for the service to accept a connection.


