### PR TITLE
zsh: move setEnvironment stuff to zprofile

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -108,8 +108,6 @@ in
         if [ -n "$__ETC_ZSHENV_SOURCED" ]; then return; fi
         export __ETC_ZSHENV_SOURCED=1
 
-        ${config.system.build.setEnvironment.text}
-
         ${cfge.shellInit}
 
         ${cfg.shellInit}
@@ -128,6 +126,8 @@ in
         # Only execute this file once per shell.
         if [ -n "$__ETC_ZPROFILE_SOURCED" ]; then return; fi
         __ETC_ZPROFILE_SOURCED=1
+
+        ${config.system.build.setEnvironment.text}
 
         ${cfge.loginShellInit}
 


### PR DESCRIPTION
.zshenv is always sourced, meaning it'll override all local environment variables with their system defaults.
It'll also make your shell startup 0.000000000<etc>0001ms slower.
.zprofile is only sourced for login shells, meaning users who set environment stuff in the .xprofile will get to keep their modifications.

The current xsession script will already source /etc/profile so all envs will still be avaiable from X.

We should probably use /etc/environment instead of a per-shell global default though IMO