### PR TITLE
Do not kill udev during boot

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -8,7 +8,7 @@ in {
 
   imports = [ ../../../modules/virtualisation/amazon-image.nix ];
 
-  # Required to avoid kernel panics on KVM instances where nvme volume availability can get delayed
+  # Required to provide good EBS experience,
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
   # TODO change value to 4294967295 when kernel is updated to 4.15 or later
   config.boot.kernelParams = [ "nvme_core.io_timeout=255" ];

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -8,6 +8,11 @@ in {
 
   imports = [ ../../../modules/virtualisation/amazon-image.nix ];
 
+  # Required to avoid kernel panics on KVM instances where nvme volume availability can get delayed
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
+  # TODO change value to 4294967295 when kernel is updated to 4.15 or later
+  config.boot.kernelParams = [ "nvme_core.io_timeout=255" ];
+
   options.amazonImage = {
     name = mkOption {
       type = types.str;

--- a/nixos/modules/system/boot/grow-partition.nix
+++ b/nixos/modules/system/boot/grow-partition.nix
@@ -30,7 +30,7 @@ with lib;
 
     boot.initrd.postDeviceCommands = ''
       rootDevice="${config.fileSystems."/".device}"
-      if [ -e "$rootDevice" ]; then
+      if waitDevice "$rootDevice"; then
         rootDevice="$(readlink -f "$rootDevice")"
         parentDevice="$rootDevice"
         while [ "''${parentDevice%[0-9]}" != "''${parentDevice}" ]; do

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -74,6 +74,32 @@ ln -s /proc/mounts /etc/mtab # to shut up mke2fs
 touch /etc/udev/hwdb.bin # to shut up udev
 touch /etc/initrd-release
 
+# Function for waiting a device to appear.
+waitDevice() {
+    local device="$1"
+
+    # USB storage devices tend to appear with some delay.  It would be
+    # great if we had a way to synchronously wait for them, but
+    # alas...  So just wait for a few seconds for the device to
+    # appear.
+    if test ! -e $device; then
+        echo -n "waiting for device $device to appear..."
+        try=20
+        while [ $try -gt 0 ]; do
+            sleep 1
+            # also re-try lvm activation now that new block devices might have appeared
+            lvm vgchange -ay
+            # and tell udev to create nodes for the new LVs
+            udevadm trigger --action=add
+            if test -e $device; then break; fi
+            echo -n "."
+            try=$((try - 1))
+        done
+        echo
+        [ $try -ne 0 ]
+    fi
+}
+
 # Mount special file systems.
 specialMount() {
   local device="$1"
@@ -377,31 +403,7 @@ lustrateRoot () {
     exec 4>&-
 }
 
-# Function for waiting a device to appear.
-waitDevice() {
-    local device="$1"
 
-    # USB storage devices tend to appear with some delay.  It would be
-    # great if we had a way to synchronously wait for them, but
-    # alas...  So just wait for a few seconds for the device to
-    # appear.
-    if test ! -e $device; then
-        echo -n "waiting for device $device to appear..."
-        try=20
-        while [ $try -gt 0 ]; do
-            sleep 1
-            # also re-try lvm activation now that new block devices might have appeared
-            lvm vgchange -ay
-            # and tell udev to create nodes for the new LVs
-            udevadm trigger --action=add
-            if test -e $device; then break; fi
-            echo -n "."
-            try=$((try - 1))
-        done
-        echo
-        [ $try -ne 0 ]
-    fi
-}
 
 
 # Try to resume - all modules are loaded now.

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -48,13 +48,6 @@ let cfg = config.ec2; in
     boot.loader.grub.extraPerEntryConfig = mkIf (!cfg.hvm) "root (hd0)";
     boot.loader.timeout = 0;
 
-    boot.initrd.postDeviceCommands =
-      ''
-        # Force udev to exit to prevent random "Device or resource busy
-        # while trying to open /dev/xvda" errors from fsck.
-        udevadm control --exit || true
-      '';
-
     boot.initrd.network.enable = true;
 
     # Mount all formatted ephemeral disks and activate all swap devices.


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/39867

So main culprit was `udevadm control --exit || true` during initrd stage. I don't know what kind of fix was that, but it is definitely outdated, and in generally killing udev is not a good idea.
Basically what was happening - when nvme device did not appear immediately and udev was killed there were no links to device created in `/dev/device-by*` that was causing inability to mount root volume. 


NVME devices may appear with some delay, so I had to add `waitDevice` to growpartition script, to ensure that root volume is resized even when device is delayed.

Tested on m5 and m4 instances.