### PR TITLE
ocamlPackages.ocamlnet: 4.1.5 -> 4.1.6

### DIFF
--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, jbuilder, opam, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm }:
 
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "gapi-ocaml is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   name = "gapi-ocaml-${version}";
   version = "0.3.6";

--- a/pkgs/development/ocaml-modules/http/default.nix
+++ b/pkgs/development/ocaml-modules/http/default.nix
@@ -1,5 +1,9 @@
 {stdenv, fetchurl, ocaml_pcre, ocamlnet, ocaml, findlib, camlp4}:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "ocaml-http is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
   name = "ocaml-http-0.1.5";
 

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -1,22 +1,16 @@
 { stdenv, fetchurl, pkgconfig, ncurses, ocaml, findlib, ocaml_pcre, camlzip
-, gnutls, nettle, fetchpatch
+, gnutls, nettle
 }:
 
-let version = "4.1.5"; in
+let version = "4.1.6"; in
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-ocamlnet-${version}";
 
   src = fetchurl {
     url = "http://download.camlcity.org/download/ocamlnet-${version}.tar.gz";
-    sha256 = "1ppcd2zjhj6s3ib9q8dngnr53qlmkhvv7a8hzp88r79k6jygn4cm";
+    sha256 = "1j0k0drybcjpysvs8xpq3cnpg3wqk6d5sy7y1h5rq8jk7hrirf0k";
   };
-
-  patches = [ (fetchpatch {
-      url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/ocamlnet/ocamlnet.4.1.5/files/netgzip.patch";
-      sha256 = "1say7zzgk24qcy9m91gcfgvz4fv7nksx4j5qnbxyq8wqw0g88ba0";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses ocaml findlib ocaml_pcre camlzip gnutls nettle ];

--- a/pkgs/development/ocaml-modules/pcre/default.nix
+++ b/pkgs/development/ocaml-modules/pcre/default.nix
@@ -1,20 +1,18 @@
-{stdenv, buildOcaml, fetchurl, pcre, ocaml, findlib}:
+{ stdenv, fetchurl, pcre, ocaml, findlib, ocamlbuild }:
 
-buildOcaml {
-  name = "pcre";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-pcre-${version}";
   version = "7.2.3";
 
   src = fetchurl {
-    url = "https://github.com/mmottl/pcre-ocaml/releases/download/v7.2.3/pcre-ocaml-7.2.3.tar.gz";
+    url = "https://github.com/mmottl/pcre-ocaml/releases/download/v${version}/pcre-ocaml-${version}.tar.gz";
     sha256 = "0rj6dw79px4sj2kq0iss2nzq3rnsn9wivvc0f44wa1mppr6njfb3";
   };
 
-  buildInputs = [ocaml findlib];
+  buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [pcre];
 
   createFindlibDestdir = true;
-
-  hasSharedObjects = true;
 
   configurePhase = "true";	# Skip configure phase
 


### PR DESCRIPTION
###### Motivation for this change

Make `ocamlnet` available for OCaml 4.07.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

