### PR TITLE
libomxil-bellagio: fix build on gcc8

### DIFF
--- a/pkgs/development/libraries/libomxil-bellagio/default.nix
+++ b/pkgs/development/libraries/libomxil-bellagio/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fedora-fixes.patch ];
 
+  # Fix for #40213, probably permanent, because upstream doesn't seem to be
+  # developed anymore. Alternatively, gcc7Stdenv could be used.
+  NIX_CFLAGS_COMPILE = "-Wno-error=array-bounds";
+
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/omxil/;
     description = "An opensource implementation of the Khronos OpenMAX Integration Layer API to access multimedia components";


### PR DESCRIPTION
Added the `-Wno-error=array-bounds` flag. Fixes #40213.

###### Motivation for this change

See #40213.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

