### PR TITLE
dmd,dtools,dub: 2.079.0 -> 2.079.1 and wrap ldc2 binary with $CC

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, overrideCC, gcc5
 , makeWrapper, unzip, which
 , curl, tzdata, gdb, darwin
-, callPackage
+, callPackage, targetPackages
 , bootstrapVersion ? false
-, version ? "2.079.0"
-, dmdSha256 ? "1k6cky71pqnss6h6391p1ich2mjs598f5fda018aygnxg87qgh4y"
-, druntimeSha256 ? "183pqygj5w4105czs5kswyjn9mrcybx3wmkynz3in0m3ylzzjmvl"
-, phobosSha256 ? "0y9i86ggmf41ww2xk2bsrlsv9b1blj5dbyan6q6r6xp8dmgrd79w"
+, version ? "2.079.1"
+, dmdSha256 ? "0mlk095aw94d940qkymfp85daggiz3f0xv598nlc7acgp6408kyj"
+, druntimeSha256 ? "18r8gwvb54ar80j5155wx0qbqq4w56hqmbf6wap20xwijg2rw90g"
+, phobosSha256 ? "1x5v1ln51nr8x2vyki864160bakdyq0acmvbfv7jcipaj2w3m9bb"
 }:
 
 let
@@ -143,6 +143,9 @@ let
     + stdenv.lib.optionalString (stdenv.hostPlatform.isLinux && bootstrapVersion) ''
       substituteInPlace ${dmdPath}/root/port.c \
         --replace "#include <bits/mathdef.h>" "#include <complex.h>"
+
+      substituteInPlace ${dmdPath}/root/port.c \
+        --replace "#include <bits/nan.h>" "#include <math.h>"
     ''
 
     + stdenv.lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -198,6 +201,8 @@ let
     
     extension = if stdenv.hostPlatform.isDarwin then "a" else "{a,so}";
 
+    dontStrip = true;
+
     installPhase = ''
         cd dmd
         mkdir $out
@@ -222,13 +227,13 @@ let
         cp -r etc $out/include/d2
 
         wrapProgram $out/bin/dmd \
-            --prefix PATH ":" "${stdenv.cc}/bin" \
-            --set-default CC "$CC"
+            --prefix PATH ":" "${targetPackages.stdenv.cc}/bin" \
+            --set-default CC "${targetPackages.stdenv.cc}/bin/cc"
 
         cd $out/bin
         tee dmd.conf << EOF
         [Environment]
-        DFLAGS=-I$out/include/d2 -L-L$out/lib ${stdenv.lib.optionalString (!stdenv.cc.isClang) "-L--export-dynamic"} -fPIC
+        DFLAGS=-I$out/include/d2 -L-L$out/lib ${stdenv.lib.optionalString (!targetPackages.stdenv.cc.isClang) "-L--export-dynamic"} -fPIC
         EOF
     '';
 

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -4,7 +4,7 @@ let
 
   dubBuild = stdenv.mkDerivation rec {
     name = "dubBuild-${version}";
-    version = "1.8.0";
+    version = "1.8.1";
 
     enableParallelBuilding = true;
 
@@ -12,7 +12,7 @@ let
       owner = "dlang";
       repo = "dub";
       rev = "v${version}";
-      sha256 = "0788d375sc6xdak9x6xclkkz243lb7di68yxfvl4v0n178mi22bk";
+      sha256 = "16r7x4jsfv5fjssvs6mwj8ymr6fjpvbkjhpr4f4368sjr5iyfad6";
     };
 
     postUnpack = ''
@@ -75,6 +75,7 @@ let
       # file under ../etc relative to the dub location.
       cp ${dubBuild}/bin/dub bin/
       export DUB=$NIX_BUILD_TOP/source/bin/dub
+      export PATH=$PATH:$NIX_BUILD_TOP/source/bin/
       export DC=${dmd.out}/bin/dmd
       export HOME=$TMP
       ./test/run-unittest.sh

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "dtools-${version}";
-  version = "2.079.0";
+  version = "2.079.1";
 
   srcs = [
     (fetchFromGitHub {
       owner = "dlang";
       repo = "dmd";
       rev = "v${version}";
-      sha256 = "1k6cky71pqnss6h6391p1ich2mjs598f5fda018aygnxg87qgh4y";
+      sha256 = "0mlk095aw94d940qkymfp85daggiz3f0xv598nlc7acgp6408kyj";
       name = "dmd";
     })
     (fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Fix dmd build on Master and update to new version.
Wrap ldc2 binary with C compiler because it's needed for linking.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

