### PR TITLE
nixos/tests/plotinus: fix non-deterministic failures

### DIFF
--- a/nixos/tests/plotinus.nix
+++ b/nixos/tests/plotinus.nix
@@ -15,11 +15,11 @@ import ./make-test.nix ({ pkgs, ... }: {
   testScript =
     ''
       $machine->waitForX;
-      $machine->execute("xterm -e 'gnome-calculator' &");
-      $machine->waitForWindow(qr/Calculator/);
-      $machine->execute("xdotool key ctrl+shift+p");
-      $machine->sleep(1); # wait for the popup
-      $machine->execute("xdotool key p r e f e r e n c e s Return");
+      $machine->succeed("gnome-calculator &");
+      $machine->waitForWindow(qr/gnome-calculator/);
+      $machine->succeed("xdotool search --sync --onlyvisible --class gnome-calculator windowfocus --sync key ctrl+shift+p");
+      $machine->sleep(5); # wait for the popup
+      $machine->succeed("xdotool key --delay 100 p r e f e r e n c e s Return");
       $machine->waitForWindow(qr/Preferences/);
       $machine->screenshot("screen");
     '';


### PR DESCRIPTION
###### Motivation for this change

The test [failed sometimes on Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.plotinus.x86_64-linux), likely because a window didn't get focus before typing into it.

Use `xdotool` to make sure the right window has focus.

