### PR TITLE
compsize: init at 2018-04-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -43,6 +43,11 @@
     github = "ChengCat";
     name = "Yucheng Zhang";
   };
+  CrazedProgrammer = {
+    email = "crazedprogrammer@gmail.com";
+    github = "CrazedProgrammer";
+    name = "CrazedProgrammer";
+  };
   CrystalGamma = {
     email = "nixos@crystalgamma.de";
     github = "CrystalGamma";

--- a/pkgs/os-specific/linux/compsize/default.nix
+++ b/pkgs/os-specific/linux/compsize/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, btrfs-progs }:
+
+stdenv.mkDerivation rec {
+  name = "compsize-${version}";
+  version = "2018-04-07";
+
+  src = fetchFromGitHub {
+    owner = "kilobyte";
+    repo = "compsize";
+    rev = "903f772e37fc0ac6d6cf94ddbc98c691763c1e62";
+    sha256 = "0jps8n0xsdh4mcww5q29rzysbv50iq6rmihxrf99lzgrw0sw5m7k";
+  };
+
+  buildInputs = [ btrfs-progs ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man8
+    install -m 0755 compsize $out/bin
+    install -m 0444 compsize.8 $out/share/man/man8
+  '';
+
+  meta = with stdenv.lib; {
+    description = "btrfs: Find compression type/ratio on a file or set of files";
+    homepage    = https://github.com/kilobyte/compsize;
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ CrazedProgrammer ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1060,6 +1060,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation AddressBook;
   };
 
+  compsize = callPackage ../os-specific/linux/compsize { };
+
   coturn = callPackage ../servers/coturn { };
 
   coursier = callPackage ../development/tools/coursier {};


### PR DESCRIPTION
###### Motivation for this change

Adds compsize, a tool for checking the compression type/ratio on a file or a set of files on Btrfs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

