### PR TITLE
[RDY] pythonPackages.configobj: enable tests

### DIFF
--- a/pkgs/development/python-modules/configobj/default.nix
+++ b/pkgs/development/python-modules/configobj/default.nix
@@ -1,18 +1,29 @@
-{ stdenv, buildPythonPackage, fetchPypi, six }:
+{ stdenv, buildPythonPackage
+, fetchFromGitHub
+, six
+, mock, pytest
+}:
 
 buildPythonPackage rec {
   pname = "configobj";
   version = "5.0.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "00h9rcmws03xvdlfni11yb60bz3kxfvsj6dg6nrpzj71f03nbxd2";
+  # Pypi archives don't contain the tests
+  src = fetchFromGitHub {
+    owner = "DiffSK";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0x97794nk3dfn0i3si9fv7y19jnpnarb34bkdwlz7ii7ag6xihhw";
   };
 
-  # error: invalid command 'test'
-  doCheck = false;
 
   propagatedBuildInputs = [ six ];
+
+  checkPhase = ''
+    pytest --deselect=tests/test_configobj.py::test_options_deprecation
+  '';
+
+  checkInputs = [ mock pytest ];
 
   meta = with stdenv.lib; {
     description = "Config file reading, writing and validation";


### PR DESCRIPTION


###### Motivation for this change
I found a bug in configobj and wanted to run the testsuite to check
things. Now that it works let's upstream it.

###### Things done
I disabled the only failing tests. Seems too minor to request an upstream change. I download the source from github since it 's not available on Pipy

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

