### PR TITLE
nix-pin: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/tools/package-management/nix-pin/default.nix
+++ b/pkgs/tools/package-management/nix-pin/default.nix
@@ -1,15 +1,15 @@
 { lib, pkgs, stdenv, fetchFromGitHub, mypy, python3, nix, git, makeWrapper }:
 let self = stdenv.mkDerivation rec {
   name = "nix-pin-${version}";
-  version = "0.3.0";
+  version = "0.3.1";
   src = fetchFromGitHub {
     owner = "timbertson";
     repo = "nix-pin";
-    rev = "version-0.3.0";
-    sha256 = "1kq50v8m8y1wji63b7y3wh6nv3ahvdxvvbsb07day2zzf5ysy8kj";
+    rev = "version-0.3.1";
+    sha256 = "1sldbrz33wz30d3vv3d2clyqyd6x1y6h6xjz1xv55fa97ig1h481";
   };
   buildInputs = [ python3 mypy makeWrapper ];
-  buildPhase = ''
+  checkPhase = ''
     mypy bin/*
   '';
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes failure due to incorrect type annotation (https://hydra.nixos.org/build/73898813) which was picked up by new mypy version https://github.com/NixOS/nixpkgs/pull/40077

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

