### PR TITLE
librealsense: init at 2.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -676,6 +676,11 @@
     github = "bramd";
     name = "Bram Duvigneau";
   };
+  brian-dawn = {
+    email = "brian.t.dawn@gmail.com";
+    github = "brian-dawn";
+    name = "Brian Dawn";
+  };
   bstrik = {
     email = "dutchman55@gmx.com";
     github = "bstrik";

--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, cmake, libusb, ninja, pkgconfig}:
+
+stdenv.mkDerivation rec {
+  name = "librealsense-${version}";
+  version = "2.11.0";
+
+  src = fetchFromGitHub {
+    owner = "IntelRealSense";
+    repo = "librealsense";
+    rev = "v${version}";
+    sha256 = "11vzs2m6jh9v1xbffr2k541pymmih6g4w641mp8rll8qzqfh89i0";
+  };
+
+  buildInputs = [
+    libusb
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkgconfig
+  ];
+
+  cmakeFlags = [ "-DBUILD_EXAMPLES=false" ];
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300)";
+    homepage = https://github.com/IntelRealSense/librealsense;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ brian-dawn ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13801,6 +13801,8 @@ with pkgs;
 
   libraw1394 = callPackage ../development/libraries/libraw1394 { };
 
+  librealsense = callPackage ../development/libraries/librealsense { };
+
   libsass = callPackage ../development/libraries/libsass { };
 
   libsexy = callPackage ../development/libraries/libsexy { };


### PR DESCRIPTION
###### Motivation for this change

The librealsense library is used to drive a series of depth cameras from Intel. The package doesn't depend on much and would be helpful to those of us who use nix for C++ building.

This is my first contribution to nixpkg so please let me know if I did anything wrong! Unfortunately testing the library is difficult as it requires having a realsense camera to really test it. I was able to test it on my machine using Ubuntu 16.04 and an intel D435.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

