### PR TITLE
gnucash: add upgrade instructions to NixOS release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -107,6 +107,17 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
      a stable URL for Nixpkgs to use to package this proprietary software.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <literal>gnucash</literal> has changed from version 2.4 to 3.x.
+     If you've been using <literal>gnucash</literal> (version 2.4) instead of
+     <literal>gnucash26</literal> (version 2.6) you must open your Gnucash 
+     data file(s) with <literal>gnucash26</literal> and then save them to
+     upgrade the file format. Then you may use your data file(s) with
+     Gnucash 3.x. See the upgrade <link xlink:href="https://wiki.gnucash.org/wiki/FAQ#Using_Different_Versions.2C_Up_And_Downgrade">documentation</link>.
+     Gnucash 2.4 is still available under the attribute <literal>gnucash24</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 


### PR DESCRIPTION
###### Motivation for this change

The default `gnucash` was changed from version 2.4 to 3.1, which requires manual intervention to upgrade successfully. See #39616 

This change adds to the NixOS release notes accordingly.

###### Things done

- [X] Built the NixOS manual with `cd nixpkgs; nix-build -I nixpkgs=$PWD nixos/release.nix -A manual.x86_64-linux`
- [X] Visually verified the generated documentation:

![nixos-release-notes](https://user-images.githubusercontent.com/13485450/39829633-11bf68f6-538d-11e8-8ed2-9b36bec2f0a2.png)

- [X] Tested the link in the doc to ensure it goes to the right place.
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ~[ ] Tested execution of all binary files (usually in `./result/bin/`)~
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

